### PR TITLE
Add recording of read assets to InMemoryAssetReader

### DIFF
--- a/build_test/lib/src/in_memory_reader.dart
+++ b/build_test/lib/src/in_memory_reader.dart
@@ -9,9 +9,9 @@ import 'package:glob/glob.dart';
 
 import 'in_memory_writer.dart';
 
-/// An [AssetReader] that records which assets have been read to [readAssets].
+/// An [AssetReader] that records which assets have been read to [assetsRead].
 abstract class RecordingAssetReader implements AssetReader {
-  Iterable<AssetId> get readAssets;
+  Iterable<AssetId> get assetsRead;
 }
 
 /// An implementation of [AssetReader] with primed in-memory assets.
@@ -19,29 +19,32 @@ class InMemoryAssetReader
     implements MultiPackageAssetReader, RecordingAssetReader {
   final Map<AssetId, DatedValue> assets;
   final String rootPackage;
-  final Set<AssetId> readAssets;
+  final Set<AssetId> assetsRead;
 
   /// Create a new asset reader that contains [sourceAssets].
   ///
   /// May optionally define a [rootPackage], which is required for some APIs.
   InMemoryAssetReader({Map<AssetId, DatedValue> sourceAssets, this.rootPackage})
       : assets = sourceAssets ?? <AssetId, DatedValue>{},
-        readAssets = new Set<AssetId>();
+        assetsRead = new Set<AssetId>();
 
   @override
-  Future<bool> canRead(AssetId id) async => assets.containsKey(id);
+  Future<bool> canRead(AssetId id) async {
+    assetsRead.add(id);
+    return assets.containsKey(id);
+  }
 
   @override
   Future<List<int>> readAsBytes(AssetId id) async {
     if (!await canRead(id)) throw new AssetNotFoundException(id);
-    readAssets.add(id);
+    assetsRead.add(id);
     return assets[id].bytesValue;
   }
 
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) async {
     if (!await canRead(id)) throw new AssetNotFoundException(id);
-    readAssets.add(id);
+    assetsRead.add(id);
     return assets[id].stringValue;
   }
 

--- a/build_test/lib/src/in_memory_reader.dart
+++ b/build_test/lib/src/in_memory_reader.dart
@@ -15,7 +15,8 @@ abstract class RecordingAssetReader implements AssetReader {
 }
 
 /// An implementation of [AssetReader] with primed in-memory assets.
-class InMemoryAssetReader implements MultiPackageAssetReader, RecordingAssetReader {
+class InMemoryAssetReader
+    implements MultiPackageAssetReader, RecordingAssetReader {
   final Map<AssetId, DatedValue> assets;
   final String rootPackage;
   final Set<AssetId> readAssets;


### PR DESCRIPTION
Gives ability to verify which assets have been read by a Builder.