### PR TITLE
Whitelist main package dirs

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Breaking Changes
 
+- There is now a whitelist of top level directories that will be used as a part
+  of the build, and other files will be ignored. For now those directories
+  include 'benchmark', 'bin', 'example', 'lib', 'test', 'tool', and 'web'.
+  - If this breaks your workflow please file an issue and we can look at either
+    adding additional directories or making the list configurable per project.
 - Remove `PackageGraph.orderedPackages` and `PackageGraph.dependentsOf`.
 
 The following changes are technically breaking but should not impact most

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -41,10 +41,12 @@ class AssetGraph {
   static Future<AssetGraph> build(
       List<BuildAction> buildActions,
       Set<AssetId> sources,
+      Set<AssetId> internalSources,
       String rootPackage,
       DigestAssetReader digestReader) async {
     var graph = new AssetGraph._(computeBuildActionsDigest(buildActions));
     var newNodes = graph._addSources(sources);
+    graph._addInternalSources(internalSources);
     graph._addOutputsForSources(buildActions, sources, rootPackage);
     // Pre-emptively compute digests for the nodes we know have outputs.
     await graph._setLastKnownDigests(
@@ -85,6 +87,14 @@ class AssetGraph {
       }
     }
     _nodesByPackage.putIfAbsent(node.id.package, () => {})[node.id.path] = node;
+  }
+
+  /// Adds [assetIds] as [InternalAssetNode]s to this graph.
+  void _addInternalSources(Set<AssetId> assetIds) {
+    for (var id in assetIds) {
+      var node = new InternalAssetNode(id);
+      _add(node);
+    }
   }
 
   /// Adds [assetIds] as [AssetNode]s to this graph, and returns the newly

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -32,6 +32,18 @@ abstract class AssetNode {
   String toString() => 'AssetNode: $id';
 }
 
+/// A node representing some internal asset.
+///
+/// These nodes are not used as primary inputs, but they are tracked in the
+/// asset graph and are readable.
+class InternalAssetNode extends AssetNode {
+  InternalAssetNode(AssetId id, {Digest lastKnownDigest})
+      : super(id, lastKnownDigest: lastKnownDigest);
+
+  @override
+  String toString() => 'InternalAssetNode: $id';
+}
+
 /// A node which is an original source asset (not generated).
 class SourceAssetNode extends AssetNode {
   SourceAssetNode(AssetId id, {Digest lastKnownDigest})

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -8,7 +8,7 @@ part of 'graph.dart';
 ///
 /// This should be incremented any time the serialize/deserialize formats
 /// change.
-const _version = 12;
+const _version = 13;
 
 /// Deserializes an [AssetGraph] from a [Map].
 class _AssetGraphDeserializer {

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -83,6 +83,10 @@ class _AssetGraphDeserializer {
             previousInputsDigest: _deserializeDigest(
                 serializedNode[_Field.PreviousInputsDigest.index] as String));
         break;
+      case _NodeType.Internal:
+        assert(serializedNode.length == _WrappedAssetNode._length);
+        node = new InternalAssetNode(id, lastKnownDigest: digest);
+        break;
     }
     node.outputs.addAll(_deserializeAssetIds(
         serializedNode[_Field.Outputs.index] as List<int>));
@@ -142,7 +146,7 @@ class _AssetGraphSerializer {
 }
 
 /// Used to serialize the type of a node using an int.
-enum _NodeType { Source, Synthetic, Generated }
+enum _NodeType { Source, Synthetic, Generated, Internal }
 
 /// Field indexes for serialized nodes.
 enum _Field {
@@ -192,6 +196,8 @@ class _WrappedAssetNode extends Object with ListMixin implements List {
           return _NodeType.Generated.index;
         } else if (node is SyntheticAssetNode) {
           return _NodeType.Synthetic.index;
+        } else if (node is InternalAssetNode) {
+          return _NodeType.Internal.index;
         } else {
           throw new StateError('Unrecognized node type');
         }

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -276,7 +276,15 @@ class _Loader {
   Future<Set<AssetId>> _findInputSources() async {
     List<String> packageIncludes(String packageName) {
       if (packageName == _options.packageGraph.root.name) {
-        return const ['**'];
+        return const [
+          'benchmark/**',
+          'bin/**',
+          'example/**',
+          'lib/**',
+          'test/**',
+          'tool/**',
+          'web/**',
+        ];
       }
       if (packageName == r'$sdk') {
         return const ['lib/dev_compiler/**.js'];

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -268,10 +268,12 @@ class _Loader {
 
     addUpdates(removedAssets, ChangeType.REMOVE);
 
-    var remainingSources = assetGraph.sources.toSet().intersection(inputSources)
-      ..addAll(internalSources);
+    var originalGraphSources = assetGraph.sources.toSet();
+    var remainingSources = originalGraphSources.intersection(inputSources)
+      ..addAll(originalGraphSources.intersection(internalSources));
     var modifyChecks = remainingSources.map((id) async {
       var node = assetGraph.get(id);
+      if (node == null) throw id;
       var originalDigest = node.lastKnownDigest;
       var currentDigest = await _options.reader.digest(id);
       if (currentDigest != originalDigest) {

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -76,7 +76,10 @@ class _Loader {
     _logger.info('Initializing inputs');
     var inputSources = await _findInputSources();
     var cacheDirSources = await _findCacheDirSources();
-    var allSources = inputSources.union(cacheDirSources);
+    var internalSources = await _findInternalSources();
+    var allSources = inputSources.toSet()
+      ..addAll(cacheDirSources)
+      ..addAll(internalSources);
 
     var assetGraph = await _tryReadCachedAssetGraph();
 
@@ -85,8 +88,8 @@ class _Loader {
       var updates = await logTimedAsync(
           _logger,
           'Checking for updates since last build',
-          () => _updateAssetGraph(
-              assetGraph, inputSources, cacheDirSources, allSources));
+          () => _updateAssetGraph(assetGraph, inputSources, cacheDirSources,
+              internalSources, allSources));
 
       buildScriptUpdates =
           await BuildScriptUpdates.create(_options, assetGraph);
@@ -103,7 +106,7 @@ class _Loader {
 
       await logTimedAsync(_logger, 'Building new asset graph', () async {
         assetGraph = await AssetGraph.build(_buildActions, inputSources,
-            _options.packageGraph.root.name, _options.reader);
+            internalSources, _options.packageGraph.root.name, _options.reader);
         buildScriptUpdates =
             await BuildScriptUpdates.create(_options, assetGraph);
         conflictingOutputs =
@@ -153,6 +156,11 @@ class _Loader {
     return new Future.value(new Set<AssetId>());
   }
 
+  /// Returns all the internal sources, such as those under [entryPointDir].
+  Future<Set<AssetId>> _findInternalSources() {
+    return _options.reader.findAssets(new Glob('$entryPointDir/**')).toSet();
+  }
+
   /// Attempts to read in an [AssetGraph] from disk, and returns `null` if it
   /// fails for any reason.
   Future<AssetGraph> _tryReadCachedAssetGraph() async {
@@ -195,9 +203,10 @@ class _Loader {
       AssetGraph assetGraph,
       Set<AssetId> inputSources,
       Set<AssetId> cacheDirSources,
+      Set<AssetId> internalSources,
       Set<AssetId> allSources) async {
     var updates = await _findUpdates(
-        assetGraph, inputSources, cacheDirSources, allSources);
+        assetGraph, inputSources, cacheDirSources, internalSources, allSources);
     await assetGraph.updateAndInvalidate(
         _buildActions,
         updates,
@@ -234,6 +243,7 @@ class _Loader {
       AssetGraph assetGraph,
       Set<AssetId> inputSources,
       Set<AssetId> generatedSources,
+      Set<AssetId> internalSources,
       Set<AssetId> allSources) async {
     var updates = <AssetId, ChangeType>{};
     addUpdates(Iterable<AssetId> assets, ChangeType type) {
@@ -258,8 +268,8 @@ class _Loader {
 
     addUpdates(removedAssets, ChangeType.REMOVE);
 
-    var remainingSources =
-        assetGraph.sources.toSet().intersection(inputSources);
+    var remainingSources = assetGraph.sources.toSet().intersection(inputSources)
+      ..addAll(internalSources);
     var modifyChecks = remainingSources.map((id) async {
       var node = assetGraph.get(id);
       var originalDigest = node.lastKnownDigest;
@@ -294,10 +304,7 @@ class _Loader {
 
     var inputSets = _options.packageGraph.allPackages.values.map(
         (package) => new InputSet(package.name, packageIncludes(package.name)));
-    var sources = (await _listAssetIds(inputSets).toSet())
-      ..addAll(await _options.reader
-          .findAssets(new Glob('$entryPointDir/**'))
-          .toSet());
+    var sources = (await _listAssetIds(inputSets).toSet());
     return sources;
   }
 

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -208,7 +208,7 @@ class BuildImpl {
     var builder = action.builder;
     await Future
         .wait(_assetGraph.packageNodes(inputSet.package).map((node) async {
-      if (node is SyntheticAssetNode) return;
+      if (node is SyntheticAssetNode || node is InternalAssetNode) return;
       if (!inputSet.matches(node.id)) return;
       if (!builder.buildExtensions.keys
           .any((inputExtension) => node.id.path.endsWith(inputExtension))) {

--- a/build_runner/lib/src/generate/input_set.dart
+++ b/build_runner/lib/src/generate/input_set.dart
@@ -5,11 +5,6 @@
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 
-import '../util/constants.dart';
-
-final List<Glob> _alwaysExclude =
-    new List.unmodifiable(toolDirs.map((d) => new Glob('$d/**')));
-
 final List<Glob> _defaultInclude = new List.unmodifiable([new Glob('**')]);
 
 /// A set of files in a package to use as primary inputs to a `Builder`.
@@ -33,10 +28,9 @@ class InputSet {
             ? _defaultInclude
             : new List.unmodifiable(globs.map((pattern) => new Glob(pattern))),
         this.excludes = excludes == null
-            ? _alwaysExclude
-            : new List.unmodifiable([]
-              ..addAll(excludes?.map((pattern) => new Glob(pattern)))
-              ..addAll(_alwaysExclude));
+            ? const []
+            : new List.unmodifiable(
+                excludes.map((pattern) => new Glob(pattern)));
 
   /// Returns whether [input] is included in [globs] and not in [excludes].
   bool matches(AssetId input) =>

--- a/build_runner/lib/src/util/constants.dart
+++ b/build_runner/lib/src/util/constants.dart
@@ -4,6 +4,7 @@
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
+import 'package:glob/glob.dart';
 
 /// Relative path to the asset graph from the root package dir.
 final String assetGraphPath = assetGraphPathFor(Platform.script.scheme == 'file'
@@ -28,3 +29,17 @@ const String cacheDir = '.dart_tool/build';
 
 /// Returns a hash for a given path.
 String scriptHashFor(String path) => md5.convert(path.codeUnits).toString();
+
+/// Whitelist of files in the root package to include.
+const List<String> rootPackageFilesWhitelist = const [
+  'benchmark/**',
+  'bin/**',
+  'example/**',
+  'lib/**',
+  'test/**',
+  'tool/**',
+  'web/**',
+];
+
+final List<Glob> rootPackageGlobsWhitelist = new List.unmodifiable(
+    rootPackageFilesWhitelist.map((pattern) => new Glob(pattern)));

--- a/build_runner/lib/src/util/constants.dart
+++ b/build_runner/lib/src/util/constants.dart
@@ -14,18 +14,6 @@ final String assetGraphPath = assetGraphPathFor(Platform.script.scheme == 'file'
 String assetGraphPathFor(String path) =>
     '$cacheDir/${scriptHashFor(path)}/asset_graph.json';
 
-/// Directories used for build tooling.
-///
-/// Reading from these directories may cause non-hermetic builds.
-const toolDirs = const [
-  '.dart_tool',
-  'build',
-  'packages',
-  '.pub',
-  '.git',
-  '.idea'
-];
-
 /// Directory containing automatically generated build entrypoints.
 ///
 /// Files in this directory must be read to do build script invalidation.

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -43,7 +43,8 @@ void main() {
 
     group('simple graph', () {
       setUp(() async {
-        graph = await AssetGraph.build([], new Set(), 'foo', digestReader);
+        graph = await AssetGraph
+            .build([], new Set(), new Set(), 'foo', digestReader);
       });
 
       test('add, contains, get, allNodes', () {
@@ -125,11 +126,14 @@ void main() {
       final primaryOutputId = makeAssetId('foo|file.copy');
       final syntheticId = makeAssetId('foo|synthetic');
       final syntheticOutputId = makeAssetId('foo|synthetic.copy');
+      final internalId =
+          makeAssetId('foo|.dart_tool/build/entrypoint/serve.dart');
 
       setUp(() async {
         graph = await AssetGraph.build(
             buildActions,
             new Set.from([primaryInputId, excludedInputId]),
+            [internalId].toSet(),
             'foo',
             digestReader);
       });
@@ -142,6 +146,7 @@ void main() {
               primaryInputId,
               excludedInputId,
               primaryOutputId,
+              internalId,
             ]));
         var node = graph.get(primaryInputId);
         expect(node.primaryOutputs, [primaryOutputId]);
@@ -153,6 +158,8 @@ void main() {
         expect(excludedNode, isNotNull);
         expect(excludedNode.lastKnownDigest, isNull,
             reason: 'Nodes with no output shouldn\'t get an eager digest.');
+
+        expect(graph.get(internalId), new isInstanceOf<InternalAssetNode>());
       });
 
       group('updateAndInvalidate', () {
@@ -249,6 +256,7 @@ void main() {
           () => AssetGraph.build(
               new List.filled(2, new BuildAction(new CopyBuilder(), 'foo')),
               [makeAssetId('foo|file')].toSet(),
+              new Set(),
               'foo',
               digestReader),
           throwsA(duplicateAssetNodeException));

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -82,6 +82,7 @@ main() {
         var originalAssetGraph = await AssetGraph.build(
             buildActions,
             [makeAssetId('a|lib/a.txt'), makeAssetId('a|lib/b.txt')].toSet(),
+            new Set(),
             'a',
             options.reader);
         var generatedAId = makeAssetId('a|lib/a.txt.copy');
@@ -111,7 +112,7 @@ main() {
         var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
 
         var originalAssetGraph = await AssetGraph.build(
-            buildActions, <AssetId>[].toSet(), 'a', options.reader);
+            buildActions, <AssetId>[].toSet(), new Set(), 'a', options.reader);
 
         await createFile(
             assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
@@ -133,8 +134,12 @@ main() {
         await createFile(p.join('lib', 'a.txt'), 'a');
         var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
 
-        var originalAssetGraph = await AssetGraph.build(buildActions,
-            [makeAssetId('a|lib/a.txt')].toSet(), 'a', options.reader);
+        var originalAssetGraph = await AssetGraph.build(
+            buildActions,
+            [makeAssetId('a|lib/a.txt')].toSet(),
+            new Set(),
+            'a',
+            options.reader);
 
         await createFile(
             assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
@@ -156,8 +161,12 @@ main() {
           new BuildAction(new OverDeclaringCopyBuilder(), 'a')
         ];
 
-        var originalAssetGraph = await AssetGraph.build(buildActions,
-            [makeAssetId('a|lib/test.txt')].toSet(), 'a', options.reader);
+        var originalAssetGraph = await AssetGraph.build(
+            buildActions,
+            [makeAssetId('a|lib/test.txt')].toSet(),
+            new Set(),
+            'a',
+            options.reader);
         var generatedSrcId = makeAssetId('a|lib/test.txt.copy');
         var generatedNode =
             originalAssetGraph.get(generatedSrcId) as GeneratedAssetNode;
@@ -180,7 +189,7 @@ main() {
         var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
 
         var assetGraph = await AssetGraph.build(
-            buildActions, new Set<AssetId>(), 'a', options.reader);
+            buildActions, new Set<AssetId>(), new Set(), 'a', options.reader);
         expect(assetGraph.allNodes, isEmpty);
 
         await createFile(assetGraphPath, JSON.encode(assetGraph.serialize()));
@@ -227,7 +236,7 @@ main() {
           onLog: logs.add);
 
       var originalAssetGraph = await AssetGraph.build(
-          buildActions, <AssetId>[].toSet(), 'a', options.reader);
+          buildActions, <AssetId>[].toSet(), new Set(), 'a', options.reader);
 
       await createFile(
           assetGraphPath, JSON.encode(originalAssetGraph.serialize()));

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -412,7 +412,8 @@ void main() {
     var cachedGraph = new AssetGraph.deserialize(
         JSON.decode(UTF8.decode(writer.assets[graphId])) as Map);
 
-    var expectedGraph = await AssetGraph.build([], new Set(), 'a', null);
+    var expectedGraph =
+        await AssetGraph.build([], new Set(), new Set(), 'a', null);
     var aCopyNode = new GeneratedAssetNode(null, makeAssetId('a|web/a.txt'),
         false, true, makeAssetId('a|web/a.txt.copy'),
         lastKnownDigest: computeDigest('a'),

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -133,7 +133,8 @@ void main() {
             as Map;
         var cachedGraph = new AssetGraph.deserialize(serialized);
 
-        var expectedGraph = await AssetGraph.build([], new Set(), 'a', null);
+        var expectedGraph =
+            await AssetGraph.build([], new Set(), new Set(), 'a', null);
         var bCopyNode = new GeneratedAssetNode(null, makeAssetId('a|web/b.txt'),
             false, true, makeAssetId('a|web/b.txt.copy'),
             lastKnownDigest: computeDigest('b2'),

--- a/e2e_example/test/build_script_invalidation_test.dart
+++ b/e2e_example/test/build_script_invalidation_test.dart
@@ -63,27 +63,27 @@ Future<Null> testEditWhileServing(bool manualScript) async {
   var filePath = manualScript
       ? 'tool/build.dart'
       : '.dart_tool/build/entrypoint/build.dart';
-  var startServer = manualScript ? startManualServer : startAutoServer;
   var terminateLine =
       nextStdOutLine('Terminating. No further builds will be scheduled');
-  await replaceAllInFile(filePath, 'Serving', 'Now serving');
+  await replaceAllInFile(filePath, 'await server.close();',
+      'await server.close(); // close the server');
   await terminateLine;
   await stopServer();
-  await startServer(extraExpects: [
+  await startManualServer(extraExpects: [
     () => nextStdOutLine('Invalidating asset graph due to build script update'),
     () => nextStdOutLine('Building new asset graph'),
-  ], verbose: true);
+  ], scriptPath: filePath, verbose: true);
 }
 
 Future<Null> testEditBetweenBuilds(bool manualScript) async {
   var filePath = manualScript
       ? 'tool/build.dart'
       : '.dart_tool/build/entrypoint/build.dart';
-  var startServer = manualScript ? startManualServer : startAutoServer;
   await stopServer();
-  await replaceAllInFile(filePath, 'Serving', 'Now serving');
-  await startServer(extraExpects: [
+  await replaceAllInFile(filePath, 'await server.close();',
+      'await server.close(); // close the server');
+  await startManualServer(extraExpects: [
     () => nextStdOutLine('Invalidating asset graph due to build script update'),
     () => nextStdOutLine('Building new asset graph'),
-  ], verbose: true);
+  ], scriptPath: filePath, verbose: true);
 }

--- a/e2e_example/test/common/utils.dart
+++ b/e2e_example/test/common/utils.dart
@@ -30,8 +30,11 @@ final String _pubBinary = Platform.isWindows ? 'pub.bat' : 'pub';
 /// For debugging purposes you can enable printing of the build script output by
 /// setting [verbose] to `true`.
 Future<Null> startManualServer(
-        {bool ensureCleanBuild, bool verbose, List<Function> extraExpects}) =>
-    _startServer('dart', ['tool/build.dart'],
+        {bool ensureCleanBuild,
+        bool verbose,
+        List<Function> extraExpects,
+        String scriptPath = 'tool/build.dart'}) =>
+    _startServer('dart', [scriptPath],
         ensureCleanBuild: ensureCleanBuild,
         verbose: verbose,
         extraExpects: extraExpects);


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/666

I also deleted the `toolDirs` constants since we don't need them any more, and replaced the handling for the entry point script with a new type of node - `InternalAssetNode`, which is similar to a `SourceAssetNode` but is never used as a primary input.