### PR TITLE
Add leading slash on gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .packages
 packages
-*/build/
+/*/build/
 .pub/
 pubspec.lock
 


### PR DESCRIPTION
Fixes annoyances with a tool that has a buggy .gitignore parse
implementation.

Git proper will treat these identically - ignore any directory named
`build` exactly 1 level down from the root.