### PR TITLE
Drop fields from PackageNode

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.7.0-dev
+
+### Breaking Changes
+
+- Removed `dependencyType`, `version`, `includes`, and `excludes` from
+  `PackageNode`. Nothing outside of this package should have been reading or
+  setting these so there should be no impact for most clients.
+- Removed `PackageNode.noPubspec` constructor.
+
+
 ## 0.6.1
 
 ### New Features

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -274,9 +274,18 @@ class _Loader {
 
   /// Returns the set of original package inputs on disk.
   Future<Set<AssetId>> _findInputSources() async {
-    var inputSets = _options.packageGraph.allPackages.values.map((package) =>
-        new InputSet(package.name, package.includes,
-            excludes: package.excludes));
+    List<String> packageIncludes(String packageName) {
+      if (packageName == _options.packageGraph.root.name) {
+        return const ['**'];
+      }
+      if (packageName == r'$sdk') {
+        return const ['lib/dev_compiler/**.js'];
+      }
+      return const ['lib/**'];
+    }
+
+    var inputSets = _options.packageGraph.allPackages.values.map(
+        (package) => new InputSet(package.name, packageIncludes(package.name)));
     var sources = (await _listAssetIds(inputSets).toSet())
       ..addAll(await _options.reader
           .findAssets(new Glob('$entryPointDir/**'))

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.6.1
+version: 0.7.0-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/test/common/package_graphs.dart
+++ b/build_runner/test/common/package_graphs.dart
@@ -15,6 +15,5 @@ PackageGraph buildPackageGraph(
   return new PackageGraph.fromRoot(packagesByName[rootPackage]);
 }
 
-PackageNode package(String packageName, {String path, List<String> includes}) =>
-    new PackageNode(packageName, '1.0.0', PackageDependencyType.path, path,
-        includes: includes);
+PackageNode package(String packageName, {String path}) =>
+    new PackageNode(packageName, path);

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -90,9 +90,7 @@ Future<BuildResult> testActions(List<BuildAction> buildActions,
     }
   });
 
-  packageGraph ??= buildPackageGraph('a', {
-    package('a', includes: ['**']): []
-  });
+  packageGraph ??= buildPackageGraph('a', {package('a'): []});
 
   var result = await build_impl.build(buildActions,
       deleteFilesByDefault: deleteFilesByDefault,

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -214,7 +214,7 @@ void main() {
     test('can\'t output files in non-root packages', () async {
       final packageGraph = buildPackageGraph('a', {
         package('a', path: 'a/'): ['b'],
-        package('b', path: 'a/b', includes: ['**']): []
+        package('b', path: 'a/b'): []
       });
       expect(
           testActions(
@@ -229,7 +229,7 @@ void main() {
       setUp(() {
         packageGraph = buildPackageGraph('a', {
           package('a', path: 'a/'): ['b'],
-          package('b', path: 'a/b/', includes: ['**']): []
+          package('b', path: 'a/b/'): []
         });
       });
       test('can output files in non-root packages', () async {
@@ -305,7 +305,7 @@ void main() {
 
     test('can glob files from packages', () async {
       final packageGraph = buildPackageGraph('a', {
-        package('a', path: 'a/', includes: ['**']): ['b'],
+        package('a', path: 'a/'): ['b'],
         package('b', path: 'a/b/'): []
       });
 
@@ -363,7 +363,7 @@ void main() {
     test('won\'t try to delete files from other packages', () async {
       final packageGraph = buildPackageGraph('a', {
         package('a', path: 'a/'): ['b'],
-        package('b', path: 'a/b', includes: ['**']): []
+        package('b', path: 'a/b'): []
       });
       var writer = new InMemoryRunnerAssetWriter()
         ..onDelete = (AssetId assetId) {

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -118,9 +118,8 @@ Future<ServeHandler> createHandler(List<BuildAction> buildActions,
   }));
   final actualAssets = writer.assets;
   final reader = new InMemoryRunnerAssetReader(actualAssets);
-  final packageGraph = buildPackageGraph('a', {
-    package('a', path: path.absolute('a')): []
-  });
+  final packageGraph =
+      buildPackageGraph('a', {package('a', path: path.absolute('a')): []});
   final watcherFactory = (String path) => new FakeWatcher(path);
 
   return watch_impl.watch(buildActions,

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -119,7 +119,7 @@ Future<ServeHandler> createHandler(List<BuildAction> buildActions,
   final actualAssets = writer.assets;
   final reader = new InMemoryRunnerAssetReader(actualAssets);
   final packageGraph = buildPackageGraph('a', {
-    package('a', path: path.absolute('a'), includes: ['**']): []
+    package('a', path: path.absolute('a')): []
   });
   final watcherFactory = (String path) => new FakeWatcher(path);
 

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -155,7 +155,7 @@ void main() {
       test('ignores events from nested packages', () async {
         var writer = new InMemoryRunnerAssetWriter();
         final packageGraph = buildPackageGraph('a', {
-          package('a', path: path.absolute('a'), includes: ['**']): ['b'],
+          package('a', path: path.absolute('a')): ['b'],
           package('b', path: path.absolute('a', 'b')): []
         });
 
@@ -407,9 +407,8 @@ Stream<BuildResult> startWatch(List<BuildAction> buildActions,
   });
   final actualAssets = writer.assets;
   final reader = new InMemoryRunnerAssetReader(actualAssets);
-  packageGraph ??= buildPackageGraph('a', {
-    package('a', path: path.absolute('a'), includes: ['**']): []
-  });
+  packageGraph ??=
+      buildPackageGraph('a', {package('a', path: path.absolute('a')): []});
   final watcherFactory = (String path) => new FakeWatcher(path);
 
   var buildState = watch_impl.watch(buildActions,

--- a/build_runner/test/package_graph/package_graph_test.dart
+++ b/build_runner/test/package_graph/package_graph_test.dart
@@ -19,8 +19,7 @@ void main() {
       });
 
       test('root', () {
-        expectPkg(graph.root, 'build_runner', isNotEmpty,
-            PackageDependencyType.path, './');
+        expectPkg(graph.root, 'build_runner', './');
       });
     });
 
@@ -45,28 +44,13 @@ void main() {
       });
 
       test('root', () {
-        expectPkg(graph.root, 'basic_pkg', '1.0.0', PackageDependencyType.path,
-            basicPkgPath, [graph['a'], graph['b'], graph['c'], graph['d']]);
+        expectPkg(graph.root, 'basic_pkg', basicPkgPath,
+            [graph['a'], graph['b'], graph['c'], graph['d']]);
       });
 
-      test('pub dependency', () {
-        expectPkg(graph['a'], 'a', '2.0.0', PackageDependencyType.pub,
-            '$basicPkgPath/pkg/a', [graph['b'], graph['c']]);
-      });
-
-      test('git dependency', () {
-        expectPkg(graph['b'], 'b', '3.0.0', PackageDependencyType.github,
-            '$basicPkgPath/pkg/b', [graph['c']]);
-      });
-
-      test('path dependency', () {
-        expectPkg(graph['c'], 'c', '4.0.0', PackageDependencyType.path,
-            '$basicPkgPath/pkg/c', [graph['basic_pkg']]);
-      });
-
-      test('hosted dependency', () {
-        expectPkg(graph['d'], 'd', '5.0.0', PackageDependencyType.hosted,
-            '$basicPkgPath/pkg/d', [graph['c']]);
+      test('dependency', () {
+        expectPkg(
+            graph['a'], 'a', '$basicPkgPath/pkg/a', [graph['b'], graph['c']]);
       });
     });
 
@@ -90,20 +74,13 @@ void main() {
 
       test('dev deps are contained in deps of root pkg, but not others', () {
         // Package `b` shows as a dep because this is the root package.
-        expectPkg(
-            graph.root,
-            'with_dev_deps',
-            '1.0.0',
-            PackageDependencyType.path,
-            withDevDepsPkgPath,
+        expectPkg(graph.root, 'with_dev_deps', withDevDepsPkgPath,
             [graph['a'], graph['b']]);
 
         // Package `c` does not appear because this is not the root package.
-        expectPkg(graph['a'], 'a', '2.0.0', PackageDependencyType.pub,
-            '$withDevDepsPkgPath/pkg/a', []);
+        expectPkg(graph['a'], 'a', '$withDevDepsPkgPath/pkg/a', []);
 
-        expectPkg(graph['b'], 'b', '3.0.0', PackageDependencyType.pub,
-            '$withDevDepsPkgPath/pkg/b', []);
+        expectPkg(graph['b'], 'b', '$withDevDepsPkgPath/pkg/b', []);
 
         expect(graph['c'], isNull);
       });
@@ -132,10 +109,10 @@ void main() {
     });
 
     test('custom creation via fromRoot', () {
-      var a = new PackageNode('a', '1.0.0', PackageDependencyType.path, null);
-      var b = new PackageNode('b', '1.0.0', PackageDependencyType.pub, null);
-      var c = new PackageNode('c', '1.0.0', PackageDependencyType.pub, null);
-      var d = new PackageNode('d', '1.0.0', PackageDependencyType.pub, null);
+      var a = new PackageNode('a', null);
+      var b = new PackageNode('b', null);
+      var c = new PackageNode('c', null);
+      var d = new PackageNode('d', null);
       a.dependencies.addAll([b, d]);
       b.dependencies.add(c);
       var graph = new PackageGraph.fromRoot(a);
@@ -224,13 +201,10 @@ void main() {
   });
 }
 
-void expectPkg(PackageNode node, String name, dynamic version,
-    PackageDependencyType type, String location,
+void expectPkg(PackageNode node, String name, String location,
     [Iterable<PackageNode> dependencies]) {
   location = p.absolute(location);
   expect(node.name, name);
-  expect(node.version, version);
-  expect(node.dependencyType, type);
   expect(node.path, location);
   if (dependencies != null) {
     expect(node.dependencies, unorderedEquals(dependencies));

--- a/build_runner/test/watcher/asset_change_test.dart
+++ b/build_runner/test/watcher/asset_change_test.dart
@@ -33,7 +33,7 @@ void main() {
       final pkgBar = p.join('/', 'foo', 'bar');
       final barFile =
           p.join(p.relative(pkgBar, from: p.current), 'lib', 'bar.dart');
-      final nodeBar = new PackageNode.noPubspec('bar', path: pkgBar);
+      final nodeBar = new PackageNode('bar', pkgBar);
 
       final event = new WatchEvent(ChangeType.ADD, barFile);
       final change = new AssetChange.fromEvent(nodeBar, event);
@@ -46,7 +46,7 @@ void main() {
       final pkgBar = p.join('/', 'foo', 'bar');
       final barFile = p.join('/', 'foo', 'bar', 'lib', 'bar.dart');
 
-      final nodeBar = new PackageNode.noPubspec('bar', path: pkgBar);
+      final nodeBar = new PackageNode('bar', pkgBar);
       final event = new WatchEvent(ChangeType.ADD, barFile);
       final change = new AssetChange.fromEvent(nodeBar, event);
 

--- a/build_runner/test/watcher/node_watcher_test.dart
+++ b/build_runner/test/watcher/node_watcher_test.dart
@@ -41,7 +41,7 @@ void main() {
     }
 
     test('should emit a changed asset', () async {
-      var node = new PackageNode.noPubspec('a', path: p.join(tmpDir.path, 'a'));
+      var node = new PackageNode('a', p.join(tmpDir.path, 'a'));
       var nodeWatcher = new PackageNodeWatcher(node);
 
       initFiles(node);
@@ -69,8 +69,8 @@ void main() {
     });
 
     test('should also respect relative watch URLs', () async {
-      var node = new PackageNode.noPubspec('a',
-          path: p.relative(p.join(tmpDir.path, 'a'), from: p.current));
+      var node = new PackageNode(
+          'a', p.relative(p.join(tmpDir.path, 'a'), from: p.current));
       var nodeWatcher = new PackageNodeWatcher(node);
 
       initFiles(node);


### PR DESCRIPTION
Towards #628

- Drop unused fields `version` and `dependencyType`.
- Drop `includes` and `excludes` - hardcode the existing usecase inside
  `build_definition.dart`.
- Drop `PackageNode.noPubspec` constructor since it's no longer
  providing value.
- Stop tracking dependnecy type when crawling package graph and reading
  pubspecs.