### PR TITLE
Add a basic BuildPerformanceTracker

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.6.0-dev
 
 - Add `orderedPackages` and `dependentsOf` utilities to `PackageGraph`.
-- Added `performanceTracker` field to `BuildResult` which gives you performance
+- Added `performance` field to `BuildResult` which gives you performance
   information about the overall build as well as the individual actions.
 - **Breaking**: The `RunnerAssetReader` interface now extends
   `MultiPackageAssetReader` which means the `packageName` named arg has changed

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.6.0-dev
 
 - Add `orderedPackages` and `dependentsOf` utilities to `PackageGraph`.
+- Added `performanceTracker` field to `BuildResult` which gives you performance
+  information about the overall build as well as the individual actions.
 - **Breaking**: The `RunnerAssetReader` interface now extends
   `MultiPackageAssetReader` which means the `packageName` named arg has changed
   to `package`.

--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -7,6 +7,7 @@ export 'src/asset/writer.dart';
 export 'src/generate/build.dart';
 export 'src/generate/build_result.dart';
 export 'src/generate/input_set.dart';
+export 'src/generate/performance_tracker.dart';
 export 'src/generate/phase.dart';
 export 'src/package_graph/package_graph.dart';
 export 'src/server/server.dart' show ServeHandler;

--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -7,7 +7,8 @@ export 'src/asset/writer.dart';
 export 'src/generate/build.dart';
 export 'src/generate/build_result.dart';
 export 'src/generate/input_set.dart';
-export 'src/generate/performance_tracker.dart';
+export 'src/generate/performance_tracker.dart'
+    show BuildPerformance, BuildActionPerformance;
 export 'src/generate/phase.dart';
 export 'src/package_graph/package_graph.dart';
 export 'src/server/server.dart' show ServeHandler;

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -182,14 +182,14 @@ class BuildImpl {
     final outputs = <AssetId>[];
     var phaseNumber = 0;
     for (var action in _buildActions) {
-      outputs.addAll(await performanceTracker.trackAction(action, () async {
+      await performanceTracker.trackAction(action, () async {
         phaseNumber++;
         var inputs = _matchingInputs(action.inputSet, phaseNumber);
         for (var output in await _runBuilder(
             phaseNumber, action.builder, inputs, resourceManager)) {
           outputs.add(output);
         }
-      }));
+      });
     }
     return new BuildResult(BuildStatus.success, outputs,
         performanceTracker: performanceTracker..stop());

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -192,7 +192,7 @@ class BuildImpl {
       });
     }
     return new BuildResult(BuildStatus.success, outputs,
-        performanceTracker: performanceTracker..stop());
+        performance: performanceTracker..stop());
   }
 
   Set<AssetId> _inputsForPhase(int phaseNumber) => _assetGraph.allNodes

--- a/build_runner/lib/src/generate/build_result.dart
+++ b/build_runner/lib/src/generate/build_result.dart
@@ -22,13 +22,11 @@ class BuildResult {
   /// All outputs created/updated during this build.
   final List<AssetId> outputs;
 
-  /// Build performance broken out by build action.
-  ///
-  /// May be `null` depending on the build implementation.
-  final BuildPerformanceTracker performanceTracker;
+  /// The [BuildPerformance] broken out by build action, may be `null`.
+  final BuildPerformance performance;
 
   BuildResult(this.status, List<AssetId> outputs,
-      {this.exception, this.stackTrace, this.performanceTracker})
+      {this.exception, this.stackTrace, this.performance})
       : outputs = new List.unmodifiable(outputs);
 
   @override

