### PR TITLE
Skip Builders which would produce no outputs

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1-dev
+
+- Skip Builders which would produce no outputs.
+
 ## 0.9.0
 
 - Deprecate `BuildStep.hasInput` in favor of `BuildStep.canRead`.

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -27,8 +27,10 @@ Future<Null> runBuilder(Builder builder, Iterable<AssetId> inputs,
   rootPackage ??= new Set.from(inputs.map((input) => input.package)).single;
   //TODO(nbosch) check overlapping outputs?
   Future<Null> buildForInput(AssetId input) async {
-    var buildStep = new BuildStepImpl(input, expectedOutputs(builder, input),
-        reader, writer, rootPackage, resolvers);
+    var outputs = expectedOutputs(builder, input);
+    if (outputs.isEmpty) return;
+    var buildStep = new BuildStepImpl(
+        input, outputs, reader, writer, rootPackage, resolvers);
     try {
       await builder.build(buildStep);
     } finally {

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.9.0
+version: 0.9.1-dev
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_barback/test/analyzer/resolver_test.dart
+++ b/build_barback/test/analyzer/resolver_test.dart
@@ -303,7 +303,7 @@ class TestBuilder extends Builder {
   TestBuilder(this.validator);
 
   @override
-  final buildExtensions = const {'': const []};
+  final buildExtensions = const {'': const ['.unused']};
 
   @override
   Future build(BuildStep buildStep) async {

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.1-dev
 
-- Declare an output extension in `_ResolveSurceBuilder` so it is not skipped
+- Declare an output extension in `_ResolveSourceBuilder` so it is not skipped
 
 ## 0.6.0
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1-dev
+
+- Declare an output extension in `_ResolveSurceBuilder` so it is not skipped
+
 ## 0.6.0
 
 - Support build 0.9.0

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -98,5 +98,7 @@ class _ResolveSourceBuilder implements Builder {
   }
 
   @override
-  Map<String, List<String>> get buildExtensions => const {'': const []};
+  final buildExtensions = const {
+    '': const ['.unused']
+  };
 }

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.6.0
+version: 0.6.1-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 


### PR DESCRIPTION
Update some test builders with no declared output extensions.