### PR TITLE
support latest version of build_test

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+1
+
+- Support `pkg/build` v0.5.0
+
 ## 0.2.0
 
 - Upgrade build package to 0.4.0

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.2.0
+version: 0.2.0+1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 dependencies:
-  build: ^0.4.0
+  build: '>=0.4.0 <0.6.0'
   logging: ^0.11.2
   test: ^0.12.0
   watcher: ^0.9.7


### PR DESCRIPTION
Need to make sure we do this after every release