### PR TITLE
ensure that the results controller is open before adding events

### DIFF
--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -149,7 +149,7 @@ class WatchImpl implements BuildState {
     }
 
     var terminate = Future.any([until, fatalBuildCompleter.future]).then((_) {
-      _logger.info('Terminating. No further builds will be scheduled');
+      _logger.info('Terminating. No further builds will be scheduled\n');
     });
 
     // Start watching files immediately, before the first build is even started.


### PR DESCRIPTION
I also added an extra await for the `currentBuild` to finish before closing the stream and cleaning up resources - previously we would clean it up in the middle of the build which is not correct. If you want to exit in the middle of a build you need to ctrl-c twice.

Fixes https://github.com/dart-lang/build/issues/730