### PR TITLE
fix bug where nodes werent synchronously updated

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -31,6 +31,8 @@
   it was never removed, causing extra builds to happen that weren't necessary.
 - Build actions are now checked for overlapping outputs in non-checked mode,
   previously this was only an assert.
+- Fixed an issue where nodes could get in an inconsistent state for short
+  periods of time, leading to various errors.
 
 ## 0.6.0+1
 


### PR DESCRIPTION
Previously there was a gap of time between when we marked a node as `wasOutput = false` and `needsUpdate = false`, and then came back later and marked `wasOuput = true` for the nodes that were really output.

Now we do all updates to nodes synchronously to ensure they are always in a valid state.