### PR TITLE
Fix log forwarding in BuilderTransformer

### DIFF
--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+- Fix a bug forwarding logs from a `BuilderTransformer`
+
 ## 0.0.1
 
 - Initial separate release - split off from `build` package.

--- a/build_barback/lib/src/transformer/transformer.dart
+++ b/build_barback/lib/src/transformer/transformer.dart
@@ -60,12 +60,11 @@ class BuilderTransformer implements Transformer, DeclaringTransformer {
       return;
     }
 
-    // Run the build step.
-    var logger = new Logger('${input.id}');
-    Logger.root.level = Level.ALL;
-    var logSubscription = logger.onRecord.listen((LogRecord log) {
-      if (log.loggerName != logger.fullName) return;
+    hierarchicalLoggingEnabled = true;
 
+    var logger = new Logger.detached('BuilderTransformer-${input.id}');
+    logger.level = Level.ALL;
+    var logSubscription = logger.onRecord.listen((LogRecord log) {
       if (log.level <= Level.CONFIG) {
         transform.logger.fine(_logRecordToMessage(log));
       } else if (log.level <= Level.INFO) {
@@ -77,6 +76,7 @@ class BuilderTransformer implements Transformer, DeclaringTransformer {
       }
     });
 
+    // Run the build step.
     var buildStep = new ManagedBuildStep(
         input, expected, reader, writer, input.id.package, _resolvers,
         logger: logger);

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_barback
-version: 0.0.1
+version: 0.0.2
 description: Utilities for translating between builders and transformers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
Fixes a bug where there would be runtime failures when double wrapping
(a Builder as a Transformer as a Builder).

- Set hierarchialLoggingEnabled to true so that a `detached` logger can
  actually stand outside the logging hierarchy rather than forward all
  logs to root
- Use a detached logger instead of a logger participating in chain since
  we don't want these logs to go anywhere other than to the
  TransformLogger