### PR TITLE
Deprecate inputs and excludes from PackageNode

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Deprecations
 
 - Deprecate `PackageGraph.orderedPackages` and `PackageGraph.dependentsOf`.
+- Deprecate `PackageNdoe.includes` and `PackageGraph.excludes`.
 
 ### Internal Improvements
 

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -272,8 +272,11 @@ class _Loader {
   /// Returns the set of original package inputs on disk.
   Future<Set<AssetId>> _findInputSources() async {
     var inputSets = _options.packageGraph.allPackages.values.map((package) =>
-        new InputSet(package.name, package.includes,
-            excludes: package.excludes));
+        new InputSet(
+            package.name,
+            package.name == _options.packageGraph.root.name
+                ? const ['**']
+                : const ['lib/**']));
     var sources = (await _listAssetIds(inputSets).toSet())
       ..addAll(await _options.reader
           .findAssets(new Glob('$entryPointDir/**'))

--- a/build_runner/lib/src/package_graph/package_graph.dart
+++ b/build_runner/lib/src/package_graph/package_graph.dart
@@ -191,20 +191,20 @@ class PackageNode {
   ///
   /// Only the files matching these patterns will end up in the asset graph,
   /// unless they also match a pattern in [excludes].
-  final List<String> _includes;
-  Iterable<String> get includes => _includes;
+  @deprecated
+  final Iterable<String> includes;
 
   /// The glob patterns to exclude from this package.
   ///
   /// Any files matching these pattern will be excluded from the asset graph.
-  final List<String> _excludes;
-  Iterable<String> get excludes => _excludes;
+  @deprecated
+  final Iterable<String> excludes;
 
   PackageNode(this.name, this.version, this.dependencyType, String path,
       {Iterable<String> includes, Iterable<String> excludes})
       : path = _toAbsolute(path),
-        this._includes = includes?.toList() ?? ['lib/**'],
-        this._excludes = excludes?.toList() ?? <String>[];
+        includes = includes?.toList() ?? const ['lib/**'],
+        excludes = excludes?.toList() ?? const [];
 
   /// Create a [PackageNode] without any details from a `pubspec.yaml` file.
   ///

--- a/build_runner/test/common/package_graphs.dart
+++ b/build_runner/test/common/package_graphs.dart
@@ -15,6 +15,5 @@ PackageGraph buildPackageGraph(
   return new PackageGraph.fromRoot(packagesByName[rootPackage]);
 }
 
-PackageNode package(String packageName, {String path, List<String> includes}) =>
-    new PackageNode(packageName, '1.0.0', PackageDependencyType.path, path,
-        includes: includes);
+PackageNode package(String packageName, {String path}) =>
+    new PackageNode(packageName, '1.0.0', PackageDependencyType.path, path);

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -90,9 +90,7 @@ Future<BuildResult> testActions(List<BuildAction> buildActions,
     }
   });
 
-  packageGraph ??= buildPackageGraph('a', {
-    package('a', includes: ['**']): []
-  });
+  packageGraph ??= buildPackageGraph('a', {package('a'): []});
 
   var result = await build_impl.build(buildActions,
       deleteFilesByDefault: deleteFilesByDefault,

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -214,7 +214,7 @@ void main() {
     test('can\'t output files in non-root packages', () async {
       final packageGraph = buildPackageGraph('a', {
         package('a', path: 'a/'): ['b'],
-        package('b', path: 'a/b', includes: ['**']): []
+        package('b', path: 'a/b'): []
       });
       expect(
           testActions(
@@ -229,7 +229,7 @@ void main() {
       setUp(() {
         packageGraph = buildPackageGraph('a', {
           package('a', path: 'a/'): ['b'],
-          package('b', path: 'a/b/', includes: ['**']): []
+          package('b', path: 'a/b/'): []
         });
       });
       test('can output files in non-root packages', () async {
@@ -305,7 +305,7 @@ void main() {
 
     test('can glob files from packages', () async {
       final packageGraph = buildPackageGraph('a', {
-        package('a', path: 'a/', includes: ['**']): ['b'],
+        package('a', path: 'a/'): ['b'],
         package('b', path: 'a/b/'): []
       });
 
@@ -363,7 +363,7 @@ void main() {
     test('won\'t try to delete files from other packages', () async {
       final packageGraph = buildPackageGraph('a', {
         package('a', path: 'a/'): ['b'],
-        package('b', path: 'a/b', includes: ['**']): []
+        package('b', path: 'a/b'): []
       });
       var writer = new InMemoryRunnerAssetWriter()
         ..onDelete = (AssetId assetId) {

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -118,9 +118,8 @@ Future<ServeHandler> createHandler(List<BuildAction> buildActions,
   }));
   final actualAssets = writer.assets;
   final reader = new InMemoryRunnerAssetReader(actualAssets);
-  final packageGraph = buildPackageGraph('a', {
-    package('a', path: path.absolute('a')): []
-  });
+  final packageGraph =
+      buildPackageGraph('a', {package('a', path: path.absolute('a')): []});
   final watcherFactory = (String path) => new FakeWatcher(path);
 
   return watch_impl.watch(buildActions,

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -119,7 +119,7 @@ Future<ServeHandler> createHandler(List<BuildAction> buildActions,
   final actualAssets = writer.assets;
   final reader = new InMemoryRunnerAssetReader(actualAssets);
   final packageGraph = buildPackageGraph('a', {
-    package('a', path: path.absolute('a'), includes: ['**']): []
+    package('a', path: path.absolute('a')): []
   });
   final watcherFactory = (String path) => new FakeWatcher(path);
 

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -155,7 +155,7 @@ void main() {
       test('ignores events from nested packages', () async {
         var writer = new InMemoryRunnerAssetWriter();
         final packageGraph = buildPackageGraph('a', {
-          package('a', path: path.absolute('a'), includes: ['**']): ['b'],
+          package('a', path: path.absolute('a')): ['b'],
           package('b', path: path.absolute('a', 'b')): []
         });
 
@@ -407,9 +407,8 @@ Stream<BuildResult> startWatch(List<BuildAction> buildActions,
   });
   final actualAssets = writer.assets;
   final reader = new InMemoryRunnerAssetReader(actualAssets);
-  packageGraph ??= buildPackageGraph('a', {
-    package('a', path: path.absolute('a'), includes: ['**']): []
-  });
+  packageGraph ??=
+      buildPackageGraph('a', {package('a', path: path.absolute('a')): []});
   final watcherFactory = (String path) => new FakeWatcher(path);
 
   var buildState = watch_impl.watch(buildActions,


### PR DESCRIPTION
The only use case for these was that we were depending on them being set
appropriately for the root and non-root packages. We had previously been
handling this in two places and it was changed to only be configued in
the PackageNode. Adding it back to BuildDefinition will allow us to
deprecate and remove the fields in the PackageGraph.