### PR TITLE
Add an `action` argument to `resolveSource`

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.0
+
+- **Breaking**: `resolveSource` and `resolveAsset` now take an `action` to
+  perform with the Resolver instance.
+
 ## 0.6.4+1
 
 - Allow `package:build_barback` v0.4.x

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -38,7 +38,7 @@ import 'package_reader.dart';
 /// Resolver resolver;
 ///
 /// setUpAll(() async {
-///   onTearDown = new Completer<Null>();
+///   resolverDone = new Completer<Null>();
 ///   resolver = await resolveSource('...', (resover) => resolver,
 ///       tearDown: resolverDone.future);
 /// });
@@ -82,7 +82,7 @@ Future<T> resolveSource<T>(
 /// Resolver resolver;
 ///
 /// setUpAll(() async {
-///   onTearDown = new Completer<Null>();
+///   resolverDone = new Completer<Null>();
 ///   resolver = await resolveAsset('...', (resover) => resolver,
 ///       tearDown: resolverDone.future);
 /// });

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.6.4+1
+version: 0.7.0
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 

--- a/build_test/test/resolve_source_test.dart
+++ b/build_test/test/resolve_source_test.dart
@@ -70,6 +70,21 @@ void main() {
         contains('asset:collection#Equality'),
       );
     });
+
+    test('can do expects inside the action', () async {
+      await resolveSource(r'''
+        library example;
+
+        import 'package:collection/collection.dart';
+
+        abstract class Foo implements Equality {}
+      ''', (resolver) async {
+        var libExample = await resolver.findLibraryByName('example');
+        var classFoo = libExample.getType('Foo');
+        expect(classFoo.allSupertypes.map(_toStringId),
+            contains('asset:collection#Equality'));
+      });
+    });
   });
 
   group('should resolveAsset', () {


### PR DESCRIPTION
Closes #355

After the Resolver apis all became async it became impossible to do any
work with the Resolver instance without also passing a `tearDown`
argument. By default expect the work to be done now inside an `action`
callback and continue to allow the old behavior by returning the
resolver in the action and passing a teardown.

Change `tearDown` from a `Future<Null>` to a `Future` for a more
flexible api. Can become `Future<void>` once the language allows it.