### PR TITLE
Try `index.html` if the requested URL is not found

### DIFF
--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -43,13 +43,12 @@ class AssetHandler {
 
   AssetHandler(this._reader, this._rootPackage);
 
-  Future<Response> handle(Request request) async {
-    var response = await _handle(request.url.pathSegments);
-    if (response.statusCode == 404) {
-      response = await _handle(
-          new List.from(request.url.pathSegments)..add('index.html'));
+  Future<Response> handle(Request request) {
+    var pathSegments = request.url.pathSegments;
+    if (request.url.path.endsWith('/')) {
+      pathSegments = new List.from(pathSegments)..add('index.html');
     }
-    return response;
+    return _handle(pathSegments);
   }
 
   Future<Response> _handle(List<String> pathSegments) async {

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -44,9 +44,17 @@ class AssetHandler {
   AssetHandler(this._reader, this._rootPackage);
 
   Future<Response> handle(Request request) async {
-    var pathSegments = request.url.pathSegments;
+    var response = await _handle(request.url.pathSegments);
+    if (response.statusCode == 404) {
+      response = await _handle(
+          new List.from(request.url.pathSegments)..add('index.html'));
+    }
+    return response;
+  }
+
+  Future<Response> _handle(List<String> pathSegments) async {
     var packagesIndex = pathSegments.indexOf('packages');
-    var assetId = packagesIndex > 0
+    var assetId = packagesIndex >= 0
         ? new AssetId(pathSegments[packagesIndex + 1],
             p.join('lib', p.joinAll(pathSegments.sublist(packagesIndex + 2))))
         : new AssetId(_rootPackage, p.joinAll(pathSegments));

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -2,16 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
-import 'package:async/async.dart';
-import 'package:logging/logging.dart';
-import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
-import 'package:watcher/watcher.dart';
 
-import 'package:build_runner/build_runner.dart';
 import 'package:build_runner/src/server/server.dart';
 
 import '../common/common.dart';

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -39,10 +39,17 @@ void main() {
     expect(await response.readAsString(), 'content');
   });
 
-  test('defaults to index.html', () async {
+  test('defaults to index.html if URI ends with slash', () async {
     reader.cacheStringAsset(makeAssetId('a|web/index.html'), 'content');
     var response = await handler
         .handle(new Request('GET', Uri.parse('http://server.com/web/')));
     expect(await response.readAsString(), 'content');
+  });
+
+  test('does not default to index.html if URI does not end in slash', () async {
+    reader.cacheStringAsset(makeAssetId('a|web/index.html'), 'content');
+    var response = await handler
+        .handle(new Request('GET', Uri.parse('http://server.com/web')));
+    expect(response.statusCode, 404);
   });
 }

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+import 'package:shelf/shelf.dart';
+import 'package:test/test.dart';
+import 'package:watcher/watcher.dart';
+
+import 'package:build_runner/build_runner.dart';
+import 'package:build_runner/src/server/server.dart';
+
+import '../common/common.dart';
+
+void main() {
+  AssetHandler handler;
+  InMemoryRunnerAssetReader reader;
+
+  setUp(() async {
+    reader = new InMemoryRunnerAssetReader();
+    handler = new AssetHandler(reader, 'a');
+  });
+
+  test('can read from the root package', () async {
+    reader.cacheStringAsset(makeAssetId('a|web/index.html'), 'content');
+    var response = await handler.handle(
+        new Request('GET', Uri.parse('http://server.com/web/index.html')));
+    expect(await response.readAsString(), 'content');
+  });
+
+  test('can read from dependencies', () async {
+    reader.cacheStringAsset(makeAssetId('b|lib/b.dart'), 'content');
+    var response = await handler.handle(
+        new Request('GET', Uri.parse('http://server.com/packages/b/b.dart')));
+    expect(await response.readAsString(), 'content');
+  });
+
+  test('can read from dependencies nested under top-level dir', () async {
+    reader.cacheStringAsset(makeAssetId('b|lib/b.dart'), 'content');
+    var response = await handler.handle(new Request(
+        'GET', Uri.parse('http://server.com/web/packages/b/b.dart')));
+    expect(await response.readAsString(), 'content');
+  });
+
+  test('defaults to index.html', () async {
+    reader.cacheStringAsset(makeAssetId('a|web/index.html'), 'content');
+    var response = await handler
+        .handle(new Request('GET', Uri.parse('http://server.com/web/')));
+    expect(await response.readAsString(), 'content');
+  });
+}


### PR DESCRIPTION
Fixes #413

- Add tests for AssetHandler
- Fix bug when `packages/` is at the beginning of the path instead of
  nested.
- Pull out a separate `_handle` method operating on the path segments
  try it again with `index.html` appended to the path whenever the first
  request is a 404.