### PR TITLE
Replace declareOutputs with buildExtensions

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `AssetWriter.writeAs*` methods now take a `FutureOr` for content. Builders
   which produce content asynchronously can now set up the write without waiting
   for it to resolve.
-- *Breaking* `declareOutputs` is replaced with `buildExtensions`. All `Builder`
+- **Breaking** `declareOutputs` is replaced with `buildExtensions`. All `Builder`
   implementations must now have outputs that vary only based on the extensions
   of inputs, rather than based on any part of the `AssetId`.
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -9,6 +9,9 @@
 - `AssetWriter.writeAs*` methods now take a `FutureOr` for content. Builders
   which produce content asynchronously can now set up the write without waiting
   for it to resolve.
+- *Breaking* `declareOutputs` is replaced with `buildExtensions`. All `Builder`
+  implementations must now have outputs that vary only based on the extensions
+  of inputs, rather than based on any part of the `AssetId`.
 
 ## 0.8.0
 

--- a/build/lib/build.dart
+++ b/build/lib/build.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 export 'src/analyzer/resolver.dart';
@@ -12,3 +12,4 @@ export 'src/builder/exceptions.dart';
 export 'src/builder/logging.dart' show log;
 export 'src/builder/multiplexing_builder.dart';
 export 'src/generate/run_builder.dart';
+export 'src/generate/find_outputs.dart';

--- a/build/lib/build.dart
+++ b/build/lib/build.dart
@@ -11,5 +11,5 @@ export 'src/builder/builder.dart';
 export 'src/builder/exceptions.dart';
 export 'src/builder/logging.dart' show log;
 export 'src/builder/multiplexing_builder.dart';
+export 'src/generate/expected_outputs.dart';
 export 'src/generate/run_builder.dart';
-export 'src/generate/find_outputs.dart';

--- a/build/lib/src/builder/builder.dart
+++ b/build/lib/src/builder/builder.dart
@@ -1,9 +1,8 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
-import '../asset/id.dart';
 import 'build_step.dart';
 
 /// The basic builder class, used to build new files from existing ones.
@@ -11,11 +10,15 @@ abstract class Builder {
   /// Generates the outputs for a given [BuildStep].
   Future build(BuildStep buildStep);
 
-  /// Declares all potential output assets given [inputId]. If an empty [List]
-  /// is returned then the asset will never be provided to [build].
+  /// Configuration for which files will be created based on the file extension
+  /// of inputs.
   ///
-  /// Note: Reading the contents of [inputId] is not supported during this
-  /// phase. You can however choose later on not to actually output assets which
-  /// you return here, but no other [Builder] will be able to output them.
-  List<AssetId> declareOutputs(AssetId inputId);
+  /// All input sources matching any key in this map will be passed as build
+  /// step to this builder. Only files with the same basename and an extension
+  /// from the values in this map are expected as outputs. If an empty key
+  /// exists, all inputs are considered matching. A builder must always return
+  /// the same configuration. Typically this will be `const` but may vary based
+  /// on build arguments. Most builders will use a single input extension and
+  /// one or more output extensions.
+  Map<String, List<String>> get buildExtensions;
 }

--- a/build/lib/src/builder/builder.dart
+++ b/build/lib/src/builder/builder.dart
@@ -10,15 +10,16 @@ abstract class Builder {
   /// Generates the outputs for a given [BuildStep].
   Future build(BuildStep buildStep);
 
-  /// Configuration for which files will be created based on the file extension
-  /// of inputs.
+  /// Mapping from input file extension to output file extensions.
   ///
   /// All input sources matching any key in this map will be passed as build
   /// step to this builder. Only files with the same basename and an extension
-  /// from the values in this map are expected as outputs. If an empty key
-  /// exists, all inputs are considered matching. A builder must always return
-  /// the same configuration. Typically this will be `const` but may vary based
-  /// on build arguments. Most builders will use a single input extension and
-  /// one or more output extensions.
+  /// from the values in this map are expected as outputs.
+  ///
+  /// - If an empty key exists, all inputs are considered matching.
+  /// - A builder must always return the same configuration. Typically this will
+  /// be `const` but may vary based on build arguments.
+  /// - Most builders will use a single input extension and one or more output
+  /// extensions.
   Map<String, List<String>> get buildExtensions;
 }

--- a/build/lib/src/generate/expected_outputs.dart
+++ b/build/lib/src/generate/expected_outputs.dart
@@ -6,7 +6,7 @@ import '../builder/builder.dart';
 
 /// Collects the expected AssetIds created by [builder] when given [input] based
 /// on the extension configuration.
