### PR TITLE
Add DDC builders in the auto generated script

### DIFF
--- a/build_compilers/build.yaml
+++ b/build_compilers/build.yaml
@@ -1,0 +1,26 @@
+builders:
+  ddc:
+    target: "build_compilers"
+    import: "package:build_compilers/builders.dart"
+    builder_factories:
+      - moduleBuilder
+      - unlinkedSummaryBuilder
+      - linkedSummaryBuilder
+      - devCompilerBuilder
+    build_extensions:
+      .dart:
+        - .module
+        - .linked.sum
+        - .unlinked.sum
+        - .js.errors
+        - .js
+        - .js.map
+  ddc_bootstrap:
+    target: "build_compilers"
+    import: "package:build_compilers/builders.dart"
+    builder_factories: ["devCompilerBootstrapBuilder"]
+    build_extensions:
+      .dart:
+        - .dart.bootstrap.js
+        - .dart.js
+        - .dart.js.map

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -28,18 +28,51 @@ Future<Null> ensureBuildScript() async {
 }
 
 Future<String> _generateBuildScript() async {
-  var packageGraph = new PackageGraph.forThisPackage();
-  var builderDefinitions =
-      (await Future.wait(packageGraph.orderedPackages.map(_packageBuildConfig)))
-          .expand((c) => c.builderDefinitions.values)
-          .where((c) => c.autoApply);
-  final library = new File(
-      (b) => b.body.addAll([_findBuildActions(builderDefinitions), _main()]));
+  final builders = await _findBuilderApplications();
+  final library =
+      new File((b) => b.body.addAll([_findBuildActions(builders), _main()]));
   final emitter = new DartEmitter(new Allocator.simplePrefixing());
   return new DartFormatter().format('${library.accept(emitter)}');
 }
 
