### PR TITLE
Expand capability of testBuilder

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.1
+
+- Additional capabilities in testBuilder:
+  - Filter sourceAssets to inputs with `isInput`
+  - Get log records
+  - Ignore output expectations when `outputs` is null
+  - Use a custom `writer`
+
 ## 0.3.0
 
 - **BREAKING** removed testPhases utility. Tests should be using testBuilder

--- a/build_test/lib/src/in_memory_reader.dart
+++ b/build_test/lib/src/in_memory_reader.dart
@@ -11,7 +11,8 @@ import 'in_memory_writer.dart';
 class InMemoryAssetReader implements AssetReader {
   final Map<AssetId, DatedString> assets;
 
-  InMemoryAssetReader(this.assets);
+  InMemoryAssetReader([Map<AssetId, DatedString> sourceAssets])
+      : assets = sourceAssets ?? <AssetId, DatedString>{};
 
   @override
   Future<bool> hasInput(AssetId id) {
@@ -22,5 +23,9 @@ class InMemoryAssetReader implements AssetReader {
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) async {
     if (!await hasInput(id)) throw new AssetNotFoundException(id);
     return assets[id].value;
+  }
+
+  void cacheAsset(Asset asset) {
+    assets[asset.id] = new DatedString(asset.stringContents);
   }
 }

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -6,48 +6,45 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:build/build.dart';
 import 'package:build_barback/build_barback.dart';
+import 'package:logging/logging.dart';
 
 import 'in_memory_writer.dart';
 import 'in_memory_reader.dart';
 import 'assets.dart';
 
 void _checkOutputs(Map<String, /*String|Matcher*/ dynamic> outputs,
-    [Map<AssetId, DatedString> actualAssets]) {
+    [Map<AssetId, Asset> actualAssets]) {
   if (outputs != null) {
     outputs.forEach((serializedId, contentsMatcher) {
       assert(contentsMatcher is String || contentsMatcher is Matcher);
 
       var assetId = makeAssetId(serializedId);
 
-      /// Check that the writer wrote the assets
-      if (actualAssets != null) {
-        expect(actualAssets, contains(assetId));
-        expect(actualAssets[assetId].value, contentsMatcher,
-            reason: 'Unexpected content for $assetId.');
-      }
-
-      /// Check that the assets exist in [result.outputs].
+      // Check that the asset was produced.
       var actual = actualAssets.remove(assetId);
       expect(actual, isNotNull,
           reason: 'Expected to find $assetId in ${actualAssets}.');
-      expect(actual.value, contentsMatcher,
+      expect(actual.stringContents, contentsMatcher,
           reason: 'Unexpected content for $assetId in result.outputs.');
     });
+    // Check that no extra assets were produced.
+    expect(actualAssets, isEmpty,
+        reason:
+            'Unexpected outputs found `$actualAssets`. Only expected $outputs');
   }
-  expect(actualAssets, isEmpty,
-      reason:
-          'Unexpected outputs found `$actualAssets`. Only expected $outputs');
 }
 
 /// Runs [builder] in a test environment.
 ///
 /// The test environment supplies in-memory build [sourceAssets] to the builders
 /// under test. [outputs] may be optionally provided to verify that the builders
-/// produce the expected output.
+/// produce the expected output. If outputs is omitted the only validation this
+/// method provides is that the build did not `throw`.
 ///
-/// [generateFor] specifies which assets should be given as inputs to the
-/// builder, this can be omitted if every asset in [sourceAssets] should be
-/// considered an input.
+/// [generateFor] or the [isInput] call back can specify which assets should be
+/// given as inputs to the builder. These can be omitted if every asset in
+/// [sourceAssets] should be considered an input. [isInput] precedent over
+/// [generateFor] if both are provided.
 ///
 /// The keys in [sourceAssets] and [outputs] are paths to file assets and the
 /// values are file contents. The paths must use the following format:
@@ -57,26 +54,41 @@ void _checkOutputs(Map<String, /*String|Matcher*/ dynamic> outputs,
 /// Where `PACKAGE_NAME` is the name of the package, and `PATH_WITHIN_PACKAGE`
 /// is the path to a file relative to the package. `PATH_WITHIN_PACKAGE` must
 /// include `lib`, `web`, `bin` or `test`. Example: "myapp|lib/utils.dart".
+///
+/// Callers may optionally provide a [writer] to stub different behavior or do
+/// more complex validation than what is possible with [outputs].
+///
+/// Callers may optionally provide an [onLog] callback to do validaiton on the
+/// logging output of the builder.
 Future testBuilder(Builder builder, Map<String, String> sourceAssets,
     {Set<String> generateFor,
-    Map<String, /*String|Matcher*/ dynamic> outputs}) async {
-  var writer = new InMemoryAssetWriter();
-  final reader = new InMemoryAssetReader(writer.assets);
+    bool isInput(String assetId),
+    String rootPackage,
+    AssetWriter writer,
+    Map<String, /*String|Matcher*/ dynamic> outputs,
+    void onLog(LogRecord log)}) async {
+  writer ??= new InMemoryAssetWriter();
+  final reader = new InMemoryAssetReader();
 
   var inputIds = <AssetId>[];
-  var sourceAssetIds = new Set<AssetId>();
   sourceAssets.forEach((serializedId, contents) {
     var asset = makeAsset(serializedId, contents);
-    writer.writeAsString(asset);
-    sourceAssetIds.add(asset.id);
-    if (generateFor == null || generateFor.contains(serializedId)) {
-      inputIds.add(asset.id);
-    }
+    reader.cacheAsset(asset);
+    inputIds.add(asset.id);
   });
-  await runBuilder(builder, inputIds, reader, writer, const BarbackResolvers());
-  var actualOutputs = <AssetId, DatedString>{}..addAll(writer.assets);
-  for (var assetId in sourceAssetIds) {
-    actualOutputs.remove(assetId);
-  }
+
+  isInput ??= generateFor?.contains ?? (_) => true;
+  inputIds = inputIds.where((id) => isInput('$id'));
+
+  var writerSpy = new AssetWriterSpy(writer);
+  var logger = new Logger('testBuilder');
+  var logSubscription = logger.onRecord.listen(onLog);
+  await runBuilder(
+      builder, inputIds, reader, writerSpy, const BarbackResolvers(),
+      rootPackage: rootPackage, logger: logger);
+  await logSubscription.cancel();
+  var actualOutputs = new Map<AssetId, Asset>.fromIterable(
+      writerSpy.assetsWritten,
+      key: (asset) => asset.id);
   _checkOutputs(outputs, actualOutputs);
 }

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -7,6 +7,7 @@ homepage: https://github.com/dart-lang/build
 dependencies:
   build: ^0.6.0
   build_barback: ^0.0.1
+  logging: ^0.11.2
   test: ^0.12.0
   watcher: ^0.9.7
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.3.0
+version: 0.3.1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 


### PR DESCRIPTION
- Add back onLog argument and dep on package:logging since there is a
  user of this feature in the old testPhases that needs to be migrated
- Only do any checking of outputs when the `outputs` argument is
  non-null rather than expect empty outpus on null
- Don't double up on the check against actual assets. This was a
  holdover from the version where we were checking both written assets
  and the `results` object
- Add in an `isInput` callback as an alternative to `generateFor` since
  this is sometimes an easier way to express the constraints (ie when
  all assets in the root package are inputs)
- Add back the `writer` argument to allow stubbing behavior or doing
  more complex validation. Take in an AssetWriter and spy on it rather
  than require an InMemoryAssetWriter
- Add a method to make new assets available through the
  InMemoryAssetWriter rather than require they are first written through
  the writer and sharing the cache