### PR TITLE
Add a `$sdk` package, and move `includes` and `excludes` to PackageNode

### DIFF
--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -163,9 +163,9 @@ class _Loader {
 
   /// Returns the set of original package inputs on disk.
   Future<Set<AssetId>> _findInputSources() async {
-    var inputSets = _options.packageGraph.allPackages.keys.map((package) =>
-        new InputSet(package,
-            [package == _options.packageGraph.root.name ? '**' : 'lib/**']));
+    var inputSets = _options.packageGraph.allPackages.values.map((package) =>
+        new InputSet(package.name, package.includes,
+            excludes: package.excludes));
     var sources = _listAssetIds(inputSets).where(_isValidInput).toSet();
     return sources;
   }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ^0.11.0
   build_barback: ^0.4.0
+  cli_util: ^0.1.2
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0
   logging: ^0.11.2

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -33,7 +33,6 @@ dependency_overrides:
 
 dev_dependencies:
   build_test: ^0.8.0
-  cli_util: ^0.1.2
   dart_style: ^1.0.0
   package_resolver: ^1.0.2
   test: ^0.12.0

--- a/build_runner/test/asset/file_based_test.dart
+++ b/build_runner/test/asset/file_based_test.dart
@@ -80,6 +80,13 @@ void main() {
       expect(reader.lastModified(makeAssetId('basic_pkg|foo.txt')),
           throwsA(assetNotFoundException));
     });
