### PR TITLE
Fix check for missing outputs

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+1
+
+- Bug Fix: Correctly identify missing outputs in testBuilder
+
 ## 0.4.0
 
 Updates to work with `build` version 0.7.0.

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -26,8 +26,9 @@ void checkOutputs(
       var assetId = makeAssetId(serializedId);
 
       // Check that the asset was produced.
-      expect(modifiableActualAssets.remove(assetId), isNotNull,
-          reason: 'Expected to find $assetId in ${actualAssets}.');
+      expect(modifiableActualAssets, contains(assetId),
+          reason: 'Builder failed to write asset $assetId');
+      modifiableActualAssets.remove(assetId);
       var actual = writer.assets[assetId];
       var expected;
       if (contentsMatcher is String) {

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.4.0
+version: 0.4.0+1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 


### PR DESCRIPTION
Fixes #182

Set.remove() returns true or false, previous check was expecting it to
return the removed value or null. Use `contains` matcher as a more
idiomatic expect with a nicer failure message.