### PR TITLE
Use runBuilders from BuilderTransformer

### DIFF
--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Support the global log from `build`
+
 ## 0.1.0
 
 Updated to reflect the new support for reading/writing as bytes in the `build`

--- a/build_barback/lib/src/transformer/transformer.dart
+++ b/build_barback/lib/src/transformer/transformer.dart
@@ -77,12 +77,8 @@ class BuilderTransformer implements Transformer, DeclaringTransformer {
       }
     });
 
-    // Run the build step.
-    var buildStep = new ManagedBuildStep(
-        inputId, expected, reader, writer, inputId.package, _resolvers,
+    await runBuilder(_builder, [inputId], reader, writer, _resolvers,
         logger: logger);
-    await _builder.build(buildStep);
-    await buildStep.complete();
     await logSubscription.cancel();
   }
 

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_barback
-version: 0.1.0
+version: 0.1.1
 description: Utilities for translating between builders and transformers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
Reuse the common wrapper around running a builder - this is slightly
less efficient but will allow us to reuse the logic around an upcoming
global log, and will allow us to make ManagedBuildStep private.