### PR TITLE
Add writeFromFuture to BuildStepImpl

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+- Add hook for `build_barback` to write assets from a Future
+
 ## 0.6.2
 
 - Remove unused dependencies

--- a/build/lib/src/asset/exceptions.dart
+++ b/build/lib/src/asset/exceptions.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import 'asset.dart';
 import 'id.dart';
 
 class AssetNotFoundException implements Exception {
@@ -23,13 +22,13 @@ class PackageNotFoundException implements Exception {
 }
 
 class InvalidOutputException implements Exception {
-  final Asset asset;
+  final AssetId assetId;
   final String message;
 
-  InvalidOutputException(this.asset, this.message);
+  InvalidOutputException(this.assetId, this.message);
 
   @override
-  String toString() => 'InvalidOutputException: $asset\n$message';
+  String toString() => 'InvalidOutputException: $assetId\n$message';
 }
 
 class InvalidInputException implements Exception {

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -71,7 +71,7 @@ class BuildStepImpl implements ManagedBuildStep {
     return done;
   }
 
-  /// Synchronousl record [id] as an asset that needs to be written and
+  /// Synchronously record [id] as an asset that needs to be written and
   /// asynchronously write it.
   ///
   /// [id] needs to be passed separately from [asset] so that a check for

--- a/build/lib/src/builder/exceptions.dart
+++ b/build/lib/src/builder/exceptions.dart
@@ -1,13 +1,13 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import '../asset/asset.dart';
+import '../asset/id.dart';
 
 class UnexpectedOutputException implements Exception {
-  final Asset asset;
+  final AssetId assetId;
 
-  UnexpectedOutputException(this.asset);
+  UnexpectedOutputException(this.assetId);
 
   @override
-  String toString() => 'UnexpectedOutputException: $asset';
+  String toString() => 'UnexpectedOutputException: $assetId';
 }

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.6.2
+version: 0.6.3
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.3
+
+- Prevent asset writing from escaping beyond the `complete()` call in
+  BuildStepImpl
+
 ## 0.0.2
 
 - Fix a bug forwarding logs from a `BuilderTransformer`

--- a/build_barback/lib/src/util/barback.dart
+++ b/build_barback/lib/src/util/barback.dart
@@ -4,8 +4,9 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:build/build.dart' as build;
 import 'package:barback/barback.dart' as barback;
+import 'package:build/build.dart' as build;
+import 'package:build/src/builder/build_step_impl.dart';
 import 'package:logging/logging.dart';
 
 barback.AssetId toBarbackAssetId(build.AssetId id) =>
@@ -60,9 +61,8 @@ class BuildStepTransform implements barback.Transform {
 
   @override
   void addOutput(barback.Asset output) {
-    toBuildAsset(output).then((asset) {
-      buildStep.writeAsString(asset);
-    });
+    (buildStep as BuildStepImpl)
+        .writeFromFuture(toBuildAssetId(output.id), toBuildAsset(output));
   }
 
   @override

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_barback
-version: 0.0.2
+version: 0.0.3
 description: Utilities for translating between builders and transformers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"
-  build: ^0.6.0
+  build: ^0.6.3
   barback: ^0.15.0
   code_transformers: ">=0.4.2+3 <0.6.0"
   crypto: ">=0.9.2 <3.0.0"

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -512,12 +512,11 @@ class BuildImpl {
       /// Validate [expectedOutputs].
       for (var output in expectedOutputs) {
         if (output.package != _packageGraph.root.name) {
-          throw new InvalidOutputException(new Asset(output, ''),
+          throw new InvalidOutputException(output,
               'Files may only be output in the root (application) package.');
         }
         if (_inputsByPackage[output.package]?.contains(output) == true) {
-          throw new InvalidOutputException(
-              new Asset(output, ''), 'Cannot overwrite inputs.');
+          throw new InvalidOutputException(output, 'Cannot overwrite inputs.');
         }
       }
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.1.0
+version: 0.1.1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"
-  build: ^0.6.0
+  build: ^0.6.3
   build_barback: ^0.0.1
   crypto: ">=0.9.2 <3.0.0"
   logging: ^0.11.2


### PR DESCRIPTION
Transform has a synchronous addOutput method, and barback Assets cannot
be read synchronously. This combination means we can't even
synchronously call the writeAsString method which would also record that
an asset needs to be written before the build step is complete. So far
this has been OK since we haven't come across cases where a Transformer
does other asynchronous work and to make the call happen after the
Builder's Future has finished. To catch the case where the call does
happen after this future add a hook to record the pending write
synchronously.

- Change some exceptions to hold an AssetId rather than an Asset since
  in some cases that is all we have, and the AssetId is the criticial
  piece of information.
- Add writeFromFuture to BuildStepImpl. Since we don't expect many use
  cases to need this don't expose it further
- Add a src import and cast to BuildStepImpl from build_barback to use
  the new method