### PR TITLE
Fix for top-level inference warning.

### DIFF
--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -203,7 +203,8 @@ void main() {
 }
 
 class SlowAssetWriter implements AssetWriter {
-  final _writeCompleter = new Completer();
+  final _writeCompleter = new Completer<Null>();
+  
   void finishWrite() {
     _writeCompleter.complete(null);
   }


### PR DESCRIPTION
(This warning starts appearing in `1.25.0`, but just getting ahead of it)