-Method _findBuildActions(Iterable<BuilderDefinition> builderDefinitions) =>
+/// Finds expressions to create all the [BuilderApplication] instances that
+/// should be applied packages in the build.
+///
+/// - Add any builders which specify `auto_apply: True` in their `build.yaml`
+/// - Add the DDC builders which apply to all packages
+/// - Add the DDC bootstrap builder to the root package
+Future<Iterable<Expression>> _findBuilderApplications() async {
+  final builderApplications = <Expression>[];
+  final packageGraph = new PackageGraph.forThisPackage();
+  final builderDefinitions =
+      (await Future.wait(packageGraph.orderedPackages.map(_packageBuildConfig)))
+          .expand((c) => c.builderDefinitions.values);
+
+  final autoAppliedBuilders = builderDefinitions.where((c) => c.autoApply);
+  builderApplications.addAll(autoAppliedBuilders.map(_applyToDependents));
+  var ddcBuilder = builderDefinitions
+      .firstWhere((b) => b.package == 'build_compilers' && b.name == 'ddc');
+  builderApplications
+      .add(_applyToAllPackages(ddcBuilder, {'isOptional': literalTrue}));
+  var ddcBootstrap = builderDefinitions.firstWhere(
+      (b) => b.package == 'build_compilers' && b.name == 'ddc_bootstrap');
+  // TODO - should this be configurable?
+  builderApplications.add(_applyBuilder(
+      ddcBootstrap,
+      refer('toPackage', 'package:build_runner/build_runner.dart')
+          .call([literalString(packageGraph.root.name)]),
+      {
+        'inputs': literalList([
+          literalString('web/**.dart'),
+          literalString('test/**.browser_test.dart')
+        ])
+      }));
+  return builderApplications;
+}
+
+/// A method which creates a list literal containing [builderApplications] and
+/// calls `createBuildActions` to resolve them.
+Method _findBuildActions(Iterable<Expression> builderApplications) =>
     new Method((b) => b
       ..name = '_buildActions'
       ..requiredParameters.add(new Parameter((b) => b
@@ -52,7 +85,9 @@ Method _findBuildActions(Iterable<BuilderDefinition> builderDefinitions) =>
           literalList([], new TypeReference((b) => b..symbol = 'String'))
               .assignVar('args')
               .statement,
-          _findBuilders(builderDefinitions).assignVar('builders').statement,
+          literalList(builderApplications.toList())
+              .assignVar('builders')
+              .statement,
           refer('createBuildActions', 'package:build_runner/build_runner.dart')
               .call([refer('packageGraph'), refer('builders')],
                   {'args': refer('args')})
@@ -98,18 +133,29 @@ Future<BuildConfig> _packageBuildConfig(PackageNode package) async =>
     BuildConfig.fromPackageDir(
         await Pubspec.fromPackageDir(package.path), package.path);
 
-/// Returns a [LiteralListExpression] with `BuilderApplication` instances
-/// created using `apply`.
-Expression _findBuilders(Iterable<BuilderDefinition> builderDefinitions) =>
-    literalList(builderDefinitions.map(_applyBuilder).toList());
+/// An expression calling `apply` to apply [definition] to all packages which
+/// depend on it's vending package.
+Expression _applyToDependents(BuilderDefinition definition) {
+  final to = refer('toDependentsOf', 'package:build_runner/build_runner.dart')
+      .call([literalString(definition.package)]);
+  return _applyBuilder(definition, to);
+}
 
-Expression _applyBuilder(BuilderDefinition definition) =>
+/// An expression calling `apply` to apply [definition] to all packages.
+Expression _applyToAllPackages(BuilderDefinition definition,
+    [Map<String, Expression> namedArgs = const {}]) {
+  final to =
+      refer('toAllPackages', 'package:build_runner/build_runner.dart').call([]);
+  return _applyBuilder(definition, to, namedArgs);
+}
+
+Expression _applyBuilder(BuilderDefinition definition, Expression toExpression,
+        [Map<String, Expression> namedArgs = const {}]) =>
     refer('apply', 'package:build_runner/build_runner.dart').call([
       literalString(definition.package),
       literalString(definition.name),
       literalList(definition.builderFactories
           .map((f) => refer(f, definition.import))
           .toList()),
-      refer('toDependentsOf', 'package:build_runner/build_runner.dart')
-          .call([literalString(definition.package)])
-    ]);
+      toExpression,
+    ], namedArgs);

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -1,12 +1,27 @@
 import 'package:build_runner/build_runner.dart' as _1;
 import 'package:provides_builder/builders.dart' as _2;
-import 'package:shelf/shelf_io.dart' as _3;
+import 'package:build_compilers/builders.dart' as _3;
+import 'package:shelf/shelf_io.dart' as _4;
 
 List<_1.BuildAction> _buildActions(_1.PackageGraph packageGraph) {
   var args = <String>[];
   var builders = [
     _1.apply('provides_builder', 'some_builder', [_2.someBuilder],
-        _1.toDependentsOf('provides_builder'))
+        _1.toDependentsOf('provides_builder')),
+    _1.apply(
+        'build_compilers',
+        'ddc',
+        [
+          _3.moduleBuilder,
+          _3.unlinkedSummaryBuilder,
+          _3.linkedSummaryBuilder,
+          _3.devCompilerBuilder
+        ],
+        _1.toAllPackages(),
+        isOptional: true),
+    _1.apply('build_compilers', 'ddc_bootstrap',
+        [_3.devCompilerBootstrapBuilder], _1.toPackage('e2e_example'),
+        inputs: ['web/**.dart', 'test/**.browser_test.dart'])
   ];
   return _1.createBuildActions(packageGraph, builders, args: args);
 }
@@ -14,7 +29,7 @@ List<_1.BuildAction> _buildActions(_1.PackageGraph packageGraph) {
 main() async {
   var actions = _buildActions(new _1.PackageGraph.forThisPackage());
   var handler = await _1.watch(actions, writeToCache: true);
-  var server = await _3.serve(handler.handlerFor('web'), 'localhost', 8000);
+  var server = await _4.serve(handler.handlerFor('web'), 'localhost', 8000);
   await handler.buildResults.drain();
   await server.close();
 }


### PR DESCRIPTION
- Add a `build.yaml` for `build_compilers` to group the buidlers into
  `ddc` and `ddc_bootstrap`.
- Hardcode in the auto generate that `ddc` runs for all packages, and
  that `ddc_bootstrap` runs for the root package.