### PR TITLE
Add lib/ when resolving package:

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add `BuildStep.inputLibrary` as a convenience.
+- Fix a bug in `AssetId.resolve` to prepend `lib/` when resolving packages.
 
 ## 0.7.2
 

--- a/build/lib/src/asset/id.dart
+++ b/build/lib/src/asset/id.dart
@@ -32,7 +32,8 @@ class AssetId implements Comparable<AssetId> {
   /// Creates a new [AssetId] from an [uri].
   ///
   /// This gracefully handles `package:` URIs, which is useful when creating an
-  /// [AssetId] from an `import` or `export` directive pointing to a package:
+  /// [AssetId] from an `import` or `export` directive pointing to a package's
+  /// _lib_ directory:
   /// ```dart
   /// AssetId assetOfDirective(UriReferencedElement element) {
   ///   return new AssetId.resolve(element.uri);
@@ -50,11 +51,10 @@ class AssetId implements Comparable<AssetId> {
     if (parsedUri.hasScheme) {
       if (parsedUri.scheme == 'package') {
         return new AssetId(parsedUri.pathSegments.first,
-            pathos.joinAll(parsedUri.pathSegments.skip(1)));
+            pathos.join('lib', pathos.joinAll(parsedUri.pathSegments.skip(1))));
       }
       throw new UnsupportedError(
-        'Cannot resolve $uri; only "package" supported'
-      );
+          'Cannot resolve $uri; only "package" supported');
     }
     if (from == null) {
       throw new ArgumentError.value(uri, 'uri',

--- a/build/test/asset/id_test.dart
+++ b/build/test/asset/id_test.dart
@@ -53,12 +53,12 @@ void main() {
   group("resolve", () {
     test("should parse a package: URI", () {
       var id = new AssetId.resolve(r"package:app/app.dart");
-      expect(id, new AssetId("app", "app.dart"));
+      expect(id, new AssetId("app", "lib/app.dart"));
     });
 
     test("should parse a package: URI with a long path", () {
       var id = new AssetId.resolve(r"package:app/src/some/path.dart");
-      expect(id, new AssetId("app", "src/some/path.dart"));
+      expect(id, new AssetId("app", "lib/src/some/path.dart"));
     });
 
     test("should throw for a file: URI", () {
@@ -76,10 +76,16 @@ void main() {
           throwsArgumentError);
     });
 
+    test("should parse a relative URI within the test/ folder", () {
+      var id = new AssetId.resolve("common.dart",
+          from: new AssetId("app", "test/some_test.dart"));
+      expect(id, new AssetId("app", "test/common.dart"));
+    });
+
     test("should parse a relative package URI", () {
       var id = new AssetId.resolve("some/relative/path.dart",
-          from: new AssetId("app", "app.dart"));
-      expect(id, new AssetId("app", "some/relative/path.dart"));
+          from: new AssetId("app", "lib/app.dart"));
+      expect(id, new AssetId("app", "lib/some/relative/path.dart"));
     });
 
     test("should parse a relative package URI pointing back", () {


### PR DESCRIPTION
See occurrences of this bug in `angular2`: https://github.com/dart-lang/angular2/blob/2506ea4977ec4c4e6fefd142dac0f69b409ca8a0/lib/src/source_gen/template_compiler/template_processor.dart#L45 (as an example).

When `package:app/app.dart` is resolved, it should point to `app|lib/app.dart`.