### PR TITLE
Load asset graph before creating BuildImpl

### DIFF
--- a/build_runner/lib/src/asset/build_cache.dart
+++ b/build_runner/lib/src/asset/build_cache.dart
@@ -7,6 +7,7 @@ import 'package:glob/glob.dart';
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../util/constants.dart';
+import 'writer.dart';
 
 /// Wraps an [AssetReader] and translates reads for generated files into reads
 /// from the build cache directory
@@ -35,8 +36,8 @@ class BuildCacheReader implements AssetReader {
       'Asset globbing should be done per phase with the AssetGraph');
 }
 
-class BuildCacheWriter implements AssetWriter {
-  final AssetWriter _delegate;
+class BuildCacheWriter implements RunnerAssetWriter {
+  final RunnerAssetWriter _delegate;
   final AssetGraph _assetGraph;
   final String _rootPackage;
 
@@ -50,6 +51,9 @@ class BuildCacheWriter implements AssetWriter {
       _delegate.writeAsString(
           cacheLocation(id, _assetGraph, _rootPackage), content,
           encoding: encoding);
+  @override
+  Future delete(AssetId id) =>
+      _delegate.delete(cacheLocation(id, _assetGraph, _rootPackage));
 }
 
 AssetId cacheLocation(AssetId id, AssetGraph assetGraph, String rootPackage) {

--- a/build_runner/lib/src/asset/file_based.dart
+++ b/build_runner/lib/src/asset/file_based.dart
@@ -77,8 +77,6 @@ AssetId _fileToAssetId(File file, PackageNode packageNode) {
 /// files to disk.
 class FileBasedAssetWriter implements RunnerAssetWriter {
   final PackageGraph packageGraph;
-  @override
-  OnDelete onDelete;
 
   FileBasedAssetWriter(this.packageGraph);
 
@@ -103,7 +101,6 @@ class FileBasedAssetWriter implements RunnerAssetWriter {
       throw new InvalidOutputException(
           id, 'Should not delete assets outside of ${packageGraph.root.name}');
     }
-    if (onDelete != null) onDelete(id);
 
     var file = _fileFor(id, packageGraph);
     return () async {

--- a/build_runner/lib/src/asset/writer.dart
+++ b/build_runner/lib/src/asset/writer.dart
@@ -5,9 +5,5 @@ import 'package:build/build.dart';
 typedef void OnDelete(AssetId id);
 
 abstract class RunnerAssetWriter implements AssetWriter {
-  /// Called synchronously whenever an asset is deleted.
-  OnDelete onDelete;
-
-  /// Deletes an asset, and calls [onDelete] synchronously.
   Future delete(AssetId id);
 }

--- a/build_runner/lib/src/changes/build_script_updates.dart
+++ b/build_runner/lib/src/changes/build_script_updates.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:mirrors';
+
+import 'package:build/build.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import '../asset/reader.dart';
+import '../generate/options.dart';
+
+class BuildScriptUpdates {
+  final RunnerAssetReader _reader;
+  final _logger = new Logger('BuildScriptUpdates');
+
+  BuildScriptUpdates(BuildOptions options) : _reader = options.reader;
+
+  /// Checks if the current running program has been updated since [time].
+  Future<bool> isNewerThan(DateTime time) async {
+    var urisInUse = currentMirrorSystem().libraries.keys;
+    var updateTimes = await Future.wait(urisInUse.map(_uriUpdateTime));
+    return updateTimes.any((u) => u.isAfter(time));
+  }
+
+  Future<DateTime> _uriUpdateTime(Uri uri) async {
+    switch (uri.scheme) {
+      case 'dart':
+        return new DateTime.fromMillisecondsSinceEpoch(0);
+      case 'package':
+        var parts = uri.pathSegments;
+        var id = new AssetId(parts[0],
+            path.url.joinAll(['lib']..addAll(parts.getRange(1, parts.length))));
+        return _reader.lastModified(id);
+      case 'file':
+
+        // TODO(jakemac): Probably shouldn't use dart:io directly, but its
+        // definitely the easiest solution and should be fine.
+        var file = new File.fromUri(uri);
+        return file.lastModified();
+      case 'data':
+
+        // Test runner uses a `data` scheme, don't invalidate for those.
+        if (uri.path.contains('package:test')) {
+          return new DateTime.fromMillisecondsSinceEpoch(0);
+        }
+    }
+    _logger.info('Unsupported uri scheme `${uri.scheme}` found for '
+        'library in build script, falling back on full rebuild. '
+        '\nThis probably means you are running in an unsupported '
+        'context, such as in an isolate or via `pub run`. Instead you '
+        'should invoke this script directly like: '
+        '`dart path_to_script.dart`.');
+    return new DateTime.now();
+  }
+}

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -59,9 +59,8 @@ Future<BuildResult> build(List<BuildAction> buildActions,
       logLevel: logLevel,
       onLog: onLog);
   var terminator = new _Terminator(terminateEventStream);
-  var buildImpl = new BuildImpl(options, buildActions);
 
-  var result = await buildImpl.runBuild();
+  var result = await singleBuild(options, buildActions);
 
   await terminator.cancel();
   await options.logListener.cancel();

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -4,63 +4,78 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
-import 'dart:mirrors';
 
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
-import 'package:path/path.dart' as path;
 import 'package:watcher/watcher.dart';
 
-import '../asset/reader.dart';
+import '../asset/build_cache.dart';
+import '../asset/writer.dart';
 import '../asset_graph/exceptions.dart';
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
+import '../changes/build_script_updates.dart';
 import '../logging/logging.dart';
 import '../package_graph/package_graph.dart';
 import '../util/constants.dart';
 import 'exceptions.dart';
 import 'input_set.dart';
+import 'options.dart';
 import 'phase.dart';
+
+final _logger = new Logger('BuildDefinition');
 
 class BuildDefinition {
   final AssetGraph assetGraph;
 
-  /// The serialized asset graph and generated files which need updates.
-  final Set<AssetId> safeDeletes;
+  /// Assets which have changed since the cached asset graph was created.
+  final Map<AssetId, ChangeType> updates;
 
   /// Assets which should be generated but already exist on disk and can't be
   /// proven to be from the last build.
   final Set<AssetId> conflictingAssets;
 
-  BuildDefinition(this.assetGraph, this.safeDeletes, this.conflictingAssets);
+  final AssetReader reader;
+  final RunnerAssetWriter writer;
+
+  final PackageGraph packageGraph;
+  final bool deleteFilesByDefault;
+
+  BuildDefinition._(this.assetGraph, this.updates, this.conflictingAssets,
+      this.reader, this.writer, this.packageGraph, this.deleteFilesByDefault);
+
+  static Future<BuildDefinition> load(
+          BuildOptions options, List<BuildAction> buildActions) =>
+      new _Loader(options, buildActions).load();
 }
 
-class BuildDefinitionLoader {
-  final _logger = new Logger('BuildDefinitionLoader');
-  final RunnerAssetReader _reader;
-  final PackageGraph _packageGraph;
+class _Loader {
   final List<BuildAction> _buildActions;
-  final bool _writeToCache;
+  final BuildOptions _options;
 
-  BuildDefinitionLoader(
-      this._reader, this._packageGraph, this._buildActions, this._writeToCache);
+  _Loader(this._options, this._buildActions);
 
   Future<BuildDefinition> load() async {
-    final assetGraphId = new AssetId(_packageGraph.root.name, assetGraphPath);
+    if (!_options.writeToCache &&
+        _buildActions.any((action) =>
+            action.inputSet.package != _options.packageGraph.root.name)) {
+      throw const InvalidBuildActionException.nonRootPackage();
+    }
+    final assetGraphId =
+        new AssetId(_options.packageGraph.root.name, assetGraphPath);
     AssetGraph assetGraph;
-    final safeDeletes = new Set<AssetId>();
     final conflictingOutputs = new Set<AssetId>();
     _logger.info('Initializing inputs');
     var currentSources = await _findCurrentSources();
+    var updates = <AssetId, ChangeType>{};
     await logWithTime(_logger, 'Reading cached dependency graph', () async {
-      if (await _reader.canRead(assetGraphId)) {
+      if (await _options.reader.canRead(assetGraphId)) {
         assetGraph = await _readAssetGraph(assetGraphId);
-        safeDeletes.add(assetGraphId);
       }
       if (assetGraph != null &&
-          (await _buildScriptUpdateTime()).isAfter(assetGraph.validAsOf)) {
+          await new BuildScriptUpdates(_options)
+              .isNewerThan(assetGraph.validAsOf)) {
         _logger.warning('Invalidating asset graph due to build script update');
         assetGraph = null;
       }
@@ -71,35 +86,30 @@ class BuildDefinitionLoader {
       } else {
         _logger
             .info('Updating dependency graph with changes since last build.');
-        var updates = <AssetId, ChangeType>{};
         var newSources = new Set<AssetId>.from(currentSources)
           ..removeAll(assetGraph.allNodes.map((n) => n.id));
         updates.addAll(
             new Map.fromIterable(newSources, value: (_) => ChangeType.ADD));
         updates.addAll(await _getUpdates(assetGraph));
-        safeDeletes
-            .addAll(assetGraph.updateAndInvalidate(_buildActions, updates));
       }
     });
-    return new BuildDefinition(assetGraph, safeDeletes, conflictingOutputs);
-  }
-
-  Future<BuildDefinition> fromGraph(
-      AssetGraph assetGraph, Map<AssetId, ChangeType> updates) async {
-    if ((await _buildScriptUpdateTime()).isAfter(assetGraph.validAsOf)) {
-      throw new BuildScriptUpdatedException();
+    AssetReader reader = _options.reader;
+    var writer = _options.writer;
+    if (_options.writeToCache) {
+      reader = new BuildCacheReader(
+          reader, assetGraph, _options.packageGraph.root.name);
+      writer = new BuildCacheWriter(
+          writer, assetGraph, _options.packageGraph.root.name);
     }
-    var safeDeletes = new Set<AssetId>();
-    _logger.info('Updating dependency graph with changes since last build.');
-    safeDeletes.addAll(assetGraph.updateAndInvalidate(_buildActions, updates));
-    return new BuildDefinition(assetGraph, safeDeletes, new Set<AssetId>());
+    return new BuildDefinition._(assetGraph, updates, conflictingOutputs,
+        reader, writer, _options.packageGraph, _options.deleteFilesByDefault);
   }
 
   /// Reads in an [AssetGraph] from disk.
   Future<AssetGraph> _readAssetGraph(AssetId assetGraphId) async {
     try {
       return new AssetGraph.deserialize(
-          JSON.decode(await _reader.readAsString(assetGraphId)) as Map);
+          JSON.decode(await _options.reader.readAsString(assetGraphId)) as Map);
     } on AssetGraphVersionException catch (_) {
       // Start fresh if the cached asset_graph version doesn't match up with
       // the current version. We don't currently support old graph versions.
@@ -119,7 +129,7 @@ class BuildDefinitionLoader {
         .map((node) async {
       bool exists;
       try {
-        exists = await _reader.canRead(node.id);
+        exists = await _options.reader.canRead(node.id);
       } on PackageNotFoundException catch (_) {
         exists = false;
       }
@@ -133,7 +143,7 @@ class BuildDefinitionLoader {
       // TODO(jakemac): https://github.com/dart-lang/build/issues/61
       if (node is GeneratedAssetNode) return;
 
-      var lastModified = await _reader.lastModified(node.id);
+      var lastModified = await _options.reader.lastModified(node.id);
       if (lastModified.compareTo(assetGraph.validAsOf) > 0) {
         updates[node.id] = ChangeType.MODIFY;
       }
@@ -141,71 +151,30 @@ class BuildDefinitionLoader {
     return updates;
   }
 
-  /// Checks if the current running program has been updated since the asset graph
-  /// was last built.
-  ///
-  /// TODO(jakemac): Come up with a better way of telling if the script has been
-  /// updated since it started running.
-  Future<DateTime> _buildScriptUpdateTime() async {
-    var urisInUse = currentMirrorSystem().libraries.keys;
-    var updateTimes = await Future.wait(urisInUse.map(_uriUpdateTime));
-    return updateTimes.reduce((l, r) => l.compareTo(r) > 0 ? l : r);
-  }
-
-  Future<DateTime> _uriUpdateTime(Uri uri) async {
-    switch (uri.scheme) {
-      case 'dart':
-        return new DateTime.fromMillisecondsSinceEpoch(0);
-      case 'package':
-        var parts = uri.pathSegments;
-        var id = new AssetId(parts[0],
-            path.url.joinAll(['lib']..addAll(parts.getRange(1, parts.length))));
-        return _reader.lastModified(id);
-      case 'file':
-
-        // TODO(jakemac): Probably shouldn't use dart:io directly, but its
-        // definitely the easiest solution and should be fine.
-        var file = new File.fromUri(uri);
-        return file.lastModified();
-      case 'data':
-
-        // Test runner uses a `data` scheme, don't invalidate for those.
-        if (uri.path.contains('package:test')) {
-          return new DateTime.fromMillisecondsSinceEpoch(0);
-        }
-    }
-    _logger.info('Unsupported uri scheme `${uri.scheme}` found for '
-        'library in build script, falling back on full rebuild. '
-        '\nThis probably means you are running in an unsupported '
-        'context, such as in an isolate or via `pub run`. Instead you '
-        'should invoke this script directly like: '
-        '`dart path_to_script.dart`.');
-    return new DateTime.now();
-  }
-
   /// Returns the set of available inputs on disk.
   Future<Set<AssetId>> _findCurrentSources() async {
-    var inputSets = _packageGraph.allPackages.keys.map((package) =>
-        new InputSet(
-            package, [package == _packageGraph.root.name ? '**' : 'lib/**']));
+    var inputSets = _options.packageGraph.allPackages.keys.map((package) =>
+        new InputSet(package,
+            [package == _options.packageGraph.root.name ? '**' : 'lib/**']));
     var sources = _listAssetIds(inputSets).where(_isValidInput).toSet();
-    if (_writeToCache) {
+    if (_options.writeToCache) {
       sources.addAll(_listGeneratedAssetIds());
     }
     return sources;
   }
 
   /// Checks if an [input] is valid.
-  bool _isValidInput(AssetId input) => input.package != _packageGraph.root.name
-      ? input.path.startsWith('lib/')
-      : !toolDirs.any((d) => input.path.startsWith(d));
+  bool _isValidInput(AssetId input) =>
+      input.package != _options.packageGraph.root.name
+          ? input.path.startsWith('lib/')
+          : !toolDirs.any((d) => input.path.startsWith(d));
 
   Iterable<AssetId> _listAssetIds(Iterable<InputSet> inputSets) sync* {
     var seenAssets = new Set<AssetId>();
     for (var inputSet in inputSets) {
       for (var glob in inputSet.globs) {
-        for (var id
-            in _reader.findAssets(glob, packageName: inputSet.package)) {
+        for (var id in _options.reader
+            .findAssets(glob, packageName: inputSet.package)) {
           if (!seenAssets.add(id)) continue;
           yield id;
         }
@@ -215,7 +184,7 @@ class BuildDefinitionLoader {
 
   Iterable<AssetId> _listGeneratedAssetIds() sync* {
     var glob = new Glob('$generatedOutputDirectory/**');
-    for (var id in _reader.findAssets(glob)) {
+    for (var id in _options.reader.findAssets(glob)) {
       var packagePath = id.path.substring(generatedOutputDirectory.length + 1);
       var firstSlash = packagePath.indexOf('/');
       var package = packagePath.substring(0, firstSlash);

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -33,6 +33,8 @@ Future<BuildResult> singleBuild(
   return (await BuildImpl.create(buildDefinition, buildActions)).firstBuild;
 }
 
+typedef void _OnDelete(AssetId id);
+
 class BuildImpl {
   BuildResult _firstBuild;
   BuildResult get firstBuild => _firstBuild;
@@ -44,7 +46,7 @@ class BuildImpl {
   final _resolvers = const BarbackResolvers();
   final AssetGraph _assetGraph;
 
-  final void Function(AssetId) _onDelete;
+  final _OnDelete _onDelete;
 
   BuildImpl._(BuildDefinition buildDefinition, List<BuildAction> buildActions,
       this._onDelete)
@@ -56,7 +58,7 @@ class BuildImpl {
 
   static Future<BuildImpl> create(
       BuildDefinition buildDefinition, List<BuildAction> buildActions,
-      {void Function(AssetId) onDelete}) async {
+      {void onDelete(AssetId id)}) async {
     var build = new BuildImpl._(buildDefinition, buildActions, onDelete);
 
     _logger.info('Checking for stale files');

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -11,7 +11,6 @@ import 'package:logging/logging.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:watcher/watcher.dart';
 
-import '../asset/build_cache.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
 import '../asset_graph/graph.dart';
@@ -26,47 +25,52 @@ import 'input_set.dart';
 import 'options.dart';
 import 'phase.dart';
 
-/// Class which manages running builds.
+final _logger = new Logger('Build');
+
+Future<BuildResult> singleBuild(
+    BuildOptions options, List<BuildAction> buildActions) async {
+  var buildDefinition = await BuildDefinition.load(options, buildActions);
+  return (await BuildImpl.create(buildDefinition, buildActions)).firstBuild;
+}
+
 class BuildImpl {
-  final AssetId _assetGraphId;
+  BuildResult _firstBuild;
+  BuildResult get firstBuild => _firstBuild;
+
   final List<BuildAction> _buildActions;
-  final bool _deleteFilesByDefault;
-  final bool _writeToCache;
-  final _logger = new Logger('Build');
   final PackageGraph _packageGraph;
-  final RunnerAssetReader _reader;
+  final AssetReader _reader;
   final RunnerAssetWriter _writer;
-  final Resolvers _resolvers = const BarbackResolvers();
-  final BuildDefinitionLoader _buildDefinitionLoader;
+  final _resolvers = const BarbackResolvers();
+  final AssetGraph _assetGraph;
 
-  AssetGraph _assetGraph;
-  AssetGraph get assetGraph => _assetGraph;
-  bool _buildRunning = false;
+  final void Function(AssetId) _onDelete;
 
-  BuildImpl(BuildOptions options, List<BuildAction> buildActions)
-      : _assetGraphId =
-            new AssetId(options.packageGraph.root.name, assetGraphPath),
-        _deleteFilesByDefault = options.deleteFilesByDefault,
-        _writeToCache = options.writeToCache,
-        _packageGraph = options.packageGraph,
-        _reader = options.reader,
-        _writer = options.writer,
-        _buildActions = buildActions,
-        _buildDefinitionLoader = new BuildDefinitionLoader(options.reader,
-            options.packageGraph, buildActions, options.writeToCache);
+  BuildImpl._(BuildDefinition buildDefinition, List<BuildAction> buildActions,
+      this._onDelete)
+      : _packageGraph = buildDefinition.packageGraph,
+        _reader = buildDefinition.reader,
+        _writer = buildDefinition.writer,
+        _assetGraph = buildDefinition.assetGraph,
+        _buildActions = buildActions;
 
-  /// Runs a build
-  ///
-  /// The returned [Future] is guaranteed to complete with a [BuildResult]. If
-  /// an exception is thrown by any phase, [BuildResult#status] will be set to
-  /// [BuildStatus.failure]. The exception and stack trace that caused the failure
-  /// will be available as [BuildResult#exception] and [BuildResult#stackTrace]
-  /// respectively.
-  Future<BuildResult> runBuild({Map<AssetId, ChangeType> updates}) async {
-    updates ??= <AssetId, ChangeType>{};
+  static Future<BuildImpl> create(
+      BuildDefinition buildDefinition, List<BuildAction> buildActions,
+      {void Function(AssetId) onDelete}) async {
+    var build = new BuildImpl._(buildDefinition, buildActions, onDelete);
+
+    _logger.info('Checking for stale files');
+    await build._firstBuildCleanup(buildDefinition.conflictingAssets,
+        buildDefinition.deleteFilesByDefault);
+
+    build._firstBuild = await build.run(buildDefinition.updates);
+    return build;
+  }
+
+  Future<BuildResult> run(Map<AssetId, ChangeType> updates) async {
     var watch = new Stopwatch()..start();
-    var result = await _safeBuild(updates);
-    _buildRunning = false;
+    if (updates.isNotEmpty) await _updateAssetGraph(updates);
+    var result = await _safeBuild();
     if (result.status == BuildStatus.success) {
       _logger.info('Succeeded after ${watch.elapsedMilliseconds}ms with '
           '${result.outputs.length} outputs\n\n');
@@ -81,32 +85,17 @@ class BuildImpl {
     return result;
   }
 
+  Future<Null> _updateAssetGraph(Map<AssetId, ChangeType> updates) async {
+    var deletes = _assetGraph.updateAndInvalidate(_buildActions, updates);
+    await Future.wait(deletes.map(_delete));
+  }
+
   /// Runs a build inside a zone with an error handler and stack chain
   /// capturing.
-  Future<BuildResult> _safeBuild(Map<AssetId, ChangeType> updates) {
+  Future<BuildResult> _safeBuild() {
     var done = new Completer<BuildResult>();
     var buildStartTime = new DateTime.now();
     Chain.capture(() async {
-      if (_buildRunning) throw const ConcurrentBuildException();
-      _buildRunning = true;
-
-      if (!_writeToCache &&
-          _buildActions.any(
-              (action) => action.inputSet.package != _packageGraph.root.name)) {
-        throw const InvalidBuildActionException.nonRootPackage();
-      }
-
-      // Initialize the [assetGraph] if its not yet set up.
-      var buildDefinition = (_assetGraph == null)
-          ? await _buildDefinitionLoader.load()
-          : await _buildDefinitionLoader.fromGraph(_assetGraph, updates);
-      _assetGraph = buildDefinition.assetGraph;
-
-      await logWithTime(_logger, 'Deleting previous outputs', () async {
-        await Future.wait(buildDefinition.safeDeletes.map(_delete));
-        await _promptDelete(buildDefinition.conflictingAssets);
-      });
-
       // Run a fresh build.
       var result = await logWithTime(_logger, 'Running build', _runPhases);
 
@@ -115,7 +104,8 @@ class BuildImpl {
           () async {
         _assetGraph.validAsOf = buildStartTime;
         await _writer.writeAsString(
-            _assetGraphId, JSON.encode(_assetGraph.serialize()));
+            new AssetId(_packageGraph.root.name, assetGraphPath),
+            JSON.encode(_assetGraph.serialize()));
       });
 
       done.complete(result);
@@ -126,19 +116,20 @@ class BuildImpl {
     return done.future;
   }
 
-  Future<Null> _promptDelete(Set<AssetId> conflictingOutputs) async {
-    if (conflictingOutputs.isEmpty) return;
+  Future<Null> _firstBuildCleanup(
+      Set<AssetId> conflictingAssets, bool deleteFilesByDefault) async {
+    if (conflictingAssets.isEmpty) return;
 
     // Skip the prompt if using this option.
-    if (_deleteFilesByDefault) {
-      _logger.info('Deleting ${conflictingOutputs.length} declared outputs '
+    if (deleteFilesByDefault) {
+      _logger.info('Deleting ${conflictingAssets.length} declared outputs '
           'which already existed on disk.');
-      await Future.wait(conflictingOutputs.map(_delete));
+      await Future.wait(conflictingAssets.map(_delete));
       return;
     }
 
     // Prompt the user to delete files that are declared as outputs.
-    _logger.warning('Found ${conflictingOutputs.length} declared outputs '
+    _logger.warning('Found ${conflictingAssets.length} declared outputs '
         'which already exist on disk. This is likely because the'
         '`$cacheDir` folder was deleted, or you are submitting generated '
         'files to your source repository.');
@@ -160,13 +151,13 @@ class BuildImpl {
         case 'y':
           stdout.writeln('Deleting files...');
           done = true;
-          await Future.wait(conflictingOutputs.map(_delete));
+          await Future.wait(conflictingAssets.map(_delete));
           break;
         case 'n':
           throw new UnexpectedExistingOutputsException();
           break;
         case 'l':
-          for (var output in conflictingOutputs) {
+          for (var output in conflictingAssets) {
             stdout.writeln(output);
           }
           break;
@@ -230,19 +221,11 @@ class BuildImpl {
       var skipBuild = !builderOutputs.any((output) =>
           (_assetGraph.get(output) as GeneratedAssetNode).needsUpdate);
       if (skipBuild) continue;
-
-      AssetReader wrappedReader = _reader;
-      AssetWriter wrappedWriter = _writer;
-      if (_writeToCache) {
-        wrappedReader = new BuildCacheReader(
-            wrappedReader, _assetGraph, _packageGraph.root.name);
-        wrappedWriter = new BuildCacheWriter(
-            wrappedWriter, _assetGraph, _packageGraph.root.name);
-      }
-      var reader = new SinglePhaseReader(
-          wrappedReader, _assetGraph, phaseNumber, _packageGraph.root.name);
-      var writer = new AssetWriterSpy(wrappedWriter);
-      await runBuilder(builder, [input], reader, writer, _resolvers);
+      var wrappedReader = new SinglePhaseReader(
+          _reader, _assetGraph, phaseNumber, _packageGraph.root.name);
+      var wrappedWriter = new AssetWriterSpy(_writer);
+      await runBuilder(
+          builder, [input], wrappedReader, wrappedWriter, _resolvers);
 
       // Mark all outputs as no longer needing an update, and mark `wasOutput`
       // as `false` for now (this will get reset to true later one).
@@ -253,7 +236,7 @@ class BuildImpl {
       }
 
       // Update the asset graph based on the dependencies discovered.
-      for (var dependency in reader.assetsRead) {
+      for (var dependency in wrappedReader.assetsRead) {
         var dependencyNode = _assetGraph.get(dependency);
         assert(dependencyNode != null, 'Asset Graph is missing $dependency');
         // We care about all builderOutputs, not just real outputs. Updates
@@ -262,7 +245,7 @@ class BuildImpl {
       }
 
       // Yield the outputs.
-      for (var output in writer.assetsWritten) {
+      for (var output in wrappedWriter.assetsWritten) {
         (_assetGraph.get(output) as GeneratedAssetNode).wasOutput = true;
         yield output;
       }
@@ -270,9 +253,7 @@ class BuildImpl {
   }
 
   Future _delete(AssetId id) {
-    if (_writeToCache) {
-      id = cacheLocation(id, _assetGraph, _packageGraph.root.name);
-    }
+    _onDelete?.call(id);
     return _writer.delete(id);
   }
 }

--- a/build_runner/lib/src/generate/exceptions.dart
+++ b/build_runner/lib/src/generate/exceptions.dart
@@ -13,16 +13,6 @@ abstract class FatalBuildException implements Exception {
   const FatalBuildException();
 }
 
-class BuildScriptUpdatedException extends FatalBuildException {
-  const BuildScriptUpdatedException();
-
-  @override
-  String toString() => 'BuildScriptUpdatedException: Build abandoned due to '
-      'change to the build script or one of its dependencies. This could be '
-      'caused by a pub get or any other change. Please restart the build '
-      'script.';
-}
-
 class UnexpectedExistingOutputsException extends FatalBuildException {
   const UnexpectedExistingOutputsException();
 

--- a/build_runner/test/common/in_memory_writer.dart
+++ b/build_runner/test/common/in_memory_writer.dart
@@ -7,9 +7,10 @@ import 'package:build/build.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:build_test/build_test.dart';
 
+typedef void OnDelete(AssetId id);
+
 class InMemoryRunnerAssetWriter extends InMemoryAssetWriter
     implements RunnerAssetWriter {
-  @override
   OnDelete onDelete;
 
   @override

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -85,9 +85,11 @@ void main() {
           'a', '0.1.0', PackageDependencyType.path, new Uri.file('a/'))
         ..dependencies.add(packageB);
       var packageGraph = new PackageGraph.fromRoot(packageA);
-      await testActions(
-          [new BuildAction(new CopyBuilder(), 'b')], {'b|lib/b.txt': 'b'},
-          packageGraph: packageGraph, outputs: {}, status: BuildStatus.failure);
+      expect(
+          testActions(
+              [new BuildAction(new CopyBuilder(), 'b')], {'b|lib/b.txt': 'b'},
+              packageGraph: packageGraph),
+          throwsA(anything));
     });
 
     test('Can output files in non-root packages with `writeToCache`', () async {


### PR DESCRIPTION
This will make it easier to use the AssetGraph to communicate about
generated assets to the upcoming handler changes for #384

- Add everything necessary for running a build to the BuildDefinition.
  Take this instead of the BuildOptios when constructing a BuildImpl.
- Wrap the asset reader and writer for the build cache when loading the
  BuildDefinition so that everything else which needs to interact with
  assets can use the same reader and writer.
- Move onDelete handling from the RunnerAssetWriter to the BuildImpl.
- Move build script update time checking to its own library. Handle the
  exception case specifically in `watch_impl` rather than throwing the
  specific exception.
- Use an `async*` method in `watch_impl` and separate out the first
  build from subsequent builds. Creating a `BuildImpl` always triggers
  the first build.

Functionally the only differences are:
- Builds which attempt to use actions on external packages without
  `writeToCache` throw an exception immediately rather than surfacing as
  a `BuildResult.failure`.
- The error message when there is build script update does not include a
  stack trace.
- Minor changes in other log messages.