### PR TITLE
Add BuilderConfig class

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `build_to` option to Builder configuration.
 - Add `BuildConfig.fromBuildConfigDir` for cases where the package name and
   dependencies are already known.
+- Add `BuilderConfig` class to configure builders applied to specific targets.
 
 ### Breaking
 

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -3,7 +3,8 @@
 - Add `build_to` option to Builder configuration.
 - Add `BuildConfig.fromBuildConfigDir` for cases where the package name and
   dependencies are already known.
-- Add `BuilderConfig` class to configure builders applied to specific targets.
+- Add `TargetBuilderConfig` class to configure builders applied to specific
+  targets.
 
 ### Breaking
 

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:build/build.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
@@ -167,8 +168,10 @@ class BuildTarget {
 
   final Iterable<String> sources;
 
-  /// A map from builder name to the configuration used for this target.
-  final Map<String, Map<String, dynamic>> builders;
+  /// A map from builder key to the configuration used for this target.
+  ///
+  /// Builder keys are in the format `"$package|$builder"`.
+  final Map<String, BuilderConfig> builders;
 
   /// The platforms supported by this target.
   ///
@@ -179,18 +182,59 @@ class BuildTarget {
   /// Whether or not this is the default dart library for the package.
   final bool isDefault;
 
-  /// Sources to use as inputs for `builders`. May be `null`, in which case
-  /// it should fall back on `sources`.
-  final Iterable<String> generateFor;
-
   BuildTarget(
       {this.builders: const {},
       this.dependencies,
       this.platforms: const [],
       this.excludeSources: const [],
-      this.generateFor,
       this.isDefault: false,
       this.name,
       this.package,
       this.sources: const ['lib/**']});
+
+  @override
+  String toString() => {
+        'package': package,
+        'name': name,
+        'isDefault': isDefault,
+        'sources': sources,
+        'excludeSources': excludeSources,
+        'builders': builders
+      }.toString();
+}
+
+/// The configuration a particular [BuildTarget] applies to a Builder.
+///
+/// Build targets may have builders applied automatically based on
+/// [BuilderDefinition.autoApply] and may override with more specific
+/// configuration.
+class BuilderConfig {
+  /// Overrides the setting of whether the Builder would run on this target.
+  ///
+  /// Builders may run on this target by default based on the `apply_to`
+  /// argument. If this value is set it overrides the default.
+  final bool isEnabled;
+
+  /// Sources to use as inputs for this Builder in glob format.
+  ///
+  /// This is always a subset of the `include` argument in the containing
+  /// [BuildTarget].
+  ///
+  /// May be `null`, in which case it should fall back on `sources`.
+  final Iterable<String> generateFor;
+
+  final BuilderOptions options;
+
+  BuilderConfig({
+    this.isEnabled,
+    this.generateFor,
+    this.options: const BuilderOptions(const {}),
+  });
+
+  @override
+  String toString() => {
+        'isEnable': isEnabled,
+        'generateFor': generateFor,
+        'options': options?.config
+      }.toString();
 }

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -170,8 +170,10 @@ class BuildTarget {
 
   /// A map from builder key to the configuration used for this target.
   ///
-  /// Builder keys are in the format `"$package|$builder"`.
-  final Map<String, BuilderConfig> builders;
+  /// Builder keys are in the format `"$package|$builder"`. This does not
+  /// represent the full set of builders that are applied to the target, only
+  /// those which have configuration customized against the default.
+  final Map<String, TargetBuilderConfig> builders;
 
   /// The platforms supported by this target.
   ///
@@ -208,7 +210,7 @@ class BuildTarget {
 /// Build targets may have builders applied automatically based on
 /// [BuilderDefinition.autoApply] and may override with more specific
 /// configuration.
-class BuilderConfig {
+class TargetBuilderConfig {
   /// Overrides the setting of whether the Builder would run on this target.
   ///
   /// Builders may run on this target by default based on the `apply_to`
@@ -223,9 +225,13 @@ class BuilderConfig {
   /// May be `null`, in which case it should fall back on `sources`.
   final Iterable<String> generateFor;
 
+  /// The options to pass to the `BuilderFactory` when constructing this
+  /// builder.
+  ///
+  /// The `options` key in the configuration.
   final BuilderOptions options;
 
-  BuilderConfig({
+  TargetBuilderConfig({
     this.isEnabled,
     this.generateFor,
     this.options: const BuilderOptions(const {}),
@@ -235,6 +241,6 @@ class BuilderConfig {
   String toString() => {
         'isEnable': isEnabled,
         'generateFor': generateFor,
-        'options': options?.config
+        'options': options.config
       }.toString();
 }

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:build/build.dart';
 import 'package:yaml/yaml.dart';
 
 import 'build_config.dart';
@@ -21,7 +22,6 @@ const _targetOptions = const [
   _default,
   _dependencies,
   _excludeSources,
-  _generateFor,
   _platforms,
   _sources,
 ];
@@ -29,11 +29,19 @@ const _builders = 'builders';
 const _default = 'default';
 const _dependencies = 'dependencies';
 const _excludeSources = 'exclude_sources';
-const _generateFor = 'generate_for';
 const _platforms = 'platforms';
 const _sources = 'sources';
 
-const _builderOptions = const [
+const _builderConfigOptions = const [
+  _generateFor,
+  _enabled,
+  _options,
+];
+const _generateFor = 'generate_for';
+const _enabled = 'enabled';
+const _options = 'options';
+
+const _builderDefinitionOptions = const [
   _builderFactories,
   _import,
   _buildExtensions,
@@ -85,15 +93,11 @@ BuildConfig parseFromYaml(
 
     final sources = _readListOfStringsOrThrow(targetConfig, _sources);
 
-    final generateFor =
-        _readListOfStringsOrThrow(targetConfig, _generateFor, allowNull: true);
-
     buildTargets[targetName] = new BuildTarget(
       builders: builders,
       dependencies: dependencies,
       platforms: platforms,
       excludeSources: excludeSources,
-      generateFor: generateFor,
       isDefault: isDefault,
       name: targetName,
       package: packageName,
@@ -121,8 +125,8 @@ BuildConfig parseFromYaml(
   final Map<String, Map> builderConfigs =
       config['builders'] as Map<String, Map> ?? {};
   for (var builderName in builderConfigs.keys) {
-    final builderConfig = _readMapOrThrow(
-        builderConfigs, builderName, _builderOptions, 'builder `$builderName`',
+    final builderConfig = _readMapOrThrow(builderConfigs, builderName,
+        _builderDefinitionOptions, 'builder `$builderName`',
         defaultValue: <String, dynamic>{});
 
     final builderFactories =
@@ -209,8 +213,10 @@ String _readStringOrThrow(Map<String, dynamic> options, String option,
 }
 
 bool _readBoolOrThrow(Map<String, dynamic> options, String option,
-    {bool defaultValue}) {
+    {bool defaultValue, bool allowNull: false}) {
   var value = options[option] ?? defaultValue;
+  // ignore: avoid_returning_null
+  if (value == null && allowNull) return null;
   if (value is! bool) {
     throw new ArgumentError(
         'Expected a boolean for `$option` but got `$value`.');
@@ -250,32 +256,44 @@ BuildTo _readBuildToOrThrow(Map<String, dynamic> options, String option,
   return allowedValues[value];
 }
 
-Map<String, Map<String, dynamic>> _readBuildersOrThrow(
+Map<String, BuilderConfig> _readBuildersOrThrow(
     Map<String, dynamic> options, String option) {
-  var values = options[option];
+  final values = options[option];
   if (values == null) return const {};
 
-  if (values is! List) {
-    throw new ArgumentError('Got `$values` for `$option` but expected a List.');
+  if (values is! Map<String, dynamic>) {
+    throw new ArgumentError('Got `$values` for `$option` but expected a Map.');
   }
+  final builderConfigs = values as Map<String, dynamic>;
 
-  final normalizedValues = <String, Map<String, dynamic>>{};
-  for (var value in values) {
-    if (value is String) {
-      normalizedValues[value] = {};
-    } else if (value is Map<String, dynamic>) {
-      if (value.length == 1) {
-        normalizedValues[value.keys.first] =
-            value.values.first as Map<String, dynamic>;
-      } else {
-        throw value;
+  final parsedConfigs = <String, BuilderConfig>{};
+  for (final builderKey in builderConfigs.keys) {
+    final builderConfig = _readMapOrThrow(builderConfigs, builderKey,
+        _builderConfigOptions, 'builder config `$builderKey`',
+        defaultValue: {});
+
+    final isEnabled =
+        _readBoolOrThrow(builderConfig, _enabled, allowNull: true);
+
+    final generateFor =
+        _readListOfStringsOrThrow(builderConfig, _generateFor, allowNull: true);
+
+    var parsedOptions = <String, dynamic>{};
+    if (builderConfig.containsKey(_options)) {
+      final options = builderConfig[_options];
+      if (options is! Map) {
+        throw new ArgumentError('Invalid builder options for `$builderKey`, '
+            'got `$options` but expected a Map');
       }
-    } else {
-      throw new ArgumentError(
-          'Got `$value` for builder but expected a String or Map');
+      parsedOptions = options as Map<String, dynamic>;
     }
+    parsedConfigs[builderKey] = new BuilderConfig(
+      isEnabled: isEnabled,
+      generateFor: generateFor,
+      options: new BuilderOptions(parsedOptions),
+    );
   }
-  return normalizedValues;
+  return parsedConfigs;
 }
 
 List<String> _readListOfStringsOrThrow(

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -256,7 +256,7 @@ BuildTo _readBuildToOrThrow(Map<String, dynamic> options, String option,
   return allowedValues[value];
 }
 
-Map<String, BuilderConfig> _readBuildersOrThrow(
+Map<String, TargetBuilderConfig> _readBuildersOrThrow(
     Map<String, dynamic> options, String option) {
   final values = options[option];
   if (values == null) return const {};
@@ -266,7 +266,7 @@ Map<String, BuilderConfig> _readBuildersOrThrow(
   }
   final builderConfigs = values as Map<String, dynamic>;
 
-  final parsedConfigs = <String, BuilderConfig>{};
+  final parsedConfigs = <String, TargetBuilderConfig>{};
   for (final builderKey in builderConfigs.keys) {
     final builderConfig = _readMapOrThrow(builderConfigs, builderKey,
         _builderConfigOptions, 'builder config `$builderKey`',
@@ -278,19 +278,19 @@ Map<String, BuilderConfig> _readBuildersOrThrow(
     final generateFor =
         _readListOfStringsOrThrow(builderConfig, _generateFor, allowNull: true);
 
-    var parsedOptions = <String, dynamic>{};
+    var parsedOptions = const BuilderOptions(const {});
     if (builderConfig.containsKey(_options)) {
       final options = builderConfig[_options];
       if (options is! Map) {
         throw new ArgumentError('Invalid builder options for `$builderKey`, '
             'got `$options` but expected a Map');
       }
-      parsedOptions = options as Map<String, dynamic>;
+      parsedOptions = new BuilderOptions(options as Map<String, dynamic>);
     }
-    parsedConfigs[builderKey] = new BuilderConfig(
+    parsedConfigs[builderKey] = new TargetBuilderConfig(
       isEnabled: isEnabled,
       generateFor: generateFor,
-      options: new BuilderOptions(parsedOptions),
+      options: parsedOptions,
     );
   }
   return parsedConfigs;

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=1.22.1 <2.0.0'
 
 dependencies:
+  build: ^0.11.2
   path: ^1.4.0
   yaml: ^2.1.11
 

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:build/build.dart';
 import 'package:test/test.dart';
 
 import 'package:build_config/build_config.dart';
@@ -12,13 +13,10 @@ void main() {
     expectBuildTargets(buildConfig.buildTargets, {
       'a': new BuildTarget(
         builders: {
-          'b:b': {},
-          ':h': {'foo': 'bar'},
+          'b|b': new BuilderConfig(generateFor: ['lib/a.dart']),
+          'a|h': new BuilderConfig(options: new BuilderOptions({'foo': 'bar'})),
         },
         dependencies: ['b', 'c:d'],
-        generateFor: [
-          'lib/a.dart',
-        ],
         name: 'a',
         package: 'example',
         sources: ['lib/a.dart', 'lib/src/a/**'],
@@ -92,14 +90,15 @@ var buildYaml = '''
 targets:
   a:
     builders:
-      - :h:
+      a|h:
+        options:
           foo: bar
-      - b:b
+      b|b:
+        generate_for:
+          - lib/a.dart
     dependencies:
       - b
       - c:d
-    generate_for:
-      - lib/a.dart
     sources:
       - "lib/a.dart"
       - "lib/src/a/**"
@@ -186,11 +185,48 @@ class _BuildTargetMatcher extends Matcher {
       item.package == _expected.package &&
       item.isDefault == _expected.isDefault &&
       equals(_expected.platforms).matches(item.platforms, _) &&
-      equals(_expected.builders).matches(item.builders, _) &&
+      new _BuilderConfigsMatcher(_expected.builders)
+          .matches(item.builders, _) &&
       equals(_expected.dependencies).matches(item.dependencies, _) &&
-      equals(_expected.generateFor).matches(item.generateFor, _) &&
       equals(_expected.sources).matches(item.sources, _) &&
       equals(_expected.excludeSources).matches(item.excludeSources, _);
+
+  @override
+  Description describe(Description description) =>
+      description.addDescriptionOf(_expected);
+}
+
+class _BuilderConfigsMatcher extends Matcher {
+  final Map<String, BuilderConfig> _expected;
+  _BuilderConfigsMatcher(this._expected);
+
+  @override
+  bool matches(item, _) {
+    if (item is! Map<String, BuilderConfig>) return false;
+    final other = item as Map<String, BuilderConfig>;
+    if (!equals(_expected.keys).matches(other.keys, _)) return false;
+    for (final key in _expected.keys) {
+      final matcher = new _BuilderConfigMatcher(_expected[key]);
+      if (!matcher.matches(other[key], _)) return false;
+    }
+    return true;
+  }
+
+  @override
+  Description describe(Description description) =>
+      description.addDescriptionOf(_expected);
+}
+
+class _BuilderConfigMatcher extends Matcher {
+  final BuilderConfig _expected;
+  _BuilderConfigMatcher(this._expected);
+
+  @override
+  bool matches(item, _) =>
+      item is BuilderConfig &&
+      item.isEnabled == _expected.isEnabled &&
+      equals(_expected.generateFor).matches(item.generateFor, _) &&
+      equals(_expected.options.config).matches(item.options.config, _);
 
   @override
   Description describe(Description description) =>

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -13,8 +13,9 @@ void main() {
     expectBuildTargets(buildConfig.buildTargets, {
       'a': new BuildTarget(
         builders: {
-          'b|b': new BuilderConfig(generateFor: ['lib/a.dart']),
-          'a|h': new BuilderConfig(options: new BuilderOptions({'foo': 'bar'})),
+          'b|b': new TargetBuilderConfig(generateFor: ['lib/a.dart']),
+          'a|h': new TargetBuilderConfig(
+              options: new BuilderOptions({'foo': 'bar'})),
         },
         dependencies: ['b', 'c:d'],
         name: 'a',
@@ -197,13 +198,13 @@ class _BuildTargetMatcher extends Matcher {
 }
 
 class _BuilderConfigsMatcher extends Matcher {
-  final Map<String, BuilderConfig> _expected;
+  final Map<String, TargetBuilderConfig> _expected;
   _BuilderConfigsMatcher(this._expected);
 
   @override
   bool matches(item, _) {
-    if (item is! Map<String, BuilderConfig>) return false;
-    final other = item as Map<String, BuilderConfig>;
+    if (item is! Map<String, TargetBuilderConfig>) return false;
+    final other = item as Map<String, TargetBuilderConfig>;
     if (!equals(_expected.keys).matches(other.keys, _)) return false;
     for (final key in _expected.keys) {
       final matcher = new _BuilderConfigMatcher(_expected[key]);
@@ -218,12 +219,12 @@ class _BuilderConfigsMatcher extends Matcher {
 }
 
 class _BuilderConfigMatcher extends Matcher {
-  final BuilderConfig _expected;
+  final TargetBuilderConfig _expected;
   _BuilderConfigMatcher(this._expected);
 
   @override
   bool matches(item, _) =>
-      item is BuilderConfig &&
+      item is TargetBuilderConfig &&
       item.isEnabled == _expected.isEnabled &&
       equals(_expected.generateFor).matches(item.generateFor, _) &&
       equals(_expected.options.config).matches(item.options.config, _);


### PR DESCRIPTION
- Add a `BuilderConfig` class to hold per-target builder configuration
- Move `generate_for` from per-target to per-builder
- Change the `builders` value from a `List<String|Map>` to a `Map`
- Add a Matcher for `BuilderConfig` and map of configs
- Add some `toString` implementations to make test failures a little
  easier to fix
- Update test yaml and built values to match new syntax.