### PR TITLE
Only BuildStep takes FutureOr

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -6,9 +6,9 @@
 - Make `canRead` return a `FutureOr` for more flexibility
 - Drop `ManagedBuildStep` class.
 - Drop `BuildStep.logger`. All logging should go through the top level `log`.
-- `AssetWriter.writeAs*` methods now take a `FutureOr` for content. Builders
-  which produce content asynchronously can now set up the write without waiting
-  for it to resolve.
+- `BuildStep.writeAs*` methods now take a `FutureOr` for content. Builders which
+  produce content asynchronously can now set up the write without waiting for it
+  to resolve.
 - **Breaking** `declareOutputs` is replaced with `buildExtensions`. All `Builder`
   implementations must now have outputs that vary only based on the extensions
   of inputs, rather than based on any part of the `AssetId`.

--- a/build/lib/src/asset/writer.dart
+++ b/build/lib/src/asset/writer.dart
@@ -14,7 +14,7 @@ abstract class AssetWriter {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws an `InvalidOutputException` if the output was not valid.
-  Future writeAsBytes(AssetId id, FutureOr<List<int>> bytes);
+  Future writeAsBytes(AssetId id, List<int> bytes);
 
   /// Writes [contents] to a text file located at [id] with [encoding].
   ///
@@ -22,7 +22,7 @@ abstract class AssetWriter {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws an `InvalidOutputException` if the output was not valid.
-  Future writeAsString(AssetId id, FutureOr<String> contents, {Encoding encoding: UTF8});
+  Future writeAsString(AssetId id, String contents, {Encoding encoding: UTF8});
 }
 
 /// An [AssetWriter] which tracks all [assetsWritten] during its lifetime.
@@ -35,13 +35,13 @@ class AssetWriterSpy implements AssetWriter {
   Iterable<AssetId> get assetsWritten => _assetsWritten;
 
   @override
-  Future writeAsBytes(AssetId id, FutureOr<List<int>> bytes) {
+  Future writeAsBytes(AssetId id, List<int> bytes) {
     _assetsWritten.add(id);
     return _delegate.writeAsBytes(id, bytes);
   }
 
   @override
-  Future writeAsString(AssetId id, FutureOr<String> contents, {Encoding encoding: UTF8}) {
+  Future writeAsString(AssetId id, String contents, {Encoding encoding: UTF8}) {
     _assetsWritten.add(id);
     return _delegate.writeAsString(id, contents, encoding: encoding);
   }

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -85,15 +85,27 @@ class BuildStepImpl implements BuildStep {
   @override
   Future writeAsBytes(AssetId id, FutureOr<List<int>> bytes) {
     _checkOutput(id);
-    var done = _writer.writeAsBytes(id, bytes);
+    Future done;
+    if (bytes is Future<List<int>>) {
+      done = bytes.then((b) => _writer.writeAsBytes(id, b));
+    } else {
+      done = _writer.writeAsBytes(id, bytes);
+    }
     _outputsCompleted = _outputsCompleted.then((_) => done);
     return done;
   }
 
   @override
-  Future writeAsString(AssetId id, FutureOr<String> content, {Encoding encoding: UTF8}) {
+  Future writeAsString(AssetId id, FutureOr<String> content,
+      {Encoding encoding: UTF8}) {
     _checkOutput(id);
-    var done = _writer.writeAsString(id, content, encoding: encoding);
+    Future done;
+    if (content is Future<String>) {
+      done =
+          content.then((c) => _writer.writeAsString(id, c, encoding: encoding));
+    } else {
+      done = _writer.writeAsString(id, content, encoding: encoding);
+    }
     _outputsCompleted = _outputsCompleted.then((_) => done);
     return done;
   }

--- a/build_test/lib/src/in_memory_writer.dart
+++ b/build_test/lib/src/in_memory_writer.dart
@@ -17,15 +17,15 @@ class InMemoryAssetWriter implements RecordingAssetWriter {
   InMemoryAssetWriter();
 
   @override
-  Future writeAsBytes(AssetId id, FutureOr<List<int>> bytes,
+  Future writeAsBytes(AssetId id, List<int> bytes,
       {Encoding encoding: UTF8, DateTime lastModified}) async {
-    assets[id] = new DatedBytes(await bytes, lastModified);
+    assets[id] = new DatedBytes(bytes, lastModified);
   }
 
   @override
-  Future writeAsString(AssetId id, FutureOr<String> contents,
+  Future writeAsString(AssetId id, String contents,
       {Encoding encoding: UTF8, DateTime lastModified}) async {
-    assets[id] = new DatedString(await contents, lastModified);
+    assets[id] = new DatedString(contents, lastModified);
   }
 }
 


### PR DESCRIPTION
Since AssetWriter is mainly used internally there is not as much value
in expanding it's interface, and a much higher cost.