### PR TITLE
Allow build_barback 0.4.x from build_test

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   glob: ^1.1.0
 
 dev_dependencies:
-  build_barback: ^0.2.0
+  build_barback: ^0.4.0
   build_test: ^0.6.0
   test: ^0.12.0
   transformer_test: ^0.2.0

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.4.0
+version: 0.4.1-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.27.1 <0.31.0"
   async: ^1.13.3
-  build: ">=0.9.0 <0.11.0"
+  build: ^0.10.0
   build_barback: '>=0.2.0 <0.4.0'
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4+1
+
+- Allow `package:build_barback` v0.4.x
+
 ## 0.6.4
 
 - Allow `package:build` v0.10.x

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   build: ">=0.9.0 <0.11.0"
-  build_barback: ">=0.2.0 <0.4.0"
+  build_barback: ">=0.2.0 <0.5.0"
   collection: ^1.14.0
   glob: ^1.1.0
   logging: ^0.11.2


### PR DESCRIPTION
Currently there exists a version lock trying to upgrade to build 0.10