### PR TITLE
Upgrade build_barback to build 0.8.0

### DIFF
--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.2-dev
 
 - Only use the global log from `build`
+- Upgrade to build 0.8.0
 
 ## 0.1.1
 

--- a/build_barback/lib/src/transformer/transformer.dart
+++ b/build_barback/lib/src/transformer/transformer.dart
@@ -4,10 +4,11 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:build/build.dart' as build;
-import 'package:build/build.dart' hide AssetId;
 import 'package:barback/barback.dart' as barback show AssetId;
 import 'package:barback/barback.dart' hide Asset, AssetId;
+import 'package:build/build.dart' as build;
+import 'package:build/build.dart' hide AssetId;
+import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 
 import '../analyzer/resolver.dart';
@@ -121,6 +122,10 @@ class _TransformAssetReader implements AssetReader {
   @override
   Future<String> readAsString(build.AssetId id, {Encoding encoding: UTF8}) =>
       transform.readInputAsString(toBarbackAssetId(id), encoding: encoding);
+
+  @override
+  Iterable<build.AssetId> findAssets(Glob glob) => throw new UnsupportedError(
+      'findAssets cannot be used within a Transformer');
 }
 
 /// Very simple [AssetWriter] which uses a [Transform].

--- a/build_barback/lib/src/transformer/transformer.dart
+++ b/build_barback/lib/src/transformer/transformer.dart
@@ -125,7 +125,9 @@ class _TransformAssetReader implements AssetReader {
 
   @override
   Iterable<build.AssetId> findAssets(Glob glob) => throw new UnsupportedError(
-      'findAssets cannot be used within a Transformer');
+      'findAssets cannot be used within a Transformer.\n'
+      'If you have a use case that requires support file an issue at '
+      'https://github.com/dart-lang/build/issues');
 }
 
 /// Very simple [AssetWriter] which uses a [Transform].

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"
   barback: ^0.15.0
-  build: ^0.7.0
+  build: ^0.8.0
   code_transformers: ">=0.5.1 <0.6.0"
   logging: ^0.11.2
 
@@ -18,3 +18,7 @@ dev_dependencies:
   build_test: ^0.4.0
   test: ^0.12.0
   transformer_test: ^0.2.0
+
+dependency_overrides:
+  build:
+    path: ../build


### PR DESCRIPTION
We won't implement the findAssets API for now, if a use case comes up
needing this we will re-evaluate.