### PR TITLE
Add findAssets to test reader implementations

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 
 dev_dependencies:
   build_barback: ^0.1.0
-  build_test: ^0.4.0
+  build_test: ^0.5.0
   test: ^0.12.0
   transformer_test: ^0.2.0
 

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -80,7 +80,7 @@ void main() {
 
       setUp(() {
         writer = new InMemoryAssetWriter();
-        reader = new InMemoryAssetReader(writer.assets);
+        reader = new InMemoryAssetReader(sourceAssets: writer.assets);
       });
 
       test('tracks dependencies and outputs when used by a builder', () async {

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0
+
+- Add `findAssets` implementations to StubAssetReader an InMemoryAssetReader
+- **BREAKING**: InMemoryAssetReader constructor uses named optional parameters
+
 ## 0.4.1
 
 - Make `scopeLog` visible so tests can be run with an available `log` without

--- a/build_test/lib/src/stub_reader.dart
+++ b/build_test/lib/src/stub_reader.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:build/build.dart';
+import 'package:glob/glob.dart';
 
 class StubAssetReader implements AssetReader {
   @override
@@ -15,4 +16,7 @@ class StubAssetReader implements AssetReader {
 
   @override
   Future<String> readAsString(_, {Encoding encoding}) => new Future.value(null);
+
+  @override
+  Iterable<AssetId> findAssets(Glob glob) => const [];
 }

--- a/build_test/lib/src/stub_reader.dart
+++ b/build_test/lib/src/stub_reader.dart
@@ -18,5 +18,5 @@ class StubAssetReader implements AssetReader {
   Future<String> readAsString(_, {Encoding encoding}) => new Future.value(null);
 
   @override
-  Iterable<AssetId> findAssets(Glob glob) => const [];
+  Iterable<AssetId> findAssets(Glob glob) => null;
 }

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -90,7 +90,7 @@ Future testBuilder(
     Map<String, /*String|List<int>|Matcher<String|List<int>>*/ dynamic> outputs,
     void onLog(LogRecord log)}) async {
   writer ??= new InMemoryAssetWriter();
-  final reader = new InMemoryAssetReader();
+  final reader = new InMemoryAssetReader(rootPackage:  rootPackage);
 
   var inputIds = <AssetId>[];
   sourceAssets.forEach((serializedId, contents) {

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.4.1
+version: 0.5.0
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 dependencies:
-  build: ^0.7.1
+  build: ^0.8.0
   build_barback: ^0.1.0
   logging: ^0.11.2
   test: ^0.12.0
@@ -13,3 +13,7 @@ dependencies:
 
 environment:
   sdk: ">=1.8.0 <2.0.0"
+
+dependency_overrides:
+  build:
+    path: ../build


### PR DESCRIPTION
Change the signature of InMemoryAssetReader to take an optional root
package and use named parameters instead of positional optional
parameters.