### PR TITLE
use the pool package to limit open file handles

### DIFF
--- a/build_runner/lib/src/asset/file_based.dart
+++ b/build_runner/lib/src/asset/file_based.dart
@@ -14,7 +14,7 @@ import '../package_graph/package_graph.dart';
 import 'reader.dart';
 import 'writer.dart';
 
-/// Pool for async file writes, we don't want to use too many file handles.
+/// Pool for async file operations, we don't want to use too many file handles.
 final _descriptorPool = new Pool(32);
 
 /// Basic [AssetReader] which uses a [PackageGraph] to look up where to read

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   glob: ^1.1.0
   logging: ^0.11.2
   path: ^1.1.0
+  pool: ^1.0.0
   shelf: ">=0.6.5 <0.8.0"
   mime: ^0.9.3
   stack_trace: ^1.6.0


### PR DESCRIPTION
This does not cause any noticeable regression in build times on angular_components_example.

Fixes https://github.com/dart-lang/build/issues/572