### PR TITLE
Add findAssets API

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,7 +1,8 @@
-## Unreleased
+## 0.8.0-dev
 
 - Add `BuildStep.inputLibrary` as a convenience.
 - Fix a bug in `AssetId.resolve` to prepend `lib/` when resolving packages.
+- Add `AssetReader.findAssets` to allow listing assets by glob.
 
 ## 0.7.2
 

--- a/build/lib/src/asset/reader.dart
+++ b/build/lib/src/asset/reader.dart
@@ -4,16 +4,20 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:glob/glob.dart';
+
 import 'id.dart';
 
 /// Abstract interface for reading assets.
 abstract class AssetReader {
-  /// Asynchronously reads [id], and returns it as a [List<int>].
   Future<List<int>> readAsBytes(AssetId id);
 
-  /// Asynchronously reads [id], and returns it as a [String].
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8});
 
-  /// Asynchronously checks if [id] exists.
+  /// Whether an asset at [id] is readable.
   Future<bool> hasInput(AssetId id);
+
+  /// Finds all of the assets which match [glob] and are readable under the root
+  /// package.
+  Iterable<AssetId> findAssets(Glob glob);
 }

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 
 import '../analyzer/resolver.dart';
@@ -74,6 +75,9 @@ class BuildStepImpl implements ManagedBuildStep {
     _checkInput(id);
     return _reader.readAsString(id, encoding: encoding);
   }
+
+  @override
+  Iterable<AssetId> findAssets(Glob glob) => _reader.findAssets(glob);
 
   @override
   Future writeAsBytes(AssetId id, List<int> bytes) {

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -18,3 +18,9 @@ dev_dependencies:
   build_test: ^0.4.0
   test: ^0.12.0
   transformer_test: ^0.2.0
+
+dependency_overrides:
+  build_barback:
+    path: ../build_barback
+  build_test:
+    path: ../build_test

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.7.2
+version: 0.8.0-dev
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -11,6 +11,7 @@ dependencies:
   analyzer: ">=0.27.1 <0.30.0"
   logging: ^0.11.2
   path: ^1.1.0
+  glob: ^1.1.3
 
 dev_dependencies:
   build_barback: ^0.1.0

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -11,11 +11,10 @@ dependencies:
   analyzer: ">=0.27.1 <0.30.0"
   logging: ^0.11.2
   path: ^1.1.0
-  glob: ^1.1.3
+  glob: ^1.1.0
 
 dev_dependencies:
   build_barback: ^0.1.0
   build_test: ^0.4.0
-  glob: ^1.1.0
   test: ^0.12.0
   transformer_test: ^0.2.0


### PR DESCRIPTION
Towards #223

Adds the api `AssetReader.findAssets`. This is a breaking change for
`build_runner`, `_bazel_codegen`, and `build_barback` so bump the
version to 0.8.0

Also remove some Doc comments which were only restatements of the method
signatures.