### PR TITLE
Further towards Stream transforms in watch_impl

### DIFF
--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   shelf: ^0.6.5
   shelf_static: ^0.2.3
   stack_trace: ^1.6.0
-  stream_transform: ^0.0.8
+  stream_transform: ^0.0.9
   watcher: ^0.9.7
   yaml: ^2.1.0
 


### PR DESCRIPTION
Removes more state in favor of modeling the logic through transforming
the Stream of file changes.

- Replace canceling the changeListener with takeUntil. `terminate()` now
  completes a Future rather than needing more detailed cleanup logic.
- Use asyncMapBuffer instead of a manual StreamController and trigger to
  prevent re-entry into the build function.
- Return the Stream of changes transformed into a Stream of build
  results rather than sidelining them into a StreamController.