### PR TITLE
Add builder factories for build_compilers

### DIFF
--- a/build_compilers/CHANGELOG.md
+++ b/build_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0-dev
+
+- Add builder factories.
+
 # 0.0.1
 
 - Initial release with support for building analyzer summaries and DDC modules.

--- a/build_compilers/lib/build/builders.dart
+++ b/build_compilers/lib/build/builders.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:build_compilers/build_compilers.dart';
+
+Builder moduleBuilder(_) => const ModuleBuilder();
+Builder unlinkedSummaryBuilder(_) => const UnlinkedSummaryBuilder();
+Builder linkedSummaryBuilder(_) => const LinkedSummaryBuilder();
+Builder devCompilerBuilder(_) => const DevCompilerBuilder();
+Builder devCompilerBootstrapBuilder(_) => const DevCompilerBootstrapBuilder();

--- a/build_compilers/lib/src/dev_compiler_bootstrap_builder.dart
+++ b/build_compilers/lib/src/dev_compiler_bootstrap_builder.dart
@@ -15,14 +15,16 @@ import 'modules.dart';
 /// Alias `_p.url` to `p`.
 _p.Context get p => _p.url;
 
-final String bootstrapJsExtension = '.dart.bootstrap.js';
-final String jsEntrypointExtension = '.dart.js';
-final String jsEntrypointSourceMapExtension = '.dart.js.map';
+const bootstrapJsExtension = '.dart.bootstrap.js';
+const jsEntrypointExtension = '.dart.js';
+const jsEntrypointSourceMapExtension = '.dart.js.map';
 
-class DevCompilerBootstrapBuilder extends Builder {
+class DevCompilerBootstrapBuilder implements Builder {
+  const DevCompilerBootstrapBuilder();
+
   @override
-  final buildExtensions = {
-    '.dart': [
+  final buildExtensions = const {
+    '.dart': const [
       bootstrapJsExtension,
       jsEntrypointExtension,
       jsEntrypointSourceMapExtension

--- a/build_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_compilers/lib/src/dev_compiler_builder.dart
@@ -17,15 +17,17 @@ import 'scratch_space.dart';
 import 'summary_builder.dart';
 import 'workers.dart';
 
-final String jsModuleErrorsExtension = '.js.errors';
-final String jsModuleExtension = '.js';
-final String jsSourceMapExtension = '.js.map';
+const jsModuleErrorsExtension = '.js.errors';
+const jsModuleExtension = '.js';
+const jsSourceMapExtension = '.js.map';
 
 /// A builder which can output ddc modules!
 class DevCompilerBuilder implements Builder {
+  const DevCompilerBuilder();
+
   @override
-  final buildExtensions = {
-    moduleExtension: [
+  final buildExtensions = const {
+    moduleExtension: const [
       jsModuleExtension,
       jsModuleErrorsExtension,
       jsSourceMapExtension

--- a/build_compilers/lib/src/module_builder.dart
+++ b/build_compilers/lib/src/module_builder.dart
@@ -14,10 +14,13 @@ const moduleExtension = '.module';
 
 /// Creates `.module` files for any `.dart` file that is the primary dart
 /// source of a [Module].
-class ModuleBuilder extends Builder {
+class ModuleBuilder implements Builder {
+
+  const ModuleBuilder();
+
   @override
-  final buildExtensions = {
-    '.dart': [moduleExtension]
+  final buildExtensions = const {
+    '.dart': const [moduleExtension]
   };
 
   @override

--- a/build_compilers/lib/src/module_builder.dart
+++ b/build_compilers/lib/src/module_builder.dart
@@ -15,7 +15,6 @@ const moduleExtension = '.module';
 /// Creates `.module` files for any `.dart` file that is the primary dart
 /// source of a [Module].
 class ModuleBuilder implements Builder {
-
   const ModuleBuilder();
 
   @override

--- a/build_compilers/lib/src/summary_builder.dart
+++ b/build_compilers/lib/src/summary_builder.dart
@@ -16,14 +16,16 @@ import 'modules.dart';
 import 'scratch_space.dart';
 import 'workers.dart';
 
-final String linkedSummaryExtension = '.linked.sum';
-final String unlinkedSummaryExtension = '.unlinked.sum';
+const linkedSummaryExtension = '.linked.sum';
+const unlinkedSummaryExtension = '.unlinked.sum';
 
 /// A builder which can output unlinked summaries!
 class UnlinkedSummaryBuilder implements Builder {
+  const UnlinkedSummaryBuilder();
+
   @override
-  final buildExtensions = {
-    moduleExtension: [unlinkedSummaryExtension]
+  final buildExtensions = const {
+    moduleExtension: const [unlinkedSummaryExtension]
   };
 
   @override
@@ -41,9 +43,11 @@ class UnlinkedSummaryBuilder implements Builder {
 
 /// A builder which can output linked summaries!
 class LinkedSummaryBuilder implements Builder {
+  const LinkedSummaryBuilder();
+
   @override
-  final buildExtensions = {
-    moduleExtension: [linkedSummaryExtension]
+  final buildExtensions = const {
+    moduleExtension: const [linkedSummaryExtension]
   };
 
   @override

--- a/build_compilers/pubspec.yaml
+++ b/build_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_compilers
-version: 0.0.2-dev
+version: 0.1.0-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_compilers/pubspec.yaml
+++ b/build_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_compilers
-version: 0.0.1
+version: 0.0.2-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
This will make the usage of build_compilers look more like other places
using `build.yaml` and may allow us to configure it similarly in the
future.

The pattern I'd like to establish is for builder factories to go in
`lib/build/builders.dart`.

Add const constructors for all the builders since they have no state.