### PR TITLE
Change autoApply to an enum

### DIFF
--- a/build_config/README.md
+++ b/build_config/README.md
@@ -27,7 +27,7 @@ the following keys:
   automatically to applied. Defaults to `'none'` The possibilities are:
   - `"none"`: Never apply this Builder unless it is manually configured
   - `"dependents"`: Apply this Builder to the package with a direct dependency
-    on the package exposign the builder.
+    on the package exposing the builder.
   - `"all_packages"`: Apply this Builder to all packages in the transitive
     dependency graph.
   - `"root_package"`; Apply this Builder only to the top-level package.

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -23,8 +23,14 @@ the following keys:
 - **build_extensions**: Required. A map from input extension to the list of
   output extensions that may be created for that input. This must match the
   merged `buildExtensions` maps from each `Builder` in `builder_factories`.
-- **auto_apply**: Optional. Whether to apply this builder automatically to
-  packages which have a dependency to this package. Defaults to `False`.
+- **auto_apply**: Optional. The packages which should have this builder
+  automatically to applied. Defaults to `'none'` The possibilities are:
+  - `"none"`: Never apply this Builder unless it is manually configured
+  - `"dependents"`: Apply this Builder to the package with a direct dependency
+    on the package exposign the builder.
+  - `"all_packages"`: Apply this Builder to all packages in the transitive
+    dependency graph.
+  - `"root_package"`; Apply this Builder only to the top-level package.
 - **required_inputs**: Optional, list of extensions. If a Builder must see every
   input with one or more file extensions they can be specified here and it will
   be guaranteed to run after any Builder which might produce an output of that
@@ -51,5 +57,5 @@ builders:
     import: "package:my_package/builder.dart"
     builder_factories: ["myBuilder"]
     build_extensions: {".dart": [".my_package.dart"]}
