### PR TITLE
Make BuilderTransformer an AggregateTransformer

### DIFF
--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0-dev
+
+- **Breaking** `BuilderTransformer` is now an `AggregateTransformer`. This
+  should be transparent for most use cases but could have errors if an instance
+  was assigned to a variable of type `Transformer`.
+
 ## 0.2.0
 
 - Update to build 0.9.0

--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -3,6 +3,8 @@
 - **Breaking** `BuilderTransformer` is now an `AggregateTransformer`. This
   should be transparent for most use cases but could have errors if an instance
   was assigned to a variable of type `Transformer`.
+- **Breaking** `BuilderTransformer` no longer accepts a `Resolvers` instance,
+  instead it will create and manage Resolvers on its own.
 
 ## 0.2.0
 

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -19,3 +19,7 @@ dev_dependencies:
   build_test: ^0.6.0
   test: ^0.12.0
   transformer_test: ^0.2.1
+
+dependency_overrides:
+  build_test:
+    path: ../build_test

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_barback
-version: 0.2.2
+version: 0.3.0-dev
 description: Utilities for translating between builders and transformers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   build_test: ^0.6.0
   test: ^0.12.0
-  transformer_test: ^0.2.0
+  transformer_test: ^0.2.1

--- a/build_barback/test/transformer/transformer_test.dart
+++ b/build_barback/test/transformer/transformer_test.dart
@@ -111,7 +111,7 @@ void main() {
         [singleCopyTransformer],
       ],
       {'a|web/a.txt': 'hello'},
-      {'a|web/a.txt.copy': 'hello'},
+      {},
       messages: [
         _fileExistsError('${new CopyBuilder()}', ['a|web/a.txt.copy']),
       ],


### PR DESCRIPTION
This is the first step towards being able to implement a more
performant Resolvers which can refresh sources per package rather than
per BuildStep.

- Switch to Aggregate versions of Transformer and Transform
- Build results for all inputs in parallel with Future.wait
- Drop the expectation for an output in a test - the output is getting
  added to the AggregateTransform but some quirk in barback or
  transformer_test is causing it to show up as missing