### PR TITLE
Refactor workers in BuildCompilers.

### DIFF
--- a/build_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_compilers/lib/src/dev_compiler_builder.dart
@@ -64,9 +64,9 @@ Future createDevCompilerModule(Module module, BuildStep buildStep,
   var jsOutputFile = scratchSpace.fileFor(module.jsId);
   var libraryRoot = '/${p.split(p.dirname(module.jsId.path)).first}';
   var sdkSummary = p.url.join(sdkDir, 'lib/_internal/ddc_sdk.sum');
-  var request = new WorkRequest();
+  var request = <String>[];
 
-  request.arguments.addAll([
+  request.addAll([
     '--dart-sdk-summary=$sdkSummary',
     '--modules=amd',
     '--dart-sdk=${sdkDir}',
@@ -79,22 +79,22 @@ Future createDevCompilerModule(Module module, BuildStep buildStep,
   ]);
 
   if (debugMode) {
-    request.arguments.addAll([
+    request.addAll([
       '--source-map',
       '--source-map-comment',
       '--inline-source-map',
     ]);
   } else {
-    request.arguments.add('--no-source-map');
+    request.add('--no-source-map');
   }
 
   // Add the default analysis_options.
   await scratchSpace.ensureAssets([defaultAnalysisOptionsId], buildStep);
-  request.arguments.add(defaultAnalysisOptionsArg(scratchSpace));
+  request.add(defaultAnalysisOptionsArg(scratchSpace));
 
   // Add all the linked summaries as summary inputs.
   for (var id in transitiveSummaryDeps) {
-    request.arguments.addAll(['-s', scratchSpace.fileFor(id).path]);
+    request.addAll(['-s', scratchSpace.fileFor(id).path]);
   }
 
   // Add URL mappings for all the package: files to tell DartDevc where to
@@ -104,17 +104,16 @@ Future createDevCompilerModule(Module module, BuildStep buildStep,
   for (var id in module.sources) {
     var uri = canonicalUriFor(id);
     if (uri.startsWith('package:')) {
-      request.arguments
-          .add('--url-mapping=$uri,${scratchSpace.fileFor(id).path}');
+      request.add('--url-mapping=$uri,${scratchSpace.fileFor(id).path}');
     } else {
       var absoluteFileUri = new Uri.file('/${id.path}');
-      request.arguments.add('--url-mapping=$absoluteFileUri,${id.path}');
+      request.add('--url-mapping=$absoluteFileUri,${id.path}');
     }
   }
 
   // And finally add all the urls to compile, using the package: path for
   // files under lib and the full absolute path for other files.
-  request.arguments.addAll(module.sources.map((id) {
+  request.addAll(module.sources.map((id) {
     var uri = canonicalUriFor(id);
     if (uri.startsWith('package:')) {
       return uri;
@@ -122,8 +121,8 @@ Future createDevCompilerModule(Module module, BuildStep buildStep,
     return new Uri.file('/${id.path}').toString();
   }));
 
-  var dartdevc = await buildStep.fetchResource(dartdevcDriverResource);
-  var response = await dartdevc.doWork(request);
+  var dartdevc = await buildStep.fetchResource(dartdevcWorker.resource);
+  var response = await dartdevc.execute(request);
   // TODO(jakemac53): Fix the ddc worker mode so it always sends back a bad
   // status code if something failed. Today we just make sure there is an output
   // JS file to verify it was successful.

--- a/build_compilers/lib/src/scratch_space.dart
+++ b/build_compilers/lib/src/scratch_space.dart
@@ -33,8 +33,8 @@ final scratchSpaceResource = new Resource<ScratchSpace>(() {
 }, beforeExit: () async {
   // The workers are running inside the scratch space, so wait for them to
   // shut down before deleting it.
-  await analyzerWorkersAreDone;
-  await dartdevcWorkersAreDone;
+  await analyzerWorker.isDone;
+  await dartdevcWorker.isDone;
   // Attempt to clean up the scratch space. Even after waiting for the workers
   // to shut down we might get file system exceptions on windows for an
   // arbitrary amount of time, so do retries with an exponential backoff.

--- a/build_compilers/lib/src/workers.dart
+++ b/build_compilers/lib/src/workers.dart
@@ -9,76 +9,134 @@ import 'dart:math' show min;
 import 'package:bazel_worker/driver.dart';
 import 'package:build/build.dart';
 import 'package:cli_util/cli_util.dart' as cli_util;
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import 'scratch_space.dart';
 
-/// Completes once the analyzer workers have been shut down.
-Future<Null> get analyzerWorkersAreDone =>
-    _analyzerWorkersAreDoneCompleter?.future ?? new Future.value(null);
-Completer<Null> _analyzerWorkersAreDoneCompleter;
+/// On windows some tools have to be executed with the `.bat` extension.
+final String _scriptExtension = Platform.isWindows ? '.bat' : '';
 
-/// Completes once the dartdevc workers have been shut down.
-Future<Null> get dartdevcWorkersAreDone =>
-    _dartdevcWorkersAreDoneCompleter?.future ?? new Future.value(null);
-Completer<Null> _dartdevcWorkersAreDoneCompleter;
+/// Returns the path to the SDK.
+final String sdkDir = cli_util.getSdkPath();
 
-String get _scriptExtension => Platform.isWindows ? '.bat' : '';
+/// Returns the path to a binary in the SDK.
+String _sdkBin(String name) => p.join(sdkDir, 'bin', '$name$_scriptExtension');
 
 final int _defaultMaxWorkers = min((Platform.numberOfProcessors / 2).ceil(), 4);
-
 const _maxWorkersEnvVar = 'BUILD_MAX_WORKERS_PER_TASK';
+final int _maxWorkersPerTask = int.parse(
+  Platform.environment[_maxWorkersEnvVar] ?? '$_defaultMaxWorkers',
+  onError: (value) {
+    log.warning('Invalid value for $_maxWorkersEnvVar environment variable, '
+        'expected an int but got `$value`. Falling back to default value '
+        'of $_defaultMaxWorkers.');
+    return _defaultMaxWorkers;
+  },
+);
 
-final int _maxWorkersPerTask = int
-    .parse(Platform.environment[_maxWorkersEnvVar] ?? '$_defaultMaxWorkers',
-        onError: (value) {
-  log.warning('Invalid value for $_maxWorkersEnvVar environment variable, '
-      'expected an int but got `$value`. Falling back to default value '
-      'of $_defaultMaxWorkers.');
-  return _defaultMaxWorkers;
-});
+/// Encapsulates running an external tool in a sandbox as a compiler.
+///
+/// TODO: Consider making this public in build_compilers(?) in the future.
+abstract class BatchWorker {
+  BazelWorkerDriver _driver;
+  Completer<Null> _onDone;
+  Resource<BatchWorker> _resource;
 
-/// Manages a shared set of persistent analyzer workers.
-BazelWorkerDriver get _analyzerDriver {
-  _analyzerWorkersAreDoneCompleter ??= new Completer<Null>();
-  return __analyzerDriver ??= new BazelWorkerDriver(
-      () => Process.start(
-          p.join(sdkDir, 'bin', 'dartanalyzer$_scriptExtension'),
-          ['--build-mode', '--persistent_worker'],
-          workingDirectory: scratchSpace.tempDir.path),
-      maxWorkers: _maxWorkersPerTask);
+  /// Returns a unified interface around a worker process.
+  BazelWorkerDriver _createDriver() {
+    return _driver ??= new BazelWorkerDriver(
+      () => startProcess(scratchSpace.tempDir.path),
+      maxWorkers: _maxWorkersPerTask,
+    );
+  }
+
+  /// Executes the following command [args] against the worker.
+  ///
+  /// Returns a [WorkResponse] object from `package:bazel_worker`.
+  Future<WorkResponse> execute(List<String> args) async {
+    return _driver.doWork(new WorkRequest()..arguments.addAll(args));
+  }
+
+  /// Completes when the worker is considered complete and shut down.
+  ///
+  /// A worker that has not started is always considered "done".
+  ///
+  /// TODO: Consider different naming, i.e. is/isNotActive(?).
+  Future<Null> get isDone => _onDone?.future ?? new Future.value();
+
+  /// Resource for accessing the spawned process.
+  ///
+  /// Can be used with [BuildStep.fetchResource].
+  Resource<BatchWorker> get resource {
+    return _resource ??= new Resource<BatchWorker>(
+      () {
+        _createDriver();
+        return this;
+      },
+      beforeExit: () async {
+        await _driver?.terminateWorkers();
+        _driver = null;
+        _onDone?.complete();
+        _onDone = null;
+      },
+    );
+  }
+
+  /// Starts a persistent worker in [workingDirectory].
+  @protected
+  Future<Process> startProcess(String workingDirectory);
 }
 
-BazelWorkerDriver __analyzerDriver;
+final BatchWorker analyzerWorker = new _AnalyzerWorker();
 
-/// Resource for fetching the current [BazelWorkerDriver] for dartanalyzer.
-final analyzerDriverResource = new Resource<BazelWorkerDriver>(
-    () => _analyzerDriver, beforeExit: () async {
-  await _analyzerDriver?.terminateWorkers();
-  _analyzerWorkersAreDoneCompleter.complete();
-  _analyzerWorkersAreDoneCompleter = null;
-  __analyzerDriver = null;
-});
+class _AnalyzerWorker extends BatchWorker {
+  static final _defaultPath = _sdkBin('dartanalyzer');
 
-/// Manages a shared set of persistent dartdevc workers.
-BazelWorkerDriver get _dartdevcDriver {
-  _dartdevcWorkersAreDoneCompleter ??= new Completer<Null>();
-  return __dartdevcDriver ??= new BazelWorkerDriver(
-      () => Process.start(p.join(sdkDir, 'bin', 'dartdevc$_scriptExtension'),
-          ['--persistent_worker'],
-          workingDirectory: scratchSpace.tempDir.path),
-      maxWorkers: _maxWorkersPerTask);
+  @override
+  Future<Process> startProcess(String workingDirectory) {
+    return Process.start(
+      _defaultPath,
+      const [
+        '--build-mode',
+        '--persistent_worker',
+      ],
+      workingDirectory: workingDirectory,
+    );
+  }
 }
 
-BazelWorkerDriver __dartdevcDriver;
+final BatchWorker dartdevcWorker = new _DartDevCWorker();
 
-/// Resource for fetching the current [BazelWorkerDriver] for dartdevc.
-final dartdevcDriverResource = new Resource<BazelWorkerDriver>(
-    () => _dartdevcDriver, beforeExit: () async {
-  await _dartdevcDriver?.terminateWorkers();
-  _dartdevcWorkersAreDoneCompleter.complete();
-  _dartdevcWorkersAreDoneCompleter = null;
-  __dartdevcDriver = null;
-});
+class _DartDevCWorker extends BatchWorker {
+  static final _defaultPath = _sdkBin('dartdevc');
 
-final sdkDir = cli_util.getSdkPath();
+  @override
+  Future<Process> startProcess(String workingDirectory) {
+    return Process.start(
+      _defaultPath,
+      const ['--persistent_worker'],
+      workingDirectory: workingDirectory,
+    );
+  }
+}
+
+final BatchWorker dart2jsWorker = new _Dart2JsWorker();
+
+// TODO: Actually use in a builder.
+//
+// It's here to make the point that refactoring the common code into
+// "BatchWorker" was worth it, but it will be used momentarily to power a
+// builder.
+class _Dart2JsWorker extends BatchWorker {
+  static final _defaultPath = _sdkBin('dartj2s');
+
+  @override
+  Future<Process> startProcess(String workingDirectory) {
+    return Process.start(
+      _defaultPath,
+      const ['--batch'],
+      workingDirectory: workingDirectory,
+    );
+  }
+}


### PR DESCRIPTION
Work towards https://github.com/dart-lang/build/issues/617.

Let me know if you'd like any changes, or to make it more `bazel_worker` specific again, but this looked like the least amount of boilerplate for creating reusable workers without getting _too_ abstract. It also looks like it might be useful to integrate external tools in the future.

(Happy to add tests, even though this mostly just wraps everything for now)