### PR TITLE
Prepare to publish build, build_test, build_barback

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.0-dev
+## 0.8.0
 
 - Add `AssetReader.findAssets` to allow listing assets by glob.
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.8.0-dev
+version: 0.8.0
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -18,9 +18,3 @@ dev_dependencies:
   build_test: ^0.5.0
   test: ^0.12.0
   transformer_test: ^0.2.0
-
-dependency_overrides:
-  build_barback:
-    path: ../build_barback
-  build_test:
-    path: ../build_test

--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.2-dev
+## 0.1.2
 
 - Only use the global log from `build`
 - Upgrade to build 0.8.0

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_barback
-version: 0.1.2-dev
+version: 0.1.2
 description: Utilities for translating between builders and transformers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -18,7 +18,3 @@ dev_dependencies:
   build_test: ^0.4.0
   test: ^0.12.0
   transformer_test: ^0.2.0
-
-dependency_overrides:
-  build:
-    path: ../build

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.5.1
 
 - Add `PackageAssetReader`, a standalone asset reader that uses a
   `PackageResolver` to map an `AssetId` to a location on disk.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.5.1-dev
+version: 0.5.1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
@@ -19,7 +19,3 @@ dev_dependencies:
 
 environment:
   sdk: ">=1.8.0 <2.0.0"
-
-dependency_overrides:
-  build:
-    path: ../build


### PR DESCRIPTION
build_runner will remain unpublished until #224 is resolved

- Drop dependency overrides
- Drop `-dev` from version numbers