### PR TITLE
initial impl of package:scratch_space

### DIFF
--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Initial release, adds the `ScratchSpace` class.

--- a/scratch_space/LICENSE
+++ b/scratch_space/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2017, the Dart project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/scratch_space/README.md
+++ b/scratch_space/README.md
@@ -1,0 +1,55 @@
+# [![Build Status](https://travis-ci.org/dart-lang/build.svg?branch=master)](https://travis-ci.org/dart-lang/build)
+
+## [`ScratchSpace`][dartdoc:ScratchSpace]
+
+A `ScratchSpace` is a thin wrapper around a temporary directory. The
+constructor takes zero arguments, so making one is as simple as doing
+`new ScratchSpace()`.
+
+### Adding assets to a `ScratchSpace`
+
+To add assets to the `ScratchSpace`, you use the `ensureAssets` method, which
+takes an `Iterable<AssetId>` and an `AssetReader` (for which you should
+generally pass your `BuildStep` which implements that interface).
+
+**Note:** It is important to note that the `ScratchSpace` does not guarantee
+that the version of a file within it is the most updated version, only that
+some version of it exists. For this reason you should create a new
+`ScratchSpace` for each build (within a single build files cannot change, but
+between builds they might).
+
+### Deleting a `ScratchSpace`
+
+When you are done with a `ScratchSpace` you should call `delete` on it to make
+sure it gets cleaned up, otherwise you can end up filling up the users tmp
+directory.
+
+**Note:** You cannot delete individual assets from a `ScratchSpace` today, you
+can only delete the entire thing. If you have a use case for deleting
+individual files you can [file an issue][tracker]. 
+
+### Getting the actual File objects for a `ScratchSpace`
+
+When invoking an external binary, you probably need to tell it where to look
+for files. There are a few fields/methods to help you do this:
+
+  * `String get packagesDir`: The `packages` directory in the `ScratchSpace`.
+  * `String get tmpDir`: The root temp directory for the `ScratchSpace`.
+  * `File fileFor(AssetId id)`: The File object for `id`.
+
+### Copying back outputs from the temp directory
+
+After running your executable, you most likely have some outputs that you
+need to notify the build system about. To do this you can use the `copyOutput`
+method, which takes an `AssetId` and `AssetWriter` (for which you should
+generally pass your `BuildStep` which implements that interface).
+
+This will copy the asset referenced by the `AssetId` from the temp directory
+back to your actual output directory.
+
+## Feature requests and bugs
+
+Please file feature requests and bugs at the [issue tracker][tracker].
+
+[tracker]: https://github.com/dart-lang/build/issues
+[dartdoc:ScratchSpace]: https://www.dartdocs.org/documentation/scratch_space/latest/scratch_space/ScratchSpace-class.html

--- a/scratch_space/lib/scratch_space.dart
+++ b/scratch_space/lib/scratch_space.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/scratch_space.dart' show ScratchSpace, canonicalUriFor;

