### PR TITLE
Lots of bug fixes relating to failed builds and recovery from them

### DIFF
--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -9,7 +9,27 @@ const Symbol logKey = #buildLog;
 /// Will be `null` when not running within a build.
 Logger get log => Zone.current[logKey] as Logger;
 
-T scopeLog<T>(T fn(), Logger log) => runZoned(fn, zoneSpecification:
-        new ZoneSpecification(print: (self, parent, zone, message) {
-      log.info(message);
-    }), zoneValues: {logKey: log});
+/// Runs [fn] in an error handling [Zone].
+///
+/// Any calls to [print] will be logged with `log.info`, and any errors will be
+/// logged with `log.severe`.
+///
+/// Completes with the first error or result of `fn`, whichever comes first.
+Future<T> scopeLogAsync<T>(Future<T> fn(), Logger log) {
+  var done = new Completer<T>();
+  runZoned(fn,
+      zoneSpecification:
+          new ZoneSpecification(print: (self, parent, zone, message) {
+        log.info(message);
+      }),
+      zoneValues: {logKey: log},
+      onError: (Object e, StackTrace s) {
+        log.severe('', e);
+        if (done.isCompleted) return;
+        done.completeError(e, s);
+      }).then((result) {
+    if (done.isCompleted) return;
+    done.complete(result);
+  });
+  return done.future;
+}

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -46,7 +46,7 @@ Future<Null> runBuilder(Builder builder, Iterable<AssetId> inputs,
     }
   }
 
-  await scopeLog(() => Future.wait(inputs.map(buildForInput)), logger);
+  await scopeLogAsync(() => Future.wait(inputs.map(buildForInput)), logger);
 
   if (shouldDisposeResourceManager) {
     await resourceManager.disposeAll();

--- a/build_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_compilers/lib/src/dev_compiler_builder.dart
@@ -40,9 +40,9 @@ class DevCompilerBuilder implements Builder {
     try {
       await createDevCompilerModule(module, buildStep);
     } on DartDevcCompilationException catch (e) {
-      log.warning('Error compiling ${module.jsId}:\n$e');
       await buildStep.writeAsString(
           buildStep.inputId.changeExtension(jsModuleErrorsExtension), '$e');
+      log.severe('', e);
     }
   }
 }

