### PR TITLE
increase the timeout of the build test

### DIFF
--- a/build_compilers/test/build_test.dart
+++ b/build_compilers/test/build_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Tags(const ['presubmit-only'])
+@Timeout(const Duration(seconds: 120))
 
 import 'dart:convert';
 import 'dart:io';


### PR DESCRIPTION
This one is flaking, upping it from 30 seconds to 2 minutes.