--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:path/path.dart' as p;
+import 'package:pool/pool.dart';
+
+import 'util.dart';
+
+/// Pool for async file writes, we don't want to use too many file handles.
+final _descriptorPool = new Pool(32);
+
+/// An on-disk temporary environment for running executables that don't have
+/// a standard Dart library API.
+class ScratchSpace {
+  /// Whether or not this scratch space still exists.
+  bool exists = true;
+
+  /// The `packages` directory under the temp directory.
+  final Directory packagesDir;
+
+  /// The temp directory at the root of this [ScratchSpace].
+  final Directory tempDir;
+
+  // Assets which have a file created but are still being written to.
+  final _pendingWrites = <AssetId, Future<Null>>{};
+
+  ScratchSpace._(Directory tempDir)
+      : packagesDir = new Directory(p.join(tempDir.path, 'packages')),
+        this.tempDir = tempDir;
+
+  factory ScratchSpace() {
+    var tempDir = Directory.systemTemp.createTempSync('build_compilers');
+    return new ScratchSpace._(tempDir);
+  }
+
+  /// Copies [id] from the tmp dir and writes it back using the [writer].
+  ///
+  /// Note that [BuildStep] implements [AssetWriter] and that is typically
+  /// what you will want to pass in.
+  ///
+  /// This must be called for all outputs which you want to be included as a
+  /// part of the actual build (any other outputs will be deleted with the
+  /// tmp dir and won't be available to other [Builder]s).
+  Future copyOutput(AssetId id, AssetWriter writer) async {
+    var file = fileFor(id);
+    var bytes = await _descriptorPool.withResource(file.readAsBytes);
+    await writer.writeAsBytes(id, bytes);
+  }
+
+  /// Deletes the temp directory for this environment.
+  ///
+  /// This class is no longer valid once the directory is deleted, you must
+  /// create a new [ScratchSpace].
+  Future delete() {
+    if (!exists) {
+      throw new StateError(
+          'Tried to delete a ScratchSpace which was already deleted');
+    }
+    exists = false;
+    return tempDir.delete(recursive: true);
+  }
+
+  /// Copies [assetIds] to [tempDir] if they don't exist, using [reader] to
+  /// read assets and mark dependencies.
+  ///
+  /// Note that [BuildStep] implements [AssetReader] and that is typically
+  /// what you will want to pass in.
+  ///
+  /// Any asset that is under a `lib` dir will be output under a `packages`
+  /// directory corresponding to its package, and any other assets are output
+  /// directly under the temp dir using their unmodified path.
+  Future ensureAssets(Iterable<AssetId> assetIds, AssetReader reader) {
+    if (!exists) {
+      throw new StateError('Tried to use a deleted ScratchSpace!');
+    }
+
+    var futures = <Future>[];
+    for (var id in assetIds) {
+      // Always track `id` as a dependency, we do this by just calling
+      // `canRead` for now.
+      //
+      // ignore: unawaited_futures
+      reader.canRead(id);
+      var file = fileFor(id);
+      if (file.existsSync()) {
+        var pending = _pendingWrites[id];
+        if (pending != null) futures.add(pending);
+      } else {
+        file.createSync(recursive: true);
+        var done = _descriptorPool.withResource(() async {
+          await file.writeAsBytes(await reader.readAsBytes(id));
+          // ignore: unawaited_futures
+          _pendingWrites.remove(id);
+        });
+        _pendingWrites[id] = done;
+        futures.add(done);
+      }
+    }
+    return Future.wait(futures);
+  }
+
+  /// Returns the actual [File] in this environment corresponding to [id].
+  ///
+  /// The returned [File] may or may not already exist. Call [ensureAssets]
+  /// with [id] to make sure it is actually present.
+  File fileFor(AssetId id) =>
+      new File(p.join(tempDir.path, _relativePathFor(id)));
+}
+
+/// Returns a canonical uri for [id].
+///
+/// If [id] is under a `lib` directory then this returns a `package:` uri,
+/// otherwise it just returns [id#path].
+String canonicalUriFor(AssetId id) {
+  if (topLevelDir(id.path) == 'lib') {
+    var packagePath =
+        p.url.join(id.package, p.url.joinAll(p.url.split(id.path).skip(1)));
+    return 'package:$packagePath';
+  } else {
+    return id.path;
+  }
+}
+
+/// The path relative to the root of the environment for a given [id].
+String _relativePathFor(AssetId id) =>
+    canonicalUriFor(id).replaceFirst('package:', 'packages/');

--- a/scratch_space/lib/src/util.dart
+++ b/scratch_space/lib/src/util.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as p;
+
+/// Returns the top level directory in [uri].
+///
+/// Throws an [ArgumentError] if [uri] is just a filename with no directory.
+String topLevelDir(String uri) {
+  var parts = p.url.split(p.url.normalize(uri));
+  String error;
+  if (parts.length == 1) {
+    error = 'The uri `$uri` does not contain a directory.';
+  } else if (parts.first == '..') {
+    error = 'The uri `$uri` reaches outside the root directory.';
+  }
+  if (error != null) {
+    throw new ArgumentError(
+        'Cannot compute top level dir for path `$uri`. $error');
+  }
+  return parts.first;
+}

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,0 +1,10 @@
+name: scratch_space
+dependencies:
+  build: ^0.10.0
+  path: ^1.1.0
+  pool: ^1.0.0
+dev_dependencies:
+  build_test: ^0.7.0
+  test: ^0.12.0
+environment:
+  sdk: ">=1.21.0 <2.0.0"

