### PR TITLE
Upgrade to latest code_transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+2
+- Stop using removed argument `useSharedSources` when constructing Resolvers
+- Support code_transformers 0.5.x
+
 ## 0.4.1+1
 - Support analyzer 0.29.x
 

--- a/lib/src/analyzer/resolver.dart
+++ b/lib/src/analyzer/resolver.dart
@@ -40,8 +40,7 @@ class Resolver {
 
 class Resolvers {
   static final code_transformers.Resolvers _resolvers =
-      new code_transformers.Resolvers(code_transformers.dartSdkDirectory,
-          useSharedSources: true);
+      new code_transformers.Resolvers(code_transformers.dartSdkDirectory);
 
   const Resolvers();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.4.1+1
+version: 0.4.1+2
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"
   barback: ^0.15.0
-  code_transformers: ^0.4.1
+  code_transformers: ">=0.4.1 <0.6.0"
   crypto: ">=0.9.2 <3.0.0"
   logging: ^0.11.2
   glob: ^1.1.0


### PR DESCRIPTION
- Stop passing `useSharedSources` argument
- Bump max version for code_transformers