### PR TITLE
Increase timeout for e2e_example's tests.

### DIFF
--- a/e2e_example/dart_test.yaml
+++ b/e2e_example/dart_test.yaml
@@ -1,4 +1,4 @@
-timeout: 2x
+timeout: 4x
 # These test suites must not run in parallel, they modify actual sources in the
 # package.
 concurrency: 1


### PR DESCRIPTION
Hopefully we don't really need the `4x`, but better safe than flakey.

Ultimately we need benchmarks/perf, but travis isn't the place for that anyway.

Closes https://github.com/dart-lang/build/issues/602.