### PR TITLE
Disallow reads outside the asset graph

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.1
+## 0.4.0+2
 
 - Bug fix: Don't crash after a Builder reads a file from another package.
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- Bug fix: Don't crash after a Builder reads a file from another package.
+
 ## 0.4.0+1
 
 - Depend on `build` 0.10.x and `build_barback` 0.4.x

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -31,7 +31,7 @@ class SinglePhaseReader implements AssetReader {
 
   bool _isReadable(AssetId id) {
     var node = _assetGraph.get(id);
-    if (node == null) return true;
+    if (node == null) return false;
     if (node is! GeneratedAssetNode) return true;
     return (node as GeneratedAssetNode).phaseNumber < _phaseNumber;
   }

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -361,13 +361,9 @@ class BuildImpl {
 
   /// Returns the set of available inputs on disk.
   Future<Set<AssetId>> _initializeInputsByPackage() async {
-    final packages = new Set<String>();
-    for (var action in _buildActions) {
-      packages.add(action.inputSet.package);
-    }
-
-    var inputSets = packages.map((package) => new InputSet(
-        package, [package == _packageGraph.root.name ? '**' : 'lib/**']));
+    var inputSets = _packageGraph.allPackages.keys.map((package) =>
+        new InputSet(
+            package, [package == _packageGraph.root.name ? '**' : 'lib/**']));
     return listAssetIds(_reader, inputSets).where(_isValidInput).toSet();
   }
 
@@ -441,6 +437,7 @@ class BuildImpl {
       // Update the asset graph based on the dependencies discovered.
       for (var dependency in reader.assetsRead) {
         var dependencyNode = _assetGraph.get(dependency);
+        assert(dependencyNode != null, 'Asset Graph is missing $dependency');
         // We care about all builderOutputs, not just real outputs. Updates
         // to dependencies may cause a file to be output which wasn't before.
         dependencyNode.outputs.addAll(builderOutputs);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.4.1+2
+version: 0.4.0+2
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.4.1
+version: 0.4.1+2
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.4.0+1
+version: 0.4.1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -79,9 +79,16 @@ void main() {
     });
 
     test('can\'t output files in non-root packages', () async {
+      var packageB = new PackageNode(
+          'b', '0.1.0', PackageDependencyType.path, new Uri.file('a/b/'));
+      var packageA = new PackageNode(
+          'a', '0.1.0', PackageDependencyType.path, new Uri.file('a/'))
+        ..dependencies.add(packageB);
+      ;
+      var packageGraph = new PackageGraph.fromRoot(packageA);
       await testActions(
           [new BuildAction(new CopyBuilder(), 'b')], {'b|lib/b.txt': 'b'},
-          outputs: {}, status: BuildStatus.failure);
+          packageGraph: packageGraph, outputs: {}, status: BuildStatus.failure);
     });
   });
 

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -90,6 +90,19 @@ void main() {
           [new BuildAction(new CopyBuilder(), 'b')], {'b|lib/b.txt': 'b'},
           packageGraph: packageGraph, outputs: {}, status: BuildStatus.failure);
     });
+
+    test('can read files from external packages', () async {
+      var buildActions = [
+        new BuildAction(
+            new CopyBuilder(touchAsset: makeAssetId('b|lib/b.txt')), 'a')
+      ];
+      await testActions(buildActions, {
+        'a|lib/a.txt': 'a',
+        'b|lib/b.txt': 'b'
+      }, outputs: {
+        'a|lib/a.txt.copy': 'a',
+      });
+    });
   });
 
   test('tracks dependency graph in a asset_graph.json file', () async {


### PR DESCRIPTION
Fixes #359

We used to rely on the graph being updated if it didn't already have the
source node but now expect the graph to keep it's structure after
initialization. In order to allow reads to any file that would have been
visible before add all packages as sources, not just those that have a
build action. This should only increase the size of the serialized graph
for projects which did not read these files anyway - which excludes
anything using BarbackResolvers and crawling imports.