### PR TITLE
Fix uses_dynamic_as_bottom hints

### DIFF
--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -134,4 +134,5 @@ class _Watch implements BuildState {
 
 Map<AssetId, ChangeType> _collectChanges(List<List<AssetChange>> changes) =>
     new Map.fromIterable(changes.expand((c) => c),
-        key: (AssetChange c) => c.id, value: (AssetChange c) => c.type);
+        key: (c) => (c as AssetChange).id,
+        value: (c) => (c as AssetChange).type);


### PR DESCRIPTION
The signatures are `K key(element)` and `V value(element)` so it is
incorrect to use a function which does not take `dynamic`. Shift the
cast to an explicit `as`.