### PR TITLE
Invalidate actions based on BuilderOptions

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### New Features
 
 - Added `toRoot` Package filter.
+- Actions are now invalidated at a fine grained level when `BuilderOptions`
+  change.
 
 ### Breaking Changes
 

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -69,7 +69,7 @@ class SingleStepReader implements DigestAssetReader {
     _assetsRead.add(id);
     var node = _assetGraph.get(id);
     if (node == null) {
-      _assetGraph.add(new SyntheticAssetNode(id));
+      _assetGraph.add(new SyntheticSourceAssetNode(id));
       return false;
     }
     if (node is SyntheticAssetNode) return false;

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -76,7 +76,7 @@ class AssetGraph {
   void _add(AssetNode node) {
     var existing = get(node.id);
     if (existing != null) {
-      if (existing is SyntheticAssetNode) {
+      if (existing is SyntheticSourceAssetNode) {
         // Don't call _removeRecursive, that recursively removes all transitive
         // primary outputs. We only want to remove this node.
         _nodesByPackage[existing.id.package].remove(existing.id.path);
@@ -326,8 +326,8 @@ class AssetGraph {
 
   /// Adds [outputs] as [GeneratedAssetNode]s to the graph.
   ///
-  /// If there are existing [SourceAssetNode]s or [SyntheticAssetNode]s  that
-  /// overlap the [GeneratedAssetNode]s, then they will be replaced with
+  /// If there are existing [SourceAssetNode]s or [SyntheticSourceAssetNode]s
+  /// that overlap the [GeneratedAssetNode]s, then they will be replaced with
   /// [GeneratedAssetNode]s, and all their `primaryOutputs` will be removed
   /// from the graph as well. The return value is the set of assets that were
   /// removed from the graph.

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -53,18 +53,6 @@ class SourceAssetNode extends AssetNode {
   String toString() => 'SourceAssetNode: $id';
 }
 
-/// A node which is not a generated or source asset.
-///
-/// Typically these are created as a result of `canRead` calls for assets that
-/// don't exist in the graph. We still need to set up proper dependencies so
-/// that if that asset gets added later the outputs are properly invalidated.
-class SyntheticAssetNode extends AssetNode {
-  SyntheticAssetNode(AssetId id) : super(id);
-
-  @override
-  String toString() => 'SyntheticAssetNode: $id';
-}
-
 /// A generated node in the asset graph.
 class GeneratedAssetNode extends AssetNode {
   /// The phase which generated this asset.
@@ -114,4 +102,30 @@ class GeneratedAssetNode extends AssetNode {
   @override
   String toString() =>
       'GeneratedAssetNode: $id generated from input $primaryInput.';
+}
+
+/// A node which is not a generated or source asset.
+abstract class SyntheticAssetNode implements AssetNode {}
+
+/// A [SyntheticAssetNode] representing a non-existent source.
+///
+/// Typically these are created as a result of `canRead` calls for assets that
+/// don't exist in the graph. We still need to set up proper dependencies so
+/// that if that asset gets added later the outputs are properly invalidated.
+class SyntheticSourceAssetNode extends AssetNode implements SyntheticAssetNode {
+  SyntheticSourceAssetNode(AssetId id) : super(id);
+}
+
+/// A [SyntheticAssetNode] which represents an individual [BuilderOptions]
+/// object.
+///
+/// These are used to track the state of a [BuilderOptions] object, and all
+/// [GeneratedAssetNode]s should depend on one of these nodes, which represents
+/// their configuration.
+class BuilderOptionsAssetNode extends AssetNode implements SyntheticAssetNode {
+  BuilderOptionsAssetNode(AssetId id, {Digest lastKnownDigest})
+      : super(id, lastKnownDigest: lastKnownDigest);
+
+  @override
+  String toString() => 'BuildOptionsAssetNode: $id';
 }

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -87,8 +87,12 @@ class GeneratedAssetNode extends AssetNode {
   /// the previous run, indicating that the previous output is still valid.
   Digest previousInputsDigest;
 
+  /// The [AssetId] of the node representing the [BuilderOptions] used to create
+  /// this node.
+  final AssetId builderOptionsId;
+
   GeneratedAssetNode(this.phaseNumber, this.primaryInput, this.needsUpdate,
-      this.wasOutput, AssetId id,
+      this.wasOutput, AssetId id, this.builderOptionsId,
       {Digest lastKnownDigest,
       Set<Glob> globs,
       Iterable<AssetId> inputs,
@@ -123,7 +127,7 @@ class SyntheticSourceAssetNode extends AssetNode implements SyntheticAssetNode {
 /// [GeneratedAssetNode]s should depend on one of these nodes, which represents
 /// their configuration.
 class BuilderOptionsAssetNode extends AssetNode implements SyntheticAssetNode {
-  BuilderOptionsAssetNode(AssetId id, {Digest lastKnownDigest})
+  BuilderOptionsAssetNode(AssetId id, Digest lastKnownDigest)
       : super(id, lastKnownDigest: lastKnownDigest);
 
   @override

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -64,9 +64,9 @@ class _AssetGraphDeserializer {
         assert(serializedNode.length == _WrappedAssetNode._length);
         node = new SourceAssetNode(id, lastKnownDigest: digest);
         break;
-      case _NodeType.Synthetic:
+      case _NodeType.SyntheticSource:
         assert(serializedNode.length == _WrappedAssetNode._length);
-        node = new SyntheticAssetNode(id);
+        node = new SyntheticSourceAssetNode(id);
         break;
       case _NodeType.Generated:
         assert(serializedNode.length == _WrappedGeneratedAssetNode._length);
@@ -86,6 +86,10 @@ class _AssetGraphDeserializer {
       case _NodeType.Internal:
         assert(serializedNode.length == _WrappedAssetNode._length);
         node = new InternalAssetNode(id, lastKnownDigest: digest);
+        break;
+      case _NodeType.BuilderOptions:
+        assert(serializedNode.length == _WrappedAssetNode._length);
+        node = new BuilderOptionsAssetNode(id, lastKnownDigest: digest);
         break;
     }
     node.outputs.addAll(_deserializeAssetIds(
@@ -146,7 +150,7 @@ class _AssetGraphSerializer {
 }
 
 /// Used to serialize the type of a node using an int.
-enum _NodeType { Source, Synthetic, Generated, Internal }
+enum _NodeType { Source, SyntheticSource, Generated, Internal, BuilderOptions }
 
 /// Field indexes for serialized nodes.
 enum _Field {
@@ -194,10 +198,12 @@ class _WrappedAssetNode extends Object with ListMixin implements List {
           return _NodeType.Source.index;
         } else if (node is GeneratedAssetNode) {
           return _NodeType.Generated.index;
-        } else if (node is SyntheticAssetNode) {
-          return _NodeType.Synthetic.index;
+        } else if (node is SyntheticSourceAssetNode) {
+          return _NodeType.SyntheticSource.index;
         } else if (node is InternalAssetNode) {
           return _NodeType.Internal.index;
+        } else if (node is BuilderOptionsAssetNode) {
+          return _NodeType.BuilderOptions.index;
         } else {
           throw new StateError('Unrecognized node type');
         }

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -390,7 +390,11 @@ class BuildImpl {
     if (node.previousInputsDigest == null || node.globs.isNotEmpty) {
       return true;
     }
-    var digest = await _computeCombinedDigest(node.inputs, reader);
+    var allInputs = <Iterable<AssetId>>[
+      node.inputs,
+      [node.builderOptionsId]
+    ].expand((i) => i);
+    var digest = await _computeCombinedDigest(allInputs, reader);
     if (digest != node.previousInputsDigest) {
       return true;
     } else {
@@ -412,6 +416,7 @@ class BuildImpl {
       var node = _assetGraph.get(id);
       if (node is BuilderOptionsAssetNode) {
         bytesSink.add(node.lastKnownDigest.bytes);
+        continue;
       } else if (!await reader.canRead(id)) {
         // We want to add something here, a missing/unreadable input should be
         // different from no input at all.
@@ -451,6 +456,7 @@ class BuildImpl {
       inputsDigest ??= await () {
         var allInputs = reader.assetsRead.toSet();
         if (node.primaryInput != null) allInputs.add(node.primaryInput);
+        allInputs.add(node.builderOptionsId);
         return _computeCombinedDigest(allInputs, reader);
       }();
 

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -410,7 +410,9 @@ class BuildImpl {
 
     for (var id in ids) {
       var node = _assetGraph.get(id);
-      if (node is SyntheticAssetNode || !await reader.canRead(id)) {
+      if (node is BuilderOptionsAssetNode) {
+        bytesSink.add(node.lastKnownDigest.bytes);
+      } else if (!await reader.canRead(id)) {
         // We want to add something here, a missing/unreadable input should be
         // different from no input at all.
         bytesSink.add([1]);

--- a/build_runner/lib/src/generate/phase.dart
+++ b/build_runner/lib/src/generate/phase.dart
@@ -23,16 +23,24 @@ abstract class BuildAction {
   /// never run.
   final bool isOptional;
 
-  BuildAction._(bool isOptional) : this.isOptional = isOptional ?? false;
+  final BuilderOptions builderOptions;
+
+  BuildAction._(this.builderOptions, bool isOptional)
+      : this.isOptional = isOptional ?? false;
 
   /// Creates an [AssetBuildAction] for a normal [Builder].
   ///
   /// Runs [builder] on [package] with [inputs] as primary inputs, excluding
   /// [excludes]. Glob syntax is supported for both [inputs] and [excludes].
   factory BuildAction(Builder builder, String package,
-      {List<String> inputs, List<String> excludes, bool isOptional}) {
+      {List<String> inputs,
+      List<String> excludes,
+      BuilderOptions builderOptions,
+      bool isOptional}) {
     var inputSet = new InputSet(package, inputs, excludes: excludes);
-    return new AssetBuildAction._(builder, inputSet, isOptional: isOptional);
+    builderOptions ??= const BuilderOptions(const {});
+    return new AssetBuildAction._(builder, inputSet, builderOptions,
+        isOptional: isOptional);
   }
 }
 
@@ -46,8 +54,9 @@ class AssetBuildAction extends BuildAction {
   @override
   String get package => inputSet.package;
 
-  AssetBuildAction._(this.builder, this.inputSet, {bool isOptional})
-      : super._(isOptional);
+  AssetBuildAction._(this.builder, this.inputSet, BuilderOptions builderOptions,
+      {bool isOptional})
+      : super._(builderOptions, isOptional);
 
   @override
   String toString() => '$builder on $inputSet';
@@ -62,6 +71,7 @@ class PackageBuildAction extends BuildAction {
   @override
   final String package;
 
-  PackageBuildAction(this.builder, this.package, {bool isOptional})
-      : super._(isOptional);
+  PackageBuildAction(this.builder, this.package,
+      {BuilderOptions builderOptions, bool isOptional})
+      : super._(builderOptions ?? const BuilderOptions(const {}), isOptional);
 }

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -117,9 +117,11 @@ Iterable<BuildAction> _createBuildActionsForBuilderInCycle(
     Iterable<PackageNode> cycle,
     PackageGraph packageGraph,
     BuilderApplication builderApplication) {
+  var options = const BuilderOptions(const {});
   return builderApplication.builderFactories.expand((b) => cycle
       .where(builderApplication.filter)
-      .map((p) => new BuildAction(b(const BuilderOptions(const {})), p.name,
+      .map((p) => new BuildAction(b(options), p.name,
+          builderOptions: options,
           inputs: builderApplication.inputs,
           excludes: builderApplication.excludes,
           isOptional: builderApplication.isOptional)));

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -87,10 +87,14 @@ void main() {
             node.outputs.add(generatedNode.id);
             node.primaryOutputs.add(generatedNode.id);
 
-            var syntheticNode = new SyntheticAssetNode(makeAssetId());
+            var syntheticNode = new SyntheticSourceAssetNode(makeAssetId());
             syntheticNode.outputs.add(generatedNode.id);
 
-            generatedNode.inputs.addAll([node.id, syntheticNode.id]);
+            var builderOptionsNode = new BuilderOptionsAssetNode(makeAssetId());
+            builderOptionsNode.outputs.add(generatedNode.id);
+
+            generatedNode.inputs
+                .addAll([node.id, syntheticNode.id, builderOptionsNode.id]);
             if (g % 2 == 1) {
               // Fake a digest using the id, we just care that this gets
               // serialized/deserialized properly.
@@ -100,6 +104,7 @@ void main() {
 
             graph.add(syntheticNode);
             graph.add(generatedNode);
+            graph.add(builderOptionsNode);
           }
         }
 
@@ -197,7 +202,7 @@ void main() {
         });
 
         test('add new primary input which replaces a synthetic node', () async {
-          var syntheticNode = new SyntheticAssetNode(syntheticId);
+          var syntheticNode = new SyntheticSourceAssetNode(syntheticId);
           graph.add(syntheticNode);
           expect(graph.get(syntheticId), syntheticNode);
 
@@ -207,13 +212,13 @@ void main() {
 
           expect(graph.contains(syntheticId), isTrue);
           expect(graph.get(syntheticId),
-              isNot(new isInstanceOf<SyntheticAssetNode>()));
+              isNot(new isInstanceOf<SyntheticSourceAssetNode>()));
           expect(graph.contains(syntheticOutputId), isTrue);
         });
 
         test('add new generated asset which replaces a synthetic node',
             () async {
-          var syntheticNode = new SyntheticAssetNode(syntheticOutputId);
+          var syntheticNode = new SyntheticSourceAssetNode(syntheticOutputId);
           graph.add(syntheticNode);
           expect(graph.get(syntheticOutputId), syntheticNode);
 

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -190,7 +190,8 @@ main() {
 
         var assetGraph = await AssetGraph.build(
             buildActions, new Set<AssetId>(), new Set(), 'a', options.reader);
-        expect(assetGraph.allNodes, isEmpty);
+        expect(assetGraph.allNodes.map((node) => node.id),
+            unorderedEquals([makeAssetId('a|Phase0.builderOptions')]));
 
         await createFile(assetGraphPath, JSON.encode(assetGraph.serialize()));
 

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -24,6 +24,7 @@ void main() {
       new TxtFilePackageBuilder(
           'a', {'web/hello.txt': 'hello', 'web/world.txt': 'world'}),
       'a');
+  final defaultBuilderOptions = const BuilderOptions(const {});
 
   group('build', () {
     group('with root package inputs', () {
@@ -193,6 +194,8 @@ void main() {
               makeAssetId('a|web/a.txt'),
               makeAssetId('a|web/a.txt.copy'),
               makeAssetId('a|web/a.txt.copy.clone'),
+              makeAssetId('a|Phase0.builderOptions'),
+              makeAssetId('a|Phase1.builderOptions'),
             ]));
         expect(cachedGraph.sources, [makeAssetId('a|web/a.txt')]);
         expect(
@@ -414,17 +417,26 @@ void main() {
 
     var expectedGraph =
         await AssetGraph.build([], new Set(), new Set(), 'a', null);
+
+    var builderOptionsId = makeAssetId('a|Phase0.builderOptions');
+    var builderOptionsNode = new BuilderOptionsAssetNode(
+        builderOptionsId, computeBuilderOptionsDigest(defaultBuilderOptions));
+    expectedGraph.add(builderOptionsNode);
+
     var aCopyNode = new GeneratedAssetNode(null, makeAssetId('a|web/a.txt'),
-        false, true, makeAssetId('a|web/a.txt.copy'),
+        false, true, makeAssetId('a|web/a.txt.copy'), builderOptionsId,
         lastKnownDigest: computeDigest('a'),
         inputs: [makeAssetId('a|web/a.txt')]);
+    builderOptionsNode.outputs.add(aCopyNode.id);
     expectedGraph.add(aCopyNode);
     expectedGraph
         .add(makeAssetNode('a|web/a.txt', [aCopyNode.id], computeDigest('a')));
+
     var bCopyNode = new GeneratedAssetNode(null, makeAssetId('a|lib/b.txt'),
-        false, true, makeAssetId('a|lib/b.txt.copy'),
+        false, true, makeAssetId('a|lib/b.txt.copy'), builderOptionsId,
         lastKnownDigest: computeDigest('b'),
         inputs: [makeAssetId('a|lib/b.txt')]);
+    builderOptionsNode.outputs.add(bCopyNode.id);
     expectedGraph.add(bCopyNode);
     expectedGraph
         .add(makeAssetNode('a|lib/b.txt', [bCopyNode.id], computeDigest('b')));


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/685

There are a lot of small structural changes here:
-  Added a `builderOptions` field to `BuildAction`
-  Added a `builderOptionsId` field to `GeneratedAssetNode`
- Added a required `builderOptionsId` field to `_computeCombinedDigest` in `BuildImpl`.
  - We had discussed trying to add this to `inputs` transparently from the `GeneratedAssetNode` but that actually ends up getting complicated - especially without regressing performance. This is because `inputs` is a set, and we use a lot of set operations on it (comparing it to reader.assetsRead). We would either have to manually add that node back in all the time or do some other weird shenanigans (like make a special set view that includes that node in its iterator but won't let you remove it?). 
  - This also allows me to mark these nodes as not readable at all in the `SingleStepAssetReader`, and `_computeCombinedDigest` can directly read the `lastKnownDigest` field from that node without having to do an extra type check on all nodes.
- Added an extra invalidation step to `BuildDefinition` to check if any of these nodes have changed and mark them as modified, since we only need to check this on startup. 