### PR TITLE
Always run tests with deleteFilesByDefault

### DIFF
--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -74,8 +74,7 @@ Future<BuildResult> nextResult(List results) {
 ///
 Future testPhases(
     PhaseGroup phases, Map<String, /*String|List<int>*/ dynamic> inputs,
-    {bool deleteFilesByDefault,
-    Map<String, /*String|List<int>*/ dynamic> outputs,
+    {Map<String, /*String|List<int>*/ dynamic> outputs,
     PackageGraph packageGraph,
     BuildStatus status: BuildStatus.success,
     Matcher exceptionMatcher,
@@ -101,7 +100,7 @@ Future testPhases(
   }
 
   var result = await build(phases,
-      deleteFilesByDefault: deleteFilesByDefault,
+      deleteFilesByDefault: true,
       reader: reader,
       writer: writer,
       packageGraph: packageGraph,

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -178,8 +178,8 @@ void main() {
     await writer.delete(outputId);
 
     // Second run, should have no extra outputs.
-    var done = testPhases(copyAPhaseGroup, inputs,
-        outputs: outputs, writer: writer, deleteFilesByDefault: true);
+    var done =
+        testPhases(copyAPhaseGroup, inputs, outputs: outputs, writer: writer);
     // Should block on user input.
     await new Future.delayed(new Duration(seconds: 1));
     // Now it should complete!


### PR DESCRIPTION
It will never make sense to not set this option in a unit test because
if we fall past this check we hit a prompt that won't get a response. We
will need an integration test to check this behavior.