### PR TITLE
Depend on build_barback 0.5.0 from build_runner

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -18,6 +18,8 @@
 The following changes are technically breaking but should not impact most
 clients:
 
+- Upgrade to `build_barback` v0.5.0 which uses strong mode analysis and no
+  longer analyzes method bodies.
 - Removed `dependencyType`, `version`, `includes`, and `excludes` from
   `PackageNode`.
 - Removed `PackageNode.noPubspec` constructor.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   args: ">=0.13.7 <2.0.0"
   async: ">=1.13.3 <3.0.0"
   build: ^0.11.0
-  build_barback: ">=0.4.0 <0.6.0"
+  build_barback: ^0.5.0
   build_compilers: ^0.1.0
   build_config: ^0.1.1
   cli_util: ^0.1.2


### PR DESCRIPTION
Towards #628 

Most dependents of build_runner won't also have a dependency on
build_barback. Since there are behavior changes between 0.4.0 and 0.5.0
we want downstream consumers to have a consistent experience, and we
want this locked t 0.5.0 for the next release since we can have breaking
changes.