### PR TITLE
Change BuildApplication to user builder factories

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,8 +7,7 @@ analyzer:
     dead_code: error
     override_on_non_overriding_method: error
   exclude:
-    - "bazel-*"
-    - "**/goldens/**"
+    - "test/goldens/generated_build_script.dart"
 linter:
   rules:
     # Errors

--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -16,6 +16,7 @@ export 'src/package_graph/apply_builders.dart'
         BuilderApplication,
         createBuildActions,
         apply,
+        applyToRoot,
         toAllPackages,
         toAll,
         toDependentsOf,

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -53,7 +53,8 @@ Method _findBuildActions(Iterable<BuildConfig> buildConfigs) =>
               .statement,
           _findBuilders(buildConfigs).assignVar('builders').statement,
           refer('createBuildActions', 'package:build_runner/build_runner.dart')
-              .call([refer('packageGraph'), refer('builders')])
+              .call([refer('packageGraph'), refer('builders')],
+                  {'args': refer('args')})
               .returned
               .statement,
         ])));

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -102,13 +102,15 @@ Expression _findBuilders(Iterable<BuildConfig> configs) =>
     literalList(configs.expand(_applyBuilders).toList());
 
 Iterable<Expression> _applyBuilders(BuildConfig config) =>
-    config.builderDefinitions.values.expand((definition) => definition
-        .builderFactories
-        .map((factory) => _applyBuilder(definition, factory)));
+    config.builderDefinitions.values.map(_applyBuilder);
 
-Expression _applyBuilder(BuilderDefinition definition, String factory) =>
+Expression _applyBuilder(BuilderDefinition definition) =>
     refer('apply', 'package:build_runner/build_runner.dart').call([
-      refer(factory, definition.import).call([refer('args')]),
+      literalString(definition.package),
+      literalString(definition.name),
+      literalList(definition.builderFactories
+          .map((f) => refer(f, definition.import))
+          .toList()),
       refer('toDependentsOf', 'package:build_runner/build_runner.dart')
           .call([literalString(definition.package)])
     ]);

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -33,8 +33,8 @@ typedef Builder BuilderFactory(List<String> args);
 /// Apply [builder] to the root package.
 BuilderApplication applyToRoot(Builder builder,
         {List<String> inputs, List<String> excludes}) =>
-    new BuilderApplication._('', '', [(_) => builder], null,
-        inputs: inputs, excludes: excludes);
+    new BuilderApplication._('', '', [(_) => builder], (_) => false,
+        inputs: inputs, excludes: excludes, applyToRoot: true);
 
 /// Apply each builder from [builderFactories] to the packages matching
 /// [filter].

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -40,7 +40,12 @@ BuilderApplication applyToRoot(Builder builder,
 /// [filter].
 ///
 /// If the builder should only run on a subset of files within a package pass
-/// globs to [inputs] or [excludes];
+/// globs to [inputs] or [excludes].
+///
+/// If [isOptional] is true the builder will only run if one of its outputs is
+/// read by a later builder, or is used as a primary input to a later builder.
+/// If no build actions read the output of an optional action, then it will
+/// never run.
 BuilderApplication apply(String providingPackage, String builderName,
         List<BuilderFactory> builderFactories, PackageFilter filter,
         {List<String> inputs, List<String> excludes, bool isOptional}) =>

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -93,8 +93,9 @@ class BuilderApplication {
 /// Builders may be filtered, for instance to run only on package which have a
 /// dependency on some other package by choosing the appropriate
 /// [BuilderApplication].
-List<BuildAction> createBuildActions(PackageGraph packageGraph,
-    Iterable<BuilderApplication> builderApplications, List<String> args) {
+List<BuildAction> createBuildActions(
+    PackageGraph packageGraph, Iterable<BuilderApplication> builderApplications,
+    {List<String> args = const []}) {
   var cycles = stronglyConnectedComponents<String, PackageNode>(
       [packageGraph.root], (node) => node.name, (node) => node.dependencies);
   return cycles

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -5,7 +5,8 @@ import 'package:shelf/shelf_io.dart' as _3;
 List<_1.BuildAction> _buildActions(_1.PackageGraph packageGraph) {
   var args = <String>[];
   var builders = [
-    _1.apply(_2.someBuilder(args), _1.toDependentsOf('provides_builder'))
+    _1.apply('provides_builder', 'some_builder', [_2.someBuilder],
+        _1.toDependentsOf('provides_builder'))
   ];
   return _1.createBuildActions(packageGraph, builders);
 }

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -8,7 +8,7 @@ List<_1.BuildAction> _buildActions(_1.PackageGraph packageGraph) {
     _1.apply('provides_builder', 'some_builder', [_2.someBuilder],
         _1.toDependentsOf('provides_builder'))
   ];
-  return _1.createBuildActions(packageGraph, builders);
+  return _1.createBuildActions(packageGraph, builders, args: args);
 }
 
 main() async {

--- a/e2e_example/tool/build.dart
+++ b/e2e_example/tool/build.dart
@@ -14,14 +14,20 @@ import 'package:shelf/shelf_io.dart' as shelf_io;
 Future main() async {
   var graph = new PackageGraph.forThisPackage();
   var builders = [
-    apply(new TestBootstrapBuilder(), toPackage(graph.root.name),
-        inputs: ['test/**_test.dart']),
-    apply(new ThrowingBuilder(), toPackage(graph.root.name)),
-    apply(new ModuleBuilder(), toAllPackages(), isOptional: true),
-    apply(new UnlinkedSummaryBuilder(), toAllPackages(), isOptional: true),
-    apply(new LinkedSummaryBuilder(), toAllPackages(), isOptional: true),
-    apply(new DevCompilerBuilder(), toAllPackages(), isOptional: true),
-    apply(new DevCompilerBootstrapBuilder(), toPackage(graph.root.name),
+    applyToRoot(new TestBootstrapBuilder(), inputs: ['test/**_test.dart']),
+    applyToRoot(new ThrowingBuilder()),
+    apply(
+        'build_compilers',
+        'ddc',
+        [
+          (_) => new ModuleBuilder(),
+          (_) => new UnlinkedSummaryBuilder(),
+          (_) => new LinkedSummaryBuilder(),
+          (_) => new DevCompilerBuilder()
+        ],
+        toAllPackages(),
+        isOptional: true),
+    applyToRoot(new DevCompilerBootstrapBuilder(),
         inputs: ['web/**.dart', 'test/**.browser_test.dart'])
   ];
   var buildActions = createBuildActions(graph, builders);


### PR DESCRIPTION
Fixes #625

We'll eventually need to support overriding what the `BuildApplication`
says with per-package or per-module config, including passing different
arguments to each `Builder` instance. We need to pass through the
`BuilderFactory` functions and add the necessary keys to relate a config
with the builder.

In order to support the old use case with less noise add `applyToRoot`
with some hacks to plumb through support for checking which package node
is the root. Once we add an `isRoot` field to `PackageNode` we can solve
this with a normal `PackageFilter`.

For now this will end up constructing more `Builder` instances than is
necessary, we can add caching by unique sets of arguments as an
enhancement.