### PR TITLE
asset graph path is now based on script uri

### DIFF
--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -1,9 +1,18 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
 
 /// Relative path to the asset graph from the root package dir.
-const assetGraphPath = '$cacheDir/asset_graph.json';
+final assetGraphPath = '$cacheDir/${scriptHash}/asset_graph.json';
 
 /// Relative path to the cache directory from the root package dir.
 const cacheDir = '.dart_tool/build';
+
+final String scriptHash = () {
+  var hasher = new MD5();
+  hasher.add(Platform.script.path.codeUnits);
+  return CryptoUtils.bytesToHex(hasher.close());
+}();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   analyzer: ^0.27.1
   barback: ^0.15.0
   code_transformers: ^0.4.1
+  crypto: 0.9.1
   logging: ^0.11.2
   glob: ^1.1.0
   path: ^1.1.0


### PR DESCRIPTION
closes https://github.com/dart-lang/build/issues/87