### PR TITLE
Take a single Builder in BuilderTransformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - **BREAKING** BuilderTransformer must be constructed with a single Builder. Use
   the MultiplexingBuilder to cover cases with a list of builders
+- When using a MultiplexingBuilder if multiple Builders have overlapping outputs
+  the entire step will not run rather than running builders up to the point
+  where there is an overlap
 
 ## 0.4.1+3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0
+
+- **BREAKING** BuilderTransformer must be constructed with a single Builder. Use
+  the MultiplexingBuilder to cover cases with a list of builders
+
 ## 0.4.1+3
 
 - With the default logger, print exceptions with a terse stack trace.

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+1
+
+- Forwards compatible version bump in package:build
+
 ## 0.2.0
 
 - Upgrade build package to 0.4.0

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 dependencies:
-  build: ^0.4.0
+  build: ">=0.4.0 <0.6.0"
   logging: ^0.11.2
   test: ^0.12.0
   watcher: ^0.9.7

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.2.0
+version: 0.2.0+1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 

--- a/e2e_example/lib/transformer.dart
+++ b/e2e_example/lib/transformer.dart
@@ -7,5 +7,5 @@ import 'copy_builder.dart';
 
 /// A pub compatible Transformer built on top of [BuilderTransformer].
 class CopyTransformer extends BuilderTransformer {
-  CopyTransformer.asPlugin(_) : super([new CopyBuilder()]);
+  CopyTransformer.asPlugin(_) : super(new CopyBuilder());
 }

--- a/lib/build.dart
+++ b/lib/build.dart
@@ -11,6 +11,7 @@ export 'src/asset/writer.dart';
 export 'src/builder/build_step.dart';
 export 'src/builder/builder.dart';
 export 'src/builder/exceptions.dart';
+export 'src/builder/multiplexing_builder.dart';
 export 'src/builder/transformer_builder.dart';
 export 'src/generate/build.dart';
 export 'src/generate/build_result.dart';

