### PR TITLE
Only check dartfmt on dev version

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -10,5 +10,7 @@ set -e
 pushd $PKG
 pub upgrade
 dartanalyzer --fatal-warnings .
-echo Any unformatted files?
-dartfmt -n --set-exit-if-changed .
+if [ "$TRAVIS_DART_VERSION" == "dev" ]; then
+  echo Any unformatted files?
+  dartfmt -n --set-exit-if-changed .
+fi


### PR DESCRIPTION
Since most of us use the dev version locally it'll be easiest to not
stick to stable.