### PR TITLE
Add golden file test for generated build script

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,6 +8,7 @@ analyzer:
     override_on_non_overriding_method: error
   exclude:
     - bazel-*
+    - **/goldens/**
 linter:
   rules:
     # Errors

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -138,7 +138,7 @@ Code _packageBuilders(BuildConfig config, String varName) =>
 
 Iterable<Expression> _builderInstantiations(BuilderDefinition builder) =>
     builder.builderFactories
-        .map((f) => refer(f, builder.import).call([literalList([])]));
+        .map((f) => refer(f, builder.import).call([refer('args')]));
 
 Future<BuildConfig> _packageBuildConfig(PackageNode package) async =>
     BuildConfig.fromPackageDir(

--- a/e2e_example/pkgs/provides_builder/build.yaml
+++ b/e2e_example/pkgs/provides_builder/build.yaml
@@ -1,0 +1,6 @@
+builders:
+  some_builder:
+    target: "provides_builder"
+    import: "package:provides_builder/builders.dart"
+    builder_factories: ["someBuilder"]
+    build_extensions: {".dart": [".something.dart"]}

--- a/e2e_example/pkgs/provides_builder/lib/builders.dart
+++ b/e2e_example/pkgs/provides_builder/lib/builders.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+
+class _SomeBuilder implements Builder {
+  const _SomeBuilder();
+
+  @override
+  final buildExtensions = const {
+    '': const ['.copy']
+  };
+
+  @override
+  Future build(BuildStep buildStep) {
+    buildStep.writeAsBytes(buildStep.inputId.addExtension('.copy'),
+        buildStep.readAsBytes(buildStep.inputId));
+    return new Future.value();
+  }
+}
+
+Builder someBuilder(_) => const _SomeBuilder();

--- a/e2e_example/pkgs/provides_builder/pubspec.yaml
+++ b/e2e_example/pkgs/provides_builder/pubspec.yaml
@@ -1,0 +1,1 @@
+name: provides_builder

--- a/e2e_example/pubspec.yaml
+++ b/e2e_example/pubspec.yaml
@@ -8,6 +8,8 @@ dev_dependencies:
   browser: any
   path: ^1.4.2
   test: ^0.12.0
+  provides_builder:
+    path: pkgs/provides_builder/
 
 dependency_overrides:
   build:

--- a/e2e_example/test/build_script_invalidation_test.dart
+++ b/e2e_example/test/build_script_invalidation_test.dart
@@ -11,7 +11,7 @@ void main() {
   group('Build script changes', () {
     setUp(() async {
       ensureCleanGitClient();
-      await startServer(ensureCleanBuild: true, verbose: true);
+      await startManualServer(ensureCleanBuild: true, verbose: true);
       addTearDown(() => stopServer(cleanUp: true));
     });
 
@@ -22,7 +22,7 @@ void main() {
           'tool/build.dart', 'ThrowingBuilder', 'FailingBuilder');
       await terminateLine;
       await stopServer();
-      await startServer(extraExpects: [
+      await startManualServer(extraExpects: [
         () => nextStdOutLine(
             'Invalidating asset graph due to build script update'),
         () => nextStdOutLine('Building new asset graph'),
@@ -33,7 +33,7 @@ void main() {
       await stopServer();
       await replaceAllInFile(
           'tool/build.dart', 'ThrowingBuilder', 'FailingBuilder');
-      await startServer(extraExpects: [
+      await startManualServer(extraExpects: [
         () => nextStdOutLine(
             'Invalidating asset graph due to build script update'),
         () => nextStdOutLine('Building new asset graph'),

--- a/e2e_example/test/common/utils.dart
+++ b/e2e_example/test/common/utils.dart
@@ -27,7 +27,32 @@ Stream<String> _stdOutLines;
 ///
 /// For debugging purposes you can enable printing of the build script output by
 /// setting [verbose] to `true`.
-Future<Null> startServer(
+Future<Null> startManualServer(
+        {bool ensureCleanBuild, bool verbose, List<Function> extraExpects}) =>
+    _startServer('dart', ['tool/build.dart'],
+        ensureCleanBuild: ensureCleanBuild,
+        verbose: verbose,
+        extraExpects: extraExpects);
+
+/// Runs `pub run build_runner:serve` in this package, and waits for the first
+/// build to complete.
+///
+/// To ensure a clean build, set [ensureCleanBuild] to `true`.
+///
+/// This expects the first build to complete successfully, but you can add extra
+/// expects that happen before that using [extraExpects]. All of these will be
+/// invoked and awaited before awaiting the next successful build.
+///
+/// For debugging purposes you can enable printing of the build script output by
+/// setting [verbose] to `true`.
+Future<Null> startAutoServer(
+        {bool ensureCleanBuild, bool verbose, List<Function> extraExpects}) =>
+    _startServer('pub', ['run', 'build_runner:serve'],
+        ensureCleanBuild: ensureCleanBuild,
+        verbose: verbose,
+        extraExpects: extraExpects);
+
+Future<Null> _startServer(String command, List<String> args,
     {bool ensureCleanBuild, bool verbose, List<Function> extraExpects}) async {
   ensureCleanBuild ??= false;
   verbose ??= false;
@@ -38,7 +63,7 @@ Future<Null> startServer(
     await _toolDir.delete(recursive: true);
   }
 
-  _process = await Process.start('dart', ['tool/build.dart']);
+  _process = await Process.start(command, args);
   _stdOutLines = _process.stdout
       .transform(UTF8.decoder)
       .transform(const LineSplitter())

--- a/e2e_example/test/generated_script_integration_test.dart
+++ b/e2e_example/test/generated_script_integration_test.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+import 'dart:io' show File;
+
+import 'package:test/test.dart';
+
+import 'common/utils.dart';
+
+void main() {
+  setUpAll(() async {
+    await startAutoServer(ensureCleanBuild: true, verbose: true);
+  });
+
+  tearDownAll(() async {
+    await stopServer(cleanUp: true);
+  });
+
+  test('Generates a build script matching the golden', () {
+    var generatedScript =
+        new File('.dart_tool/build/entrypoint/build.dart').readAsStringSync();
+    var expected =
+        new File('test/goldens/generated_build_script.dart').readAsStringSync();
+    expect(generatedScript, expected);
+  });
+}

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -1,0 +1,21 @@
+import 'package:build_runner/build_runner.dart' as _1;
+import 'package:provides_builder/builders.dart' as _2;
+import 'package:shelf/shelf_io.dart' as _3;
+
+List<_1.BuildAction> _buildActions(_1.PackageGraph packageGraph) {
+  var actions = new List<_1.BuildAction>();
+  var args = <String>[];
+  var buildersForprovides_builder = [_2.someBuilder([])];
+  packageGraph.dependentsOf('provides_builder').map((p) => p.name).forEach(
+      (p) => actions.addAll(
+          buildersForprovides_builder.map((b) => new _1.BuildAction(b, p))));
+  return actions;
+}
+
+main() async {
+  var actions = _buildActions(new _1.PackageGraph.forThisPackage());
+  var handler = await _1.watch(actions, writeToCache: true);
+  var server = await _3.serve(handler.handlerFor('web'), 'localhost', 8000);
+  await handler.buildResults.drain();
+  await server.close();
+}

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -5,7 +5,7 @@ import 'package:shelf/shelf_io.dart' as _3;
 List<_1.BuildAction> _buildActions(_1.PackageGraph packageGraph) {
   var actions = new List<_1.BuildAction>();
   var args = <String>[];
-  var buildersForprovides_builder = [_2.someBuilder([])];
+  var buildersForprovides_builder = [_2.someBuilder(args)];
   packageGraph.dependentsOf('provides_builder').map((p) => p.name).forEach(
       (p) => actions.addAll(
           buildersForprovides_builder.map((b) => new _1.BuildAction(b, p))));

--- a/e2e_example/test/serve_integration_test.dart
+++ b/e2e_example/test/serve_integration_test.dart
@@ -12,7 +12,7 @@ import 'common/utils.dart';
 
 void main() {
   setUpAll(() async {
-    await startServer(ensureCleanBuild: true, verbose: true);
+    await startManualServer(ensureCleanBuild: true, verbose: true);
   });
 
   tearDownAll(() async {


### PR DESCRIPTION
This will make it easier to see changes to the file as we adjust the
generation.

- Add a `pkgs` subdirectory with a package exporting a builder through
  `build.yaml`
- Rename `startServer` to `startManualServer` to distinguish from
  `startAutoServer` using the new entrypoint.
- Add an integration test which runs a build through the new entrypoint
  and then compares against a golden version of the generated build
  script