### PR TITLE
Use buildExtensions map

### DIFF
--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -42,14 +42,12 @@ class BuildConfig {
   static const _builderOptions = const [
     _builderFactories,
     _import,
-    _inputExtension,
-    _outputExtensions,
+    _buildExtensions,
     _target,
   ];
   static const _builderFactories = 'builder_factories';
   static const _import = 'import';
-  static const _inputExtension = 'input_extension';
-  static const _outputExtensions = 'output_extensions';
+  static const _buildExtensions = 'build_extensions';
   static const _target = 'target';
 
   /// Returns a parsed [BuildConfig] file in [path], if one exists.
@@ -165,17 +163,14 @@ class BuildConfig {
       final builderFactories =
           _readListOfStringsOrThrow(builderConfig, _builderFactories);
       final import = _readStringOrThrow(builderConfig, _import);
-      final inputExtension = _readStringOrThrow(builderConfig, _inputExtension);
-      final outputExtensions =
-          _readListOfStringsOrThrow(builderConfig, _outputExtensions);
+      final buildExtensions = _readBuildExtensions(builderConfig);
       final target = _readStringOrThrow(builderConfig, _target);
 
       builderDefinitions[builderName] = new BuilderDefinition(
         builderFactories: builderFactories,
         import: import,
-        inputExtension: inputExtension,
+        buildExtensions: buildExtensions,
         name: builderName,
-        outputExtensions: outputExtensions,
         package: pubspec.pubPackageName,
         target: target,
       );
@@ -237,6 +232,19 @@ class BuildConfig {
     return new List<String>.from(value as List);
   }
 
+  static Map<String, List<String>> _readBuildExtensions(
+      Map<String, dynamic> options) {
+    dynamic value = options[_buildExtensions];
+    if (value == null) {
+      throw new ArgumentError('Missing configuratino for build_extensions');
+    }
+    if (value is! Map<String, List<String>>) {
+      throw new ArgumentError('Invalid value for build_extensions, '
+          'got `$value` but expected a Map');
+    }
+    return value as Map<String, List<String>>;
+  }
+
   static Map<String, dynamic> _readMapOrThrow(Map<String, dynamic> options,
       String option, Iterable<String> validKeys, String description,
       {Map<String, dynamic> defaultValue}) {
@@ -288,24 +296,18 @@ class BuilderDefinition {
   /// The import to be used to load `clazz`.
   final String import;
 
-  /// The input extension to treat as primary inputs to the builder.
-  final String inputExtension;
-
-  /// The expected output extensions.
-  ///
-  /// For each file matching `inputExtension` a matching file with each of
-  /// these extensions must be output.
-  final Iterable<String> outputExtensions;
+  /// A map from input extension to the output extensions created for matching
+  /// inputs.
+  final Map<String, List<String>> buildExtensions;
 
   /// The name of the dart_library target that contains `import`.
   final String target;
 
   BuilderDefinition(
       {this.builderFactories,
-      this.inputExtension,
+      this.buildExtensions,
       this.import,
       this.name,
-      this.outputExtensions,
       this.package,
       this.target});
 }

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -38,12 +38,13 @@ void main() {
       'h': new BuilderDefinition(
         builderFactories: ['createBuilder'],
         import: 'package:example/e.dart',
-        inputExtension: '.dart',
+        buildExtensions: {
+          '.dart': [
+            '.g.dart',
+            '.json',
+          ]
+        },
         name: 'h',
-        outputExtensions: [
-          '.g.dart',
-          '.json',
-        ],
         package: 'example',
         target: 'e',
       ),
@@ -66,12 +67,13 @@ void main() {
       'a': new BuilderDefinition(
         builderFactories: ['createBuilder'],
         import: 'package:example/builder.dart',
-        inputExtension: '.dart',
         name: 'a',
-        outputExtensions: [
-          '.g.dart',
-          '.json',
-        ],
+        buildExtensions: {
+          '.dart': [
+            '.g.dart',
+            '.json',
+          ]
+        },
         package: 'example',
         target: 'example',
       ),
@@ -110,10 +112,7 @@ builders:
   h:
     builder_factories: ["createBuilder"]
     import: package:example/e.dart
-    input_extension: .dart
-    output_extensions:
-      - .g.dart
-      - .json
+    build_extensions: {".dart": [".g.dart", ".json"]}
     target: e
 ''';
 
@@ -122,10 +121,7 @@ builders:
   a:
     builder_factories: ["createBuilder"]
     import: package:example/builder.dart
-    input_extension: .dart
-    output_extensions:
-      - .g.dart
-      - .json
+    build_extensions: {".dart": [".g.dart", ".json"]}
     target: example
 ''';
 
@@ -152,10 +148,9 @@ class _BuilderDefinitionMatcher extends Matcher {
   bool matches(item, _) =>
       item is BuilderDefinition &&
       equals(_expected.builderFactories).matches(item.builderFactories, _) &&
-      item.inputExtension == _expected.inputExtension &&
+      equals(_expected.buildExtensions).matches(item.buildExtensions, _) &&
       item.import == _expected.import &&
       item.name == _expected.name &&
-      equals(item.outputExtensions).matches(_expected.outputExtensions, _) &&
       item.package == _expected.package &&
       item.target == _expected.target;
 


### PR DESCRIPTION
Replace input_extension and output_extension with a Map to match the
flexibility provided by the `Builder` interface.