### PR TITLE
add `resolve(id)` to BuildStep

### DIFF
--- a/lib/build.dart
+++ b/lib/build.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+export 'src/analyzer/resolver.dart';
 export 'src/asset/asset.dart';
 export 'src/asset/exceptions.dart';
 export 'src/asset/file_based.dart';

--- a/lib/src/analyzer/resolver.dart
+++ b/lib/src/analyzer/resolver.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+import 'package:analyzer/analyzer.dart' show Expression;
+import 'package:analyzer/src/generated/constant.dart' show EvaluationResult;
+import 'package:analyzer/src/generated/element.dart';
+import 'package:code_transformers/resolver.dart' as code_transformers
+    show Resolver;
+import 'package:source_maps/refactor.dart';
+import 'package:source_span/source_span.dart';
+
+import '../asset/id.dart';
+import '../builder/build_step.dart';
+import '../util/barback.dart';
+
+class Resolver {
+  final code_transformers.Resolver resolver;
+
+  Resolver(this.resolver);
+
+  /// Update the status of all the sources referenced by the entry points and
+  /// update the resolved library. If [entryPoints] is omitted, the input
+  /// asset of [buildStep] is used as the only entry point.
+  ///
+  /// [release] must be called when done handling this [Resolver] to allow it
+  /// to be used by later phases.
+  Future<Resolver> resolve(BuildStep buildStep,
+      [List<AssetId> entryPoints]) async {
+    return new Resolver(await resolver.resolve(toBarbackTransform(buildStep),
+        entryPoints?.map(toBarbackAssetId)?.toList()));
+  }
+
+  /// Release this resolver so it can be updated by following build steps.
+  void release() => resolver.release();
+
+  /// Gets the resolved Dart library for an asset, or null if the AST has not
+  /// been resolved.
+  ///
+  /// If the AST has not been resolved then this normally means that the
+  /// transformer hosting this needs to be in an earlier phase.
+  LibraryElement getLibrary(AssetId assetId) =>
+      resolver.getLibrary(toBarbackAssetId(assetId));
+
+  /// Gets all libraries accessible from the entry point, recursively.
+  ///
+  /// This includes all Dart SDK libraries as well.
+  Iterable<LibraryElement> get libraries => resolver.libraries;
+
+  /// Finds the first library identified by [libraryName], or null if no
+  /// library can be found.
+  LibraryElement getLibraryByName(String libraryName) =>
+      resolver.getLibraryByName(libraryName);
+
+  /// Finds the first library identified by [libraryName], or null if no
+  /// library can be found.
+  ///
+  /// [uri] must be an absolute URI of the form
+  /// `[dart:|package:]path/file.dart`.
+  LibraryElement getLibraryByUri(Uri uri) => resolver.getLibraryByUri(uri);
+
+  /// Resolves a fully-qualified type name (library_name.ClassName).
+  ///
+  /// This will resolve the first instance of [typeName], because of potential
+  /// library name conflicts the name is not guaranteed to be unique.
+  ClassElement getType(String typeName) => resolver.getType(typeName);
+
+  /// Resolves a fully-qualified top-level library variable
+  /// (library_name.variableName).
+  ///
+  /// This will resolve the first instance of [variableName], because of
+  /// potential library name conflicts the name is not guaranteed to be unique.
+  Element getLibraryVariable(String variableName) =>
+      resolver.getLibraryVariable(variableName);
+
+  /// Resolves a fully-qualified top-level library function
+  /// (library_name.functionName).
+  ///
+  /// This will resolve the first instance of [functionName], because of
+  /// potential library name conflicts the name is not guaranteed to be unique.
+  Element getLibraryFunction(String functionName) =>
+      resolver.getLibraryFunction(functionName);
+
+  /// Gets the result of evaluating the constant [expression] in the context of
+  /// a [library].
+  EvaluationResult evaluateConstant(
+          LibraryElement library, Expression expression) =>
+      resolver.evaluateConstant(library, expression);
+
+  /// Gets an URI appropriate for importing the specified library.
+  ///
+  /// Returns null if the library cannot be imported via an absolute URI or
+  /// from [from] (if provided).
+  Uri getImportUri(LibraryElement lib, {AssetId from}) => resolver
+      .getImportUri(lib, from: from == null ? null : toBarbackAssetId(from));
+
+  /// Get the asset ID of the file containing the asset.
+  AssetId getSourceAssetId(Element element) =>
+      toBuildAssetId(resolver.getSourceAssetId(element));
+
+  /// Get the source span where the specified element was defined or null if
+  /// the element came from the Dart SDK.
+  SourceSpan getSourceSpan(Element element) => resolver.getSourceSpan(element);
+
+  /// Get a [SourceFile] with the contents of the file that defines [element],
+  /// or null if the element came from the Dart SDK.
+  SourceFile getSourceFile(Element element) => resolver.getSourceFile(element);
+
+  /// Creates a text edit transaction for the given element if it is able
+  /// to be edited, returns null otherwise.
+  ///
+  /// The transaction contains the entire text of the source file where the
+  /// element originated. If the element was from a library part then the
+  /// source file is the part file rather than the library.
+  TextEditTransaction createTextEditTransaction(Element element) =>
+      resolver.createTextEditTransaction(element);
+}

