### PR TITLE
Track inputs for GeneratedAssetNodes

### DIFF
--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -57,7 +57,7 @@ class SingleStepReader implements AssetReader {
   SingleStepReader(this._delegate, this._assetGraph, this._phaseNumber,
       this._primaryPackage, this._runPhaseForInput);
 
-  Iterable<AssetId> get assetsRead => _assetsRead;
+  Set<AssetId> get assetsRead => _assetsRead;
 
   /// The [Glob]s which have been searched with [findAssets].
   ///

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -109,6 +109,12 @@ class AssetGraph {
     for (var output in node.primaryOutputs) {
       _remove(output, removedIds: removedIds);
     }
+    for (var output in node.outputs) {
+      var generatedNode = get(output) as GeneratedAssetNode;
+      if (generatedNode != null) {
+        generatedNode.inputs.remove(id);
+      }
+    }
     _nodesByPackage[id.package].remove(id.path);
     return removedIds;
   }
@@ -145,12 +151,10 @@ class AssetGraph {
 
     // Builds up `idsToDelete` and `idsToRemove` by recursively invalidating
     // the outputs of `id`.
-    void clearNodeAndDeps(AssetId id, ChangeType rootChangeType,
-        {bool rootIsSource}) {
+    void clearNodeAndDeps(AssetId id, ChangeType rootChangeType) {
       var node = this.get(id);
       if (node == null) return;
       if (!invalidatedIds.add(id)) return;
-      rootIsSource ??= node is SourceAssetNode;
 
       if (node is GeneratedAssetNode) {
         idsToDelete.add(id);
@@ -161,7 +165,7 @@ class AssetGraph {
 
       // Update all outputs of this asset as well.
       for (var output in node.outputs) {
-        clearNodeAndDeps(output, rootChangeType, rootIsSource: rootIsSource);
+        clearNodeAndDeps(output, rootChangeType);
       }
     }
 

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -72,10 +72,15 @@ class GeneratedAssetNode extends AssetNode {
   /// Any new or deleted files matching this glob should invalidate this node.
   Set<Glob> globs;
 
+  /// All the inputs that were read when generating this asset, or deciding not
+  /// to generate it.
+  final Set<AssetId> inputs;
+
   GeneratedAssetNode(this.phaseNumber, this.primaryInput, this.needsUpdate,
       this.wasOutput, AssetId id,
-      {Digest lastKnownDigest, Set<Glob> globs})
+      {Digest lastKnownDigest, Set<Glob> globs, Iterable<AssetId> inputs})
       : this.globs = globs ?? new Set<Glob>(),
+        this.inputs = inputs?.toSet() ?? new Set<AssetId>(),
         super(id, lastKnownDigest: lastKnownDigest);
 
   @override

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -32,8 +32,21 @@ class _AssetGraphDeserializer {
           new AssetId(descriptor[1] as String, descriptor[2] as String);
     }
 
+    // Read in all the nodes and their outputs.
+    //
+    // Note that this does not read in the inputs of generated nodes.
     for (var serializedItem in _serializedGraph['nodes']) {
       graph._add(_deserializeAssetNode(serializedItem as List));
+    }
+
+    // Update the inputs of all generated nodes based on the outputs of the
+    // current nodes.
+    for (var node in graph.allNodes) {
+      for (var output in node.outputs) {
+        var generatedNode = graph.get(output) as GeneratedAssetNode;
+        assert(generatedNode != null, 'Asset Graph is missing $output');
+        generatedNode.inputs.add(node.id);
+      }
     }
 
     return graph;

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -88,6 +88,8 @@ void main() {
             var syntheticNode = new SyntheticAssetNode(makeAssetId());
             syntheticNode.outputs.add(generatedNode.id);
 
+            generatedNode.inputs.addAll([node.id, syntheticNode.id]);
+
             graph.add(syntheticNode);
             graph.add(generatedNode);
           }

--- a/build_runner/test/common/matchers.dart
+++ b/build_runner/test/common/matchers.dart
@@ -84,6 +84,14 @@ class _AssetGraphMatcher extends Matcher {
             ];
             matches = false;
           }
+          if (!unorderedEquals(node.inputs)
+              .matches(expectedNode.inputs, null)) {
+            matchState['Inputs of ${node.id}'] = [
+              node.inputs,
+              expectedNode.inputs
+            ];
+            matches = false;
+          }
         } else {
           matchState['Type of ${node.id}'] = [
             node.runtimeType,

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -135,13 +135,15 @@ void main() {
         var expectedGraph = await AssetGraph.build([], new Set(), 'a', null);
         var bCopyNode = new GeneratedAssetNode(null, makeAssetId('a|web/b.txt'),
             false, true, makeAssetId('a|web/b.txt.copy'),
-            lastKnownDigest: computeDigest('b2'));
+            lastKnownDigest: computeDigest('b2'),
+            inputs: [makeAssetId('a|web/b.txt')]);
         expectedGraph.add(bCopyNode);
         expectedGraph.add(
             makeAssetNode('a|web/b.txt', [bCopyNode.id], computeDigest('b2')));
         var cCopyNode = new GeneratedAssetNode(null, makeAssetId('a|web/c.txt'),
             false, true, makeAssetId('a|web/c.txt.copy'),
-            lastKnownDigest: computeDigest('c'));
+            lastKnownDigest: computeDigest('c'),
+            inputs: [makeAssetId('a|web/c.txt')]);
         expectedGraph.add(cCopyNode);
         expectedGraph.add(
             makeAssetNode('a|web/c.txt', [cCopyNode.id], computeDigest('c')));


### PR DESCRIPTION
This fixes a bug where the set of dependencies for a given generated asset could never be reduced except if those files were deleted.

It also partially unblocks https://github.com/dart-lang/build/issues/371.