### PR TITLE
Support running builders against other packages

### DIFF
--- a/build_runner/lib/src/asset/build_cache.dart
+++ b/build_runner/lib/src/asset/build_cache.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:build/build.dart';
+import 'package:glob/glob.dart';
+
+import '../asset_graph/graph.dart';
+import '../asset_graph/node.dart';
+import '../util/constants.dart';
+
+/// Wraps an [AssetReader] and translates reads for generated files into reads
+/// from the build cache directory
+class BuildCacheReader implements AssetReader {
+  final AssetReader _delegate;
+  final AssetGraph _assetGraph;
+  final String _rootPackage;
+
+  BuildCacheReader(this._delegate, this._assetGraph, this._rootPackage);
+
+  @override
+  Future<bool> canRead(AssetId id) =>
+      _delegate.canRead(cacheLocation(id, _assetGraph, _rootPackage));
+
+  @override
+  Future<List<int>> readAsBytes(AssetId id) =>
+      _delegate.readAsBytes(cacheLocation(id, _assetGraph, _rootPackage));
+
+  @override
+  Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) =>
+      _delegate.readAsString(cacheLocation(id, _assetGraph, _rootPackage),
+          encoding: encoding);
+
+  @override
+  Iterable<AssetId> findAssets(Glob glob) => throw new UnimplementedError(
+      'Asset globbing should be done per phase with the AssetGraph');
+}
+
+class BuildCacheWriter implements AssetWriter {
+  final AssetWriter _delegate;
+  final AssetGraph _assetGraph;
+  final String _rootPackage;
+
+  BuildCacheWriter(this._delegate, this._assetGraph, this._rootPackage);
+
+  @override
+  Future writeAsBytes(AssetId id, List<int> content) => _delegate.writeAsBytes(
+      cacheLocation(id, _assetGraph, _rootPackage), content);
+  @override
+  Future writeAsString(AssetId id, String content, {Encoding encoding: UTF8}) =>
+      _delegate.writeAsString(
+          cacheLocation(id, _assetGraph, _rootPackage), content,
+          encoding: encoding);
+}
+
+AssetId cacheLocation(AssetId id, AssetGraph assetGraph, String rootPackage) {
+  if (id.path.startsWith(generatedOutputDirectory) ||
+      id.path.startsWith(cacheDir)) {
+    return id;
+  }
+  if (!assetGraph.contains(id)) {
+    throw new ArgumentError('$id  is not a valid asset');
+  }
+  if (assetGraph.get(id) is GeneratedAssetNode) {
+    return new AssetId(
+        rootPackage, '$cacheDir/generated/${id.package}/${id.path}');
+  }
+  return id;
+}

--- a/build_runner/lib/src/asset/file_based.dart
+++ b/build_runner/lib/src/asset/file_based.dart
@@ -43,13 +43,17 @@ class FileBasedAssetReader implements RunnerAssetReader {
           "remove it from your input sets.");
     }
     var packagePath = packageNode.location.toFilePath();
