### PR TITLE
Separate asset graph loading from build_impl

### DIFF
--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -1,0 +1,215 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:mirrors';
+
+import 'package:build/build.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+import 'package:watcher/watcher.dart';
+
+import '../asset/reader.dart';
+import '../asset_graph/exceptions.dart';
+import '../asset_graph/graph.dart';
+import '../asset_graph/node.dart';
+import '../logging/logging.dart';
+import '../package_graph/package_graph.dart';
+import '../util/constants.dart';
+import 'build_result.dart';
+import 'exceptions.dart';
+import 'input_set.dart';
+import 'phase.dart';
+
+class BuildDefinition {
+  final AssetGraph assetGraph;
+  final BuildType buildType;
+
+  /// The serialized asset graph and generated files which need updates.
+  final Set<AssetId> safeDeletes;
+
+  /// Assets which should be generated but already exist on disk and can't be
+  /// proven to be from the last build.
+  final Set<AssetId> conflictingAssets;
+
+  BuildDefinition(this.assetGraph, this.buildType, this.safeDeletes,
+      this.conflictingAssets);
+}
+
+class BuildDefinitionLoader {
+  final _logger = new Logger('BuildDefinitionLoader');
+  final RunnerAssetReader _reader;
+  final PackageGraph _packageGraph;
+  final List<BuildAction> _buildActions;
+
+  BuildDefinitionLoader(
+    this._reader,
+    this._packageGraph,
+    this._buildActions,
+  );
+
+  Future<BuildDefinition> load() async {
+    final assetGraphId = new AssetId(_packageGraph.root.name, assetGraphPath);
+    AssetGraph assetGraph;
+    final safeDeletes = new Set<AssetId>();
+    final conflictingOutputs = new Set<AssetId>();
+    BuildType buildType = BuildType.incremental;
+    _logger.info('Initializing inputs');
+    var currentSources = await _findCurrentSources();
+    await logWithTime(_logger, 'Reading cached dependency graph', () async {
+      if (await _reader.canRead(assetGraphId)) {
+        assetGraph = await _readAssetGraph(assetGraphId);
+        safeDeletes.add(assetGraphId);
+      }
+      if (assetGraph != null &&
+          (await _buildScriptUpdateTime()).isAfter(assetGraph.validAsOf)) {
+        _logger.warning('Invalidating asset graph due to build script update');
+        assetGraph = null;
+      }
+      if (assetGraph == null) {
+        assetGraph = new AssetGraph.build(_buildActions, currentSources);
+        conflictingOutputs
+            .addAll(assetGraph.outputs.where(currentSources.contains).toSet());
+        buildType = BuildType.full;
+      } else {
+        _logger
+            .info('Updating dependency graph with changes since last build.');
+        var updates = <AssetId, ChangeType>{};
+        var newSources = new Set<AssetId>.from(currentSources)
+          ..removeAll(assetGraph.allNodes.map((n) => n.id));
+        updates.addAll(
+            new Map.fromIterable(newSources, value: (_) => ChangeType.ADD));
+        updates.addAll(await _getUpdates(assetGraph));
+        safeDeletes
+            .addAll(assetGraph.updateAndInvalidate(_buildActions, updates));
+      }
+    });
+    return new BuildDefinition(
+        assetGraph, buildType, safeDeletes, conflictingOutputs);
+  }
+
+  Future<BuildDefinition> fromGraph(
+      AssetGraph assetGraph, Map<AssetId, ChangeType> updates) async {
+    if ((await _buildScriptUpdateTime()).isAfter(assetGraph.validAsOf)) {
+      throw new BuildScriptUpdatedException();
+    }
+    var safeDeletes = new Set<AssetId>();
+    _logger.info('Updating dependency graph with changes since last build.');
+    safeDeletes.addAll(assetGraph.updateAndInvalidate(_buildActions, updates));
+    return new BuildDefinition(
+        assetGraph, BuildType.incremental, safeDeletes, new Set<AssetId>());
+  }
+
+  /// Reads in an [AssetGraph] from disk.
+  Future<AssetGraph> _readAssetGraph(AssetId assetGraphId) async {
+    try {
+      return new AssetGraph.deserialize(
+          JSON.decode(await _reader.readAsString(assetGraphId)) as Map);
+    } on AssetGraphVersionException catch (_) {
+      // Start fresh if the cached asset_graph version doesn't match up with
+      // the current version. We don't currently support old graph versions.
+      _logger.info('Throwing away cached asset graph due to version mismatch.');
+      return null;
+    }
+  }
+
+  /// Creates and returns a map of updates to assets based on [assetGraph].
+  Future<Map<AssetId, ChangeType>> _getUpdates(AssetGraph assetGraph) async {
+    // Collect updates to the graph based on any changed assets.
+    var updates = <AssetId, ChangeType>{};
+    await Future.wait(assetGraph.allNodes
+        .where((node) =>
+            node is! GeneratedAssetNode ||
+            (node as GeneratedAssetNode).wasOutput)
+        .map((node) async {
+      bool exists;
+      try {
+        exists = await _reader.canRead(node.id);
+      } on PackageNotFoundException catch (_) {
+        exists = false;
+      }
+      if (!exists) {
+        updates[node.id] = ChangeType.REMOVE;
+        return;
+      }
+      // Only handle deletes for generated assets, their modified timestamp
+      // is always newer than the asset graph.
+      //
+      // TODO(jakemac): https://github.com/dart-lang/build/issues/61
+      if (node is GeneratedAssetNode) return;
+
+      var lastModified = await _reader.lastModified(node.id);
+      if (lastModified.compareTo(assetGraph.validAsOf) > 0) {
+        updates[node.id] = ChangeType.MODIFY;
+      }
+    }));
+    return updates;
+  }
+
+  /// Checks if the current running program has been updated since the asset graph
+  /// was last built.
+  ///
+  /// TODO(jakemac): Come up with a better way of telling if the script has been
+  /// updated since it started running.
+  Future<DateTime> _buildScriptUpdateTime() async {
+    var urisInUse = currentMirrorSystem().libraries.keys;
+    var updateTimes = await Future.wait(urisInUse.map(_uriUpdateTime));
+    return updateTimes.reduce((l, r) => l.compareTo(r) > 0 ? l : r);
+  }
+
+  Future<DateTime> _uriUpdateTime(Uri uri) async {
+    switch (uri.scheme) {
+      case 'dart':
+        return new DateTime.fromMillisecondsSinceEpoch(0);
+      case 'package':
+        var parts = uri.pathSegments;
+        var id = new AssetId(parts[0],
+            path.url.joinAll(['lib']..addAll(parts.getRange(1, parts.length))));
+        return _reader.lastModified(id);
+      case 'file':
+
+        // TODO(jakemac): Probably shouldn't use dart:io directly, but its
+        // definitely the easiest solution and should be fine.
+        var file = new File.fromUri(uri);
+        return file.lastModified();
+      case 'data':
+
+        // Test runner uses a `data` scheme, don't invalidate for those.
+        if (uri.path.contains('package:test')) {
+          return new DateTime.fromMillisecondsSinceEpoch(0);
+        }
+    }
+    _logger.info('Unsupported uri scheme `${uri.scheme}` found for '
+        'library in build script, falling back on full rebuild. '
+        '\nThis probably means you are running in an unsupported '
+        'context, such as in an isolate or via `pub run`. Instead you '
+        'should invoke this script directly like: '
+        '`dart path_to_script.dart`.');
+    return new DateTime.now();
+  }
+
+  /// Returns the set of available inputs on disk.
+  Future<Set<AssetId>> _findCurrentSources() async {
+    var inputSets = _packageGraph.allPackages.keys.map((package) =>
+        new InputSet(
+            package, [package == _packageGraph.root.name ? '**' : 'lib/**']));
+    return _listAssetIds(inputSets).where(_isValidInput).toSet();
+  }
+
+  /// Checks if an [input] is valid.
+  bool _isValidInput(AssetId input) => input.package != _packageGraph.root.name
+      ? input.path.startsWith('lib/')
+      : !toolDirs.any((d) => input.path.startsWith(d));
+
+  Iterable<AssetId> _listAssetIds(Iterable<InputSet> inputSets) sync* {
+    var seenAssets = new Set<AssetId>();
+    for (var inputSet in inputSets) {
+      for (var glob in inputSet.globs) {
+        for (var id
+            in _reader.findAssets(glob, packageName: inputSet.package)) {
+          if (!seenAssets.add(id)) continue;
+          yield id;
+        }
+      }
+    }
+  }
+}

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -4,23 +4,21 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:mirrors';
 
 import 'package:build/build.dart';
 import 'package:build_barback/build_barback.dart' show BarbackResolvers;
 import 'package:logging/logging.dart';
