### PR TITLE
fix a few scenarios where rebuilds were broken

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -8,6 +8,10 @@
     interface isn't used directly my most users.
 - Fixed an issue where `findAssets` could return declared outputs from previous
   phases that weren't actually output.
+- Fixed two issues with `writeToCache`:
+  - Over-declared outputs will no longer attempt to build on each startup.
+  - Unrecognized files in the cache dir will no longer be treated as inputs,
+    they will be ignored.
 
 ## 0.5.0
 

--- a/build_runner/lib/src/util/constants.dart
+++ b/build_runner/lib/src/util/constants.dart
@@ -11,11 +11,18 @@ final String assetGraphPath = '$cacheDir/$scriptHash/asset_graph.json';
 /// Directories used for build tooling.
 ///
 /// Reading from these directories may cause non-hermetic builds.
-const toolDirs = const ['.dart_tool', 'build', 'packages', '.pub'];
+const toolDirs = const [
+  '.dart_tool',
+  'build',
+  'packages',
+  '.pub',
+  '.git',
+  '.idea'
+];
 
 /// The directory to which assets will be written when `writeToCache` is
 /// enabled.
-const generatedOutputDirectory = '.dart_tool/build/generated';
+const generatedOutputDirectory = '$cacheDir/generated';
 
 /// Relative path to the cache directory from the root package dir.
 const String cacheDir = '.dart_tool/build';

--- a/build_runner/test/common/common.dart
+++ b/build_runner/test/common/common.dart
@@ -1,13 +1,26 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
 
 export 'package:build_runner/src/util/constants.dart';
 export 'package:build_test/build_test.dart'
-    hide InMemoryAssetReader, InMemoryAssetWriter, DatedString;
+    hide InMemoryAssetReader, InMemoryAssetWriter;
 
 export 'assets.dart';
 export 'in_memory_reader.dart';
 export 'in_memory_writer.dart';
 export 'matchers.dart';
 export 'test_phases.dart';
