### PR TITLE
Honor `buildTo` from the Builder config

### DIFF
--- a/build_compilers/CHANGELOG.md
+++ b/build_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1-dev
+
+- Mark `ddc_bootstrap` builder with `build_to: cache`.
+
 # 0.1.0
 
 - Add builder factories.

--- a/build_compilers/build.yaml
+++ b/build_compilers/build.yaml
@@ -28,3 +28,4 @@ builders:
         - .dart.js
         - .dart.js.map
     required_inputs:  [".dart", ".js"]
+    build_to: cache

--- a/build_compilers/pubspec.yaml
+++ b/build_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_compilers
-version: 0.1.0
+version: 0.1.1-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -90,7 +90,9 @@ Method _main() => new Method((b) => b
         .assignVar('actions')
         .statement,
     refer('watch', 'package:build_runner/build_runner.dart')
-        .call([refer('actions')], {'writeToCache': literalTrue})
+        // TODO - remove `deleteFileByDefault` once we have resolved handling
+        // conflicts in deps
+        .call([refer('actions')], {'deleteFilesByDefault': literalTrue})
         .awaited
         .assignVar('handler')
         .statement,
@@ -129,6 +131,9 @@ Expression _applyBuilderWithFilter(
   }
   if (definition.isOptional) {
     namedArgs['isOptional'] = literalTrue;
+  }
+  if (definition.buildTo == BuildTo.cache) {
+    namedArgs['hideOutput'] = literalTrue;
   }
   return refer('apply', 'package:build_runner/build_runner.dart').call([
     literalString(definition.package),

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -39,3 +39,7 @@ dev_dependencies:
   package_resolver: ^1.0.2
   test: ^0.12.0
   test_descriptor: ^1.0.0
+
+dependency_overrides:
+  build_config:
+    path: ../build_config

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -8,7 +8,8 @@ List<_i1.BuildAction> _buildActions(_i1.PackageGraph packageGraph) {
     _i1.apply('provides_builder', 'some_not_applied_builder', [_i2.notApplied],
         _i1.toNoneByDefault()),
     _i1.apply('provides_builder', 'some_builder', [_i2.someBuilder],
-        _i1.toDependentsOf('provides_builder')),
+        _i1.toDependentsOf('provides_builder'),
+        hideOutput: true),
     _i1.apply(
         'build_compilers',
         'ddc',
@@ -19,19 +20,21 @@ List<_i1.BuildAction> _buildActions(_i1.PackageGraph packageGraph) {
           _i3.devCompilerBuilder
         ],
         _i1.toAllPackages(),
-        isOptional: true),
+        isOptional: true,
+        hideOutput: true),
     _i1.apply('build_compilers', 'ddc_bootstrap',
-        [_i3.devCompilerBootstrapBuilder], _i1.toNoneByDefault()),
+        [_i3.devCompilerBootstrapBuilder], _i1.toNoneByDefault(),
+        hideOutput: true),
     _i1.apply('build_compilers', 'ddc_bootstrap',
         [_i3.devCompilerBootstrapBuilder], _i1.toRoot(),
-        inputs: ['web/**.dart', 'test/**.browser_test.dart'])
+        inputs: ['web/**.dart', 'test/**.browser_test.dart'], hideOutput: true)
   ];
   return _i1.createBuildActions(packageGraph, builders);
 }
 
 main() async {
   var actions = _buildActions(new _i1.PackageGraph.forThisPackage());
-  var handler = await _i1.watch(actions, writeToCache: true);
+  var handler = await _i1.watch(actions, deleteFilesByDefault: true);
   var server = await _i4.serve(handler.handlerFor('web'), 'localhost', 8000);
   await handler.buildResults.drain();
   await server.close();


### PR DESCRIPTION
Towards #647

- Use the config to set `hideOuput` when applying builders.
- Set `build_to` on DDC bootstrap builder since it isn't auto applied.
- Pass `deleteFileByDefault` since we are no longer passing
  `writeToCache`.