### PR TITLE
Use a single pattern for ignoring build outputs

### DIFF
--- a/build_runner/lib/src/asset/file_based.dart
+++ b/build_runner/lib/src/asset/file_based.dart
@@ -17,10 +17,8 @@ import 'writer.dart';
 /// files from disk.
 class FileBasedAssetReader implements RunnerAssetReader {
   final PackageGraph packageGraph;
-  final List<String> ignoredDirs;
 
-  FileBasedAssetReader(this.packageGraph,
-      {this.ignoredDirs: const ['build', 'packages', '.pub']});
+  FileBasedAssetReader(this.packageGraph);
 
   @override
   Future<bool> canRead(AssetId id) => _fileFor(id, packageGraph).exists();
@@ -45,8 +43,9 @@ class FileBasedAssetReader implements RunnerAssetReader {
           "remove it from your input sets.");
     }
     var packagePath = packageNode.location.toFilePath();
-    var files = glob.listSync(followLinks: false, root: packagePath).where(
-        (e) => e is File && !ignoredDirs.contains(path.split(e.path)[1]));
+    var files = glob
+        .listSync(followLinks: false, root: packagePath)
+        .where((e) => e is File);
     for (var file in files) {
       // TODO(jakemac): Where do these files come from???
       if (path.basename(file.path).startsWith('._')) continue;

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -389,7 +389,7 @@ class BuildImpl {
   /// Checks if an [input] is valid.
   bool _isValidInput(AssetId input) => input.package != _packageGraph.root.name
       ? input.path.startsWith('lib/')
-      : !input.path.startsWith(toolDir);
+      : !toolDirs.any((d) => input.path.startsWith(d));
 
   /// Runs [builder] with [primaryInputs] as inputs.
   Stream<AssetId> _runBuilder(int phaseNumber, Builder builder,

--- a/build_runner/lib/src/util/constants.dart
+++ b/build_runner/lib/src/util/constants.dart
@@ -8,7 +8,7 @@ import 'package:crypto/crypto.dart';
 /// Relative path to the asset graph from the root package dir.
 final String assetGraphPath = '$cacheDir/$scriptHash/asset_graph.json';
 
-/// Directory used for build tooling.
+/// Directories used for build tooling.
 ///
 /// Reading from these directories may cause non-hermetic builds.
 const toolDirs = const ['.dart_tool', 'build', 'packages', '.pub'];

--- a/build_runner/lib/src/util/constants.dart
+++ b/build_runner/lib/src/util/constants.dart
@@ -10,11 +10,11 @@ final String assetGraphPath = '$cacheDir/$scriptHash/asset_graph.json';
 
 /// Directory used for build tooling.
 ///
-/// Reading from this directory may cause non-hermetic builds.
-const String toolDir = '.dart_tool';
+/// Reading from these directories may cause non-hermetic builds.
+const toolDirs = const ['.dart_tool', 'build', 'packages', '.pub'];
 
 /// Relative path to the cache directory from the root package dir.
-const String cacheDir = '$toolDir/build';
+const String cacheDir = '.dart_tool/build';
 
 final String scriptHash =
     md5.convert(Platform.script.path.codeUnits).toString();

--- a/build_runner/test/asset/file_based_test.dart
+++ b/build_runner/test/asset/file_based_test.dart
@@ -18,7 +18,7 @@ final String newLine = Platform.isWindows ? '\r\n' : '\n';
 
 void main() {
   group('FileBasedAssetReader', () {
-    final reader = new FileBasedAssetReader(packageGraph, ignoredDirs: ['pkg']);
+    final reader = new FileBasedAssetReader(packageGraph);
 
     test('can read any application package files', () async {
       expect(await reader.readAsString(makeAssetId('basic_pkg|hello.txt')),


### PR DESCRIPTION
Fixes #374

Change `toolDir` to `toolDirs` and ignore them all when loading
potential sources. Remove the additional checking in the
`FileBasedAssetReader`.