### PR TITLE
Fold/terse-ify build_runner stack traces.

### DIFF
--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -21,6 +21,7 @@ import '../util/constants.dart';
 import 'build_definition.dart';
 import 'build_result.dart';
 import 'exceptions.dart';
+import 'fold_frames.dart';
 import 'input_set.dart';
 import 'options.dart';
 import 'phase.dart';
@@ -115,8 +116,9 @@ class BuildImpl {
 
       done.complete(result);
     }, onError: (e, Chain chain) {
+      final trace = foldInternalFrames(chain.toTrace()).terse;
       done.complete(new BuildResult(BuildStatus.failure, [],
-          exception: e, stackTrace: chain.toTrace()));
+          exception: e, stackTrace: trace));
     });
     return done.future;
   }

--- a/build_runner/lib/src/generate/fold_frames.dart
+++ b/build_runner/lib/src/generate/fold_frames.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:stack_trace/stack_trace.dart';
+
+const _foldFramesFor = const [
+  '_bazel_codegen',
+  'build',
+  'build_barback',
+  'build_runner',
+  'build_test',
+];
+
+/// Executes [Trace.foldFrames] removing known `package:build`-packages.
+Trace foldInternalFrames(Trace trace) => trace
+    .foldFrames((frame) => _foldFramesFor.contains(frame.package), terse: true);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -31,4 +31,5 @@ dependency_overrides:
 
 dev_dependencies:
   build_test: ^0.8.0
+  dart_style: ^1.0.0
   test: ^0.12.0

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -58,7 +58,7 @@ Future wait(int milliseconds) =>
 ///       });
 ///     }
 ///
-Future testActions(List<BuildAction> buildActions,
+Future<BuildResult> testActions(List<BuildAction> buildActions,
     Map<String, /*String|List<int>*/ dynamic> inputs,
     {Map<String, /*String|List<int>*/ dynamic> outputs,
     PackageGraph packageGraph,
@@ -67,7 +67,8 @@ Future testActions(List<BuildAction> buildActions,
     InMemoryRunnerAssetWriter writer,
     Level logLevel: Level.OFF,
     onLog(LogRecord record),
-    bool writeToCache}) async {
+    bool writeToCache,
+    bool checkBuildStatus: true}) async {
   writer ??= new InMemoryRunnerAssetWriter();
   writeToCache ??= false;
   final actualAssets = writer.assets;
@@ -97,13 +98,17 @@ Future testActions(List<BuildAction> buildActions,
       logLevel: logLevel,
       onLog: onLog);
 
-  checkBuild(result,
-      outputs: outputs,
-      writer: writer,
-      status: status,
-      exceptionMatcher: exceptionMatcher,
-      writeToCache: writeToCache,
-      rootPackage: packageGraph.root.name);
+  if (checkBuildStatus) {
+    checkBuild(result,
+        outputs: outputs,
+        writer: writer,
+        status: status,
+        exceptionMatcher: exceptionMatcher,
+        writeToCache: writeToCache,
+        rootPackage: packageGraph.root.name);
+  }
+
+  return result;
 }
 
 void checkBuild(BuildResult result,

--- a/build_runner/test/generate/stack_trace_test.dart
+++ b/build_runner/test/generate/stack_trace_test.dart
@@ -35,6 +35,8 @@ void main() {
     expect(result.status, BuildStatus.failure,
         reason: 'Dartfmt should fail due to invalid code emitted');
     final trace = new Trace.from(result.stackTrace);
+    expect(trace.frames.map((f) => f.package), contains('dart_style'),
+        reason: 'Should have failed due to a dartfmt error');
     expect(trace.toString(), trace.terse.toString(), reason: 'Should be terse');
     expect(trace.foldFrames((f) => f.package == 'build_runner').toString(),
         trace.toString(),
@@ -47,7 +49,6 @@ class BadCodeBuilder implements Builder {
 
   @override
   Future<Null> build(BuildStep buildStep) async {
-    // ignore: unawaited_futures
     final output = buildStep.inputId.changeExtension('.g.dart');
     await buildStep.writeAsString(output, _dartfmt.format(_badOutput));
   }

--- a/build_runner/test/generate/stack_trace_test.dart
+++ b/build_runner/test/generate/stack_trace_test.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:build_runner/build_runner.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:stack_trace/stack_trace.dart';
+import 'package:test/test.dart';
+
+import '../common/test_phases.dart';
+
+const _badOutput = r'''
+  class _Foo implements Foo {
+    // Trigger "A non-redirecting 'factory' constructor must have a body."
+    factory _Foo();
+  } 
+''';
+
+// Tests whether the stack trace emitted on a failed build is legible.
+//
+// Regression test for https://github.com/dart-lang/build/issues/427.
+void main() {
+  test('should throw a readable/terse stack trace', () async {
+    final result = await testActions([
+      new BuildAction(new BadCodeBuilder(), 'a'),
+    ], {
+      'a|lib/a.dart': 'class Foo {}',
+    }, outputs: {
+      'a|lib/a.g.dart': _badOutput
+    }, checkBuildStatus: false);
+
+    expect(result.status, BuildStatus.failure,
+        reason: 'Dartfmt should fail due to invalid code emitted');
+    final trace = new Trace.from(result.stackTrace);
+    expect(trace.toString(), trace.terse.toString(), reason: 'Should be terse');
+    expect(trace.foldFrames((f) => f.package == 'build_runner').toString(),
+        trace.toString(),
+        reason: 'Should fold build package frames');
+  });
+}
+
+class BadCodeBuilder implements Builder {
+  static final _dartfmt = new DartFormatter();
+
+  @override
+  Future<Null> build(BuildStep buildStep) async {
+    // ignore: unawaited_futures
+    final output = buildStep.inputId.changeExtension('.g.dart');
+    await buildStep.writeAsString(output, _dartfmt.format(_badOutput));
+  }
+
+  @override
+  final buildExtensions = const {
+    'dart': const ['g.dart']
+  };
+}


### PR DESCRIPTION
Closes #427 

Let me know if you'd like this handled differently, or configurable/behind a flag.

It significantly improves readability of a failed builder, but could make debugging _developing_ the `build_*` suite a bit more confusing. We could detect (?) we are in a test and not fold, for example.

/cc @natebosch 