### PR TITLE
Add back basic file caching

### DIFF
--- a/build_runner/lib/src/asset/cache.dart
+++ b/build_runner/lib/src/asset/cache.dart
@@ -8,44 +8,55 @@ import 'dart:convert';
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 
+/// An [AssetReader] that wraps another [AssetReader] and caches all results
+/// from it.
+///
+/// Assets are cached until [invalidate] is invoked.
+///
+/// Does not implement [findAssets].
 class CachingAssetReader implements AssetReader {
+  /// Cached results of [canRead].
   final _canReadCache = <AssetId, Future<bool>>{};
-  final _contentCache = <AssetId, Future<dynamic>>{};
-  final AssetReader _wrapped;
 
-  CachingAssetReader(this._wrapped);
+  /// Cached results of [readAsBytes].
+  final _bytesContentCache = <AssetId, Future<List<int>>>{};
+
+  /// Cached results of [readAsString], per [Encoding] type used.
+  ///
+  /// These are computed and stored lazily using [readAsBytes].
+  final _stringContentCache = <AssetId, Map<Encoding, Future<String>>>{};
+
+  /// The [AssetReader] to delegate all reads to.
+  final AssetReader _delegate;
+
+  CachingAssetReader(this._delegate);
 
   @override
   Future<bool> canRead(AssetId id) =>
-      _canReadCache.putIfAbsent(id, () => _wrapped.canRead(id));
+      _canReadCache.putIfAbsent(id, () => _delegate.canRead(id));
 
   @override
-  Stream<AssetId> findAssets(Glob glob, {String package}) =>
+  Stream<AssetId> findAssets(Glob glob) =>
       throw new UnimplementedError('unimplemented!');
 
   @override
-  Future<List<int>> readAsBytes(AssetId id) => _contentCache
-          .putIfAbsent(id, () => _wrapped.readAsBytes(id))
-          .then((value) {
-        if (value is List<int>) return value;
-        if (value is String) return UTF8.encode(value);
-        throw new StateError('Unrecognized cached type ${value.runtimeType}');
-      });
+  Future<List<int>> readAsBytes(AssetId id) =>
+      _bytesContentCache.putIfAbsent(id, () => _delegate.readAsBytes(id));
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) =>
-      _contentCache
-          .putIfAbsent(id, () => _wrapped.readAsString(id))
-          .then((value) {
-        if (value is String) return value;
-        if (value is List<int>) return encoding.decode(value);
-        throw new StateError('Unrecognized cached type ${value.runtimeType}');
-      });
+  Future<String> readAsString(AssetId id, {Encoding encoding}) {
+    encoding ??= UTF8;
+    return _stringContentCache
+        .putIfAbsent(id, () => {})
+        .putIfAbsent(encoding, () => readAsBytes(id).then(encoding.decode));
+  }
 
+  /// Clears all [ids] from all caches.
   void invalidate(Iterable<AssetId> ids) {
     for (var id in ids) {
       _canReadCache.remove(id);
-      _contentCache.remove(id);
+      _bytesContentCache.remove(id);
+      _stringContentCache.remove(id);
     }
   }
 }

--- a/build_runner/lib/src/asset/cache.dart
+++ b/build_runner/lib/src/asset/cache.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:build/build.dart';
+import 'package:glob/glob.dart';
+
+class CachingAssetReader implements AssetReader {
+  final _cache = <AssetId, Future<dynamic>>{};
+  final AssetReader _wrapped;
+
+  CachingAssetReader(this._wrapped);
+
+  @override
+  Future<bool> canRead(AssetId id) => _wrapped.canRead(id);
+
+  @override
+  Stream<AssetId> findAssets(Glob glob, {String package}) =>
+      throw new UnimplementedError('unimplemented!');
+
+  @override
+  Future<List<int>> readAsBytes(AssetId id) =>
+      _cache.putIfAbsent(id, () => _wrapped.readAsBytes(id)).then((value) {
+        if (value is List<int>) return value;
+        if (value is String) return UTF8.encode(value);
+        throw new StateError('Unrecognized cached type ${value.runtimeType}');
+      });
+
+  @override
+  Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) =>
+      _cache.putIfAbsent(id, () => _wrapped.readAsString(id)).then((value) {
+        if (value is String) return value;
+        if (value is List<int>) return encoding.decode(value);
+        throw new StateError('Unrecognized cached type ${value.runtimeType}');
+      });
+}

