### PR TITLE
Upgrade build_barback to build 0.9.0

### DIFF
--- a/build/lib/src/generate/expected_outputs.dart
+++ b/build/lib/src/generate/expected_outputs.dart
@@ -6,12 +6,11 @@ import '../builder/builder.dart';
 
 /// Collects the expected AssetIds created by [builder] when given [input] based
 /// on the extension configuration.
-Set<AssetId> expectedOutputs(Builder builder, AssetId input) {
+Iterable<AssetId> expectedOutputs(Builder builder, AssetId input) {
   var matchingExtensions =
       builder.buildExtensions.keys.where((e) => input.path.endsWith(e));
-  var outputs = matchingExtensions
+  return matchingExtensions
       .expand((e) => _replaceExtensions(input, e, builder.buildExtensions[e]));
-  return new Set<AssetId>.from(outputs);
 }
 
 Iterable<AssetId> _replaceExtensions(

--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.0-dev
+
+- Update to build 0.9.0
+- **Breaking** `TransformerBuilder` must be constructed with a `buildExtension`
+  configuration. Transformers wrapped as a builder must have outputs which vary
+  only by input extension.
+
 ## 0.1.2
 
 - Only use the global log from `build`

--- a/build_barback/lib/src/builder/transformer_builder.dart
+++ b/build_barback/lib/src/builder/transformer_builder.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
@@ -11,14 +11,10 @@ import '../util/barback.dart';
 /// A builder which wraps a [barback.DeclaringTransformer].
 class TransformerBuilder implements Builder {
   final barback.Transformer transformer;
+  @override
+  final Map<String, List<String>> buildExtensions;
 
-  TransformerBuilder(this.transformer) {
-    /// Unfortunately, we can't add a static type for this :(.
-    if (transformer is! barback.DeclaringTransformer) {
-      throw new ArgumentError('Only DeclaringTransformers are supported, which '
-          '$transformer is not');
-    }
-  }
+  TransformerBuilder(this.transformer, this.buildExtensions);
 
   @override
   Future build(BuildStep buildStep) {
@@ -27,36 +23,5 @@ class TransformerBuilder implements Builder {
   }
 
   @override
-  List<AssetId> declareOutputs(AssetId inputId) {
-    var barbackId = toBarbackAssetId(inputId);
-    if (!transformer.isPrimary(barbackId)) return const [];
-    var transform = new _DeclaringTransform(barbackId);
-    (transformer as barback.DeclaringTransformer).declareOutputs(transform);
-    return transform.outputs;
-  }
-
-  @override
   String toString() => 'TransformerBuilder[$transformer]';
-}
-
-/// A [barback.DeclaringTransform] which just collects outputs.
-class _DeclaringTransform implements barback.DeclaringTransform {
-  final List<AssetId> outputs = [];
-
-  @override
-  final barback.AssetId primaryId;
-
-  _DeclaringTransform(this.primaryId);
-
-  @override
-  barback.TransformLogger get logger => throw new UnimplementedError();
-
-  @override
-  void declareOutput(barback.AssetId id) {
-    outputs.add(toBuildAssetId(id));
-  }
-
-  @override
-  void consumePrimary() => throw new UnsupportedError(
-      'Consuming inputs is not allowed for builders.');
 }

--- a/build_barback/lib/src/builder/transformer_builder.dart
+++ b/build_barback/lib/src/builder/transformer_builder.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';

--- a/build_barback/lib/src/transformer/transformer.dart
+++ b/build_barback/lib/src/transformer/transformer.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
@@ -138,13 +138,15 @@ class _TransformAssetWriter implements AssetWriter {
   _TransformAssetWriter(this.transform);
 
   @override
-  Future writeAsBytes(build.AssetId id, FutureOr<List<int>> bytes) async {
-    transform.addOutput(barbackAssetFromBytes(id, await bytes));
+  Future writeAsBytes(build.AssetId id, List<int> bytes) {
+    transform.addOutput(barbackAssetFromBytes(id, bytes));
+    return new Future.value(null);
   }
 
   @override
-  Future writeAsString(build.AssetId id, FutureOr<String> contents,
-      {Encoding encoding: UTF8}) async {
-    transform.addOutput(barbackAssetFromString(id, await contents));
+  Future writeAsString(build.AssetId id, String contents,
+      {Encoding encoding: UTF8}) {
+    transform.addOutput(barbackAssetFromString(id, contents));
+    return new Future.value(null);
   }
 }

--- a/build_barback/lib/src/util/barback.dart
+++ b/build_barback/lib/src/util/barback.dart
@@ -59,12 +59,12 @@ class BuildStepTransform implements barback.Transform {
       buildStep.readAsBytes(toBuildAssetId(id)).asStream();
 
   @override
-  Future<bool> hasInput(barback.AssetId id) =>
-      buildStep.hasInput(toBuildAssetId(id));
+  Future<bool> hasInput(barback.AssetId id) async =>
+      buildStep.canRead(toBuildAssetId(id));
 
   @override
   void addOutput(barback.Asset output) {
-    (buildStep as BuildStepImpl).writeFromFutureAsBytes(
+    (buildStep as BuildStepImpl).writeAsBytes(
         toBuildAssetId(output.id), combineByteStream(output.read()));
   }
 

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -1,21 +1,27 @@
 name: build_barback
-version: 0.1.2
+version: 0.2.0-dev
 description: Utilities for translating between builders and transformers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 environment:
-  sdk: '>=1.9.1 <2.0.0'
+  sdk: '>=1.22.1 <2.0.0'
 
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"
   barback: ^0.15.0
-  build: ^0.8.0
+  build: ^0.9.0
   code_transformers: ">=0.5.1 <0.6.0"
   glob: ^1.1.0
   logging: ^0.11.2
 
 dev_dependencies:
-  build_test: ^0.5.1
+  build_test: ^0.5.3
   test: ^0.12.0
   transformer_test: ^0.2.0
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_test:
+    path: ../build_test

--- a/build_barback/test/analyzer/resolver_test.dart
+++ b/build_barback/test/analyzer/resolver_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 @TestOn('vm')
@@ -303,7 +303,7 @@ class TestBuilder extends Builder {
   TestBuilder(this.validator);
 
   @override
-  List<AssetId> declareOutputs(AssetId idOrAsset) => [];
+  final buildExtensions = const {'': const []};
 
   @override
   Future build(BuildStep buildStep) async {

--- a/build_barback/test/analyzer/resolver_test.dart
+++ b/build_barback/test/analyzer/resolver_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 @TestOn('vm')

--- a/build_barback/test/analyzer/resolver_test.dart
+++ b/build_barback/test/analyzer/resolver_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 @TestOn('vm')

--- a/build_barback/test/builder/transformer_builder_test.dart
+++ b/build_barback/test/builder/transformer_builder_test.dart
@@ -11,8 +11,12 @@ import 'package:build_test/build_test.dart';
 
 void main() {
   test('basic test', () async {
-    final copyTransformerBuilder =
-        new TransformerBuilder(new CopyTransformer());
+    final copyTransformerBuilder = new TransformerBuilder(
+      new CopyTransformer(),
+      const {
+        '': const ['.copy']
+      },
+    );
 
     await testBuilder(copyTransformerBuilder, {
       'a|web/a.txt': 'a',


### PR DESCRIPTION
- Change expectedOutputs to an Iterable. Some use cases need to check
  for duplicates. This means it will be illegal for the
  `buildExtensions` to express two ways to output the same file.
- Take `buildExtensions` as an argument to `TransformerBuilder`. We
  cannot automatically translate from declareOutputs to the new
  approach. This does mean that non DeclaringTransfomer instances can be
  wrapped.
- Update Builder, AssetReader, and AssetWriter implementations for the
  breaking changes in build