### PR TITLE
Add BuildResults and make WatchImpl private

### DIFF
--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -58,18 +58,12 @@ Future<BuildResult> build(List<BuildAction> buildActions,
       writer: writer,
       logLevel: logLevel,
       onLog: onLog);
+  var terminator = new _Terminator(terminateEventStream);
   var buildImpl = new BuildImpl(options, buildActions);
 
-  /// Run the build!
-  var futureResult = buildImpl.runBuild();
+  var result = await buildImpl.runBuild();
 
-  // Stop doing new builds when told to terminate.
-  _setupTerminateLogic(terminateEventStream, () {
-    new Logger('Build').info('Waiting for build to finish...');
-    return futureResult;
-  }, cancelWhen: futureResult);
-
-  var result = await futureResult;
+  await terminator.cancel();
   await options.logListener.cancel();
   return result;
 }
@@ -110,20 +104,16 @@ Stream<BuildResult> watch(List<BuildAction> buildActions,
       onLog: onLog,
       debounceDelay: debounceDelay,
       directoryWatcherFactory: directoryWatcherFactory);
-  var watchImpl = new WatchImpl(options, buildActions);
+  var terminator = new _Terminator(terminateEventStream);
+  var buildResults =
+      runWatch(options, buildActions, terminator.shouldTerminate);
 