-    var files = glob
-        .listSync(followLinks: false, root: packagePath)
-        .where((e) => e is File);
-    for (var file in files) {
-      // TODO(jakemac): Where do these files come from???
-      if (path.basename(file.path).startsWith('._')) continue;
-      yield _fileToAssetId(file as File, packageNode);
+    try {
+      var files = glob
+          .listSync(followLinks: false, root: packagePath)
+          .where((e) => e is File);
+      for (var file in files) {
+        // TODO(jakemac): Where do these files come from???
+        if (path.basename(file.path).startsWith('._')) continue;
+        yield _fileToAssetId(file as File, packageNode);
+      }
+    } on FileSystemException catch (_) {
+      // Empty results
     }
   }
 

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -43,6 +43,7 @@ import 'watch_impl.dart';
 /// Multiple termination events will cause a normal shutdown.
 Future<BuildResult> build(List<BuildAction> buildActions,
     {bool deleteFilesByDefault,
+    bool writeToCache,
     PackageGraph packageGraph,
     RunnerAssetReader reader,
     RunnerAssetWriter writer,
@@ -51,6 +52,7 @@ Future<BuildResult> build(List<BuildAction> buildActions,
     Stream terminateEventStream}) async {
   var options = new BuildOptions(
       deleteFilesByDefault: deleteFilesByDefault,
+      writeToCache: writeToCache,
       packageGraph: packageGraph,
       reader: reader,
       writer: writer,
@@ -89,6 +91,7 @@ Future<BuildResult> build(List<BuildAction> buildActions,
 ///  typically cause a shutdown).
 Stream<BuildResult> watch(List<BuildAction> buildActions,
     {bool deleteFilesByDefault,
+    bool writeToCache,
     PackageGraph packageGraph,
     RunnerAssetReader reader,
     RunnerAssetWriter writer,
@@ -99,6 +102,7 @@ Stream<BuildResult> watch(List<BuildAction> buildActions,
     Stream terminateEventStream}) {
   var options = new BuildOptions(
       deleteFilesByDefault: deleteFilesByDefault,
+      writeToCache: writeToCache,
       packageGraph: packageGraph,
       reader: reader,
       writer: writer,

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -24,6 +24,7 @@ class BuildOptions {
   RunnerAssetReader reader;
   RunnerAssetWriter writer;
   bool deleteFilesByDefault;
+
   /// Whether to write to a cache directory rather than the package's source
   /// directory.
   ///

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -24,6 +24,12 @@ class BuildOptions {
   RunnerAssetReader reader;
   RunnerAssetWriter writer;
   bool deleteFilesByDefault;
+  /// Whether to write to a cache directory rather than the package's source
+  /// directory.
+  ///
+  /// Enabling this option is the only way to allow builders to run against
+  /// packages other than the root.
+  bool writeToCache;
 
   // Watch mode options.
   Duration debounceDelay;
@@ -39,6 +45,7 @@ class BuildOptions {
       {this.address,
       this.debounceDelay,
       this.deleteFilesByDefault,
+      this.writeToCache,
       this.directory,
       this.directoryWatcherFactory,
       Level logLevel,
@@ -67,6 +74,7 @@ class BuildOptions {
     writer ??= new FileBasedAssetWriter(packageGraph);
     directoryWatcherFactory ??= defaultDirectoryWatcherFactory;
     deleteFilesByDefault ??= false;
+    writeToCache ??= false;
   }
 }
 

--- a/build_runner/lib/src/util/constants.dart
+++ b/build_runner/lib/src/util/constants.dart
@@ -13,6 +13,10 @@ final String assetGraphPath = '$cacheDir/$scriptHash/asset_graph.json';
 /// Reading from these directories may cause non-hermetic builds.
 const toolDirs = const ['.dart_tool', 'build', 'packages', '.pub'];
 
+/// The directory to which assets will be written when `writeToCache` is
+/// enabled.
+const generatedOutputDirectory = '.dart_tool/build/generated';
+
 /// Relative path to the cache directory from the root package dir.
 const String cacheDir = '.dart_tool/build';
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.27.1 <0.31.0"
   async: ^1.13.3
-  build: ^0.10.0
+  build: ^0.10.1
   build_barback: ^0.4.0
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0
@@ -24,5 +24,11 @@ dependencies:
   yaml: ^2.1.0
 
 dev_dependencies:
-  build_test: ^0.6.0
+  build_test: ^0.7.1
   test: ^0.12.0
+
+dependency_overrides:
+  build_test:
+    path: ../build_test
+  build:
+    path: ../build

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -90,6 +90,20 @@ void main() {
           packageGraph: packageGraph, outputs: {}, status: BuildStatus.failure);
     });
 
+    test('Can output files in non-root packages with `writeToCache`', () async {
+      var packageB = new PackageNode(
+          'b', '0.1.0', PackageDependencyType.path, new Uri.file('a/b/'));
+      var packageA = new PackageNode(
+          'a', '0.1.0', PackageDependencyType.path, new Uri.file('a/'))
+        ..dependencies.add(packageB);
+      var packageGraph = new PackageGraph.fromRoot(packageA);
+      await testActions(
+          [new BuildAction(new CopyBuilder(), 'b')], {'b|lib/b.txt': 'b'},
+          packageGraph: packageGraph,
+          outputs: {'b|lib/b.txt.copy': 'b'},
+          writeToCache: true);
+    });
+
     test('can read files from external packages', () async {
       var buildActions = [
         new BuildAction(


### PR DESCRIPTION
Closes #216

Add an argument to `build` which indicates that generated files should
be written to `.dart_tool/build/generated/<package>/<path>` rather than
in the source directory for the root package. With this argument enabled
all writes, including for the root package, go to the generated
directory. If we want to support running 'local' and 'non-local'
builders in the same build we will need to make this more fine grained.

- Don't surface the `FileSystemException` when trying to glob a
  directory that doesn't exist.
- Add BuildCacheReader and BuildCacheWriter which translates paths for
  generated assets into the special directory.
- Don't enforce that builders run only on the root package when outputs
  are written to the generated cache.
- Plumb the `writeToCache` argument through to `build_impl` for both
  `build` and `watch`. We will need further changes in `serve` to
  support this (#384)