### PR TITLE
Always update AssetGraph with static information

### DIFF
--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -134,17 +134,17 @@ class AssetGraph {
   /// Updates the structure of the graph to account for any new sources and
   /// returns true if the graph has changed.
   bool updateForSources(
-      List<List<BuildAction>> phases, Iterable<AssetId> newSources) {
-    var unseen = newSources.where((s) => !_nodesById.containsKey(s)).toList();
+      List<List<BuildAction>> phases, Iterable<AssetId> sources) {
+    var unseen = sources.where((s) => !_nodesById.containsKey(s)).toSet();
     if (unseen.isEmpty) return false;
-    _addOutputsForSources(phases, unseen.toList());
+    _addOutputsForSources(phases, unseen);
     return true;
   }
 
   void _addOutputsForSources(
-      List<List<BuildAction>> phases, Iterable<AssetId> newSources) {
+      List<List<BuildAction>> phases, Set<AssetId> newSources) {
     newSources.map((s) => new AssetNode(s)).forEach(_add);
-    var allInputs = new Set<AssetId>()..addAll(newSources);
+    var allInputs = new Set<AssetId>.from(newSources);
     var phaseNumber = 0;
     for (var phase in phases) {
       phaseNumber++;

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -123,7 +123,7 @@ void main() {
     var cachedGraph = new AssetGraph.deserialize(
         JSON.decode(writer.assets[graphId].stringValue));
 
-    var expectedGraph = new AssetGraph();
+    var expectedGraph = new AssetGraph.build([], new Set());
     var aCopyNode = makeAssetNode('a|web/a.txt.copy');
     expectedGraph.add(aCopyNode);
     expectedGraph.add(makeAssetNode('a|web/a.txt', [aCopyNode.id]));
@@ -173,7 +173,8 @@ void main() {
 
   group('incremental builds with cached graph', () {
     test('one new asset, one modified asset, one unchanged asset', () async {
-      var graph = new AssetGraph()..validAsOf = new DateTime.now();
+      var graph = new AssetGraph.build([], new Set())
+        ..validAsOf = new DateTime.now();
       var bId = makeAssetId('a|lib/b.txt');
       var bCopyNode = new GeneratedAssetNode(
           1, bId, false, true, makeAssetId('a|lib/b.txt.copy'));
@@ -206,7 +207,8 @@ void main() {
         ..addAction(new CopyBuilder(extension: 'clone'),
             new InputSet('a', ['**/*.txt.copy']));
 
-      var graph = new AssetGraph()..validAsOf = new DateTime.now();
+      var graph = new AssetGraph.build([], new Set())
+        ..validAsOf = new DateTime.now();
 
       var aCloneNode = new GeneratedAssetNode(
           1,
@@ -217,9 +219,11 @@ void main() {
       graph.add(aCloneNode);
       var aCopyNode = new GeneratedAssetNode(1, makeAssetId('a|lib/a.txt'),
           false, true, makeAssetId('a|lib/a.txt.copy'))
+        ..primaryOutputs.add(aCloneNode.id)
         ..outputs.add(aCloneNode.id);
       graph.add(aCopyNode);
-      var aNode = makeAssetNode('a|lib/a.txt', [aCopyNode.id]);
+      var aNode = makeAssetNode('a|lib/a.txt', [aCopyNode.id])
+        ..primaryOutputs.add(aCopyNode.id);
       graph.add(aNode);
 
       var bCloneNode = new GeneratedAssetNode(
@@ -231,9 +235,11 @@ void main() {
       graph.add(bCloneNode);
       var bCopyNode = new GeneratedAssetNode(1, makeAssetId('a|lib/b.txt'),
           false, true, makeAssetId('a|lib/b.txt.copy'))
+        ..primaryOutputs.add(bCloneNode.id)
         ..outputs.add(bCloneNode.id);
       graph.add(bCopyNode);
-      var bNode = makeAssetNode('a|lib/b.txt', [bCopyNode.id]);
+      var bNode = makeAssetNode('a|lib/b.txt', [bCopyNode.id])
+        ..primaryOutputs.add(bCopyNode.id);
       graph.add(bNode);
 
       var writer = new InMemoryRunnerAssetWriter();
@@ -263,7 +269,7 @@ void main() {
         ..addAction(new CopyBuilder(extension: 'clone'),
             new InputSet('a', ['**/*.txt.copy']));
 
-      var graph = new AssetGraph();
+      var graph = new AssetGraph.build([], new Set());
       var aCloneNode = new GeneratedAssetNode(
           1,
           makeAssetId('a|lib/a.txt.copy'),
@@ -301,7 +307,7 @@ void main() {
     });
 
     test('invalidates graph if build script updates', () async {
-      var graph = new AssetGraph()
+      var graph = new AssetGraph.build([], new Set())
         ..validAsOf = new DateTime.now().add(const Duration(hours: 1));
       var aId = makeAssetId('a|web/a.txt');
       var aCopyNode = new GeneratedAssetNode(

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -127,7 +127,7 @@ void main() {
         var cachedGraph = new AssetGraph.deserialize(JSON.decode(
             writer.assets[makeAssetId('a|$assetGraphPath')].stringValue));
 
-        var expectedGraph = new AssetGraph();
+        var expectedGraph = new AssetGraph.build([], new Set());
         var bCopyNode = makeAssetNode('a|web/b.txt.copy');
         expectedGraph.add(bCopyNode);
         expectedGraph.add(makeAssetNode('a|web/b.txt', [bCopyNode.id]));


### PR DESCRIPTION
Instead of build the graph up as builders are run find the structure of
the graph from declared outputs alone. The only changes to the graph
after that should be marking outputs as non-primary inputs are read.

- Remove addIfAbset method and test
- Hide add and remove - there are still public wrappers for these used
  in tests that we should drop soon.
- During graph changes based on disk changes, track whether the file
  that changed was a source and only delete GeneratedAssetNodes if they
  would have come from a deleted source file, not a deleted generated
  file. When a generated file is deleted mark it and it's descendents as
  needing an update. Remove the `seen` set since a deletion of a
  generated file could mark a node as needing and update but a later
  seen deletion of a source file should still remove it.
- Add `updateForSourcs` to fill in the asset graph with new outputs as
  new source files are discovered.
- Add a simple test for the `build` constructor on AssetGraph
- Update AssetGraph construction in tests to use the `build` constructor
  but still create an empty graph.