### PR TITLE
Skip translation to build cache for missing

### DIFF
--- a/build_runner/lib/src/asset/build_cache.dart
+++ b/build_runner/lib/src/asset/build_cache.dart
@@ -68,7 +68,7 @@ AssetId cacheLocation(AssetId id, AssetGraph assetGraph, String rootPackage) {
     return id;
   }
   if (!assetGraph.contains(id)) {
-    throw new ArgumentError('$id  is not a valid asset');
+    return id;
   }
   if (assetGraph.get(id) is GeneratedAssetNode) {
     return new AssetId(


### PR DESCRIPTION
While working towards #647 I needed to set up the reader such that it is
always wrapped to translate some assets to the generated asset
directory. We have a few tests which set up coniditions such that the
AssetGraph is empty, and they pass because they rely on not using a
BuildCacheReader. This change only is necessary to support those tests,
but it is safe in general because the delegate reader will handle
missing files anyway.