### PR TITLE
Fix dependency tracking for glob apis, and add some more tests

### DIFF
--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -18,9 +18,10 @@ abstract class RunnerAssetReader extends MultiPackageAssetReader {
 /// Tracks the assets read during the build and prevents reading files output
 /// during the current or future phases.
 class SinglePhaseReader implements AssetReader {
-  final AssetReader _delegate;
-  final Set<AssetId> _assetsRead = new Set();
   final AssetGraph _assetGraph;
+  final _assetsRead = new Set<AssetId>();
+  final AssetReader _delegate;
+  final _globsRan = new Set<Glob>();
   final int _phaseNumber;
   final String _primaryPackage;
 
@@ -28,6 +29,7 @@ class SinglePhaseReader implements AssetReader {
       this._primaryPackage);
 
   Iterable<AssetId> get assetsRead => _assetsRead;
+  Iterable<Glob> get globsRan => _globsRan;
 
   bool _isReadable(AssetId id) {
     var node = _assetGraph.get(id);
@@ -58,14 +60,17 @@ class SinglePhaseReader implements AssetReader {
   }
 
   @override
-  Iterable<AssetId> findAssets(Glob glob) => _assetGraph.allNodes
-          .where((n) => n.id.package == _primaryPackage)
-          .where((n) => glob.matches(n.id.path))
-          .where((n) {
-        if (n is GeneratedAssetNode) {
-          return n.wasOutput && n.phaseNumber < _phaseNumber;
-        } else {
-          return true;
-        }
-      }).map((n) => n.id);
+  Iterable<AssetId> findAssets(Glob glob) {
+    _globsRan.add(glob);
+    return _assetGraph.allNodes
+        .where((n) => n.id.package == _primaryPackage)
+        .where((n) => glob.matches(n.id.path))
+        .where((n) {
+      if (n is GeneratedAssetNode) {
+        return n.wasOutput && n.phaseNumber < _phaseNumber;
+      } else {
+        return true;
+      }
+    }).map((n) => n.id);
+  }
 }

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -129,8 +129,10 @@ class AssetGraph {
       var samePackageOutputNodes = allNodes
           .where((n) => n is GeneratedAssetNode && n.id.package == id.package)
           .toList();
-      for (GeneratedAssetNode node in samePackageOutputNodes) {
-        if (node.globs.any((glob) => glob.matches(id.path))) {
+      for (var node in samePackageOutputNodes) {
+        if ((node as GeneratedAssetNode)
+            .globs
+            .any((glob) => glob.matches(id.path))) {
           // The change type is irrelevant here.
           clearNodeAndDeps(node.id, null);
         }

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -121,16 +121,16 @@ class AssetGraph {
 
     var allNewAndDeletedIds = _addOutputsForSources(buildActions,
         updates.keys.where((id) => updates[id] == ChangeType.ADD).toSet())
+      ..addAll(updates.keys.where((id) => updates[id] == ChangeType.REMOVE))
       ..addAll(deletes);
 
     // For all new or deleted assets, check if they match any globs.
-    for (var newid in allNewAndDeletedIds) {
+    for (var id in allNewAndDeletedIds) {
       var samePackageOutputNodes = allNodes
-          .where(
-              (n) => n is GeneratedAssetNode && n.id.package == newid.package)
+          .where((n) => n is GeneratedAssetNode && n.id.package == id.package)
           .toList();
       for (GeneratedAssetNode node in samePackageOutputNodes) {
-        if (node.globs.any((glob) => glob.matches(newid.path))) {
+        if (node.globs.any((glob) => glob.matches(id.path))) {
           // The change type is irrelevant here.
           clearNodeAndDeps(node.id, null);
         }

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -29,7 +29,7 @@ class AssetGraph {
   ///
   /// This should be incremented any time the serialize/deserialize methods
   /// change on this class or [AssetNode].
-  static int get _version => 4;
+  static int get _version => 5;
 
   /// Deserializes this graph.
   factory AssetGraph.deserialize(Map serializedGraph) {
@@ -89,6 +89,7 @@ class AssetGraph {
   Iterable<AssetId> updateAndInvalidate(
       List<BuildAction> buildActions, Map<AssetId, ChangeType> updates) {
     var deletes = new Set<AssetId>();
+
     void clearNodeAndDeps(AssetId id, ChangeType rootChangeType,
         {AssetId parent, bool rootIsSource}) {
       var node = this.get(id);
@@ -117,8 +118,24 @@ class AssetGraph {
     }
 
     updates.forEach(clearNodeAndDeps);
-    _addOutputsForSources(buildActions,
-        updates.keys.where((id) => updates[id] == ChangeType.ADD).toSet());
+
+    var allNewAndDeletedIds = _addOutputsForSources(buildActions,
+        updates.keys.where((id) => updates[id] == ChangeType.ADD).toSet())
+      ..addAll(deletes);
+
+    // For all new or deleted assets, check if they match any globs.
+    for (var newid in allNewAndDeletedIds) {
+      var samePackageOutputNodes = allNodes
+          .where(
+              (n) => n is GeneratedAssetNode && n.id.package == newid.package)
+          .toList();
+      for (GeneratedAssetNode node in samePackageOutputNodes) {
+        if (node.globs.any((glob) => glob.matches(newid.path))) {
+          // The change type is irrelevant here.
+          clearNodeAndDeps(node.id, null);
+        }
+      }
+    }
 
     deletes.addAll(allNodes
         .where((n) => n is GeneratedAssetNode && n.needsUpdate)
@@ -126,7 +143,10 @@ class AssetGraph {
     return deletes;
   }
 
-  void _addOutputsForSources(
+  /// Returns a set containing [newSources] plus any new generated sources
+  /// based on [buildActions], and updates this graph to contain all the
+  /// new outputs.
+  Set<AssetId> _addOutputsForSources(
       List<BuildAction> buildActions, Set<AssetId> newSources) {
     newSources.map((s) => new AssetNode(s)).forEach(_add);
     var allInputs = new Set<AssetId>.from(newSources);
@@ -140,14 +160,13 @@ class AssetGraph {
         phaseOutputs.addAll(outputs);
         get(input).primaryOutputs.addAll(outputs);
         for (var output in outputs) {
-          if (contains(output) && get(output) is AssetNode) {
-            _remove(output);
-          }
+          if (contains(output)) _remove(output);
           _add(new GeneratedAssetNode(phaseNumber, input, true, false, output));
         }
       }
       allInputs.addAll(phaseOutputs);
     }
+    return allInputs;
   }
 
   @override

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -1,7 +1,9 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'package:build/build.dart';
+import 'package:glob/glob.dart';
 
 /// A node in the asset graph which may be an input to other assets.
 class AssetNode {
@@ -21,7 +23,7 @@ class AssetNode {
     AssetNode node;
     if (serializedNode.length == 3) {
       node = new AssetNode(new AssetId.deserialize(serializedNode[0] as List));
-    } else if (serializedNode.length == 6) {
+    } else if (serializedNode.length == 7) {
       node = new GeneratedAssetNode.deserialize(serializedNode);
     } else {
       throw new ArgumentError(
@@ -62,24 +64,40 @@ class GeneratedAssetNode extends AssetNode {
   /// Whether the asset was actually output.
   bool wasOutput;
 
+  /// All the [Glob]s that were ran to create this asset.
+  ///
+  /// Any new or deleted files matching this glob should invalidate this node.
+  Set<Glob> globs;
+
   GeneratedAssetNode(this.phaseNumber, this.primaryInput, this.needsUpdate,
-      this.wasOutput, AssetId id)
-      : super(id);
+      this.wasOutput, AssetId id,
+      {Set<Glob> globs})
+      : this.globs = globs ?? new Set<Glob>(),
+        super(id);
 
   factory GeneratedAssetNode.deserialize(List serialized) {
     var node = new GeneratedAssetNode(
-        serialized[5] as int,
-        new AssetId.deserialize(serialized[3] as List),
-        false,
-        serialized[4] as bool,
-        new AssetId.deserialize(serialized[0] as List));
+      serialized[5] as int,
+      new AssetId.deserialize(serialized[3] as List),
+      false,
+      serialized[4] as bool,
+      new AssetId.deserialize(serialized[0] as List),
+      globs: (serialized[6] as Iterable<String>)
+          .map((pattern) => new Glob(pattern))
+          .toSet(),
+    );
     node._addSerializedOutputs(serialized);
     return node;
   }
 
   @override
   List serialize() => super.serialize()
-    ..addAll([primaryInput.serialize(), wasOutput, phaseNumber]);
+    ..addAll([
+      primaryInput.serialize(),
+      wasOutput,
+      phaseNumber,
+      globs.map((glob) => glob.pattern).toList()
+    ]);
 
   @override
   String toString() =>

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -256,7 +256,9 @@ class BuildImpl {
 
       // Yield the outputs.
       for (var output in wrappedWriter.assetsWritten) {
-        (_assetGraph.get(output) as GeneratedAssetNode).wasOutput = true;
+        var node = _assetGraph.get(output) as GeneratedAssetNode;
+        node.wasOutput = true;
+        node.globs = wrappedReader.globsRan.toSet();
         outputs.add(output);
       }
     }

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -239,10 +239,13 @@ class BuildImpl {
 
       // Mark all outputs as no longer needing an update, and mark `wasOutput`
       // as `false` for now (this will get reset to true later one).
+      //
+      // Also tracks all the globs that were used during this build.
       for (var output in builderOutputs) {
         (_assetGraph.get(output) as GeneratedAssetNode)
           ..needsUpdate = false
-          ..wasOutput = false;
+          ..wasOutput = false
+          ..globs = wrappedReader.globsRan.toSet();
       }
 
       // Update the asset graph based on the dependencies discovered.
@@ -256,9 +259,7 @@ class BuildImpl {
 
       // Yield the outputs.
       for (var output in wrappedWriter.assetsWritten) {
-        var node = _assetGraph.get(output) as GeneratedAssetNode;
-        node.wasOutput = true;
-        node.globs = wrappedReader.globsRan.toSet();
+        (_assetGraph.get(output) as GeneratedAssetNode).wasOutput = true;
         outputs.add(output);
       }
     }

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -582,6 +582,6 @@ main() async {
       await d.dir('a', [
         d.dir('web', [d.file('a.matchingFiles', 'a|web/a.txt\na|web/b.txt')])
       ]).validate();
-    }, skip: 'https://github.com/dart-lang/build/issues/455');
+    });
   });
 }

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -623,7 +623,7 @@ main() async {
     });
 
     test('glob apis don\'t cause new builds for file changes', () async {
-      // Add a new file not matching the glob.
+      // Change a file matching the glob.
       await d.dir('a', [
         d.dir('web', [d.file('a.txt', 'changed!')])
       ]).create();


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/455

This also doesn't cause rebuilds on file changes, only on adds/deletes (unless you read the files explicitly after globbing). We might want to do something similar for `canRead` at some point as well but that is a separate issue :).

cc @natebosch 