### PR TITLE
Capture write errors before calling `complete()`

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0+1
+
+- Bug Fix: Capture asynchronous errors during asset writing.
+
 ## 0.10.0
 
 - **Breaking**: Removed deprecated method `BuildStep.hasInput` - all uses should

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.10.0
+version: 0.10.0+1
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -180,6 +180,27 @@ void main() {
       expect(isComplete, true, reason: 'File is written, should be complete');
     });
   });
+
+  group('With erroring writes', () {
+    AssetId primary;
+    BuildStepImpl buildStep;
+    AssetId output;
+
+    setUp(() {
+      var reader = new StubAssetReader();
+      var writer = new StubAssetWriter();
+      primary = makeAssetId();
+      output = makeAssetId();
+      buildStep = new BuildStepImpl(primary, [output], reader, writer,
+          primary.package, const BarbackResolvers());
+    });
+
+    test('Captures failed asynchronous writes', () {
+      // ignore: unawaited_futures
+      buildStep.writeAsString(output, new Future.error('error'));
+      expect(buildStep.complete(), throwsA('error'));
+    });
+  });
 }
 
 class SlowAssetWriter implements AssetWriter {

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -196,7 +196,6 @@ void main() {
     });
 
     test('Captures failed asynchronous writes', () {
-      // ignore: unawaited_futures
       buildStep.writeAsString(output, new Future.error('error'));
       expect(buildStep.complete(), throwsA('error'));
     });


### PR DESCRIPTION
Fixes #336

Since errors can occur before we ever call `.then()` on these Futures we
need to capture them as a `Result` to hold the error until we reease it
in `complete()`.

Add a regression test that fails before this change.