### PR TITLE
Add an `enableLowResourcesMode` option to `build` and `watch`

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.1-dev
+
+- Add an `enableLowResourcesMode` option to `build` and `watch`, which will
+  consume less memory at the cost of slower builds. This is intended for use in
+  resource constrained environments such as Travis.
+
 ## 0.6.0+1
 
 ### Internal Improvements

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -48,7 +48,8 @@ Future<BuildResult> build(List<BuildAction> buildActions,
         RunnerAssetWriter writer,
         Level logLevel,
         onLog(LogRecord record),
-        Stream terminateEventStream}) =>
+        Stream terminateEventStream,
+        bool enableLowResourcesMode}) =>
     build_impl.build(buildActions,
         deleteFilesByDefault: deleteFilesByDefault,
         writeToCache: writeToCache,
@@ -57,7 +58,8 @@ Future<BuildResult> build(List<BuildAction> buildActions,
         writer: writer,
         logLevel: logLevel,
         onLog: onLog,
-        terminateEventStream: terminateEventStream);
+        terminateEventStream: terminateEventStream,
+        enableLowResourcesMode: enableLowResourcesMode);
 
 /// Same as [build], except it watches the file system and re-runs builds
 /// automatically.
@@ -89,7 +91,8 @@ Future<ServeHandler> watch(List<BuildAction> buildActions,
         onLog(LogRecord record),
         Duration debounceDelay,
         DirectoryWatcherFactory directoryWatcherFactory,
-        Stream terminateEventStream}) =>
+        Stream terminateEventStream,
+        bool enableLowResourcesMode}) =>
     watch_impl.watch(buildActions,
         deleteFilesByDefault: deleteFilesByDefault,
         writeToCache: writeToCache,
@@ -100,4 +103,5 @@ Future<ServeHandler> watch(List<BuildAction> buildActions,
         onLog: onLog,
         debounceDelay: debounceDelay,
         directoryWatcherFactory: directoryWatcherFactory,
-        terminateEventStream: terminateEventStream);
+        terminateEventStream: terminateEventStream,
+        enableLowResourcesMode: enableLowResourcesMode);

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -46,6 +46,10 @@ class BuildDefinition {
 
   final BuildScriptUpdates buildScriptUpdates;
 
+  /// Whether or not to run in a mode that conserves RAM at the cost of build
+  /// speed.
+  final bool enableLowResourcesMode;
+
   BuildDefinition._(
       this.assetGraph,
       this.updates,
@@ -55,7 +59,8 @@ class BuildDefinition {
       this.packageGraph,
       this.deleteFilesByDefault,
       this.resourceManager,
-      this.buildScriptUpdates);
+      this.buildScriptUpdates,
+      this.enableLowResourcesMode);
 
   static Future<BuildDefinition> load(
           BuildOptions options, List<BuildAction> buildActions) =>
@@ -136,7 +141,8 @@ class _Loader {
         _options.packageGraph,
         _options.deleteFilesByDefault,
         new ResourceManager(),
-        buildScriptUpdates);
+        buildScriptUpdates,
+        _options.enableLowResourcesMode);
   }
 
   /// Reads in an [AssetGraph] from disk.

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -20,6 +20,7 @@ class BuildOptions {
   RunnerAssetReader reader;
   RunnerAssetWriter writer;
   bool deleteFilesByDefault;
+  bool enableLowResourcesMode;
 
   /// Whether to write to a cache directory rather than the package's source
   /// directory.
@@ -45,7 +46,8 @@ class BuildOptions {
       this.packageGraph,
       this.reader,
       this.writer,
-      this.skipBuildScriptCheck}) {
+      this.skipBuildScriptCheck,
+      this.enableLowResourcesMode}) {
     /// Set up logging
     logLevel ??= Level.INFO;
     Logger.root.level = logLevel;
@@ -60,5 +62,6 @@ class BuildOptions {
     deleteFilesByDefault ??= writeToCache ?? false;
     writeToCache ??= false;
     skipBuildScriptCheck ??= false;
+    enableLowResourcesMode ??= false;
   }
 }

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -39,7 +39,8 @@ Future<ServeHandler> watch(List<BuildAction> buildActions,
     Duration debounceDelay,
     DirectoryWatcherFactory directoryWatcherFactory,
     Stream terminateEventStream,
-    bool skipBuildScriptCheck}) async {
+    bool skipBuildScriptCheck,
+    bool enableLowResourcesMode}) async {
   var options = new BuildOptions(
       deleteFilesByDefault: deleteFilesByDefault,
       writeToCache: writeToCache,
@@ -50,7 +51,8 @@ Future<ServeHandler> watch(List<BuildAction> buildActions,
       onLog: onLog,
       debounceDelay: debounceDelay,
       directoryWatcherFactory: directoryWatcherFactory,
-      skipBuildScriptCheck: skipBuildScriptCheck);
+      skipBuildScriptCheck: skipBuildScriptCheck,
+      enableLowResourcesMode: enableLowResourcesMode);
   var terminator = new Terminator(terminateEventStream);
   var watch = runWatch(options, buildActions, terminator.shouldTerminate);
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.6.0+1
+version: 0.6.1-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -72,7 +72,8 @@ Future<BuildResult> testActions(List<BuildAction> buildActions,
     onLog(LogRecord record),
     bool writeToCache,
     bool checkBuildStatus: true,
-    bool deleteFilesByDefault: true}) async {
+    bool deleteFilesByDefault: true,
+    bool enableLowResourcesMode: false}) async {
   writer ??= new InMemoryRunnerAssetWriter();
   writeToCache ??= false;
   final actualAssets = writer.assets;
@@ -101,7 +102,8 @@ Future<BuildResult> testActions(List<BuildAction> buildActions,
       packageGraph: packageGraph,
       logLevel: logLevel,
       onLog: onLog,
-      skipBuildScriptCheck: true);
+      skipBuildScriptCheck: true,
+      enableLowResourcesMode: enableLowResourcesMode);
 
   if (checkBuildStatus) {
     checkBuild(result,

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -201,6 +201,13 @@ void main() {
               makeAssetId('a|web/a.txt.copy.clone'),
             ]));
       });
+
+      test('in low resources mode', () async {
+        await testActions(
+            [copyABuildAction], {'a|web/a.txt': 'a', 'a|lib/b.txt': 'b'},
+            outputs: {'a|web/a.txt.copy': 'a', 'a|lib/b.txt.copy': 'b'},
+            enableLowResourcesMode: true);
+      });
     });
 
     test('can\'t output files in non-root packages', () async {


### PR DESCRIPTION
Today this disables the file caching, but it may do more in the future.

I only added a simple unit test to make sure basic builds work - I don't know how crazy we want to get with testing the matrix of all options.

Closes https://github.com/dart-lang/build/issues/605