--- a/scratch_space/test/scratch_space_test.dart
+++ b/scratch_space/test/scratch_space_test.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:scratch_space/scratch_space.dart';
+import 'package:scratch_space/src/util.dart';
+
+void main() {
+  group('ScratchSpace', () {
+    ScratchSpace scratchSpace;
+    InMemoryAssetReader assetReader;
+
+    Map<AssetId, DatedValue> allAssets = [
+      'dep|lib/dep.dart',
+      'myapp|lib/myapp.dart',
+      'myapp|web/main.dart',
+    ].fold({}, (assets, serializedId) {
+      assets[new AssetId.parse(serializedId)] =
+          new DatedBytes(serializedId.codeUnits);
+      return assets;
+    });
+
+    setUp(() async {
+      scratchSpace = new ScratchSpace();
+      assetReader = new InMemoryAssetReader(sourceAssets: allAssets);
+      await scratchSpace.ensureAssets(allAssets.keys, assetReader);
+    });
+
+    tearDown(() async {
+      if (scratchSpace.exists) await scratchSpace.delete();
+    });
+
+    test('Creates a directory under the system temp directory', () async {
+      expect(
+          p.isWithin(Directory.systemTemp.resolveSymbolicLinksSync(),
+              scratchSpace.tempDir.resolveSymbolicLinksSync()),
+          isTrue);
+    });
+
+    test('Can read files from a ScratchSpace', () async {
+      for (var id in allAssets.keys) {
+        var file = scratchSpace.fileFor(id);
+        expect(file.existsSync(), isTrue);
+        expect(file.readAsStringSync(), equals('$id'));
+      }
+    });
+
+    test('Files in a ScratchSpace have standard dart layout', () async {
+      for (var id in allAssets.keys) {
+        var file = scratchSpace.fileFor(id);
+
+        var relativeFilePath =
+            p.relative(file.path, from: scratchSpace.tempDir.path);
+        if (topLevelDir(id.path) == 'lib') {
+          var expectedPackagesPath =
+              p.join('packages', id.package, p.relative(id.path, from: 'lib'));
+          expect(relativeFilePath, equals(expectedPackagesPath));
+        } else {
+          expect(relativeFilePath, equals(id.path));
+        }
+      }
+    });
+
+    test('Can copy outputs back from the ScratchSpace', () async {
+      // Write a fake output to the dir.
+      var outputId = new AssetId('myapp', 'lib/output.txt');
+      var outputFile = scratchSpace.fileFor(outputId);
+      var outputContent = 'test!';
+      await outputFile.writeAsString(outputContent);
+
+      var writer = new InMemoryAssetWriter();
+      await scratchSpace.copyOutput(outputId, writer);
+
+      expect(writer.assets[outputId].stringValue, outputContent);
+    });
+
+    test('Can delete a ScratchSpace', () async {
+      await scratchSpace.delete();
+      for (var id in allAssets.keys) {
+        var file = scratchSpace.fileFor(id);
+        expect(file.existsSync(), isFalse);
+      }
+      expect(scratchSpace.tempDir.existsSync(), isFalse);
+    });
+
+    test('Can\'t use a ScratchSpace after deleting it', () async {
+      // ignore: unawaited_futures
+      scratchSpace.delete();
+      expect(() => scratchSpace.ensureAssets(allAssets.keys, assetReader),
+          throwsStateError);
+    });
+
+    test('Can\'t delete a ScratchSpace twice', () async {
+      // ignore: unawaited_futures
+      scratchSpace.delete();
+      expect(scratchSpace.delete, throwsStateError);
+    });
+  });
+
+  test('canonicalUriFor', () {
+    expect(canonicalUriFor(new AssetId('a', 'lib/a.dart')),
+        equals('package:a/a.dart'));
+    expect(canonicalUriFor(new AssetId('a', 'lib/src/a.dart')),
+        equals('package:a/src/a.dart'));
+    expect(
+        canonicalUriFor(new AssetId('a', 'web/a.dart')), equals('web/a.dart'));
+
+    expect(
+        () => canonicalUriFor(new AssetId('a', 'a.dart')), throwsArgumentError);
+    expect(() => canonicalUriFor(new AssetId('a', 'lib/../a.dart')),
+        throwsArgumentError);
+    expect(() => canonicalUriFor(new AssetId('a', 'web/../a.dart')),
+        throwsArgumentError);
+  });
+}

--- a/scratch_space/test/util_test.dart
+++ b/scratch_space/test/util_test.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:scratch_space/src/util.dart';
+
+main() {
+  group('topLevelDir', () {
+    test('returns the top level dir in a path', () {
+      expect(topLevelDir('foo/bar/baz.dart'), 'foo');
+      expect(topLevelDir('foo/../bar/baz.dart'), 'bar');
+      expect(topLevelDir('./foo/baz.dart'), 'foo');
+    });
+
+    test('throws for invalid paths', () {
+      expect(() => topLevelDir('foo/../../bar.dart'), throwsArgumentError,
+          reason: 'Paths reaching outside the root dir should throw.');
+      expect(() => topLevelDir('foo.dart'), throwsArgumentError,
+          reason: 'Paths to the root directory should throw.');
+      expect(() => topLevelDir('foo/../foo.dart'), throwsArgumentError,
+          reason: 'Normalized paths to the root directory should throw.');
+    });
+  });
+}

--- a/scratch_space/test/util_test.dart
+++ b/scratch_space/test/util_test.dart
@@ -15,6 +15,8 @@ main() {
     });
 
     test('throws for invalid paths', () {
+      expect(() => topLevelDir('../bar.dart'), throwsArgumentError,
+          reason: 'Paths reaching outside the root dir should throw.');
       expect(() => topLevelDir('foo/../../bar.dart'), throwsArgumentError,
           reason: 'Paths reaching outside the root dir should throw.');
       expect(() => topLevelDir('foo.dart'), throwsArgumentError,


### PR DESCRIPTION
See README.md for full description, but at a high level this is a new package that exposes a `ScratchSpace` class which can be used to manage a temp directory that mirrors assets from the build system, under which you can run arbitrary executables that don't have dart apis, and then copying those outputs back in a way the build system can understand.