### PR TITLE
Filter inputs to sub-builders

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.11.2
+
+- Bug Fix: `MultiplexingBuilder` now filters inputs rather than calling _every_
+  builder on any input that matched _any_ builder.
+
 ## 0.11.1
 
 - Add `BuilderOptions` and `BuilderFactory` interfaces. Along with

--- a/build/lib/src/builder/multiplexing_builder.dart
+++ b/build/lib/src/builder/multiplexing_builder.dart
@@ -17,8 +17,10 @@ class MultiplexingBuilder implements Builder {
   MultiplexingBuilder(this._builders);
 
   @override
-  Future build(BuildStep buildStep) =>
-      Future.wait(_builders.map((builder) => builder.build(buildStep)));
+  Future build(BuildStep buildStep) => Future.wait(_builders
+      .where((builder) => builder.buildExtensions.keys
+          .any((extension) => buildStep.inputId.path.endsWith(extension)))
+      .map((builder) => builder.build(buildStep)));
 
   /// Merges output extensions from all builders.
   ///

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.11.1
+version: 0.11.2
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -16,5 +16,5 @@ dependencies:
 
 dev_dependencies:
   build_barback: ">=0.4.0 <0.6.0"
-  build_test: ^0.9.0
+  build_test: ^0.9.2
   test: ^0.12.0

--- a/build/test/builder/multiplexing_builder_test.dart
+++ b/build/test/builder/multiplexing_builder_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MultiplexingBuilder', () {
+    test('Only passes matching inputs', () async {
+      final builder = new MultiplexingBuilder(
+          [new PickyInput('.foo'), new PickyInput('.bar')]);
+      await testBuilder(builder, {'a|lib/a1.foo': 'a1', 'a|lib/a2.bar': 'a2'},
+          outputs: {'a|lib/a1.new': 'a1', 'a|lib/a2.new': 'a2'});
+    });
+
+    test('merges non-overlapping extension maps', () {
+      final builder = new MultiplexingBuilder(
+          [new PickyInput('.foo'), new PickyInput('.bar')]);
+      expect(builder.buildExtensions, {
+        '.foo': ['.new'],
+        '.bar': ['.new']
+      });
+    });
+
+    test('merges overlapping extension maps', () {
+      final builder = new MultiplexingBuilder([
+        new PickyInput('.foo', ['.new1', '.new2']),
+        new PickyInput('.foo', ['.new3'])
+      ]);
+      expect(builder.buildExtensions, {
+        '.foo': ['.new1', '.new2', '.new3']
+      });
+    });
+  });
+}
+
+class PickyInput implements Builder {
+  final String inputExtension;
+  final List<String> outputExtensions;
+
+  PickyInput(this.inputExtension, [this.outputExtensions = const ['.new']]);
+
+  @override
+  Map<String, List<String>> get buildExtensions =>
+      {inputExtension: outputExtensions};
+
+  @override
+  Future build(BuildStep buildStep) {
+    if (!buildStep.inputId.path.endsWith(inputExtension)) {
+      throw new ArgumentError('Should not run on input ${buildStep.inputId}');
+    }
+    for (final output in outputExtensions) {
+      buildStep.writeAsBytes(buildStep.inputId.changeExtension(output),
+          buildStep.readAsBytes(buildStep.inputId));
+    }
+    return new Future.value(null);
+  }
+}

--- a/build/test/builder/multiplexing_builder_test.dart
+++ b/build/test/builder/multiplexing_builder_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
@@ -11,52 +9,33 @@ import 'package:test/test.dart';
 void main() {
   group('MultiplexingBuilder', () {
     test('Only passes matching inputs', () async {
-      final builder = new MultiplexingBuilder(
-          [new PickyInput('.foo'), new PickyInput('.bar')]);
+      final builder = new MultiplexingBuilder([
+        new CopyBuilder(inputExtension: '.foo'),
+        new CopyBuilder(inputExtension: '.bar')
+      ]);
       await testBuilder(builder, {'a|lib/a1.foo': 'a1', 'a|lib/a2.bar': 'a2'},
-          outputs: {'a|lib/a1.new': 'a1', 'a|lib/a2.new': 'a2'});
+          outputs: {'a|lib/a1.copy': 'a1', 'a|lib/a2.copy': 'a2'});
     });
 
     test('merges non-overlapping extension maps', () {
-      final builder = new MultiplexingBuilder(
-          [new PickyInput('.foo'), new PickyInput('.bar')]);
+      final builder = new MultiplexingBuilder([
+        new CopyBuilder(inputExtension: '.foo'),
+        new CopyBuilder(inputExtension: '.bar')
+      ]);
       expect(builder.buildExtensions, {
-        '.foo': ['.new'],
-        '.bar': ['.new']
+        '.foo': ['.copy'],
+        '.bar': ['.copy']
       });
     });
 
     test('merges overlapping extension maps', () {
       final builder = new MultiplexingBuilder([
-        new PickyInput('.foo', ['.new1', '.new2']),
-        new PickyInput('.foo', ['.new3'])
+        new CopyBuilder(inputExtension: '.foo', numCopies: 2),
+        new CopyBuilder(inputExtension: '.foo', extension: 'new')
       ]);
       expect(builder.buildExtensions, {
-        '.foo': ['.new1', '.new2', '.new3']
+        '.foo': ['.copy.0', '.copy.1', '.new']
       });
     });
   });
-}
-
-class PickyInput implements Builder {
-  final String inputExtension;
-  final List<String> outputExtensions;
-
-  PickyInput(this.inputExtension, [this.outputExtensions = const ['.new']]);
-
-  @override
-  Map<String, List<String>> get buildExtensions =>
-      {inputExtension: outputExtensions};
-
-  @override
-  Future build(BuildStep buildStep) {
-    if (!buildStep.inputId.path.endsWith(inputExtension)) {
-      throw new ArgumentError('Should not run on input ${buildStep.inputId}');
-    }
-    for (final output in outputExtensions) {
-      buildStep.writeAsBytes(buildStep.inputId.changeExtension(output),
-          buildStep.readAsBytes(buildStep.inputId));
-    }
-    return new Future.value(null);
-  }
 }


### PR DESCRIPTION
Fixes #698

Add a test which fails before the change and passes after. Add
additional tests since this class previously had no coverage.