### PR TITLE
auto-release resolvers and clean up the api

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -9,6 +9,11 @@ last breaking change before the `1.0` release, but it is a fairly large one.
   `Future writeAsBytes(AssetId id, List<int> bytes)` method.
 - The `AssetReader` class now has a `Future<List<int>> readAsBytes(AssetId id)`
   method.
+- You no longer need to call `Resolver#release` on any resolvers you get from
+  a `BuildStep` (in fact, the `Resolver` interface no longer has this method).
+- There is now a `BuildStep#resolver` getter, which resolves the primary input,
+  and returns a `Future<Resolver>`. This replaces the `BuildStep#resolve`
+  method.
 
 ### Breaking Changes
 - The `Asset` class has been removed entirely.
@@ -20,6 +25,9 @@ last breaking change before the `1.0` release, but it is a fairly large one.
   changed from `Asset` to `AssetId`. This means you must now use
   `BuildStep#readAsString` or `BuildStep#readAsBytes` to read the primary input,
   instead of it already being read in for you.
+- `Resolver` no longer has a `release` method (they are released for you).
+- `BuildStep#resolve` no longer exists, and has been replaced with the
+  `BuildStep#resolver` getter.
 
 **Note**: The changes to `AssetReader` and `AssetWriter` also affect `BuildStep`
 and other classes that implement those interfaces.

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -9,9 +9,6 @@ import '../asset/id.dart';
 import '../builder/build_step.dart';
 
 abstract class Resolver {
-  /// Release this resolver so it can be updated by following build steps.
-  void release();
-
   /// Gets the resolved Dart library for an asset, or null if the AST has not
   /// been resolved.
   ///
@@ -29,7 +26,11 @@ abstract class Resolver {
   LibraryElement getLibraryByName(String libraryName);
 }
 
+abstract class ReleasableResolver implements Resolver {
+  /// Release this resolver so it can be updated by following build steps.
+  void release();
+}
+
 abstract class Resolvers {
-  Future<Resolver> get(
-      BuildStep buildStep, List<AssetId> entryPoints, bool resolveAllConstants);
+  Future<ReleasableResolver> get(BuildStep buildStep);
 }

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -31,7 +31,6 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8});
 
-
   /// **NOTE**: Most `Builder` implementations should not need to `await` this
   /// Future since the runner will be responsible for waiting until all outputs
   /// are written.
@@ -44,15 +43,8 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   @override
   Future writeAsString(AssetId id, String contents, {Encoding encoding: UTF8});
 
-  /// Gives a [Resolver] for [id]. This must be released when it is done being
-  /// used.
-  ///
-  /// If you pass a value of [false] for [resolveAllConstants], then constants
-  /// will only be resolved in [id], and not any other libraries. This gives a
-  /// significant speed boost, at the cost of not being able to assume all
-  /// constants are already resolved.
-  Future<Resolver> resolve(AssetId id,
-      {bool resolveAllConstants, List<AssetId> entryPoints});
+  /// Gives a [Resolver] for [inputId].
+  Future<Resolver> get resolver;
 }
 
 abstract class ManagedBuildStep implements BuildStep {

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -43,7 +43,7 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   @override
   Future writeAsString(AssetId id, String contents, {Encoding encoding: UTF8});
 
-  /// Gives a [Resolver] for [inputId].
+  /// A [Future<Resolver>] for [inputId].
   Future<Resolver> get resolver;
 }
 

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -51,13 +51,7 @@ class BuildStepImpl implements ManagedBuildStep {
   }
 
   @override
-  Future<Resolver> get resolver {
-    if (_resolver == null) {
-      _resolver = _resolvers.get(this);
-    }
-
-    return _resolver;
-  }
+  Future<Resolver> get resolver => _resolver ??= _resolvers.get(this);
 
   Future<ReleasableResolver> _resolver;
 
@@ -121,14 +115,15 @@ class BuildStepImpl implements ManagedBuildStep {
     return done;
   }
 
-  /// Should be called after `build` has completed. This will wait until for
-  /// [_outputsCompleted] and release all [Resolver]s that were created.
+  /// Waits for work to finish and cleans up resources.
+  ///
+  /// This method should be called after a build has completed. After the
+  /// returned [Future] completes then all outputs have been written and the
+  /// [Resolver] for this build step - if any - has been released.
   @override
   Future complete() async {
     await _outputsCompleted;
-    if (_resolver != null) {
-      (await _resolver).release();
-    }
+    (await _resolver)?.release();
   }
 
   /// Checks that [id] is a valid input, and throws an [InvalidInputException]

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -141,7 +141,7 @@ void main() {
           var primary = makeAssetId('a|web/a.dart');
           var buildStep = new BuildStepImpl(primary, [], reader, writer,
               primary.package, const BarbackResolvers());
-          var resolver = await buildStep.resolve(primary);
+          var resolver = await buildStep.resolver;
 
           var aLib = resolver.getLibrary(primary);
           expect(aLib.name, 'a');
@@ -153,7 +153,7 @@ void main() {
           expect(bLib.name, 'b');
           expect(bLib.importedLibraries.length, 1);
 
-          resolver.release();
+          await buildStep.complete();
         });
       });
     });
