### PR TITLE
Use a combined inputs hash to check if we need to run a build

### DIFF
--- a/build_compilers/lib/src/summary_builder.dart
+++ b/build_compilers/lib/src/summary_builder.dart
@@ -76,7 +76,7 @@ Future createUnlinkedSummary(Module module, BuildStep buildStep,
   request.arguments.addAll([
     '--build-summary-only',
     '--build-summary-only-unlinked',
-    '--build-summary-output=${summaryOutputFile.path}',
+    '--build-summary-output-semantic=${summaryOutputFile.path}',
     '--strong',
   ]);
 
@@ -117,17 +117,17 @@ Future createLinkedSummary(Module module, BuildStep buildStep,
   var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
 
   var allAssetIds = new Set<AssetId>()
+    // TODO: Why can't we just add the unlinked summary?
+    // That would help invalidation.
     ..addAll(module.sources)
     ..addAll(transitiveLinkedSummaryDeps)
     ..addAll(transitiveUnlinkedSummaryDeps);
   await scratchSpace.ensureAssets(allAssetIds, buildStep);
   var summaryOutputFile = scratchSpace.fileFor(module.linkedSummaryId);
   var request = new WorkRequest();
-  // TODO(jakemac53): Diet parsing results in erroneous errors in later steps,
-  // but ideally we would do that (pass '--build-summary-only-diet').
   request.arguments.addAll([
     '--build-summary-only',
-    '--build-summary-output=${summaryOutputFile.path}',
+    '--build-summary-output-semantic=${summaryOutputFile.path}',
     '--strong',
   ]);
 
@@ -145,7 +145,8 @@ Future createLinkedSummary(Module module, BuildStep buildStep,
   request.arguments.addAll(_analyzerSourceArgsForModule(module, scratchSpace));
   var analyzer = await buildStep.fetchResource(analyzerDriverResource);
   var response = await analyzer.doWork(request);
-  if (response.exitCode == EXIT_CODE_ERROR) {
+  var summaryFile = scratchSpace.fileFor(module.linkedSummaryId);
+  if (response.exitCode == EXIT_CODE_ERROR || !await summaryFile.exists()) {
     throw new AnalyzerSummaryException(module.linkedSummaryId, response.output);
   }
 

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -193,19 +193,20 @@ class AssetGraph {
         newAndModifiedNodes.where((node) => node.outputs.isNotEmpty),
         digestReader);
 
-    // Remove all deleted source assets from the graph, which also recursively
-    // removes all their primary outputs.
-    var removedSources =
-        removeIds.where((id) => get(id) is SourceAssetNode).toSet();
+    // Collects the set of all transitive ids to be removed from the graph,
+    // based on the removed `SourceAssetNode`s by following the
+    // `primaryOutputs`.
     var transitiveRemovedIds = new Set<AssetId>();
     addTransitivePrimaryOutputs(AssetId id) {
       transitiveRemovedIds.add(id);
       get(id).primaryOutputs.forEach(addTransitivePrimaryOutputs);
     }
 
-    removedSources.forEach(addTransitivePrimaryOutputs);
+    removeIds
+        .where((id) => get(id) is SourceAssetNode)
+        .forEach(addTransitivePrimaryOutputs);
 
-    // The generated nodes to delete.
+    // The generated nodes to actually delete from the file system.
     var idsToDelete = new Set<AssetId>.from(transitiveRemovedIds)
       ..removeAll(removeIds);
 

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -194,10 +194,13 @@ class AssetGraph {
 
     // Remove all deleted source assets from the graph, which also recursively
     // removes all their primary outputs.
-    var idsToDelete = new Set<AssetId>();
-    removeIds
-        .where((id) => get(id) is SourceAssetNode)
-        .forEach((id) => _remove(id, removedIds: idsToDelete));
+    var removedSources =
+        removeIds.where((id) => get(id) is SourceAssetNode).toSet();
+    var transitiveRemovedIds = new Set<AssetId>();
+    removedSources
+        .forEach((id) => _remove(id, removedIds: transitiveRemovedIds));
+    // The generated nodes to delete.
+    var idsToDelete = transitiveRemovedIds..removeAll(removeIds);
 
     var allNewAndDeletedIds =
         _addOutputsForSources(buildActions, newIds, rootPackage)

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'package:build/build.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
@@ -74,7 +76,10 @@ class GeneratedAssetNode extends AssetNode {
 
   /// All the inputs that were read when generating this asset, or deciding not
   /// to generate it.
-  final Set<AssetId> inputs;
+  ///
+  /// This needs to be an ordered set because we compute combined input digests
+  /// using this later on.
+  final SplayTreeSet<AssetId> inputs;
 
   /// A digest combining all digests of all previous inputs.
   ///
@@ -85,7 +90,9 @@ class GeneratedAssetNode extends AssetNode {
       this.wasOutput, AssetId id,
       {Digest lastKnownDigest, Set<Glob> globs, Iterable<AssetId> inputs})
       : this.globs = globs ?? new Set<Glob>(),
-        this.inputs = inputs?.toSet() ?? new Set<AssetId>(),
+        this.inputs = inputs != null
+            ? new SplayTreeSet.from(inputs)
+            : new SplayTreeSet<AssetId>(),
         super(id, lastKnownDigest: lastKnownDigest);
 
   @override

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -88,7 +88,10 @@ class GeneratedAssetNode extends AssetNode {
 
   GeneratedAssetNode(this.phaseNumber, this.primaryInput, this.needsUpdate,
       this.wasOutput, AssetId id,
-      {Digest lastKnownDigest, Set<Glob> globs, Iterable<AssetId> inputs})
+      {Digest lastKnownDigest,
+      Set<Glob> globs,
+      Iterable<AssetId> inputs,
+      this.previousInputsDigest})
       : this.globs = globs ?? new Set<Glob>(),
         this.inputs = inputs != null
             ? new SplayTreeSet.from(inputs)

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -76,6 +76,11 @@ class GeneratedAssetNode extends AssetNode {
   /// to generate it.
   final Set<AssetId> inputs;
 
+  /// A digest combining all digests of all previous inputs.
+  ///
+  /// This is used to determine if a node really needs to be output or not.
+  Digest previousInputsDigest;
+
   GeneratedAssetNode(this.phaseNumber, this.primaryInput, this.needsUpdate,
       this.wasOutput, AssetId id,
       {Digest lastKnownDigest, Set<Glob> globs, Iterable<AssetId> inputs})

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -83,7 +83,8 @@ class GeneratedAssetNode extends AssetNode {
 
   /// A digest combining all digests of all previous inputs.
   ///
-  /// This is used to determine if a node really needs to be output or not.
+  /// Used to determine whether all the inputs to a build step are identical to
+  /// the previous run, indicating that the previous output is still valid.
   Digest previousInputsDigest;
 
   GeneratedAssetNode(this.phaseNumber, this.primaryInput, this.needsUpdate,

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -8,7 +8,7 @@ part of 'graph.dart';
 ///
 /// This should be incremented any time the serialize/deserialize formats
 /// change.
-const _version = 10;
+const _version = 11;
 
 /// Deserializes an [AssetGraph] from a [Map].
 class _AssetGraphDeserializer {
@@ -159,7 +159,8 @@ enum _Field {
   WasOutput,
   PhaseNumber,
   Globs,
-  NeedsUpdate
+  NeedsUpdate,
+  PreviousInputsDigest
 }
 
 /// Wraps an [AssetNode] in a class that implements [List] instead of
@@ -253,6 +254,10 @@ class _WrappedGeneratedAssetNode extends _WrappedAssetNode {
         return generatedNode.globs.map((glob) => glob.pattern).toList();
       case _Field.NeedsUpdate:
         return _serializeBool(generatedNode.needsUpdate);
+      case _Field.PreviousInputsDigest:
+        return generatedNode.previousInputsDigest == null
+            ? null
+            : BASE64.encode(generatedNode.previousInputsDigest.bytes);
       default:
         throw new RangeError.index(index, this);
     }

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -453,6 +453,7 @@ class BuildImpl {
     //
     // Also updates the `inputs` set for each output, and the `outputs` sets for
     // all inputs.
+    var inputsDigest = await _computeCombinedDigest(reader.assetsRead, reader);
     for (var output in declaredOutputs) {
       var node = _assetGraph.get(output) as GeneratedAssetNode;
       node
@@ -484,8 +485,7 @@ class BuildImpl {
       }
 
       // And finally compute the combined digest for all inputs.
-      node.previousInputsDigest =
-          await _computeCombinedDigest(node.inputs, reader);
+      node.previousInputsDigest = inputsDigest;
     }
 
     // Mark the actual outputs as output.

--- a/build_runner/test/common/matchers.dart
+++ b/build_runner/test/common/matchers.dart
@@ -92,6 +92,12 @@ class _AssetGraphMatcher extends Matcher {
             ];
             matches = false;
           }
+          if (node.previousInputsDigest != expectedNode.previousInputsDigest) {
+            matchState['previousInputDigest of ${node.id}'] = [
+              node.previousInputsDigest,
+              expectedNode.previousInputsDigest
+            ];
+          }
         } else {
           matchState['Type of ${node.id}'] = [
             node.runtimeType,

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -331,11 +331,11 @@ void main() {
             ChangeType.REMOVE, path.absolute('a', 'web', 'a.txt.copy')));
 
         result = await results.next;
-        // Should rebuild the generated asset and its outputs.
+        // Should rebuild the generated asset, but not its outputs because its
+        // content didn't change.
         checkBuild(result,
             outputs: {
               'a|web/a.txt.copy': 'a',
-              'a|web/a.txt.copy.copy': 'a',
             },
             writer: writer);
       });

--- a/e2e_example/tool/build.dart
+++ b/e2e_example/tool/build.dart
@@ -42,13 +42,13 @@ Future main() async {
   );
 
   var server =
-      await shelf_io.serve(serveHandler.handlerFor('web'), 'localhost', 8080);
+      await shelf_io.serve(serveHandler.handlerFor('web'), 'localhost', 8086);
   var testServer =
-      await shelf_io.serve(serveHandler.handlerFor('test'), 'localhost', 8081);
+      await shelf_io.serve(serveHandler.handlerFor('test'), 'localhost', 8087);
 
   await serveHandler.currentBuild;
-  stderr.writeln('Serving `web` at http://localhost:8080/');
-  stderr.writeln('Serving `test` at http://localhost:8081/');
+  stderr.writeln('Serving `web` at http://localhost:8086/');
+  stderr.writeln('Serving `test` at http://localhost:8087/');
 
   await serveHandler.buildResults.drain();
   await server.close();

--- a/e2e_example/tool/build.dart
+++ b/e2e_example/tool/build.dart
@@ -42,13 +42,13 @@ Future main() async {
   );
 
   var server =
-      await shelf_io.serve(serveHandler.handlerFor('web'), 'localhost', 8086);
+      await shelf_io.serve(serveHandler.handlerFor('web'), 'localhost', 8080);
   var testServer =
-      await shelf_io.serve(serveHandler.handlerFor('test'), 'localhost', 8087);
+      await shelf_io.serve(serveHandler.handlerFor('test'), 'localhost', 8081);
 
   await serveHandler.currentBuild;
-  stderr.writeln('Serving `web` at http://localhost:8086/');
-  stderr.writeln('Serving `test` at http://localhost:8087/');
+  stderr.writeln('Serving `web` at http://localhost:8080/');
+  stderr.writeln('Serving `test` at http://localhost:8081/');
 
   await serveHandler.buildResults.drain();
   await server.close();


### PR DESCRIPTION
This was more nuanced than I expected, and I ended up needing to clean up a few other things in the process. Highlights are as follows:

- Changed summaries to semantic summaries (we were actually relying on the full ones before, whoops!)
- Fixed some behavior around replacing `SyntheticAssetNode`s with real ones. Previously we would remove all the outputs from the graph and clean up their inputs sets which wasn't correct (we want to retain all those edges and nodes, and just swap out the node in question).
- When invalidating nodes, we no longer pre-emptively delete them. In fact, I never explicitly delete them in this cl I just rely on the asset writer to overwrite them (unless their primary input is deleted).
- The inputs set for `GeneratedAssetNode`s is now ordered to ensure the combined md5 hash will always be the same for the same inputs.

Fixes https://github.com/dart-lang/build/issues/371