### PR TITLE
Disallow implicit casts

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,6 @@
 analyzer:
-  strong-mode: true
+  strong-mode:
+    implicit-casts: false
   errors:
     unused_import: error
     unused_local_variable: error

--- a/build/lib/src/asset/id.dart
+++ b/build/lib/src/asset/id.dart
@@ -98,7 +98,7 @@ class AssetId implements Comparable<AssetId> {
   /// A `package:` URI suitable for use directly with other systems if this
   /// asset is under it's package's `lib/` directory, else an `asset:` URI
   /// suitable for use within build tools.
-  Uri get uri => _uri ?? path.startsWith('lib/')
+  Uri get uri => _uri ??= path.startsWith('lib/')
       ? new Uri(
           scheme: 'package', path: '$package/${path.replaceFirst('lib/','')}')
       : new Uri(scheme: 'asset', path: '$package/$path');
@@ -110,9 +110,9 @@ class AssetId implements Comparable<AssetId> {
   /// Note that this is intended for communicating ids across isolates and not
   /// for persistent storage of asset identifiers. There is no guarantee of
   /// backwards compatibility in serialization form across versions.
-  AssetId.deserialize(data)
-      : package = data[0],
-        path = data[1];
+  AssetId.deserialize(List data)
+      : package = data[0] as String,
+        path = data[1] as String;
 
   /// Returns `true` if [other] is an [AssetId] with the same package and path.
   @override

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -80,7 +80,8 @@ class BuildStepImpl implements BuildStep {
   @override
   Future writeAsBytes(AssetId id, FutureOr<List<int>> bytes) {
     _checkOutput(id);
-    var done = _futureOrWrite(bytes, (b) => _writer.writeAsBytes(id, b));
+    var done =
+        _futureOrWrite<List<int>>(bytes, (b) => _writer.writeAsBytes(id, b));
     _outputsCompleted = _outputsCompleted.then((_) => done);
     return done;
   }
@@ -89,14 +90,14 @@ class BuildStepImpl implements BuildStep {
   Future writeAsString(AssetId id, FutureOr<String> content,
       {Encoding encoding: UTF8}) {
     _checkOutput(id);
-    var done = _futureOrWrite(
+    var done = _futureOrWrite<String>(
         content, (c) => _writer.writeAsString(id, c, encoding: encoding));
     _outputsCompleted = _outputsCompleted.then((_) => done);
     return done;
   }
 
   Future _futureOrWrite<T>(FutureOr<T> content, Future write(T content)) =>
-      (content is Future<T>) ? content.then(write) : write(content);
+      (content is Future<T>) ? content.then(write) : write(content as T);
 
   /// Waits for work to finish and cleans up resources.
   ///

--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -7,7 +7,7 @@ const Symbol logKey = #buildLog;
 /// The log instance for the currently running BuildStep.
 ///
 /// Will be `null` when not running within a build.
-Logger get log => Zone.current[logKey];
+Logger get log => Zone.current[logKey] as Logger;
 
 T scopeLog<T>(T fn(), Logger log) => runZoned(fn, zoneSpecification:
         new ZoneSpecification(print: (self, parent, zone, message) {

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -24,7 +24,8 @@ Future<Null> runBuilder(Builder builder, Iterable<AssetId> inputs,
     AssetReader reader, AssetWriter writer, Resolvers resolvers,
     {Logger logger, String rootPackage}) async {
   logger ??= new Logger('runBuilder');
-  rootPackage ??= new Set.from(inputs.map((input) => input.package)).single;
+  rootPackage ??=
+      new Set<String>.from(inputs.map((input) => input.package)).single;
   //TODO(nbosch) check overlapping outputs?
   Future<Null> buildForInput(AssetId input) async {
     var outputs = expectedOutputs(builder, input);

--- a/build_barback/lib/src/builder/transformer_builder.dart
+++ b/build_barback/lib/src/builder/transformer_builder.dart
@@ -19,7 +19,7 @@ class TransformerBuilder implements Builder {
   @override
   Future build(BuildStep buildStep) {
     var transform = toBarbackTransform(buildStep);
-    return transformer.apply(transform);
+    return new Future.value(transformer.apply(transform));
   }
 
   @override

--- a/build_runner/lib/src/asset/file_based.dart
+++ b/build_runner/lib/src/asset/file_based.dart
@@ -50,7 +50,7 @@ class FileBasedAssetReader implements RunnerAssetReader {
     for (var file in files) {
       // TODO(jakemac): Where do these files come from???
       if (path.basename(file.path).startsWith('._')) continue;
-      yield _fileToAssetId(file, packageNode);
+      yield _fileToAssetId(file as File, packageNode);
     }
   }
 
@@ -120,7 +120,7 @@ File _fileFor(AssetId id, PackageGraph packageGraph) {
 /// Returns a [Future<File>] for [id] given [packageGraph].
 ///
 /// Throws an `AssetNotFoundException` if it doesn't exist.
-Future<File> _fileForOrThrow(AssetId id, packageGraph) async {
+Future<File> _fileForOrThrow(AssetId id, PackageGraph packageGraph) async {
   var file = _fileFor(id, packageGraph);
   if (!await file.exists()) throw new AssetNotFoundException(id);
   return file;

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -35,15 +35,15 @@ class AssetGraph {
   factory AssetGraph.deserialize(Map serializedGraph) {
     if (serializedGraph['version'] != AssetGraph._version) {
       throw new AssetGraphVersionException(
-          serializedGraph['version'], _version);
+          serializedGraph['version'] as int, _version);
     }
 
     var graph = new AssetGraph._();
     for (var serializedItem in serializedGraph['nodes']) {
-      graph._add(new AssetNode.deserialize(serializedItem));
+      graph._add(new AssetNode.deserialize(serializedItem as List));
     }
-    graph.validAsOf =
-        new DateTime.fromMillisecondsSinceEpoch(serializedGraph['validAsOf']);
+    graph.validAsOf = new DateTime.fromMillisecondsSinceEpoch(
+        serializedGraph['validAsOf'] as int);
     return graph;
   }
 

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -20,7 +20,7 @@ class AssetNode {
   factory AssetNode.deserialize(List serializedNode) {
     AssetNode node;
     if (serializedNode.length == 3) {
-      node = new AssetNode(new AssetId.deserialize(serializedNode[0]));
+      node = new AssetNode(new AssetId.deserialize(serializedNode[0] as List));
     } else if (serializedNode.length == 6) {
       node = new GeneratedAssetNode.deserialize(serializedNode);
     } else {
@@ -32,9 +32,10 @@ class AssetNode {
   }
 
   void _addSerializedOutputs(List serialized) {
-    outputs.addAll(serialized[1].map((id) => new AssetId.deserialize(id)));
-    primaryOutputs
-        .addAll(serialized[2].map((id) => new AssetId.deserialize(id)));
+    outputs.addAll(new List.from(serialized[1]
+        .map((id) => new AssetId.deserialize(id as List)) as Iterable));
+    primaryOutputs.addAll(new List.from(serialized[2]
+        .map((id) => new AssetId.deserialize(id as List)) as Iterable));
   }
 
   List serialize() => [
@@ -67,11 +68,11 @@ class GeneratedAssetNode extends AssetNode {
 
   factory GeneratedAssetNode.deserialize(List serialized) {
     var node = new GeneratedAssetNode(
-        serialized[5],
-        new AssetId.deserialize(serialized[3]),
+        serialized[5] as int,
+        new AssetId.deserialize(serialized[3] as List),
         false,
-        serialized[4],
-        new AssetId.deserialize(serialized[0]));
+        serialized[4] as bool,
+        new AssetId.deserialize(serialized[0] as List));
     node._addSerializedOutputs(serialized);
     return node;
   }

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -4,7 +4,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:build/build.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 
@@ -91,7 +90,7 @@ Future<BuildResult> build(List<BuildAction> buildActions,
 Stream<BuildResult> watch(List<BuildAction> buildActions,
     {bool deleteFilesByDefault,
     PackageGraph packageGraph,
-    AssetReader reader,
+    RunnerAssetReader reader,
     RunnerAssetWriter writer,
     Level logLevel,
     onLog(LogRecord record),
@@ -182,7 +181,7 @@ StreamSubscription _setupTerminateLogic(
     {Future cancelWhen}) {
   terminateEventStream ??= ProcessSignal.SIGINT.watch();
   int numEventsSeen = 0;
-  var terminateListener;
+  StreamSubscription terminateListener;
   terminateListener = terminateEventStream.listen((_) {
     numEventsSeen++;
     if (numEventsSeen == 1) {

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -173,7 +173,7 @@ class BuildImpl {
     if (!await _reader.canRead(_assetGraphId)) return null;
     try {
       return new AssetGraph.deserialize(
-          JSON.decode(await _reader.readAsString(_assetGraphId)));
+          JSON.decode(await _reader.readAsString(_assetGraphId)) as Map);
     } on AssetGraphVersionException catch (_) {
       // Start fresh if the cached asset_graph version doesn't match up with
       // the current version. We don't currently support old graph versions.
@@ -194,7 +194,7 @@ class BuildImpl {
         .wait(currentMirrorSystem().libraries.keys.map((Uri uri) async {
       // Short-circuit
       if (completer.isCompleted) return;
-      var lastModified;
+      DateTime lastModified;
       switch (uri.scheme) {
         case 'dart':
           return;

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -157,4 +157,4 @@ class WatchImpl {
 
 Map<AssetId, ChangeType> _collectChanges(List<List<AssetChange>> changes) =>
     new Map.fromIterable(changes.expand((c) => c),
-        key: (c) => c.id, value: (c) => c.type);
+        key: (AssetChange c) => c.id, value: (AssetChange c) => c.type);

--- a/build_runner/lib/src/package_graph/package_graph.dart
+++ b/build_runner/lib/src/package_graph/package_graph.dart
@@ -43,7 +43,7 @@ class PackageGraph {
       throw 'Unable to generate package graph, no `pubspec.yaml` found. '
           'This program must be ran from the root directory of your package.';
     }
-    var rootYaml = loadYaml(pubspec.readAsStringSync());
+    var rootYaml = loadYaml(pubspec.readAsStringSync()) as YamlMap;
 
     /// Read in the `.packages` file to get the locations of all packages.
     var packagesFile = new File(path.join(packagePath, '.packages'));
@@ -62,7 +62,7 @@ class PackageGraph {
       if (uriString.endsWith('/')) {
         uriString = uriString.substring(0, uriString.length - 1);
       }
-      var uri;
+      Uri uri;
       try {
         uri = Uri.parse(uriString);
       } on FormatException catch (_) {
@@ -81,10 +81,10 @@ class PackageGraph {
     Map<String, dynamic> rootDeps;
     PackageNode addNodeAndDeps(YamlMap yaml, PackageDependencyType type,
         {bool isRoot: false}) {
-      var name = yaml['name'];
+      var name = yaml['name'] as String;
       assert(!nodes.containsKey(name));
-      var node =
-          new PackageNode(name, yaml['version'], type, packageLocations[name]);
+      var node = new PackageNode(
+          name, yaml['version'] as String, type, packageLocations[name]);
       nodes[name] = node;
 
       var deps = _depsFromYaml(yaml, isRoot: isRoot);
@@ -163,9 +163,10 @@ PackageDependencyType _dependencyType(source) {
   if (source is String || source == null) return PackageDependencyType.pub;
 
   assert(source is YamlMap);
+  var map = source as YamlMap;
 
-  for (var key in source.keys) {
-    switch (key) {
+  for (var key in map.keys) {
+    switch (key as String) {
       case 'git':
         return PackageDependencyType.github;
       case 'hosted':
@@ -180,11 +181,11 @@ PackageDependencyType _dependencyType(source) {
 
 /// Gets the deps from a yaml file, taking into account dependency_overrides.
 Map<String, dynamic> _depsFromYaml(YamlMap yaml, {bool isRoot: false}) {
-  var deps = new Map<String, dynamic>.from(yaml['dependencies'] ?? {});
+  var deps = new Map<String, dynamic>.from(yaml['dependencies'] as Map ?? {});
   if (isRoot) {
-    deps.addAll(new Map.from(yaml['dev_dependencies'] ?? {}));
+    deps.addAll(new Map.from(yaml['dev_dependencies'] as Map ?? {}));
     yaml['dependency_overrides']?.forEach((dep, source) {
-      deps[dep] = source;
+      deps[dep as String] = source;
     });
   }
   return deps;
@@ -197,5 +198,5 @@ YamlMap _pubspecForUri(Uri uri) {
   if (!pubspec.existsSync()) {
     throw 'Unable to generate package graph, no `$pubspecPath` found.';
   }
-  return loadYaml(pubspec.readAsStringSync());
+  return loadYaml(pubspec.readAsStringSync()) as YamlMap;
 }

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -95,7 +95,7 @@ void main() {
       }
 
       var encoded = JSON.encode(graph.serialize());
-      var decoded = new AssetGraph.deserialize(JSON.decode(encoded));
+      var decoded = new AssetGraph.deserialize(JSON.decode(encoded) as Map);
       expect(graph, equalsAssetGraph(decoded));
     });
 
@@ -103,7 +103,7 @@ void main() {
       var serialized = graph.serialize();
       serialized['version'] = -1;
       var encoded = JSON.encode(serialized);
-      expect(() => new AssetGraph.deserialize(JSON.decode(encoded)),
+      expect(() => new AssetGraph.deserialize(JSON.decode(encoded) as Map),
           throwsA(assetGraphVersionException));
     });
   });

--- a/build_runner/test/common/matchers.dart
+++ b/build_runner/test/common/matchers.dart
@@ -24,11 +24,12 @@ class _AssetGraphMatcher extends Matcher {
   @override
   bool matches(dynamic item, _) {
     if (item is! AssetGraph) return false;
-    if (item.allNodes.length != _expected.allNodes.length) return false;
-    if (_checkValidAsOf && (item.validAsOf != _expected.validAsOf)) {
+    var graph = item as AssetGraph;
+    if (graph.allNodes.length != _expected.allNodes.length) return false;
+    if (_checkValidAsOf && (graph.validAsOf != _expected.validAsOf)) {
       return false;
     }
-    for (var node in item.allNodes) {
+    for (var node in graph.allNodes) {
       var expectedNode = _expected.get(node.id);
       if (expectedNode == null || expectedNode.id != node.id) return false;
       if (!unorderedEquals(node.outputs).matches(expectedNode.outputs, null)) {
@@ -38,11 +39,11 @@ class _AssetGraphMatcher extends Matcher {
           .matches(expectedNode.primaryOutputs, null)) {
         return false;
       }
-      if (item is GeneratedAssetNode) {
+      if (node is GeneratedAssetNode) {
         if (expectedNode is GeneratedAssetNode) {
-          if (item.primaryInput != expectedNode.primaryInput) return false;
-          if (item.needsUpdate != expectedNode.needsUpdate) return false;
-          if (item.wasOutput != expectedNode.wasOutput) return false;
+          if (node.primaryInput != expectedNode.primaryInput) return false;
+          if (node.needsUpdate != expectedNode.needsUpdate) return false;
+          if (node.wasOutput != expectedNode.wasOutput) return false;
         } else {
           return false;
         }

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -15,7 +15,7 @@ import 'in_memory_writer.dart';
 Future wait(int milliseconds) =>
     new Future.delayed(new Duration(milliseconds: milliseconds));
 
-Future<BuildResult> nextResult(List results) {
+Future<BuildResult> nextResult(List<BuildResult> results) {
   var done = new Completer<BuildResult>();
   var startingLength = results.length;
   () async {

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -95,13 +95,15 @@ void main() {
     var graphId = makeAssetId('a|$assetGraphPath');
     expect(writer.assets, contains(graphId));
     var cachedGraph = new AssetGraph.deserialize(
-        JSON.decode(writer.assets[graphId].stringValue));
+        JSON.decode(writer.assets[graphId].stringValue) as Map);
 
     var expectedGraph = new AssetGraph.build([], new Set());
-    var aCopyNode = makeAssetNode('a|web/a.txt.copy');
+    var aCopyNode = new GeneratedAssetNode(null, makeAssetId('a|web/a.txt'),
+        false, true, makeAssetId('a|web/a.txt.copy'));
     expectedGraph.add(aCopyNode);
     expectedGraph.add(makeAssetNode('a|web/a.txt', [aCopyNode.id]));
-    var bCopyNode = makeAssetNode('a|lib/b.txt.copy');
+    var bCopyNode = new GeneratedAssetNode(null, makeAssetId('a|lib/b.txt'),
+        false, true, makeAssetId('a|lib/b.txt.copy'));
     expectedGraph.add(bCopyNode);
     expectedGraph.add(makeAssetNode('a|lib/b.txt', [bCopyNode.id]));
 
@@ -271,8 +273,9 @@ void main() {
           writer: writer);
 
       /// Should be deleted using the writer, and removed from the new graph.
-      var newGraph = new AssetGraph.deserialize(JSON
-          .decode(writer.assets[makeAssetId('a|$assetGraphPath')].stringValue));
+      var serialized = JSON.decode(
+          writer.assets[makeAssetId('a|$assetGraphPath')].stringValue) as Map;
+      var newGraph = new AssetGraph.deserialize(serialized);
       expect(newGraph.contains(aNode.id), isFalse);
       expect(newGraph.contains(aCopyNode.id), isFalse);
       expect(newGraph.contains(aCloneNode.id), isFalse);

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -11,6 +11,7 @@ import 'package:watcher/watcher.dart';
 
 import 'package:build_runner/build_runner.dart';
 import 'package:build_runner/src/asset_graph/graph.dart';
+import 'package:build_runner/src/asset_graph/node.dart';
 import 'package:build_test/build_test.dart';
 
 import '../common/common.dart';
@@ -121,14 +122,17 @@ void main() {
         result = await nextResult(results);
         checkBuild(result, outputs: {'a|web/c.txt.copy': 'c'}, writer: writer);
 
-        var cachedGraph = new AssetGraph.deserialize(JSON.decode(
-            writer.assets[makeAssetId('a|$assetGraphPath')].stringValue));
+        var serialized = JSON.decode(
+            writer.assets[makeAssetId('a|$assetGraphPath')].stringValue) as Map;
+        var cachedGraph = new AssetGraph.deserialize(serialized);
 
         var expectedGraph = new AssetGraph.build([], new Set());
-        var bCopyNode = makeAssetNode('a|web/b.txt.copy');
+        var bCopyNode = new GeneratedAssetNode(null, makeAssetId('a|web/b.txt'),
+            false, true, makeAssetId('a|web/b.txt.copy'));
         expectedGraph.add(bCopyNode);
         expectedGraph.add(makeAssetNode('a|web/b.txt', [bCopyNode.id]));
-        var cCopyNode = makeAssetNode('a|web/c.txt.copy');
+        var cCopyNode = new GeneratedAssetNode(null, makeAssetId('a|web/c.txt'),
+            false, true, makeAssetId('a|web/c.txt.copy'));
         expectedGraph.add(cCopyNode);
         expectedGraph.add(makeAssetNode('a|web/c.txt', [cCopyNode.id]));
 

--- a/build_test/lib/build_test.dart
+++ b/build_test/lib/build_test.dart
@@ -1,6 +1,9 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
+export 'package:build/src/builder/logging.dart' show scopeLog;
+
 export 'src/assets.dart';
 export 'src/copy_builder.dart';
 export 'src/fake_watcher.dart';
@@ -13,5 +16,3 @@ export 'src/resolve_source.dart';
 export 'src/stub_reader.dart';
 export 'src/stub_writer.dart';
 export 'src/test_builder.dart';
-
-export 'package:build/src/builder/logging.dart' show scopeLog;

--- a/build_test/lib/src/copy_builder.dart
+++ b/build_test/lib/src/copy_builder.dart
@@ -35,7 +35,7 @@ class CopyBuilder implements Builder {
   Future build(BuildStep buildStep) async {
     if (blockUntil != null) await blockUntil;
 
-    var ids = new Iterable.generate(numCopies)
+    var ids = new Iterable<int>.generate(numCopies)
         .map((copy) => _copiedAssetId(buildStep.inputId, copy));
     for (var id in ids) {
       var toCopy = copyFromAsset ?? buildStep.inputId;

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -6,11 +6,11 @@ import 'dart:async';
 
 import 'package:build/build.dart';
 import 'package:build_barback/build_barback.dart';
+import 'package:package_resolver/package_resolver.dart';
 
 import 'in_memory_reader.dart';
 import 'in_memory_writer.dart';
 import 'multi_asset_reader.dart';
-import 'package:package_resolver/package_resolver.dart';
 import 'package_reader.dart';
 
 /// Returns a future that completes with a source [Resolver] for [inputSource].

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -8,9 +8,9 @@ import 'package:build/build.dart';
 import 'package:build_barback/build_barback.dart';
 import 'package:logging/logging.dart';
 
-import 'in_memory_writer.dart';
-import 'in_memory_reader.dart';
 import 'assets.dart';
+import 'in_memory_reader.dart';
+import 'in_memory_writer.dart';
 
 void checkOutputs(
     Map<String, /*List<int>|String|Matcher<String|List<int>>*/ dynamic> outputs,
@@ -104,7 +104,7 @@ Future testBuilder(
   });
 
   isInput ??= generateFor?.contains ?? (_) => true;
-  inputIds = inputIds.where((id) => isInput('$id'));
+  inputIds = inputIds.where((id) => isInput('$id')).toList();
 
   var writerSpy = new AssetWriterSpy(writer);
   var logger = new Logger('testBuilder');


### PR DESCRIPTION
- Disable implicit casts in our analysis options.
- Fix a few bugs that were discovered:
  - Missing assignment to memoized _uri field
  - Incorrect argument types
  - Checking wrong variable in AssetGraph matcher. Fix tests that were
    relying on this matcher being a weaker check than intended.
- Fix newly errors which only needed a cast. The most annoying parts are
  around deserialization. A couple are around APIs in external packages
  that are (unintentionally?) dynamic.
- Fix a couple import ordering lints