### PR TITLE
Delete entire asset graph if build script changes

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.1-dev
 
 - Prevent reads into `.dart_tool` for more hermetic builds.
+- Bug Fix: Rebuild entire asset graph if the build script changes.
 
 ## 0.4.0+3
 

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -83,16 +83,6 @@ class AssetGraph {
   Iterable<AssetId> get sources =>
       allNodes.where((n) => n is! GeneratedAssetNode).map((n) => n.id);
 
-  /// Invalidates all generated assets.
-  ///
-  /// If the build script has changed any Builder could have new behavior which
-  /// would produce a different output.
-  void invalidateBuildScript() {
-    for (var node in allNodes) {
-      if (node is GeneratedAssetNode) node.needsUpdate = true;
-    }
-  }
-
   /// Update graph structure, invalidate outputs that may change, and return the
   /// set of assets that need to be deleted.
   Iterable<AssetId> updateAndInvalidate(Map<AssetId, ChangeType> updates) {

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -119,7 +119,7 @@ class BuildImpl {
             if (_isFirstBuild) {
               _logger.warning(
                   'Invalidating asset graph due to build script update');
-              _assetGraph.invalidateBuildScript();
+              _assetGraph = null;
             } else {
               done.complete(new BuildResult(BuildStatus.failure, buildType, [],
                   exception: new BuildScriptUpdatedException()));

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -299,7 +299,8 @@ void main() {
             inputs: ['**/*.txt.copy'])
       ];
 
-      var graph = new AssetGraph.build([], new Set());
+      var graph = new AssetGraph.build([], new Set())
+        ..validAsOf = new DateTime.now();
       var aCloneNode = new GeneratedAssetNode(
           1,
           makeAssetId('a|lib/a.txt.copy'),


### PR DESCRIPTION
Fixes #369

Instead of only marking generated assets for re-generation, clear out
the entire graph. The BuildActions may have changed which would cause
different outputs to get created.