### PR TITLE
Capture 'print' calls and log.info instead

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.2
+
+- Add an `AssetId.resolve` constructor to easily construct AssetIds from import
+  uris.
+- Capture 'print' calls inside running builds and automatically turn them in to
+  `log.info`. Depending on the environment a print can be hazardous so this
+  makes all builders safe and consistent by default.
+
 ## 0.7.1+1
 
 - Use comment syntax for generic method - not everyone is on an SDK version that

--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -10,4 +10,7 @@ const Symbol logKey = #buildLog;
 Logger get log => Zone.current[logKey];
 
 dynamic/*=T*/ scopeLog/*<T>*/(dynamic/*=T*/ fn(), Logger log) =>
-    runZoned(fn, zoneValues: {logKey: log});
+    runZoned(fn, zoneSpecification:
+        new ZoneSpecification(print: (self, parent, zone, message) {
+      log.info(message);
+    }), zoneValues: {logKey: log});

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.7.1+1
+version: 0.7.2
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
We have been doing this in worker mode in _bazel_codegen. Now we will do
it consistently in all build modes so a Builder is more predictable.