### PR TITLE
Expose scopeLog from build_test

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+- Make `scopeLog` visible so tests can be run with an available `log` without
+  going through runBuilder.
+
 ## 0.4.0+1
 
 - Bug Fix: Correctly identify missing outputs in testBuilder

--- a/build_test/lib/build_test.dart
+++ b/build_test/lib/build_test.dart
@@ -10,3 +10,5 @@ export 'src/matchers.dart';
 export 'src/stub_reader.dart';
 export 'src/stub_writer.dart';
 export 'src/test_builder.dart';
+
+export 'package:build/src/builder/logging.dart' show scopeLog;

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.4.0+1
+version: 0.4.1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 dependencies:
-  build: ^0.7.0
+  build: ^0.7.1
   build_barback: ^0.1.0
   logging: ^0.11.2
   test: ^0.12.0


### PR DESCRIPTION
Fixes #220

Since these packages are very tightly coupled we allow an import from
`/src` rather than make `scopeLog` visible to all clients of `build`.