### PR TITLE
use custom module paths to remove the top level dir for non-lib modules

### DIFF
--- a/build_compilers/test/dev_compiler_bootstrap_builder_test.dart
+++ b/build_compilers/test/dev_compiler_bootstrap_builder_test.dart
@@ -42,7 +42,11 @@ main() {
       'a|web/index.dart.js': contains('index.dart.bootstrap'),
       'a|web/index.dart.js.map': anything,
       'a|web/index.dart.bootstrap.js': allOf([
+        // Maps non-lib modules to remove the top level dir.
+        contains('"web/index": "index"'),
+        // Requires the top level module and dart sdk.
         contains('require(["web/index", "dart_sdk"]'),
+        // Calls main on the top level module.
         contains('index.main()'),
       ]),
     };


### PR DESCRIPTION
Goes hand in hand with https://github.com/dart-lang/build/pull/510

Removes the final blocker for https://github.com/dart-lang/build/issues/502.