### PR TITLE
Better AssetGraph serialization/deserialization.

### DIFF
--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -32,12 +32,6 @@ class AssetGraph {
 
   AssetGraph._();
 
-  /// Part of the serialized graph, used to ensure versioning constraints.
-  ///
-  /// This should be incremented any time the serialize/deserialize methods
-  /// change on this class or [AssetNode].
-  static int get _version => 7;
-
   /// Deserializes this graph.
   factory AssetGraph.deserialize(Map serializedGraph) =>
       new _AssetGraphDeserializer(serializedGraph).deserialize();

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 import 'package:watcher/watcher.dart';

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -19,33 +19,6 @@ class AssetNode {
 
   AssetNode(this.id);
 
-  factory AssetNode.deserialize(List serializedNode) {
-    AssetNode node;
-    if (serializedNode.length == 3) {
-      node = new AssetNode(new AssetId.deserialize(serializedNode[0] as List));
-    } else if (serializedNode.length == 8) {
-      node = new GeneratedAssetNode.deserialize(serializedNode);
-    } else {
-      throw new ArgumentError(
-          'Unrecognized serialization format! $serializedNode');
-    }
-    node._addSerializedOutputs(serializedNode);
-    return node;
-  }
-
-  void _addSerializedOutputs(List serialized) {
-    outputs.addAll(new List.from(serialized[1]
-        .map((id) => new AssetId.deserialize(id as List)) as Iterable));
-    primaryOutputs.addAll(new List.from(serialized[2]
-        .map((id) => new AssetId.deserialize(id as List)) as Iterable));
-  }
-
-  List serialize() => [
-        id.serialize(),
-        outputs.map((id) => id.serialize()).toList(),
-        primaryOutputs.map((id) => id.serialize()).toList(),
-      ];
-
   @override
   String toString() => 'AssetNode: $id';
 }
@@ -76,33 +49,6 @@ class GeneratedAssetNode extends AssetNode {
       {Set<Glob> globs})
       : this.globs = globs ?? new Set<Glob>(),
         super(id);
-
-  factory GeneratedAssetNode.deserialize(List serialized) {
-    var node = new GeneratedAssetNode(
-      serialized[5] as int,
-      serialized[3] == null
-          ? null
-          : new AssetId.deserialize(serialized[3] as List),
-      serialized[7] as bool,
-      serialized[4] as bool,
-      new AssetId.deserialize(serialized[0] as List),
-      globs: (serialized[6] as Iterable<String>)
-          .map((pattern) => new Glob(pattern))
-          .toSet(),
-    );
-    node._addSerializedOutputs(serialized);
-    return node;
-  }
-
-  @override
-  List serialize() => super.serialize()
-    ..addAll([
-      primaryInput?.serialize(),
-      wasOutput,
-      phaseNumber,
-      globs.map((glob) => glob.pattern).toList(),
-      needsUpdate,
-    ]);
 
   @override
   String toString() =>

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -4,6 +4,12 @@
 
 part of 'graph.dart';
 
+/// Part of the serialized graph, used to ensure versioning constraints.
+///
+/// This should be incremented any time the serialize/deserialize formats
+/// change.
+const _version = 7;
+
 /// Deserializes an [AssetGraph] from a [Map].
 class _AssetGraphDeserializer {
   final _idToAssetId = <int, AssetId>{};
@@ -13,9 +19,9 @@ class _AssetGraphDeserializer {
 
   /// Perform the deserialization, should only be called once.
   AssetGraph deserialize() {
-    if (_serializedGraph['version'] != AssetGraph._version) {
+    if (_serializedGraph['version'] != _version) {
       throw new AssetGraphVersionException(
-          _serializedGraph['version'] as int, AssetGraph._version);
+          _serializedGraph['version'] as int, _version);
     }
 
     var graph = new AssetGraph._();
@@ -84,7 +90,7 @@ class _AssetGraphSerializer {
     }
 
     var result = <String, dynamic>{
-      'version': AssetGraph._version,
+      'version': _version,
       'nodes': _graph.allNodes.map(_serializeNode).toList(),
       'validAsOf': _graph.validAsOf.millisecondsSinceEpoch,
     };

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -1,0 +1,115 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of 'graph.dart';
+
+class _AssetGraphDeserializer {
+  final _idToAssetId = <int, AssetId>{};
+  final Map _serializedGraph;
+
+  _AssetGraphDeserializer(this._serializedGraph);
+
+  AssetGraph deserialize() {
+    if (_serializedGraph['version'] != AssetGraph._version) {
+      throw new AssetGraphVersionException(
+          _serializedGraph['version'] as int, AssetGraph._version);
+    }
+
+    var graph = new AssetGraph._();
+
+    for (var descriptor in _serializedGraph['serializedAssetIds']) {
+      _idToAssetId[descriptor[0] as int] =
+          new AssetId(descriptor[1] as String, descriptor[2] as String);
+    }
+
+    for (var serializedItem in _serializedGraph['nodes']) {
+      graph._add(_deserializeAssetNode(serializedItem as List));
+    }
+    graph.validAsOf = new DateTime.fromMillisecondsSinceEpoch(
+        _serializedGraph['validAsOf'] as int);
+    return graph;
+  }
+
+  AssetNode _deserializeAssetNode(List serializedNode) {
+    AssetNode node;
+    if (serializedNode.length == 3) {
+      node = new AssetNode(_idToAssetId[serializedNode[0]]);
+    } else if (serializedNode.length == 8) {
+      node = new GeneratedAssetNode(
+        serializedNode[5] as int,
+        _idToAssetId[serializedNode[3]],
+        _deserializeBool(serializedNode[7] as int),
+        _deserializeBool(serializedNode[4] as int),
+        _idToAssetId[serializedNode[0]],
+        globs: (serializedNode[6] as Iterable<String>)
+            .map((pattern) => new Glob(pattern))
+            .toSet(),
+      );
+    } else {
+      throw new ArgumentError(
+          'Unrecognized serialization format! $serializedNode');
+    }
+    node.outputs.addAll(_deserializeAssetIds(serializedNode[1] as List<int>));
+    node.primaryOutputs
+        .addAll(_deserializeAssetIds(serializedNode[2] as List<int>));
+    return node;
+  }
+
+  List<AssetId> _deserializeAssetIds(List<int> serializedIds) =>
+      serializedIds.map((id) => _idToAssetId[id]).toList();
+
+  bool _deserializeBool(int value) => value == 0 ? false : true;
+}
+
+class _AssetGraphSerializer {
+  final _assetIdToId = <AssetId, int>{};
+
+  final AssetGraph _graph;
+
+  _AssetGraphSerializer(this._graph);
+
+  Map<String, dynamic> serialize() {
+    /// Compute numeric ids for all nodes.
+    var next = 0;
+    for (var node in _graph.allNodes) {
+      _assetIdToId[node.id] = next;
+      next++;
+    }
+
+    var result = <String, dynamic>{
+      'version': AssetGraph._version,
+      'nodes': _graph.allNodes.map(_serializeNode).toList(),
+      'validAsOf': _graph.validAsOf.millisecondsSinceEpoch,
+    };
+
+    var serializedAssetIds = <List>[];
+    _assetIdToId.forEach((k, v) {
+      serializedAssetIds.add([v, k.package, k.path]);
+    });
+    result['serializedAssetIds'] = serializedAssetIds;
+    return result;
+  }
+
+  List<Object> _serializeNode(AssetNode node) {
+    var serializedNode = <Object>[
+      _assetIdToId[node.id],
+      node.outputs.map((id) => _assetIdToId[id]).toList(),
+      node.primaryOutputs.map((id) => _assetIdToId[id]).toList(),
+    ];
+
+    if (node is GeneratedAssetNode) {
+      serializedNode.addAll([
+        _assetIdToId[node.primaryInput],
+        _serializeBool(node.wasOutput),
+        node.phaseNumber,
+        node.globs.map((glob) => glob.pattern).toList(),
+        _serializeBool(node.needsUpdate),
+      ]);
+    }
+
+    return serializedNode;
+  }
+
+  int _serializeBool(bool value) => value ? 1 : 0;
+}


### PR DESCRIPTION
This separates out the serialization/deserialization of the graph into separate classes, and adds in a few optimizations:

- `AssetId`s are assigned a an integer id so we don't duplicate strings all over.
- `AssetNode`s are wrapped with a class that implements `List` instead of creating a new `List` for them.
- `bool` values are now encoded with a `0` or `1`.

Overall now on the angular components example with ddc I see serialization times around ~110ms compared to around ~900ms previously. Asset graph size has gone from over 30MB to 3.2MB. Deserialization times are now around ~350ms.

Closes https://github.com/dart-lang/build/issues/490