### PR TITLE
Delete the _inputsByPackage variable

### DIFF
--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -66,9 +66,6 @@ class AssetGraph {
 
   /// Adds [node] to the graph.
   void _add(AssetNode node) {
-    if (_nodesById.containsKey(node.id)) {
-      throw new DuplicateAssetNodeException(node);
-    }
     _nodesById[node.id] = node;
   }
 
@@ -157,9 +154,6 @@ class AssetGraph {
           phaseOutputs.addAll(outputs);
           get(input).primaryOutputs.addAll(outputs);
           for (var output in outputs) {
-            if (contains(output) && get(output) is AssetNode) {
-              _remove(output);
-            }
             _add(new GeneratedAssetNode(
                 phaseNumber, input, true, false, output));
           }

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -410,19 +410,14 @@ class BuildImpl {
   /// Runs [builder] with [primaryInputs] as inputs.
   Stream<AssetId> _runBuilder(int phaseNumber, Builder builder,
       Iterable<AssetId> primaryInputs, Set<AssetId> groupOutputs) async* {
-    var phaseSources = _inputsForPhase(phaseNumber);
     for (var input in primaryInputs) {
       var builderOutputs = expectedOutputs(builder, input);
 
       // Validate builderOutputs.
-      // TODO move this check to static graph generation?
       for (var output in builderOutputs) {
         if (output.package != _packageGraph.root.name) {
           throw new InvalidOutputException(output,
               'Files may only be output in the root (application) package.');
-        }
-        if (phaseSources.contains(output)) {
-          throw new InvalidOutputException(output, 'Cannot overwrite inputs.');
         }
       }
 

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -61,11 +61,6 @@ void main() {
       expect(graph.allNodes, unorderedEquals(expectedNodes));
     });
 
-    test('duplicate adds throw DuplicateAssetNodeException', () {
-      var node = testAddNode();
-      expect(() => graph.add(node), throwsA(duplicateAssetNodeException));
-    });
-
     test('remove', () {
       var nodes = <AssetNode>[];
       for (int i = 0; i < 5; i++) {

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -123,7 +123,7 @@ void main() {
     var cachedGraph = new AssetGraph.deserialize(
         JSON.decode(writer.assets[graphId].stringValue));
 
-    var expectedGraph = new AssetGraph();
+    var expectedGraph = new AssetGraph.build([], new Set());
     var aCopyNode = makeAssetNode('a|web/a.txt.copy');
     expectedGraph.add(aCopyNode);
     expectedGraph.add(makeAssetNode('a|web/a.txt', [aCopyNode.id]));
@@ -173,7 +173,8 @@ void main() {
 
   group('incremental builds with cached graph', () {
     test('one new asset, one modified asset, one unchanged asset', () async {
-      var graph = new AssetGraph()..validAsOf = new DateTime.now();
+      var graph = new AssetGraph.build([], new Set())
+        ..validAsOf = new DateTime.now();
       var bId = makeAssetId('a|lib/b.txt');
       var bCopyNode = new GeneratedAssetNode(
           1, bId, false, true, makeAssetId('a|lib/b.txt.copy'));
@@ -206,7 +207,8 @@ void main() {
         ..addAction(new CopyBuilder(extension: 'clone'),
             new InputSet('a', ['**/*.txt.copy']));
 
-      var graph = new AssetGraph()..validAsOf = new DateTime.now();
+      var graph = new AssetGraph.build([], new Set())
+        ..validAsOf = new DateTime.now();
 
       var aCloneNode = new GeneratedAssetNode(
           1,
@@ -217,9 +219,11 @@ void main() {
       graph.add(aCloneNode);
       var aCopyNode = new GeneratedAssetNode(1, makeAssetId('a|lib/a.txt'),
           false, true, makeAssetId('a|lib/a.txt.copy'))
+        ..primaryOutputs.add(aCloneNode.id)
         ..outputs.add(aCloneNode.id);
       graph.add(aCopyNode);
-      var aNode = makeAssetNode('a|lib/a.txt', [aCopyNode.id]);
+      var aNode = makeAssetNode('a|lib/a.txt', [aCopyNode.id])
+        ..primaryOutputs.add(aCopyNode.id);
       graph.add(aNode);
 
       var bCloneNode = new GeneratedAssetNode(
@@ -231,9 +235,11 @@ void main() {
       graph.add(bCloneNode);
       var bCopyNode = new GeneratedAssetNode(1, makeAssetId('a|lib/b.txt'),
           false, true, makeAssetId('a|lib/b.txt.copy'))
+        ..primaryOutputs.add(bCloneNode.id)
         ..outputs.add(bCloneNode.id);
       graph.add(bCopyNode);
-      var bNode = makeAssetNode('a|lib/b.txt', [bCopyNode.id]);
+      var bNode = makeAssetNode('a|lib/b.txt', [bCopyNode.id])
+        ..primaryOutputs.add(bCopyNode.id);
       graph.add(bNode);
 
       var writer = new InMemoryRunnerAssetWriter();
@@ -263,7 +269,7 @@ void main() {
         ..addAction(new CopyBuilder(extension: 'clone'),
             new InputSet('a', ['**/*.txt.copy']));
 
-      var graph = new AssetGraph();
+      var graph = new AssetGraph.build([], new Set());
       var aCloneNode = new GeneratedAssetNode(
           1,
           makeAssetId('a|lib/a.txt.copy'),
@@ -301,7 +307,7 @@ void main() {
     });
 
     test('invalidates graph if build script updates', () async {
-      var graph = new AssetGraph()
+      var graph = new AssetGraph.build([], new Set())
         ..validAsOf = new DateTime.now().add(const Duration(hours: 1));
       var aId = makeAssetId('a|web/a.txt');
       var aCopyNode = new GeneratedAssetNode(

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -211,7 +211,7 @@ void main() {
         ..validAsOf = new DateTime.now();
 
       var aCloneNode = new GeneratedAssetNode(
-          1,
+          2,
           makeAssetId('a|lib/a.txt.copy'),
           false,
           true,
@@ -227,7 +227,7 @@ void main() {
       graph.add(aNode);
 
       var bCloneNode = new GeneratedAssetNode(
-          1,
+          2,
           makeAssetId('a|lib/b.txt.copy'),
           false,
           true,

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -127,7 +127,7 @@ void main() {
         var cachedGraph = new AssetGraph.deserialize(JSON.decode(
             writer.assets[makeAssetId('a|$assetGraphPath')].stringValue));
 
-        var expectedGraph = new AssetGraph();
+        var expectedGraph = new AssetGraph.build([], new Set());
         var bCopyNode = makeAssetNode('a|web/b.txt.copy');
         expectedGraph.add(bCopyNode);
         expectedGraph.add(makeAssetNode('a|web/b.txt', [bCopyNode.id]));


### PR DESCRIPTION
Moves all reads of this variable to reads of the (at the time) static
asset graph. With further refactoring the lines of communication can
become even more explicit with the AssetGraph rather than implicit and
order-dependent as they are with this variable.

There are very likely performance regressions with this change since
some Sets are built over and over from scratch rather than stored or
built up over time - we can address these later.