### PR TITLE
Log time to generate build script

### DIFF
--- a/build_runner/bin/serve.dart
+++ b/build_runner/bin/serve.dart
@@ -6,13 +6,17 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:io/io.dart';
+import 'package:logging/logging.dart';
 
 import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
+import 'package:build_runner/src/logging/std_io_logging.dart';
 
 Future<Null> main() async {
+  var logListener = Logger.root.onRecord.listen(stdIOLogListener);
   await ensureBuildScript();
   var dart = Platform.resolvedExecutable;
   var buildRun = await new ProcessManager().spawn(dart, [scriptLocation]);
   await buildRun.exitCode;
   await ProcessManager.terminateStdIn();
+  await logListener.cancel();
 }

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -9,17 +9,21 @@ import 'package:build_config/build_config.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:logging/logging.dart';
 
+import '../logging/logging.dart';
 import 'types.dart' as types;
 
 const scriptLocation = '.dart_tool/build/build.dart';
 
 Future<Null> ensureBuildScript() async {
+  var log = new Logger('ensureBuildScript');
   var scriptFile = new io.File(scriptLocation);
   // TODO - how can we invalidate this?
   //if (scriptFile.existsSync()) return;
   scriptFile.createSync(recursive: true);
-  await scriptFile.writeAsString(await _generateBuildScript());
+  await logTimedAsync(log, 'Generating build script',
+      () async => scriptFile.writeAsString(await _generateBuildScript()));
 }
 
 Future<String> _generateBuildScript() async {

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -2,15 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
 
 import 'package:logging/logging.dart';
-import 'package:stack_trace/stack_trace.dart';
 
 import '../asset/file_based.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
+import '../logging/std_io_logging.dart';
 import '../package_graph/package_graph.dart';
 import 'directory_watcher_factory.dart';
 
@@ -51,7 +49,7 @@ class BuildOptions {
     /// Set up logging
     logLevel ??= Level.INFO;
     Logger.root.level = logLevel;
-    logListener = Logger.root.onRecord.listen(onLog ?? _defaultLogListener);
+    logListener = Logger.root.onRecord.listen(onLog ?? stdIOLogListener);
 
     /// Set up other defaults.
     debounceDelay ??= const Duration(milliseconds: 250);
@@ -62,56 +60,5 @@ class BuildOptions {
     deleteFilesByDefault ??= writeToCache ?? false;
     writeToCache ??= false;
     skipBuildScriptCheck ??= false;
-  }
-}
-
-final _cyan = _isPosixTerminal ? '\u001b[36m' : '';
-final _yellow = _isPosixTerminal ? '\u001b[33m' : '';
-final _red = _isPosixTerminal ? '\u001b[31m' : '';
-final _endColor = _isPosixTerminal ? '\u001b[0m' : '';
-final _isPosixTerminal =
-    !Platform.isWindows && stdioType(stdout) == StdioType.TERMINAL;
-
-void _defaultLogListener(LogRecord record) {
-  var color;
-  if (record.level < Level.WARNING) {
-    color = _cyan;
-  } else if (record.level < Level.SEVERE) {
-    color = _yellow;
-  } else {
-    color = _red;
-  }
-  var header = '${_isPosixTerminal ? '\x1b[2K\r' : ''}'
-      '$color[${record.level}]$_endColor ${record.loggerName}: '
-      '${record.message}';
-  var lines = <Object>[header];
-
-  if (record.error != null) {
-    lines.add(record.error);
-  }
-
-  if (record.stackTrace != null) {
-    if (record.stackTrace is Trace) {
-      lines.add((record.stackTrace as Trace).terse);
-    } else {
-      lines.add(record.stackTrace);
-    }
-  }
-
-  var message = new StringBuffer(lines.join('\n'));
-
-  // We always add an extra newline at the end of each message, so it
-  // isn't multiline unless we see > 2 lines.
-  var multiLine = LineSplitter.split(message.toString()).length > 2;
-
-  if (record.level > Level.INFO || !_isPosixTerminal || multiLine) {
-    // Add an extra line to the output so the last line isn't written over.
-    message.writeln('');
-  }
-
-  if (record.level >= Level.SEVERE) {
-    stderr.write(message);
-  } else {
-    stdout.write(message);
   }
 }

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+final _cyan = _isPosixTerminal ? '\u001b[36m' : '';
+final _yellow = _isPosixTerminal ? '\u001b[33m' : '';
+final _red = _isPosixTerminal ? '\u001b[31m' : '';
+final _endColor = _isPosixTerminal ? '\u001b[0m' : '';
+final _isPosixTerminal =
+    !Platform.isWindows && stdioType(stdout) == StdioType.TERMINAL;
+
+
+void stdIOLogListener(LogRecord record) {
+  var color;
+  if (record.level < Level.WARNING) {
+    color = _cyan;
+  } else if (record.level < Level.SEVERE) {
+    color = _yellow;
+  } else {
+    color = _red;
+  }
+  var header = '${_isPosixTerminal ? '\x1b[2K\r' : ''}'
+      '$color[${record.level}]$_endColor ${record.loggerName}: '
+      '${record.message}';
+  var lines = <Object>[header];
+
+  if (record.error != null) {
+    lines.add(record.error);
+  }
+
+  if (record.stackTrace != null) {
+    if (record.stackTrace is Trace) {
+      lines.add((record.stackTrace as Trace).terse);
+    } else {
+      lines.add(record.stackTrace);
+    }
+  }
+
+  var message = new StringBuffer(lines.join('\n'));
+
+  // We always add an extra newline at the end of each message, so it
+  // isn't multiline unless we see > 2 lines.
+  var multiLine = LineSplitter.split(message.toString()).length > 2;
+
+  if (record.level > Level.INFO || !_isPosixTerminal || multiLine) {
+    // Add an extra line to the output so the last line isn't written over.
+    message.writeln('');
+  }
+
+  if (record.level >= Level.SEVERE) {
+    stderr.write(message);
+  } else {
+    stdout.write(message);
+  }
+}

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -15,7 +15,6 @@ final _endColor = _isPosixTerminal ? '\u001b[0m' : '';
 final _isPosixTerminal =
     !Platform.isWindows && stdioType(stdout) == StdioType.TERMINAL;
 
-
 void stdIOLogListener(LogRecord record) {
   var color;
   if (record.level < Level.WARNING) {


### PR DESCRIPTION
Gathering data for #585 

- Move default log listener into its own library and make it public
- Set up logging in the entrypoint
- Surround generating the build script with `logTimedAsync`