### PR TITLE
Add InMemoryAssetReader.shareAssetCache constructor

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -18,3 +18,7 @@ dev_dependencies:
   build_barback: ">=0.4.0 <0.6.0"
   build_test: ^0.9.2
   test: ^0.12.0
+
+dependency_overrides:
+  build_test:
+    path: ../build_test

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -79,7 +79,7 @@ void main() {
 
     setUp(() {
       writer = new InMemoryAssetWriter();
-      reader = new InMemoryAssetReader(sourceAssets: writer.assets);
+      reader = new InMemoryAssetReader.shareAssetCache(writer.assets);
     });
 
     test('tracks outputs created by a builder', () async {

--- a/build/test/generate/run_builder_test.dart
+++ b/build/test/generate/run_builder_test.dart
@@ -28,7 +28,7 @@ main() {
     });
     builder = new FetchingCopyBuilder(resource);
     writer = new InMemoryAssetWriter();
-    reader = new InMemoryAssetReader(sourceAssets: writer.assets);
+    reader = new InMemoryAssetReader.shareAssetCache(writer.assets);
     addAssets(inputs, writer);
   });
 

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -20,3 +20,7 @@ dev_dependencies:
   build_test: ^0.9.0
   test: ^0.12.0
   transformer_test: ^0.2.1
+
+dependency_overrides:
+  build_test:
+    path: ../build_test

