### PR TITLE
Switch to BuilderFactory from package:build

### DIFF
--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -80,14 +80,11 @@ Method _findBuildActions(Iterable<Expression> builderApplications) =>
         ..type = types.packageGraph))
       ..returns = types.buildActions
       ..body = new Block.of([
-        // TODO - Pass actual arguments
-        literalList([], refer('String')).assignVar('args').statement,
         literalList(builderApplications.toList())
             .assignVar('builders')
             .statement,
         refer('createBuildActions', 'package:build_runner/build_runner.dart')
-            .call([refer('packageGraph'), refer('builders')],
-                {'args': refer('args')})
+            .call([refer('packageGraph'), refer('builders')])
             .returned
             .statement,
       ]));

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -28,8 +28,6 @@ PackageFilter toPackages(Set<String> packages) =>
 PackageFilter toAll(Iterable<PackageFilter> filters) =>
     (p) => filters.any((f) => f(p));
 
-typedef Builder BuilderFactory(List<String> args);
-
 /// Apply [builder] to the root package.
 BuilderApplication applyToRoot(Builder builder,
         {List<String> inputs, List<String> excludes}) =>
@@ -98,38 +96,35 @@ class BuilderApplication {
 /// Builders may be filtered, for instance to run only on package which have a
 /// dependency on some other package by choosing the appropriate
 /// [BuilderApplication].
-List<BuildAction> createBuildActions(
-    PackageGraph packageGraph, Iterable<BuilderApplication> builderApplications,
-    {List<String> args = const []}) {
+List<BuildAction> createBuildActions(PackageGraph packageGraph,
+    Iterable<BuilderApplication> builderApplications) {
   var cycles = stronglyConnectedComponents<String, PackageNode>(
       [packageGraph.root], (node) => node.name, (node) => node.dependencies);
   return cycles
       .expand((cycle) => _createBuildActionsWithinCycle(
-          cycle, packageGraph, builderApplications, args))
+          cycle, packageGraph, builderApplications))
       .toList();
 }
 
 Iterable<BuildAction> _createBuildActionsWithinCycle(
         Iterable<PackageNode> cycle,
         PackageGraph packageGraph,
-        Iterable<BuilderApplication> builderApplications,
-        List<String> args) =>
+        Iterable<BuilderApplication> builderApplications) =>
     builderApplications.expand((builderApplication) =>
         _createBuildActionsForBuilderInCycle(
-            cycle, packageGraph, builderApplication, args));
+            cycle, packageGraph, builderApplication));
 
 Iterable<BuildAction> _createBuildActionsForBuilderInCycle(
     Iterable<PackageNode> cycle,
     PackageGraph packageGraph,
-    BuilderApplication builderApplication,
-    List<String> args) {
+    BuilderApplication builderApplication) {
   bool filter(PackageNode packageNode) =>
       //TODO: this is a hack until we can add `isRoot` to `PackageNode`
       (builderApplication._applyToRoot && packageNode == packageGraph.root) ||
       builderApplication.filter(packageNode);
   return builderApplication.builderFactories.expand((b) => cycle
       .where(filter)
-      .map((p) => new BuildAction(b(args), p.name,
+      .map((p) => new BuildAction(b(const BuilderOptions(const {})), p.name,
           inputs: builderApplication.inputs,
           excludes: builderApplication.excludes,
           isOptional: builderApplication.isOptional)));

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ">=0.27.1 <0.31.0"
   args: ">=0.13.7 <2.0.0"
   async: ">=1.13.3 <3.0.0"
-  build: ^0.11.0
+  build: ^0.11.1
   build_barback: ^0.4.0
   build_config: ^0.1.1
   cli_util: ^0.1.2

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -4,7 +4,6 @@ import 'package:build_compilers/builders.dart' as _i3;
 import 'package:shelf/shelf_io.dart' as _i4;
 
 List<_i1.BuildAction> _buildActions(_i1.PackageGraph packageGraph) {
-  var args = <String>[];
   var builders = [
     _i1.apply('provides_builder', 'some_builder', [_i2.someBuilder],
         _i1.toDependentsOf('provides_builder')),
@@ -23,7 +22,7 @@ List<_i1.BuildAction> _buildActions(_i1.PackageGraph packageGraph) {
         [_i3.devCompilerBootstrapBuilder], _i1.toPackage('e2e_example'),
         inputs: ['web/**.dart', 'test/**.browser_test.dart'])
   ];
-  return _i1.createBuildActions(packageGraph, builders, args: args);
+  return _i1.createBuildActions(packageGraph, builders);
 }
 
 main() async {


### PR DESCRIPTION
Towards #636 

Drop `args` handling in `createBuildActions` for now. We should be able
to add this back in a non-breaking change later when we support creating
real `BuilderOptions` instances.