### PR TITLE
Rename hasInput as canRead

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.9.0-dev
+
+- Deprecate `BuildStep.hasInput` in favor of `BuildStep.canRead`.
+- Rename `AssetReader.hasInput` as `canRead`. This is breaking for implementers
+  of `AssetReader`
+- Make `canRead` return a `FutureOr` for more flexibility
+
 ## 0.8.0
 
 - Add `AssetReader.findAssets` to allow listing assets by glob.

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Deprecate `BuildStep.hasInput` in favor of `BuildStep.canRead`.
 - Rename `AssetReader.hasInput` as `canRead`. This is breaking for implementers
-  of `AssetReader`
+  of `AssetReader` and for any clients passing a `BuildStep` as an `AssetReader`
 - Make `canRead` return a `FutureOr` for more flexibility
 
 ## 0.8.0

--- a/build/lib/src/asset/reader.dart
+++ b/build/lib/src/asset/reader.dart
@@ -26,8 +26,8 @@ abstract class AssetReader {
   /// * Throws a [AssetNotFoundException] if [id.path] is not found.
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8});
 
-  /// Returns a [Future] that completes with whether asset at [id] is readable.
-  Future<bool> hasInput(AssetId id);
+  /// Indicates whether asset at [id] is readable.
+  FutureOr<bool> canRead(AssetId id);
 
   /// Returns all readable assets matching [glob] under the root package.
   Iterable<AssetId> findAssets(Glob glob);

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -57,6 +57,9 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   @override
   Future writeAsString(AssetId id, String contents, {Encoding encoding: UTF8});
 
