### PR TITLE
Remove restrictions on outputs by package

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.1-dev
+
+- Remove restrictions around the root package when Builders are running. It is
+  the responsibility of the build system to ensure that builders are only run on
+  inputs that will produce outputs that can be written.
+
 ## 0.10.0+1
 
 - Bug Fix: Capture asynchronous errors during asset writing.

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -32,7 +32,7 @@ class BuildStepImpl implements BuildStep {
 
   /// The list of all outputs which are expected/allowed to be output from this
   /// step.
-  final List<AssetId> _expectedOutputs;
+  final Set<AssetId> _expectedOutputs;
 
   /// The result of any writes which are starting during this step.
   final _writeResults = <Future<Result>>[];
@@ -47,8 +47,8 @@ class BuildStepImpl implements BuildStep {
   final String _rootPackage;
 
   BuildStepImpl(this.inputId, Iterable<AssetId> expectedOutputs, this._reader,
-      this._writer, this._rootPackage, this._resolvers)
-      : _expectedOutputs = expectedOutputs.toList();
+      this._writer, @deprecated this._rootPackage, this._resolvers)
+      : _expectedOutputs = expectedOutputs.toSet();
 
   @override
   Resolver get resolver =>
@@ -117,17 +117,10 @@ class BuildStepImpl implements BuildStep {
     }
   }
 
-  /// Checks that [id] is a valid output, and throws an
+  /// Checks that [id] is an expected output, and throws an
   /// [InvalidOutputException] or [UnexpectedOutputException] if it's not.
   void _checkOutput(AssetId id) {
-    if (id.package != _rootPackage) {
-      throw new InvalidOutputException(
-          id,
-          'Files may only be output in the root (application) package. '
-          'Attempted to output "$id" but the root package is '
-          '"$_rootPackage".');
-    }
-    if (!_expectedOutputs.any((check) => check == id)) {
+    if (!_expectedOutputs.contains(id)) {
       throw new UnexpectedOutputException(id);
     }
   }

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -14,23 +14,21 @@ import '../builder/builder.dart';
 import '../builder/logging.dart';
 import 'expected_outputs.dart';
 
-/// Run [builder] on each asset in [inputs].
+/// Run [builder] on with asset in [inputs] as the primary input.
 ///
-///
-/// If [rootPackage] is not provided all [inputs] must be for the same
-/// package, and outputs are only allowed in this package. Builds for all
-/// inputs are run asynchronously and ordering is not guaranteed.
+/// Builds for all inputs are run asynchronously and ordering is not guaranteed.
+/// The [log] instance inside the builds will be scoped to [logger] which is
+/// defaulted to a [Logger] name 'runBuilder'.
 Future<Null> runBuilder(Builder builder, Iterable<AssetId> inputs,
     AssetReader reader, AssetWriter writer, Resolvers resolvers,
-    {Logger logger, String rootPackage}) async {
+    {Logger logger, @deprecated String rootPackage}) async {
   logger ??= new Logger('runBuilder');
-  rootPackage ??= inputs.map((input) => input.package).toSet().single;
   //TODO(nbosch) check overlapping outputs?
   Future<Null> buildForInput(AssetId input) async {
     var outputs = expectedOutputs(builder, input);
     if (outputs.isEmpty) return;
-    var buildStep = new BuildStepImpl(
-        input, outputs, reader, writer, rootPackage, resolvers);
+    var buildStep = new BuildStepImpl(input, outputs, reader, writer,
+        rootPackage ?? input.package, resolvers);
     try {
       await builder.build(buildStep);
     } finally {

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -14,7 +14,7 @@ import '../builder/builder.dart';
 import '../builder/logging.dart';
 import 'expected_outputs.dart';
 
-/// Run [builder] on with asset in [inputs] as the primary input.
+/// Run [builder] with each asset in [inputs] as the primary input.
 ///
 /// Builds for all inputs are run asynchronously and ordering is not guaranteed.
 /// The [log] instance inside the builds will be scoped to [logger] which is

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.10.0+1
+version: 0.10.1-dev
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -29,6 +29,8 @@ void main() {
       var id = makeAssetId();
       expect(() => buildStep.writeAsString(id, '$id'),
           throwsA(new isInstanceOf<UnexpectedOutputException>()));
+      expect(() => buildStep.writeAsBytes(id, [0]),
+          throwsA(new isInstanceOf<UnexpectedOutputException>()));
     });
 
     test('canRead throws invalidInputExceptions', () async {
@@ -50,19 +52,6 @@ void main() {
         expect(
             () => buildStep.readAsString(id), throwsA(invalidInputException));
         expect(() => buildStep.readAsBytes(id), throwsA(invalidInputException));
-      }
-    });
-
-    test('writeAs* throws InvalidOutputExceptions', () async {
-      var invalidOutputIds = [
-        makeAssetId('b|test.txt'),
-        makeAssetId('foo|bar.txt'),
-      ];
-      for (var id in invalidOutputIds) {
-        expect(() => buildStep.writeAsString(id, 'foo'),
-            throwsA(invalidOutputException));
-        expect(() => buildStep.writeAsBytes(id, [0]),
-            throwsA(invalidOutputException));
       }
     });
   });


### PR DESCRIPTION
Towards #378

We know that outputs can only be for the same package as inputs and we
check that the only assets written are declared outputs. We don't need
to also pass around a root package or force that all inputs are for the
same package - the build systems which call `runBuilder` will need to do
appropriate checks regardless of whether we duplicate them here.