### PR TITLE
Add some integration test utilites

### DIFF
--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -32,5 +32,7 @@ dependency_overrides:
 
 dev_dependencies:
   build_test: ^0.8.0
+  cli_util: ^0.1.2
   dart_style: ^1.0.0
   test: ^0.12.0
+  test_descriptor: ^1.0.0

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -34,5 +34,6 @@ dev_dependencies:
   build_test: ^0.8.0
   cli_util: ^0.1.2
   dart_style: ^1.0.0
+  package_resolver: ^1.0.2
   test: ^0.12.0
   test_descriptor: ^1.0.0

--- a/build_runner/test/common/common.dart
+++ b/build_runner/test/common/common.dart
@@ -11,9 +11,11 @@ export 'package:build_test/build_test.dart'
     hide InMemoryAssetReader, InMemoryAssetWriter;
 
 export 'assets.dart';
+export 'descriptors.dart';
 export 'in_memory_reader.dart';
 export 'in_memory_writer.dart';
 export 'matchers.dart';
+export 'sdk.dart';
 export 'test_phases.dart';
 
 class OverDeclaringCopyBuilder extends CopyBuilder {

--- a/build_runner/test/common/descriptors.dart
+++ b/build_runner/test/common/descriptors.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/build_runner/test/common/descriptors.dart
+++ b/build_runner/test/common/descriptors.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:package_resolver/package_resolver.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+/// Creates a `pubspec.yaml` file for package [name].
+///
+/// If [currentIsolateDependencies] is provided then it will add a path
+/// dependency for each package listed, assuming it can be resolved in the
+/// current isolate.
+///
+/// If [pathDependencies] is provided then the keys are the package names
+/// and the values are the exact paths which will be added as a dependency.
+///
+/// If [versionDependencies] is provided then the keys are the package names
+/// and the values are the exact versions which will be added as a dependency.
+Future<d.FileDescriptor> pubspec(String name,
+    {Iterable<String> currentIsolateDependencies,
+    Map<String, String> pathDependencies,
+    Map<String, String> versionDependencies}) async {
+  currentIsolateDependencies ??= [];
+  pathDependencies ??= {};
+  versionDependencies ??= {};
+
+  var buffer = new StringBuffer()
+    ..writeln('name: $name')
+    // Using dependency_overrides forces the path dependency and silences
+    // warnings about hosted vs path dependency conflicts.
+    ..writeln('dependency_overrides:');
+
+  var resolver = PackageResolver.current;
+  await Future.forEach(currentIsolateDependencies, (String package) async {
+    pathDependencies[package] = await resolver.packagePath(package);
+  });
+
+  pathDependencies.forEach((package, path) {
+    buffer..writeln('  $package:')..writeln('    path: $path');
+  });
+
+  versionDependencies.forEach((package, version) {
+    buffer..writeln('  $package:$version');
+  });
+
+  return d.file('pubspec.yaml', buffer.toString());
+}

--- a/build_runner/test/common/sdk.dart
+++ b/build_runner/test/common/sdk.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/build_runner/test/common/sdk.dart
+++ b/build_runner/test/common/sdk.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:cli_util/cli_util.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+String _dartBinary = p.join(getSdkPath(), 'bin', 'dart');
+String _pubBinary = p.join(getSdkPath(), 'bin', 'pub');
+
+/// Runs `pub get` on [package] (which is assumed to be in a directory with
+/// that name under the [d.sandbox] directory).
+Future<ProcessResult> pubGet(String package) async {
+  var pubGetresult = await Process.run(_pubBinary, ['get'],
+      workingDirectory: p.join(d.sandbox, package));
+  expect(pubGetresult.exitCode, 0, reason: pubGetresult.stderr as String);
+  return pubGetresult;
+}
+
+/// Runs the `dart` script [script] in [package] with [args].
+///
+/// The [script] should be a relative path under [package].
+Future<ProcessResult> runDart(String package, String script,
+        {Iterable<String> args}) =>
+    Process.run(_dartBinary, [script]..addAll(args ?? []),
+        workingDirectory: p.join(d.sandbox, package));
+
+/// Starts the `dart` script [script] in [package] with [args].
+///
+/// The [script] should be a relative path under [package].
+Future<Process> startDart(String package, String script,
+        {Iterable<String> args}) =>
+    Process.start(_dartBinary, [script]..addAll(args ?? []),
+        workingDirectory: p.join(d.sandbox, package));

--- a/build_runner/test/common/sdk.dart
+++ b/build_runner/test/common/sdk.dart
@@ -16,7 +16,7 @@ String _pubBinary = p.join(getSdkPath(), 'bin', 'pub');
 /// Runs `pub get` on [package] (which is assumed to be in a directory with
 /// that name under the [d.sandbox] directory).
 Future<ProcessResult> pubGet(String package) async {
-  var pubGetresult = await Process.run(_pubBinary, ['get'],
+  var pubGetresult = await Process.run(_pubBinary, ['get', '--offline'],
       workingDirectory: p.join(d.sandbox, package));
   expect(pubGetresult.exitCode, 0, reason: pubGetresult.stderr as String);
   return pubGetresult;

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -3,11 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -568,19 +568,22 @@ main() async {
       var result = await runDart('a', 'tool/build.dart');
 
       expect(result.exitCode, 0, reason: result.stderr as String);
+      await d.dir('a', [
+        d.dir('web', [d.file('a.matchingFiles', 'a|web/a.txt')])
+      ]).validate();
 
-      var sandboxDir = p.join(d.sandbox, 'a');
-      var outputFile = new File(p.join(sandboxDir, 'web', 'a.matchingFiles'));
-      expect(outputFile.existsSync(), isTrue);
-      expect(outputFile.readAsStringSync(), 'a|web/a.txt');
-
-      new File(p.join(sandboxDir, 'web', 'b.txt.copy')).createSync();
+      // Add a new file matching the glob.
+      await d.dir('a', [
+        d.dir('web', [d.file('b.txt', '')])
+      ]).create();
 
       result = await runDart('a', 'tool/build.dart');
-      expect(result.exitCode, 0);
+      expect(result.exitCode, 0, reason: result.stderr as String);
       expect(result.stdout, contains('with 1 outputs'));
-      expect(outputFile.existsSync(), isTrue);
-      expect(outputFile.readAsStringSync(), 'a|web/a.txt\na|web/b.txt');
+
+      await d.dir('a', [
+        d.dir('web', [d.file('a.matchingFiles', 'a|web/a.txt\na|web/b.txt')])
+      ]).validate();
     }, skip: 'https://github.com/dart-lang/build/issues/455');
   });
 }


### PR DESCRIPTION
Uses package:test_descriptor to allow you to create actual packages and do integration tests.

Added an example integration test to repro https://github.com/dart-lang/build/issues/455 (run with --run-skipped to run the skipped test).