### PR TITLE
Refactor checks for file changes in between builds

### DIFF
--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -14,7 +14,6 @@ import '../asset/build_cache.dart';
 import '../asset/writer.dart';
 import '../asset_graph/exceptions.dart';
 import '../asset_graph/graph.dart';
-import '../asset_graph/node.dart';
 import '../changes/build_script_updates.dart';
 import '../logging/logging.dart';
 import '../package_graph/package_graph.dart';


### PR DESCRIPTION
Fixes #408

Previous approach would not see generated files in the asset cache since
it was using the reader from the options instead of the wrapped reader.
Rather than make the `BuildCacheReader` implement `RunnerAssetReader`
refactor the check for updates to use the already loaded
`currentSources` which does honor the asset cache.