### PR TITLE
declare support for package:async 2.x

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.27.1 <0.31.0"
-  async: ^1.13.3
+  async: ">=1.13.3 <3.0.0"
   logging: ^0.11.2
   path: ^1.1.0
   glob: ^1.1.0
@@ -18,3 +18,4 @@ dev_dependencies:
   build_barback: ^0.4.0
   build_test: '>=0.6.0 <0.8.0'
   test: ^0.12.0
+  

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -18,4 +18,3 @@ dev_dependencies:
   build_barback: ^0.4.0
   build_test: '>=0.6.0 <0.8.0'
   test: ^0.12.0
-  

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.27.1 <0.31.0"
   args: ">=0.13.7 <2.0.0"
-  async: ^1.13.3
+  async: ">=1.13.3 <3.0.0"
   build: ^0.10.1
   build_barback: ^0.4.0
   crypto: ">=0.9.2 <3.0.0"


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/450

You won't pick up this version yet (blocked on package:test and package:http), but I verified with a dependency override that the tests still pass, dartanalyzer is happy, and I manually checked the e2e_example as well.