### PR TITLE
Use extensions to order builders

### DIFF
--- a/build_runner/test/common/common.dart
+++ b/build_runner/test/common/common.dart
@@ -35,16 +35,17 @@ class OverDeclaringCopyBuilder extends CopyBuilder {
 class ExistsBuilder extends Builder {
   final AssetId idToCheck;
   final Future waitFor;
+  final String inputExtension;
 
   final _hasRanCompleter = new Completer<Null>();
   Future get hasRan => _hasRanCompleter.future;
 
-  ExistsBuilder(this.idToCheck, {this.waitFor});
+  ExistsBuilder(this.idToCheck, {this.waitFor, this.inputExtension: ''});
 
   @override
-  final buildExtensions = {
-    '': ['.exists']
-  };
+  Map<String, List<String>> get buildExtensions => {
+        inputExtension: ['$inputExtension.exists']
+      };
 
   @override
   Future<Null> build(BuildStep buildStep) async {

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -167,8 +167,8 @@ void main() {
         var writer = new InMemoryRunnerAssetWriter();
         await testBuilders([
           copyABuilderApplication,
-          apply('', '', [(_) => new CopyBuilder(extension: 'clone')], toRoot(),
-              inputs: ['**.txt.copy'])
+          applyToRoot(
+              new CopyBuilder(inputExtension: '.copy', extension: 'copy.clone'))
         ], {
           'a|web/a.txt': 'a',
           'a|web/a.txt.copy': 'a',

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -46,26 +46,37 @@ void main() {
       test('optional build actions don\'t run if their outputs aren\'t read',
           () async {
         await testBuilders([
-          apply('', '', [(_) => new CopyBuilder()], toRoot(), isOptional: true),
-          apply('', '', [(_) => new CopyBuilder()], toRoot(),
-              isOptional: true, inputs: ['**.1']),
-        ], {}, outputs: {});
+          apply('', '', [(_) => new CopyBuilder(extension: '1')], toRoot(),
+              isOptional: true),
+          apply('', '', [(_) => new CopyBuilder(inputExtension: '1')], toRoot(),
+              isOptional: true),
+        ], {
+          'a|lib/a.txt': 'a'
+        }, outputs: {});
       });
 
       test('optional build actions do run if their outputs are read', () async {
         await testBuilders([
           apply('', '', [(_) => new CopyBuilder(extension: '1')], toRoot(),
               isOptional: true),
-          apply('', '', [(_) => new CopyBuilder(extension: '2')], toRoot(),
-              isOptional: true, inputs: ['**.1']),
-          apply('', '', [(_) => new CopyBuilder(extension: '3')], toRoot(),
-              inputs: ['**.2']),
+          apply(
+              '',
+              '',
+              [(_) => new CopyBuilder(inputExtension: '.1', extension: '2')],
+              toRoot(),
+              isOptional: true),
+          apply(
+            '',
+            '',
+            [(_) => new CopyBuilder(inputExtension: '.2', extension: '3')],
+            toRoot(),
+          ),
         ], {
           'a|web/a.txt': 'a'
         }, outputs: {
           'a|web/a.txt.1': 'a',
-          'a|web/a.txt.1.2': 'a',
-          'a|web/a.txt.1.2.3': 'a',
+          'a|web/a.txt.2': 'a',
+          'a|web/a.txt.3': 'a',
         });
       });
 
@@ -73,7 +84,7 @@ void main() {
         var builders = [
           copyABuilderApplication,
           apply('', '', [(_) => new CopyBuilder(extension: 'clone')], toRoot(),
-              inputs: ['**/*.txt'], isOptional: true),
+              isOptional: true),
           apply('', '', [(_) => new CopyBuilder(numCopies: 2)], toRoot(),
               inputs: ['web/*.txt.clone']),
         ];
@@ -91,41 +102,36 @@ void main() {
       });
 
       test('early step touches a not-yet-generated asset', () async {
-        var copyId = new AssetId('a', 'lib/a.txt.copy');
+        var copyId = new AssetId('a', 'lib/file.a.copy');
         var builders = [
-          apply('', '', [(_) => new CopyBuilder(touchAsset: copyId)], toRoot(),
-              inputs: ['lib/b.txt']),
-          apply('', '', [(_) => new CopyBuilder()], toRoot(),
-              inputs: ['lib/a.txt']),
-          apply('', '', [(_) => new ExistsBuilder(copyId)], toRoot(),
-              inputs: ['lib/a.txt'])
+          applyToRoot(new CopyBuilder(
+              touchAsset: copyId, inputExtension: '.b', extension: 'b.copy')),
+          applyToRoot(
+              new CopyBuilder(inputExtension: '.a', extension: 'a.copy')),
+          applyToRoot(new ExistsBuilder(copyId, inputExtension: '.a')),
         ];
         await testBuilders(builders, {
-          'a|lib/a.txt': 'a',
-          'a|lib/b.txt': 'b',
+          'a|lib/file.a': 'a',
+          'a|lib/file.b': 'b',
         }, outputs: {
-          'a|lib/a.txt.exists': 'true',
-          'a|lib/a.txt.copy': 'a',
-          'a|lib/b.txt.copy': 'b',
+          'a|lib/file.a.copy': 'a',
+          'a|lib/file.b.copy': 'b',
+          'a|lib/file.a.exists': 'true',
         });
       });
 
       test('asset is deleted mid-build, use cached canRead result', () async {
-        var aTxtId = new AssetId('a', 'lib/a.txt');
+        var aTxtId = new AssetId('a', 'lib/file.a');
         var ready = new Completer();
-        var firstBuilder = new ExistsBuilder(aTxtId);
+        var firstBuilder = new ExistsBuilder(aTxtId, inputExtension: 'a');
         var writer = new InMemoryRunnerAssetWriter();
         var reader = new InMemoryRunnerAssetReader.shareAssetCache(
             writer.assets,
             rootPackage: 'a');
         var builders = [
-          apply('', '', [(_) => firstBuilder], toRoot(), inputs: ['lib/a.txt']),
-          apply(
-              '',
-              '',
-              [(_) => new ExistsBuilder(aTxtId, waitFor: ready.future)],
-              toRoot(),
-              inputs: ['lib/b.txt']),
+          applyToRoot(firstBuilder),
+          applyToRoot(new ExistsBuilder(aTxtId,
+              waitFor: ready.future, inputExtension: 'b')),
         ];
 
         // After the first builder runs, delete the asset from the reader and
@@ -140,12 +146,12 @@ void main() {
         await testBuilders(
             builders,
             {
-              'a|lib/a.txt': '',
-              'a|lib/b.txt': '',
+              'a|lib/file.a': '',
+              'a|lib/file.b': '',
             },
             outputs: {
-              'a|lib/a.txt.exists': 'true',
-              'a|lib/b.txt.exists': 'true',
+              'a|lib/file.a.exists': 'true',
+              'a|lib/file.b.exists': 'true',
             },
             reader: reader,
             writer: writer);
@@ -405,25 +411,15 @@ void main() {
     test('Overdeclared outputs are not treated as inputs to later steps',
         () async {
       var builders = [
-        apply(
-            '',
-            '',
-            [
-              (_) => new OverDeclaringCopyBuilder(
-                  numCopies: 1, extension: 'unexpected')
-            ],
-            toRoot()),
-        apply(
-            '',
-            '',
-            [(_) => new CopyBuilder(numCopies: 1, extension: 'expected')],
-            toRoot()),
-        apply('', '', [(_) => new CopyBuilder(numCopies: 1)], toRoot(),
-            inputs: ['**.expected', '**.unexpected']),
+        applyToRoot(new OverDeclaringCopyBuilder(
+            numCopies: 1, extension: 'unexpected')),
+        applyToRoot(new CopyBuilder(extension: 'expected')),
+        applyToRoot(new CopyBuilder()),
       ];
       await testBuilders(builders, {
         'a|lib/a.txt': 'a',
       }, outputs: {
+        'a|lib/a.txt.copy': 'a',
         'a|lib/a.txt.expected': 'a',
         'a|lib/a.txt.expected.copy': 'a',
       });
@@ -562,8 +558,8 @@ void main() {
     test('graph/file system get cleaned up for deleted inputs', () async {
       var builders = [
         copyABuilderApplication,
-        apply('', '', [(_) => new CopyBuilder(extension: 'clone')], toRoot(),
-            inputs: ['**/*.txt.copy'])
+        applyToRoot(
+            new CopyBuilder(inputExtension: '.copy', extension: 'clone'))
       ];
 
       // Initial build.
@@ -575,7 +571,7 @@ void main() {
           },
           outputs: {
             'a|lib/a.txt.copy': 'a',
-            'a|lib/a.txt.copy.clone': 'a',
+            'a|lib/a.txt.clone': 'a',
           },
           writer: writer);
 
@@ -586,7 +582,7 @@ void main() {
           builders,
           {
             'a|lib/a.txt.copy': 'a',
-            'a|lib/a.txt.copy.clone': 'a',
+            'a|lib/a.txt.clone': 'a',
             'a|$assetGraphPath': serializedGraph,
           },
           outputs: {},
@@ -650,18 +646,16 @@ void main() {
       // Initial build.
       var writer = new InMemoryRunnerAssetWriter();
       await testBuilders([
-        apply(
-            '',
-            '',
-            [(_) => new CopyBuilder(copyFromAsset: makeAssetId('a|lib/b.txt'))],
-            toRoot(),
-            inputs: ['lib/a.txt'])
+        applyToRoot(new CopyBuilder(
+            copyFromAsset: makeAssetId('a|lib/file.b'),
+            inputExtension: '.a',
+            extension: 'a.copy')),
       ], {
-        'a|lib/a.txt': 'a',
-        'a|lib/b.txt': 'b',
-        'a|lib/c.txt': 'c',
+        'a|lib/file.a': 'a',
+        'a|lib/file.b': 'b',
+        'a|lib/file.c': 'c',
       }, outputs: {
-        'a|lib/a.txt.copy': 'b',
+        'a|lib/file.a.copy': 'b',
       }, writer: writer);
 
       // Followup build with same sources + cached graph, but configure the
@@ -670,51 +664,44 @@ void main() {
       writer.assets.clear();
 
       await testBuilders([
-        apply(
-            '',
-            '',
-            [(_) => new CopyBuilder(copyFromAsset: makeAssetId('a|lib/c.txt'))],
-            toRoot(),
-            inputs: ['lib/a.txt'])
+        applyToRoot(new CopyBuilder(
+            copyFromAsset: makeAssetId('a|lib/file.c'),
+            inputExtension: '.a',
+            extension: 'a.copy')),
       ], {
-        'a|lib/a.txt': 'a',
-        'a|lib/a.txt.copy': 'b',
+        'a|lib/file.a': 'a',
+        'a|lib/file.a.copy': 'b',
         // Hack to get the file to rebuild, we are being bad by changing the
         // builder but pretending its the same.
-        'a|lib/b.txt': 'b2',
-        'a|lib/c.txt': 'c',
+        'a|lib/file.b': 'b2',
+        'a|lib/file.c': 'c',
         'a|$assetGraphPath': serializedGraph,
       }, outputs: {
-        'a|lib/a.txt.copy': 'c',
+        'a|lib/file.a.copy': 'c',
       }, writer: writer);
 
       // Read cached graph and validate.
       var graph = new AssetGraph.deserialize(JSON.decode(
           UTF8.decode(writer.assets[makeAssetId('a|$assetGraphPath')])) as Map);
       var outputNode =
-          graph.get(makeAssetId('a|lib/a.txt.copy')) as GeneratedAssetNode;
-      var aTxtNode = graph.get(makeAssetId('a|lib/a.txt'));
-      var bTxtNode = graph.get(makeAssetId('a|lib/b.txt'));
-      var cTxtNode = graph.get(makeAssetId('a|lib/c.txt'));
-      expect(outputNode.inputs, unorderedEquals([aTxtNode.id, cTxtNode.id]));
-      expect(aTxtNode.outputs, contains(outputNode.id));
-      expect(bTxtNode.outputs, isEmpty);
-      expect(cTxtNode.outputs, unorderedEquals([outputNode.id]));
+          graph.get(makeAssetId('a|lib/file.a.copy')) as GeneratedAssetNode;
+      var fileANode = graph.get(makeAssetId('a|lib/file.a'));
+      var fileBNode = graph.get(makeAssetId('a|lib/file.b'));
+      var fileCNode = graph.get(makeAssetId('a|lib/file.c'));
+      expect(outputNode.inputs, unorderedEquals([fileANode.id, fileCNode.id]));
+      expect(fileANode.outputs, contains(outputNode.id));
+      expect(fileBNode.outputs, isEmpty);
+      expect(fileCNode.outputs, unorderedEquals([outputNode.id]));
     });
 
     test('Ouputs aren\'t rebuilt if their inputs didn\'t change', () async {
       var builders = [
-        apply(
-            '',
-            '',
-            [
-              (_) =>
-                  new CopyBuilder(copyFromAsset: new AssetId('a', 'lib/b.txt'))
-            ],
-            toRoot(),
-            inputs: ['lib/a.txt']),
-        apply('', '', [(_) => new CopyBuilder()], toRoot(),
-            inputs: ['lib/a.txt.copy']),
+        applyToRoot(new CopyBuilder(
+            copyFromAsset: new AssetId('a', 'lib/file.b'),
+            inputExtension: '.a',
+            extension: 'a.copy')),
+        applyToRoot(new CopyBuilder(
+            inputExtension: '.a.copy', extension: 'a.copy.copy')),
       ];
 
       // Initial build.
@@ -722,30 +709,30 @@ void main() {
       await testBuilders(
           builders,
           {
-            'a|lib/a.txt': 'a',
-            'a|lib/b.txt': 'b',
+            'a|lib/file.a': 'a',
+            'a|lib/file.b': 'b',
           },
           outputs: {
-            'a|lib/a.txt.copy': 'b',
-            'a|lib/a.txt.copy.copy': 'b',
+            'a|lib/file.a.copy': 'b',
+            'a|lib/file.a.copy.copy': 'b',
           },
           writer: writer);
 
-      // Modify the primary input of `a.txt.copy`, but its output doesn't change
-      // so `a.txt.copy.copy` shouldn't be rebuilt.
+      // Modify the primary input of `file.a.copy`, but its output doesn't
+      // change so `file.a.copy.copy` shouldn't be rebuilt.
       var serializedGraph = writer.assets[makeAssetId('a|$assetGraphPath')];
       writer.assets.clear();
       await testBuilders(
           builders,
           {
-            'a|lib/a.txt': 'a2',
-            'a|lib/b.txt': 'b',
-            'a|lib/a.txt.copy': 'b',
-            'a|lib/a.txt.copy.copy': 'b',
+            'a|lib/file.a': 'a2',
+            'a|lib/file.b': 'b',
+            'a|lib/file.a.copy': 'b',
+            'a|lib/file.a.copy.copy': 'b',
             'a|$assetGraphPath': serializedGraph,
           },
           outputs: {
-            'a|lib/a.txt.copy': 'b',
+            'a|lib/file.a.copy': 'b',
           },
           writer: writer);
     });

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -240,7 +240,8 @@ void main() {
       test('edits propagate through all phases', () async {
         var buildActions = [
           copyABuildApplication,
-          applyToRoot(new CopyBuilder(), inputs: ['**/*.copy'])
+          applyToRoot(
+              new CopyBuilder(inputExtension: '.copy', extension: 'copy.copy'))
         ];
 
         var writer = new InMemoryRunnerAssetWriter();
@@ -266,7 +267,8 @@ void main() {
       test('adds propagate through all phases', () async {
         var buildActions = [
           copyABuildApplication,
-          applyToRoot(new CopyBuilder(), inputs: ['**/*.copy'])
+          applyToRoot(
+              new CopyBuilder(inputExtension: '.copy', extension: 'copy.copy'))
         ];
 
         var writer = new InMemoryRunnerAssetWriter();
@@ -297,7 +299,8 @@ void main() {
       test('deletes propagate through all phases', () async {
         var buildActions = [
           copyABuildApplication,
-          applyToRoot(new CopyBuilder(), inputs: ['**/*.copy'])
+          applyToRoot(
+              new CopyBuilder(inputExtension: '.copy', extension: 'copy.copy'))
         ];
 
         var writer = new InMemoryRunnerAssetWriter();
@@ -338,7 +341,8 @@ void main() {
       test('deleted generated outputs are regenerated', () async {
         var buildActions = [
           copyABuildApplication,
-          applyToRoot(new CopyBuilder(), inputs: ['**/*.copy']),
+          applyToRoot(
+              new CopyBuilder(inputExtension: '.copy', extension: 'copy.copy'))
         ];
 
         var writer = new InMemoryRunnerAssetWriter();
@@ -374,54 +378,57 @@ void main() {
     group('secondary dependency', () {
       test('of an output file is edited', () async {
         var buildActions = [
-          applyToRoot(
-              new CopyBuilder(copyFromAsset: makeAssetId('a|web/b.txt')),
-              inputs: ['web/a.txt'])
+          applyToRoot(new CopyBuilder(
+              inputExtension: '.a',
+              extension: 'a.copy',
+              copyFromAsset: makeAssetId('a|web/file.b')))
         ];
 
         var writer = new InMemoryRunnerAssetWriter();
         var buildState = await startWatch(
-            buildActions, {'a|web/a.txt': 'a', 'a|web/b.txt': 'b'}, writer);
+            buildActions, {'a|web/file.a': 'a', 'a|web/file.b': 'b'}, writer);
         var results = new StreamQueue(buildState.buildResults);
 
         var result = await results.next;
-        checkBuild(result, outputs: {'a|web/a.txt.copy': 'b'}, writer: writer);
+        checkBuild(result, outputs: {'a|web/file.a.copy': 'b'}, writer: writer);
 
-        await writer.writeAsString(makeAssetId('a|web/b.txt'), 'c');
+        await writer.writeAsString(makeAssetId('a|web/file.b'), 'c');
         FakeWatcher.notifyWatchers(new WatchEvent(
-            ChangeType.MODIFY, path.absolute('a', 'web', 'b.txt')));
+            ChangeType.MODIFY, path.absolute('a', 'web', 'file.b')));
 
         result = await results.next;
-        checkBuild(result, outputs: {'a|web/a.txt.copy': 'c'}, writer: writer);
+        checkBuild(result, outputs: {'a|web/file.a.copy': 'c'}, writer: writer);
       });
 
       test(
           'of an output which is derived from another generated file is edited',
           () async {
         var buildActions = [
-          applyToRoot(new CopyBuilder(), inputs: ['web/a.txt']),
           applyToRoot(
-              new CopyBuilder(copyFromAsset: makeAssetId('a|web/b.txt')),
-              inputs: ['web/a.txt.copy'])
+              new CopyBuilder(inputExtension: '.a', extension: 'a.copy')),
+          applyToRoot(new CopyBuilder(
+              copyFromAsset: makeAssetId('a|web/file.b'),
+              inputExtension: '.a.copy',
+              extension: 'a.copy.copy'))
         ];
 
         var writer = new InMemoryRunnerAssetWriter();
         var buildState = await startWatch(
-            buildActions, {'a|web/a.txt': 'a', 'a|web/b.txt': 'b'}, writer);
+            buildActions, {'a|web/file.a': 'a', 'a|web/file.b': 'b'}, writer);
         var results = new StreamQueue(buildState.buildResults);
 
         var result = await results.next;
         checkBuild(result,
-            outputs: {'a|web/a.txt.copy': 'a', 'a|web/a.txt.copy.copy': 'b'},
+            outputs: {'a|web/file.a.copy': 'a', 'a|web/file.a.copy.copy': 'b'},
             writer: writer);
 
-        await writer.writeAsString(makeAssetId('a|web/b.txt'), 'c');
+        await writer.writeAsString(makeAssetId('a|web/file.b'), 'c');
         FakeWatcher.notifyWatchers(new WatchEvent(
-            ChangeType.MODIFY, path.absolute('a', 'web', 'b.txt')));
+            ChangeType.MODIFY, path.absolute('a', 'web', 'file.b')));
 
         result = await results.next;
         checkBuild(result,
-            outputs: {'a|web/a.txt.copy.copy': 'c'}, writer: writer);
+            outputs: {'a|web/file.a.copy.copy': 'c'}, writer: writer);
       });
     });
   });


### PR DESCRIPTION
We will be removing the `inputs` argument to `apply` and move to
`BuildTarget` to filter inputs to Builders. In each of these tests we're
mostly using the `inputs` to limit what previous outputs get read which
is not a typical use case for a build target. A closer match to this is
having intermedaite file extensions.

Where possible switch to the simpler `applyToRoot` rather than `apply`
with arguments we expect to be ignored.