### PR TITLE
Only delete conflicting sources outside the cache

### DIFF
--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -114,10 +114,14 @@ class _Loader {
         final conflictsInDeps = assetGraph.outputs
             .where((n) => n.package != _options.packageGraph.root.name)
             .where(inputSources.contains)
-            .length;
-        _logger.warning('There are $conflictsInDeps sources in dependencies '
-            'that will be ignored since they are overwritten by '
-            'generated assets');
+            .toSet();
+        // TODO(https://github.com/dart-lang/build/issues/706) - stop special
+        // casing this conflict
+        conflictsInDeps
+            .remove((new AssetId('node_preamble', 'lib/preamble.js')));
+        if (conflictsInDeps.isNotEmpty) {
+          throw new UnexpectedExistingOutputsException(conflictsInDeps);
+        }
       });
 
       await logTimedAsync(

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -107,8 +107,17 @@ class _Loader {
             internalSources, _options.packageGraph.root.name, _options.reader);
         buildScriptUpdates =
             await BuildScriptUpdates.create(_options, assetGraph);
-        conflictingOutputs =
-            assetGraph.outputs.where(inputSources.contains).toSet();
+        conflictingOutputs = assetGraph.outputs
+            .where((n) => n.package == _options.packageGraph.root.name)
+            .where(inputSources.contains)
+            .toSet();
+        final conflictsInDeps = assetGraph.outputs
+            .where((n) => n.package != _options.packageGraph.root.name)
+            .where(inputSources.contains)
+            .length;
+        _logger.warning('There are $conflictsInDeps sources in dependencies '
+            'that will be ignored since they are overwritten by '
+            'generated assets');
       });
 
       await logTimedAsync(


### PR DESCRIPTION
Since we restrict reads based on the AssetGraph we don't care whether
there are conflicts inside the build cache, we won't read them until
they have ben overwritten by the current build.

We should never have a situation where an 'internal source' conflicts
with an output since nothing in an 'internal' directory could ever be a
primary input.

- When looking for conflicts use inputSources rather than allSources
  since these are the only deletes we care about.
- Don't compute the `allSources` Set up front. Delay building the set
  until we're about to use it in `_findSourceUpdates`. On the first
  entry where the AssetGraph is null we avoid building it entirely.