### PR TITLE
EARLY FEEDBACK: New Resolvers implementation for barback

### DIFF
--- a/build_barback/lib/src/transformer/crawl_imports.dart
+++ b/build_barback/lib/src/transformer/crawl_imports.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+import 'package:analyzer/analyzer.dart' show parseDirectives;
+import 'package:analyzer/src/generated/engine.dart' show TimestampedData;
+import 'package:analyzer/src/generated/source.dart';
+import 'package:build/build.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:analyzer/dart/ast/ast.dart';
+
+/// Crawl Dart files outside of the SDK transitively imported from any library
+/// in [entryPoints] and cache it as a [Source].
+Future<Map<Uri, Source>> crawlImports(
+    Iterable<AssetId> entryPoints, Future<String> read(AssetId id)) async {
+  var roots = entryPoints.where((id) => id.path.endsWith('.dart'));
+  var assets = await _crawlAsync(roots, read, _assetImports);
+  var results = <Uri, Source>{};
+  for (var asset in assets.keys) {
+    results[asset.uri] = _toSource(asset, assets[asset]);
+  }
+  return results;
+}
+
+Iterable<AssetId> _assetImports(AssetId id, String source) {
+  var unit = parseDirectives(source);
+  return unit.directives
+      .where((d) => d is UriBasedDirective)
+      .map((d) => d as UriBasedDirective)
+      .map((d) => d.uri.stringValue)
+      .where((uri) => !uri.startsWith('dart:'))
+      .map((uri) => new AssetId.resolve(uri, from: id));
+}
+
+Source _toSource(AssetId id, String content) => new AssetSource(id, content);
+
+/// Crawl a graph where node values and edges are resolved asynchronously.
+///
+/// Nodes are keyed by type [K] and have values of type [V]. [resolve] finds the
+/// value for a node. [edges] finds the edges leaving a node.
+Future<Map<K, V>> _crawlAsync<K, V>(
+    Iterable<K> roots,
+    FutureOr<V> resolve(K key),
+    FutureOr<Iterable<K>> edges(K key, V value)) async {
+  var seen = <K, Future<V>>{};
+  await Future.wait(roots.map((k) => _visitNode(k, seen, resolve, edges)));
+  var results = <K, V>{};
+  for (var k in seen.keys) {
+    results[k] = await seen[k];
+  }
+  return results;
+}
+
+/// Synchronously record the the node a [key] has been seen, then start the
+/// work.
+///
+/// The returned Future will complete when the node at [key], and transitively
+/// reachable nodes, have either finished their crawl or are guaranteed to be
+/// completed within another future in [seen].
+Future _visitNode<K, V>(K key, Map<K, Future<V>> seen,
+    FutureOr<V> resolve(K key), FutureOr<Iterable<K>> edges(K key, V value)) {
+  if (seen.containsKey(key)) return new Future.value(null);
+  return seen[key] = _crawlFromNode(key, seen, resolve, edges);
+}
+
+/// Resolve the node at [key] and visit all transitively reachable nodes.
+Future<V> _crawlFromNode<K, V>(
+    K key,
+    Map<K, Future<V>> seen,
+    FutureOr<V> resolve(K key),
+    FutureOr<Iterable<K>> edges(K key, V value)) async {
+  var value = await resolve(key);
+  var next = await edges(key, value) ?? [];
+  await Future.wait(next.map((k) => _visitNode(k, seen, resolve, edges)));
+  return value;
+}
+
+class AssetSource implements Source {
+  final AssetId _assetId;
+  final String _content;
+
+  AssetSource(this._assetId, this._content);
+
+  @override
+  TimestampedData<String> get contents => new TimestampedData(0, _content);
+
+  @override
+  String get encoding => '$_assetId';
+
+  @override
+  String get fullName => '$_assetId';
+
+  @override
+  int get hashCode => _assetId.hashCode;
+
+  @override
+  bool get isInSystemLibrary => false;
+
+  @override
+  Source get librarySource => null;
+
+  @override
+  int get modificationStamp => 0;
+
+  @override
+  String get shortName => p.basename(_assetId.path);
+
+  @override
+  Source get source => this;
+
+  @override
+  Uri get uri => _assetId.uri;
+
+  @override
+  UriKind get uriKind {
+    if (_assetId.path.startsWith('lib/')) return UriKind.PACKAGE_URI;
+    return UriKind.FILE_URI;
+  }
+
+  @override
+  bool operator ==(Object object) =>
+      object is AssetSource && object._assetId == _assetId;
+
+  @override
+  bool exists() => true;
+
+  @override
+  String toString() => 'AssetSource[$_assetId]';
+}

