### PR TITLE
Make BuildStep implement AssetReader/Writer

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.1
+
+- `BuildStep` now implements `AssetReader` and `AssetWriter` so it's easier to
+  share with other code paths using a more limited interface.
+
 ## 0.6.0
 
 - **BREAKING** Move some classes and methods out of this package. If you are

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -15,7 +15,7 @@ import 'build_step_impl.dart';
 
 /// A single step in the build processes. This represents a single input and
 /// it also handles tracking of dependencies.
-abstract class BuildStep {
+abstract class BuildStep implements AssetReader, AssetWriter {
   /// The primary input for this build step.
   Asset get input;
 
@@ -23,14 +23,22 @@ abstract class BuildStep {
   Logger get logger;
 
   /// Checks if an [Asset] by [id] exists as an input for this [BuildStep].
+  @override
   Future<bool> hasInput(AssetId id);
 
   /// Reads an [Asset] by [id] as a [String] using [encoding].
+  @override
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8});
 
   /// Outputs an [Asset] using the current [AssetWriter], and adds [asset] to
   /// [outputs].
-  void writeAsString(Asset asset, {Encoding encoding: UTF8});
+  ///
+  /// Throws an [UnexpectedOutputException] if [asset] is not in
+  /// [expectedOutputs]. Most `Builder` implementations should not need to
+  /// `await` this Future since the runner will be responsible for waiting until
+  /// all outputs are written.
+  @override
+  Future writeAsString(Asset asset, {Encoding encoding: UTF8});
 
   /// Gives a [Resolver] for [id]. This must be released when it is done being
   /// used.

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -51,33 +51,26 @@ class BuildStepImpl implements ManagedBuildStep {
     _expectedOutputs.addAll(expectedOutputs);
   }
 
-  /// Checks if an [Asset] by [id] exists as an input for this [BuildStep].
   @override
   Future<bool> hasInput(AssetId id) {
     _checkInput(id);
     return _reader.hasInput(id);
   }
 
-  /// Reads an [Asset] by [id] as a [String] using [encoding].
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) {
     _checkInput(id);
     return _reader.readAsString(id, encoding: encoding);
   }
 
-  /// Outputs an [Asset] using the current [AssetWriter], and adds [asset] to
-  /// [outputs].
-  ///
-  /// Throws an [UnexpectedOutputException] if [asset] is not in
-  /// [expectedOutputs].
   @override
-  void writeAsString(Asset asset, {Encoding encoding: UTF8}) {
+  Future writeAsString(Asset asset, {Encoding encoding: UTF8}) {
     _checkOutput(asset);
     var done = _writer.writeAsString(asset, encoding: encoding);
     _outputsCompleted = _outputsCompleted.then((_) => done);
+    return done;
   }
 
-  /// Resolves [id] and returns a [Future<Resolver>] once that is done.
   @override
   Future<Resolver> resolve(AssetId id,
       {bool resolveAllConstants, List<AssetId> entryPoints}) async {

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.6.0
+version: 0.6.1
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
The methods were already there with a small difference in the writer
signature. This makes it easier to pass around the BuildStep for things
that need to read/write assets without having to expose the full
interface.

- Make BuildStep implement AssetReader
- Make BuildStep implement AssetWriter and change return type to Future
- Add @overrides
- Remove some Doc comments on methods with @override where the doc
  comment didn't add new information over the comment on the super class