-Set<AssetId> findOutputs(Builder builder, AssetId input) {
+Set<AssetId> expectedOutputs(Builder builder, AssetId input) {
   var matchingExtensions =
       builder.buildExtensions.keys.where((e) => input.path.endsWith(e));
   var outputs = matchingExtensions
@@ -21,6 +21,7 @@ Iterable<AssetId> _replaceExtensions(
 AssetId _replaceExtension(
     AssetId assetId, String oldExtension, String newExtension) {
   var path = assetId.path;
+  assert(path.endsWith(oldExtension));
   return new AssetId(
       assetId.package,
       path.replaceRange(

--- a/build/lib/src/generate/find_outputs.dart
+++ b/build/lib/src/generate/find_outputs.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import '../asset/id.dart';
+import '../builder/builder.dart';
+
+/// Collects the expected AssetIds created by [builder] when given [input] based
+/// on the extension configuration.
+Set<AssetId> findOutputs(Builder builder, AssetId input) {
+  var matchingExtensions =
+      builder.buildExtensions.keys.where((e) => input.path.endsWith(e));
+  var outputs = matchingExtensions
+      .expand((e) => _replaceExtensions(input, e, builder.buildExtensions[e]));
+  return new Set<AssetId>.from(outputs);
+}
+
+Iterable<AssetId> _replaceExtensions(
+        AssetId assetId, String oldExtension, List<String> newExtensions) =>
+    newExtensions.map((n) => _replaceExtension(assetId, oldExtension, n));
+
+AssetId _replaceExtension(
+    AssetId assetId, String oldExtension, String newExtension) {
+  var path = assetId.path;
+  return new AssetId(
+      assetId.package,
+      path.replaceRange(
+          path.length - oldExtension.length, path.length, newExtension));
+}

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
@@ -12,6 +12,7 @@ import '../asset/writer.dart';
 import '../builder/build_step_impl.dart';
 import '../builder/builder.dart';
 import '../builder/logging.dart';
+import 'find_outputs.dart';
 
 /// Run [builder] on each asset in [inputs].
 ///
@@ -26,7 +27,7 @@ Future<Null> runBuilder(Builder builder, Iterable<AssetId> inputs,
   rootPackage ??= new Set.from(inputs.map((input) => input.package)).single;
   //TODO(nbosch) check overlapping outputs?
   Future<Null> buildForInput(AssetId input) async {
-    var expectedOutputs = builder.declareOutputs(input);
+    var expectedOutputs = findOutputs(builder, input);
     var buildStep = new BuildStepImpl(
         input, expectedOutputs, reader, writer, rootPackage, resolvers);
     try {

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -12,7 +12,7 @@ import '../asset/writer.dart';
 import '../builder/build_step_impl.dart';
 import '../builder/builder.dart';
 import '../builder/logging.dart';
-import 'find_outputs.dart';
+import 'expected_outputs.dart';
 
 /// Run [builder] on each asset in [inputs].
 ///
@@ -27,9 +27,8 @@ Future<Null> runBuilder(Builder builder, Iterable<AssetId> inputs,
   rootPackage ??= new Set.from(inputs.map((input) => input.package)).single;
   //TODO(nbosch) check overlapping outputs?
   Future<Null> buildForInput(AssetId input) async {
-    var expectedOutputs = findOutputs(builder, input);
-    var buildStep = new BuildStepImpl(
-        input, expectedOutputs, reader, writer, rootPackage, resolvers);
+    var buildStep = new BuildStepImpl(input, expectedOutputs(builder, input),
+        reader, writer, rootPackage, resolvers);
     try {
       await builder.build(buildStep);
     } finally {

--- a/build_test/lib/src/copy_builder.dart
+++ b/build_test/lib/src/copy_builder.dart
@@ -39,7 +39,8 @@ class CopyBuilder implements Builder {
   Future build(BuildStep buildStep) async {
     if (blockUntil != null) await blockUntil;
 
-    var ids = declareOutputs(buildStep.inputId);
+    var ids = new Iterable.generate(numCopies)
+        .map((copy) => _copiedAssetId(buildStep.inputId, copy));
     for (var id in ids) {
       var toCopy = copyFromAsset ?? buildStep.inputId;
       // ignore: unawaited_futures
@@ -50,20 +51,22 @@ class CopyBuilder implements Builder {
   }
 
   @override
-  List<AssetId> declareOutputs(AssetId input) {
-    var outputs = <AssetId>[];
+  Map<String, List<String>> get buildExtensions {
+    var outputs = <String>[];
     for (int i = 0; i < numCopies; i++) {
-      outputs.add(_copiedAssetId(input, numCopies == 1 ? null : i));
+      outputs.add(_copiedAssetExtension(i));
     }
-    return outputs;
+    return {'': outputs};
   }
 
   AssetId _copiedAssetId(AssetId inputId, int copyNum) {
-    var withExtension = inputId
-        .addExtension('.$extension${copyNum == null ? '' : '.$copyNum'}');
+    var withExtension = inputId.addExtension(_copiedAssetExtension(copyNum));
     if (outputPackage == null) {
       return withExtension;
     }
     return new AssetId(outputPackage, withExtension.path);
   }
+
+  String _copiedAssetExtension(int copyNum) =>
+      '.$extension${copyNum == null ? '' : '.$copyNum'}';
 }

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -98,5 +98,5 @@ class _ResolveSourceBuilder implements Builder {
   }
 
   @override
-  List<AssetId> declareOutputs(AssetId inputId) => const [];
+  Map<String, List<String>> get buildExtensions => const {'': const []};
 }


### PR DESCRIPTION
Fixes #222

- Add a top level method `findOutputs` to create the Set<AssetId>.
  Export this in the public API
- Use findOutputs from runBuilder
- Update MultiplexingBuilder to merge the buildExtensions maps
- Update some Builder implementations to the new style