--- a/build_barback/lib/src/transformer/resolvers.dart
+++ b/build_barback/lib/src/transformer/resolvers.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/generated/engine.dart';
+import 'package:analyzer/src/generated/source.dart';
+import 'package:build/build.dart';
+import 'package:analyzer/file_system/physical_file_system.dart';
+import 'package:analyzer/src/dart/sdk/sdk.dart';
+import 'package:cli_util/cli_util.dart' as cli_util;
+
+import 'crawl_imports.dart';
+
+typedef FutureOr<String> Read(AssetId assetId);
+
+class SinglePassResolvers implements Resolvers {
+  final Iterable<AssetId> _entryPoints;
+  final Read _read;
+
+  SinglePassResolvers(this._entryPoints, this._read);
+
+  Future<ReleasableResolver> _resolver;
+  @override
+  Future<ReleasableResolver> get([_]) =>
+      _resolver ??= _createResolver(_entryPoints, _read);
+}
+
+Future<ReleasableResolver> _createResolver(Iterable<AssetId> entryPoints,
+        FutureOr<String> read(AssetId assetId)) async =>
+    new AnalysisResolver(
+        await _createAnalysisContext(entryPoints, read), entryPoints);
+
+Future<AnalysisContext> _createAnalysisContext(Iterable<AssetId> entryPoints,
+    FutureOr<String> read(AssetId assetId)) async {
+  var assetResolver =
+      new _BuildAssetUriResolver(await crawlImports(entryPoints, read));
+
+  var options = new AnalysisOptionsImpl()
+    ..preserveComments = false
+    ..analyzeFunctionBodies = true;
+  var sdk = new FolderBasedDartSdk(PhysicalResourceProvider.INSTANCE,
+      PhysicalResourceProvider.INSTANCE.getFolder(cli_util.getSdkDir().path));
+  var dartUriResolver = new DartUriResolver(sdk);
+  var context = AnalysisEngine.instance.createAnalysisContext()
+    ..analysisOptions = options
+    ..sourceFactory = new SourceFactory([dartUriResolver, assetResolver]);
+  return context;
+}
+
+/// A [UriResolver] which can read build assets by reading them as strings.
+///
+/// Will only read each asset once. This resolver does not handle cases where
+/// assets may change during a build process.
+class _BuildAssetUriResolver implements UriResolver {
+  final Map<Uri, Source> _knownAssets;
+
+  _BuildAssetUriResolver(this._knownAssets);
+
+  @override
+  Source resolveAbsolute(Uri uri, [Uri actualUri]) => _knownAssets[uri];
+
+  @override
+  Uri restoreAbsolute(Source source) {
+    throw new UnimplementedError();
+  }
+}
+
+/// a [Resolver] backed by an [AnalysisContext].
+class AnalysisResolver implements ReleasableResolver {
+  final AnalysisContext _analysisContext;
+  final List<AssetId> _assetIds;
+
+  AnalysisResolver(this._analysisContext, this._assetIds);
+
+  @override
+  void release() => _analysisContext.dispose();
+
+  @override
+  bool isLibrary(AssetId assetId) {
+    var uri = assetId.uri;
+    var source = _analysisContext.sourceFactory.forUri2(uri);
+    return source != null &&
+        _analysisContext.computeKindOf(source) == SourceKind.LIBRARY;
+  }
+
+  @override
+  LibraryElement getLibrary(AssetId assetId) {
+    var uri = assetId.uri;
+    var source = _analysisContext.sourceFactory.forUri2(uri);
+    if (source == null) throw 'missing source for $uri';
+    var kind = _analysisContext.computeKindOf(source);
+    if (kind != SourceKind.LIBRARY) return null;
+    var library = _analysisContext.computeLibraryElement(source);
+    if (library == null) throw 'Could not resolve $assetId';
+    return library;
+  }
+
+  @override
+  List<LibraryElement> get libraries {
+    var allLibraries = new Set<LibraryElement>();
+    var uncheckedLibraries = new Queue<LibraryElement>();
+    uncheckedLibraries.addAll(_assetIds.map(getLibrary));
+    while (uncheckedLibraries.isNotEmpty) {
+      var library = uncheckedLibraries.removeFirst();
+      allLibraries.add(library);
+      uncheckedLibraries.addAll(library.importedLibraries
+          .where((library) => !allLibraries.contains(library)));
+    }
+    return allLibraries.toList();
+  }
+
+  @override
+  LibraryElement getLibraryByName(String name) =>
+      libraries.firstWhere((library) => library.name == name, orElse: null);
+}


### PR DESCRIPTION
This implementation assumes that inputs won't change during the lifetime
of the Resolvers instance, so we crawl the import graph once per
aggregate transformer rather than once per BuildStep.

Sending for early feedback, this needs further manual testing.