@@ -179,8 +179,10 @@ void main() {
       });
 
       test('Completes only after writes finish', () async {
+        // ignore: unawaited_futures
         buildStep.writeAsString(outputId, outputContent);
         var isComplete = false;
+        // ignore: unawaited_futures
         buildStep.complete().then((_) {
           isComplete = true;
         });
@@ -194,8 +196,10 @@ void main() {
 
       test('Completes only after async writes finish', () async {
         var outputCompleter = new Completer<String>();
+        // ignore: unawaited_futures
         buildStep.writeFromFutureAsString(outputId, outputCompleter.future);
         var isComplete = false;
+        // ignore: unawaited_futures
         buildStep.complete().then((_) {
           isComplete = true;
         });

--- a/build/test/common/file_combiner_builder.dart
+++ b/build/test/common/file_combiner_builder.dart
@@ -17,6 +17,7 @@ class FileCombinerBuilder implements Builder {
     }
 
     var outputId = _combinedAssetId(buildStep.inputId);
+    // ignore: unawaited_futures
     buildStep.writeAsString(outputId, content.toString());
   }
 

--- a/build_barback/lib/src/analyzer/resolver.dart
+++ b/build_barback/lib/src/analyzer/resolver.dart
@@ -10,7 +10,7 @@ import 'package:code_transformers/resolver.dart' as code_transformers
 
 import '../util/barback.dart';
 
-class BarbackResolver implements Resolver {
+class BarbackResolver implements ReleasableResolver {
   final code_transformers.Resolver _resolver;
 
   BarbackResolver(this._resolver);
@@ -43,8 +43,7 @@ class BarbackResolvers implements Resolvers {
 
   const BarbackResolvers();
 
-  Future<Resolver> get(BuildStep buildStep, List<AssetId> entryPoints,
-          bool resolveAllConstants) async =>
+  Future<ReleasableResolver> get(BuildStep buildStep) async =>
       new BarbackResolver(await _resolvers.get(toBarbackTransform(buildStep),
-          entryPoints.map(toBarbackAssetId).toList(), resolveAllConstants));
+          [toBarbackAssetId(buildStep.inputId)], false));
 }

--- a/build_barback/test/analyzer/resolver_test.dart
+++ b/build_barback/test/analyzer/resolver_test.dart
@@ -20,10 +20,9 @@ class ResolversSpy implements BarbackResolvers {
       new code_transformers.Resolvers(code_transformers.dartSdkDirectory);
 
   @override
-  Future<Resolver> get(BuildStep buildStep, List<AssetId> entryPoints,
-      bool resolveAllConstants) async {
+  Future<ReleasableResolver> get(BuildStep buildStep) async {
     lastResolved = await _resolvers.get(toBarbackTransform(buildStep),
-        entryPoints.map(toBarbackAssetId).toList(), resolveAllConstants);
+        [toBarbackAssetId(buildStep.inputId)], false);
     return new BarbackResolver(lastResolved);
   }
 }
@@ -309,11 +308,6 @@ class TestBuilder extends Builder {
 
   @override
   Future build(BuildStep buildStep) async {
-    var resolver = await buildStep.resolve(buildStep.inputId);
-    try {
-      validator(resolver);
-    } finally {
-      resolver.release();
-    }
+    validator(await buildStep.resolver);
   }
 }

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -74,6 +74,7 @@ class BuildImpl {
     /// Assume incremental, change if necessary.
     var buildType = BuildType.incremental;
     var done = new Completer<BuildResult>();
+    // ignore: unawaited_futures
     Chain.capture(() async {
       if (_buildRunning) throw const ConcurrentBuildException();
       _buildRunning = true;
@@ -195,6 +196,7 @@ class BuildImpl {
   /// has been updated since it started running.
   Future<bool> _buildScriptUpdated() async {
     var completer = new Completer<bool>();
+    // ignore: unawaited_futures
     Future
         .wait(currentMirrorSystem().libraries.keys.map((Uri uri) async {
       // Short-circuit

--- a/build_runner/test/common/copy_builder.dart
+++ b/build_runner/test/common/copy_builder.dart
@@ -44,6 +44,7 @@ class CopyBuilder implements Builder {
       var content = copyFromAsset == null
           ? await buildStep.readAsString(buildStep.inputId)
           : await buildStep.readAsString(copyFromAsset);
+      // ignore: unawaited_futures
       buildStep.writeAsString(id, content);
     }
 

--- a/build_runner/test/common/file_combiner_builder.dart
+++ b/build_runner/test/common/file_combiner_builder.dart
@@ -17,6 +17,7 @@ class FileCombinerBuilder implements Builder {
     }
 
     var outputId = _combinedAssetId(buildStep.inputId);
+    // ignore: unawaited_futures
     buildStep.writeAsString(outputId, '$content');
   }
 

--- a/build_test/lib/src/copy_builder.dart
+++ b/build_test/lib/src/copy_builder.dart
@@ -44,6 +44,7 @@ class CopyBuilder implements Builder {
       var content = copyFromAsset == null
           ? await buildStep.readAsString(buildStep.inputId)
           : await buildStep.readAsString(copyFromAsset);
+      // ignore: unawaited_futures
       buildStep.writeAsString(id, content);
     }
 


### PR DESCRIPTION
- You no longer need to call `Resolver#release` on any resolvers you get from
  a `BuildStep` (in fact, the `Resolver` interface no longer has this method).
- There is now a `BuildStep#resolver` getter, which resolves the primary input,
  and returns a `Future<Resolver>`. This replaces the `BuildStep#resolve`
  method.
- `Resolver` no longer has a `release` method (they are released for you).
- `BuildStep#resolve` no longer exists, and has been replaced with the
  `BuildStep#resolver` getter.

fixes https://github.com/dart-lang/build/issues/166 and https://github.com/dart-lang/build/issues/162