### PR TITLE
Add `TargetBuilderConfigDefaults`

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -5,6 +5,8 @@
   dependencies are already known.
 - Add `TargetBuilderConfig` class to configure builders applied to specific
   targets.
+- Add `TargetBuilderConfigDefaults` class for Builder authors to provide default
+  configuration.
 
 ### Breaking
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -48,6 +48,11 @@ the following keys:
   outside the root package. Defaults to `"source"`, unless `auto_apply` is set
   to either `"all_packages"` or `"dependents"` in which case it defaults to
   `"cache"`.
+- **defaults**: Optional: Default values to apply when a user does not specify
+  the corresponding key in their `builders` section. May contain the following
+  keys:
+  - **generate_for**: A list of globs that this Builder should run on as a
+    subset of the corresponding target.
 
 Example `builders` config:
 

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -125,6 +125,8 @@ class BuilderDefinition {
   /// Where the outputs of this builder should be written.
   final BuildTo buildTo;
 
+  final TargetBuilderConfigDefaults defaults;
+
   BuilderDefinition({
     this.builderFactories,
     this.buildExtensions,
@@ -136,7 +138,16 @@ class BuilderDefinition {
     this.requiredInputs,
     this.isOptional,
     this.buildTo,
+    this.defaults,
   });
+}
+
+/// Default values that builder authors can specify when users don't fill in the
+/// corresponding key for [TargetBuilderConfig].
+class TargetBuilderConfigDefaults {
+  final List<String> generateFor;
+
+  TargetBuilderConfigDefaults({this.generateFor});
 }
 
 enum AutoApply { none, dependents, allPackages, rootPackage }

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -38,6 +38,7 @@ const _builderDefinitionOptions = const [
   _requiredInputs,
   _isOptional,
   _buildTo,
+  _defaults,
 ];
 const _builderFactories = 'builder_factories';
 const _import = 'import';
@@ -47,6 +48,10 @@ const _autoApply = 'auto_apply';
 const _requiredInputs = 'required_inputs';
 const _isOptional = 'is_optional';
 const _buildTo = 'build_to';
+const _defaults = 'defaults';
+const _builderConfigDefaultOptions = const [
+  _generateFor,
+];
 
 BuildConfig parseFromYaml(
         String packageName, Iterable<String> dependencies, String configYaml) =>
@@ -138,6 +143,13 @@ BuildConfig parseFromMap(String packageName,
     final buildTo = _readBuildToOrThrow(builderConfig, _buildTo,
         defaultValue: mustBuildToCache ? BuildTo.cache : BuildTo.source);
 
+    final defaultOptions = _readMapOrThrow(
+        builderConfig, _defaults, _builderConfigDefaultOptions, 'defaults',
+        defaultValue: {});
+    final defaultGenerateFor = _readListOfStringsOrThrow(
+        defaultOptions, _generateFor,
+        allowNull: true);
+
     if (mustBuildToCache && buildTo != BuildTo.cache) {
       throw new ArgumentError('`hide_output` may not be set to `False` '
           'when using `auto_apply: ${builderConfig[_autoApply]}`');
@@ -154,6 +166,8 @@ BuildConfig parseFromMap(String packageName,
       requiredInputs: requiredInputs,
       isOptional: isOptional,
       buildTo: buildTo,
+      defaults:
+          new TargetBuilderConfigDefaults(generateFor: defaultGenerateFor),
     );
   }
   return new BuildConfig(

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -48,6 +48,7 @@ void main() {
         package: 'example',
         target: 'e',
         requiredInputs: ['.dart'],
+        defaults: new TargetBuilderConfigDefaults(generateFor: ['lib/**']),
       ),
     });
   });
@@ -121,6 +122,8 @@ builders:
     auto_apply: dependents
     required_inputs: [".dart"]
     is_optional: True
+    defaults:
+      generate_for: ["lib/**"]
 ''';
 
 var buildYamlNoTargets = '''
@@ -150,6 +153,8 @@ class _BuilderDefinitionMatcher extends Matcher {
       equals(_expected.builderFactories).matches(item.builderFactories, _) &&
       equals(_expected.buildExtensions).matches(item.buildExtensions, _) &&
       equals(_expected.requiredInputs).matches(item.requiredInputs, _) &&
+      equals(_expected.defaults?.generateFor)
+          .matches(item.defaults?.generateFor, _) &&
       item.autoApply == _expected.autoApply &&
       item.isOptional == _expected.isOptional &&
       item.buildTo == _expected.buildTo &&


### PR DESCRIPTION
For now this only allows a single key: `generate_for`. In the future
this may expand and having a separate class and sub-map in the yaml make
this easier to extend in a sane way.