### PR TITLE
Add support for `asset:` URI to AssetId

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.3
+
+- Add support for resolving `asset:` URIs into AssetIds
+- Add `uri` property on AssetId
+
 ## 0.9.1
 
 - Skip Builders which would produce no outputs.

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.9.2
+version: 0.9.3
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build/test/asset/id_test.dart
+++ b/build/test/asset/id_test.dart
@@ -61,6 +61,11 @@ void main() {
       expect(id, new AssetId("app", "lib/src/some/path.dart"));
     });
 
+    test("should parse an asset: URI", () {
+      var id = new AssetId.resolve(r"asset:app/test/foo_test.dart");
+      expect(id, new AssetId("app", "test/foo_test.dart"));
+    });
+
     test("should throw for a file: URI", () {
       expect(() => new AssetId.resolve(r"file://localhost/etc/fstab1"),
           throwsUnsupportedError);


### PR DESCRIPTION
Closes #287

Since build tools may end up seeing `asset:` URIs from _bazel_codegen,
make them a fully supported scheme.

- Add support for parsting `asset:` uris in `resolve`.
- Add a `uri` property to create a canonical URI which could be
  resolved.