### PR TITLE
Change to async apis in Resolver interface

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -3,8 +3,9 @@
 - **Breaking**: Removed deprecated method `BuildStep.hasInput` - all uses should
   be going through `BuildStep.canRead`.
 - **Breaking**: `Resolver` has asynchronous APIs for resolution and is retrieved
-  synchronously from the `BuildStep`. Added `libraryFor` to eventually replace
-  `getLibrary` and `findLibraryByName` to replace `getLibraryByName`.
+  synchronously from the `BuildStep`.
+- **Breaking**:  Replaced `Resolver.getLibrary` with `libraryFor` and
+  `getLibraryByName` with `findLibraryByName`.
 
 ## 0.9.3
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - **Breaking**: Removed deprecated method `BuildStep.hasInput` - all uses should
   be going through `BuildStep.canRead`.
+- **Breaking**: `Resolver` has asynchronous APIs for resolution and is retrieved
+  synchronously from the `BuildStep`. Added `libraryFor` to eventually replace
+  `getLibrary` and `findLibraryByName` to replace `getLibraryByName`.
 
 ## 0.9.3
 

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -14,29 +14,30 @@ abstract class Resolver {
   ///
   /// This will be `false` in the case where the file is not Dart source code,
   /// or is a `part of` file (not a standalone Dart library).
-  bool isLibrary(AssetId assetId);
+  Future<bool> isLibrary(AssetId assetId);
 
   /// All libraries accessible from the entry point, recursively.
   ///
   /// **NOTE**: This includes all Dart SDK libraries as well.
-  Iterable<LibraryElement> get libraries;
+  Stream<LibraryElement> get libraries;
 
   /// Returns a resolved library representing the file defined in [assetId].
   ///
   /// * Throws [NonLibraryAssetException] if [assetId] is not a Dart library.
-  LibraryElement getLibrary(AssetId assetId);
-
-  /// Finds the first library identified by [libraryName], or null if no
-  /// library can be found.
+  Future<LibraryElement> libraryFor(AssetId assetId);
+  @Deprecated('Use libraryFor')
+  Future<LibraryElement> getLibrary(AssetId assetId);
 
   /// Returns the first library identified by [libraryName].
   ///
   /// If no library can be found, returns `null`.
   ///
-  /// **NOTE**: In general, its recommended to use [getLibrary] with an absolute
+  /// **NOTE**: In general, its recommended to use [libraryFor] with an absolute
   /// asset id instead of a named identifier that has the possibility of not
   /// being unique.
-  LibraryElement getLibraryByName(String libraryName);
+  Future<LibraryElement> findLibraryByName(String libraryName);
+  @Deprecated('Use findLibraryByName')
+  Future<LibraryElement> getLibraryByName(String libraryName);
 }
 
 /// A resolver that should be manually released at the end of a build step.

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -25,8 +25,6 @@ abstract class Resolver {
   ///
   /// * Throws [NonLibraryAssetException] if [assetId] is not a Dart library.
   Future<LibraryElement> libraryFor(AssetId assetId);
-  @Deprecated('Use libraryFor')
-  Future<LibraryElement> getLibrary(AssetId assetId);
 
   /// Returns the first library identified by [libraryName].
   ///
@@ -36,8 +34,6 @@ abstract class Resolver {
   /// asset id instead of a named identifier that has the possibility of not
   /// being unique.
   Future<LibraryElement> findLibraryByName(String libraryName);
-  @Deprecated('Use findLibraryByName')
-  Future<LibraryElement> getLibraryByName(String libraryName);
 }
 
 /// A resolver that should be manually released at the end of a build step.

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -52,6 +52,6 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   Future writeAsString(AssetId id, FutureOr<String> contents,
       {Encoding encoding: UTF8});
 
-  /// Completes with a [Resolver] for [inputId].
-  Future<Resolver> get resolver;
+  /// A [Resolver] for [inputId].
+  Resolver get resolver;
 }

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:async/async.dart';
 import 'package:glob/glob.dart';
 
 import '../analyzer/resolver.dart';
