### PR TITLE
Add equality and hashCode on BuildAction

### DIFF
--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -372,16 +372,7 @@ class AssetGraph {
 Digest computeBuildActionsDigest(Iterable<BuildAction> buildActions) {
   var digestSink = new AccumulatorSink<Digest>();
   var bytesSink = md5.startChunkedConversion(digestSink);
-  for (var action in buildActions) {
-    bytesSink.add(UTF8.encode(action.package));
-    bytesSink.add([action.builder.runtimeType.toString().hashCode]);
-    for (var glob in action.inputSet.globs) {
-      bytesSink.add([glob.pattern.hashCode]);
-    }
-    for (var glob in action.inputSet.excludes) {
-      bytesSink.add([glob.pattern.hashCode]);
-    }
-  }
+  bytesSink.add(buildActions.map((a) => a.hashCode).toList());
   bytesSink.close();
   assert(digestSink.events.length == 1);
   return digestSink.events.first;

--- a/build_runner/lib/src/generate/input_set.dart
+++ b/build_runner/lib/src/generate/input_set.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
+import 'package:collection/collection.dart';
 import 'package:glob/glob.dart';
 
 final List<Glob> _defaultInclude = new List.unmodifiable([new Glob('**')]);
@@ -54,4 +55,20 @@ class InputSet {
     buffer.writeln('');
     return buffer.toString();
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is InputSet &&
+          other.package == package &&
+          _deepEquals.equals(_patterns(globs), _patterns(other.globs)) &&
+          _deepEquals.equals(_patterns(excludes), _patterns(other.excludes)));
+
+  @override
+  int get hashCode =>
+      _deepEquals.hash([package, _patterns(globs), _patterns(excludes)]);
 }
+
+final _deepEquals = const DeepCollectionEquality();
+
+Iterable<String> _patterns(Iterable<Glob> globs) => globs.map((g) => g.pattern);

--- a/build_runner/lib/src/generate/phase.dart
+++ b/build_runner/lib/src/generate/phase.dart
@@ -79,7 +79,7 @@ class BuildAction {
       other is BuildAction &&
           // Risky, but we don't want to force all Builders to implement a sane
           // hashcode/equals
-          other.builder.runtimeType == builder.runtimeType &&
+          '${other.builder.runtimeType}' == '${builder.runtimeType}' &&
           other.inputSet == inputSet &&
           other.isOptional == isOptional &&
           other.hideOutput == hideOutput &&
@@ -88,7 +88,7 @@ class BuildAction {
 
   @override
   int get hashCode => _deepEquals.hash([
-        builder.runtimeType,
+        '${builder.runtimeType}',
         inputSet,
         isOptional,
         hideOutput,

--- a/build_runner/lib/src/generate/phase.dart
+++ b/build_runner/lib/src/generate/phase.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
+import 'package:collection/collection.dart';
 
 import 'input_set.dart';
 
@@ -63,5 +64,28 @@ class BuildAction {
   }
 
   @override
-  String toString() => '$builder on $inputSet';
+  String toString() {
+    final settings = <String>[];
+    if (isOptional) settings.add('optional');
+    if (hideOutput) settings.add('hidden');
+    var result = '$builder on $inputSet';
+    if (settings.isNotEmpty) result += ' $settings';
+    return result;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BuildAction &&
+          other.inputSet == inputSet &&
+          other.isOptional == isOptional &&
+          other.hideOutput == hideOutput &&
+          _deepEquals.equals(
+              other.builderOptions.config, builderOptions.config);
+
+  @override
+  int get hashCode => _deepEquals
+      .hash([inputSet, isOptional, hideOutput, builderOptions.config]);
 }
+
+final _deepEquals = const DeepCollectionEquality();

--- a/build_runner/lib/src/generate/phase.dart
+++ b/build_runner/lib/src/generate/phase.dart
@@ -77,6 +77,9 @@ class BuildAction {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is BuildAction &&
+          // Risky, but we don't want to force all Builders to implement a sane
+          // hashcode/equals
+          other.builder.runtimeType == builder.runtimeType &&
           other.inputSet == inputSet &&
           other.isOptional == isOptional &&
           other.hideOutput == hideOutput &&
@@ -84,8 +87,13 @@ class BuildAction {
               other.builderOptions.config, builderOptions.config);
 
   @override
-  int get hashCode => _deepEquals
-      .hash([inputSet, isOptional, hideOutput, builderOptions.config]);
+  int get hashCode => _deepEquals.hash([
+        builder.runtimeType,
+        inputSet,
+        isOptional,
+        hideOutput,
+        builderOptions.config
+      ]);
 }
 
 final _deepEquals = const DeepCollectionEquality();

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   build_config: ^0.1.1
   cli_util: ^0.1.2
   code_builder: ^2.3.0
+  collection: ^1.14.0
   convert: ^2.0.1
   crypto: ">=0.9.2 <3.0.0"
   dart_style: ^1.0.0


### PR DESCRIPTION
This will let us do further refactoring within BuildAction and InputSet
without impacting other usages.

Also add more detail to the BuildAction toString.