### PR TITLE
Don't serve non-output files

### DIFF
--- a/build_compilers/lib/src/dev_compiler_bootstrap_builder.dart
+++ b/build_compilers/lib/src/dev_compiler_bootstrap_builder.dart
@@ -280,6 +280,9 @@ final _requireJsConfig = '''
       xhr.onreadystatechange = function() {
         if (this.readyState == 4 && this.status == 200) {
           console.error(this.responseText);
+          var errorEvent = new CustomEvent(
+            'dartLoadException', { detail: this.responseText });
+          window.dispatchEvent(errorEvent);
         }
       };
       xhr.open("GET", e.originalError.srcElement.src + ".errors", true);

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -136,6 +136,7 @@ class SingleStepReader implements DigestAssetReader {
   }
 
   Future<Null> _ensureAssetIsBuilt(AssetId id) async {
+    if (_runPhaseForInput == null) return null;
     var node = _assetGraph.get(id);
     if (node is GeneratedAssetNode && node.needsUpdate) {
       await _runPhaseForInput(node.phaseNumber, node.primaryInput);

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -177,7 +177,12 @@ class WatchImpl implements BuildState {
       _buildDefinition = await BuildDefinition.prepareWorkspace(
           options, buildActions,
           onDelete: _expectedDeletes.add);
-      _readerCompleter.complete(_buildDefinition.reader);
+      _readerCompleter.complete(new SingleStepReader(
+          _buildDefinition.reader,
+          _buildDefinition.assetGraph,
+          buildActions.length,
+          packageGraph.root.name,
+          null));
       _assetGraph = _buildDefinition.assetGraph;
       build = await BuildImpl.create(_buildDefinition, buildActions,
           onDelete: _expectedDeletes.add);

--- a/e2e_example/test/serve_integration_test.dart
+++ b/e2e_example/test/serve_integration_test.dart
@@ -75,6 +75,7 @@ void main() {
       await deleteFile(path);
       await error;
       await nextBuild;
+      await expectTestsFail();
 
       nextBuild = nextSuccessfulBuild;
       await createFile(path, "String get message => 'Hello World!';");


### PR DESCRIPTION
I ended up just wrapping the reader with a SingleStepReader before we complete it in the WatchImpl which seems to work fine.

I also added a test that creating a compile time error causes the next test to fail - which led to firing the `dartLoadException` event so we don't have to wait for timeouts. This means you get compilation errors in your console when you run tests which is nice :).