### PR TITLE
Add (unused) {Build|Watch}Options.

### DIFF
--- a/build_runner/lib/src/generate/build_options.dart
+++ b/build_runner/lib/src/generate/build_options.dart
@@ -1,0 +1,86 @@
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+
+import '../asset/file_based.dart';
+import '../asset/reader.dart';
+import '../asset/writer.dart';
+import '../package_graph/package_graph.dart';
+import 'directory_watcher_factory.dart';
+
+/// Configuration for a given invocation of a `build`.
+class BuildOptions {
+  /// Whether to delete previously generated files before running a build.
+  final bool deleteFilesByDefault;
+
+  /// Whether to write to a cache directory instead of the source directory.
+  ///
+  /// Enabling this option is the only way to allow builders to run against
+  /// packages other than the root.
+  final bool writeToCache;
+
+  /// Dependencies to execute a build against.
+  final PackageGraph packageGraph;
+
+  /// Manages reading files from the file system.
+  final RunnerAssetReader reader;
+
+  /// Manages writing files to the file system.
+  final RunnerAssetWriter writer;
+
+  factory BuildOptions({
+    bool writeToCache,
+    bool deleteFilesByDefault,
+    PackageGraph packageGraph,
+    Level logLevel,
+    RunnerAssetReader reader(PackageGraph graph),
+    RunnerAssetWriter writer(PackageGraph graph),
+  }) {
+    writeToCache ??= false;
+    deleteFilesByDefault ??= writeToCache;
+    packageGraph ??= new PackageGraph.forThisPackage();
+    Logger.root.level = logLevel ??= Level.INFO;
+    reader ??= (graph) => new FileBasedAssetReader(graph);
+    writer ??= (graph) => new FileBasedAssetWriter(graph);
+    return new BuildOptions._(
+      deleteFilesByDefault: deleteFilesByDefault,
+      writeToCache: writeToCache,
+      packageGraph: packageGraph,
+      reader: reader(packageGraph),
+      writer: writer(packageGraph),
+    );
+  }
+
+  const BuildOptions._({
+    @required this.deleteFilesByDefault,
+    @required this.writeToCache,
+    @required this.packageGraph,
+    @required this.reader,
+    @required this.writer,
+  });
+}
+
+/// Additional configuration for a given invocation of a `watch`.
+class WatchOptions {
+  /// How long to debounce before starting a build when a file changes.
+  final Duration debounceDelay;
+
+  /// Strategy for watching a directory for changes.
+  final DirectoryWatcherFactory directoryWatcherFactory;
+
+  factory WatchOptions({
+    Duration debounceDelay,
+    DirectoryWatcherFactory directoryWatcherFactory,
+  }) {
+    debounceDelay ??= const Duration(milliseconds: 250);
+    directoryWatcherFactory ??= defaultDirectoryWatcherFactory;
+    return new WatchOptions._(
+      debounceDelay: debounceDelay,
+      directoryWatcherFactory: directoryWatcherFactory,
+    );
+  }
+
+  const WatchOptions._({
+    @required this.debounceDelay,
+    @required this.directoryWatcherFactory,
+  });
+}


### PR DESCRIPTION
Progress towards https://github.com/dart-lang/build/issues/95.

The current implementation (as used) is not quite stateless. I'm not sure if this one should be.

Some open questions:

1. Should log listening/printing be handled through another abstraction/mechanism?
2. Should `BuildOptions` expose creating asset readers/writers, or a single instance?
3. Should the defaults be documented?
