### PR TITLE
Add `PackageNode.isRoot`

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,12 +1,17 @@
 ## 0.7.0-dev
 
+### New Features
+
+- Added `toRoot` Package filter.
+
 ### Breaking Changes
 
 - Removed `dependencyType`, `version`, `includes`, and `excludes` from
   `PackageNode`. Nothing outside of this package should have been reading or
   setting these so there should be no impact for most clients.
 - Removed `PackageNode.noPubspec` constructor.
-
+- PackageGraph instances enforce that the `root` node is the only node with
+  `isRoot == true`.
 
 ## 0.6.1
 

--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -22,6 +22,7 @@ export 'src/package_graph/apply_builders.dart'
         toDependentsOf,
         toNoneByDefault,
         toPackage,
-        toPackages;
+        toPackages,
+        toRoot;
 export 'src/package_graph/package_graph.dart';
 export 'src/server/server.dart' show ServeHandler;

--- a/build_runner/test/common/package_graphs.dart
+++ b/build_runner/test/common/package_graphs.dart
@@ -4,16 +4,19 @@
 
 import 'package:build_runner/build_runner.dart';
 
-PackageGraph buildPackageGraph(
-    String rootPackage, Map<PackageNode, Iterable<String>> packages) {
+PackageGraph buildPackageGraph(Map<PackageNode, Iterable<String>> packages) {
   var packagesByName = new Map<String, PackageNode>.fromIterable(packages.keys,
       key: (p) => (p as PackageNode).name);
   for (final package in packages.keys) {
     package.dependencies
         .addAll(packages[package].map((name) => packagesByName[name]));
   }
-  return new PackageGraph.fromRoot(packagesByName[rootPackage]);
+  var root = packages.keys.singleWhere((n) => n.isRoot);
+  return new PackageGraph.fromRoot(root);
 }
 
 PackageNode package(String packageName, {String path}) =>
     new PackageNode(packageName, path);
+
+PackageNode rootPackage(String packageName, {String path}) =>
+    new PackageNode(packageName, path, isRoot: true);

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -90,7 +90,7 @@ Future<BuildResult> testActions(List<BuildAction> buildActions,
     }
   });
 
-  packageGraph ??= buildPackageGraph('a', {package('a'): []});
+  packageGraph ??= buildPackageGraph({rootPackage('a'): []});
 
   var result = await build_impl.build(buildActions,
       deleteFilesByDefault: deleteFilesByDefault,

--- a/build_runner/test/generate/build_error_test.dart
+++ b/build_runner/test/generate/build_error_test.dart
@@ -21,8 +21,7 @@ void main() {
           )
         ],
         {},
