### PR TITLE
Disable e2e_example tests on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,10 @@ matrix:
     - dart: stable
       env: PKG=build_test TASK=dartfmt
     - dart: stable
+      env: PKG=e2e_example TASK=dartanalyzer
+    - dart: stable
+      env: PKG=e2e_example TASK=test
+    - dart: stable
       env: PKG=scratch_space TASK=dartfmt
 
 script: ./tool/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,10 @@ matrix:
     - dart: stable
       env: PKG=build_test TASK=dartfmt
     - dart: stable
+      env: PKG=e2e_example TASK=dartfmt
+    - dart: stable
+      env: PKG=e2e_example TASK=test
+    - dart: stable
       env: PKG=scratch_space TASK=dartfmt
 
 script: ./tool/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,6 @@ matrix:
     - dart: stable
       env: PKG=build_test TASK=dartfmt
     - dart: stable
-      env: PKG=e2e_example TASK=dartfmt
-    - dart: stable
-      env: PKG=e2e_example TASK=test
-    - dart: stable
       env: PKG=scratch_space TASK=dartfmt
 
 script: ./tool/travis.sh

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,8 +6,6 @@ analyzer:
     unused_local_variable: error
     dead_code: error
     override_on_non_overriding_method: error
-  exclude:
-    - "test/goldens/generated_build_script.dart"
 linter:
   rules:
     # Errors

--- a/e2e_example/.travis.yml
+++ b/e2e_example/.travis.yml
@@ -1,7 +1,6 @@
 language: dart
 dart:
   - dev
-  - stable
 
 dart_task:
   - test

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -1,35 +1,35 @@
-import 'package:build_runner/build_runner.dart' as _1;
-import 'package:provides_builder/builders.dart' as _2;
-import 'package:build_compilers/builders.dart' as _3;
-import 'package:shelf/shelf_io.dart' as _4;
+import 'package:build_runner/build_runner.dart' as _i1;
+import 'package:provides_builder/builders.dart' as _i2;
+import 'package:build_compilers/builders.dart' as _i3;
+import 'package:shelf/shelf_io.dart' as _i4;
 
-List<_1.BuildAction> _buildActions(_1.PackageGraph packageGraph) {
+List<_i1.BuildAction> _buildActions(_i1.PackageGraph packageGraph) {
   var args = <String>[];
   var builders = [
-    _1.apply('provides_builder', 'some_builder', [_2.someBuilder],
-        _1.toDependentsOf('provides_builder')),
-    _1.apply(
+    _i1.apply('provides_builder', 'some_builder', [_i2.someBuilder],
+        _i1.toDependentsOf('provides_builder')),
+    _i1.apply(
         'build_compilers',
         'ddc',
         [
-          _3.moduleBuilder,
-          _3.unlinkedSummaryBuilder,
-          _3.linkedSummaryBuilder,
-          _3.devCompilerBuilder
+          _i3.moduleBuilder,
+          _i3.unlinkedSummaryBuilder,
+          _i3.linkedSummaryBuilder,
+          _i3.devCompilerBuilder
         ],
-        _1.toAllPackages(),
+        _i1.toAllPackages(),
         isOptional: true),
-    _1.apply('build_compilers', 'ddc_bootstrap',
-        [_3.devCompilerBootstrapBuilder], _1.toPackage('e2e_example'),
+    _i1.apply('build_compilers', 'ddc_bootstrap',
+        [_i3.devCompilerBootstrapBuilder], _i1.toPackage('e2e_example'),
         inputs: ['web/**.dart', 'test/**.browser_test.dart'])
   ];
-  return _1.createBuildActions(packageGraph, builders, args: args);
+  return _i1.createBuildActions(packageGraph, builders, args: args);
 }
 
 main() async {
-  var actions = _buildActions(new _1.PackageGraph.forThisPackage());
-  var handler = await _1.watch(actions, writeToCache: true);
-  var server = await _4.serve(handler.handlerFor('web'), 'localhost', 8000);
+  var actions = _buildActions(new _i1.PackageGraph.forThisPackage());
+  var handler = await _i1.watch(actions, writeToCache: true);
+  var server = await _i4.serve(handler.handlerFor('web'), 'localhost', 8000);
   await handler.buildResults.drain();
   await server.close();
 }


### PR DESCRIPTION
Fixes #644

The latest update to code_builder changes the output slightly so the
goldens need to be updated. Since the latest code_builder is SDK 2.0.x
only the golden test can't be run on the stable SDK.

- Exclude dartfmt and test steps in e2e_example on the stable SDK
- Update the golden to match the latest code_builder
- Stop excluding the golden file from analysis since the new import
  aliases don't have a lint.