### PR TITLE
Replace `serve` with `ServeHandler`

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## 0.5.0-dev
 
 - **Breaking**: Removed `buildType` field from `BuildResult`.
+- **Breaking**: `watch` now returns a `ServeHandler` instead of a
+  `Stream<BuildResult>`. Use `ServeHandler.buildResults` to get back to the
+  original stream.
+- **Breaking**: `serve` has been removed. Instead use `watch` and use the
+  resulting `ServeHandler.handle` method along with a server created in the
+  client script to start a server.
 - Prevent reads into `.dart_tool` for more hermetic builds.
 - Bug Fix: Rebuild entire asset graph if the build script changes.
 - Add `writeToCache` argument to `build` and `watch` which separates generated

--- a/build_runner/README.md
+++ b/build_runner/README.md
@@ -18,9 +18,8 @@ The script will use one of the three top level functions defined by this
 library:
 
 - **build**: Runs a single build and exits.
-- **watch**: Continuously runs builds as you edit files.
-- **serve**: Same as `watch`, but also provides a basic file server which blocks
-    if there are ongoing builds.
+- **watch**: Continuously runs builds as you edit files and allow serving assets
+  as a `shelf` handler.
 
 All three of these methods have a single required argument, a
 `List<BuildAction>`. Each of these `BuildActions`s may run in parallel, but they

--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -9,4 +9,4 @@ export 'src/generate/build_result.dart';
 export 'src/generate/input_set.dart';
 export 'src/generate/phase.dart';
 export 'src/package_graph/package_graph.dart';
-export 'src/server/server.dart' show BuildHandler;
+export 'src/server/server.dart' show ServeHandler;

--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -9,3 +9,4 @@ export 'src/generate/build_result.dart';
 export 'src/generate/input_set.dart';
 export 'src/generate/phase.dart';
 export 'src/package_graph/package_graph.dart';
