### PR TITLE
Prepare to publish build_test.

### DIFF
--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-dev
+## 0.3.0
 
 - **Breaking** `BuilderTransformer` is now an `AggregateTransformer`. This
   should be transparent for most use cases but could have errors if an instance

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_barback
-version: 0.3.0-dev
+version: 0.3.0
 description: Utilities for translating between builders and transformers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -10,6 +10,8 @@ var resolver = await resolveAsset(pkgCollection);
 // ...
 ```
 
+- Supports `package:build_barback >=0.2.0 <0.4.0`.
+
 ## 0.6.2
 
 - Internal version bump.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.6.3-dev
+version: 0.6.3
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   build: ^0.9.0
-  build_barback: ^0.2.0
+  build_barback: ">=0.2.0 <0.4.0"
   collection: ^1.14.0
   glob: ^1.1.0
   logging: ^0.11.2


### PR DESCRIPTION
Needed to publish `build_barback` which is needed for AngularDart 4.x.

/cc @natebosch 