### PR TITLE
Add MultiAssetReader (to pkg/build_test)

### DIFF
--- a/build_test/lib/src/multi_asset_reader.dart
+++ b/build_test/lib/src/multi_asset_reader.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:build/build.dart';
+import 'package:glob/glob.dart';
+
+/// An [AssetReader] that delegates to multiple other asset readers.
+///
+/// [MultiAssetReader] attempts to check every provided [AssetReader] to see if
+/// they are capable of reading an [AssetId], otherwise checks the next reader.
+///
+/// **INTERNAL ONLY**: Only used as part of `build_test` for now for allowing a
+/// combination of "fake" assets (in-memory provided by a test) and "real"
+/// assets (i.e. dependencies we want resolved).
+class MultiAssetReader implements AssetReader {
+  final List<AssetReader> _readers;
+
+  const MultiAssetReader(this._readers);
+
+  @override
+  Future<bool> hasInput(AssetId id) async {
+    for (var reader in _readers) {
+      if (await reader.hasInput(id)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @override
+  Future<List<int>> readAsBytes(AssetId id) async =>
+      (await _readerWith(id)).readAsBytes(id);
+
+  @override
+  Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) async =>
+      (await _readerWith(id)).readAsString(id, encoding: encoding);
+
+  /// Returns all readable assets matching [glob] under the root package.
+  ///
+  /// **NOTE**: This is a combined view of all provided readers.
+  @override
+  Iterable<AssetId> findAssets(Glob glob) => new CombinedIterableView(
+      _readers.map((reader) => reader.findAssets(glob)));
+
+  /// Returns the first [AssetReader] that contains [id].
+  ///
+  /// Otherwise throws [AssetNotFoundException].
+  Future<AssetReader> _readerWith(AssetId id) async {
+    for (var reader in _readers) {
+      if (await reader.hasInput(id)) {
+        return reader;
+      }
+    }
+    throw new AssetNotFoundException(id);
+  }
+}

--- a/build_test/lib/src/multi_asset_reader.dart
+++ b/build_test/lib/src/multi_asset_reader.dart
@@ -42,7 +42,9 @@ class MultiAssetReader implements AssetReader {
 
   /// Returns all readable assets matching [glob] under the root package.
   ///
-  /// **NOTE**: This is a combined view of all provided readers.
+  /// **NOTE**: This is a combined view of all provided readers. As such it is
+  /// possible that an [AssetId] will be iterated over more than once, unlike
+  /// other implementations of [AssetReader].
   @override
   Iterable<AssetId> findAssets(Glob glob) => new CombinedIterableView(
       _readers.map((reader) => reader.findAssets(glob)));

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/dart-lang/build
 dependencies:
   build: ^0.8.0
   build_barback: ^0.1.0
-  collection: ^1.4.1
+  collection: ^1.14.0
   logging: ^0.11.2
   package_resolver: ^1.0.2
   path: ^1.4.1

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -7,6 +7,7 @@ homepage: https://github.com/dart-lang/build
 dependencies:
   build: ^0.8.0
   build_barback: ^0.1.0
+  collection: ^1.4.1
   logging: ^0.11.2
   package_resolver: ^1.0.2
   path: ^1.4.1

--- a/build_test/test/multi_asset_reader_test.dart
+++ b/build_test/test/multi_asset_reader_test.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:build_test/src/multi_asset_reader.dart';
+import 'package:glob/glob.dart';
+import 'package:test/test.dart';
+
+final isAssetNotFound = const isInstanceOf<AssetNotFoundException>();
+final throwsAssetNotFound = throwsA(isAssetNotFound);
+
+void main() {
+  group('$MultiAssetReader', () {
+    AssetReader assetReader;
+
+    test('should throw an $AssetNotFoundException with no readers', () {
+      var missingId = new AssetId('some_pkg', 'some_pkg.dart');
+      assetReader = new MultiAssetReader([]);
+      expect(
+        assetReader.readAsString(missingId),
+        throwsAssetNotFound,
+      );
+    });
+
+    test('should read an asset from an underyling reader', () async {
+      var idA = new AssetId('some_pkg', 'a.dart');
+      var idB = new AssetId('some_pkg', 'b.dart');
+      var idC = new AssetId('some_pkg', 'missing.dart');
+      assetReader = new MultiAssetReader([
+        new InMemoryAssetReader(sourceAssets: {
+          idA: new DatedString('A'),
+        }),
+        new InMemoryAssetReader(sourceAssets: {
+          idB: new DatedString('B'),
+        }),
+      ]);
+      expect(await assetReader.readAsString(idA), 'A');
+      expect(await assetReader.readAsString(idB), 'B');
+      expect(assetReader.readAsString(idC), throwsAssetNotFound);
+    });
+
+    test('should combine files when using `findAssets`', () {
+      var idA = new AssetId('some_pkg', 'a.dart');
+      var idB = new AssetId('some_pkg', 'b.dart');
+      assetReader = new MultiAssetReader([
+        new InMemoryAssetReader(
+          sourceAssets: {
+            idA: new DatedString('A'),
+          },
+          rootPackage: 'some_pkg',
+        ),
+        new InMemoryAssetReader(
+          sourceAssets: {
+            idB: new DatedString('B'),
+          },
+          rootPackage: 'some_pkg',
+        ),
+      ]);
+      // TODO: Follow-up on https://github.com/dart-lang/build/issues/241.
+      expect(assetReader.findAssets(new Glob('*.dart')), [idA, idB]);
+    });
+  });
+}

--- a/build_test/test/multi_asset_reader_test.dart
+++ b/build_test/test/multi_asset_reader_test.dart
@@ -42,8 +42,8 @@ void main() {
     });
 
     test('should combine files when using `findAssets`', () {
-      var idA = new AssetId('some_pkg', 'a.dart');
-      var idB = new AssetId('some_pkg', 'b.dart');
+      var idA = new AssetId('some_pkg', 'lib/a.dart');
+      var idB = new AssetId('some_pkg', 'lib/b.dart');
       assetReader = new MultiAssetReader([
         new InMemoryAssetReader(
           sourceAssets: {
@@ -58,8 +58,7 @@ void main() {
           rootPackage: 'some_pkg',
         ),
       ]);
-      // TODO: Follow-up on https://github.com/dart-lang/build/issues/241.
-      expect(assetReader.findAssets(new Glob('*.dart')), [idA, idB]);
+      expect(assetReader.findAssets(new Glob('lib/*.dart')), [idA, idB]);
     });
   });
 }


### PR DESCRIPTION
Partial work towards https://github.com/dart-lang/build/issues/168:

For running test code that is a combination of "fake" (stub) code and "real" code (such as dependencies you'd expect to be resolved, such as annotations, other classes, types, etc), this will allow something like:

```dart
runBuilder(..., new MutliAssetReader([
  new InMemoryAssetReader(...), // Fakes/Stubs
  new PackageAssetReader(...), // Real code on disk
])
```

I could see this having value in `pkg/build` (i.e. `new AssetReader.fromMulti(...)`), but I figure it's probably better to not add to the public API until it's stabilized and supports the #168 use-case, so I've kept it package private to `build_test`.

Test cases look good, so next step will be using it with `testBuilder` in some more e2e-y way.