### PR TITLE
Outline binary to generate and run build script

### DIFF
--- a/build_runner/bin/serve.dart
+++ b/build_runner/bin/serve.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:io/io.dart';
+
+import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
+
+Future<Null> main() async {
+  await ensureBuildScript();
+  var dart = Platform.resolvedExecutable;
+  var buildRun = await new ProcessManager().spawn(dart, [scriptLocation]);
+  await buildRun.exitCode;
+  await ProcessManager.terminateStdIn();
+}

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:build_runner/build_runner.dart';
+import 'package:build_config/build_config.dart';
+
+const _scriptDir = '.dart_tool/build';
+const scriptLocation = '$_scriptDir/build.dart';
+
+Future<Null> ensureBuildScript() async {
+  var scriptFile = new File(scriptLocation);
+  // TODO - how can we invalidate this?
+  if (scriptFile.existsSync()) return;
+  var scriptDir = new Directory(_scriptDir);
+  if (!scriptDir.existsSync()) scriptDir.createSync(recursive: true);
+  await scriptFile.writeAsString(await _generateBuildScript());
+}
+
+Future<String> _generateBuildScript() async {
+  var result = new StringBuffer();
+  var packageGraph = new PackageGraph.forThisPackage();
+  var buildConfigs =
+      await Future.wait(packageGraph.orderedPackages.map(_packageBuildConfig));
+  result.writeln('void main() {');
+  for (var config in buildConfigs) {
+    if (config.builderDefinitions.isNotEmpty) {
+      result.writeln('print("I would run: ${config.packageName} - '
+          '${config.builderDefinitions.keys.toList()}");');
+    }
+  }
+  result.writeln('}');
+  return '$result';
+}
+
+Future<BuildConfig> _packageBuildConfig(PackageNode package) async =>
+    BuildConfig.fromPackageDir(
+        await Pubspec.fromPackageDir(package.path), package.path);

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -8,15 +8,13 @@ import 'dart:io';
 import 'package:build_runner/build_runner.dart';
 import 'package:build_config/build_config.dart';
 
-const _scriptDir = '.dart_tool/build';
-const scriptLocation = '$_scriptDir/build.dart';
+const scriptLocation = '.dart_tool/build/build.dart';
 
 Future<Null> ensureBuildScript() async {
   var scriptFile = new File(scriptLocation);
   // TODO - how can we invalidate this?
   if (scriptFile.existsSync()) return;
-  var scriptDir = new Directory(_scriptDir);
-  if (!scriptDir.existsSync()) scriptDir.createSync(recursive: true);
+  scriptFile.createSync(recursive: true);
   await scriptFile.writeAsString(await _generateBuildScript());
 }
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.6.0
+version: 0.6.1-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -13,9 +13,12 @@ dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ^0.11.0
   build_barback: ^0.4.0
+  build_config:
+    path: ../build_config
   cli_util: ^0.1.2
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0
+  io: ^0.3.0
   logging: ^0.11.2
   path: ^1.1.0
   shelf: ">=0.6.5 <0.8.0"


### PR DESCRIPTION
This script does not do anything useful yet - demonstrate finding
builders, writing a script to disk, and running it with `dart`.

- Add a binary ad bin/serve.dart
- Create a PackageGraph and find packages which have a `build.yaml`
- Write a script to `.dart_tool/build/build.dart` and execute it