### PR TITLE
Avoid attempting deletes in other packages

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Prevent reads into `.dart_tool` for more hermetic builds.
 - Bug Fix: Rebuild entire asset graph if the build script changes.
+- Add `writeToCache` argument to `build` and `watch` which separates generated
+  files from the source directory and allows running builders against other
+  packages.
 
 ## 0.4.0+3
 

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -106,7 +106,7 @@ class BuildImpl {
       buildType = buildDefinition.buildType;
 
       await logWithTime(_logger, 'Deleting previous outputs', () async {
-        await Future.wait(buildDefinition.safeDeletes.map(_writer.delete));
+        await Future.wait(buildDefinition.safeDeletes.map(_delete));
         await _promptDelete(buildDefinition.conflictingAssets);
       });
 
@@ -163,7 +163,7 @@ class BuildImpl {
         case 'y':
           stdout.writeln('Deleting files...');
           done = true;
-          await Future.wait(conflictingOutputs.map(_writer.delete));
+          await Future.wait(conflictingOutputs.map(_delete));
           break;
         case 'n':
           throw new UnexpectedExistingOutputsException();

--- a/build_runner/test/common/in_memory_reader.dart
+++ b/build_runner/test/common/in_memory_reader.dart
@@ -11,12 +11,16 @@ import 'package:glob/glob.dart';
 
 class InMemoryRunnerAssetReader extends InMemoryAssetReader
     implements RunnerAssetReader {
-  InMemoryRunnerAssetReader([Map<AssetId, DatedValue> sourceAssets])
-      : super(sourceAssets: sourceAssets);
+  InMemoryRunnerAssetReader(
+      [Map<AssetId, DatedValue> sourceAssets, String rootPackage])
+      : super(sourceAssets: sourceAssets, rootPackage: rootPackage);
 
   @override
-  Iterable<AssetId> findAssets(Glob glob, {String packageName}) => assets.keys
-      .where((id) => id.package == packageName && glob.matches(id.path));
+  Iterable<AssetId> findAssets(Glob glob, {String packageName}) {
+    packageName ??= rootPackage;
+    return assets.keys
+        .where((id) => id.package == packageName && glob.matches(id.path));
+  }
 
   final Map<Uri, LibraryMirror> _allLibraries = currentMirrorSystem().libraries;
 

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -71,7 +71,8 @@ Future testActions(List<BuildAction> buildActions,
   writer ??= new InMemoryRunnerAssetWriter();
   writeToCache ??= false;
   final actualAssets = writer.assets;
-  final reader = new InMemoryRunnerAssetReader(actualAssets, packageGraph?.root?.name);
+  final reader =
+      new InMemoryRunnerAssetReader(actualAssets, packageGraph?.root?.name);
 
   inputs.forEach((serializedId, contents) {
     var id = makeAssetId(serializedId);

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -71,7 +71,7 @@ Future testActions(List<BuildAction> buildActions,
   writer ??= new InMemoryRunnerAssetWriter();
   writeToCache ??= false;
   final actualAssets = writer.assets;
-  final reader = new InMemoryRunnerAssetReader(actualAssets);
+  final reader = new InMemoryRunnerAssetReader(actualAssets, packageGraph?.root?.name);
 
   inputs.forEach((serializedId, contents) {
     var id = makeAssetId(serializedId);


### PR DESCRIPTION
Some paths were going through `_writer.delete` rather than `_delete`
which would not translate paths into the build cache and so existing
generated files from other packages could try delets in the wrong place.

- Add `rootPackage` handling to `InMemoryRunnerAssetReader` so that
  `fineAssets` can work correcly.
- Use the wrapped `_delete` method which translates paths everywhere in
  `build_impl`.
- Add a test which exercises the case of deleting existing assets in the
  generated directory. This test would have passed anyway since the
  `_deleteFilesByDefault` path must be used in tests (StdIoType won't
  work correctly in tests) and that branch was correctly using
  `_delete`.