### PR TITLE
Remove TODO for invalidating build script

### DIFF
--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -22,8 +22,6 @@ const scriptLocation = '$entryPointDir/build.dart';
 Future<Null> ensureBuildScript() async {
   var log = new Logger('ensureBuildScript');
   var scriptFile = new File(scriptLocation);
-  // TODO - how can we invalidate this?
-  //if (scriptFile.existsSync()) return;
   scriptFile.createSync(recursive: true);
   await logTimedAsync(log, 'Generating build script',
       () async => scriptFile.writeAsString(await _generateBuildScript()));


### PR DESCRIPTION
Closes #585

We're seeing good enough performance from the generation that we can
ignore this for now. If this starts to become a significant amount of
time we'll reopen the issue.