### PR TITLE
Updates to serve handler, now provides a factory for handlers of specified top level dirs

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -18,6 +18,10 @@
   `MultiPackageAssetReader`, which means the `packageName` named argument has
   changed to `package`; while technically breaking most users do not rely on
   this interface explicitly.
+- **Breaking**: `ServeHandler.handle` has been replaced with
+  `Handler ServeHandler.handleFor(String rootDir)`. This allows you to create
+  separate handlers per directory you want to serve, which maintains pub serve
+  conventions and allows interoperation with `pub run test --pub-serve=$PORT`.
 
 ### Bug fixes
 

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -55,14 +55,15 @@ void main() {
 
       var handler =
           await createHandler([copyABuildAction], {'a|web/a.txt': 'a'}, writer);
+      var webHandler = handler.handlerFor('web');
       var results = new StreamQueue(handler.buildResults);
       // Give the build enough time to get started.
       await wait(100);
 
       var request =
-          new Request('GET', Uri.parse('http://localhost:8000/CHANGELOG.md'));
+          new Request('GET', Uri.parse('http://localhost:8000/a.txt'));
       // ignore: unawaited_futures
-      handler.handle(request).then((Response response) {
+      (webHandler(request) as Future<Response>).then((Response response) {
         expect(buildBlocker1.isCompleted, isTrue,
             reason: 'Server shouldn\'t respond until builds are done.');
       });
@@ -74,7 +75,7 @@ void main() {
       /// Next request completes right away.
       var buildBlocker2 = new Completer();
       // ignore: unawaited_futures
-      handler.handle(request).then((response) {
+      (webHandler(request) as Future<Response>).then((response) {
         expect(buildBlocker1.isCompleted, isTrue);
         expect(buildBlocker2.isCompleted, isFalse);
       });
@@ -88,7 +89,7 @@ void main() {
       await wait(500);
       var done = new Completer();
       // ignore: unawaited_futures
-      handler.handle(request).then((response) {
+      (webHandler(request) as Future<Response>).then((response) {
         expect(buildBlocker1.isCompleted, isTrue);
         expect(buildBlocker2.isCompleted, isTrue);
         done.complete();

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -21,35 +21,44 @@ void main() {
   test('can read from the root package', () async {
     reader.cacheStringAsset(makeAssetId('a|web/index.html'), 'content');
     var response = await handler.handle(
-        new Request('GET', Uri.parse('http://server.com/web/index.html')));
+        new Request('GET', Uri.parse('http://server.com/index.html')), 'web');
     expect(await response.readAsString(), 'content');
   });
 
   test('can read from dependencies', () async {
     reader.cacheStringAsset(makeAssetId('b|lib/b.dart'), 'content');
     var response = await handler.handle(
-        new Request('GET', Uri.parse('http://server.com/packages/b/b.dart')));
+        new Request('GET', Uri.parse('http://server.com/packages/b/b.dart')),
+        'web');
     expect(await response.readAsString(), 'content');
   });
 
   test('can read from dependencies nested under top-level dir', () async {
     reader.cacheStringAsset(makeAssetId('b|lib/b.dart'), 'content');
-    var response = await handler.handle(new Request(
-        'GET', Uri.parse('http://server.com/web/packages/b/b.dart')));
+    var response = await handler.handle(
+        new Request('GET', Uri.parse('http://server.com/packages/b/b.dart')),
+        'web');
+    expect(await response.readAsString(), 'content');
+  });
+
+  test('defaults to index.html if path is empty', () async {
+    reader.cacheStringAsset(makeAssetId('a|web/index.html'), 'content');
+    var response = await handler.handle(
+        new Request('GET', Uri.parse('http://server.com/')), 'web');
     expect(await response.readAsString(), 'content');
   });
 
   test('defaults to index.html if URI ends with slash', () async {
-    reader.cacheStringAsset(makeAssetId('a|web/index.html'), 'content');
-    var response = await handler
-        .handle(new Request('GET', Uri.parse('http://server.com/web/')));
+    reader.cacheStringAsset(makeAssetId('a|web/sub/index.html'), 'content');
+    var response = await handler.handle(
+        new Request('GET', Uri.parse('http://server.com/sub/')), 'web');
     expect(await response.readAsString(), 'content');
   });
 
   test('does not default to index.html if URI does not end in slash', () async {
-    reader.cacheStringAsset(makeAssetId('a|web/index.html'), 'content');
-    var response = await handler
-        .handle(new Request('GET', Uri.parse('http://server.com/web')));
+    reader.cacheStringAsset(makeAssetId('a|web/sub/index.html'), 'content');
+    var response = await handler.handle(
+        new Request('GET', Uri.parse('http://server.com/sub')), 'web');
     expect(response.statusCode, 404);
   });
 }

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:shelf/shelf.dart';
+import 'package:test/test.dart';
+
+import 'package:build/build.dart';
+import 'package:build_runner/build_runner.dart';
+import 'package:build_runner/src/generate/build_result.dart';
+import 'package:build_runner/src/generate/watch_impl.dart';
+import 'package:build_runner/src/server/server.dart';
+
+import '../common/common.dart';
+
+void main() {
+  ServeHandler serveHandler;
+  InMemoryRunnerAssetReader reader;
+
+  setUp(() async {
+    reader = new InMemoryRunnerAssetReader();
+    var packageGraph =
+        new PackageGraph.fromRoot(new PackageNode.noPubspec('a'));
+    serveHandler =
+        await createServeHandler(new MockWatchImpl(reader, packageGraph));
+  });
+
+  test('can get handlers for a subdirectory', () async {
+    reader.cacheStringAsset(makeAssetId('a|web/index.html'), 'content');
+    var response = await serveHandler.handlerFor('web')(
+        new Request('GET', Uri.parse('http://server.com/index.html')));
+    expect(await response.readAsString(), 'content');
+  });
+
+  test('throws if you pass a non-root directory', () {
+    expect(() => serveHandler.handlerFor('web/sub'), throwsArgumentError);
+  });
+}
+
+class MockWatchImpl implements WatchImpl {
+  @override
+  Future<BuildResult> get currentBuild => new Future.value(null);
+  @override
+  set currentBuild(_) => throw new UnsupportedError('unsupported!');
+
+  @override
+  get buildResults => throw new UnsupportedError('unsupported!');
+  @override
+  set buildResults(_) => throw new UnsupportedError('unsupported!');
+
+  @override
+  final PackageGraph packageGraph;
+
+  @override
+  final Future<AssetReader> reader;
+
+  MockWatchImpl(AssetReader reader, this.packageGraph)
+      : this.reader = new Future.value(reader);
+}


### PR DESCRIPTION
`ServeHandler.handle` has been replaced with `Handler ServeHandler.handleFor(String rootDir)`. This allows you to create separate handlers per directory you want to serve, which maintains pub serve conventions and allows interoperation with `pub run test --pub-serve=$PORT` (which requires you to be serving the `test` dir).

More work towards https://github.com/dart-lang/build/issues/502 (and general unblocking of running tests)

cc @kevmoo @matanlurey 