### PR TITLE
Add a top-level `log` getter

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.1
+
+- Add a top-level `log` getter which is scoped to running builds and can be used
+  anywhere within a build rather than pass around a logger. This replaces the
+  `BuildStep.logger` field.
+- Deprecate `BuildStep.logger` - it is replaced by `log`
+- Deprecate `ManagedBuildStep`, all build runs should go through `runBuilders`.
+
 ## 0.7.0
 
 A number of changes to the apis, primarily to support reading/writing as bytes,

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.7.1
 
 - Add a top-level `log` getter which is scoped to running builds and can be used
-  anywhere within a build rather than pass around a logger. This replaces the
+  anywhere within a build rather than passing around a logger. This replaces the
   `BuildStep.logger` field.
 - Deprecate `BuildStep.logger` - it is replaced by `log`
 - Deprecate `ManagedBuildStep`, all build runs should go through `runBuilders`.

--- a/build/lib/build.dart
+++ b/build/lib/build.dart
@@ -9,5 +9,6 @@ export 'src/asset/writer.dart';
 export 'src/builder/build_step.dart';
 export 'src/builder/builder.dart';
 export 'src/builder/exceptions.dart';
+export 'src/builder/logging.dart' show log;
 export 'src/builder/multiplexing_builder.dart';
 export 'src/generate/run_builder.dart';

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -19,6 +19,7 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   AssetId get inputId;
 
   /// A [Logger] for this [BuildStep].
+  @Deprecated('Use the top-level `log` instead')
   Logger get logger;
 
   /// Checks if an [Asset] by [id] exists as an input for this [BuildStep].
@@ -47,6 +48,7 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   Future<Resolver> get resolver;
 }
 
+@Deprecated('Use `runBuilder` instead of creating a BuildStep manually')
 abstract class ManagedBuildStep implements BuildStep {
   /// Mark the build step as finished and wait for any side effects to settle.
   Future complete();
@@ -57,6 +59,5 @@ abstract class ManagedBuildStep implements BuildStep {
       AssetReader reader,
       AssetWriter writer,
       String packageName,
-      Resolvers resolvers,
-      {Logger logger}) = BuildStepImpl;
+      Resolvers resolvers) = BuildStepImpl;
 }

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -13,6 +13,7 @@ import '../asset/reader.dart';
 import '../asset/writer.dart';
 import 'build_step.dart';
 import 'exceptions.dart';
+import 'logging.dart';
 
 /// A single step in the build processes. This represents a single input and
 /// its expected and real outputs. It also handles tracking of dependencies.
@@ -24,11 +25,11 @@ class BuildStepImpl implements ManagedBuildStep {
   final AssetId inputId;
 
   @override
-  final Logger logger;
+  Logger get logger => log;
 
   /// The list of all outputs which are expected/allowed to be output from this
   /// step.
-  final List<AssetId> _expectedOutputs = [];
+  final List<AssetId> _expectedOutputs;
 
   /// A future that completes once all outputs current are done writing.
   Future _outputsCompleted = new Future(() {});
@@ -42,13 +43,9 @@ class BuildStepImpl implements ManagedBuildStep {
   /// The current root package, used for input/output validation.
   final String _rootPackage;
 
-  BuildStepImpl(AssetId inputId, Iterable<AssetId> expectedOutputs,
-      this._reader, this._writer, this._rootPackage, this._resolvers,
-      {Logger logger})
-      : this.inputId = inputId,
-        this.logger = logger ?? new Logger('$inputId') {
-    _expectedOutputs.addAll(expectedOutputs);
-  }
+  BuildStepImpl(this.inputId, Iterable<AssetId> expectedOutputs, this._reader,
+      this._writer, this._rootPackage, this._resolvers)
+      : _expectedOutputs = expectedOutputs.toList();
 
   @override
   Future<Resolver> get resolver => _resolver ??= _resolvers.get(this);

--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -1,0 +1,12 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
+const Symbol logKey = #buildLog;
+
+/// The log instance for the currently running BuildStep.
+///
+/// Will be `null` when not running within a build.
+Logger get log => Zone.current[logKey];
+
+T scopeLog<T>(T fn(), Logger log) => runZoned(fn, zoneValues: {logKey: log});

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -9,8 +9,9 @@ import '../analyzer/resolver.dart';
 import '../asset/id.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
+import '../builder/build_step_impl.dart';
 import '../builder/builder.dart';
-import '../builder/build_step.dart';
+import '../builder/logging.dart';
 
 /// Run [builder] on each asset in [inputs].
 ///
@@ -26,9 +27,8 @@ Future<Null> runBuilder(Builder builder, Iterable<AssetId> inputs,
   //TODO(nbosch) check overlapping outputs?
   Future<Null> buildForInput(AssetId input) async {
     var expectedOutputs = builder.declareOutputs(input);
-    var buildStep = new ManagedBuildStep(
-        input, expectedOutputs, reader, writer, rootPackage, resolvers,
-        logger: logger);
+    var buildStep = new BuildStepImpl(
+        input, expectedOutputs, reader, writer, rootPackage, resolvers);
     try {
       await builder.build(buildStep);
     } finally {
@@ -36,5 +36,5 @@ Future<Null> runBuilder(Builder builder, Iterable<AssetId> inputs,
     }
   }
 
-  await Future.wait(inputs.map(buildForInput));
+  await scopeLog(() => Future.wait(inputs.map(buildForInput)), logger);
 }

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.7.0
+version: 0.7.1
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -29,31 +29,13 @@ void main() {
         writer = new StubAssetWriter();
         primary = makeAssetId();
         buildStep = new BuildStepImpl(primary, [], reader, writer,
-            primary.package, const BarbackResolvers(),
-            logger: new Logger('$primary'));
+            primary.package, const BarbackResolvers());
       });
 
       test('doesnt allow non-expected outputs', () {
         var id = makeAssetId();
         expect(() => buildStep.writeAsString(id, '$id'),
             throwsA(new isInstanceOf<UnexpectedOutputException>()));
-      });
-
-      test('has a useable logger', () async {
-        Logger.root.level = Level.ALL;
-        var logger = buildStep.logger;
-        expect(logger.fullName, '$primary');
-        var logs = <LogRecord>[];
-        var listener = logger.onRecord.listen(logs.add);
-        logger.fine('hello');
-        logger.warning('world');
-        logger.severe('goodbye');
-        await listener.cancel();
-        expect(logs.map((l) => l.toString()), [
-          '[FINE] $primary: hello',
-          '[WARNING] $primary: world',
-          '[SEVERE] $primary: goodbye',
-        ]);
       });
 
       test('hasInput throws invalidInputExceptions', () async {


### PR DESCRIPTION
Discussed in #191

- Run builds inside a zone to hold the logger
- Add a `log` getter which pulls from the zone-scoped logger
- Deprecate ManagedBuildStep - prefer for all use cases to go through
  runBuilder so they can get the log
- Point `BuildStep.logger` at the new top-level getter and mark it
  deprecated