### PR TITLE
Remove unused dependencies

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+- Remove unused dependencies
+
 ## 0.6.1
 
 - `BuildStep` now implements `AssetReader` and `AssetWriter` so it's easier to

--- a/build/lib/src/asset/id.dart
+++ b/build/lib/src/asset/id.dart
@@ -3,8 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'package:path/path.dart' as pathos;
 
-/// Forked from the `barback` package.
-///
 /// Identifies an asset within a package.
 class AssetId implements Comparable<AssetId> {
   /// The name of the package containing this asset.

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.6.1
+version: 0.6.2
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -9,20 +9,12 @@ environment:
 
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"
-  barback: ^0.15.0
-  code_transformers: ">=0.4.2+3 <0.6.0"
-  crypto: ">=0.9.2 <3.0.0"
   logging: ^0.11.2
-  glob: ^1.1.0
   path: ^1.1.0
-  shelf: ^0.6.5
-  shelf_static: ^0.2.3
-  stack_trace: ^1.6.0
-  watcher: ^0.9.7
-  yaml: ^2.1.0
 
 dev_dependencies:
-  build_test: ">=0.2.1 <0.4.0"
   build_barback: ^0.0.1
+  build_test: ">=0.2.1 <0.4.0"
+  glob: ^1.1.0
   test: ^0.12.0
   transformer_test: ^0.2.0


### PR DESCRIPTION
After the package split I never cleaned these up.

- Remove unused deps from pubspec
- Remove lib/ references to barback
- Bump version and changelog