### PR TITLE
Update build_barback with support for reading and writing as bytes

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
 dev_dependencies:
   build_barback: ^0.0.1
-  build_test: ">=0.2.1 <0.4.0"
+  build_test: "^0.4.0"
   glob: ^1.1.0
   test: ^0.12.0
   transformer_test: ^0.2.0

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
 dev_dependencies:
   build_barback: ^0.0.1
-  build_test: "^0.4.0"
+  build_test: ^0.4.0
   glob: ^1.1.0
   test: ^0.12.0
   transformer_test: ^0.2.0

--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.1.0-dev
+
+Updated to reflect the new support for reading/writing as bytes in the `build`
+package, and the removal of the `Asset` class.
+
+### New Features
+- `BuilderTransformer` now supports wrapping transformers that read or write
+  their inputs as bytes.
+- Added `barbackAssetFromBytes` and `backbackAssetFromString` methods to replace
+  `toBarbackAsset`.
+
+### Breaking Changes
+- `toBuildAsset` and `toBarbackAsset` no longer exists since there is no `Asset`
+  class any longer in the `build` package.
+
 ## 0.0.3
 
 - Prevent asset writing from escaping beyond the `complete()` call in

--- a/build_barback/lib/src/transformer/transformer.dart
+++ b/build_barback/lib/src/transformer/transformer.dart
@@ -5,13 +5,14 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:build/build.dart' as build;
-import 'package:build/build.dart' hide Asset, AssetId;
+import 'package:build/build.dart' hide AssetId;
 import 'package:barback/barback.dart' as barback show AssetId;
 import 'package:barback/barback.dart' hide Asset, AssetId;
 import 'package:logging/logging.dart';
 
 import '../analyzer/resolver.dart';
 import '../util/barback.dart';
+import '../util/stream.dart';
 
 /// A [Transformer] which runs a single [Builder] with a new [BuildStep].
 ///