+
+    test('can read from the SDK', () async {
+      expect(
+          await reader
+              .canRead(makeAssetId(r'$sdk|lib/dev_compiler/amd/dart_sdk.js')),
+          true);
+    });
   });
 
   group('FileBasedAssetWriter', () {

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -85,7 +85,7 @@ Future<BuildResult> testActions(List<BuildAction> buildActions,
   });
 
   if (packageGraph == null) {
-    var rootPackage = new PackageNode.noPubspec('a');
+    var rootPackage = new PackageNode.noPubspec('a', includes: ['**']);
     packageGraph = new PackageGraph.fromRoot(rootPackage);
   }
 

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -131,8 +131,9 @@ void main() {
     });
 
     test('can\'t output files in non-root packages', () async {
-      var packageB =
-          new PackageNode('b', '0.1.0', PackageDependencyType.path, 'a/b/');
+      var packageB = new PackageNode(
+          'b', '0.1.0', PackageDependencyType.path, 'a/b/',
+          includes: ['**']);
       var packageA =
           new PackageNode('a', '0.1.0', PackageDependencyType.path, 'a/')
             ..dependencies.add(packageB);
@@ -148,8 +149,9 @@ void main() {
       PackageGraph packageGraph;
 
       setUp(() {
-        var packageB =
-            new PackageNode('b', '0.1.0', PackageDependencyType.path, 'a/b/');
+        var packageB = new PackageNode(
+            'b', '0.1.0', PackageDependencyType.path, 'a/b/',
+            includes: ['**']);
         var packageA =
             new PackageNode('a', '0.1.0', PackageDependencyType.path, 'a/')
               ..dependencies.add(packageB);
@@ -228,9 +230,10 @@ void main() {
     test('can glob files from packages', () async {
       var packageB =
           new PackageNode('b', '0.1.0', PackageDependencyType.path, 'a/b/');
-      var packageA =
-          new PackageNode('a', '0.1.0', PackageDependencyType.path, 'a/')
-            ..dependencies.add(packageB);
+      var packageA = new PackageNode(
+          'a', '0.1.0', PackageDependencyType.path, 'a/',
+          includes: ['**'])
+        ..dependencies.add(packageB);
       var packageGraph = new PackageGraph.fromRoot(packageA);
 
       var buildActions = [
@@ -285,8 +288,9 @@ void main() {
     });
 
     test('won\'t try to delete files from other packages', () async {
-      var packageB =
-          new PackageNode('b', '0.1.0', PackageDependencyType.path, 'a/b/');
+      var packageB = new PackageNode(
+          'b', '0.1.0', PackageDependencyType.path, 'a/b/',
+          includes: ['**']);
       var packageA =
           new PackageNode('a', '0.1.0', PackageDependencyType.path, 'a/')
             ..dependencies.add(packageB);
@@ -594,8 +598,9 @@ void main() {
           makeAssetId('a|.dart_tool/build/generated/a/web/a.txt'), '',
           lastModified: graph.validAsOf.add(new Duration(hours: 2)));
 
-      var packageA =
-          new PackageNode('a', '0.1.0', PackageDependencyType.path, 'a/');
+      var packageA = new PackageNode(
+          'a', '0.1.0', PackageDependencyType.path, 'a/',
+          includes: ['**']);
       var packageGraph = new PackageGraph.fromRoot(packageA);
       await testActions([
         copyABuildAction

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -115,7 +115,8 @@ Future<ServeHandler> createHandler(List<BuildAction> buildActions,
   });
   final actualAssets = writer.assets;
   final reader = new InMemoryRunnerAssetReader(actualAssets);
-  final rootPackage = new PackageNode.noPubspec('a', path: path.absolute('a'));
+  final rootPackage = new PackageNode.noPubspec('a',
+      path: path.absolute('a'), includes: ['**']);
   final packageGraph = new PackageGraph.fromRoot(rootPackage);
   final watcherFactory = (String path) => new FakeWatcher(path);
 

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -157,7 +157,8 @@ void main() {
       test('ignores events from nested packages', () async {
         var writer = new InMemoryRunnerAssetWriter();
         var packageA = new PackageNode(
-            'a', '0.1.0', PackageDependencyType.path, path.absolute('a'));
+            'a', '0.1.0', PackageDependencyType.path, path.absolute('a'),
+            includes: ['**']);
         var packageB = new PackageNode(
             'b', '0.1.0', PackageDependencyType.path, path.absolute('a', 'b'));
         packageA.dependencies.add(packageB);
@@ -386,8 +387,8 @@ Stream<BuildResult> startWatch(List<BuildAction> buildActions,
   final actualAssets = writer.assets;
   final reader = new InMemoryRunnerAssetReader(actualAssets);
   if (packageGraph == null) {
-    packageGraph ??= new PackageGraph.fromRoot(
-        new PackageNode.noPubspec('a', path: path.absolute('a')));
+    packageGraph ??= new PackageGraph.fromRoot(new PackageNode.noPubspec('a',
+        path: path.absolute('a'), includes: ['**']));
   }
   final watcherFactory = (String path) => new FakeWatcher(path);
 

--- a/build_runner/test/package_graph/package_graph_test.dart
+++ b/build_runner/test/package_graph/package_graph_test.dart
@@ -30,13 +30,16 @@ void main() {
       });
 
       test('allPackages', () {
-        expect(graph.allPackages, {
-          'a': graph['a'],
-          'b': graph['b'],
-          'c': graph['c'],
-          'd': graph['d'],
-          'basic_pkg': graph['basic_pkg'],
-        });
+        expect(
+            graph.allPackages,
+            equals({
+              'a': graph['a'],
+              'b': graph['b'],
+              'c': graph['c'],
+              'd': graph['d'],
+              'basic_pkg': graph['basic_pkg'],
+              r'$sdk': anything,
+            }));
       });
 
       test('root', () {
@@ -79,6 +82,7 @@ void main() {
           'a': graph['a'],
           'b': graph['b'],
           'with_dev_deps': graph['with_dev_deps'],
+          r'$sdk': graph[r'$sdk'],
         });
       });
 
@@ -120,6 +124,7 @@ void main() {
           'flutter_gallery_assets',
           'flutter_test',
           'flutter_driver',
+          r'$sdk',
         ]);
       });
     });
@@ -133,7 +138,8 @@ void main() {
       b.dependencies.add(c);
       var graph = new PackageGraph.fromRoot(a);
       expect(graph.root, a);
-      expect(graph.allPackages, {'a': a, 'b': b, 'c': c, 'd': d});
+      expect(graph.allPackages,
+          equals({'a': a, 'b': b, 'c': c, 'd': d, r'$sdk': anything}));
     });
 
     test('missing pubspec throws on create', () {

--- a/build_runner/test/watcher/graph_watcher_test.dart
+++ b/build_runner/test/watcher/graph_watcher_test.dart
@@ -22,6 +22,7 @@ void main() {
       final nodes = {
         'a': new FakeNodeWatcher(pkgA),
         'b': new FakeNodeWatcher(pkgB),
+        r'$sdk': new FakeNodeWatcher(null),
       };
       final watcher = new PackageGraphWatcher(graph, watch: (node) {
         return nodes[node.name];
@@ -47,6 +48,7 @@ void main() {
       final nodes = {
         'a': new FakeNodeWatcher(pkgA),
         'b': new FakeNodeWatcher(pkgB),
+        r'$sdk': new FakeNodeWatcher(null),
       };
       final watcher = new PackageGraphWatcher(graph, watch: (node) {
         return nodes[node.name];


### PR DESCRIPTION
This allows us to serve ddc resources and dart files for sourcemaps directly from the sdk.