### PR TITLE
Clean up previous generated files before rebuilding

### DIFF
--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -286,6 +286,9 @@ class BuildImpl {
     if (!await _buildShouldRun(builderOutputs, wrappedReader)) {
       return <AssetId>[];
     }
+
+    await _cleanUpStaleOutputs(builderOutputs);
+
     // We may have read some inputs in the call to `_buildShouldRun`, we want
     // to remove those.
     wrappedReader.assetsRead.clear();
@@ -339,6 +342,18 @@ class BuildImpl {
       }
       return false;
     }
+  }
+
+  /// Deletes any of `outputs` which previously were output.
+  ///
+  /// This should be called after deciding that an asset really needs to be
+  /// regenerated based on its inputs hash changing.
+  Future<Null> _cleanUpStaleOutputs(Iterable<AssetId> outputs) async {
+    await Future.wait(outputs.map((output) {
+      var node = _assetGraph.get(output) as GeneratedAssetNode;
+      if (node.wasOutput) return _writer.delete(output);
+      return new Future.value(null);
+    }));
   }
 
   /// Computes a single [Digest] based on the combined [Digest]s of [ids] and

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -344,7 +344,7 @@ class BuildImpl {
     }
   }
 
-  /// Deletes any of `outputs` which previously were output.
+  /// Deletes any of [outputs] which previously were output.
   ///
   /// This should be called after deciding that an asset really needs to be
   /// regenerated based on its inputs hash changing.

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 0.9.4
+## 0.9.4-dev
 
 - Added `InMemoryAssetReader.shareAssetCache` constructor. This is useful for the
   case where the reader should be kept up to date as assets are written through
   a writer.
+- Added `buildInputs` stream to `CopyBuilder` which emits an event for each
+  `BuildStep.inputId` at the top of the `build` method.
 
 ## 0.9.3
 

--- a/build_test/lib/src/copy_builder.dart
+++ b/build_test/lib/src/copy_builder.dart
@@ -33,7 +33,7 @@ class CopyBuilder implements Builder {
   /// A stream of all the [BuildStep.inputId]s that are seen.
   ///
   /// Events are added at the top of the [build] method.
-  final _buildInputsController = new StreamController<AssetId>();
+  final _buildInputsController = new StreamController<AssetId>.broadcast();
   Stream<AssetId> get buildInputs => _buildInputsController.stream;
 
   CopyBuilder(

--- a/build_test/lib/src/copy_builder.dart
+++ b/build_test/lib/src/copy_builder.dart
@@ -30,6 +30,12 @@ class CopyBuilder implements Builder {
   /// are passed which do not match the input extension then [build] will throw.
   final String inputExtension;
 
+  /// A stream of all the [BuildStep.inputId]s that are seen.
+  ///
+  /// Events are added at the top of the [build] method.
+  final _buildInputsController = new StreamController<AssetId>();
+  Stream<AssetId> get buildInputs => _buildInputsController.stream;
+
   CopyBuilder(
       {this.numCopies: 1,
       this.extension: 'copy',
@@ -40,6 +46,7 @@ class CopyBuilder implements Builder {
 
   @override
   Future build(BuildStep buildStep) async {
+    _buildInputsController.add(buildStep.inputId);
     if (!buildStep.inputId.path.endsWith(inputExtension)) {
       throw new ArgumentError('Only expected inputs with extension '
           '$inputExtension but got ${buildStep.inputId}');


### PR DESCRIPTION
Also added `buildInputs` stream to `CopyBuilder` which is similar to some previous efforts but allows waiting for specific files to be built which is more explicit.