### PR TITLE
Verify build actions against previous ones

### DIFF
--- a/e2e_example/test/build_script_invalidation_test.dart
+++ b/e2e_example/test/build_script_invalidation_test.dart
@@ -21,8 +21,7 @@ void main() {
     test('while serving prompt the user to restart', () async {
       var terminateLine =
           nextStdOutLine('Terminating. No further builds will be scheduled');
-      await replaceAllInFile(
-          'tool/build.dart', 'ThrowingBuilder', 'FailingBuilder');
+      await replaceAllInFile('tool/build.dart', 'Serving', 'Now serving');
       await terminateLine;
       await stopServer();
       await startManualServer(extraExpects: [
@@ -34,8 +33,7 @@ void main() {
 
     test('while not serving invalidate the next build', () async {
       await stopServer();
-      await replaceAllInFile(
-          'tool/build.dart', 'ThrowingBuilder', 'FailingBuilder');
+      await replaceAllInFile('tool/build.dart', 'Serving', 'Now serving');
       await startManualServer(extraExpects: [
         () => nextStdOutLine(
             'Invalidating asset graph due to build script update'),


### PR DESCRIPTION
Currently using the `runtimeType` to verify builders - I don't know that `Object.hashCode` would be consistent across runs (or even if it is today, I don't see anything guaranteeing that will always be the case).

This technically allows you to change a builder implementation to one by the same name in a different file and we wouldn't detect that, but I think that is fine.

Closes https://github.com/dart-lang/build/issues/559