### PR TITLE
Add build_runner:create_merged_dir command

### DIFF
--- a/build_compilers/CHANGELOG.md
+++ b/build_compilers/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add builder factories.
 - Fixed temp dir cleanup bug on windows.
+- Enabled support for running tests in --precompiled mode.
 
 # 0.0.1
 

--- a/build_runner/bin/create_merged_dir.dart
+++ b/build_runner/bin/create_merged_dir.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:build/build.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:build_runner/src/asset/build_cache.dart';
+import 'package:build_runner/src/asset/file_based.dart';
+import 'package:build_runner/src/asset_graph/graph.dart';
+import 'package:build_runner/src/asset_graph/node.dart';
+import 'package:build_runner/src/package_graph/package_graph.dart';
+import 'package:build_runner/src/util/constants.dart';
+
+AssetGraph assetGraph;
+PackageGraph packageGraph;
+
+Future main(List<String> args) async {
+  stdout.writeln(
+      'Warning: this tool is unsupported and usage may change at any time, '
+      'use at your own risk.\n\n'
+      'This tool also assumes you are using the `writeToCache=true` option.');
+
+  var parsedArgs = argParser.parse(args);
+
+  var scriptPath = parsedArgs['script'] as String;
+  if (scriptPath == null) {
+    throw new ArgumentError.notNull('--script');
+  }
+
+  var outputDir = new Directory(parsedArgs['output-dir'] as String);
+  if (outputDir.existsSync()) {
+    stdout.writeln('Deleting existing output dir `$outputDir`');
+    outputDir.deleteSync(recursive: true);
+  }
+  outputDir.createSync(recursive: true);
+
+  var scriptFile = new File(scriptPath);
+  if (!scriptFile.existsSync()) {
+    throw new ArgumentError(
+        'Expected a build script at $scriptPath but didn\'t find one.');
+  }
+
+  var assetGraphFile = new File(assetGraphPathFor(p.absolute(scriptPath)));
+  if (!assetGraphFile.existsSync()) {
+    throw new ArgumentError(
+        'Unable to find AssetGraph for $scriptPath at ${assetGraphFile.path}');
+  }
+  stdout.writeln('Loading asset graph at ${assetGraphFile.path}...');
+
+  assetGraph = new AssetGraph.deserialize(
+      JSON.decode(assetGraphFile.readAsStringSync()) as Map);
+
+  packageGraph = new PackageGraph.forThisPackage();
+
+  stdout.writeln('Creating output dir at ${outputDir.path}...');
+  var rootDirs = new Set<String>();
+  for (var node in assetGraph.packageNodes(packageGraph.root.name)) {
+    var parts = p.url.split(node.id.path);
+    if (parts.length == 1) continue;
+    var dir = parts.first;
+    if (dir == outputDir.path) continue;
+    rootDirs.add(parts.first);
+  }
+
+  var reader = new BuildCacheReader(new FileBasedAssetReader(packageGraph),
+      assetGraph, packageGraph.root.name);
+
+  for (var node in assetGraph.allNodes) {
+    if (node is SyntheticAssetNode) continue;
+    if (node is GeneratedAssetNode && !node.wasOutput) continue;
+    if (node.id.path == '.packages') continue;
+    var assetPaths = <String>[];
+    if (node.id.path.startsWith('lib')) {
+      assetPaths.add(p.url.join(
+          'packages', node.id.package, node.id.path.substring('lib/'.length)));
+    } else {
+      assetPaths.add(node.id.path);
+    }
+    for (var path in assetPaths) {
+      var outputId = new AssetId(packageGraph.root.name, path);
+      writeAsBytes(outputDir, outputId, await reader.readAsBytes(node.id));
+    }
+  }
+
+  var packagesFileContent =
+      packageGraph.allPackages.keys.map((p) => '$p:packages/$p/').join('\r\n');
+  for (var dir in rootDirs) {
+    writeAsString(
+        outputDir,
+        new AssetId(packageGraph.root.name, p.url.join(dir, '.packages')),
+        packagesFileContent);
+    var link = new Link(p.join(outputDir.path, dir, 'packages'));
+    print(link.path);
+    link.createSync(p.join('..', 'packages'), recursive: true);
+  }
+}
+
+void writeAsBytes(Directory outputDir, AssetId id, List<int> bytes) {
+  var file = fileFor(outputDir, id);
+  file.writeAsBytesSync(bytes);
+}
+
+void writeAsString(Directory outputDir, AssetId id, String contents) {
+  var file = fileFor(outputDir, id);
+  file.writeAsStringSync(contents);
+}
+
+File fileFor(Directory outputDir, AssetId id) {
+  String relativePath;
+  if (id.path.startsWith('lib')) {
+    relativePath =
+        p.join('packages', id.package, p.joinAll(p.url.split(id.path).skip(1)));
+  } else {
+    relativePath = id.path;
+  }
+  var file = new File(p.join(outputDir.path, relativePath));
+  file.createSync(recursive: true);
+  return file;
+}
+
+final argParser = new ArgParser()
+  ..addFlag('help', negatable: false)
+  ..addOption('script', help: 'The build script to load the asset graph for.')
+  ..addOption('output-dir',
+      abbr: 'o', help: 'The output directory.', defaultsTo: 'build');

--- a/build_runner/bin/create_merged_dir.dart
+++ b/build_runner/bin/create_merged_dir.dart
@@ -33,13 +33,6 @@ Future main(List<String> args) async {
     throw new ArgumentError.notNull('--script');
   }
 