--- a/build_compilers/lib/src/modules.dart
+++ b/build_compilers/lib/src/modules.dart
@@ -116,9 +116,14 @@ class Module extends Object with _$ModuleSerializerMixin {
       var next = modulesToCrawl.last;
       modulesToCrawl.remove(next);
       if (transitiveDeps.containsKey(next)) continue;
-      var module = new Module.fromJson(JSON.decode(
-              await reader.readAsString(next.changeExtension(moduleExtension)))
-          as Map<String, dynamic>);
+      var nextModuleId = next.changeExtension(moduleExtension);
+      if (!await reader.canRead(nextModuleId)) {
+        log.warning('Missing module $nextModuleId');
+        continue;
+      }
+      var module = new Module.fromJson(
+          JSON.decode(await reader.readAsString(nextModuleId))
+              as Map<String, dynamic>);
       transitiveDeps[next] = module;
       modulesToCrawl.addAll(module.directDependencies);
     }

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -35,8 +35,13 @@ class SinglePhaseReader implements AssetReader {
   Iterable<Glob> get globsRan => _globsRan;
 
   bool _isReadable(AssetId id) {
+    _assetsRead.add(id);
     var node = _assetGraph.get(id);
-    if (node == null) return false;
+    if (node == null) {
+      _assetGraph.add(new SyntheticAssetNode(id));
+      return false;
+    }
+    if (node is SyntheticAssetNode) return false;
     if (node is! GeneratedAssetNode) return true;
     return (node as GeneratedAssetNode).phaseNumber < _phaseNumber;
   }
@@ -44,7 +49,6 @@ class SinglePhaseReader implements AssetReader {
   @override
   Future<bool> canRead(AssetId id) async {
     if (!_isReadable(id)) return new Future.value(false);
-    _assetsRead.add(id);
     await _ensureAssetIsBuilt(id);
     var node = _assetGraph.get(id);
     if (node is GeneratedAssetNode) {
@@ -59,7 +63,6 @@ class SinglePhaseReader implements AssetReader {
   @override
   Future<List<int>> readAsBytes(AssetId id) async {
     if (!_isReadable(id)) throw new AssetNotFoundException(id);
-    _assetsRead.add(id);
     await _ensureAssetIsBuilt(id);
     return _delegate.readAsBytes(id);
   }
@@ -67,7 +70,6 @@ class SinglePhaseReader implements AssetReader {
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding: UTF8}) async {
     if (!_isReadable(id)) throw new AssetNotFoundException(id);
-    _assetsRead.add(id);
     await _ensureAssetIsBuilt(id);
     return _delegate.readAsString(id, encoding: encoding);
   }

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -60,10 +60,17 @@ class AssetGraph {
   ///
   /// Throws a [StateError] if it already exists in the graph.
   void _add(AssetNode node) {
-    if (contains(node.id)) {
-      throw new StateError(
-          'Tried to add node ${node.id} to the asset graph but it already '
-          'exists.');
+    var existing = get(node.id);
+    if (existing != null) {
+      if (existing is SyntheticAssetNode) {
+        _remove(existing.id);
+        node.outputs.addAll(existing.outputs);
+        node.primaryOutputs.addAll(existing.primaryOutputs);
+      } else {
+        throw new StateError(
+            'Tried to add node ${node.id} to the asset graph but it already '
+            'exists.');
+      }
     }
     _nodesByPackage.putIfAbsent(node.id.package, () => {})[node.id.path] = node;
   }
@@ -105,30 +112,31 @@ class AssetGraph {
     // Builds up `idsToDelete` and `idsToRemove` by recursively invalidating
     // the outputs of `id`.
     void clearNodeAndDeps(AssetId id, ChangeType rootChangeType,
-        {AssetId parent, bool rootIsSource}) {
+        {bool rootIsSource}) {
       var node = this.get(id);
       if (node == null) return;
       if (!invalidatedIds.add(id)) return;
-      if (parent == null) rootIsSource = node is! GeneratedAssetNode;
-
-      // Update all outputs of this asset as well.
-      for (var output in node.outputs) {
-        clearNodeAndDeps(output, rootChangeType,
-            parent: node.id, rootIsSource: rootIsSource);
-      }
+      rootIsSource ??= node is! GeneratedAssetNode;
 
       if (node is GeneratedAssetNode) {
         idsToDelete.add(id);
         if (rootIsSource &&
             rootChangeType == ChangeType.REMOVE &&
-            node.primaryInput == parent) {
+            idsToRemove.contains(node.primaryInput)) {
           idsToRemove.add(id);
         } else {
           node.needsUpdate = true;
+          node.wasOutput = false;
+          node.globs = new Set();
         }
       } else {
         // This is a source
         if (rootChangeType == ChangeType.REMOVE) idsToRemove.add(id);
+      }
+
+      // Update all outputs of this asset as well.
+      for (var output in node.outputs) {
+        clearNodeAndDeps(output, rootChangeType, rootIsSource: rootIsSource);
       }
     }
 

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -91,8 +91,9 @@ class AssetGraph {
       allNodes.where((n) => n is GeneratedAssetNode).map((n) => n.id);
 
   /// All the source files in the graph.
-  Iterable<AssetId> get sources =>
-      allNodes.where((n) => n is! GeneratedAssetNode).map((n) => n.id);
+  Iterable<AssetId> get sources => allNodes
+      .where((n) => n is! GeneratedAssetNode && n is! SyntheticAssetNode)
+      .map((n) => n.id);
 
   /// Updates graph structure, invalidating and deleting any outputs that were
   /// affected.

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -30,6 +30,9 @@ class AssetNode {
 /// that if that asset gets added later the outputs are properly invalidated.
 class SyntheticAssetNode extends AssetNode {
   SyntheticAssetNode(AssetId id) : super(id);
+
+  @override
+  String toString() => 'SyntheticAssetNode: $id';
 }
 
 /// A generated node in the asset graph.

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -23,6 +23,15 @@ class AssetNode {
   String toString() => 'AssetNode: $id';
 }
 
+/// A node which is not a generated or source asset.
+///
+/// Typically these are created as a result of `canRead` calls for assets that
+/// don't exist in the graph. We still need to set up proper dependencies so
+/// that if that asset gets added later the outputs are properly invalidated.
+class SyntheticAssetNode extends AssetNode {
+  SyntheticAssetNode(AssetId id) : super(id);
+}
+
 /// A generated node in the asset graph.
 class GeneratedAssetNode extends AssetNode {
   /// The phase which generated this asset.

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -8,7 +8,7 @@ part of 'graph.dart';
 ///
 /// This should be incremented any time the serialize/deserialize formats
 /// change.
-const _version = 7;
+const _version = 8;
 
 /// Deserializes an [AssetGraph] from a [Map].
 class _AssetGraphDeserializer {
@@ -43,16 +43,21 @@ class _AssetGraphDeserializer {
 
   AssetNode _deserializeAssetNode(List serializedNode) {
     AssetNode node;
-    if (serializedNode.length == 3) {
-      node = new AssetNode(_idToAssetId[serializedNode[0]]);
-    } else if (serializedNode.length == 8) {
+    var id = _idToAssetId[serializedNode[0]];
+    if (serializedNode.length == 4) {
+      if (_deserializeBool(serializedNode[3] as int)) {
+        node = new SyntheticAssetNode(id);
+      } else {
+        node = new AssetNode(id);
+      }
+    } else if (serializedNode.length == 9) {
       node = new GeneratedAssetNode(
-        serializedNode[5] as int,
-        _idToAssetId[serializedNode[3]],
-        _deserializeBool(serializedNode[7] as int),
-        _deserializeBool(serializedNode[4] as int),
-        _idToAssetId[serializedNode[0]],
-        globs: (serializedNode[6] as Iterable<String>)
+        serializedNode[6] as int,
+        _idToAssetId[serializedNode[4]],
+        _deserializeBool(serializedNode[8] as int),
+        _deserializeBool(serializedNode[5] as int),
+        id,
+        globs: (serializedNode[7] as Iterable<String>)
             .map((pattern) => new Glob(pattern))
             .toSet(),
       );
@@ -125,7 +130,7 @@ class _WrappedAssetNode extends Object with ListMixin implements List {
   _WrappedAssetNode(this.node, this.serializer);
 
   @override
-  int get length => 3;
+  int get length => 4;
   @override
   set length(_) => throw new UnsupportedError(
       'length setter not unsupported for WrappedAssetNode');
@@ -141,6 +146,8 @@ class _WrappedAssetNode extends Object with ListMixin implements List {
         return node.primaryOutputs
             .map((id) => serializer._assetIdToId[id])
             .toList();
+      case 3:
+        return _serializeBool(node is SyntheticAssetNode);
       default:
         throw new RangeError.index(index, this);
     }
@@ -167,22 +174,22 @@ class _WrappedGeneratedAssetNode extends _WrappedAssetNode {
   Object operator [](int index) {
     if (index < super.length) return super[index];
     switch (index) {
-      case 3:
+      case 4:
         return generatedNode.primaryInput != null
             ? serializer._assetIdToId[generatedNode.primaryInput]
             : null;
-      case 4:
-        return _serializeBool(generatedNode.wasOutput);
       case 5:
-        return generatedNode.phaseNumber;
+        return _serializeBool(generatedNode.wasOutput);
       case 6:
-        return generatedNode.globs.map((glob) => glob.pattern).toList();
+        return generatedNode.phaseNumber;
       case 7:
+        return generatedNode.globs.map((glob) => glob.pattern).toList();
+      case 8:
         return _serializeBool(generatedNode.needsUpdate);
       default:
         throw new RangeError.index(index, this);
     }
   }
-
-  static int _serializeBool(bool value) => value ? 1 : 0;
 }
+
+int _serializeBool(bool value) => value ? 1 : 0;

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -153,12 +153,17 @@ class _Loader {
       }
     }
 
-    var newSources = inputSources
-        .difference(assetGraph.allNodes.map((node) => node.id).toSet());
+    var newSources = inputSources.difference(assetGraph.allNodes
+        .where((node) => node is! SyntheticAssetNode)
+        .map((node) => node.id)
+        .toSet());
     addUpdates(newSources, ChangeType.ADD);
     var removedAssets = assetGraph.allNodes
-        .where((n) =>
-            n is! GeneratedAssetNode || (n as GeneratedAssetNode).wasOutput)
+        .where((n) {
+          if (n is SyntheticAssetNode) return false;
+          if (n is GeneratedAssetNode) return n.wasOutput;
+          return true;
+        })
         .map((n) => n.id)
         .where((id) => !allSources.contains((id)));
 

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -345,7 +345,11 @@ class BuildImpl {
     var buildStep = new BuildStepImpl(null, builderOutputs, wrappedReader,
         wrappedWriter, _packageGraph.root.name, _resolvers, resourceManager);
     try {
-      await scopeLogAsync(() => builder.build(buildStep), logger);
+      // Wrapping in `new Future.value` to work around
+      // https://github.com/dart-lang/sdk/issues/31237, users might return
+      // synchronously and not have any analysis errors today.
+      await scopeLogAsync(
+          () => new Future.value(builder.build(buildStep)), logger);
     } finally {
       await buildStep.complete();
     }

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -227,6 +227,7 @@ class BuildImpl {
     var ids = new Set<AssetId>();
     await Future
         .wait(_assetGraph.packageNodes(inputSet.package).map((node) async {
+      if (node is SyntheticAssetNode) return;
       if (!inputSet.matches(node.id)) return;
       if (node is GeneratedAssetNode) {
         if (node.phaseNumber >= phaseNumber) return;
@@ -310,8 +311,9 @@ class BuildImpl {
         input.package,
         (phase, input) => _runLazyPhaseForInput(phase, input, resourceManager));
     var wrappedWriter = new AssetWriterSpy(_writer);
+    var logger = new Logger('$builder on $input');
     await runBuilder(builder, [input], wrappedReader, wrappedWriter, _resolvers,
-        resourceManager: resourceManager);
+        logger: logger, resourceManager: resourceManager);
 
     // Reset the state for all the `builderOutputs` nodes based on what was
     // read and written.
@@ -339,11 +341,11 @@ class BuildImpl {
         (phase, input) => _runLazyPhaseForInput(phase, input, resourceManager));
     var wrappedWriter = new AssetWriterSpy(_writer);
 
-    var logger = new Logger('runBuilder');
+    var logger = new Logger('$builder on $package');
     var buildStep = new BuildStepImpl(null, builderOutputs, wrappedReader,
         wrappedWriter, _packageGraph.root.name, _resolvers, resourceManager);
     try {
-      await scopeLog(() => builder.build(buildStep), logger);
+      await scopeLogAsync(() => builder.build(buildStep), logger);
     } finally {
       await buildStep.complete();
     }

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -81,6 +81,11 @@ void main() {
                 0, node.id, g % 2 == 1, g % 2 == 0, makeAssetId());
             node.outputs.add(generatedNode.id);
             node.primaryOutputs.add(generatedNode.id);
+
+            var syntheticNode = new SyntheticAssetNode(makeAssetId());
+            syntheticNode.outputs.add(generatedNode.id);
+
+            graph.add(syntheticNode);
             graph.add(generatedNode);
           }
         }

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -108,6 +108,8 @@ void main() {
       final buildActions = [new BuildAction(new CopyBuilder(), 'foo')];
       final primaryInputId = makeAssetId('foo|file');
       final primaryOutputId = makeAssetId('foo|file.copy');
+      final syntheticId = makeAssetId('foo|synthetic');
+      final syntheticOutputId = makeAssetId('foo|synthetic.copy');
 
       setUp(() {
         graph = new AssetGraph.build(
@@ -154,6 +156,35 @@ void main() {
           expect(graph.contains(primaryInputId), isTrue);
           expect(graph.contains(primaryOutputId), isTrue);
           expect(deletes, equals([primaryOutputId]));
+        });
+
+        test('add new primary input which replaces a synthetic node', () async {
+          var syntheticNode = new SyntheticAssetNode(syntheticId);
+          graph.add(syntheticNode);
+          expect(graph.get(syntheticId), syntheticNode);
+
+          var changes = {syntheticId: ChangeType.ADD};
+          await graph.updateAndInvalidate(buildActions, changes, 'foo', null);
+
+          expect(graph.contains(syntheticId), isTrue);
+          expect(graph.get(syntheticId),
+              isNot(new isInstanceOf<SyntheticAssetNode>()));
+          expect(graph.contains(syntheticOutputId), isTrue);
+        });
+
+        test('add new generated asset which replaces a synthetic node',
+            () async {
+          var syntheticNode = new SyntheticAssetNode(syntheticOutputId);
+          graph.add(syntheticNode);
+          expect(graph.get(syntheticOutputId), syntheticNode);
+
+          var changes = {syntheticId: ChangeType.ADD};
+          await graph.updateAndInvalidate(buildActions, changes, 'foo', null);
+
+          expect(graph.contains(syntheticOutputId), isTrue);
+          expect(graph.get(syntheticOutputId),
+              new isInstanceOf<GeneratedAssetNode>());
+          expect(graph.contains(syntheticOutputId), isTrue);
         });
       });
     });

--- a/build_runner/test/common/common.dart
+++ b/build_runner/test/common/common.dart
@@ -44,7 +44,7 @@ class TxtFilePackageBuilder extends PackageBuilder {
   TxtFilePackageBuilder(this.package, this.outputContents);
 
   @override
-  build(BuildStep buildStep) {
+  Future<Null> build(BuildStep buildStep) async {
     outputContents.forEach((path, content) =>
         buildStep.writeAsString(new AssetId(package, path), content));
   }

--- a/build_runner/test/common/matchers.dart
+++ b/build_runner/test/common/matchers.dart
@@ -31,6 +31,7 @@ class _AssetGraphMatcher extends Matcher {
     }
     for (var node in graph.allNodes) {
       var expectedNode = _expected.get(node.id);
+      if (node.runtimeType != expectedNode.runtimeType) return false;
       if (expectedNode == null || expectedNode.id != node.id) return false;
       if (!unorderedEquals(node.outputs).matches(expectedNode.outputs, null)) {
         return false;

--- a/build_test/lib/build_test.dart
+++ b/build_test/lib/build_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'package:build/src/builder/logging.dart' show scopeLog;
+export 'package:build/src/builder/logging.dart' show scopeLogAsync;
 
 export 'src/assets.dart';
 export 'src/copy_builder.dart';

--- a/build_test/lib/src/record_logs.dart
+++ b/build_test/lib/src/record_logs.dart
@@ -25,7 +25,7 @@ import 'package:logging/logging.dart';
 Stream<LogRecord> recordLogs(dynamic run(), {String name: ''}) {
   final logger = new Logger(name);
   Timer.run(() async {
-    await scopeLog(run, logger);
+    await scopeLogAsync(() => new Future.value(run()), logger);
     logger.clearListeners();
   });
   return logger.onRecord;

--- a/e2e_example/test/integration_test.dart
+++ b/e2e_example/test/integration_test.dart
@@ -127,7 +127,7 @@ void main() {
       await createFile(path, "String get message => 'Hello World!';");
       await nextSuccessfulBuild;
       await expectTestsPass();
-    }, skip: 'https://github.com/dart-lang/build/issues/548');
+    });
   });
 }
 

--- a/e2e_example/tool/build.dart
+++ b/e2e_example/tool/build.dart
@@ -16,6 +16,7 @@ Future main() async {
   var buildActions = <BuildAction>[
     new BuildAction(new TestBootstrapBuilder(), graph.root.name,
         inputs: ['test/**_test.dart']),
+    new BuildAction(new ThrowingBuilder(), graph.root.name),
   ];
 
   void addBuilderForAll(Builder builder, String inputExtension) {
@@ -52,4 +53,16 @@ Future main() async {
   await serveHandler.buildResults.drain();
   await server.close();
   await testServer.close();
+}
+
+class ThrowingBuilder extends Builder {
+  @override
+  final buildExtensions = {
+    '.fail': ['.fail.message']
+  };
+
+  @override
+  Future<Null> build(BuildStep buildStep) async {
+    throw await buildStep.readAsString(buildStep.inputId);
+  }
 }


### PR DESCRIPTION
- Adds a new type of asset node, a `SyntheticAssetNode`. These are created if a build step calls `canRead` for an asset that doesn't exist. Those files still need to be tracked so if they are added later on that build step gets invalidated.
- Changes `scopeLog` to `scopeLogAsync`, since its always used in an async context, and we now run in an error handling zone that logs errors to `logger.severe`. Any call to `scopeLogAsync` is now guaranteed to eventually complete with exactly one error or value, and will not leak unhandled async errors.
- Updates the call to `runBuilder` to pass in a logger whose name is `$builder on $input`, so you get more context for errors.
- Fixes the `computeTransitiveModules` to check that modules exist before trying to read them, and warn if they don't. Eventually we probably want this to fail the build as well, but only on some equivalent of "--mode=release". For dev time we probably don't want any builds to fail so the app can serve errors in a friendly fashion.
- Fixes a bug in `updateAndInvalidate` where it would delete nodes that shouldn't be deleted.

Fixes https://github.com/dart-lang/build/issues/548.