-        packageGraph:
-            buildPackageGraph('root_package', {package('root_package'): []}),
+        packageGraph: buildPackageGraph({rootPackage('root_package'): []}),
       );
     } catch (e) {
       // TODO: Write a throwsAWith(...) matcher?
@@ -44,7 +43,7 @@ void main() {
           'a|lib/a.dart': '',
           'a|lib/a.dart.copy': '',
         },
-        packageGraph: buildPackageGraph('a', {package('a'): []}),
+        packageGraph: buildPackageGraph({rootPackage('a'): []}),
         deleteFilesByDefault: false,
       ),
       throwsA(const isInstanceOf<UnexpectedExistingOutputsException>()),

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -212,8 +212,8 @@ void main() {
     });
 
     test('can\'t output files in non-root packages', () async {
-      final packageGraph = buildPackageGraph('a', {
-        package('a', path: 'a/'): ['b'],
+      final packageGraph = buildPackageGraph({
+        rootPackage('a', path: 'a/'): ['b'],
         package('b', path: 'a/b'): []
       });
       expect(
@@ -227,8 +227,8 @@ void main() {
       PackageGraph packageGraph;
 
       setUp(() {
-        packageGraph = buildPackageGraph('a', {
-          package('a', path: 'a/'): ['b'],
+        packageGraph = buildPackageGraph({
+          rootPackage('a', path: 'a/'): ['b'],
           package('b', path: 'a/b/'): []
         });
       });
@@ -304,8 +304,8 @@ void main() {
     });
 
     test('can glob files from packages', () async {
-      final packageGraph = buildPackageGraph('a', {
-        package('a', path: 'a/'): ['b'],
+      final packageGraph = buildPackageGraph({
+        rootPackage('a', path: 'a/'): ['b'],
         package('b', path: 'a/b/'): []
       });
 
@@ -361,8 +361,8 @@ void main() {
     });
 
     test('won\'t try to delete files from other packages', () async {
-      final packageGraph = buildPackageGraph('a', {
-        package('a', path: 'a/'): ['b'],
+      final packageGraph = buildPackageGraph({
+        rootPackage('a', path: 'a/'): ['b'],
         package('b', path: 'a/b'): []
       });
       var writer = new InMemoryRunnerAssetWriter()

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -119,7 +119,7 @@ Future<ServeHandler> createHandler(List<BuildAction> buildActions,
   final actualAssets = writer.assets;
   final reader = new InMemoryRunnerAssetReader(actualAssets);
   final packageGraph =
-      buildPackageGraph('a', {package('a', path: path.absolute('a')): []});
+      buildPackageGraph({rootPackage('a', path: path.absolute('a')): []});
   final watcherFactory = (String path) => new FakeWatcher(path);
 
   return watch_impl.watch(buildActions,

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -154,8 +154,8 @@ void main() {
 
       test('ignores events from nested packages', () async {
         var writer = new InMemoryRunnerAssetWriter();
-        final packageGraph = buildPackageGraph('a', {
-          package('a', path: path.absolute('a')): ['b'],
+        final packageGraph = buildPackageGraph({
+          rootPackage('a', path: path.absolute('a')): ['b'],
           package('b', path: path.absolute('a', 'b')): []
         });
 
@@ -408,7 +408,7 @@ Stream<BuildResult> startWatch(List<BuildAction> buildActions,
   final actualAssets = writer.assets;
   final reader = new InMemoryRunnerAssetReader(actualAssets);
   packageGraph ??=
-      buildPackageGraph('a', {package('a', path: path.absolute('a')): []});
+      buildPackageGraph({rootPackage('a', path: path.absolute('a')): []});
   final watcherFactory = (String path) => new FakeWatcher(path);
 
   var buildState = watch_impl.watch(buildActions,

--- a/build_runner/test/package_graph/dependency_odering_test.dart
+++ b/build_runner/test/package_graph/dependency_odering_test.dart
@@ -8,8 +8,8 @@ import '../common/package_graphs.dart';
 void main() {
   group('stronglyConnectedComponents', () {
     test('with two sub trees', () {
-      var graph = buildPackageGraph('a', {
-        package('a'): ['left1', 'right1'],
+      var graph = buildPackageGraph({
+        rootPackage('a'): ['left1', 'right1'],
         package('left1'): ['left2'],
         package('left2'): [],
         package('right1'): ['right2'],
@@ -36,8 +36,8 @@ void main() {
     });
 
     test('includes the root last in the strongly connected component', () {
-      var graph = buildPackageGraph('a', {
-        package('a'): ['b'],
+      var graph = buildPackageGraph({
+        rootPackage('a'): ['b'],
         package('b'): ['a']
       });
       var inOrder = stronglyConnectedComponents<String, PackageNode>(
@@ -48,8 +48,8 @@ void main() {
     });
 
     test('handles cycles from beneath the root', () {
-      var graph = buildPackageGraph('a', {
-        package('a'): ['b'],
+      var graph = buildPackageGraph({
+        rootPackage('a'): ['b'],
         package('b'): ['c'],
         package('c'): ['b']
       });
@@ -66,8 +66,8 @@ void main() {
     });
 
     test('handles diamonds', () {
-      var graph = buildPackageGraph('a', {
-        package('a'): ['left', 'right'],
+      var graph = buildPackageGraph({
+        rootPackage('a'): ['left', 'right'],
         package('left'): ['sharedDep'],
         package('right'): ['sharedDep'],
         package('sharedDep'): []

--- a/build_runner/test/package_graph/package_graph_test.dart
+++ b/build_runner/test/package_graph/package_graph_test.dart
@@ -109,7 +109,7 @@ void main() {
     });
 
     test('custom creation via fromRoot', () {
-      var a = new PackageNode('a', null);
+      var a = new PackageNode('a', null, isRoot: true);
       var b = new PackageNode('b', null);
       var c = new PackageNode('c', null);
       var d = new PackageNode('d', null);
@@ -138,8 +138,8 @@ void main() {
 
   group('orderedPackages', () {
     test('with two sub trees', () {
-      var graph = buildPackageGraph('a', {
-        package('a'): ['left1', 'right1'],
+      var graph = buildPackageGraph({
+        rootPackage('a'): ['left1', 'right1'],
         package('left1'): ['left2'],
         package('left2'): [],
         package('right1'): ['right2'],
@@ -151,8 +151,8 @@ void main() {
     });
 
     test('includes root last in cycle', () {
-      var graph = buildPackageGraph('a', {
-        package('a'): ['b'],
+      var graph = buildPackageGraph({
+        rootPackage('a'): ['b'],
         package('b'): ['a']
       });
       var inOrder = graph.orderedPackages.map((n) => n.name).toList();
@@ -160,8 +160,8 @@ void main() {
     });
 
     test('handles cycles from beneath the root', () {
-      var graph = buildPackageGraph('a', {
-        package('a'): ['b'],
+      var graph = buildPackageGraph({
+        rootPackage('a'): ['b'],
         package('b'): ['c'],
         package('c'): ['b']
       });
@@ -171,8 +171,8 @@ void main() {
     });
 
     test('handles diamonds', () {
-      var graph = buildPackageGraph('a', {
-        package('a'): ['left', 'right'],
+      var graph = buildPackageGraph({
+        rootPackage('a'): ['left', 'right'],
         package('left'): ['sharedDep'],
         package('right'): ['sharedDep'],
         package('sharedDep'): []
@@ -184,8 +184,8 @@ void main() {
 
   group('dependentsOf', () {
     test('with two sub trees', () {
-      var graph = buildPackageGraph('a', {
-        package('a'): ['left1', 'right1', 'needle'],
+      var graph = buildPackageGraph({
+        rootPackage('a'): ['left1', 'right1', 'needle'],
         package('left1'): ['left2', 'needle'],
         package('left2'): [],
         package('right1'): ['right2'],

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   setUp(() async {
     reader = new InMemoryRunnerAssetReader();
-    final packageGraph = buildPackageGraph('a', {package('a'): []});
+    final packageGraph = buildPackageGraph({rootPackage('a'): []});
     watchImpl = new MockWatchImpl(reader, packageGraph);
     serveHandler = await createServeHandler(watchImpl);
     watchImpl.addFutureResult(

--- a/build_runner/test/server/serve_integration_test.dart
+++ b/build_runner/test/server/serve_integration_test.dart
@@ -28,8 +28,7 @@ void main() {
   final path = p.absolute('example');
 
   setUp(() async {
-    final graph =
-        buildPackageGraph('example', {package('example', path: path): []});
+    final graph = buildPackageGraph({rootPackage('example', path: path): []});
     writer = new InMemoryRunnerAssetWriter();
     reader = new InMemoryRunnerAssetReader(writer.assets, 'example');
     reader.cacheStringAsset(

--- a/build_runner/test/watcher/graph_watcher_test.dart
+++ b/build_runner/test/watcher/graph_watcher_test.dart
@@ -18,8 +18,8 @@ import '../common/package_graphs.dart';
 void main() {
   group('PackageGraphWatcher', () {
     test('should aggregate changes from all nodes', () {
-      final graph = buildPackageGraph('a', {
-        package('a', path: '/g/a'): ['b'],
+      final graph = buildPackageGraph({
+        rootPackage('a', path: '/g/a'): ['b'],
         package('b', path: '/g/b'): []
       });
       final nodes = {
@@ -43,8 +43,8 @@ void main() {
     });
 
     test('should avoid duplicate changes with nested packages', () {
-      final graph = buildPackageGraph('a', {
-        package('a', path: '/g/a'): ['b'],
+      final graph = buildPackageGraph({
+        rootPackage('a', path: '/g/a'): ['b'],
         package('b', path: '/g/a/b'): []
       });
       final nodes = {

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -23,7 +23,7 @@ List<_i1.BuildAction> _buildActions(_i1.PackageGraph packageGraph) {
     _i1.apply('build_compilers', 'ddc_bootstrap',
         [_i3.devCompilerBootstrapBuilder], _i1.toNoneByDefault()),
     _i1.apply('build_compilers', 'ddc_bootstrap',
-        [_i3.devCompilerBootstrapBuilder], _i1.toPackage('e2e_example'),
+        [_i3.devCompilerBootstrapBuilder], _i1.toRoot(),
         inputs: ['web/**.dart', 'test/**.browser_test.dart'])
   ];
   return _i1.createBuildActions(packageGraph, builders);


### PR DESCRIPTION
Towards #628

- Add `isRoot` field and validation that it is set correctly.
- Add `toRoot` package filter and drop hacks for `applyToRoot`.
- Use `toRoot` in generated build script rather than `toPackage` with
  the name of the root package.
- Add `rootPackage` test utility to make test graphs more readable. Drop
  `rootPackage` argument to `buildPackageGraph` and search through nodes
  instead.