-  var outputDir = new Directory(parsedArgs['output-dir'] as String);
-  if (outputDir.existsSync()) {
-    stdout.writeln('Deleting existing output dir `$outputDir`');
-    outputDir.deleteSync(recursive: true);
-  }
-  outputDir.createSync(recursive: true);
-
   var scriptFile = new File(scriptPath);
   if (!scriptFile.existsSync()) {
     throw new ArgumentError(
@@ -51,6 +44,14 @@ Future main(List<String> args) async {
     throw new ArgumentError(
         'Unable to find AssetGraph for $scriptPath at ${assetGraphFile.path}');
   }
+
+  var outputDir = new Directory(parsedArgs['output-dir'] as String);
+  if (outputDir.existsSync()) {
+    stdout.writeln('Deleting existing output dir `$outputDir`');
+    outputDir.deleteSync(recursive: true);
+  }
+  outputDir.createSync(recursive: true);
+
   stdout.writeln('Loading asset graph at ${assetGraphFile.path}...');
 
   assetGraph = new AssetGraph.deserialize(

--- a/e2e_example/test/common/utils.dart
+++ b/e2e_example/test/common/utils.dart
@@ -158,7 +158,7 @@ Future<ProcessResult> runTests({bool usePrecompiled}) async {
     var result = await Process.run(_pubBinary, [
       'run',
       'build_runner:create_merged_dir',
-      '--script=tool/build.dart',
+      '--script=${p.join('tool', 'build.dart')}',
       '--output-dir=build'
     ]);
     expect(result.exitCode, 0,

--- a/e2e_example/test/common/utils.dart
+++ b/e2e_example/test/common/utils.dart
@@ -98,7 +98,8 @@ Future<Null> stopServer({bool cleanUp}) async {
   _stdOutLines = null;
   _stdErrLines = null;
 
-  if (cleanUp && await _toolDir.exists()) await _toolDir.delete(recursive: true);
+  if (cleanUp && await _toolDir.exists())
+    await _toolDir.delete(recursive: true);
 }
 
 /// Checks whether the current git client is "clean" (no pending changes) for
@@ -150,20 +151,28 @@ Future<String> nextStdErrLine(String message) =>
 Future<String> nextStdOutLine(String message) =>
     _stdOutLines.firstWhere((line) => line.contains(message)) as Future<String>;
 
-Future<ProcessResult> runTests() =>
-    Process.run(_pubBinary, ['run', 'test', '--pub-serve', '8081', '-p', 'chrome']);
+Future<ProcessResult> runTests({bool usePrecompiled}) {
+  usePrecompiled ??= false;
+  var args = ['run', 'test', '-p', 'chrome'];
+  if (usePrecompiled) {
+    args.addAll(['--precompiled', 'build/']);
+  } else {
+    args.addAll(['--pub-serve', '8081']);
+  }
+  return Process.run(_pubBinary, args);
+}
 
 Future<Null> expectTestsFail() async {
   var result = await runTests();
   expect(result.stdout, contains('Some tests failed'));
 }
 
-Future<Null> expectTestsPass([int numRan]) async {
-  var result = await runTests();
+Future<Null> expectTestsPass({int expectedNumRan, bool usePrecompiled}) async {
+  var result = await runTests(usePrecompiled: usePrecompiled);
   expect(result.stdout, contains('All tests passed!'));
-  if (numRan != null) {
-    expect(result.stdout, contains('+$numRan'));
-    expect(result.stdout, isNot(contains('+${numRan + 1}')));
+  if (expectedNumRan != null) {
+    expect(result.stdout, contains('+$expectedNumRan'));
+    expect(result.stdout, isNot(contains('+${expectedNumRan + 1}')));
   }
 }
 

--- a/e2e_example/test/common/utils.dart
+++ b/e2e_example/test/common/utils.dart
@@ -166,7 +166,7 @@ Future<ProcessResult> runTests({bool usePrecompiled}) async {
     expect(mergedDirResult.exitCode, 0,
         reason: 'stdout:${mergedDirResult.stdout}\n'
             'stderr${mergedDirResult.stderr}');
-    args.addAll(['--precompiled', '${precompiledTmpDir}/']);
+    args.addAll(['--precompiled', '${precompiledTmpDir.path}/']);
   } else {
     args.addAll(['--pub-serve', '8081']);
   }

--- a/e2e_example/test/serve_integration_test.dart
+++ b/e2e_example/test/serve_integration_test.dart
@@ -24,8 +24,12 @@ void main() {
         isNot(contains('Hello World!')));
   });
 
-  test('Can run passing tests', () async {
+  test('Can run passing tests with --pub-serve', () async {
     await expectTestsPass();
+  });
+
+  test('Can run passing tests with --precompiled', () async {
+    await expectTestsPass(usePrecompiled: true);
   });
 
   group('File changes', () {
@@ -52,14 +56,14 @@ void main() {
       var nextBuild = nextSuccessfulBuild;
       await createFile(p.join('test', 'other_test.dart'), basicTestContents);
       await nextBuild;
-      await expectTestsPass(3);
+      await expectTestsPass(expectedNumRan: 3);
     });
 
     test('delete test', () async {
       var nextBuild = nextSuccessfulBuild;
       await deleteFile(p.join('test', 'subdir', 'subdir_test.dart'));
       await nextBuild;
-      await expectTestsPass(1);
+      await expectTestsPass(expectedNumRan: 1);
     });
 
     test('ddc errors can be fixed', () async {


### PR DESCRIPTION
This is experimental only, primarily just to get angular off of a git dependency for travis builds.

Given the path to a build script it will read the corresponding output graph and create a merged output directory based on those sources.

I also included some of the other fixes from the `build_dir` branch to get --precompiled working with tests.