### PR TITLE
Add magic placeholder assets under lib, web, and test

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -5,6 +5,17 @@
 - Added `toRoot` Package filter.
 - Actions are now invalidated at a fine grained level when `BuilderOptions`
   change.
+- Added magic placeholder files in all packages, which can be used when your
+  builder doesn't have a clear primary input file.
+  - For non-root packages the placeholder exists at `lib/$lib$`, you should
+    declare your `buildExtensions` like this `{r'$lib$': 'my_output_file.txt'}`,
+    which would result in an output file at `lib/my_output_file.txt` in the
+    package.
+  - For the root package there are also placeholders at `web/$web$` and
+    `test/$test$` which should cover most use cases. Please file an issue if you
+    need additional placeholders.
+  - Note that these placeholders are not real assets and attempting to read them
+    will result in an `AssetNotFoundException`.
 
 ### Breaking Changes
 
@@ -18,6 +29,8 @@
 - Remove `PackageGraph.orderedPackages` and `PackageGraph.dependentsOf`.
 - Remove `writeToCache` argument of `build` and `watch`. Each `apply` call
   should specify `hideOutput` to keep this behavior.
+- Removed `PackageBuilder` and `PackageBuildActions` classes. Use the new
+  magic placeholder files instead (see new features section for this release).
 
 The following changes are technically breaking but should not impact most
 clients:

--- a/build_runner/bin/create_merged_dir.dart
+++ b/build_runner/bin/create_merged_dir.dart
@@ -72,7 +72,7 @@ Future main(List<String> args) async {
       assetGraph, packageGraph.root.name);
 
   for (var node in assetGraph.allNodes) {
-    if (node is SyntheticAssetNode) continue;
+    if (!node.isReadable) continue;
     if (node is GeneratedAssetNode && !node.wasOutput) continue;
     if (node.id.path == '.packages') continue;
     var assetPaths = <String>[];

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -72,10 +72,10 @@ class SingleStepReader implements DigestAssetReader {
       _assetGraph.add(new SyntheticSourceAssetNode(id));
       return false;
     }
-    if (node is SyntheticAssetNode) return false;
-    if (node is SourceAssetNode) return true;
-    assert(node is GeneratedAssetNode);
-    return (node as GeneratedAssetNode).phaseNumber < _phaseNumber;
+    if (node.isGenerated) {
+      return (node as GeneratedAssetNode).phaseNumber < _phaseNumber;
+    }
+    return node.isReadable;
   }
 
   @override

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -403,5 +403,8 @@ AssetId builderOptionsIdForPhase(String package, int phase) =>
     new AssetId(package, 'Phase$phase.builderOptions');
 
 Set<AssetId> placeholderIdsFor(PackageGraph packageGraph) =>