--- a/lib/src/builder/multiplexing_builder.dart
+++ b/lib/src/builder/multiplexing_builder.dart
@@ -26,7 +26,8 @@ class MultiplexingBuilder implements Builder {
   /// If multiple builders declare the same output it will appear in this List
   /// more than once. This should be considered an error.
   @override
-  List<AssetId> declareOutputs(AssetId inputId) => _collectOutputs(inputId);
+  List<AssetId> declareOutputs(AssetId inputId) =>
+      _collectOutputs(inputId).toList();
 
   Iterable<AssetId> _collectOutputs(AssetId id) sync* {
     for (var builder in _builders) {

--- a/lib/src/builder/multiplexing_builder.dart
+++ b/lib/src/builder/multiplexing_builder.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+import '../asset/id.dart';
+import 'build_step.dart';
+import 'builder.dart';
+
+/// A [Builder] that runs multiple delegate builders asynchronously.
+///
+/// **Note**: All builders are ran without ordering guarantees. Thus, none of
+/// the builders can use the outputs of other builders in this group. All
+/// builders must also have distinct outputs.
+class MultiplexingBuilder implements Builder {
+  final Iterable<Builder> _builders;
+
+  MultiplexingBuilder(this._builders);
+
+  @override
+  Future build(BuildStep buildStep) =>
+      Future.wait(_builders.map((builder) => builder.build(buildStep)));
+
+  /// Collects declared outputs from all of the builders.
+  ///
+  /// If multiple builders declare the same output it will appear in this List
+  /// more than once. This should be considered an error.
+  @override
+  List<AssetId> declareOutputs(AssetId inputId) => _collectOutputs(inputId);
+
+  Iterable<AssetId> _collectOutputs(AssetId id) sync* {
+    for (var builder in _builders) {
+      yield* builder.declareOutputs(id);
+    }
+  }
+
+  @override
+  String toString() => '$_builders';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.4.1+3
+version: 0.5.0
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/test/transformer/transformer_test.dart
+++ b/test/transformer/transformer_test.dart
@@ -53,7 +53,8 @@ void main() {
   ], {
     'a|web/a.txt': 'hello',
   }, {}, messages: [
-    _fileExistsError('CopyBuilder', ['a|web/a.txt.copy']),
+    _fileExistsError(
+        '${[new CopyBuilder(), new CopyBuilder()]}', ['a|web/a.txt.copy']),
   ]);
 
   testPhases('multiple phases', [
@@ -87,7 +88,7 @@ void main() {
       {'a|web/a.txt': 'hello', 'a|web/a.txt.copy': 'hello'},
       {},
       messages: [
-        _fileExistsError("CopyBuilder", ["a|web/a.txt.copy"]),
+        _fileExistsError('${new CopyBuilder()}', ['a|web/a.txt.copy']),
       ],
       expectBarbackErrors: true);
 
@@ -112,7 +113,7 @@ void main() {
       {'a|web/a.txt': 'hello'},
       {'a|web/a.txt.copy': 'hello'},
       messages: [
-        _fileExistsError("CopyBuilder", ["a|web/a.txt.copy"]),
+        _fileExistsError('${new CopyBuilder()}', ['a|web/a.txt.copy']),
       ],
       expectBarbackErrors: true);
 
@@ -149,7 +150,7 @@ class LoggingCopyBuilder extends CopyBuilder {
 }
 
 String _fileExistsError(String builder, List<String> files) {
-  return "error: Builder `Instance of '$builder'` declared outputs "
-      "`$files` but those files already exist. That build step has been "
+  return "error: Builder `$builder` declared outputs "
+      "`$files` but those files already exist. This build step has been "
       "skipped.";
 }

--- a/test/transformer/transformer_test.dart
+++ b/test/transformer/transformer_test.dart
@@ -11,11 +11,12 @@ import 'package:transformer_test/utils.dart';
 import '../common/common.dart' hide testPhases;
 
 void main() {
-  var singleCopyTransformer = new BuilderTransformer([new CopyBuilder()]);
+  var singleCopyTransformer = new BuilderTransformer(new CopyBuilder());
   var multiCopyTransformer =
-      new BuilderTransformer([new CopyBuilder(numCopies: 2)]);
+      new BuilderTransformer(new CopyBuilder(numCopies: 2));
   var singleAndMultiCopyTransformer = new BuilderTransformer(
-      [new CopyBuilder(), new CopyBuilder(numCopies: 2)]);
+      new MultiplexingBuilder(
+          [new CopyBuilder(), new CopyBuilder(numCopies: 2)]));
 
   testPhases('single builder, single output', [
     [singleCopyTransformer],
@@ -46,7 +47,8 @@ void main() {
 
   testPhases('multiple builders, same outputs', [
     [
-      new BuilderTransformer([new CopyBuilder(), new CopyBuilder()])
+      new BuilderTransformer(
+          new MultiplexingBuilder([new CopyBuilder(), new CopyBuilder()]))
     ],
   ], {
     'a|web/a.txt': 'hello',
@@ -93,10 +95,7 @@ void main() {
   testPhases(
       'builders in the same phase can\'t output the same file',
       [
-        [
-          singleCopyTransformer,
-          new BuilderTransformer([new CopyBuilder()])
-        ]
+        [singleCopyTransformer, new BuilderTransformer(new CopyBuilder())]
       ],
       {
         'a|web/a.txt': 'hello',
@@ -118,9 +117,7 @@ void main() {
       expectBarbackErrors: true);
 
   testPhases('loggers log errors', [
-    [
-      new BuilderTransformer([new LoggingCopyBuilder()])
-    ],
+    [new BuilderTransformer(new LoggingCopyBuilder())],
   ], {
     'a|web/a.txt': 'a',
     'a|web/b.txt': 'b',


### PR DESCRIPTION
Typical use case is to have a single Builder and this will make it
easier to write helper code around using BuilderTransformers for
codegen.

- Take a single Builder in the constructor of BuilderTransformer
- Remove looping around builders
- Add MultiplexingBuilder to make it easier to compose builders for the
  few use cases that may need it
- Update package version as a breaking change
- Loosen version constraint from build_test since it is not impacted
- Update tests to use the new interface and expect slightly different log
  messages