### PR TITLE
Collapse a Future<Stream> to a Stream

### DIFF
--- a/build_runner/lib/src/generate/change_watcher.dart
+++ b/build_runner/lib/src/generate/change_watcher.dart
@@ -3,11 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
+import 'package:async/async.dart';
 import 'package:build/build.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:watcher/watcher.dart';
 
+import '../logging/logging.dart';
 import '../package_graph/package_graph.dart';
 import 'directory_watcher_factory.dart';
 
@@ -17,7 +19,18 @@ class AssetChange {
   AssetChange(this.id, this.type);
 }
 
-Future<Stream<AssetChange>> startFileWatchers(PackageGraph packageGraph,
+Stream<AssetChange> startFileWatchers(PackageGraph packageGraph, Logger logger,
+    DirectoryWatcherFactory directoryWatcherFactory) {
+  var completer = new StreamCompleter<AssetChange>();
+  logWithTime(
+      logger,
+      'Setting up file watchers',
+      () => _startFileWatchers(packageGraph, logger, directoryWatcherFactory)
+          .then((stream) => completer.setSourceStream(stream)));
+  return completer.stream;
+}
+
+Future<Stream<AssetChange>> _startFileWatchers(PackageGraph packageGraph,
     Logger logger, DirectoryWatcherFactory directoryWatcherFactory) async {
   var controller = new StreamController<AssetChange>();
   final watchers = <DirectoryWatcher>[];

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -10,7 +10,6 @@ import 'package:stream_transform/stream_transform.dart';
 
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
-import '../logging/logging.dart';
 import '../package_graph/package_graph.dart';
 import '../util/constants.dart';
 import 'build_impl.dart';

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.27.1 <0.31.0"
+  async: ^1.13.3
   build: ^0.9.0
   build_barback: '>=0.2.0 <0.4.0'
   crypto: ">=0.9.2 <3.0.0"

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   shelf: ^0.6.5
   shelf_static: ^0.2.3
   stack_trace: ^1.6.0
-  stream_transform: ^0.0.1
+  stream_transform: ^0.0.8
   watcher: ^0.9.7
   yaml: ^2.1.0
 


### PR DESCRIPTION
Wrapping a Stream is Future is awkward - this is exactly the case that
StreamCompleter is meant to solve.

- Move the `logWithTime` into the code actually starting the watchers.
- Start the _changeListener synchronously.
- Change a listen with a function literal to a map then listen.
- Remove `force` argument. Since we are filtering updates at the event
  level we can be confident that the map will never be empty.
- Move a manual triggering of the build to a `startWith` transformer.