### PR TITLE
Support mixed-mode building

### DIFF
--- a/build_runner/README.md
+++ b/build_runner/README.md
@@ -160,9 +160,8 @@ information.
 
 * You may output files anywhere in the current package.
 
-> **NOTE**: When using the `writeToCache: true` option with either `build` or
-> `watch`, builders _are_ allowed to output under the `lib` folder of _any_
-> package you depend on.
+> **NOTE**: When a `BuilderApplication` specifies `hideOutput: true` it may
+> output under the `lib` folder of _any_ package you depend on.
 
 * You are not allowed to overwrite existing files, only create new ones.
 * Outputs from previous builds will not be treated as inputs to later ones.

--- a/build_runner/bin/create_merged_dir.dart
+++ b/build_runner/bin/create_merged_dir.dart
@@ -23,8 +23,7 @@ PackageGraph packageGraph;
 Future main(List<String> args) async {
   stdout.writeln(
       'Warning: this tool is unsupported and usage may change at any time, '
-      'use at your own risk.\n\n'
-      'This tool also assumes you are using the `writeToCache=true` option.');
+      'use at your own risk.\n\n');
 
   var parsedArgs = argParser.parse(args);
 

--- a/build_runner/lib/src/asset/build_cache.dart
+++ b/build_runner/lib/src/asset/build_cache.dart
@@ -70,7 +70,8 @@ AssetId cacheLocation(AssetId id, AssetGraph assetGraph, String rootPackage) {
   if (!assetGraph.contains(id)) {
     return id;
   }
-  if (assetGraph.get(id) is GeneratedAssetNode) {
+  final assetNode = assetGraph.get(id);
+  if (assetNode is GeneratedAssetNode && assetNode.isHidden) {
     return new AssetId(
         rootPackage, '$cacheDir/generated/${id.package}/${id.path}');
   }

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 import 'package:build/build.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
+import 'package:meta/meta.dart';
 
 /// A node in the asset graph which may be an input to other assets.
 abstract class AssetNode {
@@ -91,12 +92,22 @@ class GeneratedAssetNode extends AssetNode {
   /// this node.
   final AssetId builderOptionsId;
 
-  GeneratedAssetNode(this.phaseNumber, this.primaryInput, this.needsUpdate,
-      this.wasOutput, AssetId id, this.builderOptionsId,
-      {Digest lastKnownDigest,
-      Set<Glob> globs,
-      Iterable<AssetId> inputs,
-      this.previousInputsDigest})
+  /// Whether the asset should be placed in the build cache.
+  final bool isHidden;
+
+  GeneratedAssetNode(
+    this.phaseNumber,
+    this.primaryInput,
+    this.needsUpdate,
+    this.wasOutput,
+    AssetId id,
+    this.builderOptionsId, {
+    Digest lastKnownDigest,
+    Set<Glob> globs,
+    Iterable<AssetId> inputs,
+    this.previousInputsDigest,
+    @required this.isHidden,
+  })
       : this.globs = globs ?? new Set<Glob>(),
         this.inputs = inputs != null
             ? new SplayTreeSet.from(inputs)

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -8,7 +8,7 @@ part of 'graph.dart';
 ///
 /// This should be incremented any time the serialize/deserialize formats
 /// change.
-const _version = 14;
+const _version = 15;
 
 /// Deserializes an [AssetGraph] from a [Map].
 class _AssetGraphDeserializer {
@@ -74,18 +74,21 @@ class _AssetGraphDeserializer {
       case _NodeType.Generated:
         assert(serializedNode.length == _WrappedGeneratedAssetNode._length);
         node = new GeneratedAssetNode(
-            serializedNode[_Field.PhaseNumber.index] as int,
-            _idToAssetId[serializedNode[_Field.PrimaryInput.index] as int],
-            _deserializeBool(serializedNode[_Field.NeedsUpdate.index] as int),
-            _deserializeBool(serializedNode[_Field.WasOutput.index] as int),
-            id,
-            _idToAssetId[serializedNode[_Field.BuilderOptions.index] as int],
-            globs: (serializedNode[_Field.Globs.index] as Iterable<String>)
-                .map((pattern) => new Glob(pattern))
-                .toSet(),
-            lastKnownDigest: digest,
-            previousInputsDigest: _deserializeDigest(
-                serializedNode[_Field.PreviousInputsDigest.index] as String));
+          serializedNode[_Field.PhaseNumber.index] as int,
+          _idToAssetId[serializedNode[_Field.PrimaryInput.index] as int],
+          _deserializeBool(serializedNode[_Field.NeedsUpdate.index] as int),
+          _deserializeBool(serializedNode[_Field.WasOutput.index] as int),
+          id,
+          _idToAssetId[serializedNode[_Field.BuilderOptions.index] as int],
+          globs: (serializedNode[_Field.Globs.index] as Iterable<String>)
+              .map((pattern) => new Glob(pattern))
+              .toSet(),
+          lastKnownDigest: digest,
+          previousInputsDigest: _deserializeDigest(
+              serializedNode[_Field.PreviousInputsDigest.index] as String),
+          isHidden:
+              _deserializeBool(serializedNode[_Field.IsHidden.index] as int),
+        );
         break;
       case _NodeType.Internal:
         assert(serializedNode.length == _WrappedAssetNode._length);
@@ -175,6 +178,7 @@ enum _Field {
   NeedsUpdate,
   PreviousInputsDigest,
   BuilderOptions,
+  IsHidden,
 }
 
 /// Wraps an [AssetNode] in a class that implements [List] instead of
@@ -274,6 +278,8 @@ class _WrappedGeneratedAssetNode extends _WrappedAssetNode {
         return _serializeDigest(generatedNode.previousInputsDigest);
       case _Field.BuilderOptions:
         return serializer._assetIdToId[generatedNode.builderOptionsId];
+      case _Field.IsHidden:
+        return _serializeBool(generatedNode.isHidden);
       default:
         throw new RangeError.index(index, this);
     }

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -135,7 +135,7 @@ class _Loader {
         _onDelete);
   }
 
-  /// Checks that the [_buildActions] are valid based on whethere they are
+  /// Checks that the [_buildActions] are valid based on whether they are
   /// written to the build cache.
   void _checkBuildActions() {
     final root = _options.packageGraph.root.name;

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -120,13 +120,13 @@ class _Loader {
           () => _initialBuildCleanup(
               conflictingOutputs,
               _options.deleteFilesByDefault,
-              _maybeWrapWriter(_options.writer, assetGraph)));
+              _wrapWriter(_options.writer, assetGraph)));
     }
 
     return new BuildDefinition._(
         assetGraph,
-        _maybeWrapReader(_options.reader, assetGraph),
-        _maybeWrapWriter(_options.writer, assetGraph),
+        _wrapReader(_options.reader, assetGraph),
+        _wrapWriter(_options.writer, assetGraph),
         _options.packageGraph,
         _options.deleteFilesByDefault,
         new ResourceManager(),
@@ -135,15 +135,14 @@ class _Loader {
         _onDelete);
   }
 
-  /// Checks that the [_buildActions] are valid based on the
-  /// `_options.writeToCache` setting.
+  /// Checks that the [_buildActions] are valid based on whethere they are
+  /// written to the build cache.
   void _checkBuildActions() {
-    if (!_options.writeToCache) {
-      final root = _options.packageGraph.root.name;
-      for (final action in _buildActions) {
-        if (action.package != _options.packageGraph.root.name) {
-          throw new InvalidBuildActionException.nonRootPackage(action, root);
-        }
+    final root = _options.packageGraph.root.name;
+    for (final action in _buildActions) {
+      if (!action.hideOutput &&
+          action.package != _options.packageGraph.root.name) {
+        throw new InvalidBuildActionException.nonRootPackage(action, root);
       }
     }
   }
@@ -158,14 +157,9 @@ class _Loader {
     }
   }
 
-  /// If `_options.writeToCache` is `true` then this returns the all the sources
-  /// found in the cache directory, otherwise it returns an empty set.
-  Future<Set<AssetId>> _findCacheDirSources() {
-    if (_options.writeToCache) {
-      return _listGeneratedAssetIds().toSet();
-    }
-    return new Future.value(new Set<AssetId>());
-  }
+  /// Returns the all the sources found in the cache directory.
+  Future<Set<AssetId>> _findCacheDirSources() =>
+      _listGeneratedAssetIds().toSet();
 
   /// Returns all the internal sources, such as those under [entryPointDir].
   Future<Set<AssetId>> _findInternalSources() {
@@ -225,27 +219,23 @@ class _Loader {
         _buildActions,
         updates,
         _options.packageGraph.root.name,
-        (id) => _delete(id, _maybeWrapWriter(_options.writer, assetGraph)),
-        _maybeWrapReader(_options.reader, assetGraph));
+        (id) => _delete(id, _wrapWriter(_options.writer, assetGraph)),
+        _wrapReader(_options.reader, assetGraph));
     return updates;
   }
 
-  /// Wraps [original] in a [BuildCacheWriter] if `_options.writeToCache` is
-  /// `true`.
-  RunnerAssetWriter _maybeWrapWriter(
+  /// Wraps [original] in a [BuildCacheWriter].
+  RunnerAssetWriter _wrapWriter(
       RunnerAssetWriter original, AssetGraph assetGraph) {
     assert(assetGraph != null);
-    if (!_options.writeToCache) return original;
     return new BuildCacheWriter(
         original, assetGraph, _options.packageGraph.root.name);
   }
 
-  /// Wraps [original] in a [BuildCacheReader] if `_options.writeToCache` is
-  /// `true`.
-  DigestAssetReader _maybeWrapReader(
+  /// Wraps [original] in a [BuildCacheReader].
+  DigestAssetReader _wrapReader(
       DigestAssetReader original, AssetGraph assetGraph) {
     assert(assetGraph != null);
-    if (!_options.writeToCache) return original;
     return new BuildCacheReader(
         original, assetGraph, _options.packageGraph.root.name);
   }

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -59,7 +59,7 @@ Future<BuildResult> build(List<BuildAction> buildActions,
       onLog: onLog,
       skipBuildScriptCheck: skipBuildScriptCheck,
       enableLowResourcesMode: enableLowResourcesMode);
-  if (writeToCache ?? false) {
+  if (writeToCache == true) {
     buildActions = buildActions.map(hiddenAction).toList();
   }
   var terminator = new Terminator(terminateEventStream);

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -40,6 +40,7 @@ final _logger = new Logger('Build');
 
 Future<BuildResult> build(List<BuildAction> buildActions,
     {bool deleteFilesByDefault,
+    //TODO - remove `writeToCache`
     bool writeToCache,
     PackageGraph packageGraph,
     RunnerAssetReader reader,
@@ -50,8 +51,7 @@ Future<BuildResult> build(List<BuildAction> buildActions,
     bool skipBuildScriptCheck,
     bool enableLowResourcesMode}) async {
   var options = new BuildOptions(
-      deleteFilesByDefault: deleteFilesByDefault,
-      writeToCache: writeToCache,
+      deleteFilesByDefault: deleteFilesByDefault ?? writeToCache,
       packageGraph: packageGraph,
       reader: reader,
       writer: writer,
@@ -59,6 +59,9 @@ Future<BuildResult> build(List<BuildAction> buildActions,
       onLog: onLog,
       skipBuildScriptCheck: skipBuildScriptCheck,
       enableLowResourcesMode: enableLowResourcesMode);
+  if (writeToCache ?? false) {
+    buildActions = buildActions.map(hiddenAction).toList();
+  }
   var terminator = new Terminator(terminateEventStream);
 
   var result = await singleBuild(options, buildActions);

--- a/build_runner/lib/src/generate/exceptions.dart
+++ b/build_runner/lib/src/generate/exceptions.dart
@@ -39,11 +39,13 @@ class InvalidBuildActionException extends FatalBuildException {
       : _reason = 'A build action ($action) is attempting to operate on '
             'package "${action.package}", but the build script is '
             'located in package "$root". It\'s not valid to attempt to '
-            'generate files for another package unless "writeToCache: true" '
-            'is used.'
+            'generate files for another package unless the BuilderApplication'
+            'specified "hideOutput".'
             '\n\n'
             'Did you mean to write:\n'
-            '  new BuildAction(..., \'$root\')\n'
+            '  new BuilderApplication(..., toRoot())\n'
+            'or\n'
+            '  new BuilderApplication(..., hideOutput: true)\n'
             '... instead?';
 
   InvalidBuildActionException.unrecognizedType(BuildAction action)

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -22,13 +22,6 @@ class BuildOptions {
   bool deleteFilesByDefault;
   bool enableLowResourcesMode;
 
-  /// Whether to write to a cache directory rather than the package's source
-  /// directory.
-  ///
-  /// Enabling this option is the only way to allow builders to run against
-  /// packages other than the root.
-  bool writeToCache;
-
   // Watch mode options.
   Duration debounceDelay;
   DirectoryWatcherFactory directoryWatcherFactory;
@@ -39,7 +32,6 @@ class BuildOptions {
   BuildOptions(
       {this.debounceDelay,
       this.deleteFilesByDefault,
-      this.writeToCache,
       this.directoryWatcherFactory,
       Level logLevel,
       onLog(LogRecord record),
@@ -59,8 +51,7 @@ class BuildOptions {
     reader ??= new FileBasedAssetReader(packageGraph);
     writer ??= new FileBasedAssetWriter(packageGraph);
     directoryWatcherFactory ??= defaultDirectoryWatcherFactory;
-    deleteFilesByDefault ??= writeToCache ?? false;
-    writeToCache ??= false;
+    deleteFilesByDefault ??= false;
     skipBuildScriptCheck ??= false;
     enableLowResourcesMode ??= false;
   }

--- a/build_runner/lib/src/generate/phase.dart
+++ b/build_runner/lib/src/generate/phase.dart
@@ -25,22 +25,39 @@ abstract class BuildAction {
 
   final BuilderOptions builderOptions;
 
-  BuildAction._(this.builderOptions, bool isOptional)
-      : this.isOptional = isOptional ?? false;
+  /// Whether generated assets should be placed in the build cache.
+  ///
+  /// When this is `false` the Builder may not run on any [package] other than
+  /// the root.
+  final bool hideOutput;
+
+  BuildAction._(this.builderOptions, {bool isOptional, bool hideOutput})
+      : this.isOptional = isOptional ?? false,
+        this.hideOutput = hideOutput ?? false;
 
   /// Creates an [AssetBuildAction] for a normal [Builder].
   ///
   /// Runs [builder] on [package] with [inputs] as primary inputs, excluding
   /// [excludes]. Glob syntax is supported for both [inputs] and [excludes].
-  factory BuildAction(Builder builder, String package,
-      {List<String> inputs,
-      List<String> excludes,
-      BuilderOptions builderOptions,
-      bool isOptional}) {
+  ///
+  /// [isOptional] specifies that a Builder may not be run unless some other
+  /// Builder in a later phase attempts to read one of the potential outputs.
+  ///
+  /// [hideOutput] specifies that the generated asses should be placed in the
+  /// build cache rather than the source tree.
+  factory BuildAction(
+    Builder builder,
+    String package, {
+    List<String> inputs,
+    List<String> excludes,
+    BuilderOptions builderOptions,
+    bool isOptional,
+    bool hideOutput,
+  }) {
     var inputSet = new InputSet(package, inputs, excludes: excludes);
     builderOptions ??= const BuilderOptions(const {});
     return new AssetBuildAction._(builder, inputSet, builderOptions,
-        isOptional: isOptional);
+        isOptional: isOptional, hideOutput: hideOutput);
   }
 }
 
@@ -55,8 +72,8 @@ class AssetBuildAction extends BuildAction {
   String get package => inputSet.package;
 
   AssetBuildAction._(this.builder, this.inputSet, BuilderOptions builderOptions,
-      {bool isOptional})
-      : super._(builderOptions, isOptional);
+      {bool isOptional, bool hideOutput})
+      : super._(builderOptions, isOptional: isOptional, hideOutput: hideOutput);
 
   @override
   String toString() => '$builder on $inputSet';
@@ -72,6 +89,23 @@ class PackageBuildAction extends BuildAction {
   final String package;
 
   PackageBuildAction(this.builder, this.package,
-      {BuilderOptions builderOptions, bool isOptional})
-      : super._(builderOptions ?? const BuilderOptions(const {}), isOptional);
+      {BuilderOptions builderOptions, bool isOptional, bool hideOutput})
+      : super._(builderOptions ?? const BuilderOptions(const {}),
+            isOptional: isOptional, hideOutput: hideOutput);
+}
+
+// TODO - remove this once we are no longer using `writeToCache` argument
+BuildAction hiddenAction(BuildAction action) {
+  if (action is AssetBuildAction) {
+    return new AssetBuildAction._(
+        action.builder, action.inputSet, action.builderOptions,
+        isOptional: action.isOptional, hideOutput: true);
+  }
+  if (action is PackageBuildAction) {
+    return new PackageBuildAction(action.builder, action.package,
+        builderOptions: action.builderOptions,
+        isOptional: action.isOptional,
+        hideOutput: true);
+  }
+  throw new ArgumentError('must be AssetBuildAction or PackageBuildAction');
 }

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -30,6 +30,7 @@ final _logger = new Logger('Watch');
 
 Future<ServeHandler> watch(List<BuildAction> buildActions,
     {bool deleteFilesByDefault,
+    //TODO - remove `writeToCache`
     bool writeToCache,
     PackageGraph packageGraph,
     RunnerAssetReader reader,
@@ -42,8 +43,7 @@ Future<ServeHandler> watch(List<BuildAction> buildActions,
     bool skipBuildScriptCheck,
     bool enableLowResourcesMode}) async {
   var options = new BuildOptions(
-      deleteFilesByDefault: deleteFilesByDefault,
-      writeToCache: writeToCache,
+      deleteFilesByDefault: deleteFilesByDefault ?? writeToCache,
       packageGraph: packageGraph,
       reader: reader,
       writer: writer,
@@ -53,6 +53,9 @@ Future<ServeHandler> watch(List<BuildAction> buildActions,
       directoryWatcherFactory: directoryWatcherFactory,
       skipBuildScriptCheck: skipBuildScriptCheck,
       enableLowResourcesMode: enableLowResourcesMode);
+  if (writeToCache ?? false) {
+    buildActions = buildActions.map(hiddenAction).toList();
+  }
   var terminator = new Terminator(terminateEventStream);
   var watch = runWatch(options, buildActions, terminator.shouldTerminate);
 

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -53,7 +53,7 @@ Future<ServeHandler> watch(List<BuildAction> buildActions,
       directoryWatcherFactory: directoryWatcherFactory,
       skipBuildScriptCheck: skipBuildScriptCheck,
       enableLowResourcesMode: enableLowResourcesMode);
-  if (writeToCache ?? false) {
+  if (writeToCache == true) {
     buildActions = buildActions.map(hiddenAction).toList();
   }
   var terminator = new Terminator(terminateEventStream);

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -51,10 +51,16 @@ BuilderApplication applyToRoot(Builder builder,
 /// never run.
 BuilderApplication apply(String providingPackage, String builderName,
         List<BuilderFactory> builderFactories, PackageFilter filter,
-        {List<String> inputs, List<String> excludes, bool isOptional}) =>
+        {List<String> inputs,
+        List<String> excludes,
+        bool isOptional,
+        bool hideOutput}) =>
     new BuilderApplication._(
         providingPackage, builderName, builderFactories, filter,
-        inputs: inputs, excludes: excludes, isOptional: isOptional);
+        inputs: inputs,
+        excludes: excludes,
+        isOptional: isOptional,
+        hideOutput: hideOutput);
 
 /// A description of which packages need a given [Builder] applied.
 class BuilderApplication {
@@ -79,9 +85,12 @@ class BuilderApplication {
   final List<String> excludes;
   final bool isOptional;
 
+  /// Whether genereated assets should be placed in the build cache.
+  final bool hideOutput;
+
   const BuilderApplication._(this.providingPackage, this.builderName,
       this.builderFactories, this.filter,
-      {this.inputs, this.excludes, this.isOptional});
+      {this.inputs, this.excludes, this.isOptional, this.hideOutput});
 }
 
 /// Creates a [BuildAction] to apply each builder in [builderApplications] to
@@ -124,5 +133,6 @@ Iterable<BuildAction> _createBuildActionsForBuilderInCycle(
           builderOptions: options,
           inputs: builderApplication.inputs,
           excludes: builderApplication.excludes,
-          isOptional: builderApplication.isOptional)));
+          isOptional: builderApplication.isOptional,
+          hideOutput: builderApplication.hideOutput)));
 }

--- a/build_runner/lib/src/util/constants.dart
+++ b/build_runner/lib/src/util/constants.dart
@@ -20,8 +20,7 @@ String assetGraphPathFor(String path) =>
 /// Files in this directory must be read to do build script invalidation.
 const entryPointDir = '.dart_tool/build/entrypoint';
 
-/// The directory to which assets will be written when `writeToCache` is
-/// enabled.
+/// The directory to which hidden assets will be written.
 const generatedOutputDirectory = '$cacheDir/generated';
 
 /// Relative path to the cache directory from the root package dir.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -38,3 +38,7 @@ dev_dependencies:
   package_resolver: ^1.0.2
   test: ^0.12.0
   test_descriptor: ^1.0.0
+
+dependency_overrides:
+  build_test:
+    path: ../build_test

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -38,7 +38,3 @@ dev_dependencies:
   package_resolver: ^1.0.2
   test: ^0.12.0
   test_descriptor: ^1.0.0
-
-dependency_overrides:
-  build_test:
-    path: ../build_test

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -86,7 +86,8 @@ void main() {
                 makeAssetId(), md5.convert(UTF8.encode('test')));
 
             var generatedNode = new GeneratedAssetNode(0, node.id, g % 2 == 1,
-                g % 2 == 0, makeAssetId(), builderOptionsNode.id);
+                g % 2 == 0, makeAssetId(), builderOptionsNode.id,
+                isHidden: false);
             node.outputs.add(generatedNode.id);
             node.primaryOutputs.add(generatedNode.id);
             builderOptionsNode.outputs.add(generatedNode.id);

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -87,7 +87,7 @@ void main() {
 
             var generatedNode = new GeneratedAssetNode(0, node.id, g % 2 == 1,
                 g % 2 == 0, makeAssetId(), builderOptionsNode.id,
-                isHidden: false);
+                isHidden: g % 3 == 0);
             node.outputs.add(generatedNode.id);
             node.primaryOutputs.add(generatedNode.id);
             builderOptionsNode.outputs.add(generatedNode.id);

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -28,11 +28,15 @@ Future wait(int milliseconds) =>
 /// The keys in [inputs] and [outputs] are paths to file assets and the values
 /// are file contents. The paths must use the following format:
 ///
-///     PACKAGE_NAME:PATH_WITHIN_PACKAGE
+///     PACKAGE_NAME|PATH_WITHIN_PACKAGE
 ///
 /// Where `PACKAGE_NAME` is the name of the package, and `PATH_WITHIN_PACKAGE`
 /// is the path to a file relative to the package. `PATH_WITHIN_PACKAGE` must
 /// include `lib`, `web`, `bin` or `test`. Example: "myapp|lib/utils.dart".
+///
+/// When an output is expected in the build cache start the package with `$$`.
+/// For example `$$myapp|lib/utils.copy.dart` will check that the generated
+/// output was written to the build cache.
 ///
 /// [packageGraph] supplies the root package into which the outputs are to be
 /// written.
@@ -112,6 +116,8 @@ Future<BuildResult> testActions(List<BuildAction> buildActions,
   return result;
 }
 
+/// Translates expected outptus which start with `$$` to the build cache and
+/// validates the success and outputs of the build.
 void checkBuild(BuildResult result,
     {Map<String, dynamic> outputs,
     InMemoryAssetWriter writer,

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -65,7 +65,6 @@ main() {
       options = new BuildOptions(
           packageGraph: packageGraph,
           logLevel: Level.OFF,
-          writeToCache: true,
           skipBuildScriptCheck: true);
     });
 
@@ -77,7 +76,9 @@ main() {
       test('for deleted source and generated nodes', () async {
         await createFile(p.join('lib', 'a.txt'), 'a');
         await createFile(p.join('lib', 'b.txt'), 'b');
-        var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
+        var buildActions = [
+          new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+        ];
 
         var originalAssetGraph = await AssetGraph.build(
             buildActions,
@@ -109,7 +110,9 @@ main() {
       });
 
       test('for new sources and generated nodes', () async {
-        var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
+        var buildActions = [
+          new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+        ];
 
         var originalAssetGraph = await AssetGraph.build(
             buildActions, <AssetId>[].toSet(), new Set(), 'a', options.reader);
@@ -132,7 +135,9 @@ main() {
 
       test('for changed sources', () async {
         await createFile(p.join('lib', 'a.txt'), 'a');
-        var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
+        var buildActions = [
+          new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+        ];
 
         var originalAssetGraph = await AssetGraph.build(
             buildActions,
@@ -158,7 +163,7 @@ main() {
       test('retains non-output generated nodes', () async {
         await createFile(p.join('lib', 'test.txt'), 'a');
         var buildActions = [
-          new BuildAction(new OverDeclaringCopyBuilder(), 'a')
+          new BuildAction(new OverDeclaringCopyBuilder(), 'a', hideOutput: true)
         ];
 
         var originalAssetGraph = await AssetGraph.build(
@@ -183,9 +188,9 @@ main() {
       test('for changed BuilderOptions', () async {
         await createFile(p.join('lib', 'a.txt'), 'a');
         var buildActions = [
-          new BuildAction(new CopyBuilder(), 'a'),
+          new BuildAction(new CopyBuilder(), 'a', hideOutput: true),
           new BuildAction(new CopyBuilder(extension: 'clone'), 'a',
-              inputs: ['**/*.txt']),
+              inputs: ['**/*.txt'], hideOutput: true),
         ];
 
         var originalAssetGraph = await AssetGraph.build(
@@ -208,9 +213,10 @@ main() {
         // Same as before, but change the `BuilderOptions` for the first action.
         var newBuildActions = [
           new BuildAction(new CopyBuilder(), 'a',
-              builderOptions: new BuilderOptions({'test': 'option'})),
+              builderOptions: new BuilderOptions({'test': 'option'}),
+              hideOutput: true),
           new BuildAction(new CopyBuilder(extension: 'clone'), 'a',
-              inputs: ['**/*.txt']),
+              inputs: ['**/*.txt'], hideOutput: true),
         ];
         var buildDefinition =
             await BuildDefinition.prepareWorkspace(options, newBuildActions);
@@ -235,7 +241,9 @@ main() {
         var generatedId = new AssetId(
             'a', p.url.join(generatedOutputDirectory, 'a', 'lib', 'test.txt'));
         await createFile(generatedId.path, 'a');
-        var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
+        var buildActions = [
+          new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+        ];
 
         var assetGraph = await AssetGraph.build(
             buildActions, new Set<AssetId>(), new Set(), 'a', options.reader);
@@ -261,7 +269,9 @@ main() {
       test('does not run Builders on generated entrypoint', () async {
         var entryPoint =
             new AssetId('a', p.url.join(entryPointDir, 'build.dart'));
-        var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
+        var buildActions = [
+          new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+        ];
         var buildDefinition =
             await BuildDefinition.prepareWorkspace(options, buildActions);
         expect(
@@ -276,12 +286,13 @@ main() {
       // object.
       await options.logListener.cancel();
 
-      var buildActions = [new BuildAction(new CopyBuilder(), 'a')];
+      var buildActions = [
+        new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+      ];
       var logs = <LogRecord>[];
       options = new BuildOptions(
           packageGraph: options.packageGraph,
           logLevel: Level.WARNING,
-          writeToCache: true,
           skipBuildScriptCheck: true,
           onLog: logs.add);
 
@@ -291,8 +302,8 @@ main() {
       await createFile(
           assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
 
-      buildActions
-          .add(new BuildAction(new CopyBuilder(), 'a', inputs: ['.copy']));
+      buildActions.add(new BuildAction(new CopyBuilder(), 'a',
+          inputs: ['.copy'], hideOutput: true));
       logs.clear();
 
       var buildDefinition =

--- a/build_runner/test/generate/build_error_test.dart
+++ b/build_runner/test/generate/build_error_test.dart
@@ -29,7 +29,7 @@ void main() {
     } finally {
       expect(error, isNotNull, reason: 'Did not throw!');
       expect(error, contains('operate on package "not_root_package"'));
-      expect(error, contains('new BuildAction(..., \'root_package\')'));
+      expect(error, contains('new BuilderApplication(..., toRoot())'));
     }
   });
 

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -252,6 +252,22 @@ void main() {
             });
       });
 
+      test('handles mixed hidden and non-hidden outputs', () async {
+        await testActions(
+            [
+              new BuildAction(new CopyBuilder(), 'a'),
+              new BuildAction(new CopyBuilder(extension: 'hiddencopy'), 'a',
+                  hideOutput: true),
+            ],
+            {'a|lib/a.txt': 'a'},
+            packageGraph: packageGraph,
+            outputs: {
+              r'$$a|lib/a.txt.hiddencopy': 'a',
+              r'$$a|lib/a.txt.copy.hiddencopy': 'a',
+              r'a|lib/a.txt.copy': 'a',
+            });
+      });
+
       test(
           'PackageBuilder can\'t output files outside of `lib` in non-root '
           'packages.', () async {

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -226,7 +226,7 @@ void main() {
           throwsA(anything));
     });
 
-    group('with `writeToCache: true`', () {
+    group('with `hideOutput: true`', () {
       PackageGraph packageGraph;
 
       setUp(() {
@@ -238,18 +238,18 @@ void main() {
       test('can output files in non-root packages', () async {
         await testActions(
             [
-              new BuildAction(new CopyBuilder(), 'b'),
+              new BuildAction(new CopyBuilder(), 'b', hideOutput: true),
               new PackageBuildAction(
                   new TxtFilePackageBuilder('b', {'lib/hello.txt': 'hello'}),
-                  'b')
+                  'b',
+                  hideOutput: true)
             ],
             {'b|lib/b.txt': 'b'},
             packageGraph: packageGraph,
             outputs: {
-              'b|lib/b.txt.copy': 'b',
-              'b|lib/hello.txt': 'hello',
-            },
-            writeToCache: true);
+              r'$$b|lib/b.txt.copy': 'b',
+              r'$$b|lib/hello.txt': 'hello',
+            });
       });
 
       test(
@@ -261,14 +261,14 @@ void main() {
                   new PackageBuildAction(
                       new TxtFilePackageBuilder(
                           'b', {'web/hello.txt': 'hello'}),
-                      'b')
+                      'b',
+                      hideOutput: true)
                 ],
                 {},
                 packageGraph: packageGraph,
                 outputs: {
-                  'b|web/hello.txt': 'hello',
-                },
-                writeToCache: true),
+                  r'$$b|web/hello.txt': 'hello',
+                }),
             throwsA(new isInstanceOf<InvalidPackageBuilderOutputsException>()));
       });
 
@@ -281,15 +281,14 @@ void main() {
             }
           };
         await testActions(
-            [new BuildAction(new CopyBuilder(), 'b')],
+            [new BuildAction(new CopyBuilder(), 'b', hideOutput: true)],
             {
               'b|lib/b.txt': 'b',
               'a|.dart_tool/build/generated/b/lib/b.txt.copy': 'b'
             },
             packageGraph: packageGraph,
             writer: writer,
-            outputs: {'b|lib/b.txt.copy': 'b'},
-            writeToCache: true);
+            outputs: {r'$$b|lib/b.txt.copy': 'b'});
       });
     });
 
@@ -313,8 +312,8 @@ void main() {
       });
 
       var buildActions = [
-        new BuildAction(globBuilder, 'a'),
-        new BuildAction(globBuilder, 'b'),
+        new BuildAction(globBuilder, 'a', hideOutput: true),
+        new BuildAction(globBuilder, 'b', hideOutput: true),
       ];
 
       await testActions(
@@ -330,25 +329,25 @@ void main() {
             'b|web/b.txt': '',
           },
           outputs: {
-            'a|lib/a.matchingFiles': 'a|lib/a.txt\na|lib/b.txt\na|web/a.txt',
-            'b|lib/b.matchingFiles': 'b|lib/c.txt\nb|lib/d.txt',
+            r'$$a|lib/a.matchingFiles': 'a|lib/a.txt\na|lib/b.txt\na|web/a.txt',
+            r'$$b|lib/b.matchingFiles': 'b|lib/c.txt\nb|lib/d.txt',
           },
-          packageGraph: packageGraph,
-          writeToCache: true);
+          packageGraph: packageGraph);
     });
 
     test('can glob files from packages with excludes applied', () async {
       await testActions([
-        new BuildAction(new CopyBuilder(), 'a', excludes: ['lib/a/*.txt'])
+        new BuildAction(new CopyBuilder(), 'a',
+            excludes: ['lib/a/*.txt'], hideOutput: true)
       ], {
         'a|lib/a/1.txt': '',
         'a|lib/a/2.txt': '',
         'a|lib/b/1.txt': '',
         'a|lib/b/2.txt': '',
       }, outputs: {
-        'a|lib/b/1.txt.copy': '',
-        'a|lib/b/2.txt.copy': '',
-      }, writeToCache: true);
+        r'$$a|lib/b/1.txt.copy': '',
+        r'$$a|lib/b/2.txt.copy': '',
+      });
     });
 
     test('can\'t read files in .dart_tool', () async {
@@ -426,7 +425,8 @@ void main() {
     var aCopyNode = new GeneratedAssetNode(null, makeAssetId('a|web/a.txt'),
         false, true, makeAssetId('a|web/a.txt.copy'), builderOptionsId,
         lastKnownDigest: computeDigest('a'),
-        inputs: [makeAssetId('a|web/a.txt')]);
+        inputs: [makeAssetId('a|web/a.txt')],
+        isHidden: false);
     builderOptionsNode.outputs.add(aCopyNode.id);
     expectedGraph.add(aCopyNode);
     expectedGraph
@@ -435,7 +435,8 @@ void main() {
     var bCopyNode = new GeneratedAssetNode(null, makeAssetId('a|lib/b.txt'),
         false, true, makeAssetId('a|lib/b.txt.copy'), builderOptionsId,
         lastKnownDigest: computeDigest('b'),
-        inputs: [makeAssetId('a|lib/b.txt')]);
+        inputs: [makeAssetId('a|lib/b.txt')],
+        isHidden: false);
     builderOptionsNode.outputs.add(bCopyNode.id);
     expectedGraph.add(bCopyNode);
     expectedGraph
@@ -586,29 +587,24 @@ void main() {
       }, outputs: {});
     });
 
-    test('no outputs if no changed sources using `writeToCache`', () async {
-      var buildActions = [copyABuildAction];
+    test('no outputs if no changed sources using `hideOutput: true`', () async {
+      var buildActions = [hiddenAction(copyABuildAction)];
 
       // Initial build.
       var writer = new InMemoryRunnerAssetWriter();
       await testActions(buildActions, {'a|web/a.txt': 'a'},
           // Note that `testActions` converts generated cache dir paths to the
           // original ones for matching.
-          outputs: {'a|web/a.txt.copy': 'a'},
-          writer: writer,
-          writeToCache: true);
+          outputs: {r'$$a|web/a.txt.copy': 'a'},
+          writer: writer);
 
       // Followup build with same sources + cached graph.
       var serializedGraph = writer.assets[makeAssetId('a|$assetGraphPath')];
-      await testActions(
-          buildActions,
-          {
-            'a|web/a.txt': 'a',
-            'a|web/a.txt.copy': 'a',
-            'a|$assetGraphPath': serializedGraph,
-          },
-          outputs: {},
-          writeToCache: true);
+      await testActions(buildActions, {
+        'a|web/a.txt': 'a',
+        'a|web/a.txt.copy': 'a',
+        'a|$assetGraphPath': serializedGraph,
+      }, outputs: {});
     });
 
     test('inputs/outputs are updated if they change', () async {

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -146,7 +146,8 @@ void main() {
         var bCopyNode = new GeneratedAssetNode(0, makeAssetId('a|web/b.txt'),
             false, true, makeAssetId('a|web/b.txt.copy'), builderOptionsId,
             lastKnownDigest: computeDigest('b2'),
-            inputs: [makeAssetId('a|web/b.txt')]);
+            inputs: [makeAssetId('a|web/b.txt')],
+            isHidden: false);
         builderOptionsNode.outputs.add(bCopyNode.id);
         expectedGraph.add(bCopyNode);
         expectedGraph.add(
@@ -155,7 +156,8 @@ void main() {
         var cCopyNode = new GeneratedAssetNode(0, makeAssetId('a|web/c.txt'),
             false, true, makeAssetId('a|web/c.txt.copy'), builderOptionsId,
             lastKnownDigest: computeDigest('c'),
-            inputs: [makeAssetId('a|web/c.txt')]);
+            inputs: [makeAssetId('a|web/c.txt')],
+            isHidden: false);
         builderOptionsNode.outputs.add(cCopyNode.id);
         expectedGraph.add(cCopyNode);
         expectedGraph.add(


### PR DESCRIPTION
Towards #647

- Add hideOutput to BuildAction
- Add hideOutput to BuilderApplication and forward when creating actions
- Add isHidden to GeneratedAssetNode and serialize it
- Update the BuildCacheReader/Writer to check per-node whether to
  translate to the build cache.
- Always wrap with the BuildCacheReader/Writer since they can choose not
  to translate as appropriate.
- When passed the arg `writeToCache` update all the actions to set
  `hideOutput`
- Add support for tagging an expected output with `$$` and update the
  way we translate expected output locations to use this tag. We can
  support having only some assets hidden in the tests.
- Switch from `writeToCache` to `hideOutputs` on BuildActions in tests
- Remove text references to `writeToCache`

Remaining work:
- Drop `writeToCache` argument entirely
- Add Builder config for this option and update build script generator