+export 'src/server/server.dart' show BuildHandler;

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -97,11 +97,7 @@ Future<ServeHandler> watch(List<BuildAction> buildActions,
     onLog(LogRecord record),
     Duration debounceDelay,
     DirectoryWatcherFactory directoryWatcherFactory,
-    Stream terminateEventStream,
-    String directory,
-    String address,
-    int port,
-    Handler requestHandler}) {
+    Stream terminateEventStream}) {
   var options = new BuildOptions(
       deleteFilesByDefault: deleteFilesByDefault,
       writeToCache: writeToCache,
@@ -111,10 +107,7 @@ Future<ServeHandler> watch(List<BuildAction> buildActions,
       logLevel: logLevel,
       onLog: onLog,
       debounceDelay: debounceDelay,
-      directoryWatcherFactory: directoryWatcherFactory,
-      directory: directory,
-      address: address,
-      port: port);
+      directoryWatcherFactory: directoryWatcherFactory);
   var terminator = new _Terminator(terminateEventStream);
   var watch = runWatch(options, buildActions, terminator.shouldTerminate);
 

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -6,8 +6,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:shelf/shelf.dart';
-import 'package:shelf_static/shelf_static.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 import '../asset/file_based.dart';
@@ -36,25 +34,16 @@ class BuildOptions {
   Duration debounceDelay;
   DirectoryWatcherFactory directoryWatcherFactory;
 
-  // Server options.
-  int port;
-  String address;
-  String directory;
-  Handler requestHandler;
-
   BuildOptions(
-      {this.address,
+      {
       this.debounceDelay,
       this.deleteFilesByDefault,
       this.writeToCache,
-      this.directory,
       this.directoryWatcherFactory,
       Level logLevel,
       onLog(LogRecord record),
       this.packageGraph,
-      this.port,
       this.reader,
-      this.requestHandler,
       this.writer}) {
     /// Set up logging
     logLevel ??= Level.INFO;
@@ -62,13 +51,6 @@ class BuildOptions {
     logListener = Logger.root.onRecord.listen(onLog ?? _defaultLogListener);
 
     /// Set up other defaults.
-    address ??= 'localhost';
-    directory ??= '.';
-    port ??= 8000;
-    requestHandler ??= createStaticHandler(directory,
-        defaultDocument: 'index.html',
-        listDirectories: true,
-        serveFilesOutsidePath: true);
     debounceDelay ??= const Duration(milliseconds: 250);
     packageGraph ??= new PackageGraph.forThisPackage();
     reader ??= new FileBasedAssetReader(packageGraph);

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -35,8 +35,7 @@ class BuildOptions {
   DirectoryWatcherFactory directoryWatcherFactory;
 
   BuildOptions(
-      {
-      this.debounceDelay,
+      {this.debounceDelay,
       this.deleteFilesByDefault,
       this.writeToCache,
       this.directoryWatcherFactory,

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -45,8 +45,10 @@ class AssetHandler {
 
   Future<Response> handle(Request request) async {
     var pathSegments = request.url.pathSegments;
-    var assetId = (pathSegments.first == 'packages')
-        ? new AssetId(pathSegments[1], p.joinAll(pathSegments.sublist(2)))
+    var packagesIndex = pathSegments.indexOf('packages');
+    var assetId = packagesIndex > 0
+        ? new AssetId(pathSegments[packagesIndex + 1],
+            p.join('lib', p.joinAll(pathSegments.sublist(packagesIndex + 2))))
         : new AssetId(_rootPackage, p.joinAll(pathSegments));
     try {
       if (!await _reader.canRead(assetId)) {

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -11,17 +11,17 @@ import 'package:shelf/shelf.dart';
 import '../generate/build_result.dart';
 import '../generate/watch_impl.dart';
 
-class BuildHandler implements BuildState {
+Future<ServeHandler> createServeHandler(WatchImpl watch) async {
+  var rootPackage = watch.packageGraph.root.name;
+  var assetHandler = new AssetHandler(await watch.reader, rootPackage);
+  return new ServeHandler._(watch, assetHandler);
+}
+
+class ServeHandler implements BuildState {
   final BuildState _state;
   final AssetHandler _assetHandler;
 
-  static Future<BuildHandler> create(WatchImpl watch) async {
-    var rootPackage = watch.packageGraph.root.name;
-    var assetHandler = new AssetHandler(await watch.reader, rootPackage);
-    return new BuildHandler(watch, assetHandler);
-  }
-
-  BuildHandler(this._state, this._assetHandler);
+  ServeHandler._(this._state, this._assetHandler);
 
   @override
   Future<BuildResult> get currentBuild => _state.currentBuild;

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -4,45 +4,56 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:build/build.dart';
+import 'package:path/path.dart' as p;
 import 'package:shelf/shelf.dart';
-import 'package:shelf/shelf_io.dart';
 
 import '../generate/build_result.dart';
-import '../generate/options.dart';
+import '../generate/watch_impl.dart';
 
-/// The actual [HttpServer] in use.
-Future<HttpServer> _futureServer;
+class BuildHandler implements BuildState {
+  final BuildState _state;
+  final AssetHandler _assetHandler;
 
-/// Public for testing purposes only :(. This file is not directly exported
-/// though so it is effectively package private.
-Handler blockingHandler;
-
-/// Starts a server which blocks on any ongoing builds.
-Future<HttpServer> startServer(BuildState buildState, BuildOptions options) {
-  if (_futureServer != null) {
-    throw new StateError('Server already running.');
+  static Future<BuildHandler> create(WatchImpl watch) async {
+    var rootPackage = watch.packageGraph.root.name;
+    var assetHandler = new AssetHandler(await watch.reader, rootPackage);
+    return new BuildHandler(watch, assetHandler);
   }
 
-  try {
-    blockingHandler = (Request request) async {
-      await buildState.currentBuild;
-      return await options.requestHandler(request);
-    };
-    _futureServer = serve(blockingHandler, options.address, options.port);
-    return _futureServer;
-  } catch (e, s) {
-    stderr.writeln('Error setting up server: $e\n\n$s');
-    return new Future.value(null);
+  BuildHandler(this._state, this._assetHandler);
+
+  @override
+  Future<BuildResult> get currentBuild => _state.currentBuild;
+  @override
+  Stream<BuildResult> get buildResults => _state.buildResults;
+
+  Future<Response> handle(Request request) async {
+    await currentBuild;
+    return _assetHandler.handle(request);
   }
 }
 
-Future stopServer() {
-  if (_futureServer == null) {
-    throw new StateError('Server not running.');
+class AssetHandler {
+  final AssetReader _reader;
+  final String _rootPackage;
+
+  AssetHandler(this._reader, this._rootPackage);
+
+  Future<Response> handle(Request request) async {
+    var pathSegments = request.url.pathSegments;
+    var assetId = (pathSegments.first == 'packages')
+        ? new AssetId(pathSegments[1], p.joinAll(pathSegments.sublist(2)))
+        : new AssetId(_rootPackage, p.joinAll(pathSegments));
+    try {
+      if (!await _reader.canRead(assetId)) {
+        return new Response.notFound('Not Found');
+      }
+    } on ArgumentError catch (_) {
+      return new Response.notFound('Not Found');
+    }
+    var bytes = await _reader.readAsBytes(assetId);
+    var headers = {HttpHeaders.CONTENT_LENGTH: '${bytes.length}'};
+    return new Response.ok(bytes, headers: headers);
   }
-  return _futureServer.then((server) {
-    server.close();
-    _futureServer = null;
-    blockingHandler = null;
-  });
 }

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:build/build.dart';
+import 'package:mime/mime.dart';
 import 'package:path/path.dart' as p;
 import 'package:shelf/shelf.dart';
 
@@ -38,6 +39,8 @@ class AssetHandler {
   final AssetReader _reader;
   final String _rootPackage;
 
+  final _typeResolver = new MimeTypeResolver();
+
   AssetHandler(this._reader, this._rootPackage);
 
   Future<Response> handle(Request request) async {
@@ -53,7 +56,10 @@ class AssetHandler {
       return new Response.notFound('Not Found');
     }
     var bytes = await _reader.readAsBytes(assetId);
-    var headers = {HttpHeaders.CONTENT_LENGTH: '${bytes.length}'};
+    var headers = {
+      HttpHeaders.CONTENT_LENGTH: '${bytes.length}',
+      HttpHeaders.CONTENT_TYPE: _typeResolver.lookup(assetId.path)
+    };
     return new Response.ok(bytes, headers: headers);
   }
 }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   logging: ^0.11.2
   path: ^1.1.0
   shelf: ">=0.6.5 <0.8.0"
+  mime: ^0.9.3
   stack_trace: ^1.6.0
   stream_transform: ^0.0.9
   watcher: ^0.9.7

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   logging: ^0.11.2
   path: ^1.1.0
   shelf: ">=0.6.5 <0.8.0"
-  shelf_static: ^0.2.3
   stack_trace: ^1.6.0
   stream_transform: ^0.0.9
   watcher: ^0.9.7

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -16,7 +16,7 @@ import 'package:build_test/build_test.dart';
 import '../common/common.dart';
 
 void main() {
-  group('BuildHandler', () {
+  group('ServeHandler', () {
     InMemoryRunnerAssetWriter writer;
     CopyBuilder copyBuilder;
     BuildAction copyABuildAction;
@@ -108,7 +108,7 @@ final _debounceDelay = new Duration(milliseconds: 10);
 StreamController _terminateServeController;
 
 /// Start serving files and running builds.
-Future<BuildHandler> createHandler(List<BuildAction> buildActions,
+Future<ServeHandler> createHandler(List<BuildAction> buildActions,
     Map<String, String> inputs, InMemoryRunnerAssetWriter writer) {
   inputs.forEach((serializedId, contents) {
     writer.writeAsString(makeAssetId(serializedId), contents);

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -119,7 +119,7 @@ Future<ServeHandler> createHandler(List<BuildAction> buildActions,
   final packageGraph = new PackageGraph.fromRoot(rootPackage);
   final watcherFactory = (String path) => new FakeWatcher(path);
 
-  return buildHandler(buildActions,
+  return watch(buildActions,
       deleteFilesByDefault: true,
       debounceDelay: _debounceDelay,
       directoryWatcherFactory: watcherFactory,

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -11,7 +11,6 @@ import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 
 import 'package:build_runner/build_runner.dart';
-import 'package:build_runner/src/server/server.dart' as server;
 import 'package:build_test/build_test.dart';
 
 import '../common/common.dart';

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -17,7 +17,7 @@ import 'package:build_test/build_test.dart';
 import '../common/common.dart';
 
 void main() {
-  group('serve', () {
+  group('BuildHandler', () {
     InMemoryRunnerAssetWriter writer;
     CopyBuilder copyBuilder;
     BuildAction copyABuildAction;
@@ -26,7 +26,6 @@ void main() {
       _terminateServeController = new StreamController();
       writer = new InMemoryRunnerAssetWriter();
 
-      /// Basic phases/phase groups which get used in many tests
       copyBuilder = new CopyBuilder();
       copyABuildAction = new BuildAction(copyBuilder, 'a');
     });
@@ -37,8 +36,9 @@ void main() {
     });
 
     test('does basic builds', () async {
-      var results = new StreamQueue(
-          startServe([copyABuildAction], {'a|web/a.txt': 'a'}, writer));
+      var handler =
+          await createHandler([copyABuildAction], {'a|web/a.txt': 'a'}, writer);
+      var results = new StreamQueue(handler.buildResults);
       var result = await results.next;
       checkBuild(result, outputs: {'a|web/a.txt.copy': 'a'}, writer: writer);
 
@@ -54,15 +54,16 @@ void main() {
       var buildBlocker1 = new Completer();
       copyBuilder.blockUntil = buildBlocker1.future;
 
-      var results = new StreamQueue(
-          startServe([copyABuildAction], {'a|web/a.txt': 'a'}, writer));
+      var handler =
+          await createHandler([copyABuildAction], {'a|web/a.txt': 'a'}, writer);
+      var results = new StreamQueue(handler.buildResults);
       // Give the build enough time to get started.
       await wait(100);
 
       var request =
           new Request('GET', Uri.parse('http://localhost:8000/CHANGELOG.md'));
       // ignore: unawaited_futures
-      (server.blockingHandler(request) as Future).then((Response response) {
+      handler.handle(request).then((Response response) {
         expect(buildBlocker1.isCompleted, isTrue,
             reason: 'Server shouldn\'t respond until builds are done.');
       });
@@ -74,7 +75,7 @@ void main() {
       /// Next request completes right away.
       var buildBlocker2 = new Completer();
       // ignore: unawaited_futures
-      (server.blockingHandler(request) as Future).then((response) {
+      handler.handle(request).then((response) {
         expect(buildBlocker1.isCompleted, isTrue);
         expect(buildBlocker2.isCompleted, isFalse);
       });
@@ -88,7 +89,7 @@ void main() {
       await wait(500);
       var done = new Completer();
       // ignore: unawaited_futures
-      (server.blockingHandler(request) as Future).then((response) {
+      handler.handle(request).then((response) {
         expect(buildBlocker1.isCompleted, isTrue);
         expect(buildBlocker2.isCompleted, isTrue);
         done.complete();
@@ -108,7 +109,7 @@ final _debounceDelay = new Duration(milliseconds: 10);
 StreamController _terminateServeController;
 
 /// Start serving files and running builds.
-Stream<BuildResult> startServe(List<BuildAction> buildActions,
+Future<BuildHandler> createHandler(List<BuildAction> buildActions,
     Map<String, String> inputs, InMemoryRunnerAssetWriter writer) {
   inputs.forEach((serializedId, contents) {
     writer.writeAsString(makeAssetId(serializedId), contents);
@@ -119,7 +120,7 @@ Stream<BuildResult> startServe(List<BuildAction> buildActions,
   final packageGraph = new PackageGraph.fromRoot(rootPackage);
   final watcherFactory = (String path) => new FakeWatcher(path);
 
-  return serve(buildActions,
+  return buildHandler(buildActions,
       deleteFilesByDefault: true,
       debounceDelay: _debounceDelay,
       directoryWatcherFactory: watcherFactory,


### PR DESCRIPTION
Closes #384

It will now be the responsibility of the calling script to start the
server with shelf.

- Add `BuildHandler` class which implement `BuildState` and adds a shelf
  handler method.
- Add a handler backed by an `AssetReader`.
- Make `WatchImpl` public again and expose the necessary properties for
  creating the new handler.