### PR TITLE
Fix non lib sub libraries

### DIFF
--- a/build_compilers/lib/src/dev_compiler_bootstrap_builder.dart
+++ b/build_compilers/lib/src/dev_compiler_bootstrap_builder.dart
@@ -65,7 +65,6 @@ class DevCompilerBootstrapBuilder extends Builder {
     var modulePaths = {'dart_sdk': 'packages/\$sdk/dev_compiler/amd/dart_sdk'};
     var transitiveNoneLibJsModules = [module.jsId]
       ..addAll((await module.computeTransitiveDependencies(buildStep))
-          .values
           .map((module) => module.jsId))
       ..where((id) => !id.path.startsWith('lib/'));
     for (var module in transitiveNoneLibJsModules) {
@@ -103,7 +102,7 @@ class DevCompilerBootstrapBuilder extends Builder {
       Module module, AssetReader reader) async {
     // Collect all the modules this module depends on, plus this module.
     var transitiveDeps = await module.computeTransitiveDependencies(reader);
-    var jsModules = transitiveDeps.values.map((module) => module.jsId).toList()
+    var jsModules = transitiveDeps.map((module) => module.jsId).toList()
       ..add(module.jsId);
     // Check that each module is readable, and warn otherwise.
     await Future.wait(jsModules.map((jsId) async {

--- a/build_compilers/lib/src/dev_compiler_bootstrap_builder.dart
+++ b/build_compilers/lib/src/dev_compiler_bootstrap_builder.dart
@@ -9,7 +9,6 @@ import 'package:analyzer/analyzer.dart';
 import 'package:build/build.dart';
 import 'package:path/path.dart' as _p; // ignore: library_prefixes
 
-import 'dev_compiler_builder.dart';
 import 'module_builder.dart';
 import 'modules.dart';
 
@@ -65,9 +64,10 @@ class DevCompilerBootstrapBuilder extends Builder {
     // Map from module name to module path for custom modules.
     var modulePaths = {'dart_sdk': 'packages/\$sdk/dev_compiler/amd/dart_sdk'};
     var transitiveNoneLibJsModules = [module.jsId]
-      ..addAll((await module.computeTransitiveDependencies(buildStep)))
-      ..where((dartId) => !dartId.path.startsWith('lib/'))
-          .map((dartId) => dartId.changeExtension(jsModuleExtension));
+      ..addAll((await module.computeTransitiveDependencies(buildStep))
+          .values
+          .map((module) => module.jsId))
+      ..where((id) => !id.path.startsWith('lib/'));
     for (var module in transitiveNoneLibJsModules) {
       // Strip out the top level dir from the path for any non-lib module. We
       // set baseUrl to `/` to simplify things, and we only allow you to serve
@@ -103,10 +103,8 @@ class DevCompilerBootstrapBuilder extends Builder {
       Module module, AssetReader reader) async {
     // Collect all the modules this module depends on, plus this module.
     var transitiveDeps = await module.computeTransitiveDependencies(reader);
-    var jsModules = transitiveDeps
-        .map((id) => id.changeExtension(jsModuleExtension))
-        .toList()
-          ..add(module.jsId);
+    var jsModules = transitiveDeps.values.map((module) => module.jsId).toList()
+      ..add(module.jsId);
     // Check that each module is readable, and warn otherwise.
     await Future.wait(jsModules.map((jsId) async {
       if (await reader.canRead(jsId)) return;

--- a/build_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_compilers/lib/src/dev_compiler_builder.dart
@@ -52,7 +52,7 @@ Future createDevCompilerModule(Module module, BuildStep buildStep,
     {bool debugMode = true}) async {
   var transitiveDeps = await module.computeTransitiveDependencies(buildStep);
   var transitiveSummaryDeps =
-      transitiveDeps.values.map((module) => module.linkedSummaryId);
+      transitiveDeps.map((module) => module.linkedSummaryId);
   var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
 
   var allAssetIds = new Set<AssetId>()

--- a/build_compilers/lib/src/modules.dart
+++ b/build_compilers/lib/src/modules.dart
@@ -109,17 +109,18 @@ class Module extends Object with _$ModuleSerializerMixin {
 
   /// Computes the [primarySource]s of all [Module]s that are transitively
   /// depended on by this module.
-  Future<Set<AssetId>> computeTransitiveDependencies(AssetReader reader) async {
-    var transitiveDeps = new Set<AssetId>();
+  Future<Map<AssetId, Module>> computeTransitiveDependencies(
+      AssetReader reader) async {
+    var transitiveDeps = <AssetId, Module>{};
     var modulesToCrawl = directDependencies.toSet();
     while (modulesToCrawl.isNotEmpty) {
       var next = modulesToCrawl.last;
       modulesToCrawl.remove(next);
-      if (transitiveDeps.contains(next)) continue;
-      transitiveDeps.add(next);
+      if (transitiveDeps.containsKey(next)) continue;
       var module = new Module.fromJson(JSON.decode(
               await reader.readAsString(next.changeExtension(moduleExtension)))
           as Map<String, dynamic>);
+      transitiveDeps[next] = module;
       modulesToCrawl.addAll(module.directDependencies);
     }
     return transitiveDeps;

--- a/build_compilers/lib/src/modules.dart
+++ b/build_compilers/lib/src/modules.dart
@@ -109,8 +109,7 @@ class Module extends Object with _$ModuleSerializerMixin {
 
   /// Computes the [primarySource]s of all [Module]s that are transitively
   /// depended on by this module.
-  Future<Map<AssetId, Module>> computeTransitiveDependencies(
-      AssetReader reader) async {
+  Future<List<Module>> computeTransitiveDependencies(AssetReader reader) async {
     var transitiveDeps = <AssetId, Module>{};
     var modulesToCrawl = directDependencies.toSet();
     while (modulesToCrawl.isNotEmpty) {
@@ -123,7 +122,7 @@ class Module extends Object with _$ModuleSerializerMixin {
       transitiveDeps[next] = module;
       modulesToCrawl.addAll(module.directDependencies);
     }
-    return transitiveDeps;
+    return transitiveDeps.values.toList();
   }
 }
 

--- a/build_compilers/lib/src/scratch_space.dart
+++ b/build_compilers/lib/src/scratch_space.dart
@@ -5,8 +5,15 @@
 import 'package:build/build.dart';
 import 'package:scratch_space/scratch_space.dart';
 
-/// A shared [ScratchSpace] for ddc and analyzer workers that persists during
-/// individual builds.
-final scratchSpaceResource = new Resource<ScratchSpace>(
-    () => new ScratchSpace(),
-    dispose: (old) => old.delete());
+/// A shared [ScratchSpace] for ddc and analyzer workers that persists
+/// throughout builds.
+final scratchSpace = new ScratchSpace();
+
+/// A shared [Resource] for a [ScratchSpace], which cleans up the contents of
+/// the [ScratchSpace] in dispose, but doesn't delete it entirely.
+final scratchSpaceResource =
+    new Resource<ScratchSpace>(() => scratchSpace, dispose: (_) async {
+  await for (var entity in scratchSpace.tempDir.list()) {
+    await entity.delete(recursive: true);
+  }
+});

--- a/build_compilers/lib/src/summary_builder.dart
+++ b/build_compilers/lib/src/summary_builder.dart
@@ -101,13 +101,11 @@ Future createLinkedSummary(Module module, BuildStep buildStep,
 
   // Provide linked summaries where possible (if created in a previous phase),
   // otherwise provide unlinked summaries.
-  await Future.wait(transitiveDeps.map((dartId) async {
-    var linkedSummary = dartId.changeExtension(linkedSummaryExtension);
-    if (await buildStep.canRead(linkedSummary)) {
-      transitiveLinkedSummaryDeps.add(linkedSummary);
+  await Future.wait(transitiveDeps.values.map((module) async {
+    if (await buildStep.canRead(module.linkedSummaryId)) {
+      transitiveLinkedSummaryDeps.add(module.linkedSummaryId);
     } else {
-      transitiveUnlinkedSummaryDeps
-          .add(dartId.changeExtension(unlinkedSummaryExtension));
+      transitiveUnlinkedSummaryDeps.add(module.unlinkedSummaryId);
     }
   }));
 
@@ -155,7 +153,7 @@ Iterable<String> _analyzerSourceArgsForModule(
     var uri = canonicalUriFor(id);
     var file = scratchSpace.fileFor(id);
     if (!uri.startsWith('package:')) {
-      uri = file.uri.toString();
+      uri = new Uri.file('/${id.path}').toString();
     }
     return '$uri|${file.path}';
   });

--- a/build_compilers/lib/src/summary_builder.dart
+++ b/build_compilers/lib/src/summary_builder.dart
@@ -101,7 +101,7 @@ Future createLinkedSummary(Module module, BuildStep buildStep,
 
   // Provide linked summaries where possible (if created in a previous phase),
   // otherwise provide unlinked summaries.
-  await Future.wait(transitiveDeps.values.map((module) async {
+  await Future.wait(transitiveDeps.map((module) async {
     if (await buildStep.canRead(module.linkedSummaryId)) {
       transitiveLinkedSummaryDeps.add(module.linkedSummaryId);
     } else {

--- a/build_compilers/lib/src/workers.dart
+++ b/build_compilers/lib/src/workers.dart
@@ -10,6 +10,8 @@ import 'package:build/build.dart';
 import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:path/path.dart' as p;
 
+import 'scratch_space.dart';
+
 String get _scriptExtension => Platform.isWindows ? '.bat' : '';
 
 final int _defaultMaxWorkers = min((Platform.numberOfProcessors / 2).ceil(), 4);
@@ -28,13 +30,15 @@ final int _maxWorkersPerTask = int
 /// Manages a shared set of persistent analyzer workers.
 final analyzerDriver = new BazelWorkerDriver(
     () => Process.start(p.join(sdkDir, 'bin', 'dartanalyzer$_scriptExtension'),
-        ['--build-mode', '--persistent_worker']),
+        ['--build-mode', '--persistent_worker'],
+        workingDirectory: scratchSpace.tempDir.path),
     maxWorkers: _maxWorkersPerTask);
 
 /// Manages a shared set of persistent dartdevc workers.
 final dartdevcDriver = new BazelWorkerDriver(
     () => Process.start(p.join(sdkDir, 'bin', 'dartdevc$_scriptExtension'),
-        ['--persistent_worker']),
+        ['--persistent_worker'],
+        workingDirectory: scratchSpace.tempDir.path),
     maxWorkers: _maxWorkersPerTask);
 
 final sdkDir = cli_util.getSdkPath();

--- a/e2e_example/lib/app.dart
+++ b/e2e_example/lib/app.dart
@@ -4,7 +4,8 @@
 
 import 'dart:html';
 
-void startApp() {
-  var component = new DivElement()..text = 'Hello World!';
+void startApp({String text}) {
+  text ??= 'Hello World!';
+  var component = new DivElement()..text = text;
   document.body.append(component);
 }

--- a/e2e_example/pubspec.yaml
+++ b/e2e_example/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: '>=1.24.0 <2.0.0'
 
 dev_dependencies:
+  browser: any
   path: ^1.4.2
   test: ^0.12.0
 
@@ -20,6 +21,8 @@ dependency_overrides:
     path: ../build_runner
   build_test:
     path: ../build_test
+  scratch_space:
+    path: ../scratch_space
 
 transformers:
 # TODO: only needed because pub serve complains otherwise

--- a/e2e_example/test/integration_test.dart
+++ b/e2e_example/test/integration_test.dart
@@ -94,13 +94,13 @@ void main() {
           'test/common/message.dart', 'Hello World!', 'Goodbye World!');
       await nextSuccessfulBuild;
       await expectTestsFail();
-    }, skip: 'https://github.com/dart-lang/build/issues/533');
+    });
 
     test('edit dependency lib causing test to fail and rerun', () async {
       await replaceAllInFile('lib/app.dart', 'Hello World!', 'Goodbye World!');
       await nextSuccessfulBuild;
       await expectTestsFail();
-    }, skip: 'https://github.com/dart-lang/build/issues/533');
+    });
 
     test('create new test', () async {
       await createFile(p.join('test', 'other_test.dart'), basicTestContents);

--- a/e2e_example/test/integration_test.dart
+++ b/e2e_example/test/integration_test.dart
@@ -45,6 +45,12 @@ void main() {
     await toolDir.delete(recursive: true);
   });
 
+  test('Doesn\'t compile submodules into the root module', () {
+    var testJsFile = new File(p.join('.dart_tool', 'build', 'generated',
+        'e2e_example', 'test', 'hello_world_test.js'));
+    expect(testJsFile.readAsStringSync(), isNot(contains('Hello World!')));
+  });
+
   test('Can run passing tests', () async {
     await expectTestsPass();
   });

--- a/e2e_example/web/main.dart
+++ b/e2e_example/web/main.dart
@@ -4,6 +4,8 @@
 
 import 'package:e2e_example/app.dart';
 
+import 'sub/message.dart';
+
 void main() {
-  startApp();
+  startApp(text: message);
 }

--- a/e2e_example/web/sub/index.html
+++ b/e2e_example/web/sub/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>e2e_example</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script defer src="main.dart" type="application/dart"></script>
+  <script defer src="packages/browser/dart.js"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/e2e_example/web/sub/main.dart
+++ b/e2e_example/web/sub/main.dart
@@ -1,0 +1,5 @@
+import '../main.dart' as other;
+
+main() {
+  other.main();
+}

--- a/e2e_example/web/sub/message.dart
+++ b/e2e_example/web/sub/message.dart
@@ -1,0 +1,1 @@
+String get message => 'Hello World';


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/533

This changes how we run ddc/analyzer workers to be much closer to how bazel runs them. The scratch space now persists across builds (although we clean it up manually), which means ddc and analyzer can now run directly under that directory (similar to how it runs at bazel root).

I also changed all usages of --uri-mapping to match exactly what we do in bazel as much as I could.

I snuck in a minor cleanup of `computeTransitiveDependencies` as well so it returns `Module`s now instead of the primary ids, which means we can use its getters to reference the related ids to that module instead of doing manual `changeExtension` hacks.