### PR TITLE
Update example after build package split

### DIFF
--- a/e2e_example/lib/copy_builder.dart
+++ b/e2e_example/lib/copy_builder.dart
@@ -4,8 +4,6 @@
 import 'dart:async';
 
 import 'package:build/build.dart';
-import 'package:build/src/generate/input_set.dart';
-import 'package:build/src/generate/phase.dart';
 
 // Makes copies of things!
 class CopyBuilder extends Builder {
@@ -13,17 +11,11 @@ class CopyBuilder extends Builder {
   Future build(BuildStep buildStep) async {
     var input = buildStep.input;
     var copy = new Asset(_copiedAssetId(input.id), input.stringContents);
-    await buildStep.writeAsString(copy);
+    buildStep.writeAsString(copy);
   }
 
   @override
   List<AssetId> declareOutputs(AssetId inputId) => [_copiedAssetId(inputId)];
-
-  /// Only runs on the root package, and copies all *.txt files.
-  static void addPhases(PhaseGroup group, PackageGraph graph) {
-    group.newPhase().addAction(
-        new CopyBuilder(), new InputSet(graph.root.name, ['**/*.txt']));
-  }
 }
 
 AssetId _copiedAssetId(AssetId inputId) => inputId.addExtension('.copy');

--- a/e2e_example/lib/packages_dir_builder.dart
+++ b/e2e_example/lib/packages_dir_builder.dart
@@ -6,8 +6,6 @@ import 'dart:async';
 import 'package:path/path.dart' as p;
 
 import 'package:build/build.dart';
-import 'package:build/src/generate/input_set.dart';
-import 'package:build/src/generate/phase.dart';
 
 // Makes copies of things!
 class PackagesDirBuilder extends Builder {
@@ -20,19 +18,11 @@ class PackagesDirBuilder extends Builder {
   Future build(BuildStep buildStep) async {
     var input = buildStep.input;
     var copy = new Asset(_copiedAssetId(input.id), input.stringContents);
-    await buildStep.writeAsString(copy);
+    buildStep.writeAsString(copy);
   }
 
   @override
   List<AssetId> declareOutputs(AssetId inputId) => [_copiedAssetId(inputId)];
-
-  static void addPhases(PhaseGroup group, PackageGraph graph) {
-    var builder = new PackagesDirBuilder(graph.root.name, 'web');
-    var phase = group.newPhase();
-    for (var package in graph.allPackages.values) {
-      phase.addAction(builder, new InputSet(package.name, ['lib/**']));
-    }
-  }
 
   AssetId _copiedAssetId(AssetId inputId) => new AssetId(
       outputPackage,

--- a/e2e_example/lib/transformer.dart
+++ b/e2e_example/lib/transformer.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import 'package:build/build.dart';
+import 'package:build_barback/build_barback.dart';
 
 import 'copy_builder.dart';
 

--- a/e2e_example/pubspec.yaml
+++ b/e2e_example/pubspec.yaml
@@ -1,12 +1,23 @@
 name: e2e_example
-version: 0.1.0
+version: 0.2.0
 
 environment:
   sdk: '>=1.9.1 <2.0.0'
 
 dependencies:
+  build: any
+  build_barback: any
+
+dev_dependencies:
+  build_runner: any
+
+dependency_overrides:
   build:
-    path: ../
+    path: ../build
+  build_runner:
+    path: ../build_runner
+  build_barback:
+    path: ../build_barback
 
 transformers:
 - e2e_example:

--- a/e2e_example/tool/build.dart
+++ b/e2e_example/tool/build.dart
@@ -3,19 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
-import 'package:build/build.dart';
+import 'package:build_runner/build_runner.dart';
 
 import 'package:e2e_example/copy_builder.dart';
 
 Future main() async {
   /// Builds a full package dependency graph for the current package.
   var graph = new PackageGraph.forThisPackage();
-  var phases = new PhaseGroup();
-
-  /// Give [Builder]s access to a [PackageGraph] so they can choose which
-  /// packages to run on. This simplifies user code a lot, and helps to mitigate
-  /// the transitive deps issue.
-  CopyBuilder.addPhases(phases, graph);
+  var phases = new PhaseGroup()
+    ..newPhase().addAction(
+        new CopyBuilder(), new InputSet(graph.root.name, ['**/*.txt']));
 
   await build(phases);
 }


### PR DESCRIPTION
- Move InputSet discovery from lib/ to tool/.
- Update imports to point to new packages
- Update pubspec.yam with new package paths and use dependency_overrides
  to accomplish the path dependencies to not conflict with the hosted
  depenendencies in the other packages