### PR TITLE
Fix Resource bug with multiple ResourceManagers

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.2+1
+
+- Fix an issue where multiple `ResourceManager`s would share `Resource`
+  instances if running at the same time. 
+
 ## 0.10.2
 
 - Added the `MultiPackageAssetReader` interface which allows globbing within

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.10.2
+version: 0.10.2+1
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build/test/resource/resource_test.dart
+++ b/build/test/resource/resource_test.dart
@@ -80,5 +80,15 @@ main() {
       await resourceManager.disposeAll();
       expect(numDisposed, length);
     });
+
+    test('doesn\'t share resources with other ResourceManagers', () async {
+      var otherManager = new ResourceManager();
+      var last = 0;
+      var intResource = new Resource(() => last++);
+
+      var original = await resourceManager.fetch(intResource);
+      var other = await otherManager.fetch(intResource);
+      expect(original, isNot(other));
+    });
   });
 }


### PR DESCRIPTION
Previously multiple `ResourceManager`s would share `Resource` instances if running at the same time.