### PR TITLE
Track primary outputs explicitly

### DIFF
--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -28,7 +28,7 @@ class AssetGraph {
   ///
   /// This should be incremented any time the serialize/deserialize methods
   /// change on this class or [AssetNode].
-  static int get _version => 3;
+  static int get _version => 4;
 
   /// Deserializes this graph.
   factory AssetGraph.deserialize(Map serializedGraph) {

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -494,6 +494,7 @@ class BuildImpl {
           _assetGraph.addIfAbsent(input, () => new AssetNode(input));
       for (var output in builderOutputs) {
         inputNode.outputs.add(output);
+        inputNode.primaryOutputs.add(output);
         var existing = _assetGraph.get(output);
 
         // If its null or of type AssetNode, then insert a

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -90,6 +90,7 @@ void main() {
           var generatedNode = new GeneratedAssetNode(
               1, node.id, false, g % 2 == 0, makeAssetId());
           node.outputs.add(generatedNode.id);
+          node.primaryOutputs.add(generatedNode.id);
           graph.add(generatedNode);
         }
       }

--- a/build_runner/test/common/assets.dart
+++ b/build_runner/test/common/assets.dart
@@ -7,6 +7,9 @@ import 'package:build_test/build_test.dart';
 
 AssetNode makeAssetNode([String assetIdString, List<AssetId> outputs]) {
   var node = new AssetNode(makeAssetId(assetIdString));
-  if (outputs != null) node.outputs.addAll(outputs);
+  if (outputs != null) {
+    node.outputs.addAll(outputs);
+    node.primaryOutputs.addAll(outputs);
+  }
   return node;
 }

--- a/build_runner/test/common/matchers.dart
+++ b/build_runner/test/common/matchers.dart
@@ -34,6 +34,10 @@ class _AssetGraphMatcher extends Matcher {
       if (!unorderedEquals(node.outputs).matches(expectedNode.outputs, null)) {
         return false;
       }
+      if (!unorderedEquals(node.primaryOutputs)
+          .matches(expectedNode.primaryOutputs, null)) {
+        return false;
+      }
       if (item is GeneratedAssetNode) {
         if (expectedNode is GeneratedAssetNode) {
           if (item.primaryInput != expectedNode.primaryInput) return false;


### PR DESCRIPTION
`outputs` is a mix of primary and non-primary outputs which may be
impacted by the asset. Add `primaryOutputs` to track explicitly the
files which may be generated for an input.

- Add primaryOutputs field and append when we run a Builder
- Update serialization and deserialization to pick up outputs
- Bump serialization spec number to invalidate old graphs