### PR TITLE
fix potential deadlock issue

### DIFF
--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.1+1
+
+- Fix a deadlock issue around the file descriptor pool, only take control of a
+  resource right before actually touching disk instead of also encapsulating
+  the `readAsBytes` call from the wrapped `AssetReader`.  
+
 ## 0.0.1
 
 - Initial release, adds the `ScratchSpace` class.

--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -92,11 +92,14 @@ class ScratchSpace {
         if (pending != null) futures.add(pending);
       } else {
         file.createSync(recursive: true);
-        var done = _descriptorPool.withResource(() async {
-          await file.writeAsBytes(await reader.readAsBytes(id));
-          // ignore: unawaited_futures
-          _pendingWrites.remove(id);
-        });
+        var done = () async {
+          var bytes = await reader.readAsBytes(id);
+          await _descriptorPool.withResource(() async {
+            await file.writeAsBytes(bytes);
+            // ignore: unawaited_futures
+            _pendingWrites.remove(id);
+          });
+        }();
         _pendingWrites[id] = done;
         futures.add(done);
       }

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scratch_space
-version: 0.0.1
+version: 0.0.1+1
 description: A tool to manage running external executables within package:build
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
Once you have lazy builders this gets into deadlock if `reader.readAsBytes` actually blocks on other builders which also used a scratch space. Instead only grab an item from the pool for the actual file write which is guaranteed not to block infinitely.