### PR TITLE
Extract method in build_impl

### DIFF
--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -120,10 +120,6 @@ class WatchImpl {
       // Don't schedule more builds if we are turning down.
       if (_terminating) return;
 
-      // Any updates after this point should cause updates to the [AssetGraph]
-      // for later builds.
-      var validAsOf = new DateTime.now();
-
       _expectedDeletes.clear();
       if (updatedInputs.isEmpty && !force) {
         return;
@@ -131,7 +127,7 @@ class WatchImpl {
 
       _logger.info('Starting next build');
       _currentBuild =
-          _buildImpl.runBuild(validAsOf: validAsOf, updates: updatedInputs);
+          _buildImpl.runBuild(updates: updatedInputs);
       _currentBuild.then((result) {
         // Terminate the watcher if the build script is updated, there is no
         // need to continue listening.


### PR DESCRIPTION
Small refactor in build_impl for shorter methods.

- Drop validAsOf argument. It is only passed in one place, and there it
  uses the default value of `now`
- Pull out building in _safeBuild which uses the error handling zone.
  Since this method is not async it is does not have an unawaited future
- Changes some triple-slash non-doc comments to double slash