### PR TITLE
Move BuildConfig from package:dazel

### DIFF
--- a/build_config/lib/build_config.dart
+++ b/build_config/lib/build_config.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/build_config.dart';
+export 'src/config_set.dart';
+export 'src/pubspec.dart';

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -13,9 +13,14 @@ import 'pubspec.dart';
 /// The parsed values from a `build.yaml` file.
 class BuildConfig {
   /// Supported values for the `platforms` attribute.
-  static const _allPlatforms = const [_vmPlatform, _webPlatform];
+  static const _allPlatforms = const [
+    _vmPlatform,
+    _webPlatform,
+    _flutterPlatform,
+  ];
   static const _vmPlatform = 'vm';
   static const _webPlatform = 'web';
+  static const _flutterPlatform = 'flutter';
 
   static const _targetOptions = const [
     _builders,
@@ -74,14 +79,14 @@ class BuildConfig {
   /// The default config if you have no `build.yaml` file.
   BuildConfig.useDefault(Pubspec pubspec,
       {bool includeWebSources: false,
-      bool enableDdc: true,
+      List<String> platforms: const [],
       Iterable<String> excludeSources: const []})
       : packageName = pubspec.pubPackageName {
     var sources = ["lib/**"];
     if (includeWebSources) sources.add("web/**");
     dartLibraries[packageName] = new BuildTarget(
         dependencies: pubspec.dependencies,
-        enableDdc: enableDdc,
+        platforms: platforms,
         isDefault: true,
         name: packageName,
         package: pubspec.pubPackageName,
@@ -114,7 +119,7 @@ class BuildConfig {
           _readBoolOrThrow(targetConfig, _default, defaultValue: false);
 
       final platforms = _readListOfStringsOrThrow(targetConfig, _platforms,
-          defaultValue: _allPlatforms, validValues: _allPlatforms);
+          defaultValue: [], validValues: _allPlatforms);
 
       final sources = _readListOfStringsOrThrow(targetConfig, _sources);
 
@@ -124,7 +129,7 @@ class BuildConfig {
       dartLibraries[targetName] = new BuildTarget(
         builders: builders,
         dependencies: dependencies,
-        enableDdc: platforms.contains(_webPlatform),
+        platforms: platforms,
         excludeSources: excludeSources,
         generateFor: generateFor,
         isDefault: isDefault,
@@ -319,10 +324,11 @@ class BuildTarget {
   /// A map from builder name to the configuration used for this target.
   final Map<String, Map<String, dynamic>> builders;
 
-  /// Whether or not  to enable the dart development compiler.
+  /// The platforms supported by this target.
   ///
-  /// This is configured using the "platforms" option in a build.yaml file.
-  final bool enableDdc;
+  /// May be limited by, for isntance, importing core libraries that are not
+  /// cross platform. An empty list indicates all platforms are supported.
+  final List<String> platforms;
 
   /// Whether or not this is the default dart library for the package.
   final bool isDefault;
@@ -334,7 +340,7 @@ class BuildTarget {
   BuildTarget(
       {this.builders: const {},
       this.dependencies,
-      this.enableDdc: true,
+      this.platforms: const [],
       this.excludeSources: const [],
       this.generateFor,
       this.isDefault: false,

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -71,10 +71,10 @@ class BuildConfig {
   final String packageName;
 
   /// All the `builders` defined in a `build.yaml` file.
-  final dartBuilderBinaries = <String, BuilderDefinition>{};
+  final builderDefinitions = <String, BuilderDefinition>{};
 
   /// All the `targets` defined in a `build.yaml` file.
-  final dartLibraries = <String, BuildTarget>{};
+  final buildTargets = <String, BuildTarget>{};
 
   /// The default config if you have no `build.yaml` file.
   BuildConfig.useDefault(Pubspec pubspec,
@@ -84,7 +84,7 @@ class BuildConfig {
       : packageName = pubspec.pubPackageName {
     var sources = ["lib/**"];
     if (includeWebSources) sources.add("web/**");
-    dartLibraries[packageName] = new BuildTarget(
+    buildTargets[packageName] = new BuildTarget(
         dependencies: pubspec.dependencies,
         platforms: platforms,
         isDefault: true,
@@ -126,7 +126,7 @@ class BuildConfig {
       final generateFor = _readListOfStringsOrThrow(targetConfig, _generateFor,
           allowNull: true);
 
-      dartLibraries[targetName] = new BuildTarget(
+      buildTargets[targetName] = new BuildTarget(
         builders: builders,
         dependencies: dependencies,
         platforms: platforms,
@@ -140,10 +140,10 @@ class BuildConfig {
     }
 
     // Add the default dart library if there are no targets discovered.
-    if (dartLibraries.isEmpty) {
+    if (buildTargets.isEmpty) {
       var sources = ["lib/**"];
       if (includeWebSources) sources.add("web/**");
-      dartLibraries[pubspec.pubPackageName] = new BuildTarget(
+      buildTargets[pubspec.pubPackageName] = new BuildTarget(
           dependencies: pubspec.dependencies,
           isDefault: true,
           name: pubspec.pubPackageName,
@@ -151,7 +151,7 @@ class BuildConfig {
           sources: sources);
     }
 
-    if (dartLibraries.values.where((l) => l.isDefault).length != 1) {
+    if (buildTargets.values.where((l) => l.isDefault).length != 1) {
       throw new ArgumentError('Found no targets with `$_default: true`. '
           'Expected exactly one.');
     }
@@ -170,7 +170,7 @@ class BuildConfig {
           _readListOfStringsOrThrow(builderConfig, _outputExtensions);
       final target = _readStringOrThrow(builderConfig, _target);
 
-      dartBuilderBinaries[builderName] = new BuilderDefinition(
+      builderDefinitions[builderName] = new BuilderDefinition(
         builderFactories: builderFactories,
         import: import,
         inputExtension: inputExtension,
@@ -183,7 +183,7 @@ class BuildConfig {
   }
 
   BuildTarget get defaultBuildTarget =>
-      dartLibraries.values.singleWhere((l) => l.isDefault);
+      buildTargets.values.singleWhere((l) => l.isDefault);
 
   static Map<String, Map<String, dynamic>> _readBuildersOrThrow(
       Map<String, dynamic> options, String option) {

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -1,0 +1,344 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import 'pubspec.dart';
+
+/// The parsed values from a `build.yaml` file.
+class BuildConfig {
+  /// Supported values for the `platforms` attribute.
+  static const _allPlatforms = const [_vmPlatform, _webPlatform];
+  static const _vmPlatform = 'vm';
+  static const _webPlatform = 'web';
+
+  static const _targetOptions = const [
+    _builders,
+    _default,
+    _dependencies,
+    _excludeSources,
+    _generateFor,
+    _platforms,
+    _sources,
+  ];
+  static const _builders = 'builders';
+  static const _default = 'default';
+  static const _dependencies = 'dependencies';
+  static const _excludeSources = 'exclude_sources';
+  static const _generateFor = 'generate_for';
+  static const _platforms = 'platforms';
+  static const _sources = 'sources';
+
+  static const _builderOptions = const [
+    _builderFactories,
+    _import,
+    _inputExtension,
+    _outputExtensions,
+    _target,
+  ];
+  static const _builderFactories = 'builder_factories';
+  static const _import = 'import';
+  static const _inputExtension = 'input_extension';
+  static const _outputExtensions = 'output_extensions';
+  static const _target = 'target';
+
+  /// Returns a parsed [BuildConfig] file in [path], if one exists.
+  ///
+  /// Otherwise uses the default setup.
+  static Future<BuildConfig> fromPackageDir(Pubspec pubspec, String path,
+      {bool includeWebSources: false}) async {
+    final configPath = p.join(path, 'build.yaml');
+    final file = new File(configPath);
+    if (await file.exists()) {
+      return new BuildConfig.parse(pubspec, await file.readAsString(),
+          includeWebSources: includeWebSources);
+    } else {
+      return new BuildConfig.useDefault(pubspec,
+          includeWebSources: includeWebSources);
+    }
+  }
+
+  final String packageName;
+
+  /// All the `builders` defined in a `build.yaml` file.
+  final dartBuilderBinaries = <String, BuilderDefinition>{};
+
+  /// All the `targets` defined in a `build.yaml` file.
+  final dartLibraries = <String, BuildTarget>{};
+
+  /// The default config if you have no `build.yaml` file.
+  BuildConfig.useDefault(Pubspec pubspec,
+      {bool includeWebSources: false,
+      bool enableDdc: true,
+      Iterable<String> excludeSources: const []})
+      : packageName = pubspec.pubPackageName {
+    var sources = ["lib/**"];
+    if (includeWebSources) sources.add("web/**");
+    dartLibraries[packageName] = new BuildTarget(
+        dependencies: pubspec.dependencies,
+        enableDdc: enableDdc,
+        isDefault: true,
+        name: packageName,
+        package: pubspec.pubPackageName,
+        sources: sources,
+        excludeSources: excludeSources);
+  }
+
+  /// Create a [BuildConfig] by parsing [configYaml].
+  BuildConfig.parse(Pubspec pubspec, String configYaml,
+      {bool includeWebSources: false})
+      : packageName = pubspec.pubPackageName {
+    final config = loadYaml(configYaml);
+
+    final Map<String, Map> targetConfigs = config['targets'] ?? {};
+    for (var targetName in targetConfigs.keys) {
+      var targetConfig = _readMapOrThrow(
+          targetConfigs, targetName, _targetOptions, 'target `$targetName`');
+
+      final builders = _readBuildersOrThrow(targetConfig, _builders);
+
+      final dependencies = _readListOfStringsOrThrow(
+          targetConfig, _dependencies,
+          defaultValue: []);
+
+      final excludeSources = _readListOfStringsOrThrow(
+          targetConfig, _excludeSources,
+          defaultValue: []);
+
+      var isDefault =
+          _readBoolOrThrow(targetConfig, _default, defaultValue: false);
+
+      final platforms = _readListOfStringsOrThrow(targetConfig, _platforms,
+          defaultValue: _allPlatforms, validValues: _allPlatforms);
+
+      final sources = _readListOfStringsOrThrow(targetConfig, _sources);
+
+      final generateFor = _readListOfStringsOrThrow(targetConfig, _generateFor,
+          allowNull: true);
+
+      dartLibraries[targetName] = new BuildTarget(
+        builders: builders,
+        dependencies: dependencies,
+        enableDdc: platforms.contains(_webPlatform),
+        excludeSources: excludeSources,
+        generateFor: generateFor,
+        isDefault: isDefault,
+        name: targetName,
+        package: packageName,
+        sources: sources,
+      );
+    }
+
+    // Add the default dart library if there are no targets discovered.
+    if (dartLibraries.isEmpty) {
+      var sources = ["lib/**"];
+      if (includeWebSources) sources.add("web/**");
+      dartLibraries[pubspec.pubPackageName] = new BuildTarget(
+          dependencies: pubspec.dependencies,
+          isDefault: true,
+          name: pubspec.pubPackageName,
+          package: pubspec.pubPackageName,
+          sources: sources);
+    }
+
+    if (dartLibraries.values.where((l) => l.isDefault).length != 1) {
+      throw new ArgumentError('Found no targets with `$_default: true`. '
+          'Expected exactly one.');
+    }
+
+    final Map<String, Map> builderConfigs = config['builders'] ?? {};
+    for (var builderName in builderConfigs.keys) {
+      final builderConfig = _readMapOrThrow(builderConfigs, builderName,
+          _builderOptions, 'builder `$builderName`',
+          defaultValue: <String, dynamic>{});
+
+      final builderFactories =
+          _readListOfStringsOrThrow(builderConfig, _builderFactories);
+      final import = _readStringOrThrow(builderConfig, _import);
+      final inputExtension = _readStringOrThrow(builderConfig, _inputExtension);
+      final outputExtensions =
+          _readListOfStringsOrThrow(builderConfig, _outputExtensions);
+      final target = _readStringOrThrow(builderConfig, _target);
+
+      dartBuilderBinaries[builderName] = new BuilderDefinition(
+        builderFactories: builderFactories,
+        import: import,
+        inputExtension: inputExtension,
+        name: builderName,
+        outputExtensions: outputExtensions,
+        package: pubspec.pubPackageName,
+        target: target,
+      );
+    }
+  }
+
+  BuildTarget get defaultBuildTarget =>
+      dartLibraries.values.singleWhere((l) => l.isDefault);
+
+  static Map<String, Map<String, dynamic>> _readBuildersOrThrow(
+      Map<String, dynamic> options, String option) {
+    var values = options[option];
+    if (values == null) return const {};
+
+    if (values is! List) {
+      throw new ArgumentError(
+          'Got `$values` for `$option` but expected a List.');
+    }
+
+    final normalizedValues = <String, Map<String, dynamic>>{};
+    for (var value in values) {
+      if (value is String) {
+        normalizedValues[value] = {};
+      } else if (value is Map<String, dynamic>) {
+        if (value.length == 1) {
+          normalizedValues[value.keys.first] =
+              value.values.first as Map<String, dynamic>;
+        } else {
+          throw value;
+        }
+      } else {
+        throw new ArgumentError(
+            'Got `$value` for builder but expected a String or Map');
+      }
+    }
+    return normalizedValues;
+  }
+
+  static List<String> _readListOfStringsOrThrow(
+      Map<String, dynamic> options, String option,
+      {List<String> defaultValue,
+      Iterable<String> validValues,
+      bool allowNull: false}) {
+    var value = options[option] ?? defaultValue;
+    if (value == null && allowNull) return null;
+
+    if (value is! List || (value as List).any((v) => v is! String)) {
+      throw new ArgumentError(
+          'Got `$value` for `$option` but expected a List<String>.');
+    }
+    if (validValues != null) {
+      var invalidValues =
+          (value as List).where((v) => !validValues.contains(v));
+      if (invalidValues.isNotEmpty) {
+        throw new ArgumentError('Got invalid values ``$invalidValues` for '
+            '`$option`. Only `$validValues` are supported.');
+      }
+    }
+    return new List<String>.from(value as List);
+  }
+
+  static Map<String, dynamic> _readMapOrThrow(Map<String, dynamic> options,
+      String option, Iterable<String> validKeys, String description,
+      {Map<String, dynamic> defaultValue}) {
+    var value = options[option] ?? defaultValue;
+    if (value is! Map) {
+      throw new ArgumentError('Invalid options for `$option`, got `$value` but '
+          'expected a Map.');
+    }
+    var mapValue = value as Map<String, dynamic>;
+    var invalidOptions = mapValue.keys.toList()
+      ..removeWhere((k) => validKeys.contains(k));
+    if (invalidOptions.isNotEmpty) {
+      throw new ArgumentError('Got invalid options `$invalidOptions` for '
+          '$description. Only `$validKeys` are supported keys.');
+    }
+    return mapValue;
+  }
+
+  static String _readStringOrThrow(Map<String, dynamic> options, String option,
+      {String defaultValue, bool allowNull: false}) {
+    var value = options[option];
+    if (value == null && allowNull) return null;
+    if (value is! String) {
+      throw new ArgumentError(
+          'Expected a String for `$option` but got `$value`.');
+    }
+    return value as String;
+  }
+
+  static bool _readBoolOrThrow(Map<String, dynamic> options, String option,
+      {bool defaultValue}) {
+    var value = options[option] ?? defaultValue;
+    if (value is! bool) {
+      throw new ArgumentError(
+          'Expected a boolean for `$option` but got `$value`.');
+    }
+    return value as bool;
+  }
+}
+
+class BuilderDefinition {
+  final String name;
+
+  final String package;
+
+  /// The names of the top-level methods in [import] from args -> Builder.
+  final List<String> builderFactories;
+
+  /// The import to be used to load `clazz`.
+  final String import;
+
+  /// The input extension to treat as primary inputs to the builder.
+  final String inputExtension;
+
+  /// The expected output extensions.
+  ///
+  /// For each file matching `inputExtension` a matching file with each of
+  /// these extensions must be output.
+  final Iterable<String> outputExtensions;
+
+  /// The name of the dart_library target that contains `import`.
+  final String target;
+
+  BuilderDefinition(
+      {this.builderFactories,
+      this.inputExtension,
+      this.import,
+      this.name,
+      this.outputExtensions,
+      this.package,
+      this.target});
+}
+
+class BuildTarget {
+  final Iterable<String> dependencies;
+
+  final Iterable<String> excludeSources;
+
+  final String name;
+
+  final String package;
+
+  final Iterable<String> sources;
+
+  /// A map from builder name to the configuration used for this target.
+  final Map<String, Map<String, dynamic>> builders;
+
+  /// Whether or not  to enable the dart development compiler.
+  ///
+  /// This is configured using the "platforms" option in a build.yaml file.
+  final bool enableDdc;
+
+  /// Whether or not this is the default dart library for the package.
+  final bool isDefault;
+
+  /// Sources to use as inputs for `builders`. May be `null`, in which case
+  /// it should fall back on `sources`.
+  final Iterable<String> generateFor;
+
+  BuildTarget(
+      {this.builders: const {},
+      this.dependencies,
+      this.enableDdc: true,
+      this.excludeSources: const [],
+      this.generateFor,
+      this.isDefault: false,
+      this.name,
+      this.package,
+      this.sources: const ['lib/**']});
+}

--- a/build_config/lib/src/config_set.dart
+++ b/build_config/lib/src/config_set.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'build_config.dart';
+import 'pubspec.dart';
+
+/// The [BuildConfig]s for a package and it's dependencies.
+class BuildConfigSet {
+  final BuildConfig local;
+  final Map<String, BuildConfig> dependencies;
+
+  static Future<BuildConfigSet> forPackages(
+          String localPackagePath,
+          Map<String, String> dependencyPaths,
+          Map<String, Pubspec> dependencyPubspecs) async =>
+      new BuildConfigSet(await _readLocalBuildConfig(localPackagePath),
+          await _readBuildConfigs(dependencyPaths, dependencyPubspecs));
+
+  BuildConfigSet(this.local, this.dependencies);
+
+  BuildConfig operator [](String packageName) =>
+      packageName == local.packageName ? local : dependencies[packageName];
+
+  bool get hasCodegen =>
+      _hasCodegen(local) || dependencies.values.any(_hasCodegen);
+}
+
+bool _hasCodegen(BuildConfig config) => config.dartBuilderBinaries.isNotEmpty;
+
+/// Returns a Map from packageName to the [BuildConfig] for the package.
+Future<Map<String, BuildConfig>> _readBuildConfigs(
+    Map<String, String> packagePaths, Map<String, Pubspec> pubspecs) async {
+  final buildConfigs = <String, BuildConfig>{};
+  for (var package in packagePaths.keys) {
+    buildConfigs[package] = await BuildConfig.fromPackageDir(
+        pubspecs[package], packagePaths[package]);
+  }
+  return buildConfigs;
+}
+
+Future<BuildConfig> _readLocalBuildConfig(String packagePath) async {
+  final pubspec = await Pubspec.fromPackageDir(packagePath);
+  return BuildConfig.fromPackageDir(pubspec, packagePath,
+      includeWebSources: true);
+}

--- a/build_config/lib/src/pubspec.dart
+++ b/build_config/lib/src/pubspec.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+/// The parsed values from a Dart `pubspec.yaml` file.
+class Pubspec {
+  /// Returns a parsed [Pubspec] file in [path], if one exists.
+  ///
+  /// Otherwise throws [FileSystemException].
+  static Future<Pubspec> fromPackageDir(String path) async {
+    final pubspec = p.join(path, 'pubspec.yaml');
+    final file = new File(pubspec);
+    if (await file.exists()) {
+      return new Pubspec.parse(await file.readAsString());
+    }
+    throw new FileSystemException('No file found', p.absolute(pubspec));
+  }
+
+  final Map<String, dynamic> _pubspecContents;
+
+  /// Create a [Pubspec] by parsing [pubspecYaml].
+  Pubspec.parse(String pubspecYaml)
+      : _pubspecContents = loadYaml(pubspecYaml) as Map<String, dynamic>;
+
+  /// Dependencies for a pub package.
+  ///
+  /// Maps directly to the `dependencies` list in `pubspec.yaml`.
+  Iterable<String> get dependencies => _deps('dependencies');
+
+  /// Development dependencies for a pub package.
+  ///
+  /// Maps directly to the `dev_dependencies` list in `pubspec.yaml`.
+  Iterable<String> get devDependencies => _deps('dev_dependencies');
+
+  // Extract dependencies.
+  Iterable<String> _deps(String flavor) =>
+      (_pubspecContents[flavor] ?? const {}).keys as Iterable<String>;
+
+  /// Name of the package.
+  String get pubPackageName => _pubspecContents['name'] as String;
+}

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,0 +1,15 @@
+name: build_config
+version: 0.0.1-dev
+description: Support for parsing `build.yaml` configuration.
+author: Dart Team <misc@dartlang.org>
+homepage: https://github.com/dart-lang/build
+
+environment:
+  sdk: '>=1.22.1 <2.0.0'
+
+dependencies:
+  path: ^1.4.0
+  yaml: ^2.1.11
+
+dev_dependencies:
+  test: ^0.12.24

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -26,7 +26,7 @@ void main() {
       ),
       'e': new BuildTarget(
         dependencies: ['f', ':a'],
-        enableDdc: false,
+        platforms: ['vm'],
         excludeSources: ['lib/src/e/g.dart'],
         isDefault: true,
         name: 'e',
@@ -168,7 +168,8 @@ void expectDartLibraries(
     Map<String, BuildTarget> actual, Map<String, BuildTarget> expected) {
   expect(actual.keys, unorderedEquals(expected.keys));
   for (var p in actual.keys) {
-    expect(actual[p], new _BuildTargetMatcher(expected[p]));
+    expect(actual[p], new _BuildTargetMatcher(expected[p]),
+        reason: '${actual[p].platforms} vs ${expected[p].platforms}');
   }
 }
 
@@ -182,7 +183,7 @@ class _BuildTargetMatcher extends Matcher {
       item.name == _expected.name &&
       item.package == _expected.package &&
       item.isDefault == _expected.isDefault &&
-      item.enableDdc == _expected.enableDdc &&
+      equals(_expected.platforms).matches(item.platforms, _) &&
       equals(_expected.builders).matches(item.builders, _) &&
       equals(_expected.dependencies).matches(item.dependencies, _) &&
       equals(_expected.generateFor).matches(item.generateFor, _) &&

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -10,7 +10,7 @@ void main() {
   test('build.yaml can be parsed', () {
     var pubspec = new Pubspec.parse(pubspecYaml);
     var buildConfig = new BuildConfig.parse(pubspec, buildYaml);
-    expectDartLibraries(buildConfig.dartLibraries, {
+    expectBuildTargets(buildConfig.buildTargets, {
       'a': new BuildTarget(
         builders: {
           'b:b': {},
@@ -34,7 +34,7 @@ void main() {
         sources: ['lib/e.dart', 'lib/src/e/**'],
       )
     });
-    expectDartBuilderBinaries(buildConfig.dartBuilderBinaries, {
+    expectBuilderDefinitions(buildConfig.builderDefinitions, {
       'h': new BuilderDefinition(
         builderFactories: ['createBuilder'],
         import: 'package:example/e.dart',
@@ -53,7 +53,7 @@ void main() {
   test('build.yaml can omit a targets section', () {
     var pubspec = new Pubspec.parse(pubspecYaml);
     var buildConfig = new BuildConfig.parse(pubspec, buildYamlNoTargets);
-    expectDartLibraries(buildConfig.dartLibraries, {
+    expectBuildTargets(buildConfig.buildTargets, {
       'example': new BuildTarget(
         dependencies: ['a', 'b'],
         isDefault: true,
@@ -62,7 +62,7 @@ void main() {
         sources: ['lib/**'],
       ),
     });
-    expectDartBuilderBinaries(buildConfig.dartBuilderBinaries, {
+    expectBuilderDefinitions(buildConfig.builderDefinitions, {
       'a': new BuilderDefinition(
         builderFactories: ['createBuilder'],
         import: 'package:example/builder.dart',
@@ -136,7 +136,7 @@ dependencies:
   b: 2.0.0
 ''';
 
-void expectDartBuilderBinaries(Map<String, BuilderDefinition> actual,
+void expectBuilderDefinitions(Map<String, BuilderDefinition> actual,
     Map<String, BuilderDefinition> expected) {
   expect(actual.keys, unorderedEquals(expected.keys));
   for (var p in actual.keys) {
@@ -164,7 +164,7 @@ class _BuilderDefinitionMatcher extends Matcher {
       description.addDescriptionOf(_expected);
 }
 
-void expectDartLibraries(
+void expectBuildTargets(
     Map<String, BuildTarget> actual, Map<String, BuildTarget> expected) {
   expect(actual.keys, unorderedEquals(expected.keys));
   for (var p in actual.keys) {

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -1,0 +1,195 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:build_config/build_config.dart';
+
+void main() {
+  test('build.yaml can be parsed', () {
+    var pubspec = new Pubspec.parse(pubspecYaml);
+    var buildConfig = new BuildConfig.parse(pubspec, buildYaml);
+    expectDartLibraries(buildConfig.dartLibraries, {
+      'a': new BuildTarget(
+        builders: {
+          'b:b': {},
+          ':h': {'foo': 'bar'},
+        },
+        dependencies: ['b', 'c:d'],
+        generateFor: [
+          'lib/a.dart',
+        ],
+        name: 'a',
+        package: 'example',
+        sources: ['lib/a.dart', 'lib/src/a/**'],
+      ),
+      'e': new BuildTarget(
+        dependencies: ['f', ':a'],
+        enableDdc: false,
+        excludeSources: ['lib/src/e/g.dart'],
+        isDefault: true,
+        name: 'e',
+        package: 'example',
+        sources: ['lib/e.dart', 'lib/src/e/**'],
+      )
+    });
+    expectDartBuilderBinaries(buildConfig.dartBuilderBinaries, {
+      'h': new BuilderDefinition(
+        builderFactories: ['createBuilder'],
+        import: 'package:example/e.dart',
+        inputExtension: '.dart',
+        name: 'h',
+        outputExtensions: [
+          '.g.dart',
+          '.json',
+        ],
+        package: 'example',
+        target: 'e',
+      ),
+    });
+  });
+
+  test('build.yaml can omit a targets section', () {
+    var pubspec = new Pubspec.parse(pubspecYaml);
+    var buildConfig = new BuildConfig.parse(pubspec, buildYamlNoTargets);
+    expectDartLibraries(buildConfig.dartLibraries, {
+      'example': new BuildTarget(
+        dependencies: ['a', 'b'],
+        isDefault: true,
+        name: 'example',
+        package: 'example',
+        sources: ['lib/**'],
+      ),
+    });
+    expectDartBuilderBinaries(buildConfig.dartBuilderBinaries, {
+      'a': new BuilderDefinition(
+        builderFactories: ['createBuilder'],
+        import: 'package:example/builder.dart',
+        inputExtension: '.dart',
+        name: 'a',
+        outputExtensions: [
+          '.g.dart',
+          '.json',
+        ],
+        package: 'example',
+        target: 'example',
+      ),
+    });
+  });
+}
+
+var buildYaml = '''
+targets:
+  a:
+    builders:
+      - :h:
+          foo: bar
+      - b:b
+    dependencies:
+      - b
+      - c:d
+    generate_for:
+      - lib/a.dart
+    sources:
+      - "lib/a.dart"
+      - "lib/src/a/**"
+  e:
+    default: true
+    dependencies:
+      - f
+      - :a
+    sources:
+      - "lib/e.dart"
+      - "lib/src/e/**"
+    exclude_sources:
+      - "lib/src/e/g.dart"
+    platforms:
+      - vm
+builders:
+  h:
+    builder_factories: ["createBuilder"]
+    import: package:example/e.dart
+    input_extension: .dart
+    output_extensions:
+      - .g.dart
+      - .json
+    target: e
+''';
+
+var buildYamlNoTargets = '''
+builders:
+  a:
+    builder_factories: ["createBuilder"]
+    import: package:example/builder.dart
+    input_extension: .dart
+    output_extensions:
+      - .g.dart
+      - .json
+    target: example
+''';
+
+var pubspecYaml = '''
+name: example
+dependencies:
+  a: 1.0.0
+  b: 2.0.0
+''';
+
+void expectDartBuilderBinaries(Map<String, BuilderDefinition> actual,
+    Map<String, BuilderDefinition> expected) {
+  expect(actual.keys, unorderedEquals(expected.keys));
+  for (var p in actual.keys) {
+    expect(actual[p], new _BuilderDefinitionMatcher(expected[p]));
+  }
+}
+
+class _BuilderDefinitionMatcher extends Matcher {
+  final BuilderDefinition _expected;
+  _BuilderDefinitionMatcher(this._expected);
+
+  @override
+  bool matches(item, _) =>
+      item is BuilderDefinition &&
+      equals(_expected.builderFactories).matches(item.builderFactories, _) &&
+      item.inputExtension == _expected.inputExtension &&
+      item.import == _expected.import &&
+      item.name == _expected.name &&
+      equals(item.outputExtensions).matches(_expected.outputExtensions, _) &&
+      item.package == _expected.package &&
+      item.target == _expected.target;
+
+  @override
+  Description describe(Description description) =>
+      description.addDescriptionOf(_expected);
+}
+
+void expectDartLibraries(
+    Map<String, BuildTarget> actual, Map<String, BuildTarget> expected) {
+  expect(actual.keys, unorderedEquals(expected.keys));
+  for (var p in actual.keys) {
+    expect(actual[p], new _BuildTargetMatcher(expected[p]));
+  }
+}
+
+class _BuildTargetMatcher extends Matcher {
+  final BuildTarget _expected;
+  _BuildTargetMatcher(this._expected);
+
+  @override
+  bool matches(item, _) =>
+      item is BuildTarget &&
+      item.name == _expected.name &&
+      item.package == _expected.package &&
+      item.isDefault == _expected.isDefault &&
+      item.enableDdc == _expected.enableDdc &&
+      equals(_expected.builders).matches(item.builders, _) &&
+      equals(_expected.dependencies).matches(item.dependencies, _) &&
+      equals(_expected.generateFor).matches(item.generateFor, _) &&
+      equals(_expected.sources).matches(item.sources, _) &&
+      equals(_expected.excludeSources).matches(item.excludeSources, _);
+
+  @override
+  Description describe(Description description) =>
+      description.addDescriptionOf(_expected);
+}


### PR DESCRIPTION
This is mostly a copy of the code from `dazel` with a few modifications:

- Shuffle `pubspec.dart` under the same src diretory as the other files
  rather than `bazelify`
- Rename `DartLibrary` as `BuildTarget` and don't implement any parent
  interface.
- Rename `DartBuilderBinary` as `BuilderDefinition` and don't implement
  any parent interface
- Fix some strong mode errors by adding explicit casts.