@@ -27,8 +28,7 @@ class BuildStepImpl implements BuildStep {
   final AssetId inputId;
 
   @override
-  Future<LibraryElement> get inputLibrary async =>
-      (await resolver).getLibrary(inputId);
+  Future<LibraryElement> get inputLibrary async => resolver.libraryFor(inputId);
 
   /// The list of all outputs which are expected/allowed to be output from this
   /// step.
@@ -51,7 +51,8 @@ class BuildStepImpl implements BuildStep {
       : _expectedOutputs = expectedOutputs.toList();
 
   @override
-  Future<Resolver> get resolver => _resolver ??= _resolvers.get(this);
+  Resolver get resolver =>
+      new _DelayedResolver(_resolver ??= _resolvers.get(this));
 
   Future<ReleasableResolver> _resolver;
 
@@ -129,4 +130,34 @@ class BuildStepImpl implements BuildStep {
       throw new UnexpectedOutputException(id);
     }
   }
+}
+
+class _DelayedResolver implements Resolver {
+  final Future<Resolver> _delegate;
+
+  _DelayedResolver(this._delegate);
+
+  @override
+  Future<bool> isLibrary(AssetId assetId) async =>
+      (await _delegate).isLibrary(assetId);
+
+  @override
+  Stream<LibraryElement> get libraries {
+    var completer = new StreamCompleter<LibraryElement>();
+    _delegate.then((r) => completer.setSourceStream(r.libraries));
+    return completer.stream;
+  }
+
+  @override
+  Future<LibraryElement> libraryFor(AssetId assetId) async =>
+      (await _delegate).libraryFor(assetId);
+  @override
+  Future<LibraryElement> getLibrary(AssetId assetId) => libraryFor(assetId);
+
+  @override
+  Future<LibraryElement> findLibraryByName(String libraryName) async =>
+      (await _delegate).findLibraryByName(libraryName);
+  @override
+  Future<LibraryElement> getLibraryByName(String libraryName) =>
+      findLibraryByName(libraryName);
 }

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -151,13 +151,8 @@ class _DelayedResolver implements Resolver {
   @override
   Future<LibraryElement> libraryFor(AssetId assetId) async =>
       (await _delegate).libraryFor(assetId);
-  @override
-  Future<LibraryElement> getLibrary(AssetId assetId) => libraryFor(assetId);
 
   @override
   Future<LibraryElement> findLibraryByName(String libraryName) async =>
       (await _delegate).findLibraryByName(libraryName);
-  @override
-  Future<LibraryElement> getLibraryByName(String libraryName) =>
-      findLibraryByName(libraryName);
 }

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.27.1 <0.31.0"
+  async: ^1.13.3
   logging: ^0.11.2
   path: ^1.1.0
   glob: ^1.1.0

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -111,15 +111,15 @@ void main() {
         var primary = makeAssetId('a|web/a.dart');
         var buildStep = new BuildStepImpl(primary, [], reader, writer,
             primary.package, const BarbackResolvers());
-        var resolver = await buildStep.resolver;
+        var resolver = buildStep.resolver;
 
-        var aLib = resolver.getLibrary(primary);
+        var aLib = await resolver.libraryFor(primary);
         expect(aLib.name, 'a');
         expect(aLib.importedLibraries.length, 2);
         expect(aLib.importedLibraries.any((library) => library.name == 'b'),
             isTrue);
 
-        var bLib = resolver.getLibraryByName('b');
+        var bLib = await resolver.findLibraryByName('b');
         expect(bLib.name, 'b');
         expect(bLib.importedLibraries.length, 1);
 

--- a/build_barback/CHANGELOG.md
+++ b/build_barback/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0-dev
+
+- **Breaking**: Resolver interface updated for breaking change in
+  `package:build` v0.10.0
+
 ## 0.3.0
 
 - **Breaking** `BuilderTransformer` is now an `AggregateTransformer`. This

--- a/build_barback/lib/src/analyzer/resolver.dart
+++ b/build_barback/lib/src/analyzer/resolver.dart
@@ -19,22 +19,29 @@ class BarbackResolver implements ReleasableResolver {
   void release() => _resolver.release();
 
   @override
-  bool isLibrary(AssetId assetId) =>
+  Future<bool> isLibrary(AssetId assetId) async =>
       _resolver.isLibrary(toBarbackAssetId(assetId));
 
   @override
-  LibraryElement getLibrary(AssetId assetId) {
+  Future<LibraryElement> libraryFor(AssetId assetId) async {
     var library = _resolver.getLibrary(toBarbackAssetId(assetId));
     if (library == null) throw new NonLibraryAssetException(assetId);
     return library;
   }
 
   @override
-  Iterable<LibraryElement> get libraries => _resolver.libraries;
+  Future<LibraryElement> getLibrary(AssetId assetId) => libraryFor(assetId);
 
   @override
-  LibraryElement getLibraryByName(String libraryName) =>
+  Stream<LibraryElement> get libraries =>
+      new Stream.fromIterable(_resolver.libraries);
+
+  @override
+  Future<LibraryElement> findLibraryByName(String libraryName) async =>
       _resolver.getLibraryByName(libraryName);
+  @override
+  Future<LibraryElement> getLibraryByName(String libraryName) =>
+      findLibraryByName(libraryName);
 }
 
 class BarbackResolvers implements Resolvers {

--- a/build_barback/lib/src/analyzer/resolver.dart
+++ b/build_barback/lib/src/analyzer/resolver.dart
@@ -30,18 +30,12 @@ class BarbackResolver implements ReleasableResolver {
   }
 
   @override
-  Future<LibraryElement> getLibrary(AssetId assetId) => libraryFor(assetId);
-
-  @override
   Stream<LibraryElement> get libraries =>
       new Stream.fromIterable(_resolver.libraries);
 
   @override
   Future<LibraryElement> findLibraryByName(String libraryName) async =>
       _resolver.getLibraryByName(libraryName);
-  @override
-  Future<LibraryElement> getLibraryByName(String libraryName) =>
-      findLibraryByName(libraryName);
 }
 
 class BarbackResolvers implements Resolvers {

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_barback
-version: 0.3.0
+version: 0.4.0-dev
 description: Utilities for translating between builders and transformers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.27.1 <0.31.0"
   barback: ^0.15.0
-  build: ^0.9.0
+  build: ^0.10.0
   code_transformers: ">=0.5.1 <0.6.0"
   glob: ^1.1.0
   logging: ^0.11.2
@@ -19,3 +19,9 @@ dev_dependencies:
   build_test: ^0.6.0
   test: ^0.12.0
   transformer_test: ^0.2.1
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_test:
+    path: ../build_test

--- a/build_barback/test/analyzer/resolver_test.dart
+++ b/build_barback/test/analyzer/resolver_test.dart
@@ -40,7 +40,7 @@ void main() {
 
   Future validateResolver(
       {Map<String, String> inputs,
-      validator(Resolver resolver),
+      Future validator(Resolver resolver),
       List messages: const []}) async {
     var writer = new InMemoryAssetWriter();
     var reader = new InMemoryAssetReader(sourceAssets: writer.assets);
@@ -67,28 +67,30 @@ void main() {
           inputs: {
             'a|web/main.dart': ' main() {}',
           },
-          validator: (resolver) {
+          validator: (resolver) async {
+            var lib = await resolver.libraryFor(entryPoint);
+
             var source = (_resolvers.lastResolved as dynamic)
                 .sources[toBarbackAssetId(entryPoint)];
             expect(source.modificationStamp, 1);
 
-            var lib = resolver.getLibrary(entryPoint);
             expect(lib, isNotNull);
           });
     });
 
-    test('should update when sources change', () {
+    test('should update when sources change', () async {
       return validateResolver(
           inputs: {
             'a|web/main.dart': ''' main() {
                 } ''',
           },
-          validator: (resolver) {
+          validator: (resolver) async {
+            var lib = await resolver.libraryFor(entryPoint);
+
             var source = (_resolvers.lastResolved as dynamic)
                 .sources[toBarbackAssetId(entryPoint)];
             expect(source.modificationStamp, 2);
 
-            var lib = resolver.getLibrary(entryPoint);
             expect(lib, isNotNull);
             expect(lib.entryPoint, isNotNull);
           });
@@ -106,8 +108,8 @@ void main() {
               library a;
               ''',
           },
-          validator: (resolver) {
-            var lib = resolver.getLibrary(entryPoint);
+          validator: (resolver) async {
+            var lib = await resolver.libraryFor(entryPoint);
             expect(lib.importedLibraries, hasLength(2));
             var libA = lib.importedLibraries.where((l) => l.name == 'a').single;
             expect(libA.getType('Foo'), isNull);
@@ -127,8 +129,8 @@ void main() {
               class Foo {}
               ''',
           },
-          validator: (resolver) {
-            var lib = resolver.getLibrary(entryPoint);
+          validator: (resolver) async {
+            var lib = await resolver.libraryFor(entryPoint);
             expect(lib.importedLibraries, hasLength(2));
             var libA = lib.importedLibraries.where((l) => l.name == 'a').single;
             expect(libA.getType('Foo'), isNotNull);
@@ -147,8 +149,8 @@ void main() {
               library b;
               ''',
           },
-          validator: (resolver) {
-            var lib = resolver.getLibrary(entryPoint);
+          validator: (resolver) async {
+            var lib = await resolver.libraryFor(entryPoint);
             expect(lib.importedLibraries, hasLength(2));
             var libB = lib.importedLibraries.where((l) => l.name == 'b').single;
             expect(libB.getType('Foo'), isNull);
@@ -164,8 +166,8 @@ void main() {
               main() {
               } ''',
           },
-          validator: (resolver) {
-            var lib = resolver.getLibrary(entryPoint);
+          validator: (resolver) async {
+            var lib = await resolver.libraryFor(entryPoint);
             expect(lib.importedLibraries, hasLength(2));
           });
     });
@@ -184,8 +186,8 @@ void main() {
               class Bar {}
               ''',
           },
-          validator: (resolver) {
-            var lib = resolver.getLibrary(entryPoint);
+          validator: (resolver) async {
+            var lib = await resolver.libraryFor(entryPoint);
             expect(lib.importedLibraries, hasLength(2));
             var libB = lib.importedLibraries.where((l) => l.name == 'b').single;
             expect(libB.getType('Bar'), isNotNull);
@@ -201,8 +203,8 @@ void main() {
               main() {
               } ''',
           },
-          validator: (resolver) {
-            var lib = resolver.getLibrary(entryPoint);
+          validator: (resolver) async {
+            var lib = await resolver.libraryFor(entryPoint);
             expect(lib.importedLibraries, hasLength(2));
           });
     });
@@ -220,8 +222,8 @@ void main() {
           messages: [
             '[WARNING] test: $warningMessage "/b.dart"',
           ],
-          validator: (resolver) {
-            var lib = resolver.getLibrary(entryPoint);
+          validator: (resolver) async {
+            var lib = await resolver.libraryFor(entryPoint);
             expect(lib.importedLibraries, hasLength(2));
           });
     });
@@ -240,8 +242,8 @@ void main() {
             'a|lib/c.dart': 'library a.c;',
             'a|lib/d.dart': 'library a.d;'
           },
-          validator: (resolver) {
-            var libs = resolver.libraries.where((l) => !l.isInSdk);
+          validator: (resolver) async {
+            var libs = await resolver.libraries.where((l) => !l.isInSdk).toList();
             expect(
                 libs.map((l) => l.name),
                 unorderedEquals([
@@ -267,30 +269,30 @@ void main() {
                 library b;
                 import 'package:a/a.dart'; ''',
           },
-          validator: (resolver) {
-            var libs = resolver.libraries.map((lib) => lib.name);
+          validator: (resolver) async {
+            var libs = await resolver.libraries.map((lib) => lib.name).toList();
             expect(libs.contains('a'), isTrue);
             expect(libs.contains('b'), isTrue);
           });
     });
 
-    test('handles parallel resolves', () {
+    test('handles parallel resolves', () async {
       return Future.wait([
         validateResolver(
             inputs: {
               'a|web/main.dart': '''
                 library foo;'''
             },
-            validator: (resolver) {
-              expect(resolver.getLibrary(entryPoint).name, 'foo');
+            validator: (resolver) async {
+              expect((await resolver.libraryFor(entryPoint)).name, 'foo');
             }),
         validateResolver(
             inputs: {
               'a|web/main.dart': '''
                 library bar;'''
             },
-            validator: (resolver) {
-              expect(resolver.getLibrary(entryPoint).name, 'bar');
+            validator: (resolver) async {
+              expect((await resolver.libraryFor(entryPoint)).name, 'bar');
             }),
       ]);
     });
@@ -298,7 +300,7 @@ void main() {
 }
 
 class TestBuilder extends Builder {
-  final Function validator;
+  final Future Function(Resolver) validator;
 
   TestBuilder(this.validator);
 
@@ -309,6 +311,6 @@ class TestBuilder extends Builder {
 
   @override
   Future build(BuildStep buildStep) async {
-    validator(await buildStep.resolver);
+    await validator(buildStep.resolver);
   }
 }

--- a/build_barback/test/analyzer/resolver_test.dart
+++ b/build_barback/test/analyzer/resolver_test.dart
@@ -243,7 +243,8 @@ void main() {
             'a|lib/d.dart': 'library a.d;'
           },
           validator: (resolver) async {
-            var libs = await resolver.libraries.where((l) => !l.isInSdk).toList();
+            var libs =
+                await resolver.libraries.where((l) => !l.isInSdk).toList();
             expect(
                 libs.map((l) => l.name),
                 unorderedEquals([


### PR DESCRIPTION
Closes #339

Since we have some churn anyway rename `get*` methods.

- Change the APIs on resolver to return Future.
- Change the BuildStep to return a Resolver synchronously.
- Allow `Resolvers` to keep returning a Future since we likely need to
  keep doing async work setting up a resolver. Add a wrapper to turn a
  `Future<Resolver>` into a `Resolver` - this will continue to work as
  long as *all* the public apis are async.