### PR TITLE
Add PackageResolver support.

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Add `PackageAssetReader`, a standalone asset reader that uses a
+  `PackageResolver` to map an `AssetId` to a location on disk.
+
 ## 0.5.0
 
 - Add `findAssets` implementations to StubAssetReader an InMemoryAssetReader

--- a/build_test/lib/build_test.dart
+++ b/build_test/lib/build_test.dart
@@ -7,6 +7,7 @@ export 'src/fake_watcher.dart';
 export 'src/in_memory_reader.dart';
 export 'src/in_memory_writer.dart';
 export 'src/matchers.dart';
+export 'src/package_reader.dart';
 export 'src/stub_reader.dart';
 export 'src/stub_writer.dart';
 export 'src/test_builder.dart';

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -32,13 +32,7 @@ class PackageAssetReader implements AssetReader {
   }
 
   File _resolve(AssetId id) {
-    String path = id.path;
-    // The PackageResolver API can only resolve files in lib/.
-    if (path.startsWith('lib/')) {
-      path = path.substring('lib/'.length);
-      return new File.fromUri(_packageResolver.urlFor(id.package, path));
-    }
-    var nonLibPath = '${_packageResolver.packagePath(id.package)}/$path';
+    var nonLibPath = '${_packageResolver.packagePath(id.package)}/${id.path}';
     return new File(nonLibPath);
   }
 

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -9,7 +9,7 @@ import 'dart:io';
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 import 'package:package_resolver/package_resolver.dart';
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 /// Resolves using a [SyncPackageResolver] before reading from the file system.
 class PackageAssetReader implements AssetReader {
@@ -33,7 +33,7 @@ class PackageAssetReader implements AssetReader {
   }
 
   File _resolve(AssetId id) =>
-      new File(path.join(_packageResolver.packagePath(id.package), id.path));
+      new File(p.join(_packageResolver.packagePath(id.package), id.path));
 
   @override
   Iterable<AssetId> findAssets(Glob glob) {
@@ -48,7 +48,7 @@ class PackageAssetReader implements AssetReader {
   }
 
   AssetId _toAsset(String assetPath, String rootPackagePath) {
-    var relative = path.relative(assetPath, from: rootPackagePath);
+    var relative = p.relative(assetPath, from: rootPackagePath);
     return new AssetId(_rootPackage, relative);
   }
 

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 import 'package:package_resolver/package_resolver.dart';
+import 'package:path/path.dart' as path;
 
 /// Resolves using a [SyncPackageResolver] before reading from the file system.
 class PackageAssetReader implements AssetReader {
@@ -31,10 +32,8 @@ class PackageAssetReader implements AssetReader {
     return new PackageAssetReader(await resolver.asSync, rootPackage);
   }
 
-  File _resolve(AssetId id) {
-    var nonLibPath = '${_packageResolver.packagePath(id.package)}/${id.path}';
-    return new File(nonLibPath);
-  }
+  File _resolve(AssetId id) =>
+      new File(path.join(_packageResolver.packagePath(id.package), id.path));
 
   @override
   Iterable<AssetId> findAssets(Glob glob) {
@@ -45,11 +44,11 @@ class PackageAssetReader implements AssetReader {
     return glob
         .listSync(root: rootPackagePath)
         .where((entity) => entity is File)
-        .map((file) => _toAsset(file.path, rootPackagePath, glob));
+        .map((file) => _toAsset(file.path, rootPackagePath));
   }
 
-  AssetId _toAsset(String path, String rootPackagePath, Glob glob) {
-    var relative = glob.context.relative(path, from: rootPackagePath);
+  AssetId _toAsset(String assetPath, String rootPackagePath) {
+    var relative = path.relative(assetPath, from: rootPackagePath);
     return new AssetId(_rootPackage, relative);
   }
 
@@ -60,7 +59,6 @@ class PackageAssetReader implements AssetReader {
   Future<List<int>> readAsBytes(AssetId id) => _resolve(id).readAsBytes();
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) async {
-    return _resolve(id).readAsString(encoding: encoding);
-  }
+  Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) =>
+      _resolve(id).readAsString(encoding: encoding);
 }

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:glob/glob.dart';
+import 'package:package_resolver/package_resolver.dart';
+
+/// Resolves using a [SyncPackageResolver] before reading from the file system.
+class PackageAssetReader implements AssetReader {
+  final SyncPackageResolver _packageResolver;
+
+  /// What package is the originating build occurring in.
+  final String _rootPackage;
+
+  /// Wrap a [SyncPackageResolver] to identify where files are located.
+  ///
+  /// To use a normal [PackageResolver] use `asSync`:
+  /// ```
+  /// new PackageAssetReader(await packageResolver.asSync);
+  /// ```
+  const PackageAssetReader(this._packageResolver, [this._rootPackage]);
+
+  /// A reader that can resolve files known to the current isolate.
+  static Future<PackageAssetReader> currentIsolate({String rootPackage}) async {
+    var resolver = PackageResolver.current;
+    return new PackageAssetReader(await resolver.asSync, rootPackage);
+  }
+
+  File _resolve(AssetId id) {
+    // Gets around inconsistencies with asset URIs.
+    //
+    // Sometimes build_test|build_test.dart = package:build_test/build_test.dart
+    // and sometimes you need |lib/build_test.dart. The package resolver is the
+    // former, so a prefix of 'lib/' results in 'lib/lib/'.
+    //
+    // TODO: https://github.com/dart-lang/build/issues/238.
+    if (id.path.startsWith('lib/')) {
+      id = new AssetId(id.package, id.path.substring('lib/'.length));
+    }
+    return new File.fromUri(_packageResolver.urlFor(id.package, id.path));
+  }
+
+  @override
+  Iterable<AssetId> findAssets(Glob glob) {
+    if (_rootPackage == null) {
+      throw new UnsupportedError('Root package must be provided to use.');
+    }
+    var rootPackagePath = _packageResolver.packagePath(_rootPackage);
+    return glob
+        .listSync(root: rootPackagePath)
+        .where((entity) => entity is File)
+        .map((file) => _toAsset(file.path, rootPackagePath, glob));
+  }
+
+  AssetId _toAsset(String path, String rootPackagePath, Glob glob) {
+    var relative = glob.context.relative(path, from: rootPackagePath);
+    return new AssetId(_rootPackage, relative);
+  }
+
+  @override
+  Future<bool> hasInput(AssetId id) async => _resolve(id).exists();
+
+  @override
+  Future<List<int>> readAsBytes(AssetId id) => _resolve(id).readAsBytes();
+
+  @override
+  Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) async {
+    return _resolve(id).readAsString(encoding: encoding);
+  }
+}

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -32,17 +32,14 @@ class PackageAssetReader implements AssetReader {
   }
 
   File _resolve(AssetId id) {
-    // Gets around inconsistencies with asset URIs.
-    //
-    // Sometimes build_test|build_test.dart = package:build_test/build_test.dart
-    // and sometimes you need |lib/build_test.dart. The package resolver is the
-    // former, so a prefix of 'lib/' results in 'lib/lib/'.
-    //
-    // TODO: https://github.com/dart-lang/build/issues/238.
-    if (id.path.startsWith('lib/')) {
-      id = new AssetId(id.package, id.path.substring('lib/'.length));
+    String path = id.path;
+    // The PackageResolver API can only resolve files in lib/.
+    if (path.startsWith('lib/')) {
+      path = path.substring('lib/'.length);
+      return new File.fromUri(_packageResolver.urlFor(id.package, path));
     }
-    return new File.fromUri(_packageResolver.urlFor(id.package, id.path));
+    var nonLibPath = '${_packageResolver.packagePath(id.package)}/$path';
+    return new File(nonLibPath);
   }
 
   @override

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -32,8 +32,8 @@ class PackageAssetReader implements AssetReader {
     return new PackageAssetReader(await resolver.asSync, rootPackage);
   }
 
-  File _resolve(AssetId id) =>
-      new File(p.join(_packageResolver.packagePath(id.package), id.path));
+  File _resolve(AssetId id) => new File(p
+      .canonicalize(p.join(_packageResolver.packagePath(id.package), id.path)));
 
   @override
   Iterable<AssetId> findAssets(Glob glob) {

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -7,7 +7,9 @@ homepage: https://github.com/dart-lang/build
 dependencies:
   build: ^0.8.0
   build_barback: ^0.1.0
+  func: ^0.1.0
   logging: ^0.11.2
+  package_resolver: ^1.0.2
   test: ^0.12.0
   watcher: ^0.9.7
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.5.0
+version: 0.5.1-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   build_barback: ^0.1.0
   logging: ^0.11.2
   package_resolver: ^1.0.2
+  path: ^1.4.1
   test: ^0.12.0
   watcher: ^0.9.7
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -7,7 +7,6 @@ homepage: https://github.com/dart-lang/build
 dependencies:
   build: ^0.8.0
   build_barback: ^0.1.0
-  func: ^0.1.0
   logging: ^0.11.2
   package_resolver: ^1.0.2
   test: ^0.12.0

--- a/build_test/test/package_reader_test.dart
+++ b/build_test/test/package_reader_test.dart
@@ -13,6 +13,7 @@ void main() {
 
     final buildTest = new AssetId('build_test', 'lib/build_test.dart');
     final buildMissing = new AssetId('build_test', 'lib/build_missing.dart');
+    final thisFile = new AssetId('build_test', 'test/package_reader_test.dart');
 
     setUp(() async {
       reader = await PackageAssetReader.currentIsolate(
@@ -25,14 +26,20 @@ void main() {
       expect(await reader.readAsString(buildTest), isNotEmpty);
     });
 
+    test('should be able to read this file (in test/)', () async {
+      expect(await reader.hasInput(thisFile), isTrue);
+    });
+
     test('should not be able to read a missing file', () async {
       expect(await reader.hasInput(buildMissing), isFalse);
     });
 
-    test('should be able to use `findAssets`', () {
-      expect(reader.findAssets(new Glob('lib/*.dart')), [
-        buildTest,
-      ]);
+    test('should be able to use `findAssets` for files in lib', () {
+      expect(reader.findAssets(new Glob('lib/*.dart')), contains(buildTest));
+    });
+
+    test('should be able to use `findAssets` for files in test', () {
+      expect(reader.findAssets(new Glob('test/*.dart')), contains(thisFile));
     });
   });
 }

--- a/build_test/test/package_reader_test.dart
+++ b/build_test/test/package_reader_test.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:glob/glob.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('$PackageAssetReader', () {
+    AssetReader reader;
+
+    final buildTest = new AssetId('build_test', 'lib/build_test.dart');
+    final buildMissing = new AssetId('build_test', 'lib/build_missing.dart');
+
+    setUp(() async {
+      reader = await PackageAssetReader.currentIsolate(
+        rootPackage: 'build_test',
+      );
+    });
+
+    test('should be able to read `build_test.dart`', () async {
+      expect(await reader.hasInput(buildTest), isTrue);
+      expect(await reader.readAsString(buildTest), isNotEmpty);
+    });
+
+    test('should not be able to read a missing file', () async {
+      expect(await reader.hasInput(buildMissing), isFalse);
+    });
+
+    test('should be able to use `findAssets`', () {
+      expect(reader.findAssets(new Glob('lib/*.dart')), [
+        buildTest,
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
Partial work towards https://github.com/dart-lang/build/issues/168.

It looks like in my testing that `PackageResolver.current` receives the appropriate package configuration (in the Dart VM) for both pub and bazel executables. If this holds I should be able to use it to handle reading files in upcoming PRs.

(Happy to make this package-private if you are worried about use)