### PR TITLE
Add resolveAsset.

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.3
 
-- Added `resolveAsset`, which is similar to `resolveSource` but specified a
+- Added `resolveAsset`, which is similar to `resolveSource` but specifies a
   real asset that lives on the file system. For example, to resolve the main
   library of `package:collection`:
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.6.3
+
+- Added `resolveAsset`, which is similar to `resolveSource` but specified a
+  real asset that lives on the file system. For example, to resolve the main
+  library of `package:collection`:
+
+```dart
+var pkgCollection = new AssetId('collection', 'lib/collection.dart');
+var resolver = await resolveAsset(pkgCollection);
+// ...
+```
+
+## 0.6.2
+
+- Internal version bump.
+
 ## 0.6.1
 
 - Declare an output extension in `_ResolveSourceBuilder` so it is not skipped

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -50,21 +50,66 @@ import 'package_reader.dart';
 /// - by default, [PackageAssetReader.currentIsolate]. A custom [resolver] may
 /// be provided to map files not visible to the current package's runtime.
 Future<Resolver> resolveSource(String inputSource,
-    {AssetId inputId, PackageResolver resolver, Future<Null> tearDown}) async {
-  // If not provided use a fake asset and package.
-  inputId ??= new AssetId('_resolve_source', '_resolve_source.dart');
+        {AssetId inputId, PackageResolver resolver, Future<Null> tearDown}) =>
+    _resolveAsset(
+        inputId ?? new AssetId('_resolver_source', 'lib/_resolve_source.dart'),
+        inputContents: inputSource,
+        resolver: resolver,
+        tearDown: tearDown);
+
+/// Returns a future that completes with a source [Resolver] for [input].
+///
+/// Example use:
+/// ```dart
+/// var pkgBuildTest = new AssetId('build_test', 'lib/build_test.dart');
+/// var resolver = await resolveSource(pkgBuildTest);
+/// ```
+///
+/// By default, the returned [Resolver] is destroyed after the event loop is
+/// completed. In order to control the lifecycle, pass a [Completer] and
+/// complete it turning the `tearDown` phase of testing:
+/// ```dart
+/// Completer<Null> onTearDown;
+///
+/// setUp(() {
+///   onTearDown = new Completer<Null>();
+/// });
+///
+/// tearDown(() => onTearDown.complete());
+///
+/// test('...', () async {
+///   var resolver = await resolveAsset('...', tearDown: onTearDown.future);
+///   // Use resolver.
+/// });
+/// ```
+///
+/// **NOTE**: All `package` dependencies are resolved using [PackageAssetReader]
+/// - by default, [PackageAssetReader.currentIsolate]. A custom [resolver] may
+/// be provided to map files not visible to the current package's runtime.
+Future<Resolver> resolveAsset(AssetId input,
+        {PackageResolver resolver, Future<Null> tearDown}) =>
+    _resolveAsset(input, resolver: resolver, tearDown: tearDown);
+
+/// Internal only backing implementation of `resolveAsset` and `resolveSource`.
+///
+/// If [inputContents] is non-null, it is used instead of reading [input] from
+/// the file system.
+Future<Resolver> _resolveAsset(AssetId input,
+    {String inputContents,
+    PackageResolver resolver,
+    Future<Null> tearDown}) async {
   resolver ??= PackageResolver.current;
   tearDown ??= new Future.delayed(Duration.ZERO);
   var syncResolver = await resolver.asSync;
-  var reader = new PackageAssetReader(syncResolver, inputId.package);
+  var reader = new PackageAssetReader(syncResolver, input.package);
   var completer = new Completer<Resolver>();
   var builder = new _ResolveSourceBuilder(completer, tearDown);
-  var inputs = [inputId];
+  var inputs = [input];
   var inMemory = new InMemoryAssetReader(
     sourceAssets: {
-      inputId: new DatedString(inputSource),
+      input: new DatedString(inputContents ?? await reader.readAsString(input)),
     },
-    rootPackage: inputId.package,
+    rootPackage: input.package,
   );
   // We don't care about the results of this build.
   // ignore: unawaited_futures
@@ -74,7 +119,7 @@ Future<Resolver> resolveSource(String inputSource,
     new MultiAssetReader([inMemory, reader]),
     new InMemoryAssetWriter(),
     const BarbackResolvers(),
-    rootPackage: inputId.package,
+    rootPackage: input.package,
   );
   return completer.future;
 }

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.6.2
+version: 0.6.3-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 

--- a/build_test/test/_files/example_lib.dart
+++ b/build_test/test/_files/example_lib.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library example_lib;
+
+class Example {}

--- a/build_test/test/resolve_source_test.dart
+++ b/build_test/test/resolve_source_test.dart
@@ -53,6 +53,17 @@ void main() {
       );
     });
   });
+
+  group('should resolveAsset', () {
+    Resolver resolver;
+
+    test('asset:build_test/test/_files/example_lib.dart', () async {
+      var asset = new AssetId('build_test', 'test/_files/example_lib.dart');
+      resolver = await resolveAsset(asset);
+      var libExample = resolver.getLibraryByName('example_lib');
+      expect(libExample.getType('Example'), isNotNull);
+    });
+  });
 }
 
 String _toStringId(InterfaceType t) =>


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/297.

Internally both `resolveAsset` and `resolveSource` use `_resolveAsset`, with the only difference that `resolveSource` specifies a string to use as the "source code" of the input asset, while `resolveAsset` reads the file from disk using the `resolver` class.

/cc @kevmoo and @natebosch for FYI.