--- a/lib/src/builder/build_step.dart
+++ b/lib/src/builder/build_step.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import '../analyzer/resolver.dart';
 import '../asset/asset.dart';
 import '../asset/id.dart';
 
@@ -22,4 +23,8 @@ abstract class BuildStep {
   /// Outputs an [Asset] using the current [AssetWriter], and adds [asset] to
   /// [outputs].
   void writeAsString(Asset asset, {Encoding encoding: UTF8});
+
+  /// Gives a [Resolver] for [id]. This must be released when it is done being
+  /// used.
+  Future<Resolver> resolve(id);
 }

--- a/lib/src/builder/build_step_impl.dart
+++ b/lib/src/builder/build_step_impl.dart
@@ -5,16 +5,23 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:code_transformers/resolver.dart' as code_transformers;
+
+import '../analyzer/resolver.dart';
 import '../asset/asset.dart';
 import '../asset/id.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
+import '../util/barback.dart';
 import 'build_step.dart';
 import 'exceptions.dart';
 
 /// A single step in the build processes. This represents a single input and
 /// its expected and real outputs. It also handles tracking of dependencies.
 class BuildStepImpl implements BuildStep {
+  static code_transformers.Resolvers _resolvers =
+      new code_transformers.Resolvers(code_transformers.dartSdkDirectory);
+
   /// The primary input for this build step.
   @override
   final Asset input;
@@ -76,4 +83,8 @@ class BuildStepImpl implements BuildStep {
     var done = _writer.writeAsString(asset, encoding: encoding);
     _outputsCompleted = _outputsCompleted.then((_) => done);
   }
+
+  /// Resolves [id] and returns a [Future<Resolver>] once that is done.
+  Future<Resolver> resolve(AssetId id) async => new Resolver(
+      await _resolvers.get(toBarbackTransform(this), [toBarbackAssetId(id)]));
 }

