### PR TITLE
Add required_inputs config option

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.1-dev
 
 - Add `auto_apply` option to Builder configuration.
+- Add `required_inputs` option to Builder configuration.
 
 ## 0.1.0
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -25,12 +25,12 @@ the following keys:
   merged `buildExtensions` maps from each `Builder` in `builder_factories`.
 - **auto_apply**: Optional. Whether to apply this builder automatically to
   packages which have a dependency to this package. Defaults to `False`.
-- **required_inputs**: Optional. If a Builder must see every input with one or
-  more file extensions they can be specified here and it will be guaranteed to
-  run after any Builder which might produce an output of that type. For instance
-  a compiler must run after any Builder which can produce `.dart` outputs or
-  those libraries can't be compiled. This option should be rare. Defaults to an
-  empty list.
+- **required_inputs**: Optional, list of extensions. If a Builder must see every
+  input with one or more file extensions they can be specified here and it will
+  be guaranteed to run after any Builder which might produce an output of that
+  type. For instance a compiler must run after any Builder which can produce
+  `.dart` outputs or those libraries can't be compiled. This option should be
+  rare. Defaults to an empty list.
 
 Example `builders` config:
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -25,6 +25,12 @@ the following keys:
   merged `buildExtensions` maps from each `Builder` in `builder_factories`.
 - **auto_apply**: Optional. Whether to apply this builder automatically to
   packages which have a dependency to this package. Defaults to `False`.
+- **required_inputs**: Optional. If a Builder must see every input with one or
+  more file extensions they can be specified here and it will be guaranteed to
+  run after any Builder which might produce an output of that type. For instance
+  a compiler must run after any Builder which can produce `.dart` outputs or
+  those libraries can't be compiled. This option should be rare. Defaults to an
+  empty list.
 
 Example `builders` config:
 

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -45,12 +45,14 @@ class BuildConfig {
     _buildExtensions,
     _target,
     _autoApply,
+    _requiredInputs,
   ];
   static const _builderFactories = 'builder_factories';
   static const _import = 'import';
   static const _buildExtensions = 'build_extensions';
   static const _target = 'target';
   static const _autoApply = 'auto_apply';
+  static const _requiredInputs = 'required_inputs';
 
   /// Returns a parsed [BuildConfig] file in [path], if one exists.
   ///
@@ -171,6 +173,9 @@ class BuildConfig {
       final target = _readStringOrThrow(builderConfig, _target);
       final autoApply =
           _readBoolOrThrow(builderConfig, _autoApply, defaultValue: false);
+      final requiredInputs = _readListOfStringsOrThrow(
+          builderConfig, _requiredInputs,
+          defaultValue: const []);
 
       builderDefinitions[builderName] = new BuilderDefinition(
         builderFactories: builderFactories,
@@ -180,6 +185,7 @@ class BuildConfig {
         package: pubspec.pubPackageName,
         target: target,
         autoApply: autoApply,
+        requiredInputs: requiredInputs,
       );
     }
   }
@@ -314,6 +320,12 @@ class BuilderDefinition {
   /// a dependency on [package].
   final bool autoApply;
 
+  /// A list of file extensions which are required to run this builder.
+  ///
+  /// No builder which outputs any extension in this list is allowed to run
+  /// after this builder.
+  final List<String> requiredInputs;
+
   BuilderDefinition(
       {this.builderFactories,
       this.buildExtensions,
@@ -321,7 +333,8 @@ class BuilderDefinition {
       this.name,
       this.package,
       this.target,
-      this.autoApply});
+      this.autoApply,
+      this.requiredInputs});
 }
 
 class BuildTarget {

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -48,6 +48,7 @@ void main() {
         name: 'h',
         package: 'example',
         target: 'e',
+        requiredInputs: ['.dart'],
       ),
     });
   });
@@ -78,6 +79,7 @@ void main() {
         },
         package: 'example',
         target: 'example',
+        requiredInputs: const [],
       ),
     });
   });
@@ -117,6 +119,7 @@ builders:
     build_extensions: {".dart": [".g.dart", ".json"]}
     target: e
     auto_apply: True
+    required_inputs: [".dart"]
 ''';
 
 var buildYamlNoTargets = '''
@@ -152,6 +155,7 @@ class _BuilderDefinitionMatcher extends Matcher {
       item is BuilderDefinition &&
       equals(_expected.builderFactories).matches(item.builderFactories, _) &&
       equals(_expected.buildExtensions).matches(item.buildExtensions, _) &&
+      equals(_expected.requiredInputs).matches(item.requiredInputs, _) &&
       item.autoApply == _expected.autoApply &&
       item.import == _expected.import &&
       item.name == _expected.name &&


### PR DESCRIPTION
Towards #639

We want to be able to specify that `DDC` needs all builders which
generate Dart files to have already run before it can run. We won't have
a full order solver, but this will us allow us to solve the two use
cases we have seen so far: all `.dart` before a compiler, and all `.css`
before the Angular stylesheet compiler.