@@ -35,7 +36,7 @@ class BuilderTransformer implements Transformer, DeclaringTransformer {
 
   @override
   Future apply(Transform transform) async {
-    var input = await toBuildAsset(transform.primaryInput);
+    var inputId = await toBuildAssetId(transform.primaryInput.id);
     var reader = new _TransformAssetReader(transform);
     var writer = new _TransformAssetWriter(transform);
 
@@ -62,7 +63,7 @@ class BuilderTransformer implements Transformer, DeclaringTransformer {
 
     hierarchicalLoggingEnabled = true;
 
-    var logger = new Logger.detached('BuilderTransformer-${input.id}');
+    var logger = new Logger.detached('BuilderTransformer-${inputId}');
     logger.level = Level.ALL;
     var logSubscription = logger.onRecord.listen((LogRecord log) {
       if (log.level <= Level.CONFIG) {
@@ -78,7 +79,7 @@ class BuilderTransformer implements Transformer, DeclaringTransformer {
 
     // Run the build step.
     var buildStep = new ManagedBuildStep(
-        input, expected, reader, writer, input.id.package, _resolvers,
+        inputId, expected, reader, writer, inputId.package, _resolvers,
         logger: logger);
     await _builder.build(buildStep);
     await buildStep.complete();
@@ -118,6 +119,10 @@ class _TransformAssetReader implements AssetReader {
       transform.hasInput(toBarbackAssetId(id));
 
   @override
+  Future<List<int>> readAsBytes(build.AssetId id) async =>
+      await combineByteStream(transform.readInput(toBarbackAssetId(id)));
+
+  @override
   Future<String> readAsString(build.AssetId id, {Encoding encoding: UTF8}) =>
       transform.readInputAsString(toBarbackAssetId(id), encoding: encoding);
 }
@@ -129,8 +134,15 @@ class _TransformAssetWriter implements AssetWriter {
   _TransformAssetWriter(this.transform);
 
   @override
-  Future writeAsString(build.Asset asset, {Encoding encoding: UTF8}) {
-    transform.addOutput(toBarbackAsset(asset));
+  Future writeAsBytes(build.AssetId id, List<int> bytes) {
+    transform.addOutput(barbackAssetFromBytes(id, bytes));
+    return new Future.value(null);
+  }
+
+  @override
+  Future writeAsString(build.AssetId id, String contents,
+      {Encoding encoding: UTF8}) {
+    transform.addOutput(barbackAssetFromString(id, contents));
     return new Future.value(null);
   }
 }

--- a/build_barback/lib/src/transformer/transformer.dart
+++ b/build_barback/lib/src/transformer/transformer.dart
@@ -63,7 +63,7 @@ class BuilderTransformer implements Transformer, DeclaringTransformer {
 
     hierarchicalLoggingEnabled = true;
 
-    var logger = new Logger.detached('BuilderTransformer-${inputId}');
+    var logger = new Logger.detached('BuilderTransformer-$inputId');
     logger.level = Level.ALL;
     var logSubscription = logger.onRecord.listen((LogRecord log) {
       if (log.level <= Level.CONFIG) {

--- a/build_barback/lib/src/util/barback.dart
+++ b/build_barback/lib/src/util/barback.dart
@@ -100,15 +100,19 @@ barback.TransformLogger toTransformLogger(Logger logger) {
 }
 
 class _BuildStepAsset implements barback.Asset {
+  @override
   final barback.AssetId id;
+
   final build.BuildStep _buildStep;
 
   _BuildStepAsset(this.id, this._buildStep);
 
+  @override
   Stream<List<int>> read() async* {
     yield await _buildStep.readAsBytes(toBuildAssetId(id));
   }
 
+  @override
   Future<String> readAsString({Encoding encoding: UTF8}) =>
       _buildStep.readAsString(toBuildAssetId(id), encoding: encoding);
 }

--- a/build_barback/lib/src/util/barback.dart
+++ b/build_barback/lib/src/util/barback.dart
@@ -9,17 +9,19 @@ import 'package:build/build.dart' as build;
 import 'package:build/src/builder/build_step_impl.dart';
 import 'package:logging/logging.dart';
 
+import 'stream.dart';
+
 barback.AssetId toBarbackAssetId(build.AssetId id) =>
     new barback.AssetId(id.package, id.path);
 
 build.AssetId toBuildAssetId(barback.AssetId id) =>
     new build.AssetId(id.package, id.path);
 
-barback.Asset toBarbackAsset(build.Asset asset) => new barback.Asset.fromString(
-    toBarbackAssetId(asset.id), asset.stringContents);
+barback.Asset barbackAssetFromBytes(build.AssetId id, List<int> bytes) =>
+    new barback.Asset.fromBytes(toBarbackAssetId(id), bytes);
 
-Future<build.Asset> toBuildAsset(barback.Asset asset) async =>
-    new build.Asset(toBuildAssetId(asset.id), await asset.readAsString());
+barback.Asset barbackAssetFromString(build.AssetId id, String contents) =>
+    new barback.Asset.fromString(toBarbackAssetId(id), contents);
 
 barback.Transform toBarbackTransform(build.BuildStep buildStep) =>
     new BuildStepTransform(buildStep);
@@ -30,7 +32,10 @@ class BuildStepTransform implements barback.Transform {
   BuildStepTransform(this.buildStep);
 
   @override
-  barback.Asset get primaryInput => toBarbackAsset(buildStep.input);
+  barback.Asset get primaryInput {
+    var id = toBarbackAssetId(buildStep.inputId);
+    return new _BuildStepAsset(id, buildStep);
+  }
 
   @override
   barback.TransformLogger get logger {
@@ -52,8 +57,9 @@ class BuildStepTransform implements barback.Transform {
       buildStep.readAsString(toBuildAssetId(id), encoding: encoding);
 
   @override
-  Stream<List<int>> readInput(barback.AssetId id) =>
-      throw new UnimplementedError();
+  Stream<List<int>> readInput(barback.AssetId id) async* {
+    yield await buildStep.readAsBytes(toBuildAssetId(id));
+  }
 
   @override
   Future<bool> hasInput(barback.AssetId id) =>
@@ -61,8 +67,8 @@ class BuildStepTransform implements barback.Transform {
 
   @override
   void addOutput(barback.Asset output) {
-    (buildStep as BuildStepImpl)
-        .writeFromFuture(toBuildAssetId(output.id), toBuildAsset(output));
+    (buildStep as BuildStepImpl).writeFromFutureAsBytes(
+        toBuildAssetId(output.id), combineByteStream(output.read()));
   }
 
   @override
@@ -91,4 +97,18 @@ barback.TransformLogger toTransformLogger(Logger logger) {
     if (logLevel == null) throw 'Unrecognized LogLevel $level.';
     logger.log(logLevel, buffer);
   });
+}
+
+class _BuildStepAsset implements barback.Asset {
+  final barback.AssetId id;
+  final build.BuildStep _buildStep;
+
+  _BuildStepAsset(this.id, this._buildStep);
+
+  Stream<List<int>> read() async* {
+    yield await _buildStep.readAsBytes(toBuildAssetId(id));
+  }
+
+  Future<String> readAsString({Encoding encoding: UTF8}) =>
+      _buildStep.readAsString(toBuildAssetId(id), encoding: encoding);
 }

--- a/build_barback/lib/src/util/barback.dart
+++ b/build_barback/lib/src/util/barback.dart
@@ -34,7 +34,7 @@ class BuildStepTransform implements barback.Transform {
   @override
   barback.Asset get primaryInput {
     var id = toBarbackAssetId(buildStep.inputId);
-    return new _BuildStepAsset(id, buildStep);
+    return new _BuildAsset(id, buildStep);
   }
 
   @override
@@ -57,9 +57,8 @@ class BuildStepTransform implements barback.Transform {
       buildStep.readAsString(toBuildAssetId(id), encoding: encoding);
 
   @override
-  Stream<List<int>> readInput(barback.AssetId id) async* {
-    yield await buildStep.readAsBytes(toBuildAssetId(id));
-  }
+  Stream<List<int>> readInput(barback.AssetId id) =>
+      buildStep.readAsBytes(toBuildAssetId(id)).asStream();
 
   @override
   Future<bool> hasInput(barback.AssetId id) =>
@@ -99,20 +98,19 @@ barback.TransformLogger toTransformLogger(Logger logger) {
   });
 }
 
-class _BuildStepAsset implements barback.Asset {
+class _BuildAsset implements barback.Asset {
   @override
   final barback.AssetId id;
 
-  final build.BuildStep _buildStep;
+  final build.AssetReader _assetReader;
 
-  _BuildStepAsset(this.id, this._buildStep);
+  _BuildAsset(this.id, this._assetReader);
 
   @override
-  Stream<List<int>> read() async* {
-    yield await _buildStep.readAsBytes(toBuildAssetId(id));
-  }
+  Stream<List<int>> read() =>
+      _assetReader.readAsBytes(toBuildAssetId(id)).asStream();
 
   @override
   Future<String> readAsString({Encoding encoding: UTF8}) =>
-      _buildStep.readAsString(toBuildAssetId(id), encoding: encoding);
+      _assetReader.readAsString(toBuildAssetId(id), encoding: encoding);
 }

--- a/build_barback/lib/src/util/stream.dart
+++ b/build_barback/lib/src/util/stream.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+Future<List<int>> combineByteStream(Stream<List<int>> stream) async {
+  var chunks = await stream.toList();
+  return chunks.fold(<int>[], (p, e) {
+    p.addAll(e);
+    return p;
+  });
+}

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_barback
-version: 0.0.3
+version: 0.1.0-dev
 description: Utilities for translating between builders and transformers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"
-  build: ^0.6.3
+  build: ^0.7.0
   barback: ^0.15.0
   code_transformers: ">=0.4.2+3 <0.6.0"
   crypto: ">=0.9.2 <3.0.0"
@@ -23,6 +23,12 @@ dependencies:
   yaml: ^2.1.0
 
 dev_dependencies:
-  build_test: ^0.3.0
+  build_test: ^0.4.0
   test: ^0.12.0
   transformer_test: ^0.2.0
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_test:
+    path: ../build_test

--- a/build_barback/test/analyzer/resolver_test.dart
+++ b/build_barback/test/analyzer/resolver_test.dart
@@ -45,12 +45,13 @@ void main() {
       List messages: const []}) async {
     var writer = new InMemoryAssetWriter();
     var reader = new InMemoryAssetReader(writer.assets);
-    var assets = makeAssets(inputs);
-    addAssets(assets.values, writer);
+    var actualInputs = <AssetId, String>{};
+    inputs.forEach((k, v) => actualInputs[makeAssetId(k)] = v);
+    addAssets(actualInputs, writer);
 
     var builder = new TestBuilder(validator);
-    var buildStep = new ManagedBuildStep(
-        assets[entryPoint], [], reader, writer, 'a', _resolvers);
+    var buildStep =
+        new ManagedBuildStep(entryPoint, [], reader, writer, 'a', _resolvers);
     var logs = <LogRecord>[];
     if (messages != null) {
       buildStep.logger.onRecord.listen(logs.add);
@@ -69,8 +70,8 @@ void main() {
             'a|web/main.dart': ' main() {}',
           },
           validator: (resolver) {
-            var source = (_resolvers.lastResolved as dynamic).sources[
-                toBarbackAssetId(entryPoint)];
+            var source = (_resolvers.lastResolved as dynamic)
+                .sources[toBarbackAssetId(entryPoint)];
             expect(source.modificationStamp, 1);
 
             var lib = resolver.getLibrary(entryPoint);
@@ -85,8 +86,8 @@ void main() {
                 } ''',
           },
           validator: (resolver) {
-            var source = (_resolvers.lastResolved as dynamic).sources[
-                toBarbackAssetId(entryPoint)];
+            var source = (_resolvers.lastResolved as dynamic)
+                .sources[toBarbackAssetId(entryPoint)];
             expect(source.modificationStamp, 2);
 
             var lib = resolver.getLibrary(entryPoint);
@@ -308,7 +309,7 @@ class TestBuilder extends Builder {
 
   @override
   Future build(BuildStep buildStep) async {
-    var resolver = await buildStep.resolve(buildStep.input.id);
+    var resolver = await buildStep.resolve(buildStep.inputId);
     try {
       validator(resolver);
     } finally {

--- a/build_barback/test/util/stream_test.dart
+++ b/build_barback/test/util/stream_test.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:build_barback/src/util/stream.dart';
+
+main() {
+  test('combineByteStream', () async {
+    var stream = _toByteStream([
+      [1, 2, 3],
+      [4, 5],
+      [],
+      [6]
+    ]);
+    var bytes = await combineByteStream(stream);
+    expect(bytes, [1, 2, 3, 4, 5, 6]);
+  });
+}
+
+Stream<List<int>> _toByteStream(List<List<int>> chunks) async* {
+  for (var chunk in chunks) {
+    yield chunk;
+  }
+}

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -9,6 +9,8 @@ Updates to work with `build` version 0.7.0.
 ### Breaking Changes
 - The `testBuilder` method now requires a `RecordingAssetWriter` instead of
   just an `AssetWriter` for the `writer` parameter.
+- If a `Matcher` is supplied for the `outputs` parameter of `testBuilder`, it
+  will now need to match against a `DatedValue` instead of a `String`.
 - Deleted the `makeAsset` and `makeAssets` methods. There is no more `Asset`
   class so these don't really have any value any more.
 - The signature of `addAssets` has changed to

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 dependencies:
-  build: ^0.6.0
+  build: ^0.7.0
   build_barback: ^0.0.1
   logging: ^0.11.2
   test: ^0.12.0


### PR DESCRIPTION
Updated to reflect the new support for reading/writing as bytes in the `build`
package, and the removal of the `Asset` class.

### New Features
- `BuilderTransformer` now supports wrapping transformers that read or write
  their inputs as bytes.
- Added `barbackAssetFromBytes` and `backbackAssetFromString` methods to replace
  `toBarbackAsset`.

### Breaking Changes
- `toBuildAsset` and `toBarbackAsset` no longer exists since there is no `Asset`
  class any longer in the `build` package.