### PR TITLE
resolve symbolic links for scratchSpace.tempDir

### DIFF
--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -34,7 +34,9 @@ class ScratchSpace {
         this.tempDir = tempDir;
 
   factory ScratchSpace() {
-    var tempDir = Directory.systemTemp.createTempSync('build_compilers');
+    var tempDir = new Directory(Directory.systemTemp
+        .createTempSync('build_compilers')
+        .resolveSymbolicLinksSync());
     return new ScratchSpace._(tempDir);
   }
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/555 for both mac/windows

cc @alorenzen 