### PR TITLE
Add `CopyBuilder.builds` stream

### DIFF
--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -208,13 +208,14 @@ void main() {
 
       test('rebuilds on file updates during first build', () async {
         var blocker = new Completer<Null>();
-        var buildAction =
-            applyToRoot(new CopyBuilder(blockUntil: blocker.future));
+        var builder = new CopyBuilder(blockUntil: blocker.future);
+        var firstBuildStarted = builder.builds.first;
+        var buildAction = applyToRoot(builder);
         var writer = new InMemoryRunnerAssetWriter();
         var results = new StreamQueue(
             startWatch([buildAction], {'a|web/a.txt': 'a'}, writer));
 
-        await new Future(() {});
+        await firstBuildStarted;
         FakeWatcher.notifyWatchers(new WatchEvent(
             ChangeType.MODIFY, path.absolute('a', 'web', 'a.txt')));
         blocker.complete();

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 0.9.4
 
-- Added `InMemoryAssetReader.shareAssetCache` constructor. This is useful for the
-  case where the reader should be kept up to date as assets are written through
-  a writer.
+- Added `InMemoryAssetReader.shareAssetCache` constructor. This is useful for
+  the case where the reader should be kept up to date as assets are written
+  through a writer.
+- Added `CopyBuilder.builds` stream which emits each time a build is started.
 
 ## 0.9.3
 

--- a/build_test/lib/src/copy_builder.dart
+++ b/build_test/lib/src/copy_builder.dart
@@ -38,8 +38,13 @@ class CopyBuilder implements Builder {
       this.inputExtension: '',
       this.blockUntil});
 
+  /// A stream which emits the primary input each time [build] is called.
+  Stream<AssetId> get builds => _builds.stream;
+  final _builds = new StreamController<AssetId>.broadcast();
+
   @override
   Future build(BuildStep buildStep) async {
+    _builds.add(buildStep.inputId);
     if (!buildStep.inputId.path.endsWith(inputExtension)) {
       throw new ArgumentError('Only expected inputs with extension '
           '$inputExtension but got ${buildStep.inputId}');


### PR DESCRIPTION
We have some tests which need to wait for setup to be finished. The
current pattern of `await new Future(() {})` is unsafe if the setup may
take extra trips around the event loop. Instead get a concrete signal of
the the Builder has started doing work.