### PR TITLE
Allow the generated entrypoint in the AssetGraph

### DIFF
--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -12,9 +12,10 @@ import 'package:dart_style/dart_style.dart';
 import 'package:logging/logging.dart';
 
 import '../logging/logging.dart';
+import '../util/constants.dart';
 import 'types.dart' as types;
 
-const scriptLocation = '.dart_tool/build/build.dart';
+const scriptLocation = '$entryPointDir/build.dart';
 
 Future<Null> ensureBuildScript() async {
   var log = new Logger('ensureBuildScript');

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -206,11 +206,12 @@ class _Loader {
     return sources;
   }
 
-  /// Checks if an [input] is valid.
+  /// Checks whether [input] is allowed to be read over the course of a build.
   bool _isValidInput(AssetId input) =>
       input.package != _options.packageGraph.root.name
           ? input.path.startsWith('lib/')
-          : !toolDirs.any((d) => input.path.startsWith(d));
+          : !toolDirs.any((d) => input.path.startsWith(d)) ||
+              input.path.startsWith(entryPointDir);
 
   Stream<AssetId> _listAssetIds(Iterable<InputSet> inputSets) async* {
     var seenAssets = new Set<AssetId>();

--- a/build_runner/lib/src/util/constants.dart
+++ b/build_runner/lib/src/util/constants.dart
@@ -24,6 +24,11 @@ const toolDirs = const [
   '.idea'
 ];
 
+/// Directory containing automatically generated build entrypoints.
+///
+/// Files in this directory must be read to do build script invalidation.
+const entryPointDir = '.dart_tool/build/entrypoint';
+
 /// The directory to which assets will be written when `writeToCache` is
 /// enabled.
 const generatedOutputDirectory = '$cacheDir/generated';

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -41,6 +41,11 @@ main() {
         [
           await pubspec('a'),
           d.file('.packages', '\na:./lib/'),
+          d.dir('.dart_tool', [
+            d.dir('build', [
+              d.dir('entrypoint', [d.file('build.dart', '// builds!')])
+            ])
+          ]),
           d.dir('lib'),
         ],
       ).create();
@@ -108,6 +113,13 @@ main() {
         var buildDefinition = await BuildDefinition.load(options, buildActions);
         expect(buildDefinition.updates, isNot(contains(generatedId)));
         expect(buildDefinition.assetGraph.contains(generatedId), isFalse);
+      });
+
+      test('includes generated entrypoint', () async {
+        var entryPoint =
+            new AssetId('a', p.url.join(entryPointDir, 'build.dart'));
+        var buildDefinition = await BuildDefinition.load(options, []);
+        expect(buildDefinition.assetGraph.contains(entryPoint), isTrue);
       });
     });
   });


### PR DESCRIPTION
Fixes #587

Moves the entrypoint into a subdirectory in case we end up needing to
generate multiple files with relative imports. Add an exception for the
entrypoint directory to allow those files into the asset graph.