### PR TITLE
Remove outputPackage from copyBuilder

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 
 dev_dependencies:
   build_barback: ^0.1.0
-  build_test: ^0.5.0
+  build_test: ^0.6.0
   test: ^0.12.0
   transformer_test: ^0.2.0
 

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   logging: ^0.11.2
 
 dev_dependencies:
-  build_test: ^0.5.3
+  build_test: ^0.6.0
   test: ^0.12.0
   transformer_test: ^0.2.0
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 0.5.3-dev
+## 0.6.0-dev
 
 - Support build 0.9.0
-  - Rename hasInput to canRead in AssetReader implementations
+  - Rename `hasInput` to `canRead` in `AssetReader` implementations
+  - Replace `declareOutputs` with `buildExtensions` in `Builder` implementations
+- *Breaking* `CopyBuilder` no longer has an `outputPackage` field since outputs
+  can only ever be in the same package as inputs.
 
 ## 0.5.2
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Support build 0.9.0
   - Rename `hasInput` to `canRead` in `AssetReader` implementations
   - Replace `declareOutputs` with `buildExtensions` in `Builder` implementations
-- *Breaking* `CopyBuilder` no longer has an `outputPackage` field since outputs
+- **Breaking** `CopyBuilder` no longer has an `outputPackage` field since outputs
   can only ever be in the same package as inputs.
 
 ## 0.5.2

--- a/build_test/lib/src/copy_builder.dart
+++ b/build_test/lib/src/copy_builder.dart
@@ -6,15 +6,12 @@ import 'dart:async';
 import 'package:build/build.dart';
 
 class CopyBuilder implements Builder {
-  /// If > 0, then multiple copies will be output, using the copy number as an
+  /// If > 1, then multiple copies will be output, using the copy number as an
   /// additional extension.
   final int numCopies;
 
   /// The file extension to add to files.
   final String extension;
-
-  /// The package in which to output files.
-  final String outputPackage;
 
   /// Copies content from this asset into all files, instead of the primary
   /// asset.
@@ -30,7 +27,6 @@ class CopyBuilder implements Builder {
   CopyBuilder(
       {this.numCopies: 1,
       this.extension: 'copy',
-      this.outputPackage,
       this.copyFromAsset,
       this.touchAsset,
       this.blockUntil});
@@ -59,13 +55,8 @@ class CopyBuilder implements Builder {
     return {'': outputs};
   }
 
-  AssetId _copiedAssetId(AssetId inputId, int copyNum) {
-    var withExtension = inputId.addExtension(_copiedAssetExtension(copyNum));
-    if (outputPackage == null) {
-      return withExtension;
-    }
-    return new AssetId(outputPackage, withExtension.path);
-  }
+  AssetId _copiedAssetId(AssetId inputId, int copyNum) =>
+      inputId.addExtension(_copiedAssetExtension(copyNum));
 
   String _copiedAssetExtension(int copyNum) =>
       '.$extension${numCopies == 1 ? '' : '.$copyNum'}';

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,12 +1,15 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.5.3-dev
+version: 0.6.0-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
+environment:
+  sdk: ">=1.22.1 <2.0.0"
+
 dependencies:
   build: ^0.9.0
-  build_barback: ^0.1.0
+  build_barback: ^0.2.0
   collection: ^1.14.0
   glob: ^1.1.0
   logging: ^0.11.2
@@ -18,9 +21,8 @@ dependencies:
 dev_dependencies:
   analyzer: ">=0.27.1 <0.30.0"
 
-environment:
-  sdk: ">=1.8.0 <2.0.0"
-
 dependency_overrides:
   build:
     path: ../build
+  build_barback:
+    path: ../build_barback


### PR DESCRIPTION
This property doesn't work anymore.

- Fix up changelog with some already changed details
- Bump to 0.6.0 since this is a breaking change