### PR TITLE
Fix Analyzer warning in latest dev SDK

### DIFF
--- a/build_barback/lib/src/util/stream.dart
+++ b/build_barback/lib/src/util/stream.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 
 Future<List<int>> combineByteStream(Stream<List<int>> stream) async {
   var chunks = await stream.toList();
-  return chunks.fold(<int>[], (List<int> p, e) {
+  return chunks.fold<List<int>>(<int>[], (p, e) {
     p.addAll(e);
     return p;
   });


### PR DESCRIPTION
This should fix the failure on Travis.

See https://github.com/dart-lang/sdk/issues/29164

Since the latest analyzer in strong mode uses downward inference from
the return type it expects the type parameter T on the `fold` call to be
`FutureOr<List<int>>` and so the callback we are passign does not fit
the signature it expects. Work around this by specifying the type
parameter ourselves rather than havt it get inferred.