### PR TITLE
Disallow reading assets from current/future phases

### DIFF
--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -14,7 +14,7 @@ abstract class RunnerAssetReader extends AssetReader {
   Future<DateTime> lastModified(AssetId id);
 }
 
-final _false = new Future.value(false);
+final _asyncFalse = new Future.value(false);
 
 /// An [AssetReader] with a lifetime equivalent to that of a single Phase in a
 /// build.
@@ -40,7 +40,7 @@ class SinglePhaseReader implements AssetReader {
 
   @override
   Future<bool> hasInput(AssetId id) {
-    if (!_isReadable(id)) return _false;
+    if (!_isReadable(id)) return _asyncFalse;
     _assetsRead.add(id);
     return _delegate.hasInput(id);
   }

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -19,7 +19,7 @@ class AssetNode {
     var node;
     if (serializedNode.length == 2) {
       node = new AssetNode(new AssetId.deserialize(serializedNode[0]));
-    } else if (serializedNode.length == 4) {
+    } else if (serializedNode.length == 5) {
       node = new GeneratedAssetNode.deserialize(serializedNode);
     } else {
       throw new ArgumentError(
@@ -40,6 +40,9 @@ class AssetNode {
 
 /// A generated node in the asset graph.
 class GeneratedAssetNode extends AssetNode {
+  /// The phase which generated this asset.
+  final int phaseNumber;
+
   /// The primary input which generated this node.
   final AssetId primaryInput;
 
@@ -49,21 +52,25 @@ class GeneratedAssetNode extends AssetNode {
   /// Whether the asset was actually output.
   bool wasOutput;
 
-  GeneratedAssetNode(
-      this.primaryInput, this.needsUpdate, this.wasOutput, AssetId id)
+  GeneratedAssetNode(this.phaseNumber, this.primaryInput, this.needsUpdate,
+      this.wasOutput, AssetId id)
       : super(id);
 
   factory GeneratedAssetNode.deserialize(List serialized) {
-    var node = new GeneratedAssetNode(new AssetId.deserialize(serialized[2]),
-        false, serialized[3], new AssetId.deserialize(serialized[0]));
+    var node = new GeneratedAssetNode(
+        serialized[4],
+        new AssetId.deserialize(serialized[2]),
+        false,
+        serialized[3],
+        new AssetId.deserialize(serialized[0]));
     node.outputs.addAll((serialized[1] as Iterable)
         .map((serializedOutput) => new AssetId.deserialize(serializedOutput)));
     return node;
   }
 
   @override
-  List serialize() =>
-      super.serialize()..addAll([primaryInput.serialize(), wasOutput]);
+  List serialize() => super.serialize()
+    ..addAll([primaryInput.serialize(), wasOutput, phaseNumber]);
 
   @override
   String toString() =>

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"
-  build: ^0.7.0
+  build: ^0.8.0
   build_barback: ^0.1.0
   crypto: ">=0.9.2 <3.0.0"
   logging: ^0.11.2
@@ -22,5 +22,5 @@ dependencies:
   yaml: ^2.1.0
 
 dev_dependencies:
-  build_test: ^0.4.0
+  build_test: ^0.5.0
   test: ^0.12.0

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -87,8 +87,8 @@ void main() {
         var node = makeAssetNode();
         graph.add(node);
         for (int g = 0; g < 5 - n; g++) {
-          var generatedNode =
-              new GeneratedAssetNode(node.id, false, g % 2 == 0, makeAssetId());
+          var generatedNode = new GeneratedAssetNode(
+              1, node.id, false, g % 2 == 0, makeAssetId());
           node.outputs.add(generatedNode.id);
           graph.add(generatedNode);
         }

--- a/build_runner/test/common/in_memory_reader.dart
+++ b/build_runner/test/common/in_memory_reader.dart
@@ -12,7 +12,7 @@ import 'package:glob/glob.dart';
 class InMemoryRunnerAssetReader extends InMemoryAssetReader
     implements RunnerAssetReader {
   InMemoryRunnerAssetReader([Map<AssetId, DatedValue> sourceAssets])
-      : super(sourceAssets);
+      : super(sourceAssets: sourceAssets);
 
   @override
   Iterable<AssetId> findAssets(Glob glob, {String packageName}) => assets.keys

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -230,7 +230,7 @@ void main() {
       var graph = new AssetGraph();
       var bId = makeAssetId('a|lib/b.txt');
       var bCopyNode = new GeneratedAssetNode(
-          bId, false, true, makeAssetId('a|lib/b.txt.copy'));
+          1, bId, false, true, makeAssetId('a|lib/b.txt.copy'));
       graph.add(bCopyNode);
       var bNode = makeAssetNode('a|lib/b.txt', [bCopyNode.id]);
       graph.add(bNode);
@@ -258,21 +258,29 @@ void main() {
 
       var graph = new AssetGraph()..validAsOf = new DateTime.now();
 
-      var aCloneNode = new GeneratedAssetNode(makeAssetId('a|lib/a.txt.copy'),
-          false, true, makeAssetId('a|lib/a.txt.copy.clone'));
+      var aCloneNode = new GeneratedAssetNode(
+          1,
+          makeAssetId('a|lib/a.txt.copy'),
+          false,
+          true,
+          makeAssetId('a|lib/a.txt.copy.clone'));
       graph.add(aCloneNode);
-      var aCopyNode = new GeneratedAssetNode(makeAssetId('a|lib/a.txt'), false,
-          true, makeAssetId('a|lib/a.txt.copy'))
+      var aCopyNode = new GeneratedAssetNode(1, makeAssetId('a|lib/a.txt'),
+          false, true, makeAssetId('a|lib/a.txt.copy'))
         ..outputs.add(aCloneNode.id);
       graph.add(aCopyNode);
       var aNode = makeAssetNode('a|lib/a.txt', [aCopyNode.id]);
       graph.add(aNode);
 
-      var bCloneNode = new GeneratedAssetNode(makeAssetId('a|lib/b.txt.copy'),
-          false, true, makeAssetId('a|lib/b.txt.copy.clone'));
+      var bCloneNode = new GeneratedAssetNode(
+          1,
+          makeAssetId('a|lib/b.txt.copy'),
+          false,
+          true,
+          makeAssetId('a|lib/b.txt.copy.clone'));
       graph.add(bCloneNode);
-      var bCopyNode = new GeneratedAssetNode(makeAssetId('a|lib/b.txt'), false,
-          true, makeAssetId('a|lib/b.txt.copy'))
+      var bCopyNode = new GeneratedAssetNode(1, makeAssetId('a|lib/b.txt'),
+          false, true, makeAssetId('a|lib/b.txt.copy'))
         ..outputs.add(bCloneNode.id);
       graph.add(bCopyNode);
       var bNode = makeAssetNode('a|lib/b.txt', [bCopyNode.id]);
@@ -306,11 +314,15 @@ void main() {
             new InputSet('a', ['**/*.txt.copy']));
 
       var graph = new AssetGraph();
-      var aCloneNode = new GeneratedAssetNode(makeAssetId('a|lib/a.txt.copy'),
-          false, true, makeAssetId('a|lib/a.txt.copy.clone'));
+      var aCloneNode = new GeneratedAssetNode(
+          1,
+          makeAssetId('a|lib/a.txt.copy'),
+          false,
+          true,
+          makeAssetId('a|lib/a.txt.copy.clone'));
       graph.add(aCloneNode);
-      var aCopyNode = new GeneratedAssetNode(makeAssetId('a|lib/a.txt'), false,
-          true, makeAssetId('a|lib/a.txt.copy'))
+      var aCopyNode = new GeneratedAssetNode(1, makeAssetId('a|lib/a.txt'),
+          false, true, makeAssetId('a|lib/a.txt.copy'))
         ..outputs.add(aCloneNode.id);
       graph.add(aCopyNode);
       var aNode = makeAssetNode('a|lib/a.txt', [aCopyNode.id]);
@@ -342,7 +354,7 @@ void main() {
       var graph = new AssetGraph();
       var aId = makeAssetId('a|web/a.txt');
       var aCopyNode = new GeneratedAssetNode(
-          aId, false, true, makeAssetId('a|web/a.txt.copy'));
+          1, aId, false, true, makeAssetId('a|web/a.txt.copy'));
       graph.add(aCopyNode);
       var aNode = makeAssetNode('a|web/a.txt', [aCopyNode.id]);
       graph.add(aNode);


### PR DESCRIPTION
Fixes #234

- Expand AssetReaderSpy into SinglePhaseReader. It is now has the
additional responsibility of preventing reads to generated assets
- Add a phaseNumber concept to GenereatedAssetNode. The number is
assigned while looping over phases in build_impl
- Upgrade to package:build 0.8.0 and mark that the AssetReader
overrides findAssets