### PR TITLE
Fix rebuild test for build script change

### DIFF
--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -301,7 +301,8 @@ void main() {
     });
 
     test('invalidates graph if build script updates', () async {
-      var graph = new AssetGraph();
+      var graph = new AssetGraph()
+        ..validAsOf = new DateTime.now().add(const Duration(hours: 1));
       var aId = makeAssetId('a|web/a.txt');
       var aCopyNode = new GeneratedAssetNode(
           1, aId, false, true, makeAssetId('a|web/a.txt.copy'));
@@ -314,14 +315,18 @@ void main() {
       /// Spoof the `package:test/test.dart` import and pretend its newer than
       /// the current graph to cause a rebuild.
       await writer.writeAsString(makeAssetId('test|lib/test.dart'), '',
-          lastModified: graph.validAsOf.add(new Duration(hours: 1)));
-      await testPhases(copyAPhaseGroup, {
-        'a|web/a.txt': 'a',
-        'a|web/a.txt.copy': 'a',
-        'a|$assetGraphPath': JSON.encode(graph.serialize()),
-      }, outputs: {
-        'a|web/a.txt.copy': 'a',
-      });
+          lastModified: graph.validAsOf.add(new Duration(hours: 2)));
+      await testPhases(
+          copyAPhaseGroup,
+          {
+            'a|web/a.txt': 'a',
+            'a|web/a.txt.copy': 'a',
+            'a|$assetGraphPath': JSON.encode(graph.serialize()),
+          },
+          outputs: {
+            'a|web/a.txt.copy': 'a',
+          },
+          writer: writer);
     });
   });
 }


### PR DESCRIPTION
Currently the test passes because the `AssetGraph` is considered older
than the assets which means the rebuild happens because of a stale
graph. By setting the graph to look like it is written newer than the
inputs, but older than the build script, the test is asserting the
behavior it claims.