-    new Set<AssetId>.from(packageGraph.allPackages.keys
-        .map((package) => new AssetId(package, r'lib/$lib$')));
+    new Set<AssetId>.from(packageGraph.allPackages.keys.expand((package) => [
+          new AssetId(package, r'lib/$lib$'),
+          new AssetId(package, r'test/$test$'),
+          new AssetId(package, r'web/$web$'),
+        ]));

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -45,10 +45,11 @@ class AssetGraph {
       PackageGraph packageGraph,
       DigestAssetReader digestReader) async {
     var graph = new AssetGraph._(computeBuildActionsDigest(buildActions));
-    graph._addPlaceHolderNodes(packageGraph);
+    var placeholders = graph._addPlaceHolderNodes(packageGraph);
     var sourceNodes = graph._addSources(sources);
     graph._addBuilderOptionsNodes(buildActions);
-    graph._addOutputsForSources(buildActions, sources, packageGraph.root.name);
+    graph._addOutputsForSources(buildActions, sources, packageGraph.root.name,
+        placeholders: placeholders);
     // Pre-emptively compute digests for the nodes we know have outputs.
     await graph._setLastKnownDigests(
         sourceNodes.where((node) => node.outputs.isNotEmpty), digestReader);
@@ -103,10 +104,12 @@ class AssetGraph {
   }
 
   /// Adds [PlaceHolderAssetNode]s for every package in [packageGraph].
-  _addPlaceHolderNodes(PackageGraph packageGraph) {
-    for (var package in packageGraph.allPackages.keys) {
-      _add(new PlaceHolderAssetNode(new AssetId(package, r'lib/$lib$')));
+  Set<AssetId> _addPlaceHolderNodes(PackageGraph packageGraph) {
+    var placeholders = placeholderIdsFor(packageGraph);
+    for (var id in placeholders) {
+      _add(new PlaceHolderAssetNode(id));
     }
+    return placeholders;
   }
 
   /// Adds [assetIds] as [AssetNode]s to this graph, and returns the newly
@@ -303,9 +306,15 @@ class AssetGraph {
   /// Returns a set containing [newSources] plus any new generated sources
   /// based on [buildActions], and updates this graph to contain all the
   /// new outputs.
+  ///
+  /// If [placeholders] is supplied they will be added to [newSources] to create
+  /// the full input set.
   Set<AssetId> _addOutputsForSources(List<BuildAction> buildActions,
-      Set<AssetId> newSources, String rootPackage) {
+      Set<AssetId> newSources, String rootPackage,
+      {Set<AssetId> placeholders}) {
     var allInputs = new Set<AssetId>.from(newSources);
+    if (placeholders != null) allInputs.addAll(placeholders);
+
     for (var phase = 0; phase < buildActions.length; phase++) {
       var phaseOutputs = <AssetId>[];
       var action = buildActions[phase];
@@ -392,3 +401,7 @@ Digest computeBuilderOptionsDigest(BuilderOptions options) =>
 
 AssetId builderOptionsIdForPhase(String package, int phase) =>
     new AssetId(package, 'Phase$phase.builderOptions');
+
+Set<AssetId> placeholderIdsFor(PackageGraph packageGraph) =>
+    new Set<AssetId>.from(packageGraph.allPackages.keys
+        .map((package) => new AssetId(package, r'lib/$lib$')));

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -36,11 +36,11 @@ abstract class AssetNode {
   /// at this moment in time.
   bool get isReadable => true;
 
-  /// Whether or not this node can be used as a primary or secondary input.
+  /// Whether or not this node can be used as a primary input.
   ///
-  /// Some nodes are valid inputs but are not readable (see
-  /// [PlaceHolderAssetNode]), while others can are readable but are not valid
-  /// inputs (see [InternalAssetNode]).
+  /// Some nodes are valid primary inputs but are not readable (see
+  /// [PlaceHolderAssetNode]), while others are readable but are not valid
+  /// primary inputs (see [InternalAssetNode]).
   bool get isValidInput => true;
 
   /// Whether or not changes to this node will have any effect on other nodes.

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -30,10 +30,17 @@ abstract class AssetNode {
   /// Whether or not this node was an output of this build.
   bool get isGenerated => false;
 
-  /// Whether or not this asset can be read.
+  /// Whether or not this asset type can be read.
+  ///
+  /// This does not indicate whether or not this specific node actually exists
+  /// at this moment in time.
   bool get isReadable => true;
 
   /// Whether or not this node can be used as a primary or secondary input.
+  ///
+  /// Some nodes are valid inputs but are not readable (see
+  /// [PlaceHolderAssetNode]), while others can are readable but are not valid
+  /// inputs (see [InternalAssetNode]).
   bool get isValidInput => true;
 
   /// Whether or not changes to this node will have any effect on other nodes.

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -102,6 +102,10 @@ class _AssetGraphDeserializer {
         assert(serializedNode.length == _WrappedAssetNode._length);
         node = new BuilderOptionsAssetNode(id, digest);
         break;
+      case _NodeType.Placeholder:
+        assert(serializedNode.length == _WrappedAssetNode._length);
+        node = new PlaceHolderAssetNode(id);
+        break;
     }
     node.outputs.addAll(_deserializeAssetIds(
         serializedNode[_Field.Outputs.index] as List<int>));
@@ -161,7 +165,14 @@ class _AssetGraphSerializer {
 }
 
 /// Used to serialize the type of a node using an int.
-enum _NodeType { Source, SyntheticSource, Generated, Internal, BuilderOptions }
+enum _NodeType {
+  Source,
+  SyntheticSource,
+  Generated,
+  Internal,
+  BuilderOptions,
+  Placeholder
+}
 
 /// Field indexes for serialized nodes.
 enum _Field {
@@ -217,6 +228,8 @@ class _WrappedAssetNode extends Object with ListMixin implements List {
           return _NodeType.Internal.index;
         } else if (node is BuilderOptionsAssetNode) {
           return _NodeType.BuilderOptions.index;
+        } else if (node is PlaceHolderAssetNode) {
+          return _NodeType.Placeholder.index;
         } else {
           throw new StateError('Unrecognized node type');
         }

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -104,7 +104,7 @@ class _Loader {
 
       await logTimedAsync(_logger, 'Building new asset graph', () async {
         assetGraph = await AssetGraph.build(_buildActions, inputSources,
-            internalSources, _options.packageGraph.root.name, _options.reader);
+            internalSources, _options.packageGraph, _options.reader);
         buildScriptUpdates =
             await BuildScriptUpdates.create(_options, assetGraph);
         conflictingOutputs = assetGraph.outputs
@@ -265,13 +265,13 @@ class _Loader {
     }
 
     var newSources = inputSources.difference(assetGraph.allNodes
-        .where((node) => node is! SyntheticAssetNode)
+        .where((node) => node.isValidInput)
         .map((node) => node.id)
         .toSet());
     addUpdates(newSources, ChangeType.ADD);
     var removedAssets = assetGraph.allNodes
         .where((n) {
-          if (n is SyntheticAssetNode) return false;
+          if (!n.isReadable) return false;
           if (n is GeneratedAssetNode) return n.wasOutput;
           return true;
         })

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -204,7 +204,7 @@ class BuildImpl {
     var builder = action.builder;
     await Future
         .wait(_assetGraph.packageNodes(action.package).map((node) async {
-      if (node is SyntheticAssetNode || node is InternalAssetNode) return;
+      if (!node.isValidInput) return;
       if (!action.matches(node.id)) return;
       if (!builder.buildExtensions.keys
           .any((inputExtension) => node.id.path.endsWith(inputExtension))) {

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -213,7 +213,7 @@ class WatchImpl implements BuildState {
     if (_isCacheFile(change) && !_assetGraph.contains(change.id)) return false;
     var node = _assetGraph.get(change.id);
     if (node != null) {
-      if (_isUninterestingNode(node)) return false;
+      if (!node.isInteresting) return false;
       if (_isEditOnGeneratedFile(node, change.type)) return false;
     } else {
       if (change.type == ChangeType.REMOVE) return false;
@@ -225,24 +225,8 @@ class WatchImpl implements BuildState {
 
   bool _isCacheFile(AssetChange change) => change.id.path.startsWith(cacheDir);
 
-  bool _isUninterestingNode(AssetNode node) {
-    if (node is InternalAssetNode) {
-      // All `InternalAssetNode`s are interesting, at least for now.
-      return false;
-    } else if (node.outputs.isEmpty && node.lastKnownDigest == null) {
-      // If we haven't computed a digest for this asset and it has no outputs,
-      // then we don't care about changes to it.
-      //
-      // Checking for a digest alone isn't enough because a file may be deleted
-      // and re-added, in which case it won't have a digest.
-      return true;
-    } else {
-      return false;
-    }
-  }
-
   bool _isEditOnGeneratedFile(AssetNode node, ChangeType changeType) =>
-      node is GeneratedAssetNode && changeType != ChangeType.REMOVE;
+      node.isGenerated && changeType != ChangeType.REMOVE;
 
   bool _isExpectedDelete(AssetChange change) =>
       _expectedDeletes.remove(change.id);

--- a/build_runner/test/common/common.dart
+++ b/build_runner/test/common/common.dart
@@ -55,3 +55,32 @@ class ExistsBuilder extends Builder {
     _hasRanCompleter.complete(null);
   }
 }
+
+class PlaceholderBuilder extends Builder {
+  final String inputExtension;
+  final Map<String, String> outputExtensionsToContent;
+
+  @override
+  Map<String, List<String>> get buildExtensions =>
+      {inputExtension: outputExtensionsToContent.keys.toList()};
+
+  PlaceholderBuilder(this.outputExtensionsToContent,
+      {this.inputExtension: r'$lib$'});
+
+  @override
+  Future build(BuildStep buildStep) async {
+    outputExtensionsToContent.forEach((extension, content) {
+      buildStep.writeAsString(
+          _outputId(buildStep.inputId, inputExtension, extension), content);
+    });
+  }
+}
+
+AssetId _outputId(
+    AssetId inputId, String inputExtension, String outputExtension) {
+  assert(inputId.path.endsWith(inputExtension));
+  var newPath =
+      inputId.path.substring(0, inputId.path.length - inputExtension.length) +
+          outputExtension;
+  return new AssetId(inputId.package, newPath);
+}

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -21,8 +21,11 @@ import 'package:build_runner/src/package_graph/package_graph.dart';
 import 'package:build_runner/src/util/constants.dart';
 
 import '../common/common.dart';
+import '../common/package_graphs.dart';
 
 main() {
+  final aPackageGraph = buildPackageGraph({rootPackage('a'): []});
+
   group('BuildDefinition.load', () {
     BuildOptions options;
     String pkgARoot;
@@ -85,7 +88,7 @@ main() {
             buildActions,
             [makeAssetId('a|lib/a.txt'), makeAssetId('a|lib/b.txt')].toSet(),
             new Set(),
-            'a',
+            aPackageGraph,
             options.reader);
         var generatedAId = makeAssetId('a|lib/a.txt.copy');
         var generatedANode =
@@ -115,8 +118,8 @@ main() {
           new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
         ];
 
-        var originalAssetGraph = await AssetGraph.build(
-            buildActions, <AssetId>[].toSet(), new Set(), 'a', options.reader);
+        var originalAssetGraph = await AssetGraph.build(buildActions,
+            <AssetId>[].toSet(), new Set(), aPackageGraph, options.reader);
 
         await createFile(
             assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
@@ -144,7 +147,7 @@ main() {
             buildActions,
             [makeAssetId('a|lib/a.txt')].toSet(),
             new Set(),
-            'a',
+            aPackageGraph,
             options.reader);
 
         await createFile(
@@ -171,7 +174,7 @@ main() {
             buildActions,
             [makeAssetId('a|lib/test.txt')].toSet(),
             new Set(),
-            'a',
+            aPackageGraph,
             options.reader);
         var generatedSrcId = makeAssetId('a|lib/test.txt.copy');
         var generatedNode =
@@ -198,7 +201,7 @@ main() {
             buildActions,
             [makeAssetId('a|lib/a.txt')].toSet(),
             new Set(),
-            'a',
+            aPackageGraph,
             options.reader);
         var generatedACopyId = makeAssetId('a|lib/a.txt.copy');
         var generatedACloneId = makeAssetId('a|lib/a.txt.clone');
@@ -243,13 +246,18 @@ main() {
             'a', p.url.join(generatedOutputDirectory, 'a', 'lib', 'test.txt'));
         await createFile(generatedId.path, 'a');
         var buildActions = [
-          new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+          new BuildAction(
+              new CopyBuilder(inputExtension: '.txt', extension: 'txt.copy'),
+              'a',
+              hideOutput: true)
         ];
 
-        var assetGraph = await AssetGraph.build(
-            buildActions, new Set<AssetId>(), new Set(), 'a', options.reader);
+        var assetGraph = await AssetGraph.build(buildActions,
+            new Set<AssetId>(), new Set(), aPackageGraph, options.reader);
+        var expectedIds = placeholderIdsFor(aPackageGraph)
+          ..addAll([makeAssetId('a|Phase0.builderOptions')]);
         expect(assetGraph.allNodes.map((node) => node.id),
-            unorderedEquals([makeAssetId('a|Phase0.builderOptions')]));
+            unorderedEquals(expectedIds));
 
         await createFile(assetGraphPath, JSON.encode(assetGraph.serialize()));
 
@@ -297,8 +305,8 @@ main() {
           skipBuildScriptCheck: true,
           onLog: logs.add);
 
-      var originalAssetGraph = await AssetGraph.build(
-          buildActions, <AssetId>[].toSet(), new Set(), 'a', options.reader);
+      var originalAssetGraph = await AssetGraph.build(buildActions,
+          <AssetId>[].toSet(), new Set(), aPackageGraph, options.reader);
 
       await createFile(
           assetGraphPath, JSON.encode(originalAssetGraph.serialize()));

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -17,9 +17,12 @@ import '../common/package_graphs.dart';
 
 void main() {
   /// Basic phases/phase groups which get used in many tests
-  final copyABuilderApplication = applyToRoot(new CopyBuilder());
+  final copyABuilderApplication = applyToRoot(
+      new CopyBuilder(inputExtension: '.txt', extension: 'txt.copy'));
   final globBuilder = new GlobbingBuilder(new Glob('**.txt'));
   final defaultBuilderOptions = const BuilderOptions(const {});
+  final placeholders =
+      placeholderIdsFor(buildPackageGraph({rootPackage('a'): []}));
 
   group('build', () {
     group('with root package inputs', () {
@@ -183,7 +186,7 @@ void main() {
               makeAssetId('a|web/a.txt.copy.clone'),
               makeAssetId('a|Phase0.builderOptions'),
               makeAssetId('a|Phase1.builderOptions'),
-            ]));
+            ]..addAll(placeholders)));
         expect(cachedGraph.sources, [makeAssetId('a|web/a.txt')]);
         expect(
             cachedGraph.outputs,
@@ -206,7 +209,10 @@ void main() {
             outputs: {'a|web/a.txt.copy': 'a'}, writer: writer);
 
         var blockingCompleter = new Completer<Null>();
-        var builder = new CopyBuilder(blockUntil: blockingCompleter.future);
+        var builder = new CopyBuilder(
+            blockUntil: blockingCompleter.future,
+            inputExtension: '.txt',
+            extension: 'txt.copy');
         var done = testBuilders([applyToRoot(builder)], {'a|web/a.txt': 'b'},
             outputs: {'a|web/a.txt.copy': 'b'}, writer: writer);
 
@@ -442,8 +448,8 @@ void main() {
     var cachedGraph = new AssetGraph.deserialize(
         JSON.decode(UTF8.decode(writer.assets[graphId])) as Map);
 
-    var expectedGraph =
-        await AssetGraph.build([], new Set(), new Set(), 'a', null);
+    var expectedGraph = await AssetGraph.build([], new Set(), new Set(),
+        buildPackageGraph({rootPackage('a'): []}), null);
 
     var builderOptionsId = makeAssetId('a|Phase0.builderOptions');
     var builderOptionsNode = new BuilderOptionsAssetNode(

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -32,6 +32,14 @@ void main() {
             outputs: {'a|web/a.txt.copy': 'a', 'a|lib/b.txt.copy': 'b'});
       });
 
+      test('with placeholder as input', () async {
+        await testBuilders([
+          applyToRoot(new PlaceholderBuilder({'placeholder.txt': 'sometext'}))
+        ], {}, outputs: {
+          'a|lib/placeholder.txt': 'sometext'
+        });
+      });
+
       test('one phase, one builder, one-to-many outputs', () async {
         await testBuilders([
           applyToRoot(new CopyBuilder(numCopies: 2))

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -22,7 +22,8 @@ import '../common/package_graphs.dart';
 
 void main() {
   /// Basic phases/phase groups which get used in many tests
-  final copyABuildApplication = applyToRoot(new CopyBuilder());
+  final copyABuildApplication = applyToRoot(
+      new CopyBuilder(inputExtension: '.txt', extension: 'txt.copy'));
   final defaultBuilderOptions = const BuilderOptions(const {});
 
   group('watch', () {
@@ -139,8 +140,8 @@ void main() {
             as Map;
         var cachedGraph = new AssetGraph.deserialize(serialized);
 
-        var expectedGraph =
-            await AssetGraph.build([], new Set(), new Set(), 'a', null);
+        var expectedGraph = await AssetGraph.build([], new Set(), new Set(),
+            buildPackageGraph({rootPackage('a'): []}), null);
 
         var builderOptionsId = makeAssetId('a|Phase0.builderOptions');
         var builderOptionsNode = new BuilderOptionsAssetNode(builderOptionsId,

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -5,6 +5,9 @@
   a writer.
 - Added `buildInputs` stream to `CopyBuilder` which emits an event for each
   `BuildStep.inputId` at the top of the `build` method.
+- `CopyBuilder` automatically skips the placeholder files (any file ending in
+  `$`). This is technically breaking but should not affect any real users and is
+  not being released as a breaking change.
 
 ## 0.9.3
 

--- a/build_test/lib/src/copy_builder.dart
+++ b/build_test/lib/src/copy_builder.dart
@@ -46,6 +46,9 @@ class CopyBuilder implements Builder {
 
   @override
   Future build(BuildStep buildStep) async {
+    // Skip placeholder files from build_runner.
+    if (buildStep.inputId.path.endsWith(r'$')) return;
+
     _buildInputsController.add(buildStep.inputId);
     if (!buildStep.inputId.path.endsWith(inputExtension)) {
       throw new ArgumentError('Only expected inputs with extension '

--- a/e2e_example/pkgs/provides_builder/lib/builders.dart
+++ b/e2e_example/pkgs/provides_builder/lib/builders.dart
@@ -15,10 +15,11 @@ class _SomeBuilder implements Builder {
   };
 
   @override
-  Future build(BuildStep buildStep) {
-    buildStep.writeAsBytes(buildStep.inputId.addExtension('.copy'),
+  Future build(BuildStep buildStep) async {
+    if (!await buildStep.canRead(buildStep.inputId)) return;
+
+    await buildStep.writeAsBytes(buildStep.inputId.addExtension('.copy'),
         buildStep.readAsBytes(buildStep.inputId));
-    return new Future.value();
   }
 }
 


### PR DESCRIPTION
These assets are available to use as primary inputs, but cannot be read (and will give an `AssetNotFoundException` if you do try to read them). They are represented by a new type of node, `PlaceholderAssetNode`.

Note that this is a potentially breaking change for builders which have over-broad input extensions (looking at you `CopyBuilder`). These builders may attempt to read the input and throw an exception, but I don't think this is a major issue since it should be a very uncommon case. It may however break existing tests for people using `CopyBuilder` (it broke a bunch of ours).

I also added a bunch of boolean getters to describe functionality of the different asset node types, and replaced is checks where possible with those.

Closes https://github.com/dart-lang/build/issues/710