### PR TITLE
Generate a real serve script

### DIFF
--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -61,8 +61,6 @@ Method _findBuildActions(Iterable<BuildConfig> buildConfigs) =>
           ..addAll(_addBuildActions(buildConfigs))
           ..add(refer('actions').returned.statement))));
 
-//Expression _instantiatedBuilders(Iterable<BuildConfig> buildCongifs) => null;
-
 Method _main() => new Method((b) => b
   ..name = 'main'
   ..modifier = MethodModifier.async

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -15,29 +15,136 @@ const scriptLocation = '.dart_tool/build/build.dart';
 Future<Null> ensureBuildScript() async {
   var scriptFile = new io.File(scriptLocation);
   // TODO - how can we invalidate this?
-  if (scriptFile.existsSync()) return;
+  //if (scriptFile.existsSync()) return;
   scriptFile.createSync(recursive: true);
   await scriptFile.writeAsString(await _generateBuildScript());
 }
 
+final _packageGraph = new TypeReference((b) => b
+  ..symbol = 'PackageGraph'
+  ..url = 'package:build_runner/build_runner.dart');
+
+final _buildAction = new TypeReference((b) => b
+  ..symbol = 'BuildAction'
+  ..url = 'package:build_runner/build_runner.dart');
+
+final _buildActions = new TypeReference((b) => b
+  ..symbol = 'List'
+  ..types.add(_buildAction));
+
 Future<String> _generateBuildScript() async {
   var packageGraph = new PackageGraph.forThisPackage();
   var buildConfigs =
-      await Future.wait(packageGraph.orderedPackages.map(_packageBuildConfig));
-  var printStatements = buildConfigs
-      .where((config) => config.builderDefinitions.isNotEmpty)
-      .map((config) => refer('print').call([
-            literalString('I would run: \'${config.packageName} - '
-                '${config.builderDefinitions.keys.toList()}')
-          ]).statement);
-  final library = new File((b) => b.body.addAll([
-        new Method.returnsVoid((b) => b
-          ..name = 'main'
-          ..body = new Block((b) => b..statements.addAll(printStatements)))
-      ]));
-  final emitter = new DartEmitter();
+      (await Future.wait(packageGraph.orderedPackages.map(_packageBuildConfig)))
+          .where((c) => c.builderDefinitions.isNotEmpty);
+  final library = new File(
+      (b) => b.body.addAll([_findBuildActions(buildConfigs), _main()]));
+  final emitter = new DartEmitter(new Allocator.simplePrefixing());
   return new DartFormatter().format('${library.accept(emitter)}');
 }
+
+Method _findBuildActions(Iterable<BuildConfig> buildConfigs) =>
+    new Method((b) => b
+      ..name = '_buildActions'
+      ..requiredParameters.add(new Parameter((b) => b
+        ..name = 'graph'
+        ..type = _packageGraph))
+      ..returns = _buildActions
+      ..body = new Block((b) => b
+        ..statements.addAll([
+          _buildActions.newInstance([]).assignVar('actions').statement,
+          // TODO - Pass actual arguments
+          literalList([], new TypeReference((b) => b..symbol = 'String'))
+              .assignVar('args')
+              .statement,
+        ]
+          ..addAll(_addBuildActions(buildConfigs))
+          ..add(refer('actions').returned.statement))));
+
+//Expression _instantiatedBuilders(Iterable<BuildConfig> buildCongifs) => null;
+
+Method _main() => new Method((b) => b
+  ..name = 'main'
+  ..modifier = MethodModifier.async
+  ..body = new Block((b) => b
+    ..statements.addAll([
+      refer('_buildActions')
+          .call([_packageGraph.newInstanceNamed('forThisPackage', [])])
+          .assignVar('actions')
+          .statement,
+      refer('watch', 'package:build_runner/build_runner.dart')
+          .call([refer('actions')], {'writeToCache': literalTrue})
+          .awaited
+          .assignVar('handler')
+          .statement,
+      refer('serve', 'package:shelf/shelf_io.dart')
+          .call([
+            refer('handler')
+                .property('handlerFor')
+                .call([literalString('web')]),
+            literalString('localhost'),
+            literal(8000)
+          ])
+          .awaited
+          .assignVar('server')
+          .statement,
+      refer('handler')
+          .property('buildResults')
+          .property('drain')
+          .call([])
+          .awaited
+          .statement,
+      refer('server').property('close').call([]).awaited.statement
+    ])));
+
+Iterable<Code> _addBuildActions(Iterable<BuildConfig> configs) {
+  var statements = <Code>[];
+  for (var config in configs) {
+    var varName = 'buildersFor${config.packageName}';
+    statements.addAll([
+      _packageBuilders(config, varName),
+      refer('graph')
+          .property('dependentsOf')
+          .call([literalString(config.packageName)])
+          .property('map')
+          .call([
+            new Method((b) => b
+              ..requiredParameters.add(new Parameter((b) => b..name = 'n'))
+              ..body = refer('n').property('name').code
+              ..lambda = true).closure
+          ])
+          .property('forEach')
+          .call([
+            new Method((b) => b
+              ..requiredParameters.add(new Parameter((b) => b..name = 'p'))
+              ..lambda = true
+              ..body = refer('actions').property('addAll').call([
+                refer(varName).property('map').call([
+                  new Method((b) => b
+                    ..requiredParameters
+                        .add(new Parameter((b) => b..name = 'b'))
+                    ..lambda = true
+                    ..body = _buildAction
+                        .newInstance([refer('b'), refer('p')]).code).closure
+                ])
+              ]).code).closure
+          ])
+          .statement
+    ]);
+  }
+  return statements;
+}
+
+Code _packageBuilders(BuildConfig config, String varName) =>
+    literalList(config.builderDefinitions.values
+            .expand(_builderInstantiations)
+            .toList())
+        .assignVar(varName)
+        .statement;
+
+Iterable<Expression> _builderInstantiations(BuilderDefinition builder) =>
+    builder.builderFactories
+        .map((f) => refer(f, builder.import).call([literalList([])]));
 
 Future<BuildConfig> _packageBuildConfig(PackageNode package) async =>
     BuildConfig.fromPackageDir(

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -10,6 +10,8 @@ import 'package:build_runner/build_runner.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 
+import 'types.dart' as types;
+
 const scriptLocation = '.dart_tool/build/build.dart';
 
 Future<Null> ensureBuildScript() async {
@@ -19,18 +21,6 @@ Future<Null> ensureBuildScript() async {
   scriptFile.createSync(recursive: true);
   await scriptFile.writeAsString(await _generateBuildScript());
 }
-
-final _packageGraph = new TypeReference((b) => b
-  ..symbol = 'PackageGraph'
-  ..url = 'package:build_runner/build_runner.dart');
-
-final _buildAction = new TypeReference((b) => b
-  ..symbol = 'BuildAction'
-  ..url = 'package:build_runner/build_runner.dart');
-
-final _buildActions = new TypeReference((b) => b
-  ..symbol = 'List'
-  ..types.add(_buildAction));
 
 Future<String> _generateBuildScript() async {
   var packageGraph = new PackageGraph.forThisPackage();
@@ -48,11 +38,11 @@ Method _findBuildActions(Iterable<BuildConfig> buildConfigs) =>
       ..name = '_buildActions'
       ..requiredParameters.add(new Parameter((b) => b
         ..name = 'graph'
-        ..type = _packageGraph))
-      ..returns = _buildActions
+        ..type = types.packageGraph))
+      ..returns = types.buildActions
       ..body = new Block((b) => b
         ..statements.addAll([
-          _buildActions.newInstance([]).assignVar('actions').statement,
+          types.buildActions.newInstance([]).assignVar('actions').statement,
           // TODO - Pass actual arguments
           literalList([], new TypeReference((b) => b..symbol = 'String'))
               .assignVar('args')
@@ -67,7 +57,7 @@ Method _main() => new Method((b) => b
   ..body = new Block((b) => b
     ..statements.addAll([
       refer('_buildActions')
-          .call([_packageGraph.newInstanceNamed('forThisPackage', [])])
+          .call([types.packageGraph.newInstanceNamed('forThisPackage', [])])
           .assignVar('actions')
           .statement,
       refer('watch', 'package:build_runner/build_runner.dart')
@@ -122,7 +112,7 @@ Iterable<Code> _addBuildActions(Iterable<BuildConfig> configs) {
                     ..requiredParameters
                         .add(new Parameter((b) => b..name = 'b'))
                     ..lambda = true
-                    ..body = _buildAction
+                    ..body = types.buildAction
                         .newInstance([refer('b'), refer('p')]).code).closure
                 ])
               ]).code).closure

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -33,23 +33,24 @@ Future<String> _generateBuildScript() async {
   return new DartFormatter().format('${library.accept(emitter)}');
 }
 
-Method _findBuildActions(Iterable<BuildConfig> buildConfigs) =>
-    new Method((b) => b
-      ..name = '_buildActions'
-      ..requiredParameters.add(new Parameter((b) => b
-        ..name = 'graph'
-        ..type = types.packageGraph))
-      ..returns = types.buildActions
-      ..body = new Block((b) => b
-        ..statements.addAll([
-          types.buildActions.newInstance([]).assignVar('actions').statement,
-          // TODO - Pass actual arguments
-          literalList([], new TypeReference((b) => b..symbol = 'String'))
-              .assignVar('args')
-              .statement,
-        ]
-          ..addAll(_addBuildActions(buildConfigs))
-          ..add(refer('actions').returned.statement))));
+Method _findBuildActions(Iterable<BuildConfig> buildConfigs) {
+  var statements = <Code>[
+    types.buildActions.newInstance([]).assignVar('actions').statement,
+    // TODO - Pass actual arguments
+    literalList([], new TypeReference((b) => b..symbol = 'String'))
+        .assignVar('args')
+        .statement,
+  ];
+  statements.addAll(_addBuildActions(buildConfigs));
+  statements.add(refer('actions').returned.statement);
+  return new Method((b) => b
+    ..name = '_buildActions'
+    ..requiredParameters.add(new Parameter((b) => b
+      ..name = 'graph'
+      ..type = types.packageGraph))
+    ..returns = types.buildActions
+    ..body = new Block((b) => b..statements.addAll(statements)));
+}
 
 Method _main() => new Method((b) => b
   ..name = 'main'

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -46,7 +46,7 @@ Method _findBuildActions(Iterable<BuildConfig> buildConfigs) {
   return new Method((b) => b
     ..name = '_buildActions'
     ..requiredParameters.add(new Parameter((b) => b
-      ..name = 'graph'
+      ..name = 'packageGraph'
       ..type = types.packageGraph))
     ..returns = types.buildActions
     ..body = new Block((b) => b..statements.addAll(statements)));
@@ -92,7 +92,7 @@ Iterable<Code> _addBuildActions(Iterable<BuildConfig> configs) {
     var varName = 'buildersFor${config.packageName}';
     statements.addAll([
       _packageBuilders(config, varName),
-      refer('graph')
+      refer('packageGraph')
           .property('dependentsOf')
           .call([literalString(config.packageName)])
           .property('map')

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -98,8 +98,8 @@ Iterable<Code> _addBuildActions(Iterable<BuildConfig> configs) {
           .property('map')
           .call([
             new Method((b) => b
-              ..requiredParameters.add(new Parameter((b) => b..name = 'n'))
-              ..body = refer('n').property('name').code
+              ..requiredParameters.add(new Parameter((b) => b..name = 'p'))
+              ..body = refer('p').property('name').code
               ..lambda = true).closure
           ])
           .property('forEach')

--- a/build_runner/lib/src/build_script_generate/types.dart
+++ b/build_runner/lib/src/build_script_generate/types.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:code_builder/code_builder.dart';
+
+final packageGraph = new TypeReference((b) => b
+  ..symbol = 'PackageGraph'
+  ..url = 'package:build_runner/build_runner.dart');
+
+final buildAction = new TypeReference((b) => b
+  ..symbol = 'BuildAction'
+  ..url = 'package:build_runner/build_runner.dart');
+
+final buildActions = new TypeReference((b) => b
+  ..symbol = 'List'
+  ..types.add(buildAction));


### PR DESCRIPTION
Towards #353

- Instantate builders discovered in `build.yaml` and apply them to
  direct dependencies
- Call `watch` from `build_runner` and set up `serve` from `shelf`
- Always regenerate the script for now until we figured out a better
  appraoch for invalidation

Open issues:
- Does not run DDC
- Does not honor manually configured `build.yaml` to apply a builder
- Does not handle Builder arguments