-    auto_apply: True
+    auto_apply: dependents
 ```

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -171,8 +171,8 @@ class BuildConfig {
       final import = _readStringOrThrow(builderConfig, _import);
       final buildExtensions = _readBuildExtensions(builderConfig);
       final target = _readStringOrThrow(builderConfig, _target);
-      final autoApply =
-          _readBoolOrThrow(builderConfig, _autoApply, defaultValue: false);
+      final autoApply = _readAutoApplyOrThrow(builderConfig, _autoApply,
+          defaultValue: AutoApply.none);
       final requiredInputs = _readListOfStringsOrThrow(
           builderConfig, _requiredInputs,
           defaultValue: const []);
@@ -296,6 +296,24 @@ class BuildConfig {
     }
     return value as bool;
   }
+
+  static AutoApply _readAutoApplyOrThrow(
+      Map<String, dynamic> options, String option,
+      {AutoApply defaultValue}) {
+    final value = options[option];
+    if (value == null && defaultValue != null) return defaultValue;
+    final allowedValues = const {
+      'none': AutoApply.none,
+      'dependents': AutoApply.dependents,
+      'all_packages': AutoApply.allPackages,
+      'root_package': AutoApply.rootPackage
+    };
+    if (value is! String || !allowedValues.containsKey(value)) {
+      throw new ArgumentError('Expected one of ${allowedValues.keys.toList()} '
+          'for `$option` but got `$value`');
+    }
+    return allowedValues[value];
+  }
 }
 
 class BuilderDefinition {
@@ -316,9 +334,8 @@ class BuilderDefinition {
   /// The name of the dart_library target that contains `import`.
   final String target;
 
-  /// Whether the builder should be automatically applied to packages which have
-  /// a dependency on [package].
-  final bool autoApply;
+  /// Which packages should have this builder applied automatically.
+  final AutoApply autoApply;
 
   /// A list of file extensions which are required to run this builder.
   ///
@@ -336,6 +353,8 @@ class BuilderDefinition {
       this.autoApply,
       this.requiredInputs});
 }
+
+enum AutoApply { none, dependents, allPackages, rootPackage }
 
 class BuildTarget {
   final Iterable<String> dependencies;

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -37,7 +37,7 @@ void main() {
     expectBuilderDefinitions(buildConfig.builderDefinitions, {
       'h': new BuilderDefinition(
         builderFactories: ['createBuilder'],
-        autoApply: true,
+        autoApply: AutoApply.dependents,
         import: 'package:example/e.dart',
         buildExtensions: {
           '.dart': [
@@ -68,7 +68,7 @@ void main() {
     expectBuilderDefinitions(buildConfig.builderDefinitions, {
       'a': new BuilderDefinition(
         builderFactories: ['createBuilder'],
-        autoApply: false,
+        autoApply: AutoApply.none,
         import: 'package:example/builder.dart',
         name: 'a',
         buildExtensions: {
@@ -118,7 +118,7 @@ builders:
     import: package:example/e.dart
     build_extensions: {".dart": [".g.dart", ".json"]}
     target: e
-    auto_apply: True
+    auto_apply: dependents
     required_inputs: [".dart"]
 ''';
 

--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -14,12 +14,13 @@ export 'src/package_builder/package_builder.dart' show PackageBuilder;
 export 'src/package_graph/apply_builders.dart'
     show
         BuilderApplication,
-        createBuildActions,
         apply,
         applyToRoot,
-        toAllPackages,
+        createBuildActions,
         toAll,
+        toAllPackages,
         toDependentsOf,
+        toNoneByDefault,
         toPackage,
         toPackages;
 export 'src/package_graph/package_graph.dart';

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -165,5 +165,5 @@ Expression _findToExpression(
       return refer('toPackage', 'package:build_runner/build_runner.dart')
           .call([literalString(packageGraph.root.name)]);
   }
-  throw new StateError('Unhandled AutoApply type: ${definition.autoApply}');
+  throw new ArgumentError('Unhandled AutoApply type: ${definition.autoApply}');
 }

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -165,5 +165,5 @@ Expression _findToExpression(
       return refer('toPackage', 'package:build_runner/build_runner.dart')
           .call([literalString(packageGraph.root.name)]);
   }
-  throw 'Unreachable';
+  throw new StateError('Unhandled AutoApply type: ${definition.autoApply}');
 }

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -13,6 +13,9 @@ typedef bool PackageFilter(PackageNode node);
 /// Run a builder on all packages in the package graph.
 PackageFilter toAllPackages() => (_) => true;
 
+/// Require manual configuration to opt in to a builder.
+PackageFilter toNoneByDefault() => (_) => false;
+
 /// Run a builder on all packages with an immediate dependency on [packageName].
 PackageFilter toDependentsOf(String packageName) =>
     (p) => p.dependencies.any((d) => d.name == packageName);

--- a/e2e_example/pkgs/provides_builder/build.yaml
+++ b/e2e_example/pkgs/provides_builder/build.yaml
@@ -4,7 +4,7 @@ builders:
     import: "package:provides_builder/builders.dart"
     builder_factories: ["someBuilder"]
     build_extensions: {".dart": [".something.dart"]}
-    auto_apply: True
+    auto_apply: dependents
   some_not_applied_builder:
     target: "provides_builder"
     import: "package:provides_builder/builders.dart"

--- a/e2e_example/pkgs/provides_builder/lib/builders.dart
+++ b/e2e_example/pkgs/provides_builder/lib/builders.dart
@@ -23,3 +23,4 @@ class _SomeBuilder implements Builder {
 }
 
 Builder someBuilder(_) => const _SomeBuilder();
+Builder notApplied(_) => null;

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -6,8 +6,22 @@ import 'package:shelf/shelf_io.dart' as _i4;
 List<_i1.BuildAction> _buildActions(_i1.PackageGraph packageGraph) {
   var args = <String>[];
   var builders = [
+    _i1.apply('provides_builder', 'some_not_applied_builder', [_i2.notApplied],
+        _i1.toNoneByDefault()),
     _i1.apply('provides_builder', 'some_builder', [_i2.someBuilder],
         _i1.toDependentsOf('provides_builder')),
+    _i1.apply('build_compilers', 'ddc_bootstrap',
+        [_i3.devCompilerBootstrapBuilder], _i1.toNoneByDefault()),
+    _i1.apply(
+        'build_compilers',
+        'ddc',
+        [
+          _i3.moduleBuilder,
+          _i3.unlinkedSummaryBuilder,
+          _i3.linkedSummaryBuilder,
+          _i3.devCompilerBuilder
+        ],
+        _i1.toNoneByDefault()),
     _i1.apply(
         'build_compilers',
         'ddc',


### PR DESCRIPTION
Towards #639

- Add `toNoneByDefault` package filter so that all `BuilderDefinitions`
  can be present in the `BuilderApplications` which will allow us to
  apply them manually later.
- Continue to manually apply the DDC builders in the generated build
  script until. This does mean that the builders show up twice but in
  one case they won't be applied.