--- a/build_barback/test/analyzer/resolver_test.dart
+++ b/build_barback/test/analyzer/resolver_test.dart
@@ -43,7 +43,7 @@ void main() {
       Future validator(Resolver resolver),
       List messages: const []}) async {
     var writer = new InMemoryAssetWriter();
-    var reader = new InMemoryAssetReader(sourceAssets: writer.assets);
+    var reader = new InMemoryAssetReader.shareAssetCache(writer.assets);
     var actualInputs = <AssetId, String>{};
     inputs.forEach((k, v) => actualInputs[makeAssetId(k)] = v);
     addAssets(actualInputs, writer);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -43,3 +43,5 @@ dev_dependencies:
 dependency_overrides:
   build_config:
     path: ../build_config
+  build_test:
+    path: ../build_test

--- a/build_runner/test/common/in_memory_reader.dart
+++ b/build_runner/test/common/in_memory_reader.dart
@@ -12,9 +12,15 @@ import 'package:glob/glob.dart';
 /// Workaround class for mixin application limitations, if
 /// [InMemoryRunnerAssetReader] extends [InMemoryAssetReader] directly then it
 /// can't use mixins ([Md5DigestReader] in this case).
+///
+/// Classes with Mixings can't call a `super` constructor with named arguments.
 class _InMemoryAssetReader extends InMemoryAssetReader {
   _InMemoryAssetReader(Map<AssetId, dynamic> sourceAssets, String rootPackage)
       : super(sourceAssets: sourceAssets, rootPackage: rootPackage);
+
+  _InMemoryAssetReader.shareAssetCache(
+      Map<AssetId, List<int>> sourceAssets, String rootPackage)
+      : super.shareAssetCache(sourceAssets, rootPackage: rootPackage);
 }
 
 class InMemoryRunnerAssetReader extends _InMemoryAssetReader
@@ -23,6 +29,10 @@ class InMemoryRunnerAssetReader extends _InMemoryAssetReader
   InMemoryRunnerAssetReader(
       [Map<AssetId, dynamic> sourceAssets, String rootPackage])
       : super(sourceAssets, rootPackage);
+
+  InMemoryRunnerAssetReader.shareAssetCache(Map<AssetId, List<int>> assetCache,
+      {String rootPackage})
+      : super.shareAssetCache(assetCache, rootPackage);
 
   @override
   Stream<AssetId> findAssets(Glob glob, {String package}) {

--- a/build_runner/test/common/in_memory_reader.dart
+++ b/build_runner/test/common/in_memory_reader.dart
@@ -13,7 +13,7 @@ import 'package:glob/glob.dart';
 /// [InMemoryRunnerAssetReader] extends [InMemoryAssetReader] directly then it
 /// can't use mixins ([Md5DigestReader] in this case).
 ///
-/// Classes with Mixings can't call a `super` constructor with named arguments.
+/// Classes with mixins can't call a `super` constructor with named arguments.
 class _InMemoryAssetReader extends InMemoryAssetReader {
   _InMemoryAssetReader(Map<AssetId, dynamic> sourceAssets, String rootPackage)
       : super(sourceAssets: sourceAssets, rootPackage: rootPackage);

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -79,9 +79,8 @@ Future<BuildResult> testBuilders(List<BuilderApplication> builders,
     bool deleteFilesByDefault: true,
     bool enableLowResourcesMode: false}) async {
   writer ??= new InMemoryRunnerAssetWriter();
-  final actualAssets = writer.assets;
-  reader ??=
-      new InMemoryRunnerAssetReader(actualAssets, packageGraph?.root?.name);
+  reader ??= new InMemoryRunnerAssetReader.shareAssetCache(writer.assets,
+      rootPackage: packageGraph?.root?.name);
 
   inputs.forEach((serializedId, contents) {
     var id = makeAssetId(serializedId);

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -115,7 +115,9 @@ void main() {
         var ready = new Completer();
         var firstBuilder = new ExistsBuilder(aTxtId);
         var writer = new InMemoryRunnerAssetWriter();
-        var reader = new InMemoryRunnerAssetReader(writer.assets, 'a');
+        var reader = new InMemoryRunnerAssetReader.shareAssetCache(
+            writer.assets,
+            rootPackage: 'a');
         var builders = [
           apply('', '', [(_) => firstBuilder], toRoot(), inputs: ['lib/a.txt']),
           apply(

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -116,8 +116,7 @@ Future<ServeHandler> createHandler(List<BuilderApplication> builders,
   await Future.wait(inputs.keys.map((serializedId) async {
     await writer.writeAsString(makeAssetId(serializedId), inputs[serializedId]);
   }));
-  final actualAssets = writer.assets;
-  final reader = new InMemoryRunnerAssetReader(actualAssets);
+  final reader = new InMemoryRunnerAssetReader.shareAssetCache(writer.assets);
   final packageGraph =
       buildPackageGraph({rootPackage('a', path: path.absolute('a')): []});
   final watcherFactory = (String path) => new FakeWatcher(path);

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -427,8 +427,7 @@ Stream<BuildResult> startWatch(List<BuilderApplication> builders,
   inputs.forEach((serializedId, contents) {
     writer.writeAsString(makeAssetId(serializedId), contents);
   });
-  final actualAssets = writer.assets;
-  final reader = new InMemoryRunnerAssetReader(actualAssets);
+  final reader = new InMemoryRunnerAssetReader.shareAssetCache(writer.assets);
   packageGraph ??=
       buildPackageGraph({rootPackage('a', path: path.absolute('a')): []});
   final watcherFactory = (String path) => new FakeWatcher(path);

--- a/build_runner/test/server/serve_integration_test.dart
+++ b/build_runner/test/server/serve_integration_test.dart
@@ -30,7 +30,8 @@ void main() {
   setUp(() async {
     final graph = buildPackageGraph({rootPackage('example', path: path): []});
     writer = new InMemoryRunnerAssetWriter();
-    reader = new InMemoryRunnerAssetReader(writer.assets, 'example');
+    reader = new InMemoryRunnerAssetReader.shareAssetCache(writer.assets,
+        rootPackage: 'example');
     reader.cacheStringAsset(
         new AssetId('example', 'web/initial.txt'), 'initial');
     terminateController = new StreamController();

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.4
+
+- Added `InMemoryAssetReader.shareAssetCache` constructor. This is useful for the
+  case where the reader should be kept up to date as assets are written through
+  a writer.
+
 ## 0.9.3
 
 - Added `resolveSources`, a way to resolve multiple libraries for testing,

--- a/build_test/lib/src/in_memory_reader.dart
+++ b/build_test/lib/src/in_memory_reader.dart
@@ -19,7 +19,7 @@ class InMemoryAssetReader
   final String rootPackage;
 
   @override
-  final Set<AssetId> assetsRead;
+  final Set<AssetId> assetsRead = new Set<AssetId>();
 
   /// Create a new asset reader that contains [sourceAssets].
   ///
@@ -28,8 +28,10 @@ class InMemoryAssetReader
   ///
   /// May optionally define a [rootPackage], which is required for some APIs.
   InMemoryAssetReader({Map<AssetId, dynamic> sourceAssets, this.rootPackage})
-      : assets = _assetsAsBytes(sourceAssets) ?? <AssetId, List<int>>{},
-        assetsRead = new Set<AssetId>();
+      : assets = _assetsAsBytes(sourceAssets) ?? <AssetId, List<int>>{};
+
+  /// Create a new asset reader backed by [assets].
+  InMemoryAssetReader.shareAssetCache(this.assets, {this.rootPackage});
 
   static Map<AssetId, List<int>> _assetsAsBytes(Map<AssetId, dynamic> assets) {
     if (assets == null || assets.isEmpty) {

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.9.3
+version: 0.9.4-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 


### PR DESCRIPTION
When we started copying asset rather than continuing to use the same Map
instance it broke an undocumented behavior that we relied on in some
tests - that we could automatically keep new written assets reflected by
the writer.

Keep the strong mode types accurate and add a new contstructor which
solves this use case specificall.