--- a/lib/src/util/barback.dart
+++ b/lib/src/util/barback.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:barback/barback.dart' as barback;
+
+import '../asset/asset.dart' as build;
+import '../asset/id.dart' as build;
+import '../builder/build_step.dart' as build;
+
+barback.AssetId toBarbackAssetId(build.AssetId id) =>
+    new barback.AssetId(id.package, id.path);
+
+build.AssetId toBuildAssetId(barback.AssetId id) =>
+    new build.AssetId(id.package, id.path);
+
+barback.Asset toBarbackAsset(build.Asset asset) => new barback.Asset.fromString(
+    toBarbackAssetId(asset.id), asset.stringContents);
+
+Future<build.Asset> toBuildAsset(barback.Asset asset) async =>
+    new build.Asset(toBuildAssetId(asset.id), await asset.readAsString());
+
+barback.Transform toBarbackTransform(build.BuildStep buildStep) =>
+    new BuildStepTransform(buildStep);
+
+class BuildStepTransform implements barback.Transform {
+  final build.BuildStep buildStep;
+
+  BuildStepTransform(this.buildStep);
+
+  @override
+  barback.Asset get primaryInput => toBarbackAsset(buildStep.input);
+
+  @override
+  barback.TransformLogger get logger =>
+      new barback.TransformLogger((asset, level, message, span) {
+        var buffer = new StringBuffer();
+        buffer.write('$level: ');
+        if (asset != null) {
+          buffer.write('From $asset');
+          if (span != null) {
+            buffer.write('()$span)');
+          }
+          buffer.write(': ');
+        }
+        buffer.write(message);
+        print(buffer);
+      });
+
+  @override
+  Future<barback.Asset> getInput(barback.AssetId id, {Encoding encoding}) =>
+      throw new UnimplementedError();
+
+  @override
+  Future<String> readInputAsString(barback.AssetId id, {Encoding encoding}) {
+    return buildStep.readAsString(toBuildAssetId(id), encoding: encoding);
+  }
+
+  @override
+  Stream<List<int>> readInput(barback.AssetId id) =>
+      throw new UnimplementedError();
+
+  @override
+  Future<bool> hasInput(barback.AssetId id) =>
+      buildStep.hasInput(toBuildAssetId(id));
+
+  @override
+  void addOutput(barback.Asset output) {
+    toBuildAsset(output).then((asset) {
+      buildStep.writeAsString(asset);
+    });
+  }
+
+  @override
+  void consumePrimary() => throw new UnimplementedError();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,9 +8,13 @@ environment:
   sdk: '>=1.9.1 <2.0.0'
 
 dependencies:
+  analyzer: ^0.27.1
   barback: ^0.15.0
+  code_transformers: ^0.4.0
   glob: ^1.1.0
   path: ^1.1.0
+  source_maps: '>=0.9.4 <0.11.0'
+  source_span: '>=1.0.0 <2.0.0'
   stack_trace: ^1.6.0
   yaml: ^2.1.0
 

--- a/test/analyzer/resolver_test.dart
+++ b/test/analyzer/resolver_test.dart
@@ -1,0 +1,321 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+@TestOn('vm')
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:build/build.dart';
+import 'package:build/src/builder/build_step_impl.dart';
+import 'package:build/src/util/barback.dart';
+
+import '../common/common.dart';
+
+// Ported from
+// https://github.com/dart-lang/code_transformers/blob/master/test/resolver_test.dart
+main() {
+  var entryPoint = makeAssetId('a|web/main.dart');
+  Future validateResolver(
+      {Map<String, String> inputs, validator(Resolver)}) async {
+    var writer = new InMemoryAssetWriter();
+    var reader = new InMemoryAssetReader(writer.assets);
+    var assets = makeAssets(inputs);
+    addAssets(assets.values, writer);
+
+    var builder = new TestBuilder(validator);
+    var buildStep = new BuildStepImpl(assets[entryPoint], [], reader, writer);
+    await builder.build(buildStep);
+  }
+
+  group('Resolver', () {
+    test('should handle initial files', () {
+      return validateResolver(inputs: {'a|web/main.dart': ' main() {}',},
+          validator: (resolver) {
+        var source = resolver.resolver.sources[toBarbackAssetId(entryPoint)];
+        expect(source.modificationStamp, 1);
+
+        var lib = resolver.getLibrary(entryPoint);
+        expect(lib, isNotNull);
+      });
+    });
+
+    test('should update when sources change', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': ''' main() {
+                } ''',
+      }, validator: (resolver) {
+        var source = resolver.resolver.sources[toBarbackAssetId(entryPoint)];
+        expect(source.modificationStamp, 2);
+
+        var lib = resolver.getLibrary(entryPoint);
+        expect(lib, isNotNull);
+        expect(lib.entryPoint, isNotNull);
+      });
+    });
+
+    test('should follow imports', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+              import 'a.dart';
+
+              main() {
+              } ''',
+        'a|web/a.dart': '''
+              library a;
+              ''',
+      }, validator: (resolver) {
+        var lib = resolver.getLibrary(entryPoint);
+        expect(lib.importedLibraries.length, 2);
+        var libA = lib.importedLibraries.where((l) => l.name == 'a').single;
+        expect(libA.getType('Foo'), isNull);
+      });
+    });
+
+    test('should update changed imports', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+              import 'a.dart';
+
+              main() {
+              } ''',
+        'a|web/a.dart': '''
+              library a;
+              class Foo {}
+              ''',
+      }, validator: (resolver) {
+        var lib = resolver.getLibrary(entryPoint);
+        expect(lib.importedLibraries.length, 2);
+        var libA = lib.importedLibraries.where((l) => l.name == 'a').single;
+        expect(libA.getType('Foo'), isNotNull);
+      });
+    });
+
+    test('should follow package imports', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+              import 'package:b/b.dart';
+
+              main() {
+              } ''',
+        'b|lib/b.dart': '''
+              library b;
+              ''',
+      }, validator: (resolver) {
+        var lib = resolver.getLibrary(entryPoint);
+        expect(lib.importedLibraries.length, 2);
+        var libB = lib.importedLibraries.where((l) => l.name == 'b').single;
+        expect(libB.getType('Foo'), isNull);
+      });
+    });
+
+    test('handles missing files', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+              import 'package:b/missing.dart';
+
+              main() {
+              } ''',
+      }, validator: (resolver) {
+        var lib = resolver.getLibrary(entryPoint);
+        expect(lib.importedLibraries.length, 1);
+      });
+    });
+
+    test('should update on changed package imports', () {
+      // TODO(sigmund): remove modification below, see dartbug.com/22638
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+              import 'package:b/missing.dart';
+
+              main() {
+              } // modified, but we shouldn't need to! ''',
+        'b|lib/missing.dart': '''
+              library b;
+              class Bar {}
+              ''',
+      }, validator: (resolver) {
+        var lib = resolver.getLibrary(entryPoint);
+        expect(lib.importedLibraries.length, 2);
+        var libB = lib.importedLibraries.where((l) => l.name == 'b').single;
+        expect(libB.getType('Bar'), isNotNull);
+      });
+    });
+
+    test('should handle deleted files', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+              import 'package:b/missing.dart';
+
+              main() {
+              } ''',
+      }, validator: (resolver) {
+        var lib = resolver.getLibrary(entryPoint);
+        expect(lib.importedLibraries.length, 1);
+      });
+    });
+
+    test('should fail on absolute URIs', () {
+      // var warningPrefix = 'warning: absolute paths not allowed';
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+              import '/b.dart';
+
+              main() {
+              } ''',
+      }, /*messages: [
+        // First from the AST walker
+        '$warningPrefix: "/b.dart" (web/main.dart 0 14)',
+        '$warningPrefix: "/b.dart"',
+      ],*/
+          validator: (resolver) {
+        var lib = resolver.getLibrary(entryPoint);
+        expect(lib.importedLibraries.length, 1);
+      });
+    });
+
+    test('should list all libraries', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+              library a.main;
+              import 'package:a/a.dart';
+              import 'package:a/b.dart';
+              export 'package:a/d.dart';
+              ''',
+        'a|lib/a.dart': 'library a.a;\n import "package:a/c.dart";',
+        'a|lib/b.dart': 'library a.b;\n import "c.dart";',
+        'a|lib/c.dart': 'library a.c;',
+        'a|lib/d.dart': 'library a.d;'
+      }, validator: (resolver) {
+        var libs = resolver.libraries.where((l) => !l.isInSdk);
+        expect(libs.map((l) => l.name),
+            unorderedEquals(['a.main', 'a.a', 'a.b', 'a.c', 'a.d',]));
+      });
+    });
+
+    test('should resolve types and library uris', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+              import 'dart:core';
+              import 'package:a/a.dart';
+              import 'package:a/b.dart';
+              import 'sub_dir/d.dart';
+              class Foo {}
+              ''',
+        'a|lib/a.dart': 'library a.a;\n import "package:a/c.dart";',
+        'a|lib/b.dart': 'library a.b;\n import "c.dart";',
+        'a|lib/c.dart': '''
+                library a.c;
+                class Bar {}
+                ''',
+        'a|web/sub_dir/d.dart': '''
+                library a.web.sub_dir.d;
+                class Baz{}
+                ''',
+      }, validator: (resolver) {
+        var a = resolver.getLibraryByName('a.a');
+        expect(a, isNotNull);
+        expect(resolver.getImportUri(a).toString(), 'package:a/a.dart');
+        expect(resolver.getLibraryByUri(Uri.parse('package:a/a.dart')), a);
+
+        var main = resolver.getLibraryByName('');
+        expect(main, isNotNull);
+        expect(resolver.getImportUri(main), isNull);
+
+        var fooType = resolver.getType('Foo');
+        expect(fooType, isNotNull);
+        expect(fooType.library, main);
+
+        var barType = resolver.getType('a.c.Bar');
+        expect(barType, isNotNull);
+        expect(resolver.getImportUri(barType.library).toString(),
+            'package:a/c.dart');
+        expect(
+            resolver.getSourceAssetId(barType), new AssetId('a', 'lib/c.dart'));
+
+        var bazType = resolver.getType('a.web.sub_dir.d.Baz');
+        expect(bazType, isNotNull);
+        expect(resolver.getImportUri(bazType.library), isNull);
+        expect(
+            resolver.getImportUri(bazType.library, from: entryPoint).toString(),
+            'sub_dir/d.dart');
+      });
+    });
+
+    test('deleted files should be removed', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''import 'package:a/a.dart';''',
+        'a|lib/a.dart': '''import 'package:a/b.dart';''',
+        'a|lib/b.dart': '''class Engine{}''',
+      }, validator: (resolver) {
+        var engine = resolver.getType('Engine');
+        var uri = resolver.getImportUri(engine.library);
+        expect(uri.toString(), 'package:a/b.dart');
+      }).then((_) {
+        return validateResolver(inputs: {
+          'a|web/main.dart': '''import 'package:a/a.dart';''',
+          'a|lib/a.dart': '''lib a;\n class Engine{}'''
+        }, validator: (resolver) {
+          var engine = resolver.getType('Engine');
+          var uri = resolver.getImportUri(engine.library);
+          expect(uri.toString(), 'package:a/a.dart');
+
+          // Make sure that we haven't leaked any sources.
+          expect(resolver.resolver.sources.length, 2);
+        });
+      });
+    });
+
+    test('handles circular imports', () {
+      return validateResolver(inputs: {
+        'a|web/main.dart': '''
+                library main;
+                import 'package:a/a.dart'; ''',
+        'a|lib/a.dart': '''
+                library a;
+                import 'package:a/b.dart'; ''',
+        'a|lib/b.dart': '''
+                library b;
+                import 'package:a/a.dart'; ''',
+      }, validator: (resolver) {
+        var libs = resolver.libraries.map((lib) => lib.name);
+        expect(libs.contains('a'), isTrue);
+        expect(libs.contains('b'), isTrue);
+      });
+    });
+
+    test('handles parallel resolves', () {
+      return Future.wait([
+        validateResolver(inputs: {
+          'a|web/main.dart': '''
+                library foo;'''
+        }, validator: (resolver) {
+          expect(resolver.getLibrary(entryPoint).name, 'foo');
+        }),
+        validateResolver(inputs: {
+          'a|web/main.dart': '''
+                library bar;'''
+        }, validator: (resolver) {
+          expect(resolver.getLibrary(entryPoint).name, 'bar');
+        }),
+      ]);
+    });
+  });
+}
+
+class TestBuilder extends Builder {
+  final Function validator;
+
+  TestBuilder(this.validator);
+
+  List<AssetId> declareOutputs(idOrAsset) => [];
+
+  build(BuildStep buildStep) async {
+    var resolver = await buildStep.resolve(buildStep.input.id);
+    try {
+      validator(resolver);
+    } finally {
+      resolver.release();
+    }
+  }
+}


### PR DESCRIPTION
This adds essentially the `code_transformers` package logic directly to this package. It is up in the air still if this is really a good idea or not though ;).

cc @munificent @nex3 

closes https://github.com/dart-lang/build/issues/24