### PR TITLE
Move some graph manipulation into asset_graph.dart

### DIFF
--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -107,8 +107,9 @@ class AssetGraph {
         clearNodeAndDeps(output, rootChangeType, parent: node.id);
       }
 
-      // For deletes, prune the graph.
       if (parent == null && rootChangeType == ChangeType.REMOVE) {
+        // This is the root asset, it was removed on disk so it needs to be
+        // removed from the graph.
         remove(id);
       }
       if (node is GeneratedAssetNode) {

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'package:build/build.dart';
 
-/// A node in the asset graph which may be inputs to other assets.
+/// A node in the asset graph which may be an input to other assets.
 class AssetNode {
   final AssetId id;
 

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -3,11 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'package:build/build.dart';
 
-/// A node in the asset graph.
-///
-/// This class specifically represents normal (ie: non-generated) assets.
+/// A node in the asset graph which may be inputs to other assets.
 class AssetNode {
-  /// The asset this node represents.
   final AssetId id;
 
   /// The [AssetId]s of all generated assets which depend on this node.
@@ -16,7 +13,7 @@ class AssetNode {
   AssetNode(this.id);
 
   factory AssetNode.deserialize(List serializedNode) {
-    var node;
+    AssetNode node;
     if (serializedNode.length == 2) {
       node = new AssetNode(new AssetId.deserialize(serializedNode[0]));
     } else if (serializedNode.length == 5) {


### PR DESCRIPTION
Centralizing the logic will make it easier to see how it is used and
update it. This covers most use cases for writing the `needsUpdate`
field - the remaining case is setting it to false after building an
ouptut.

Also clean up some Doc comments