### PR TITLE
Default to writeToCache for deleteFilesByDefault

### DIFF
--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -55,7 +55,7 @@ class BuildOptions {
     reader ??= new FileBasedAssetReader(packageGraph);
     writer ??= new FileBasedAssetWriter(packageGraph);
     directoryWatcherFactory ??= defaultDirectoryWatcherFactory;
-    deleteFilesByDefault ??= false;
+    deleteFilesByDefault ??= writeToCache ?? false;
     writeToCache ??= false;
   }
 }


### PR DESCRIPTION
Fixes #416

Since it won't delete a handwritten file it should be safe. Can still be
overridden with an explicit argument if every necessary.