### PR TITLE
Add orderedPackages and dependentsOf utilities

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1-dev
+
+- Add `orderedPackages` and `dependentsOf` utilities to `PackageGraph`.
+
 ## 0.5.0
 
 - **Breaking**: Removed `buildType` field from `BuildResult`.

--- a/build_runner/lib/src/package_graph/package_graph.dart
+++ b/build_runner/lib/src/package_graph/package_graph.dart
@@ -138,25 +138,8 @@ class PackageGraph {
   /// last. For any two packages for which neither is a transitive dependency of
   /// the other the relative position of the packages within the cycle is
   /// non-deterministic.
-  Iterable<PackageNode> get orderedPackages sync* {
-    var seen = new Set<PackageNode>();
-    var emitted = new Set<PackageNode>();
-    var queue = new Queue<PackageNode>();
-    queue.addLast(root);
-    while (queue.isNotEmpty) {
-      var next = queue.last;
-      if (next.dependencies.isEmpty || seen.contains(next)) {
-        var toEmit = queue.removeLast();
-        if (!emitted.contains(toEmit)) {
-          emitted.add(toEmit);
-          yield toEmit;
-        }
-      } else {
-        queue.addAll(next.dependencies);
-        seen.add(next);
-      }
-    }
-  }
+  Iterable<PackageNode> get orderedPackages =>
+      _orderedPackages(root, new Set<PackageNode>());
 
   @override
   String toString() {
@@ -166,6 +149,16 @@ class PackageGraph {
     }
     return buffer.toString();
   }
+}
+
+Iterable<PackageNode> _orderedPackages(
+    PackageNode current, Set<PackageNode> seen) sync* {
+  seen.add(current);
+  for (var dep in current.dependencies) {
+    if (seen.contains(dep)) continue;
+    yield* _orderedPackages(dep, seen);
+  }
+  yield current;
 }
 
 /// A node in a [PackageGraph].

--- a/build_runner/lib/src/package_graph/package_graph.dart
+++ b/build_runner/lib/src/package_graph/package_graph.dart
@@ -132,12 +132,12 @@ class PackageGraph {
 
   /// All of the packages in postorder by dependencies.
   ///
-  /// Depedenencies of a package will come after the package in the result. If
+  /// Depedenencies of a package will come before the package in the result. If
   /// there is a package cycle the relative position of packages within the
-  /// cycle is non-deterministic. For any two packages for which neither is a
-  /// transitive dependency of the other the relative position of the packages
-  /// within the cycle is non-deterministic. The root package will always be
-  /// last in this list regardless of it's position in a cycle.
+  /// cycle is non-deterministic, ecept that the root package will always come
+  /// last. For any two packages for which neither is a transitive dependency of
+  /// the other the relative position of the packages within the cycle is
+  /// non-deterministic.
   Iterable<PackageNode> get orderedPackages sync* {
     var seen = new Set<PackageNode>();
     var queue = new Queue<PackageNode>();

--- a/build_runner/lib/src/package_graph/package_graph.dart
+++ b/build_runner/lib/src/package_graph/package_graph.dart
@@ -140,12 +140,17 @@ class PackageGraph {
   /// non-deterministic.
   Iterable<PackageNode> get orderedPackages sync* {
     var seen = new Set<PackageNode>();
+    var emitted = new Set<PackageNode>();
     var queue = new Queue<PackageNode>();
     queue.addLast(root);
     while (queue.isNotEmpty) {
       var next = queue.last;
       if (next.dependencies.isEmpty || seen.contains(next)) {
-        yield queue.removeLast();
+        var toEmit = queue.removeLast();
+        if (!emitted.contains(toEmit)) {
+          emitted.add(toEmit);
+          yield toEmit;
+        }
       } else {
         queue.addAll(next.dependencies);
         seen.add(next);

--- a/build_runner/lib/src/package_graph/package_graph.dart
+++ b/build_runner/lib/src/package_graph/package_graph.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:collection';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;

--- a/build_runner/lib/src/package_graph/package_graph.dart
+++ b/build_runner/lib/src/package_graph/package_graph.dart
@@ -132,9 +132,9 @@ class PackageGraph {
 
   /// All of the packages in postorder by dependencies.
   ///
-  /// Depedenencies of a package will come before the package in the result. If
+  /// Depedencies of a package will come before the package in the result. If
   /// there is a package cycle the relative position of packages within the
-  /// cycle is non-deterministic, ecept that the root package will always come
+  /// cycle is non-deterministic, except that the root package will always come
   /// last. For any two packages for which neither is a transitive dependency of
   /// the other the relative position of the packages within the cycle is
   /// non-deterministic.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.5.0
+version: 0.5.1-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/test/package_graph/package_graph_test.dart
+++ b/build_runner/test/package_graph/package_graph_test.dart
@@ -180,6 +180,22 @@ void main() {
       var inOrder = graph.orderedPackages.map((n) => n.name).toList();
       expect(inOrder, containsAllInOrder(['a', 'b']));
     });
+
+    test('handles diamonds', () {
+      var a = new PackageNode('a', '1.0.0', PackageDependencyType.path, null);
+      var left =
+          new PackageNode('left', '1.0.0', PackageDependencyType.path, null);
+      var right =
+          new PackageNode('right', '1.0.0', PackageDependencyType.path, null);
+      var sharedDep = new PackageNode(
+          'sharedDep', '1.0.0', PackageDependencyType.path, null);
+      a.dependencies.addAll([left, right]);
+      left.dependencies.add(sharedDep);
+      right.dependencies.add(sharedDep);
+      var graph = new PackageGraph.fromRoot(a);
+      var inOrder = graph.orderedPackages.map((n) => n.name).toList();
+      expect(inOrder, hasLength(4));
+    });
   });
 
   group('dependentsOf', () {

--- a/build_runner/test/package_graph/package_graph_test.dart
+++ b/build_runner/test/package_graph/package_graph_test.dart
@@ -171,14 +171,27 @@ void main() {
       expect(inOrder, containsAllInOrder(['right2', 'right1', 'a']));
     });
 
-    test('handles cycles', () {
+    test('includes root last in cycle', () {
       var a = new PackageNode('a', '1.0.0', PackageDependencyType.path, null);
       var b = new PackageNode('b', '1.0.0', PackageDependencyType.path, null);
       a.dependencies.add(b);
       b.dependencies.add(a);
       var graph = new PackageGraph.fromRoot(a);
       var inOrder = graph.orderedPackages.map((n) => n.name).toList();
-      expect(inOrder, containsAllInOrder(['a', 'b']));
+      expect(inOrder, ['b', 'a']);
+    });
+
+    test('handles cycles from beneath the root', () {
+      var a = new PackageNode('a', '1.0.0', PackageDependencyType.path, null);
+      var b = new PackageNode('b', '1.0.0', PackageDependencyType.path, null);
+      var c = new PackageNode('c', '1.0.0', PackageDependencyType.path, null);
+      a.dependencies.add(b);
+      b.dependencies.add(c);
+      c.dependencies.add(b);
+      var graph = new PackageGraph.fromRoot(a);
+      var inOrder = graph.orderedPackages.map((n) => n.name).toList();
+      expect(inOrder, containsAllInOrder(['b', 'a']));
+      expect(inOrder, containsAllInOrder(['c', 'a']));
     });
 
     test('handles diamonds', () {


### PR DESCRIPTION
As we implement automatic build scripts it's useful to be able to have a
proeorder sort of packages by dependency. Add a method to get the
preorder sort, and a method to filter it to the packages which have a
certain dependency.