-  var resultStream = watchImpl.runWatch();
-
-  // Stop doing new builds when told to terminate.
-  _setupTerminateLogic(terminateEventStream, () async {
-    await watchImpl.terminate();
-  }, cancelWhen: watchImpl.onTerminated);
-
-  watchImpl.onTerminated.then((_) {
-    options.logListener.cancel();
+  buildResults.builds.drain().then((_) async {
+    await terminator.cancel();
+    await options.logListener.cancel();
   });
 
-  return resultStream;
+  return buildResults.builds;
 }
 
 /// Same as [watch], except it also provides a server.
@@ -159,46 +149,42 @@ Stream<BuildResult> serve(List<BuildAction> buildActions,
       directory: directory,
       address: address,
       port: port);
-  var watchImpl = new WatchImpl(options, buildActions);
+  var terminator = new _Terminator(terminateEventStream);
+  var buildResults =
+      runWatch(options, buildActions, terminator.shouldTerminate);
 
-  var resultStream = watchImpl.runWatch();
-  var serverStarted = startServer(watchImpl, options);
+  var serverStarted = startServer(buildResults, options);
 
-  // Stop doing new builds when told to terminate.
-  _setupTerminateLogic(terminateEventStream, () async {
-    await watchImpl.terminate();
-  }, cancelWhen: watchImpl.onTerminated);
-
-  watchImpl.onTerminated.then((_) async {
+  buildResults.builds.drain().then((_) async {
+    await terminator.cancel();
     await serverStarted;
     await stopServer();
     await options.logListener.cancel();
   });
 
-  return resultStream;
+  return buildResults.builds;
 }
 
-/// Given [terminateEventStream], call [onTerminate] the first time an event is
-/// seen. If a second event is received, simply exit.
-StreamSubscription _setupTerminateLogic(
-    Stream terminateEventStream, Future onTerminate(),
-    {Future cancelWhen}) {
-  terminateEventStream ??= ProcessSignal.SIGINT.watch();
-  int numEventsSeen = 0;
-  StreamSubscription terminateListener;
-  terminateListener = terminateEventStream.listen((_) {
-    numEventsSeen++;
-    if (numEventsSeen == 1) {
-      onTerminate().then((_) {
-        terminateListener.cancel();
-      });
-    } else {
-      exit(2);
-    }
-  });
+class _Terminator {
+  final Future shouldTerminate;
+  final StreamSubscription _subscription;
 
-  cancelWhen?.then((_) {
-    terminateListener.cancel();
-  });
-  return terminateListener;
+  factory _Terminator(Stream terminateEventStream) {
+    var shouldTerminate = new Completer();
+    terminateEventStream ??= ProcessSignal.SIGINT.watch();
+    int numEventsSeen = 0;
+    StreamSubscription terminateListener = terminateEventStream.listen((_) {
+      numEventsSeen++;
+      if (numEventsSeen == 1) {
+        shouldTerminate.complete();
+      } else {
+        exit(2);
+      }
+    });
+    return new _Terminator._(shouldTerminate.future, terminateListener);
+  }
+
+  _Terminator._(this.shouldTerminate, this._subscription);
+
+  Future cancel() => _subscription.cancel();
 }

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -165,12 +165,12 @@ Stream<BuildResult> serve(List<BuildAction> buildActions,
 
 /// Fires [shouldTerminate] once a `SIGINT` is intercepted.
 ///
-/// The `SIGINT` stream can optionally be replaces with another Stream in the
+/// The `SIGINT` stream can optionally be replaced with another Stream in the
 /// constructor. [cancel] should be called after work is finished. If multiple
 /// events are receieved on the terminate event stream before work is finished
 /// the process will be terminated with [exit].
 class _Terminator {
-  /// A Future that fires when a signal has been received indicated that builds
+  /// A Future that fires when a signal has been received indicating that builds
   /// should stop.
   final Future shouldTerminate;
   final StreamSubscription _subscription;

--- a/build_runner/lib/src/generate/build_result.dart
+++ b/build_runner/lib/src/generate/build_result.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
 import 'package:build/build.dart';
 
 /// The result of an individual build, this may be an incremental build or
@@ -54,3 +56,8 @@ enum BuildStatus {
 
 /// The type of a build.
 enum BuildType { incremental, full }
+
+abstract class BuildResults {
+  Future<BuildResult> get currentBuild;
+  Stream<BuildResult> get builds;
+}

--- a/build_runner/lib/src/generate/build_result.dart
+++ b/build_runner/lib/src/generate/build_result.dart
@@ -57,7 +57,7 @@ enum BuildStatus {
 /// The type of a build.
 enum BuildType { incremental, full }
 
-abstract class BuildResults {
+abstract class BuildState {
   Future<BuildResult> get currentBuild;
-  Stream<BuildResult> get builds;
+  Stream<BuildResult> get buildResults;
 }

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -96,7 +96,9 @@ class _Watch implements BuildState {
       return currentBuild;
     }
 
-    var terminate = Future.any([until, fatalBuild.future]);
+    var terminate = Future.any([until, fatalBuild.future]).then((_) {
+      _logger.info('Terminating. No further builds will be scheduled');
+    });
 
     var changes =
         startFileWatchers(_packageGraph, _logger, _directoryWatcherFactory);
@@ -109,7 +111,9 @@ class _Watch implements BuildState {
         .transform(tap(checkResult))
         .asBroadcastStream();
     // Make sure there is at least 1 listener
-    buildResults.drain();
+    buildResults.drain().then((_) {
+      _logger.info('Builds finished. Safe to exit');
+    });
     return buildResults;
   }
 

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -20,9 +20,13 @@ import 'exceptions.dart';
 import 'options.dart';
 import 'phase.dart';
 
+BuildResults runWatch(
+        BuildOptions options, List<BuildAction> buildActions, Future until) =>
+    new _Watch(options, buildActions, until);
+
 /// Watches all inputs for changes, and uses a [BuildImpl] to rerun builds as
 /// appropriate.
-class WatchImpl {
+class _Watch implements BuildResults {
   /// The [AssetGraph] being shared with [_buildImpl]
   AssetGraph get _assetGraph => _buildImpl.assetGraph;
 
@@ -41,23 +45,13 @@ class WatchImpl {
   /// The [PackageGraph] for the current program.
   final PackageGraph _packageGraph;
 
-  /// A future that completes when the current build is done.
-  Future<BuildResult> _currentBuild;
-  Future<BuildResult> get currentBuild => _currentBuild;
-
-  /// Whether or not we are currently watching and running builds.
-  bool _runningWatch = false;
-
-  /// Whether we are in the process of terminating.
-  bool _terminating = false;
-
-  final Completer _onTerminatedCompleter = new Completer();
-  Future get onTerminated => _onTerminatedCompleter.future;
+  @override
+  Future<BuildResult> currentBuild;
 
   /// Pending expected delete events from the writer.
   final Set<AssetId> _expectedDeletes = new Set<AssetId>();
 
-  WatchImpl(BuildOptions options, List<BuildAction> buildActions)
+  _Watch(BuildOptions options, List<BuildAction> buildActions, Future until)
       : _directoryWatcherFactory = options.directoryWatcherFactory,
         _debounceDelay = options.debounceDelay,
         _packageGraph = options.packageGraph,
@@ -67,48 +61,34 @@ class WatchImpl {
       _expectedDeletes.add(id);
       if (existingOnDelete != null) existingOnDelete(id);
     };
+    builds = this.runWatch(until);
   }
 
-  final _terminate = new Completer<Null>();
-
-  /// Completes after the current build is done, and stops further builds from
-  /// happening.
-  Future terminate() async {
-    if (_terminating) {
-      _logger.warning('Already terminating.');
-      return;
-    }
-    _terminating = true;
-    _logger.info('Terminating watchers, no futher builds will be scheduled.');
-    _terminate.complete();
-    if (_currentBuild != null) {
-      _logger.info('Waiting for ongoing build to finish.');
-      await _currentBuild;
-    }
-    _terminating = false;
-    _logger.info('Build watching terminated, safe to exit.\n');
-    _onTerminatedCompleter.complete();
-  }
+  @override
+  Stream<BuildResult> builds;
 
   /// Runs a build any time relevant files change.
   ///
   /// Only one build will run at a time, and changes are batched.
-  Stream<BuildResult> runWatch() {
-    if (_runningWatch) {
-      throw new StateError(
-          '`runWatch` called twice, `terminate` must be called in between.');
+  Stream<BuildResult> runWatch(Future until) {
+    var fatalBuild = new Completer();
+    checkResult(BuildResult result) {
+      if (result.status == BuildStatus.failure &&
+          result.exception is FatalBuildException) {
+        fatalBuild.complete();
+      }
     }
-
-    _runningWatch = true;
 
     Future<BuildResult> doBuild(List<List<AssetChange>> changes) {
       _logger.info('Starting next build');
       _expectedDeletes.clear();
       var updates = _collectChanges(changes);
-      _currentBuild = _buildImpl.runBuild(updates: updates);
-      _currentBuild.then((_) => _currentBuild = null);
-      return _currentBuild;
+      currentBuild = _buildImpl.runBuild(updates: updates);
+      currentBuild.then((_) => currentBuild = null);
+      return currentBuild;
     }
+
+    var terminate = Future.any([until, fatalBuild.future]);
 
     var changes =
         startFileWatchers(_packageGraph, _logger, _directoryWatcherFactory);
@@ -116,21 +96,13 @@ class WatchImpl {
         .where(_shouldProcess)
         .transform(debounceBuffer(_debounceDelay))
         .transform(startWith([]))
-        .transform(takeUntil(_terminate.future))
+        .transform(takeUntil(terminate))
         .transform(asyncMapBuffer(doBuild))
-        .transform(tap(_terminateIfFatal))
+        .transform(tap(checkResult))
         .asBroadcastStream();
     // Make sure there is at least 1 listener
     buildResults.drain();
     return buildResults;
-  }
-
-  /// Terminate the watch if the build script updates.
-  void _terminateIfFatal(BuildResult result) {
-    if (result.status == BuildStatus.failure &&
-        result.exception is FatalBuildException) {
-      terminate();
-    }
   }
 
   /// Checks if we should skip a watch event for this [change].

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -25,7 +25,7 @@ Future<HttpServer> startServer(BuildState buildState, BuildOptions options) {
 
   try {
     blockingHandler = (Request request) async {
-      if (buildState.currentBuild != null) await buildState.currentBuild;
+      await buildState.currentBuild;
       return await options.requestHandler(request);
     };
     _futureServer = serve(blockingHandler, options.address, options.port);

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -18,14 +18,14 @@ Future<HttpServer> _futureServer;
 Handler blockingHandler;
 
 /// Starts a server which blocks on any ongoing builds.
-Future<HttpServer> startServer(BuildResults results, BuildOptions options) {
+Future<HttpServer> startServer(BuildState buildState, BuildOptions options) {
   if (_futureServer != null) {
     throw new StateError('Server already running.');
   }
 
   try {
     blockingHandler = (Request request) async {
-      if (results.currentBuild != null) await results.currentBuild;
+      if (buildState.currentBuild != null) await buildState.currentBuild;
       return await options.requestHandler(request);
     };
     _futureServer = serve(blockingHandler, options.address, options.port);

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -7,8 +7,8 @@ import 'dart:io';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart';
 
+import '../generate/build_result.dart';
 import '../generate/options.dart';
-import '../generate/watch_impl.dart';
 
 /// The actual [HttpServer] in use.
 Future<HttpServer> _futureServer;
@@ -18,14 +18,14 @@ Future<HttpServer> _futureServer;
 Handler blockingHandler;
 
 /// Starts a server which blocks on any ongoing builds.
-Future<HttpServer> startServer(WatchImpl watchImpl, BuildOptions options) {
+Future<HttpServer> startServer(BuildResults results, BuildOptions options) {
   if (_futureServer != null) {
     throw new StateError('Server already running.');
   }
 
   try {
     blockingHandler = (Request request) async {
-      if (watchImpl.currentBuild != null) await watchImpl.currentBuild;
+      if (results.currentBuild != null) await results.currentBuild;
       return await options.requestHandler(request);
     };
     _futureServer = serve(blockingHandler, options.address, options.port);


### PR DESCRIPTION
Towards #400

- Add `BuildResults` to allow signaling when there is an ongoing build.
- Rename `WatchImpl` to the private `_Watch` and expose it only through
  the new top level `runWatch` as a `BuildResult`.
- Remove gates around already running watcher since it's not possible to
  get a handle on the instance to run it twice
- Remove `terminate()` and eagerly pass in a `Future` to signal
  termination.
- Add `_Terminator` class in `build.dart` to hold this signal and remove
  the multiple paths to cancel the listen. Previously either the Future
  returned from terminate, or the end of the Stream, would signal
  completion, now only use the end of the Stream.