--- a/build_runner/lib/src/generate/build_result.dart
+++ b/build_runner/lib/src/generate/build_result.dart
@@ -23,6 +23,8 @@ class BuildResult {
   final List<AssetId> outputs;
 
   /// Build performance broken out by build action.
+  ///
+  /// May be `null` depending on the build implementation.
   final BuildPerformanceTracker performanceTracker;
 
   BuildResult(this.status, List<AssetId> outputs,

--- a/build_runner/lib/src/generate/build_result.dart
+++ b/build_runner/lib/src/generate/build_result.dart
@@ -5,6 +5,8 @@ import 'dart:async';
 
 import 'package:build/build.dart';
 
+import 'performance_tracker.dart';
+
 /// The result of an individual build, this may be an incremental build or
 /// a full build.
 class BuildResult {
@@ -20,8 +22,11 @@ class BuildResult {
   /// All outputs created/updated during this build.
   final List<AssetId> outputs;
 
+  /// Build performance broken out by build action.
+  final BuildPerformanceTracker performanceTracker;
+
   BuildResult(this.status, List<AssetId> outputs,
-      {this.exception, this.stackTrace})
+      {this.exception, this.stackTrace, this.performanceTracker})
       : outputs = new List.unmodifiable(outputs);
 
   @override

--- a/build_runner/lib/src/generate/performance_tracker.dart
+++ b/build_runner/lib/src/generate/performance_tracker.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/build_runner/lib/src/generate/performance_tracker.dart
+++ b/build_runner/lib/src/generate/performance_tracker.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+
+import 'phase.dart';
+
+/// Tracks the performance of an entire build, as well as all of the
+/// individual [actions] that were ran in that build.
+class BuildPerformanceTracker extends TimeTracker {
+  /// All the actions ran in this build.
+  ///
+  /// Use [trackAction] to track individual actions.
+  Iterable<BuildActionTracker> get actions => _actions;
+  final _actions = <BuildActionTracker>[];
+
+  /// Tracks [action] which is ran with [runAction].
+  Future<Iterable<AssetId>> trackAction(
+      BuildAction action, Future<Iterable<AssetId>> runAction()) {
+    var tracker = new BuildActionTracker(action);
+    _actions.add(tracker);
+    return tracker.track(runAction);
+  }
+}
+
+/// Tracks how long it took to run an individual [BuildAction].
+///
+/// Tracks total time it took to run on all inputs available to that action.
+///
+/// It isn't feasible to accurately track how long it took to run on each
+/// individual input because they are all ran at the same time.
+class BuildActionTracker extends TimeTracker {
+  final BuildAction action;
+
+  BuildActionTracker(this.action);
+
+  Future<Iterable<AssetId>> track(Future<Iterable<AssetId>> runAction()) {
+    assert(startTime == null && stopTime == null);
+    start();
+    return runAction().then((outputs) {
+      stop();
+      return outputs;
+    });
+  }
+}
+
+/// Base class for time tracking of an individual operation.
+///
+/// Tracks a [startTime], [stopTime], and [duration].
+class TimeTracker {
+  /// When this operation started, call [start] to set this.
+  DateTime get startTime => _startTime;
+  DateTime _startTime;
+
+  /// When this operation stopped, call [stop] to set this.
+  DateTime get stopTime => _stopTime;
+  DateTime _stopTime;
+
+  /// The total duration of this operation, equivalent to taking the difference
+  /// between [stopTime] and [startTime].
+  Duration get duration {
+    assert(_startTime != null && _stopTime != null);
+    return new Duration(
+        microseconds:
+            stopTime.microsecondsSinceEpoch - startTime.microsecondsSinceEpoch);
+  }
+
+  /// Start tracking this operation, must only be called once, before [stop].
+  void start() {
+    assert(_startTime == null && _stopTime == null);
+    _startTime = new DateTime.now();
+  }
+
+  /// Stop tracking this operation, must only be called once, after [start].
+  void stop() {
+    assert(_startTime != null && _stopTime == null);
+    _stopTime = new DateTime.now();
+  }
+}

--- a/build_runner/lib/src/generate/performance_tracker.dart
+++ b/build_runner/lib/src/generate/performance_tracker.dart
@@ -20,6 +20,7 @@ class BuildPerformanceTracker extends TimeTracker {
   /// Tracks [action] which is ran with [runAction].
   Future<Iterable<AssetId>> trackAction(
       BuildAction action, Future<Iterable<AssetId>> runAction()) {
+    assert(startTime != null && stopTime == null);
     var tracker = new BuildActionTracker(action);
     _actions.add(tracker);
     return tracker.track(runAction);

--- a/build_runner/test/generate/performance_tracker_test.dart
+++ b/build_runner/test/generate/performance_tracker_test.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:build/build.dart';
+import 'package:build_runner/build_runner.dart';
+import 'package:build_test/build_test.dart';
+
+main() {
+  group('PerformanceTracker', () {
+    BuildPerformanceTracker tracker;
+
+    setUp(() {
+      tracker = new BuildPerformanceTracker()..start();
+    });
+
+    test('can track start/stop times and total duration', () {
+      tracker.stop();
+      expect(tracker.startTime.microsecondsSinceEpoch,
+          lessThan(new DateTime.now().microsecondsSinceEpoch));
+      expect(
+          tracker.stopTime.microsecondsSinceEpoch,
+          allOf(lessThan(new DateTime.now().microsecondsSinceEpoch),
+              greaterThan(tracker.startTime.microsecondsSinceEpoch)));
+      expect(
+          tracker.duration,
+          new Duration(
+              microseconds: tracker.stopTime.microsecondsSinceEpoch -
+                  tracker.startTime.microsecondsSinceEpoch));
+    });
+
+    test('can track multiple actions', () async {
+      var packages = ['a', 'b', 'c'];
+      var buildActions =
+          packages.map((p) => new BuildAction(new CopyBuilder(), p)).toList();
+      for (var action in buildActions) {
+        await tracker.trackAction(action, () async {
+          await new Future.delayed(new Duration(milliseconds: 5));
+          var package = action.inputSet.package;
+          return [new AssetId(package, 'lib/$package.txt')];
+        });
+      }
+      tracker.stop();
+
+      expect(tracker.actions.map((trackedAction) => trackedAction.action),
+          orderedEquals(buildActions));
+      var last = tracker.startTime;
+      var actionsTotal = new Duration(microseconds: 0);
+      for (var trackedAction in tracker.actions) {
+        actionsTotal += trackedAction.duration;
+        expect(trackedAction.startTime.microsecondsSinceEpoch,
+            greaterThan(last.microsecondsSinceEpoch));
+        expect(trackedAction.stopTime.microsecondsSinceEpoch,
+            greaterThan(trackedAction.startTime.microsecondsSinceEpoch));
+        last = trackedAction.stopTime;
+      }
+      expect(tracker.stopTime.microsecondsSinceEpoch,
+          greaterThan(last.microsecondsSinceEpoch));
+      expect(actionsTotal, lessThanOrEqualTo(tracker.duration));
+    });
+  });
+}

--- a/build_runner/test/generate/performance_tracker_test.dart
+++ b/build_runner/test/generate/performance_tracker_test.dart
@@ -10,6 +10,8 @@ import 'package:build/build.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:build_test/build_test.dart';
 
+import 'package:build_runner/src/generate/performance_tracker.dart';
+
 main() {
   group('PerformanceTracker', () {
     BuildPerformanceTracker tracker;


### PR DESCRIPTION
This tracks the time it took to run each `BuildAction` (phase effectively), and total time for a build.

You can pretty easily use this to roll up the total time per `Builder` type etc, and since I added it to the `BuildResult` you can easily slice and dice things however you want in your builder script after each build.