### PR TITLE
Add `auto_apply` option to build.yaml

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1-dev
+
+- Add `auto_apply` option to Builder configuration.
+
 ## 0.1.0
 
 - Initial release - pulled from `package:dazel`. Updated to support

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -23,6 +23,8 @@ the following keys:
 - **build_extensions**: Required. A map from input extension to the list of
   output extensions that may be created for that input. This must match the
   merged `buildExtensions` maps from each `Builder` in `builder_factories`.
+- **auto_apply**: Optional. Whether to apply this builder automatically to
+  packages which have a dependency to this package. Defaults to `False`.
 
 Example `builders` config:
 
@@ -43,4 +45,5 @@ builders:
     import: "package:my_package/builder.dart"
     builder_factories: ["myBuilder"]
     build_extensions: {".dart": [".my_package.dart"]}
+    auto_apply: True
 ```

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -44,11 +44,13 @@ class BuildConfig {
     _import,
     _buildExtensions,
     _target,
+    _autoApply,
   ];
   static const _builderFactories = 'builder_factories';
   static const _import = 'import';
   static const _buildExtensions = 'build_extensions';
   static const _target = 'target';
+  static const _autoApply = 'auto_apply';
 
   /// Returns a parsed [BuildConfig] file in [path], if one exists.
   ///
@@ -167,6 +169,8 @@ class BuildConfig {
       final import = _readStringOrThrow(builderConfig, _import);
       final buildExtensions = _readBuildExtensions(builderConfig);
       final target = _readStringOrThrow(builderConfig, _target);
+      final autoApply =
+          _readBoolOrThrow(builderConfig, _autoApply, defaultValue: false);
 
       builderDefinitions[builderName] = new BuilderDefinition(
         builderFactories: builderFactories,
@@ -175,6 +179,7 @@ class BuildConfig {
         name: builderName,
         package: pubspec.pubPackageName,
         target: target,
+        autoApply: autoApply,
       );
     }
   }
@@ -305,13 +310,18 @@ class BuilderDefinition {
   /// The name of the dart_library target that contains `import`.
   final String target;
 
+  /// Whether the builder should be automatically applied to packages which have
+  /// a dependency on [package].
+  final bool autoApply;
+
   BuilderDefinition(
       {this.builderFactories,
       this.buildExtensions,
       this.import,
       this.name,
       this.package,
-      this.target});
+      this.target,
+      this.autoApply});
 }
 
 class BuildTarget {

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.1.0
+version: 0.1.1-dev
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -37,6 +37,7 @@ void main() {
     expectBuilderDefinitions(buildConfig.builderDefinitions, {
       'h': new BuilderDefinition(
         builderFactories: ['createBuilder'],
+        autoApply: true,
         import: 'package:example/e.dart',
         buildExtensions: {
           '.dart': [
@@ -66,6 +67,7 @@ void main() {
     expectBuilderDefinitions(buildConfig.builderDefinitions, {
       'a': new BuilderDefinition(
         builderFactories: ['createBuilder'],
+        autoApply: false,
         import: 'package:example/builder.dart',
         name: 'a',
         buildExtensions: {
@@ -114,6 +116,7 @@ builders:
     import: package:example/e.dart
     build_extensions: {".dart": [".g.dart", ".json"]}
     target: e
+    auto_apply: True
 ''';
 
 var buildYamlNoTargets = '''
@@ -149,6 +152,7 @@ class _BuilderDefinitionMatcher extends Matcher {
       item is BuilderDefinition &&
       equals(_expected.builderFactories).matches(item.builderFactories, _) &&
       equals(_expected.buildExtensions).matches(item.buildExtensions, _) &&
+      item.autoApply == _expected.autoApply &&
       item.import == _expected.import &&
       item.name == _expected.name &&
       item.package == _expected.package &&


### PR DESCRIPTION
The DDC builders should not be applied automatically, and most package
won't have a dependency on `build_compilers`.