### PR TITLE
move initial asset graph updates into BuildDefinition.load

### DIFF
--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -57,10 +57,10 @@ class BuildDefinition {
       this.enableLowResourcesMode,
       this.onDelete);
 
-  static Future<BuildDefinition> load(
+  static Future<BuildDefinition> prepareWorkspace(
           BuildOptions options, List<BuildAction> buildActions,
           {void onDelete(AssetId id)}) =>
-      new _Loader(options, buildActions, onDelete).load();
+      new _Loader(options, buildActions, onDelete).prepareWorkspace();
 }
 
 class _Loader {
@@ -70,7 +70,7 @@ class _Loader {
 
   _Loader(this._options, this._buildActions, this._onDelete);
 
-  Future<BuildDefinition> load() async {
+  Future<BuildDefinition> prepareWorkspace() async {
     if (!_options.writeToCache) {
       final root = _options.packageGraph.root.name;
       for (final action in _buildActions) {

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -68,7 +68,8 @@ Future<BuildResult> build(List<BuildAction> buildActions,
 
 Future<BuildResult> singleBuild(
     BuildOptions options, List<BuildAction> buildActions) async {
-  var buildDefinition = await BuildDefinition.load(options, buildActions);
+  var buildDefinition =
+      await BuildDefinition.prepareWorkspace(options, buildActions);
   var result =
       (await BuildImpl.create(buildDefinition, buildActions)).firstBuild;
   await buildDefinition.resourceManager.beforeExit();

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -75,43 +75,35 @@ Future<BuildResult> singleBuild(
   return result;
 }
 
-typedef void _OnDelete(AssetId id);
-
 class BuildImpl {
   BuildResult _firstBuild;
   BuildResult get firstBuild => _firstBuild;
 
   final AssetGraph _assetGraph;
   final List<BuildAction> _buildActions;
-  final _OnDelete _onDelete;
+  final OnDelete _onDelete;
   final PackageGraph _packageGraph;
   final DigestAssetReader _reader;
   final _resolvers = const BarbackResolvers();
   final ResourceManager _resourceManager;
   final RunnerAssetWriter _writer;
 
-  BuildImpl._(
-      BuildDefinition buildDefinition, this._buildActions, this._onDelete)
+  BuildImpl._(BuildDefinition buildDefinition, this._buildActions)
       : _packageGraph = buildDefinition.packageGraph,
         _reader = buildDefinition.enableLowResourcesMode
             ? buildDefinition.reader
             : new CachingAssetReader(buildDefinition.reader),
         _writer = buildDefinition.writer,
         _assetGraph = buildDefinition.assetGraph,
-        _resourceManager = buildDefinition.resourceManager;
+        _resourceManager = buildDefinition.resourceManager,
+        _onDelete = buildDefinition.onDelete;
 
   static Future<BuildImpl> create(
       BuildDefinition buildDefinition, List<BuildAction> buildActions,
       {void onDelete(AssetId id)}) async {
-    var build = new BuildImpl._(buildDefinition, buildActions, onDelete);
+    var build = new BuildImpl._(buildDefinition, buildActions);
 
-    await logTimedAsync(
-        _logger,
-        'Checking for stale files',
-        () => build._firstBuildCleanup(buildDefinition.conflictingAssets,
-            buildDefinition.deleteFilesByDefault));
-
-    build._firstBuild = await build.run(buildDefinition.updates);
+    build._firstBuild = await build.run({});
     return build;
   }
 
@@ -170,58 +162,6 @@ class BuildImpl {
           exception: e, stackTrace: trace));
     });
     return done.future;
-  }
-
-  Future<Null> _firstBuildCleanup(
-      Set<AssetId> conflictingAssets, bool deleteFilesByDefault) async {
-    if (conflictingAssets.isEmpty) return;
-
-    // Skip the prompt if using this option.
-    if (deleteFilesByDefault) {
-      _logger.info('Deleting ${conflictingAssets.length} declared outputs '
-          'which already existed on disk.');
-      await Future.wait(conflictingAssets.map(_delete));
-      return;
-    }
-
-    // Prompt the user to delete files that are declared as outputs.
-    _logger.info('Found ${conflictingAssets.length} declared outputs '
-        'which already exist on disk. This is likely because the'
-        '`$cacheDir` folder was deleted, or you are submitting generated '
-        'files to your source repository.');
-
-    // If not in a standard terminal then we just exit, since there is no way
-    // for the user to provide a yes/no answer.
-    bool runningInPubRunTest() => Platform.script.scheme == 'data';
-    if (stdioType(stdin) != StdioType.TERMINAL || runningInPubRunTest()) {
-      throw new UnexpectedExistingOutputsException(conflictingAssets);
-    }
-
-    // Give a little extra space after the last message, need to make it clear
-    // this is a prompt.
-    stdout.writeln();
-    var done = false;
-    while (!done) {
-      stdout.write('\nDelete these files (y/n) (or list them (l))?: ');
-      var input = stdin.readLineSync();
-      switch (input.toLowerCase()) {
-        case 'y':
-          stdout.writeln('Deleting files...');
-          done = true;
-          await Future.wait(conflictingAssets.map(_delete));
-          break;
-        case 'n':
-          throw new UnexpectedExistingOutputsException(conflictingAssets);
-          break;
-        case 'l':
-          for (var output in conflictingAssets) {
-            stdout.writeln(output);
-          }
-          break;
-        default:
-          stdout.writeln('Unrecognized option $input, (y/n/l) expected.');
-      }
-    }
   }
 
   /// Runs the actions in [_buildActions] and returns a [Future<BuildResult>]

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -174,7 +174,8 @@ class WatchImpl implements BuildState {
     // Schedule the actual first build for the future so we can return the
     // stream synchronously.
     () async {
-      _buildDefinition = await BuildDefinition.load(options, buildActions);
+      _buildDefinition = await BuildDefinition.load(options, buildActions,
+          onDelete: _expectedDeletes.add);
       _readerCompleter.complete(_buildDefinition.reader);
       _assetGraph = _buildDefinition.assetGraph;
       build = await BuildImpl.create(_buildDefinition, buildActions,

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -174,7 +174,8 @@ class WatchImpl implements BuildState {
     // Schedule the actual first build for the future so we can return the
     // stream synchronously.
     () async {
-      _buildDefinition = await BuildDefinition.load(options, buildActions,
+      _buildDefinition = await BuildDefinition.prepareWorkspace(
+          options, buildActions,
           onDelete: _expectedDeletes.add);
       _readerCompleter.complete(_buildDefinition.reader);
       _assetGraph = _buildDefinition.assetGraph;

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -90,7 +90,8 @@ main() {
             assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
 
         await deleteFile(p.join('lib', 'b.txt'));
-        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        var buildDefinition =
+            await BuildDefinition.prepareWorkspace(options, buildActions);
         var newAssetGraph = buildDefinition.assetGraph;
 
         generatedANode = newAssetGraph.get(generatedAId) as GeneratedAssetNode;
@@ -112,7 +113,8 @@ main() {
             assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
 
         await createFile(p.join('lib', 'a.txt'), 'a');
-        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        var buildDefinition =
+            await BuildDefinition.prepareWorkspace(options, buildActions);
         var newAssetGraph = buildDefinition.assetGraph;
 
         expect(newAssetGraph.contains(makeAssetId('a|lib/a.txt')), isTrue);
@@ -134,7 +136,8 @@ main() {
             assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
 
         await modifyFile(p.join('lib', 'a.txt'), 'b');
-        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        var buildDefinition =
+            await BuildDefinition.prepareWorkspace(options, buildActions);
         var newAssetGraph = buildDefinition.assetGraph;
 
         var generatedANode = newAssetGraph.get(makeAssetId('a|lib/a.txt.copy'))
@@ -159,7 +162,8 @@ main() {
         await createFile(
             assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
 
-        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        var buildDefinition =
+            await BuildDefinition.prepareWorkspace(options, buildActions);
         expect(buildDefinition.assetGraph.contains(generatedSrcId), isTrue);
       });
     });
@@ -177,7 +181,8 @@ main() {
 
         await createFile(assetGraphPath, JSON.encode(assetGraph.serialize()));
 
-        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        var buildDefinition =
+            await BuildDefinition.prepareWorkspace(options, buildActions);
 
         expect(buildDefinition.assetGraph.contains(generatedId), isFalse);
       });
@@ -185,7 +190,8 @@ main() {
       test('includes generated entrypoint', () async {
         var entryPoint =
             new AssetId('a', p.url.join(entryPointDir, 'build.dart'));
-        var buildDefinition = await BuildDefinition.load(options, []);
+        var buildDefinition =
+            await BuildDefinition.prepareWorkspace(options, []);
         expect(buildDefinition.assetGraph.contains(entryPoint), isTrue);
       });
 
@@ -193,7 +199,8 @@ main() {
         var entryPoint =
             new AssetId('a', p.url.join(entryPointDir, 'build.dart'));
         var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
-        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        var buildDefinition =
+            await BuildDefinition.prepareWorkspace(options, buildActions);
         expect(
             buildDefinition.assetGraph
                 .contains(entryPoint.addExtension('.copy')),

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -10,7 +10,6 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
-import 'package:watcher/watcher.dart';
 
 import 'package:build_runner/build_runner.dart';
 import 'package:build_runner/src/asset_graph/graph.dart';
@@ -32,7 +31,19 @@ main() {
       expect(await file.exists(), isFalse);
       await file.create(recursive: true);
       await file.writeAsString(contents);
-      addTearDown(() => file.delete());
+      addTearDown(() async => await file.exists() ? await file.delete() : null);
+    }
+
+    Future<Null> deleteFile(String path) async {
+      var file = new File(p.join(pkgARoot, path));
+      expect(await file.exists(), isTrue);
+      await file.delete();
+    }
+
+    Future<Null> modifyFile(String path, String contents) async {
+      var file = new File(p.join(pkgARoot, path));
+      expect(await file.exists(), isTrue);
+      await file.writeAsString(contents);
     }
 
     setUp(() async {
@@ -58,42 +69,98 @@ main() {
           skipBuildScriptCheck: true);
     });
 
-    group('updates', () {
-      test('contains deleted outputs as remove events', () async {
-        await createFile(p.join('lib', 'test.txt'), 'a');
+    group('updates the asset graph', () {
+      test('for deleted source and generated nodes', () async {
+        await createFile(p.join('lib', 'a.txt'), 'a');
+        await createFile(p.join('lib', 'b.txt'), 'b');
         var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
 
-        var assetGraph = await AssetGraph.build(buildActions,
-            [makeAssetId('a|lib/test.txt')].toSet(), 'a', options.reader);
-        var generatedSrcId = makeAssetId('a|lib/test.txt.copy');
-        var generatedNode =
-            assetGraph.get(generatedSrcId) as GeneratedAssetNode;
-        generatedNode.wasOutput = true;
+        var originalAssetGraph = await AssetGraph.build(
+            buildActions,
+            [makeAssetId('a|lib/a.txt'), makeAssetId('a|lib/b.txt')].toSet(),
+            'a',
+            options.reader);
+        var generatedAId = makeAssetId('a|lib/a.txt.copy');
+        var generatedANode =
+            originalAssetGraph.get(generatedAId) as GeneratedAssetNode;
+        generatedANode.wasOutput = true;
+        generatedANode.needsUpdate = false;
 
-        await createFile(assetGraphPath, JSON.encode(assetGraph.serialize()));
+        await createFile(
+            assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
 
+        await deleteFile(p.join('lib', 'b.txt'));
         var buildDefinition = await BuildDefinition.load(options, buildActions);
-        expect(buildDefinition.updates, contains(generatedSrcId));
-        expect(buildDefinition.updates[generatedSrcId], ChangeType.REMOVE);
+        var newAssetGraph = buildDefinition.assetGraph;
+
+        generatedANode = newAssetGraph.get(generatedAId) as GeneratedAssetNode;
+        expect(generatedANode, isNotNull);
+        expect(generatedANode.needsUpdate, isTrue);
+
+        expect(newAssetGraph.contains(makeAssetId('a|lib/b.txt')), isFalse);
+        expect(
+            newAssetGraph.contains(makeAssetId('a|lib/b.txt.copy')), isFalse);
       });
 
-      test('ignores non-output generated nodes', () async {
+      test('for new sources and generated nodes', () async {
+        var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
+
+        var originalAssetGraph = await AssetGraph.build(
+            buildActions, <AssetId>[].toSet(), 'a', options.reader);
+
+        await createFile(
+            assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
+
+        await createFile(p.join('lib', 'a.txt'), 'a');
+        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        var newAssetGraph = buildDefinition.assetGraph;
+
+        expect(newAssetGraph.contains(makeAssetId('a|lib/a.txt')), isTrue);
+
+        var generatedANode = newAssetGraph.get(makeAssetId('a|lib/a.txt.copy'))
+            as GeneratedAssetNode;
+        expect(generatedANode, isNotNull);
+        expect(generatedANode.needsUpdate, isTrue);
+      });
+
+      test('for changed sources', () async {
+        await createFile(p.join('lib', 'a.txt'), 'a');
+        var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
+
+        var originalAssetGraph = await AssetGraph.build(buildActions,
+            [makeAssetId('a|lib/a.txt')].toSet(), 'a', options.reader);
+
+        await createFile(
+            assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
+
+        await modifyFile(p.join('lib', 'a.txt'), 'b');
+        var buildDefinition = await BuildDefinition.load(options, buildActions);
+        var newAssetGraph = buildDefinition.assetGraph;
+
+        var generatedANode = newAssetGraph.get(makeAssetId('a|lib/a.txt.copy'))
+            as GeneratedAssetNode;
+        expect(generatedANode, isNotNull);
+        expect(generatedANode.needsUpdate, isTrue);
+      });
+
+      test('retains non-output generated nodes', () async {
         await createFile(p.join('lib', 'test.txt'), 'a');
         var buildActions = [
           new BuildAction(new OverDeclaringCopyBuilder(), 'a')
         ];
 
-        var assetGraph = await AssetGraph.build(buildActions,
+        var originalAssetGraph = await AssetGraph.build(buildActions,
             [makeAssetId('a|lib/test.txt')].toSet(), 'a', options.reader);
         var generatedSrcId = makeAssetId('a|lib/test.txt.copy');
         var generatedNode =
-            assetGraph.get(generatedSrcId) as GeneratedAssetNode;
+            originalAssetGraph.get(generatedSrcId) as GeneratedAssetNode;
         generatedNode.wasOutput = false;
 
-        await createFile(assetGraphPath, JSON.encode(assetGraph.serialize()));
+        await createFile(
+            assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
 
         var buildDefinition = await BuildDefinition.load(options, buildActions);
-        expect(buildDefinition.updates, isNot(contains(generatedSrcId)));
+        expect(buildDefinition.assetGraph.contains(generatedSrcId), isTrue);
       });
     });
 
@@ -111,7 +178,7 @@ main() {
         await createFile(assetGraphPath, JSON.encode(assetGraph.serialize()));
 
         var buildDefinition = await BuildDefinition.load(options, buildActions);
-        expect(buildDefinition.updates, isNot(contains(generatedId)));
+
         expect(buildDefinition.assetGraph.contains(generatedId), isFalse);
       });
 

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -278,7 +278,8 @@ void main() {
         var writer = new InMemoryRunnerAssetWriter()
           ..onDelete = (AssetId assetId) {
             if (assetId.package != 'a') {
-              throw 'Should not delete outside of package:a';
+              throw 'Should not delete outside of package:a, '
+                  'tried to delete $assetId';
             }
           };
         await testActions(


### PR DESCRIPTION
- Fixes a bug where if between builds your build script changed such that it imports a new asset that didn't exist in the graph before you would get an error like `BuildScriptUpdates: e2e_example|tool/foo.dart was not found in the asset graph, incremental builds will not work. This probably means you don't have your dependencies specified fully in your pubspec.yaml`.
  - Now the asset graph is updated with new sources before that check so you won't see the error.
- Allows us to remove the updates and conflictingAssets fields from BuildDefinition which were always a bit weird.