### PR TITLE
Upgrade build_runner to build 0.9.0

### DIFF
--- a/build_runner/lib/src/asset/file_based.dart
+++ b/build_runner/lib/src/asset/file_based.dart
@@ -23,9 +23,7 @@ class FileBasedAssetReader implements RunnerAssetReader {
       {this.ignoredDirs: const ['build', 'packages', '.pub']});
 
   @override
-  Future<bool> hasInput(AssetId id) async {
-    return _fileFor(id, packageGraph).exists();
-  }
+  FutureOr<bool> canRead(AssetId id) => _fileFor(id, packageGraph).exists();
 
   @override
   Future<List<int>> readAsBytes(AssetId id) async =>

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -14,8 +14,6 @@ abstract class RunnerAssetReader extends AssetReader {
   Future<DateTime> lastModified(AssetId id);
 }
 
-final _asyncFalse = new Future.value(false);
-
 /// An [AssetReader] with a lifetime equivalent to that of a single Phase in a
 /// build.
 ///
@@ -39,10 +37,10 @@ class SinglePhaseReader implements AssetReader {
   }
 
   @override
-  Future<bool> hasInput(AssetId id) {
-    if (!_isReadable(id)) return _asyncFalse;
+  FutureOr<bool> canRead(AssetId id) {
+    if (!_isReadable(id)) return false;
     _assetsRead.add(id);
-    return _delegate.hasInput(id);
+    return _delegate.canRead(id);
   }
 
   @override

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,15 +1,15 @@
 name: build_runner
-version: 0.3.1+1
+version: 0.3.2-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 environment:
-  sdk: '>=1.9.1 <2.0.0'
+  sdk: '>=1.22.1 <2.0.0'
 
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"
-  build: ^0.8.0
+  build: ^0.9.0
   build_barback: ^0.1.0
   crypto: ">=0.9.2 <3.0.0"
   logging: ^0.11.2
@@ -22,5 +22,11 @@ dependencies:
   yaml: ^2.1.0
 
 dev_dependencies:
-  build_test: ^0.5.0
+  build_test: ^0.6.0
   test: ^0.12.0
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_test:
+    path: ../build_test

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.27.1 <0.30.0"
   build: ^0.9.0
-  build_barback: ^0.1.0
+  build_barback: ^0.2.0
   crypto: ">=0.9.2 <3.0.0"
   logging: ^0.11.2
   glob: ^1.1.0
@@ -30,3 +30,5 @@ dependency_overrides:
     path: ../build
   build_test:
     path: ../build_test
+  build_barback:
+    path: ../build_barback

--- a/build_runner/test/asset/file_based_test.dart
+++ b/build_runner/test/asset/file_based_test.dart
@@ -35,21 +35,21 @@ void main() {
     });
 
     test('can check for existence of any application package files', () async {
-      expect(await reader.hasInput(makeAssetId('basic_pkg|hello.txt')), isTrue);
-      expect(await reader.hasInput(makeAssetId('basic_pkg|lib/hello.txt')),
+      expect(await reader.canRead(makeAssetId('basic_pkg|hello.txt')), isTrue);
+      expect(await reader.canRead(makeAssetId('basic_pkg|lib/hello.txt')),
           isTrue);
-      expect(await reader.hasInput(makeAssetId('basic_pkg|web/hello.txt')),
+      expect(await reader.canRead(makeAssetId('basic_pkg|web/hello.txt')),
           isTrue);
 
-      expect(await reader.hasInput(makeAssetId('basic_pkg|a.txt')), isFalse);
+      expect(await reader.canRead(makeAssetId('basic_pkg|a.txt')), isFalse);
       expect(
-          await reader.hasInput(makeAssetId('basic_pkg|lib/a.txt')), isFalse);
+          await reader.canRead(makeAssetId('basic_pkg|lib/a.txt')), isFalse);
     });
 
     test('can check for existence of package dependency files in lib',
         () async {
-      expect(await reader.hasInput(makeAssetId('a|lib/a.txt')), isTrue);
-      expect(await reader.hasInput(makeAssetId('a|lib/b.txt')), isFalse);
+      expect(await reader.canRead(makeAssetId('a|lib/a.txt')), isTrue);
+      expect(await reader.canRead(makeAssetId('a|lib/b.txt')), isFalse);
     });
 
     test('throws when attempting to read a non-existent file', () async {

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -103,51 +103,12 @@ void main() {
       });
     });
 
-    group('inputs from other packages', () {
-      test('only gets inputs from lib, can output to root package', () async {
-        var phases = new PhaseGroup.singleAction(
-            new CopyBuilder(outputPackage: 'a'), new InputSet('b', ['**/*']));
+    test('can\'t output files in non-root packages', () async {
+      var phases = new PhaseGroup.singleAction(
+          new CopyBuilder(), new InputSet('b', ['**/*']));
 
-        await testPhases(phases, {'b|web/b.txt': 'b', 'b|lib/b.txt': 'b'},
-            outputs: {'a|lib/b.txt.copy': 'b'});
-      });
-
-      test('can\'t output files in non-root packages', () async {
-        var phases = new PhaseGroup.singleAction(
-            new CopyBuilder(), new InputSet('b', ['**/*']));
-
-        await testPhases(phases, {'b|lib/b.txt': 'b'},
-            outputs: {}, status: BuildStatus.failure);
-      });
-    });
-
-    test('multiple phases, inputs from multiple packages', () async {
-      var phases = new PhaseGroup();
-      phases.newPhase()
-        ..addAction(new CopyBuilder(), aFiles)
-        ..addAction(new CopyBuilder(extension: 'clone', outputPackage: 'a'),
-            new InputSet('b', ['**/*.txt']));
-      var twoCopyBuilder = new CopyBuilder(numCopies: 2, outputPackage: 'a');
-      phases.newPhase()
-        ..addAction(twoCopyBuilder, new InputSet('a', ['lib/*.txt.*']))
-        ..addAction(twoCopyBuilder, new InputSet('b', ['**/*.dart']));
-
-      await testPhases(phases, {
-        'a|web/1.txt': '1',
-        'a|lib/2.txt': '2',
-        'b|lib/3.txt': '3',
-        'b|lib/b.dart': 'main() {}',
-      }, outputs: {
-        'a|web/1.txt.copy': '1',
-        'a|lib/2.txt.copy': '2',
-        'a|lib/3.txt.clone': '3',
-        'a|lib/2.txt.copy.copy.0': '2',
-        'a|lib/2.txt.copy.copy.1': '2',
-        'a|lib/3.txt.clone.copy.0': '3',
-        'a|lib/3.txt.clone.copy.1': '3',
-        'a|lib/b.dart.copy.0': 'main() {}',
-        'a|lib/b.dart.copy.1': 'main() {}',
-      });
+      await testPhases(phases, {'b|lib/b.txt': 'b'},
+          outputs: {}, status: BuildStatus.failure);
     });
   });
 


### PR DESCRIPTION
- Update reader implementations to `canRead`
- Drop _asyncFalse since we can return a synchronous value
- Use expectedOutputs rather than declareOutputs
- Update dependencies
- Drop the test expecting to be able to use other package sources as
  inputs and write to the root package

Clean up:
- Make some triple slash comments double slash