### PR TITLE
Drop `resolvers` argument in build_runner

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -6,6 +6,8 @@
   If your current build has multiple actions in a single phase which are
   depending on *not* seeing the outputs from other actions in the phase you will
   need to instead set up the `InputSet`s so that the outputs are filtered out.
+- **Breaking**: The `resolvers` argument has been removed from `build`, `watch`,
+  and `serve`.
 
 ## 0.3.4+1
 

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -49,7 +49,6 @@ Future<BuildResult> build(List<BuildAction> buildActions,
     RunnerAssetWriter writer,
     Level logLevel,
     onLog(LogRecord record),
-    Resolvers resolvers,
     Stream terminateEventStream}) async {
   var options = new BuildOptions(
       deleteFilesByDefault: deleteFilesByDefault,
@@ -57,8 +56,7 @@ Future<BuildResult> build(List<BuildAction> buildActions,
       reader: reader,
       writer: writer,
       logLevel: logLevel,
-      onLog: onLog,
-      resolvers: resolvers);
+      onLog: onLog);
   var buildImpl = new BuildImpl(options, buildActions);
 
   /// Run the build!
@@ -97,7 +95,6 @@ Stream<BuildResult> watch(List<BuildAction> buildActions,
     RunnerAssetWriter writer,
     Level logLevel,
     onLog(LogRecord record),
-    Resolvers resolvers,
     Duration debounceDelay,
     DirectoryWatcherFactory directoryWatcherFactory,
     Stream terminateEventStream}) {
@@ -108,7 +105,6 @@ Stream<BuildResult> watch(List<BuildAction> buildActions,
       writer: writer,
       logLevel: logLevel,
       onLog: onLog,
-      resolvers: resolvers,
       debounceDelay: debounceDelay,
       directoryWatcherFactory: directoryWatcherFactory);
   var watchImpl = new WatchImpl(options, buildActions);
@@ -141,7 +137,6 @@ Stream<BuildResult> serve(List<BuildAction> buildActions,
     RunnerAssetWriter writer,
     Level logLevel,
     onLog(LogRecord record),
-    Resolvers resolvers,
     Duration debounceDelay,
     DirectoryWatcherFactory directoryWatcherFactory,
     Stream terminateEventStream,
@@ -156,7 +151,6 @@ Stream<BuildResult> serve(List<BuildAction> buildActions,
       writer: writer,
       logLevel: logLevel,
       onLog: onLog,
-      resolvers: resolvers,
       debounceDelay: debounceDelay,
       directoryWatcherFactory: directoryWatcherFactory,
       directory: directory,

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -36,7 +36,7 @@ class BuildImpl {
   final PackageGraph _packageGraph;
   final RunnerAssetReader _reader;
   final RunnerAssetWriter _writer;
-  final Resolvers _resolvers;
+  final Resolvers _resolvers = const BarbackResolvers();
 
   AssetGraph _assetGraph;
   AssetGraph get assetGraph => _assetGraph;
@@ -49,8 +49,7 @@ class BuildImpl {
         _deleteFilesByDefault = options.deleteFilesByDefault,
         _packageGraph = options.packageGraph,
         _reader = options.reader,
-        _writer = options.writer,
-        _resolvers = options.resolvers ?? const BarbackResolvers();
+        _writer = options.writer;
 
   /// Runs a build
   ///

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:build/build.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_static/shelf_static.dart';
@@ -25,7 +24,6 @@ class BuildOptions {
   RunnerAssetReader reader;
   RunnerAssetWriter writer;
   bool deleteFilesByDefault;
-  Resolvers resolvers;
 
   // Watch mode options.
   Duration debounceDelay;
@@ -49,7 +47,6 @@ class BuildOptions {
       this.port,
       this.reader,
       this.requestHandler,
-      this.resolvers,
       this.writer}) {
     /// Set up logging
     logLevel ??= Level.INFO;


### PR DESCRIPTION
Closes #347

This will make it easier to optimize a new Resolver implementation if we
are confident we control the entire lifespan.