+  @Deprecated('Use `canRead` instead')
+  Future<bool> hasInput(AssetId id);
+
   /// Completes with a [Resolver] for [inputId].
   Future<Resolver> get resolver;
 }

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -59,9 +59,12 @@ class BuildStepImpl implements ManagedBuildStep {
   Future<ReleasableResolver> _resolver;
 
   @override
-  Future<bool> hasInput(AssetId id) {
+  Future<bool> hasInput(AssetId id) async => canRead(id);
+
+  @override
+  FutureOr<bool> canRead(AssetId id) {
     _checkInput(id);
-    return _reader.hasInput(id);
+    return _reader.canRead(id);
   }
 
   @override

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -59,12 +59,15 @@ class BuildStepImpl implements ManagedBuildStep {
   Future<ReleasableResolver> _resolver;
 
   @override
-  Future<bool> hasInput(AssetId id) async => canRead(id);
+  Future<bool> hasInput(AssetId id) {
+    var result = canRead(id);
+    return new Future.value(result);
+  }
 
   @override
   FutureOr<bool> canRead(AssetId id) {
     _checkInput(id);
-    return _reader.canRead(id);
+    return new Future.value(_reader.canRead(id));
   }
 
   @override

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 environment:
-  sdk: '>=1.21.1 <2.0.0'
+  sdk: '>=1.22.1 <2.0.0'
 
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -18,3 +18,9 @@ dev_dependencies:
   build_test: ^0.5.0
   test: ^0.12.0
   transformer_test: ^0.2.0
+
+dependency_overrides:
+  build_test:
+    path: ../build_test
+  build_barback:
+    path: ../build_barback

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.8.0
+version: 0.9.0-dev
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -46,6 +46,15 @@ void main() {
             throwsA(invalidInputException));
       });
 
+      test('hasInput behaves like canRead', () async {
+        expect(() => buildStep.hasInput(makeAssetId('b|web/a.txt')),
+            throwsA(invalidInputException));
+        expect(() => buildStep.hasInput(makeAssetId('b|a.txt')),
+            throwsA(invalidInputException));
+        expect(() => buildStep.hasInput(makeAssetId('foo|bar.txt')),
+            throwsA(invalidInputException));
+      });
+
       test('readAs* throws InvalidInputExceptions', () async {
         var invalidInputs = [
           makeAssetId('b|web/a.txt'),

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -37,12 +37,12 @@ void main() {
             throwsA(new isInstanceOf<UnexpectedOutputException>()));
       });
 
-      test('hasInput throws invalidInputExceptions', () async {
-        expect(() => buildStep.hasInput(makeAssetId('b|web/a.txt')),
+      test('canRead throws invalidInputExceptions', () async {
+        expect(() => buildStep.canRead(makeAssetId('b|web/a.txt')),
             throwsA(invalidInputException));
-        expect(() => buildStep.hasInput(makeAssetId('b|a.txt')),
+        expect(() => buildStep.canRead(makeAssetId('b|a.txt')),
             throwsA(invalidInputException));
-        expect(() => buildStep.hasInput(makeAssetId('foo|bar.txt')),
+        expect(() => buildStep.canRead(makeAssetId('foo|bar.txt')),
             throwsA(invalidInputException));
       });
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.5.3-dev
 
 - Support build 0.9.0
-  - Rename hasInput to canReade in AssetReader implementations
+  - Rename hasInput to canRead in AssetReader implementations
 
 ## 0.5.2
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.3-dev
+
+- Support build 0.9.0
+  - Rename hasInput to canReade in AssetReader implementations
+
 ## 0.5.2
 
 - Add `MultiAssetReader` to the public API.

--- a/build_test/lib/src/copy_builder.dart
+++ b/build_test/lib/src/copy_builder.dart
@@ -48,7 +48,7 @@ class CopyBuilder implements Builder {
       buildStep.writeAsString(id, content);
     }
 
-    if (touchAsset != null) await buildStep.hasInput(touchAsset);
+    if (touchAsset != null) await buildStep.canRead(touchAsset);
   }
 
   @override

--- a/build_test/lib/src/in_memory_reader.dart
+++ b/build_test/lib/src/in_memory_reader.dart
@@ -17,19 +17,17 @@ class InMemoryAssetReader implements AssetReader {
       : assets = sourceAssets ?? <AssetId, DatedValue>{};
 
   @override
-  Future<bool> hasInput(AssetId id) {
-    return new Future.value(assets.containsKey(id));
-  }
+  FutureOr<bool> canRead(AssetId id) => assets.containsKey(id);
 
   @override
   Future<List<int>> readAsBytes(AssetId id) async {
-    if (!await hasInput(id)) throw new AssetNotFoundException(id);
+    if (!await canRead(id)) throw new AssetNotFoundException(id);
     return assets[id].bytesValue;
   }
 
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) async {
-    if (!await hasInput(id)) throw new AssetNotFoundException(id);
+    if (!await canRead(id)) throw new AssetNotFoundException(id);
     return assets[id].stringValue;
   }
 

--- a/build_test/lib/src/multi_asset_reader.dart
+++ b/build_test/lib/src/multi_asset_reader.dart
@@ -23,9 +23,9 @@ class MultiAssetReader implements AssetReader {
   const MultiAssetReader(this._readers);
 
   @override
-  Future<bool> hasInput(AssetId id) async {
+  Future<bool> canRead(AssetId id) async {
     for (var reader in _readers) {
-      if (await reader.hasInput(id)) {
+      if (await reader.canRead(id)) {
         return true;
       }
     }
@@ -54,7 +54,7 @@ class MultiAssetReader implements AssetReader {
   /// Otherwise throws [AssetNotFoundException].
   Future<AssetReader> _readerWith(AssetId id) async {
     for (var reader in _readers) {
-      if (await reader.hasInput(id)) {
+      if (await reader.canRead(id)) {
         return reader;
       }
     }

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -48,7 +48,7 @@ class PackageAssetReader implements AssetReader {
   }
 
   @override
-  Future<bool> hasInput(AssetId id) async => _resolve(id).exists();
+  FutureOr<bool> canRead(AssetId id) => _resolve(id).exists();
 
   @override
   Future<List<int>> readAsBytes(AssetId id) => _resolve(id).readAsBytes();

--- a/build_test/lib/src/stub_reader.dart
+++ b/build_test/lib/src/stub_reader.dart
@@ -9,7 +9,7 @@ import 'package:glob/glob.dart';
 
 class StubAssetReader implements AssetReader {
   @override
-  Future<bool> hasInput(_) => new Future.value(null);
+  FutureOr<bool> canRead(_) => null;
 
   @override
   Future<List<int>> readAsBytes(_) => new Future.value(null);

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.5.2
+version: 0.5.3-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 dependencies:
-  build: ^0.8.0
+  build: ^0.9.0
   build_barback: ^0.1.0
   collection: ^1.14.0
   glob: ^1.1.0
@@ -20,3 +20,7 @@ dev_dependencies:
 
 environment:
   sdk: ">=1.8.0 <2.0.0"
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_test/test/package_reader_test.dart
+++ b/build_test/test/package_reader_test.dart
@@ -22,16 +22,16 @@ void main() {
     });
 
     test('should be able to read `build_test.dart`', () async {
-      expect(await reader.hasInput(buildTest), isTrue);
+      expect(await reader.canRead(buildTest), isTrue);
       expect(await reader.readAsString(buildTest), isNotEmpty);
     });
 
     test('should be able to read this file (in test/)', () async {
-      expect(await reader.hasInput(thisFile), isTrue);
+      expect(await reader.canRead(thisFile), isTrue);
     });
 
     test('should not be able to read a missing file', () async {
-      expect(await reader.hasInput(buildMissing), isFalse);
+      expect(await reader.canRead(buildMissing), isFalse);
     });
 
     test('should be able to use `findAssets` for files in lib', () {


### PR DESCRIPTION
First step on #256
Fixes #254

- Rename hasInput on AssetReader
- Add canRead on BuildStep but keep hasInput marked deprecated. Limits
  the impact on most clients.

This will break implementations, so build_test, build_runner, and
_bazel_codegen will need to be updated.