--- a/build_runner/lib/src/asset/cache.dart
+++ b/build_runner/lib/src/asset/cache.dart
@@ -9,21 +9,24 @@ import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 
 class CachingAssetReader implements AssetReader {
-  final _cache = <AssetId, Future<dynamic>>{};
+  final _canReadCache = <AssetId, Future<bool>>{};
+  final _contentCache = <AssetId, Future<dynamic>>{};
   final AssetReader _wrapped;
 
   CachingAssetReader(this._wrapped);
 
   @override
-  Future<bool> canRead(AssetId id) => _wrapped.canRead(id);
+  Future<bool> canRead(AssetId id) =>
+      _canReadCache.putIfAbsent(id, () => _wrapped.canRead(id));
 
   @override
   Stream<AssetId> findAssets(Glob glob, {String package}) =>
       throw new UnimplementedError('unimplemented!');
 
   @override
-  Future<List<int>> readAsBytes(AssetId id) =>
-      _cache.putIfAbsent(id, () => _wrapped.readAsBytes(id)).then((value) {
+  Future<List<int>> readAsBytes(AssetId id) => _contentCache
+          .putIfAbsent(id, () => _wrapped.readAsBytes(id))
+          .then((value) {
         if (value is List<int>) return value;
         if (value is String) return UTF8.encode(value);
         throw new StateError('Unrecognized cached type ${value.runtimeType}');
@@ -31,9 +34,18 @@ class CachingAssetReader implements AssetReader {
 
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) =>
-      _cache.putIfAbsent(id, () => _wrapped.readAsString(id)).then((value) {
+      _contentCache
+          .putIfAbsent(id, () => _wrapped.readAsString(id))
+          .then((value) {
         if (value is String) return value;
         if (value is List<int>) return encoding.decode(value);
         throw new StateError('Unrecognized cached type ${value.runtimeType}');
       });
+
+  void invalidate(Iterable<AssetId> ids) {
+    for (var id in ids) {
+      _canReadCache.remove(id);
+      _contentCache.remove(id);
+    }
+  }
 }

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -46,7 +46,14 @@ class SinglePhaseReader implements AssetReader {
     if (!_isReadable(id)) return new Future.value(false);
     _assetsRead.add(id);
     await _ensureAssetIsBuilt(id);
-    return _delegate.canRead(id);
+    var node = _assetGraph.get(id);
+    if (node is GeneratedAssetNode) {
+      // Short circut, we know this file exists because its readable and it was
+      // output.
+      return node.wasOutput;
+    } else {
+      return _delegate.canRead(id);
+    }
   }
 
   @override

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -79,11 +79,14 @@ class AssetGraph {
 
   /// Updates graph structure, invalidating and deleting any outputs that were
   /// affected.
-  Future<Null> updateAndInvalidate(
+  ///
+  /// Returns the list of [AssetId]s that were invalidated.
+  Future<Set<AssetId>> updateAndInvalidate(
       List<BuildAction> buildActions,
       Map<AssetId, ChangeType> updates,
       String rootPackage,
       Future delete(AssetId id)) async {
+    var invalidatedIds = new Set<AssetId>();
     // All the assets that should be deleted.
     var idsToDelete = new Set<AssetId>();
     // All the assets that should be removed from the graph entirely.
@@ -95,6 +98,7 @@ class AssetGraph {
         {AssetId parent, bool rootIsSource}) {
       var node = this.get(id);
       if (node == null) return;
+      invalidatedIds.add(id);
       if (parent == null) rootIsSource = node is! GeneratedAssetNode;
 
       // Update all outputs of this asset as well.
@@ -146,6 +150,8 @@ class AssetGraph {
     // the graph.
     await Future.wait(idsToDelete.map(delete));
     idsToRemove.forEach(_remove);
+
+    return invalidatedIds;
   }
 
   /// Returns a set containing [newSources] plus any new generated sources

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -108,7 +108,7 @@ class AssetGraph {
         {AssetId parent, bool rootIsSource}) {
       var node = this.get(id);
       if (node == null) return;
-      invalidatedIds.add(id);
+      if (!invalidatedIds.add(id)) return;
       if (parent == null) rootIsSource = node is! GeneratedAssetNode;
 
       // Update all outputs of this asset as well.

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -14,6 +14,7 @@ import 'package:logging/logging.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:watcher/watcher.dart';
 
+import '../asset/cache.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
 import '../asset_graph/graph.dart';
@@ -57,7 +58,7 @@ class BuildImpl {
   BuildImpl._(
       BuildDefinition buildDefinition, this._buildActions, this._onDelete)
       : _packageGraph = buildDefinition.packageGraph,
-        _reader = buildDefinition.reader,
+        _reader = new CachingAssetReader(buildDefinition.reader),
         _writer = buildDefinition.writer,
         _assetGraph = buildDefinition.assetGraph;
 

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -48,7 +48,7 @@ class BuildImpl {
 
   final List<BuildAction> _buildActions;
   final PackageGraph _packageGraph;
-  final AssetReader _reader;
+  final CachingAssetReader _reader;
   final RunnerAssetWriter _writer;
   final _resolvers = const BarbackResolvers();
   final AssetGraph _assetGraph;
@@ -101,9 +101,10 @@ class BuildImpl {
     return result;
   }
 
-  Future<Null> _updateAssetGraph(Map<AssetId, ChangeType> updates) =>
-      _assetGraph.updateAndInvalidate(
-          _buildActions, updates, _packageGraph.root.name, _delete);
+  Future<Null> _updateAssetGraph(Map<AssetId, ChangeType> updates) async {
+    _reader.invalidate(await _assetGraph.updateAndInvalidate(
+        _buildActions, updates, _packageGraph.root.name, _delete));
+  }
 
   /// Runs a build inside a zone with an error handler and stack chain
   /// capturing.

--- a/build_runner/test/asset/cache_test.dart
+++ b/build_runner/test/asset/cache_test.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+import 'package:build_runner/src/asset/cache.dart';
+
+import '../common/common.dart';
+
+void main() {
+  var fooTxt = new AssetId('a', 'foo.txt');
+  var missingTxt = new AssetId('a', 'missing.txt');
+  var fooContent = 'bar';
+  var fooUTF8Bytes = UTF8.encode('bar');
+  var assets = <AssetId, DatedValue>{
+    fooTxt: new DatedString('bar'),
+  };
+  InMemoryAssetReader delegate;
+  CachingAssetReader reader;
+
+  setUp(() {
+    delegate = new InMemoryAssetReader(sourceAssets: assets);
+    reader = new CachingAssetReader(delegate);
+  });
+
+  group('canRead', () {
+    test('should read from the delegate', () async {
+      expect(await reader.canRead(fooTxt), isTrue);
+      expect(await reader.canRead(missingTxt), isFalse);
+      expect(delegate.assetsRead, [fooTxt, missingTxt]);
+    });
+
+    test('should not re-read from the delegate', () async {
+      expect(await reader.canRead(fooTxt), isTrue);
+      delegate.assetsRead.clear();
+      expect(await reader.canRead(fooTxt), isTrue);
+      expect(delegate.assetsRead, []);
+    });
+
+    test('can be invalidated with invalidate', () async {
+      expect(await reader.canRead(fooTxt), isTrue);
+      delegate.assetsRead.clear();
+      expect(delegate.assetsRead, []);
+
+      reader.invalidate([fooTxt]);
+      expect(await reader.canRead(fooTxt), isTrue);
+      expect(delegate.assetsRead, [fooTxt]);
+    });
+  });
+
+  group('readAsBytes', () {
+    test('should read from the delegate', () async {
+      expect(await reader.readAsBytes(fooTxt), fooUTF8Bytes);
+      expect(delegate.assetsRead, [fooTxt]);
+    });
+
+    test('should not re-read from the delegate', () async {
+      expect(await reader.readAsBytes(fooTxt), fooUTF8Bytes);
+      delegate.assetsRead.clear();
+      expect(await reader.readAsBytes(fooTxt), fooUTF8Bytes);
+      expect(delegate.assetsRead, []);
+    });
+
+    test('can be invalidated with invalidate', () async {
+      expect(await reader.readAsBytes(fooTxt), fooUTF8Bytes);
+      delegate.assetsRead.clear();
+      expect(delegate.assetsRead, []);
+
+      reader.invalidate([fooTxt]);
+      expect(await reader.readAsBytes(fooTxt), fooUTF8Bytes);
+      expect(delegate.assetsRead, [fooTxt]);
+    });
+
+    test('caches bytes from readAsString calls', () async {
+      expect(await reader.readAsString(fooTxt), fooContent);
+      expect(delegate.assetsRead, [fooTxt]);
+      delegate.assetsRead.clear();
+
+      expect(await reader.readAsBytes(fooTxt), fooUTF8Bytes);
+      expect(delegate.assetsRead, []);
+    });
+  });
+
+  group('readAsString', () {
+    test('should read from the delegate', () async {
+      expect(await reader.readAsString(fooTxt), fooContent);
+      expect(delegate.assetsRead, [fooTxt]);
+    });
+
+    test('should not re-read from the delegate', () async {
+      expect(await reader.readAsString(fooTxt), fooContent);
+      delegate.assetsRead.clear();
+      expect(await reader.readAsString(fooTxt), fooContent);
+      expect(delegate.assetsRead, []);
+    });
+
+    test('can be invalidated with invalidate', () async {
+      expect(await reader.readAsString(fooTxt), fooContent);
+      delegate.assetsRead.clear();
+      expect(delegate.assetsRead, []);
+
+      reader.invalidate([fooTxt]);
+      expect(await reader.readAsString(fooTxt), fooContent);
+      expect(delegate.assetsRead, [fooTxt]);
+    });
+
+    test('uses cached bytes if available', () async {
+      expect(await reader.readAsBytes(fooTxt), fooUTF8Bytes);
+      expect(delegate.assetsRead, [fooTxt]);
+      delegate.assetsRead.clear();
+
+      expect(await reader.readAsString(fooTxt), fooContent);
+      expect(delegate.assetsRead, []);
+    });
+  });
+}

--- a/build_runner/test/common/common.dart
+++ b/build_runner/test/common/common.dart
@@ -49,3 +49,27 @@ class TxtFilePackageBuilder extends PackageBuilder {
         buildStep.writeAsString(new AssetId(package, path), content));
   }
 }
+
+class ExistsBuilder extends Builder {
+  final AssetId idToCheck;
+  final Future waitFor;
+
+  final _hasRanCompleter = new Completer<Null>();
+  Future get hasRan => _hasRanCompleter.future;
+
+  ExistsBuilder(this.idToCheck, {this.waitFor});
+
+  @override
+  final buildExtensions = {
+    '': ['.exists']
+  };
+
+  @override
+  Future<Null> build(BuildStep buildStep) async {
+    await waitFor; // await works on null too!
+    var exists = await buildStep.canRead(idToCheck);
+    await buildStep.writeAsString(
+        buildStep.inputId.addExtension('.exists'), '$exists');
+    _hasRanCompleter.complete(null);
+  }
+}

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -64,6 +64,7 @@ Future<BuildResult> testActions(List<BuildAction> buildActions,
     PackageGraph packageGraph,
     BuildStatus status: BuildStatus.success,
     Matcher exceptionMatcher,
+    InMemoryRunnerAssetReader reader,
     InMemoryRunnerAssetWriter writer,
     Level logLevel: Level.OFF,
     onLog(LogRecord record),
@@ -73,7 +74,7 @@ Future<BuildResult> testActions(List<BuildAction> buildActions,
   writer ??= new InMemoryRunnerAssetWriter();
   writeToCache ??= false;
   final actualAssets = writer.assets;
-  final reader =
+  reader ??=
       new InMemoryRunnerAssetReader(actualAssets, packageGraph?.root?.name);
 
   inputs.forEach((serializedId, contents) {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/526, well enough at least (It guarantees that all builders see the same version of a file within a build).

We could still end up scheduling an extra build that isn't necessary (if the file was first read during a build after the change happened), but that is less of an issue and could be resolved using asset hashes.

This also has the nice benefit of speeding up builds, especially the larger builds. Initial build for angular_components_example goes from ~140s for me to ~83s.

I will follow up with some unit tests.