### PR TITLE
Fix backwards incompatibilities

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.1+1
+
+- Bug Fix: Update AssetGraph version so builds can be run without manually
+  deleting old build directory.
+- Bug Fix: Check for unreadable assets in an async method rather than throw
+  synchronously
+
 ## 0.3.1
 
 - Internal refactoring of RunnerAssetReader.

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -46,14 +46,14 @@ class SinglePhaseReader implements AssetReader {
   }
 
   @override
-  Future<List<int>> readAsBytes(AssetId id) {
+  Future<List<int>> readAsBytes(AssetId id) async {
     if (!_isReadable(id)) throw new AssetNotFoundException(id);
     _assetsRead.add(id);
     return _delegate.readAsBytes(id);
   }
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) {
+  Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) async {
     if (!_isReadable(id)) throw new AssetNotFoundException(id);
     _assetsRead.add(id);
     return _delegate.readAsString(id, encoding: encoding);

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -25,7 +25,7 @@ class AssetGraph {
   ///
   /// This should be incremented any time the serialize/deserialize methods
   /// change on this class or [AssetNode].
-  static int get _version => 2;
+  static int get _version => 3;
 
   /// Deserializes this graph.
   factory AssetGraph.deserialize(Map serializedGraph) {

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.3.1
+version: 0.3.1+1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
- Upgrade AssetGraph serialization version number so we don't try and
  fail to read existing graphs from disk
- Make the check for unreadable assets asychronous so we don't
  synchronously throw and break the BarbackResolvers as it tries to read
  reachable sources