### PR TITLE
Drop `platform` concept

### DIFF
--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -56,14 +56,13 @@ class BuildConfig {
       String packageName, Iterable<String> dependencies,
       {
       Iterable<String> excludeSources: const []}) {
-    final sources = ['**'];
     final buildTargets = {
       packageName: new BuildTarget(
           dependencies: dependencies,
           isDefault: true,
           name: packageName,
           package: packageName,
-          sources: sources,
+          sources: const ['**'],
           excludeSources: excludeSources)
     };
     return new BuildConfig(

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -75,9 +75,8 @@ class BuildConfig {
 
   /// Create a [BuildConfig] read a map which was already parsed.
   factory BuildConfig.fromMap(String packageName, Iterable<String> dependencies,
-          Map<String, dynamic> config, {bool includeWebSources: false}) =>
-      parseFromMap(packageName, dependencies, config,
-          includeWebSources: includeWebSources);
+          Map<String, dynamic> config) =>
+      parseFromMap(packageName, dependencies, config);
 
   BuildConfig({
     @required this.packageName,

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -19,12 +19,11 @@ class BuildConfig {
   ///
   /// [path] must be a directory which contains a `pubspec.yaml` file and
   /// optionally a `build.yaml`.
-  static Future<BuildConfig> fromPackageDir(String path,
-      {bool includeWebSources: false}) async {
+  static Future<BuildConfig> fromPackageDir(String path) async {
     final pubspec = await Pubspec.fromPackageDir(path);
     return fromBuildConfigDir(
-        pubspec.pubPackageName, pubspec.dependencies, path,
-        includeWebSources: includeWebSources);
+        pubspec.pubPackageName, pubspec.dependencies, path
+        );
   }
 
   /// Returns a parsed [BuildConfig] file in [path], if one exists, otherwise a
@@ -32,17 +31,15 @@ class BuildConfig {
   ///
   /// [path] should the path to a directory which may contain a `build.yaml`.
   static Future<BuildConfig> fromBuildConfigDir(
-      String packageName, Iterable<String> dependencies, String path,
-      {bool includeWebSources: false}) async {
+      String packageName, Iterable<String> dependencies, String path) async {
     final configPath = p.join(path, 'build.yaml');
     final file = new File(configPath);
     if (await file.exists()) {
       return new BuildConfig.parse(
-          packageName, dependencies, await file.readAsString(),
-          includeWebSources: includeWebSources);
+          packageName, dependencies, await file.readAsString());
     } else {
-      return new BuildConfig.useDefault(packageName, dependencies,
-          includeWebSources: includeWebSources);
+      return new BuildConfig.useDefault(packageName, dependencies
+          );
     }
   }
 
@@ -57,15 +54,12 @@ class BuildConfig {
   /// The default config if you have no `build.yaml` file.
   factory BuildConfig.useDefault(
       String packageName, Iterable<String> dependencies,
-      {bool includeWebSources: false,
-      List<String> platforms: const [],
+      {
       Iterable<String> excludeSources: const []}) {
-    final sources = ["lib/**"];
-    if (includeWebSources) sources.add("web/**");
+    final sources = ['**'];
     final buildTargets = {
       packageName: new BuildTarget(
           dependencies: dependencies,
-          platforms: platforms,
           isDefault: true,
           name: packageName,
           package: packageName,
@@ -80,10 +74,9 @@ class BuildConfig {
 
   /// Create a [BuildConfig] by parsing [configYaml].
   factory BuildConfig.parse(
-          String packageName, Iterable<String> dependencies, String configYaml,
-          {bool includeWebSources: false}) =>
-      parseFromYaml(packageName, dependencies, configYaml,
-          includeWebSources: includeWebSources);
+          String packageName, Iterable<String> dependencies, String configYaml) =>
+      parseFromYaml(packageName, dependencies, configYaml
+          );
 
   BuildConfig({
     @required this.packageName,
@@ -175,12 +168,6 @@ class BuildTarget {
   /// those which have configuration customized against the default.
   final Map<String, TargetBuilderConfig> builders;
 
-  /// The platforms supported by this target.
-  ///
-  /// May be limited by, for isntance, importing core libraries that are not
-  /// cross platform. An empty list indicates all platforms are supported.
-  final List<String> platforms;
-
   /// Whether or not this is the default dart library for the package.
   final bool isDefault;
 
@@ -191,7 +178,6 @@ class BuildTarget {
     this.excludeSources: const [],
     this.dependencies,
     this.builders: const {},
-    this.platforms: const [],
     this.isDefault: false,
   });
 
@@ -203,7 +189,6 @@ class BuildTarget {
         excludeSources: other.excludeSources,
         dependencies: other.dependencies,
         builders: other.builders,
-        platforms: other.platforms,
       );
 
   @override

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -7,29 +7,17 @@ import 'package:yaml/yaml.dart';
 
 import 'build_config.dart';
 
-/// Supported values for the `platforms` attribute.
-const _allPlatforms = const [
-  _vmPlatform,
-  _webPlatform,
-  _flutterPlatform,
-];
-const _vmPlatform = 'vm';
-const _webPlatform = 'web';
-const _flutterPlatform = 'flutter';
-
 const _targetOptions = const [
   _builders,
   _default,
   _dependencies,
   _excludeSources,
-  _platforms,
   _sources,
 ];
 const _builders = 'builders';
 const _default = 'default';
 const _dependencies = 'dependencies';
 const _excludeSources = 'exclude_sources';
-const _platforms = 'platforms';
 const _sources = 'sources';
 
 const _builderConfigOptions = const [
@@ -61,10 +49,7 @@ const _isOptional = 'is_optional';
 const _buildTo = 'build_to';
 
 BuildConfig parseFromYaml(
-    String packageName, Iterable<String> dependencies, String configYaml,
-    {bool includeWebSources}) {
-  includeWebSources ??= false;
-
+    String packageName, Iterable<String> dependencies, String configYaml) {
   final buildTargets = <String, BuildTarget>{};
   final builderDefinitions = <String, BuilderDefinition>{};
 
@@ -88,15 +73,11 @@ BuildConfig parseFromYaml(
     var isDefault =
         _readBoolOrThrow(targetConfig, _default, defaultValue: false);
 
-    final platforms = _readListOfStringsOrThrow(targetConfig, _platforms,
-        defaultValue: [], validValues: _allPlatforms);
-
     final sources = _readListOfStringsOrThrow(targetConfig, _sources);
 
     buildTargets[targetName] = new BuildTarget(
       builders: builders,
       dependencies: dependencies,
-      platforms: platforms,
       excludeSources: excludeSources,
       isDefault: isDefault,
       name: targetName,
@@ -107,8 +88,7 @@ BuildConfig parseFromYaml(
 
   if (buildTargets.isEmpty) {
     // Add the default dart library if there are no targets discovered.
-    var sources = ["lib/**"];
-    if (includeWebSources) sources.add("web/**");
+    var sources = ['**'];
     buildTargets[packageName] = new BuildTarget(
         dependencies: dependencies,
         isDefault: true,

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -88,13 +88,12 @@ BuildConfig parseFromYaml(
 
   if (buildTargets.isEmpty) {
     // Add the default dart library if there are no targets discovered.
-    var sources = ['**'];
     buildTargets[packageName] = new BuildTarget(
         dependencies: dependencies,
         isDefault: true,
         name: packageName,
         package: packageName,
-        sources: sources);
+        sources: const ['**']);
   } else if (buildTargets.length == 1 &&
       !buildTargets.values.single.isDefault) {
     // Allow omitting `isDefault` if there is exactly 1 target.

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -24,7 +24,6 @@ void main() {
       ),
       'e': new BuildTarget(
         dependencies: ['f', ':a'],
-        platforms: ['vm'],
         excludeSources: ['lib/src/e/g.dart'],
         isDefault: true,
         name: 'e',
@@ -62,7 +61,7 @@ void main() {
         isDefault: true,
         name: 'example',
         package: 'example',
-        sources: ['lib/**'],
+        sources: ['**'],
       ),
     });
     expectBuilderDefinitions(buildConfig.builderDefinitions, {
@@ -113,8 +112,6 @@ targets:
       - "lib/src/e/**"
     exclude_sources:
       - "lib/src/e/g.dart"
-    platforms:
-      - vm
 builders:
   h:
     builder_factories: ["createBuilder"]
@@ -170,8 +167,7 @@ void expectBuildTargets(
     Map<String, BuildTarget> actual, Map<String, BuildTarget> expected) {
   expect(actual.keys, unorderedEquals(expected.keys));
   for (var p in actual.keys) {
-    expect(actual[p], new _BuildTargetMatcher(expected[p]),
-        reason: '${actual[p].platforms} vs ${expected[p].platforms}');
+    expect(actual[p], new _BuildTargetMatcher(expected[p]));
   }
 }
 
@@ -185,7 +181,6 @@ class _BuildTargetMatcher extends Matcher {
       item.name == _expected.name &&
       item.package == _expected.package &&
       item.isDefault == _expected.isDefault &&
-      equals(_expected.platforms).matches(item.platforms, _) &&
       new _BuilderConfigsMatcher(_expected.builders)
           .matches(item.builders, _) &&
       equals(_expected.dependencies).matches(item.dependencies, _) &&


### PR DESCRIPTION
This is not fully baked. Drop it for now and we can revisit when we get
back around to `dazel`.

- Drop `platforms` options and fields.
- Drop `includeWebSources` and include the entire package in the default
  target.