-import 'package:path/path.dart' as path;
 import 'package:stack_trace/stack_trace.dart';
 import 'package:watcher/watcher.dart';
 
 import '../asset/reader.dart';
 import '../asset/writer.dart';
-import '../asset_graph/exceptions.dart';
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../logging/logging.dart';
 import '../package_graph/package_graph.dart';
 import '../util/constants.dart';
+import 'build_definition.dart';
 import 'build_result.dart';
 import 'exceptions.dart';
 import 'input_set.dart';
@@ -37,19 +35,22 @@ class BuildImpl {
   final RunnerAssetReader _reader;
   final RunnerAssetWriter _writer;
   final Resolvers _resolvers = const BarbackResolvers();
+  final BuildDefinitionLoader _buildDefinitionLoader;
 
   AssetGraph _assetGraph;
   AssetGraph get assetGraph => _assetGraph;
   bool _buildRunning = false;
-  bool _isFirstBuild = true;
 
-  BuildImpl(BuildOptions options, this._buildActions)
+  BuildImpl(BuildOptions options, List<BuildAction> buildActions)
       : _assetGraphId =
             new AssetId(options.packageGraph.root.name, assetGraphPath),
         _deleteFilesByDefault = options.deleteFilesByDefault,
         _packageGraph = options.packageGraph,
         _reader = options.reader,
-        _writer = options.writer;
+        _writer = options.writer,
+        _buildActions = buildActions,
+        _buildDefinitionLoader = new BuildDefinitionLoader(
+            options.reader, options.packageGraph, buildActions);
 
   /// Runs a build
   ///
@@ -63,7 +64,6 @@ class BuildImpl {
     var watch = new Stopwatch()..start();
     var result = await _safeBuild(updates);
     _buildRunning = false;
-    _isFirstBuild = false;
     if (result.status == BuildStatus.success) {
       _logger.info('Succeeded after ${watch.elapsedMilliseconds}ms with '
           '${result.outputs.length} outputs\n\n');
@@ -84,7 +84,7 @@ class BuildImpl {
     var done = new Completer<BuildResult>();
     // Assume incremental, change if necessary.
     var buildType = BuildType.incremental;
-    var validAsOf = new DateTime.now();
+    var buildStartTime = new DateTime.now();
     Chain.capture(() async {
       if (_buildRunning) throw const ConcurrentBuildException();
       _buildRunning = true;
@@ -95,62 +95,19 @@ class BuildImpl {
       }
 
       // Initialize the [assetGraph] if its not yet set up.
+      BuildDefinition buildDefinition;
       if (_assetGraph == null) {
-        await logWithTime(_logger, 'Reading cached dependency graph', () async {
-          _assetGraph = await _readAssetGraph();
-          if (_assetGraph == null) {
-            buildType = BuildType.full;
-          } else {
-            /// Collect updates since the asset graph was last created. This only
-            /// handles updates and deletes, not adds. We list the file system for
-            /// all inputs later on (in [_initializeInputsByPackage]).
-            updates.addAll(await _getUpdates());
-          }
-        });
+        buildDefinition = await _buildDefinitionLoader.load();
+      } else {
+        buildDefinition =
+            await _buildDefinitionLoader.fromGraph(_assetGraph, updates);
       }
+      _assetGraph = buildDefinition.assetGraph;
+      buildType = buildDefinition.buildType;
 
-      // If the build script gets updated, we need to either fully invalidate
-      // the graph (if the script current running is up to date), or we need to
-      // terminate and ask the user to restart the script (if the currently
-      // running script is out of date).
-      //
-      // The [_isFirstBuild] flag is used as a proxy for "has this script been
-      // updated since it started running".
-      if (_assetGraph != null) {
-        await logWithTime(_logger, 'Checking build script for updates',
-            () async {
-          if (await _buildScriptUpdated()) {
-            buildType = BuildType.full;
-            if (_isFirstBuild) {
-              _logger.warning(
-                  'Invalidating asset graph due to build script update');
-              _assetGraph = null;
-            } else {
-              done.complete(new BuildResult(BuildStatus.failure, buildType, [],
-                  exception: new BuildScriptUpdatedException()));
-            }
-          }
-        });
-        // Bail if the previous step completed the build.
-        if (done.isCompleted) return;
-      }
-
-      await logWithTime(_logger, 'Finalizing build setup', () async {
-        // Wait while all inputs are collected.
-        _logger.info('Initializing inputs');
-        var currentSources = await _initializeInputsByPackage();
-
-        if (_assetGraph != null) {
-          await _writer.delete(_assetGraphId);
-          _logger
-              .info('Updating dependency graph with changes since last build.');
-          _assetGraph.updateForSources(_buildActions, currentSources);
-          await _updateWithChanges(updates);
-        }
-
-        // Delete all previous outputs!
-        _logger.info('Deleting previous outputs');
-        await _deletePreviousOutputs(currentSources);
+      await logWithTime(_logger, 'Deleting previous outputs', () async {
+        await Future.wait(buildDefinition.safeDeletes.map(_writer.delete));
+        await _promptDelete(buildDefinition.conflictingAssets);
       });
 
       // Run a fresh build.
@@ -159,7 +116,7 @@ class BuildImpl {
       // Write out the dependency graph file.
       await logWithTime(_logger, 'Caching finalized dependency graph',
           () async {
-        _assetGraph.validAsOf = validAsOf;
+        _assetGraph.validAsOf = buildStartTime;
         await _writer.writeAsString(
             _assetGraphId, JSON.encode(_assetGraph.serialize()));
       });
@@ -170,181 +127,6 @@ class BuildImpl {
           exception: e, stackTrace: chain.toTrace()));
     });
     return done.future;
-  }
-
-  /// Reads in the [assetGraph] from disk.
-  Future<AssetGraph> _readAssetGraph() async {
-    if (!await _reader.canRead(_assetGraphId)) return null;
-    try {
-      return new AssetGraph.deserialize(
-          JSON.decode(await _reader.readAsString(_assetGraphId)) as Map);
-    } on AssetGraphVersionException catch (_) {
-      // Start fresh if the cached asset_graph version doesn't match up with
-      // the current version. We don't currently support old graph versions.
-      _logger.info('Throwing away cached asset graph due to version mismatch.');
-      return null;
-    }
-  }
-
-  /// Checks if the current running program has been updated since the asset
-  /// graph was last built.
-  ///
-  /// TODO(jakemac): Come up with a better way of telling if the script
-  /// has been updated since it started running.
-  Future<bool> _buildScriptUpdated() async {
-    var completer = new Completer<bool>();
-    // ignore: unawaited_futures
-    Future
-        .wait(currentMirrorSystem().libraries.keys.map((Uri uri) async {
-      // Short-circuit
-      if (completer.isCompleted) return;
-      DateTime lastModified;
-      switch (uri.scheme) {
-        case 'dart':
-          return;
-        case 'package':
-          var parts = uri.pathSegments;
-          var id = new AssetId(
-              parts[0],
-              path.url
-                  .joinAll(['lib']..addAll(parts.getRange(1, parts.length))));
-          lastModified = await _reader.lastModified(id);
-          break;
-        case 'file':
-
-          // TODO(jakemac): Probably shouldn't use dart:io directly, but its
-          // definitely the easiest solution and should be fine.
-          var file = new File.fromUri(uri);
-          lastModified = await file.lastModified();
-          break;
-        case 'data':
-
-          // Test runner uses a `data` scheme, don't invalidate for those.
-          if (uri.path.contains('package:test')) return;
-          continue unknownUri;
-        unknownUri:
-        default:
-          _logger.info('Unsupported uri scheme `${uri.scheme}` found for '
-              'library in build script, falling back on full rebuild. '
-              '\nThis probably means you are running in an unsupported '
-              'context, such as in an isolate or via `pub run`. Instead you '
-              'should invoke this script directly like: '
-              '`dart path_to_script.dart`.');
-          if (!completer.isCompleted) completer.complete(true);
-          return;
-      }
-      assert(lastModified != null);
-      if (lastModified.compareTo(_assetGraph.validAsOf) > 0) {
-        if (!completer.isCompleted) completer.complete(true);
-      }
-    }))
-        .then((_) {
-      if (!completer.isCompleted) completer.complete(false);
-    });
-    return completer.future;
-  }
-
-  /// Creates and returns a map of updates to assets based on [_assetGraph].
-  Future<Map<AssetId, ChangeType>> _getUpdates() async {
-    // Collect updates to the graph based on any changed assets.
-    var updates = <AssetId, ChangeType>{};
-    await Future.wait(_assetGraph.allNodes
-        .where((node) =>
-            node is! GeneratedAssetNode ||
-            (node as GeneratedAssetNode).wasOutput)
-        .map((node) async {
-      bool exists;
-      try {
-        exists = await _reader.canRead(node.id);
-      } on PackageNotFoundException catch (_) {
-        exists = false;
-      }
-      if (!exists) {
-        updates[node.id] = ChangeType.REMOVE;
-        return;
-      }
-      // Only handle deletes for generated assets, their modified timestamp
-      // is always newer than the asset graph.
-      //
-      // TODO(jakemac): https://github.com/dart-lang/build/issues/61
-      if (node is GeneratedAssetNode) return;
-
-      var lastModified = await _reader.lastModified(node.id);
-      if (lastModified.compareTo(_assetGraph.validAsOf) > 0) {
-        updates[node.id] = ChangeType.MODIFY;
-      }
-    }));
-    return updates;
-  }
-
-  /// Applies all [updates] to the [_assetGraph] as well as doing other
-  /// necessary cleanup such as deleting outputs as necessary.
-  Future _updateWithChanges(Map<AssetId, ChangeType> updates) async {
-    var deletes = _assetGraph.updateAndInvalidate(updates);
-    await Future.wait(deletes.map(_writer.delete));
-  }
-
-  /// Deletes all previous output files that are in need of an update.
-  Future _deletePreviousOutputs(Set<AssetId> currentSources) async {
-    if (_assetGraph != null) {
-      await Future.wait(_assetGraph.allNodes
-          .where((n) => n is GeneratedAssetNode && n.needsUpdate)
-          .map((node) => _writer.delete(node.id)));
-      return;
-    }
-    _assetGraph = new AssetGraph.build(_buildActions, currentSources);
-
-    final conflictingOutputs =
-        _assetGraph.outputs.where(currentSources.contains).toSet();
-
-    // Check conflictingOutputs, prompt user to delete files.
-    if (conflictingOutputs.isEmpty) return;
-
-    // Skip the prompt if using this option.
-    if (_deleteFilesByDefault) {
-      _logger.info('Deleting ${conflictingOutputs.length} declared outputs '
-          'which already existed on disk.');
-      await Future.wait(conflictingOutputs.map(_writer.delete));
-      return;
-    }
-
-    // Prompt the user to delete files that are declared as outputs.
-    _logger.warning('Found ${conflictingOutputs.length} declared outputs '
-        'which already exist on disk. This is likely because the'
-        '`$cacheDir` folder was deleted, or you are submitting generated '
-        'files to your source repository.');
-
-    // If not in a standard terminal then we just exit, since there is no way
-    // for the user to provide a yes/no answer.
-    if (stdioType(stdin) != StdioType.TERMINAL) {
-      throw new UnexpectedExistingOutputsException();
-    }
-
-    // Give a little extra space after the last message, need to make it clear
-    // this is a prompt.
-    stdout.writeln();
-    var done = false;
-    while (!done) {
-      stdout.write('\nDelete these files (y/n) (or list them (l))?: ');
-      var input = stdin.readLineSync();
-      switch (input.toLowerCase()) {
-        case 'y':
-          stdout.writeln('Deleting files...');
-          await Future.wait(conflictingOutputs.map(_writer.delete));
-          done = true;
-          break;
-        case 'n':
-          throw new UnexpectedExistingOutputsException();
-          break;
-        case 'l':
-          for (var output in conflictingOutputs) {
-            stdout.writeln(output);
-          }
-          break;
-        default:
-          stdout.writeln('Unrecognized option $input, (y/n/l) expected.');
-      }
-    }
   }
 
   /// Runs the actions in [_buildActions] and returns a [Future<BuildResult>]
@@ -363,14 +145,6 @@ class BuildImpl {
     return new BuildResult(BuildStatus.success, BuildType.full, outputs);
   }
 
-  /// Returns the set of available inputs on disk.
-  Future<Set<AssetId>> _initializeInputsByPackage() async {
-    var inputSets = _packageGraph.allPackages.keys.map((package) =>
-        new InputSet(
-            package, [package == _packageGraph.root.name ? '**' : 'lib/**']));
-    return listAssetIds(_reader, inputSets).where(_isValidInput).toSet();
-  }
-
   Set<AssetId> _inputsForPhase(int phaseNumber) => _assetGraph.allNodes
       .where((n) =>
           n is! GeneratedAssetNode ||
@@ -385,11 +159,6 @@ class BuildImpl {
               input.package == inputSet.package &&
               inputSet.globs.any((g) => g.matches(input.path)))
           .toSet();
-
-  /// Checks if an [input] is valid.
-  bool _isValidInput(AssetId input) => input.package != _packageGraph.root.name
-      ? input.path.startsWith('lib/')
-      : !toolDirs.any((d) => input.path.startsWith(d));
 
   /// Runs [builder] with [primaryInputs] as inputs.
   Stream<AssetId> _runBuilder(int phaseNumber, Builder builder,
@@ -444,17 +213,53 @@ class BuildImpl {
       }
     }
   }
-}
 
-Iterable<AssetId> listAssetIds(
-    RunnerAssetReader assetReader, Iterable<InputSet> inputSets) sync* {
-  var seenAssets = new Set<AssetId>();
-  for (var inputSet in inputSets) {
-    for (var glob in inputSet.globs) {
-      for (var id
-          in assetReader.findAssets(glob, packageName: inputSet.package)) {
-        if (!seenAssets.add(id)) continue;
-        yield id;
+  Future<Null> _promptDelete(Set<AssetId> conflictingOutputs) async {
+    if (conflictingOutputs.isEmpty) return;
+
+    // Skip the prompt if using this option.
+    if (_deleteFilesByDefault) {
+      _logger.info('Deleting ${conflictingOutputs.length} declared outputs '
+          'which already existed on disk.');
+      await Future.wait(conflictingOutputs.map(_writer.delete));
+      return;
+    }
+
+    // Prompt the user to delete files that are declared as outputs.
+    _logger.warning('Found ${conflictingOutputs.length} declared outputs '
+        'which already exist on disk. This is likely because the'
+        '`$cacheDir` folder was deleted, or you are submitting generated '
+        'files to your source repository.');
+
+    // If not in a standard terminal then we just exit, since there is no way
+    // for the user to provide a yes/no answer.
+    if (stdioType(stdin) != StdioType.TERMINAL) {
+      throw new UnexpectedExistingOutputsException();
+    }
+
+    // Give a little extra space after the last message, need to make it clear
+    // this is a prompt.
+    stdout.writeln();
+    var done = false;
+    while (!done) {
+      stdout.write('\nDelete these files (y/n) (or list them (l))?: ');
+      var input = stdin.readLineSync();
+      switch (input.toLowerCase()) {
+        case 'y':
+          stdout.writeln('Deleting files...');
+          done = true;
+          await Future.wait(conflictingOutputs.map(_writer.delete));
+          break;
+        case 'n':
+          throw new UnexpectedExistingOutputsException();
+          break;
+        case 'l':
+          for (var output in conflictingOutputs) {
+            stdout.writeln(output);
+          }
+          break;
+        default:
+          stdout.writeln('Unrecognized option $input, (y/n/l) expected.');
       }
     }
   }


### PR DESCRIPTION
When we add support for writing to a cache directory the location of an
asset read by the AssetReader can vary based on whether it is a
GeneratedAssetNode so there may be a feedback loop between the
AssetGraph and the AssetReader. This is trick before the refactoring
since the AssetGraph can become null and rebuild over the course of the
build. Pull out the logic for loading the AssetGraph and BuildType into
a separate class so the lifecycle is explicit and contained.

- Add BuildDefinition and BuildDefinitionLoader extracted from BuildImpl
  to separate responsibilities.
- Refactor such that the two entry points - first build and subsequent
  builds - have their own logic rather than being interleaved.
- Remove explicit `_isFirstBuild` field since it can be inferred based
  on whether there are updates or an existing asset graph.
- Drop updateForSources method in AssetGraph. Instead, find the changes
  in the same format as `updates` and apply them consistently. Add
  support for new sources in `updateAndInvalidate`.

No new tests because no behavior has changed - I will add test of the
BuildDefinitionLoader when we need to change it's behavior.