### PR TITLE
Disallow reads into .dart_tool

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1-dev
+
+- Prevent reads into `.dart_tool` for more hermetic builds.
+
 ## 0.4.0+3
 
 - Bug fix: Don't try to delete files generated for other packages.

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -137,7 +137,6 @@ class BuildImpl {
 
         if (_assetGraph != null) {
           await _writer.delete(_assetGraphId);
-          currentSources.remove(_assetGraphId);
           _logger
               .info('Updating dependency graph with changes since last build.');
           _assetGraph.updateForSources(_buildActions, currentSources);
@@ -383,11 +382,9 @@ class BuildImpl {
           .toSet();
 
   /// Checks if an [input] is valid.
-  bool _isValidInput(AssetId input) {
-    var parts = path.split(input.path);
-    if (input.package != _packageGraph.root.name) return parts[0] == 'lib';
-    return true;
-  }
+  bool _isValidInput(AssetId input) => input.package != _packageGraph.root.name
+      ? input.path.startsWith('lib/')
+      : !input.path.startsWith(toolDir);
 
   /// Runs [builder] with [primaryInputs] as inputs.
   Stream<AssetId> _runBuilder(int phaseNumber, Builder builder,

--- a/build_runner/lib/src/util/constants.dart
+++ b/build_runner/lib/src/util/constants.dart
@@ -8,8 +8,13 @@ import 'package:crypto/crypto.dart';
 /// Relative path to the asset graph from the root package dir.
 final String assetGraphPath = '$cacheDir/$scriptHash/asset_graph.json';
 
+/// Directory used for build tooling.
+///
+/// Reading from this directory make cause non-hermetic builds.
+const String toolDir = '.dart_tool';
+
 /// Relative path to the cache directory from the root package dir.
-const String cacheDir = '.dart_tool/build';
+const String cacheDir = '$toolDir/build';
 
 final String scriptHash =
     md5.convert(Platform.script.path.codeUnits).toString();

--- a/build_runner/lib/src/util/constants.dart
+++ b/build_runner/lib/src/util/constants.dart
@@ -10,7 +10,7 @@ final String assetGraphPath = '$cacheDir/$scriptHash/asset_graph.json';
 
 /// Directory used for build tooling.
 ///
-/// Reading from this directory make cause non-hermetic builds.
+/// Reading from this directory may cause non-hermetic builds.
 const String toolDir = '.dart_tool';
 
 /// Relative path to the cache directory from the root package dir.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.4.0+3
+version: 0.4.1-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -103,6 +103,19 @@ void main() {
       });
     });
 
+    test('can\'t read files in .dart_tool', () async {
+      await testActions([
+        new BuildAction(
+            new CopyBuilder(
+                copyFromAsset: makeAssetId('a|.dart_tool/any_file')),
+            'a')
+      ], {
+        'a|lib/a.txt': 'a',
+        'a|.dart_tool/any_file': 'content'
+      }, status: BuildStatus.failure);
+      await new Future.delayed(const Duration(milliseconds: 500));
+    });
+
     test('won\'t try to delete files from other packages', () async {
       var packageB = new PackageNode(
           'b', '0.1.0', PackageDependencyType.path, new Uri.file('a/b/'));

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -113,7 +113,6 @@ void main() {
         'a|lib/a.txt': 'a',
         'a|.dart_tool/any_file': 'content'
       }, status: BuildStatus.failure);
-      await new Future.delayed(const Duration(milliseconds: 500));
     });
 
     test('won\'t try to delete files from other packages', () async {


### PR DESCRIPTION
Fixes #326

.dart_tool will never be considered an input or be available for reads.

Add a regression test which expects to fail when trying to read from
this directory.