### PR TITLE
Add a README for build_config

### DIFF
--- a/build_config/README.md
+++ b/build_config/README.md
@@ -1,0 +1,46 @@
+# Customizing builds
+
+Customizing the build behavior of a package is done  by creating a `build.yaml`
+file, which describes your configuration.
+
+## Defining `Builder`s to apply to dependents (similar to transformers)
+
+If users of your package need to apply some code generation to their package,
+then you can define `Builder`s and have those applied to packages with a
+dependency on yours.
+
+Exposed `Builder`s are configured in the `builders` section of the `build.yaml`.
+This is a map of builder names to configuration. Each builder config may contain
+the following keys:
+
+- **target**: The name of the target which defines contains the `Builder` class
+  definition.
+- **import**: Required. The import uri that should be used to import the library
+  containing the `Builder` class. This should always be a `package:` uri.
+- **builder_factories**: A `List<String>` which contains the names of the
+  top-level methods in the imported library which are a function fitting the
+  typedef `Builder factoryName(List<String> args)`.
+- **build_extensions**: Required. A map from input extension to the list of
+  output extensions that may be created for that input. This must match the
+  merged `buildExtensions` maps from each `Builder` in `builder_factories`.
+
+Example `builders` config:
+
+```yaml
+targets:
+  # The target containing the builder sources.
+  _my_builder: # By convention, this is private
+    sources:
+      - "lib/src/builder/**/*.dart"
+      - "lib/builder.dart"
+    dependencies:
+      - "build"
+      - "source_gen"
+builders:
+  # The actual builder config.
+  my_builder:
+    target: ":_my_builder"
+    import: "package:my_package/builder.dart"
+    builder_factories: ["myBuilder"]
+    build_extensions: {".dart": [".my_package.dart"]}
+```


### PR DESCRIPTION
Copied from `package:dazel` and trimmed down to just the section which
is used by `build_runner` today.