### PR TITLE
Add `isLibrary` method to `Resolver`

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -14,6 +14,8 @@ last breaking change before the `1.0` release, but it is a fairly large one.
 - There is now a `BuildStep#resolver` getter, which resolves the primary input,
   and returns a `Future<Resolver>`. This replaces the `BuildStep#resolve`
   method.
+- `Resolver` has a new `isLibrary` method to check whether an asset is a Dart
+  library source file before trying to resolve it's LibraryElement
 
 ### Breaking Changes
 - The `Asset` class has been removed entirely.
@@ -28,6 +30,8 @@ last breaking change before the `1.0` release, but it is a fairly large one.
 - `Resolver` no longer has a `release` method (they are released for you).
 - `BuildStep#resolve` no longer exists, and has been replaced with the
   `BuildStep#resolver` getter.
+- `Resolver.getLibrary` will now throw a `NonLibraryAssetException` instead of
+  return null if it is asked to resolve an impossible library.
 
 **Note**: The changes to `AssetReader` and `AssetWriter` also affect `BuildStep`
 and other classes that implement those interfaces.

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -9,11 +9,16 @@ import '../asset/id.dart';
 import '../builder/build_step.dart';
 
 abstract class Resolver {
-  /// Gets the resolved Dart library for an asset, or null if the AST has not
-  /// been resolved.
+  /// Whether [assetId] represents an Dart library file.
   ///
-  /// If the AST has not been resolved then this normally means that the
-  /// transformer hosting this needs to be in an earlier phase.
+  /// This will be false in the case where the file is not Dart source code, or
+  /// is a 'part of' file.
+  bool isLibrary(AssetId assetId);
+
+  /// Gets the resolved Dart library  defined in [assetId].
+  ///
+  /// If the asset is not a Dart library file throws a
+  /// [NonLibraryAssetException].
   LibraryElement getLibrary(AssetId assetId);
 
   /// Gets all libraries accessible from the entry point, recursively.
@@ -33,4 +38,13 @@ abstract class ReleasableResolver implements Resolver {
 
 abstract class Resolvers {
   Future<ReleasableResolver> get(BuildStep buildStep);
+}
+
+class NonLibraryAssetException implements Exception {
+  final AssetId assetId;
+
+  NonLibraryAssetException(this.assetId);
+
+  @override
+  String toString() => 'Asset [$assetId] is not a Dart library source file.';
 }

--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -6,6 +6,7 @@ package, and the removal of the `Asset` class.
 ### New Features
 - `BuilderTransformer` now supports wrapping transformers that read or write
   their inputs as bytes.
+- The Resolver implementation can check whether an Asset is a Library.
 
 ### Breaking Changes
 - Stopped exporting `lib/src/util/barback.dart` which contains internal only

--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -6,7 +6,9 @@ package, and the removal of the `Asset` class.
 ### New Features
 - `BuilderTransformer` now supports wrapping transformers that read or write
   their inputs as bytes.
-- The Resolver implementation can check whether an Asset is a Library.
+- The Resolver implementation now has `isLibrary` to check whether an Asset is a
+  Library and throws an exception rather than returns null on `getLibrary` when
+  it isn't
 
 ### Breaking Changes
 - Stopped exporting `lib/src/util/barback.dart` which contains internal only

--- a/build_barback/lib/src/analyzer/resolver.dart
+++ b/build_barback/lib/src/analyzer/resolver.dart
@@ -19,6 +19,10 @@ class BarbackResolver implements ReleasableResolver {
   void release() => _resolver.release();
 
   @override
+  bool isLibrary(AssetId assetId) =>
+      _resolver.isLibrary(toBarbackAssetId(assetId));
+
+  @override
   LibraryElement getLibrary(AssetId assetId) {
     var library = _resolver.getLibrary(toBarbackAssetId(assetId));
     if (library == null) throw new NonLibraryAssetException(assetId);

--- a/build_barback/lib/src/analyzer/resolver.dart
+++ b/build_barback/lib/src/analyzer/resolver.dart
@@ -15,24 +15,20 @@ class BarbackResolver implements ReleasableResolver {
 
   BarbackResolver(this._resolver);
 
-  /// Release this resolver so it can be updated by following build steps.
+  @override
   void release() => _resolver.release();
 
-  /// Gets the resolved Dart library for an asset, or null if the AST has not
-  /// been resolved.
-  ///
-  /// If the AST has not been resolved then this normally means that the
-  /// transformer hosting this needs to be in an earlier phase.
-  LibraryElement getLibrary(AssetId assetId) =>
-      _resolver.getLibrary(toBarbackAssetId(assetId));
+  @override
+  LibraryElement getLibrary(AssetId assetId) {
+    var library = _resolver.getLibrary(toBarbackAssetId(assetId));
+    if (library == null) throw new NonLibraryAssetException(assetId);
+    return library;
+  }
 
-  /// Gets all libraries accessible from the entry point, recursively.
-  ///
-  /// This includes all Dart SDK libraries as well.
+  @override
   Iterable<LibraryElement> get libraries => _resolver.libraries;
 
-  /// Finds the first library identified by [libraryName], or null if no
-  /// library can be found.
+  @override
   LibraryElement getLibraryByName(String libraryName) =>
       _resolver.getLibraryByName(libraryName);
 }

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ">=0.27.1 <0.30.0"
   build: ^0.7.0
   barback: ^0.15.0
-  code_transformers: ">=0.4.2+3 <0.6.0"
+  code_transformers: ">=0.5.1 <0.6.0"
   crypto: ">=0.9.2 <3.0.0"
   logging: ^0.11.2
   glob: ^1.1.0


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/177

- Add isLibrary to check whether a source file is a Dart library
- Throw instead of return null when the asset is not a Dart library
- Implement the new interface in build_barback
- Clean up some repeated Doc comments and add @override instead