### PR TITLE
Use comment syntax for generic method

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.1+1
+
+- Use comment syntax for generic method - not everyone is on an SDK version that
+  supports the real syntax.
+
 ## 0.7.1
 
 - Add a top-level `log` getter which is scoped to running builds and can be used

--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -9,4 +9,5 @@ const Symbol logKey = #buildLog;
 /// Will be `null` when not running within a build.
 Logger get log => Zone.current[logKey];
 
-T scopeLog<T>(T fn(), Logger log) => runZoned(fn, zoneValues: {logKey: log});
+dynamic/*=T*/ scopeLog/*<T>*/(dynamic/*=T*/ fn(), Logger log) =>
+    runZoned(fn, zoneValues: {logKey: log});

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.7.1
+version: 0.7.1+1
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
Anyone on an old SDK who upgrades to 0.7.1 will be broken - bump to
0.7.1+1 so a `pub upgrade` will get to this version and change to the
backwards compatible comment syntax.