### PR TITLE
Preemptively implement findAssets API

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1-dev
+
+- Internal refactoring of RunnerAssetReader.
+
 ## 0.3.0
 
 ### Bug Fixes

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -2,12 +2,10 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:build/build.dart';
-
-import '../generate/input_set.dart';
+import 'package:glob/glob.dart';
 
 abstract class RunnerAssetReader extends AssetReader {
-  /// Gets a [Stream<AssetId>] of all assets available matching [inputSets].
-  Stream<AssetId> listAssetIds(Iterable<InputSet> inputSets);
+  Iterable<AssetId> findAssets(Glob glob, {String packageName});
 
   /// Asynchronously gets the last modified [DateTime] of [id].
   Future<DateTime> lastModified(AssetId id);

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -466,7 +466,7 @@ class BuildImpl {
 
     var inputSets = packages.map((package) => new InputSet(
         package, [package == _packageGraph.root.name ? '**' : 'lib/**']));
-    var allInputs = await _reader.listAssetIds(inputSets).toList();
+    var allInputs = listAssetIds(_reader, inputSets);
     _inputsByPackage.clear();
 
     // Initialize the set of inputs for each package.
@@ -575,6 +575,20 @@ class BuildImpl {
         (_assetGraph.get(output) as GeneratedAssetNode).wasOutput = true;
         groupOutputs.add(output);
         yield output;
+      }
+    }
+  }
+}
+
+Iterable<AssetId> listAssetIds(
+    RunnerAssetReader assetReader, Iterable<InputSet> inputSets) sync* {
+  var seenAssets = new Set<AssetId>();
+  for (var inputSet in inputSets) {
+    for (var glob in inputSet.globs) {
+      for (var id
+          in assetReader.findAssets(glob, packageName: inputSet.package)) {
+        if (!seenAssets.add(id)) continue;
+        yield id;
       }
     }
   }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.3.0+1
+version: 0.3.1-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/test/asset/file_based_test.dart
+++ b/build_runner/test/asset/file_based_test.dart
@@ -4,6 +4,7 @@
 @TestOn('vm')
 import 'dart:io';
 
+import 'package:glob/glob.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
@@ -60,30 +61,14 @@ void main() {
           throwsA(packageNotFoundException));
     });
 
-    test('can list files based on simple InputSets', () async {
-      var inputSets = <InputSet>[
-        new InputSet('basic_pkg', ['{lib,web}/**']),
-        new InputSet('a', ['lib/**']),
-      ];
+    test('can list files based on glob', () async {
       expect(
-          await reader.listAssetIds(inputSets).toList(),
+          reader
+              .findAssets(new Glob('{lib,web}/**'), packageName: 'basic_pkg')
+              .toList(),
           unorderedEquals([
             makeAssetId('basic_pkg|lib/hello.txt'),
             makeAssetId('basic_pkg|web/hello.txt'),
-            makeAssetId('a|lib/a.txt'),
-          ]));
-    });
-
-    test('can list files based on InputSets with globs', () async {
-      var inputSets = <InputSet>[
-        new InputSet('basic_pkg', ['web/*.txt']),
-        new InputSet('a', ['lib/*']),
-      ];
-      expect(
-          await reader.listAssetIds(inputSets).toList(),
-          unorderedEquals([
-            makeAssetId('basic_pkg|web/hello.txt'),
-            makeAssetId('a|lib/a.txt'),
           ]));
     });
 

--- a/build_runner/test/common/in_memory_reader.dart
+++ b/build_runner/test/common/in_memory_reader.dart
@@ -7,6 +7,7 @@ import 'dart:mirrors';
 import 'package:build/build.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:build_test/build_test.dart';
+import 'package:glob/glob.dart';
 
 class InMemoryRunnerAssetReader extends InMemoryAssetReader
     implements RunnerAssetReader {
@@ -14,15 +15,8 @@ class InMemoryRunnerAssetReader extends InMemoryAssetReader
       : super(sourceAssets);
 
   @override
-  Stream<AssetId> listAssetIds(Iterable<InputSet> inputSets) async* {
-    for (var id in assets.keys) {
-      var matches = inputSets.any((inputSet) {
-        if (inputSet.package != id.package) return false;
-        return inputSet.globs.any((glob) => glob.matches(id.path));
-      });
-      if (matches) yield id;
-    }
-  }
+  Iterable<AssetId> findAssets(Glob glob, {String packageName}) => assets.keys
+      .where((id) => id.package == packageName && glob.matches(id.path));
 
   final Map<Uri, LibraryMirror> _allLibraries = currentMirrorSystem().libraries;
 


### PR DESCRIPTION
We will be implementing a findAssets API in AssetReader soon. Since
build_barback can't implement the api including a `packageName`
argument, but build_runner needs this we'll still have a
`RunnerAssetReader` interface for now.

First step for #223 

- Refactor listAssetIds to iterate over input sets and globs in
  build_impl.dart rather than the asset reader to facility reuse of the
  more general findAssets API.
- Update InMemoryAssetReader to the new API
- Update tests against listAssetIds to instead test findAssetIds