### PR TITLE
Delete test for bad error behavior

### DIFF
--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -112,21 +112,6 @@ void main() {
     });
   });
 
-  group('errors', () {
-    test('when overwriting files', () async {
-      var emptyGraph = new AssetGraph();
-      await testPhases(
-          copyAPhaseGroup,
-          {
-            'a|lib/a.txt': 'a',
-            'a|lib/a.txt.copy': 'a',
-            'a|$assetGraphPath': JSON.encode(emptyGraph.serialize()),
-          },
-          status: BuildStatus.failure,
-          exceptionMatcher: invalidOutputException);
-    });
-  });
-
   test('tracks dependency graph in a asset_graph.json file', () async {
     final writer = new InMemoryRunnerAssetWriter();
     await testPhases(copyAPhaseGroup, {'a|web/a.txt': 'a', 'a|lib/b.txt': 'b'},


### PR DESCRIPTION
This test matches behavior today, but the behavior we'd like is instead
to prompt to delete the files like we would if the AssetGraph was brand
new instead of just constructued without these files.

For now delete the test and we'll restore a similar test with #323