### PR TITLE
Add `mapAssetIds` argument to `checkOutputs`

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.1-dev
+
+- Add `mapAssetIds` argument to `checkOutputs` for cases where the logical asset
+  location recorded by the builder does not match the written location.
+
 ## 0.7.0+1
 
 - Switch to a typedef from function type syntax for compatibility with older

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.7.0+1
+version: 0.7.1-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 

--- a/build_test/test/check_outputs_test.dart
+++ b/build_test/test/check_outputs_test.dart
@@ -1,0 +1,63 @@
+import 'package:test/test.dart';
+
+import 'package:build_test/build_test.dart';
+
+void main() {
+  group('checkOutputs', () {
+    test('with exact outputs', () async {
+      var a = makeAssetId('a|lib/a.txt');
+      var b = makeAssetId('a|lib/b.txt');
+      var actualAssets = [a, b];
+      var writer = new InMemoryAssetWriter();
+      await writer.writeAsString(a, 'a');
+      await writer.writeAsString(b, 'b');
+
+      var outputs = {'a|lib/a.txt': 'a', 'a|lib/b.txt': 'b'};
+
+      expect(
+          () => checkOutputs(outputs, actualAssets, writer), returnsNormally);
+    });
+    test('with extra output', () async {
+      var a = makeAssetId('a|lib/a.txt');
+      var b = makeAssetId('a|lib/b.txt');
+      var actualAssets = [a, b];
+      var writer = new InMemoryAssetWriter();
+      await writer.writeAsString(a, 'a');
+      await writer.writeAsString(b, 'b');
+
+      var outputs = {'a|lib/a.txt': 'a'};
+
+      expect(() => checkOutputs(outputs, actualAssets, writer),
+          throwsA(new isInstanceOf<TestFailure>()));
+    });
+
+    test('with missing output', () async {
+      var a = makeAssetId('a|lib/a.txt');
+      var actualAssets = [a];
+      var writer = new InMemoryAssetWriter();
+      await writer.writeAsString(a, 'a');
+
+      var outputs = {'a|lib/a.txt': 'a', 'a|lib/b.txt': 'b'};
+
+      expect(() => checkOutputs(outputs, actualAssets, writer),
+          throwsA(new isInstanceOf<TestFailure>()));
+    });
+
+    test('with asset mapping', () async {
+      var a = makeAssetId('a|lib/a.txt');
+      var b = makeAssetId('b|lib/b.txt');
+      var bMapped = makeAssetId('a|.generated/b/lib/b.txt');
+      var actualAssets = [a, b];
+      var writer = new InMemoryAssetWriter();
+      await writer.writeAsString(a, 'a');
+      await writer.writeAsString(bMapped, 'b');
+
+      var outputs = {'a|lib/a.txt': 'a', 'b|lib/b.txt': 'b'};
+
+      expect(
+          () => checkOutputs(outputs, actualAssets, writer,
+              mapAssetIds: (id) => id == b ? bMapped : a),
+          returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
In order to accomplish #216 we will need `build_runner` to be able to
write assets to a different location on disk than their logical location
within a package. The translation will happen at a lower level than the
writer that gets spied on during the build so that apparent outputs from
the builder might not match the written assets to the
`InMemoryAssetWriter`. Add an argument that can perform the same mapping
as would happen in the actual asset writer during the build.

- Add a Doc comment to checkOutputs
- Add the mapAssetIds argument and default to a passthrough.
- Add tests for checkOutputs