+
+class OverDeclaringCopyBuilder extends CopyBuilder {
+  OverDeclaringCopyBuilder({int numCopies: 1, String extension: 'copy'})
+      : super(numCopies: numCopies, extension: extension);
+
+  // Override to not actually output anything.
+  @override
+  Future build(BuildStep buildStep) async {}
+}

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:convert';
+
+import 'package:build/build.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+import 'package:watcher/watcher.dart';
+
+import 'package:build_runner/build_runner.dart';
+import 'package:build_runner/src/asset_graph/graph.dart';
+import 'package:build_runner/src/asset_graph/node.dart';
+import 'package:build_runner/src/generate/build_definition.dart';
+import 'package:build_runner/src/generate/options.dart';
+import 'package:build_runner/src/package_graph/package_graph.dart';
+import 'package:build_runner/src/util/constants.dart';
+
+import '../common/common.dart';
+
+main() {
+  group('load', () {
+    Map<AssetId, DatedValue> assets;
+    BuildOptions options;
+
+    setUp(() {
+      assets = <AssetId, DatedValue>{};
+      var assetReader = new InMemoryRunnerAssetReader(assets, 'a');
+      var assetWriter = new InMemoryRunnerAssetWriter();
+      var packageA = new PackageNode('a', null, null, null);
+      var packageGraph = new PackageGraph.fromRoot(packageA);
+      options = new BuildOptions(
+          reader: assetReader,
+          writer: assetWriter,
+          packageGraph: packageGraph,
+          logLevel: Level.OFF,
+          writeToCache: true);
+    });
+
+    group('updates', () {
+      test('deleted outputs are captured as remove events', () async {
+        var lastBuild = new DateTime.now();
+        assets[makeAssetId('a|lib/test.txt')] =
+            new DatedString('a', lastBuild.subtract(new Duration(seconds: 1)));
+        var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
+
+        var assetGraph = new AssetGraph.build(buildActions, assets.keys.toSet())
+          ..validAsOf = new DateTime.now();
+        var generatedSrcId = makeAssetId('a|lib/test.txt.copy');
+        var generatedNode =
+            assetGraph.get(generatedSrcId) as GeneratedAssetNode;
+        generatedNode.wasOutput = true;
+
+        assets[makeAssetId('a|$assetGraphPath')] =
+            new DatedString(JSON.encode(assetGraph.serialize()));
+
+        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        expect(buildDefinition.updates.keys, [generatedSrcId]);
+        expect(buildDefinition.updates[generatedSrcId], ChangeType.REMOVE);
+      });
+
+      test('non-output generated nodes are not captured as remove events',
+          () async {
+        var lastBuild = new DateTime.now();
+        assets[makeAssetId('a|lib/test.txt')] =
+            new DatedString('a', lastBuild.subtract(new Duration(seconds: 1)));
+        var buildActions = [
+          new BuildAction(new OverDeclaringCopyBuilder(), 'a')
+        ];
+
+        var assetGraph = new AssetGraph.build(buildActions, assets.keys.toSet())
+          ..validAsOf = lastBuild;
+        var generatedSrcId = makeAssetId('a|lib/test.txt.copy');
+        var generatedNode =
+            assetGraph.get(generatedSrcId) as GeneratedAssetNode;
+        generatedNode.wasOutput = false;
+
+        assets[makeAssetId('a|$assetGraphPath')] =
+            new DatedString(JSON.encode(assetGraph.serialize()));
+
+        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        expect(buildDefinition.updates, isEmpty);
+      });
+    });
+
+    group('assetGraph', () {
+      test('doesn\'t capture unrecognized cacheDir files as inputs', () async {
+        assets[makeAssetId('a|$generatedOutputDirectory/a/lib/test.txt')] =
+            new DatedString('a');
+        var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
+
+        var assetGraph = new AssetGraph.build(buildActions, new Set<AssetId>())
+          ..validAsOf = new DateTime.now();
+        expect(assetGraph.allNodes, isEmpty);
+
+        assets[makeAssetId('a|$assetGraphPath')] =
+            new DatedString(JSON.encode(assetGraph.serialize()));
+
+        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        expect(buildDefinition.updates, isEmpty);
+        expect(buildDefinition.assetGraph.allNodes, isEmpty);
+      });
+    });
+  });
+}

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -19,7 +19,7 @@ import 'package:build_runner/src/util/constants.dart';
 import '../common/common.dart';
 
 main() {
-  group('load', () {
+  group('BuildDefinition.load', () {
     Map<AssetId, DatedValue> assets;
     BuildOptions options;
 
@@ -38,7 +38,7 @@ main() {
     });
 
     group('updates', () {
-      test('deleted outputs are captured as remove events', () async {
+      test('contains deleted outputs as remove events', () async {
         var lastBuild = new DateTime.now();
         assets[makeAssetId('a|lib/test.txt')] =
             new DatedString('a', lastBuild.subtract(new Duration(seconds: 1)));
@@ -59,8 +59,7 @@ main() {
         expect(buildDefinition.updates[generatedSrcId], ChangeType.REMOVE);
       });
 
-      test('non-output generated nodes are not captured as remove events',
-          () async {
+      test('ignores non-output generated nodes', () async {
         var lastBuild = new DateTime.now();
         assets[makeAssetId('a|lib/test.txt')] =
             new DatedString('a', lastBuild.subtract(new Duration(seconds: 1)));

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -519,12 +519,3 @@ void main() {
     });
   });
 }
-
-class OverDeclaringCopyBuilder extends CopyBuilder {
-  OverDeclaringCopyBuilder({int numCopies: 1, String extension})
-      : super(numCopies: numCopies, extension: extension);
-
-  // Override to not actually output anything.
-  @override
-  Future build(BuildStep buildStep) async {}
-}


### PR DESCRIPTION
This fixes two bugs related to the cache directory:

- files in the cache dir that aren't in the serialized asset graph are no longer treated as inputs
- it will no longer try to build over-declared outputs (outputs with `wasOutput == false`) on startup for every build