### PR TITLE
Split out BuildActions by BuildTarget

### DIFF
--- a/build_compilers/build.yaml
+++ b/build_compilers/build.yaml
@@ -29,3 +29,6 @@ builders:
         - .dart.js.map
     required_inputs:  [".dart", ".js"]
     build_to: cache
+    auto_apply: root_package
+    defaults:
+      generate_for: ["web/**", "test/**.browser_test.dart"]

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:build/build.dart';
 import 'package:build_barback/build_barback.dart' show BarbackResolvers;
+import 'package:build_config/build_config.dart';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
@@ -35,17 +36,20 @@ import 'terminator.dart';
 
 final _logger = new Logger('Build');
 
-Future<BuildResult> build(List<BuilderApplication> builders,
-    {bool deleteFilesByDefault,
-    bool assumeTty,
-    PackageGraph packageGraph,
-    RunnerAssetReader reader,
-    RunnerAssetWriter writer,
-    Level logLevel,
-    onLog(LogRecord record),
-    Stream terminateEventStream,
-    bool skipBuildScriptCheck,
-    bool enableLowResourcesMode}) async {
+Future<BuildResult> build(
+  List<BuilderApplication> builders, {
+  bool deleteFilesByDefault,
+  bool assumeTty,
+  PackageGraph packageGraph,
+  RunnerAssetReader reader,
+  RunnerAssetWriter writer,
+  Level logLevel,
+  onLog(LogRecord record),
+  Stream terminateEventStream,
+  bool skipBuildScriptCheck,
+  bool enableLowResourcesMode,
+  Map<String, BuildConfig> overrideBuildConfig,
+}) async {
   var options = new BuildOptions(
       assumeTty: assumeTty,
       deleteFilesByDefault: deleteFilesByDefault,
@@ -58,7 +62,8 @@ Future<BuildResult> build(List<BuilderApplication> builders,
       enableLowResourcesMode: enableLowResourcesMode);
   var terminator = new Terminator(terminateEventStream);
 
-  final buildActions = createBuildActions(options.packageGraph, builders);
+  final buildActions = await createBuildActions(options.packageGraph, builders,
+      overrideBuildConfig: overrideBuildConfig);
 
   var result = await singleBuild(options, buildActions);
 

--- a/build_runner/lib/src/generate/input_matcher.dart
+++ b/build_runner/lib/src/generate/input_matcher.dart
@@ -12,6 +12,8 @@ abstract class InputMatcher {
   bool matches(AssetId input);
   factory InputMatcher({Iterable<String> include, Iterable<String> exclude}) =
       _GlobInputMatcher;
+  factory InputMatcher.allOf(Iterable<InputMatcher> matchers) =>
+      new _MultiMatcher(matchers.toList());
 }
 
 class _GlobInputMatcher implements InputMatcher {
@@ -61,12 +63,33 @@ class _GlobInputMatcher implements InputMatcher {
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is _GlobInputMatcher &&
-          _deepEquals.equals(_patterns(include), _patterns(exclude)) &&
+          _deepEquals.equals(_patterns(include), _patterns(other.include)) &&
           _deepEquals.equals(_patterns(exclude), _patterns(other.exclude)));
 
   @override
   int get hashCode =>
       _deepEquals.hash([_patterns(include), _patterns(exclude)]);
+}
+
+class _MultiMatcher implements InputMatcher {
+  final List<InputMatcher> delegates;
+
+  _MultiMatcher(this.delegates);
+
+  @override
+  matches(AssetId input) => delegates.every((d) => d.matches(input));
+
+  @override
+  String toString() => 'All of $delegates';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is _MultiMatcher &&
+          _deepEquals.equals(delegates, other.delegates));
+
+  @override
+  int get hashCode => _deepEquals.hash(delegates);
 }
 
 final _deepEquals = const DeepCollectionEquality();

--- a/build_runner/lib/src/generate/phase.dart
+++ b/build_runner/lib/src/generate/phase.dart
@@ -38,8 +38,10 @@ class BuildAction implements InputMatcher {
 
   /// Creates an [BuildAction] for a normal [Builder].
   ///
-  /// Runs [builder] on [package] with [include] as primary inputs, excluding
-  /// [exclude]. Glob syntax is supported for both [include] and [exclude].
+  /// The build target is defined by [package] as well as [include] and
+  /// [exclude]. By default all sources in the target are used as primary inputs
+  /// to the builder, but it can be further filtered with [generateFor]. Glob
+  /// syntax is supported for [include], [exclude], and [generateFor].
   ///
   /// [isOptional] specifies that a Builder may not be run unless some other
   /// Builder in a later phase attempts to read one of the potential outputs.
@@ -51,11 +53,16 @@ class BuildAction implements InputMatcher {
     String package, {
     Iterable<String> include,
     Iterable<String> exclude,
+    Iterable<String> generateFor,
     BuilderOptions builderOptions,
     bool isOptional,
     bool hideOutput,
   }) {
     var inputs = new InputMatcher(include: include, exclude: exclude);
+    if (generateFor != null && generateFor.isNotEmpty) {
+      inputs = new InputMatcher.allOf(
+          [inputs, new InputMatcher(include: generateFor)]);
+    }
     builderOptions ??= const BuilderOptions(const {});
     return new BuildAction._(package, builder, inputs, builderOptions,
         isOptional: isOptional, hideOutput: hideOutput);

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -56,7 +56,7 @@ Future<ServeHandler> watch(List<BuilderApplication> builders,
       enableLowResourcesMode: enableLowResourcesMode);
   var terminator = new Terminator(terminateEventStream);
 
-  final buildActions = createBuildActions(options.packageGraph, builders);
+  final buildActions = await createBuildActions(options.packageGraph, builders);
 
   var watch = runWatch(options, buildActions, terminator.shouldTerminate);
 

--- a/build_runner/lib/src/package_graph/target_graph.dart
+++ b/build_runner/lib/src/package_graph/target_graph.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build_config/build_config.dart';
+
+import 'package_graph.dart';
+
+/// Like a [PackageGraph] but packages are further broken down into modules
+/// based on build config.
+class TargetGraph {
+  /// All [TargetNode]s indexed by `"$packageName:$targetName"`.
+  final Map<String, TargetNode> allModules;
+
+  TargetGraph._(this.allModules);
+
+  static Future<TargetGraph> forPackageGraph(PackageGraph packageGraph,
+      {Map<String, BuildConfig> overrideBuildConfig}) async {
+    overrideBuildConfig ??= const {};
+    final modules = <String, TargetNode>{};
+    for (final package in packageGraph.allPackages.values) {
+      final config = overrideBuildConfig[package.name] ??
+          await _packageBuildConfig(package);
+      final nodes = config.buildTargets.values
+          .map((target) => new TargetNode(target, package));
+      for (final node in nodes) {
+        modules[node.target.name] = node;
+      }
+    }
+    return new TargetGraph._(modules);
+  }
+}
+
+class TargetNode {
+  final BuildTarget target;
+  final PackageNode package;
+  TargetNode(this.target, this.package);
+
+  @override
+  String toString() => '${package.name}:${target.name}';
+}
+
+Future<BuildConfig> _packageBuildConfig(PackageNode package) async {
+  final dependencyNames = package.dependencies.map((n) => n.name);
+  if (package.path == null) {
+    return new BuildConfig.useDefault(package.name, dependencyNames);
+  }
+  return BuildConfig.fromBuildConfigDir(
+      package.name, dependencyNames, package.path);
+}

--- a/build_runner/test/common/build_configs.dart
+++ b/build_runner/test/common/build_configs.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build_config/build_config.dart';
+
+Map<String, BuildConfig> parseBuildConfigs(
+        Map<String, Map<String, dynamic>> configs) =>
+    new Map<String, BuildConfig>.fromIterable(configs.keys,
+        value: (key) =>
+            new BuildConfig.fromMap(key as String, [], configs[key]));

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:build/build.dart';
+import 'package:build_config/build_config.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
@@ -65,19 +66,22 @@ Future wait(int milliseconds) =>
 ///       });
 ///     }
 ///
-Future<BuildResult> testBuilders(List<BuilderApplication> builders,
-    Map<String, /*String|List<int>*/ dynamic> inputs,
-    {Map<String, /*String|List<int>*/ dynamic> outputs,
-    PackageGraph packageGraph,
-    BuildStatus status: BuildStatus.success,
-    Matcher exceptionMatcher,
-    InMemoryRunnerAssetReader reader,
-    InMemoryRunnerAssetWriter writer,
-    Level logLevel: Level.OFF,
-    onLog(LogRecord record),
-    bool checkBuildStatus: true,
-    bool deleteFilesByDefault: true,
-    bool enableLowResourcesMode: false}) async {
+Future<BuildResult> testBuilders(
+  List<BuilderApplication> builders,
+  Map<String, /*String|List<int>*/ dynamic> inputs, {
+  Map<String, /*String|List<int>*/ dynamic> outputs,
+  PackageGraph packageGraph,
+  BuildStatus status: BuildStatus.success,
+  Matcher exceptionMatcher,
+  InMemoryRunnerAssetReader reader,
+  InMemoryRunnerAssetWriter writer,
+  Level logLevel: Level.OFF,
+  onLog(LogRecord record),
+  bool checkBuildStatus: true,
+  bool deleteFilesByDefault: true,
+  bool enableLowResourcesMode: false,
+  Map<String, BuildConfig> overrideBuildConfig,
+}) async {
   writer ??= new InMemoryRunnerAssetWriter();
   reader ??= new InMemoryRunnerAssetReader.shareAssetCache(writer.assets,
       rootPackage: packageGraph?.root?.name);
@@ -93,15 +97,18 @@ Future<BuildResult> testBuilders(List<BuilderApplication> builders,
 
   packageGraph ??= buildPackageGraph({rootPackage('a'): []});
 
-  var result = await build_impl.build(builders,
-      deleteFilesByDefault: deleteFilesByDefault,
-      reader: reader,
-      writer: writer,
-      packageGraph: packageGraph,
-      logLevel: logLevel,
-      onLog: onLog,
-      skipBuildScriptCheck: true,
-      enableLowResourcesMode: enableLowResourcesMode);
+  var result = await build_impl.build(
+    builders,
+    deleteFilesByDefault: deleteFilesByDefault,
+    reader: reader,
+    writer: writer,
+    packageGraph: packageGraph,
+    logLevel: logLevel,
+    onLog: onLog,
+    skipBuildScriptCheck: true,
+    enableLowResourcesMode: enableLowResourcesMode,
+    overrideBuildConfig: overrideBuildConfig,
+  );
 
   if (checkBuildStatus) {
     checkBuild(result,

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -258,7 +258,8 @@ import 'package:build_test/build_test.dart';
 main() async {
   await build([
     applyToRoot(new CopyBuilder()),
-    applyToRoot(new CopyBuilder(), inputs: ['**.txt.copy']),
+    applyToRoot(new CopyBuilder(
+        inputExtension: '.txt.copy', extension: 'txt.copy.copy')),
   ]);
 }
 ''')

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -12,6 +12,7 @@ import 'package:build_runner/build_runner.dart';
 import 'package:build_runner/src/asset_graph/graph.dart';
 import 'package:build_runner/src/asset_graph/node.dart';
 
+import '../common/build_configs.dart';
 import '../common/common.dart';
 import '../common/package_graphs.dart';
 
@@ -59,7 +60,8 @@ void main() {
         await testBuilders([
           apply('', '', [(_) => new CopyBuilder(extension: '1')], toRoot(),
               isOptional: true),
-          apply('', '', [(_) => new CopyBuilder(inputExtension: '1')], toRoot(),
+          apply('a', 'only_on_1', [(_) => new CopyBuilder(inputExtension: '1')],
+              toRoot(),
               isOptional: true),
         ], {
           'a|lib/a.txt': 'a'
@@ -94,22 +96,44 @@ void main() {
       test('multiple mixed build actions', () async {
         var builders = [
           copyABuilderApplication,
-          apply('', '', [(_) => new CopyBuilder(extension: 'clone')], toRoot(),
+          apply('a', 'clone_txt', [(_) => new CopyBuilder(extension: 'clone')],
+              toRoot(),
               isOptional: true),
-          apply('', '', [(_) => new CopyBuilder(numCopies: 2)], toRoot(),
-              inputs: ['web/*.txt.clone']),
+          apply('a', 'copy_web_clones', [(_) => new CopyBuilder(numCopies: 2)],
+              toRoot()),
         ];
-        await testBuilders(builders, {
-          'a|web/a.txt': 'a',
-          'a|lib/b.txt': 'b',
-        }, outputs: {
-          'a|web/a.txt.copy': 'a',
-          'a|web/a.txt.clone': 'a',
-          'a|lib/b.txt.copy': 'b',
-          // No b.txt.clone since nothing else read it and its optional.
-          'a|web/a.txt.clone.copy.0': 'a',
-          'a|web/a.txt.clone.copy.1': 'a',
+        var buildConfigs = parseBuildConfigs({
+          'a': {
+            'targets': {
+              'a': {
+                'sources': ['**'],
+                'builders': {
+                  'a|clone_txt': {
+                    'generate_for': ['**/*.txt']
+                  },
+                  'a|copy_web_clones': {
+                    'generate_for': ['web/*.txt.clone']
+                  }
+                }
+              }
+            }
+          }
         });
+        await testBuilders(
+            builders,
+            {
+              'a|web/a.txt': 'a',
+              'a|lib/b.txt': 'b',
+            },
+            overrideBuildConfig: buildConfigs,
+            outputs: {
+              'a|web/a.txt.copy': 'a',
+              'a|web/a.txt.clone': 'a',
+              'a|lib/b.txt.copy': 'b',
+              // No b.txt.clone since nothing else read it and its optional.
+              'a|web/a.txt.clone.copy.0': 'a',
+              'a|web/a.txt.clone.copy.1': 'a',
+            });
       });
 
       test('early step touches a not-yet-generated asset', () async {
@@ -369,18 +393,28 @@ void main() {
     });
 
     test('can glob files from packages with excludes applied', () async {
-      await testBuilders([
-        apply('', '', [(_) => new CopyBuilder()], toRoot(),
-            excludes: ['lib/a/*.txt'], hideOutput: true)
-      ], {
-        'a|lib/a/1.txt': '',
-        'a|lib/a/2.txt': '',
-        'a|lib/b/1.txt': '',
-        'a|lib/b/2.txt': '',
-      }, outputs: {
-        r'$$a|lib/b/1.txt.copy': '',
-        r'$$a|lib/b/2.txt.copy': '',
-      });
+      await testBuilders(
+          [applyToRoot(new CopyBuilder())],
+          {
+            'a|lib/a/1.txt': '',
+            'a|lib/a/2.txt': '',
+            'a|lib/b/1.txt': '',
+            'a|lib/b/2.txt': '',
+          },
+          overrideBuildConfig: parseBuildConfigs({
+            'a': {
+              'targets': {
+                'a': {
+                  'sources': ['**'],
+                  'exclude_sources': ['lib/a/**']
+                }
+              }
+            }
+          }),
+          outputs: {
+            'a|lib/b/1.txt.copy': '',
+            'a|lib/b/2.txt.copy': '',
+          });
     });
 
     test('can\'t read files in .dart_tool', () async {

--- a/build_test/lib/builder.dart
+++ b/build_test/lib/builder.dart
@@ -26,3 +26,5 @@ class TestBootstrapBuilder extends TransformerBuilder {
     await super.build(buildStep);
   }
 }
+
+Builder testBootstrapBuilder(_) => new TestBootstrapBuilder();

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -1,6 +1,7 @@
 import 'package:build_runner/build_runner.dart' as _i1;
 import 'package:provides_builder/builders.dart' as _i2;
-import 'package:build_compilers/builders.dart' as _i3;
+import 'package:build_test/builder.dart' as _i3;
+import 'package:build_compilers/builders.dart' as _i4;
 
 final _builders = [
   _i1.apply('provides_builder', 'some_not_applied_builder', [_i2.notApplied],
@@ -9,22 +10,23 @@ final _builders = [
       _i1.toDependentsOf('provides_builder'),
       hideOutput: true),
   _i1.apply(
+      'build_test', 'test_bootstrap', [_i3.testBootstrapBuilder], _i1.toRoot(),
+      isOptional: true, hideOutput: true, defaultGenerateFor: ['test/**']),
+  _i1.apply(
       'build_compilers',
       'ddc',
       [
-        _i3.moduleBuilder,
-        _i3.unlinkedSummaryBuilder,
-        _i3.linkedSummaryBuilder,
-        _i3.devCompilerBuilder
+        _i4.moduleBuilder,
+        _i4.unlinkedSummaryBuilder,
+        _i4.linkedSummaryBuilder,
+        _i4.devCompilerBuilder
       ],
       _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true),
   _i1.apply('build_compilers', 'ddc_bootstrap',
-      [_i3.devCompilerBootstrapBuilder], _i1.toNoneByDefault(),
-      hideOutput: true),
-  _i1.apply('build_compilers', 'ddc_bootstrap',
-      [_i3.devCompilerBootstrapBuilder], _i1.toRoot(),
-      inputs: ['web/**.dart', 'test/**.browser_test.dart'], hideOutput: true)
+      [_i4.devCompilerBootstrapBuilder], _i1.toRoot(),
+      hideOutput: true,
+      defaultGenerateFor: ['web/**', 'test/**.browser_test.dart'])
 ];
 main(List<String> args) => _i1.run(args, _builders);

--- a/e2e_example/tool/build.dart
+++ b/e2e_example/tool/build.dart
@@ -13,10 +13,10 @@ Future main(List<String> args) async {
   var builders = [
     apply('e2e_example', 'throwing_builder', [(_) => new ThrowingBuilder()],
         toRoot(),
-        hideOutput: true),
+        hideOutput: true, defaultGenerateFor: const ['test/**']),
     apply('build_test', 'test_bootstrap', [(_) => new TestBootstrapBuilder()],
         toRoot(),
-        inputs: ['test/**_test.dart'], hideOutput: true),
+        hideOutput: true),
     apply(
         'build_compilers',
         'ddc',
@@ -29,9 +29,10 @@ Future main(List<String> args) async {
         toAllPackages(),
         isOptional: true,
         hideOutput: true),
-    apply('build_compilers', 'ddc_boostrap',
+    apply('build_compilers', 'ddc_bootstrap',
         [(_) => new DevCompilerBootstrapBuilder()], toRoot(),
-        inputs: ['web/**.dart', 'test/**.browser_test.dart'], hideOutput: true)
+        hideOutput: true,
+        defaultGenerateFor: const ['web/**', 'test/**.browser_test.dart'])
   ];
 
   await run(args, builders);


### PR DESCRIPTION
This allows builders to be targeted more specifically within a package.

- Add a `TargetGraph` which mirrors the `PackageGraph` but my have more
  fine grained nodes.
- Remove `inputs` and `excludes` from `BuilderApplication`. This is now
  controlled by the `BuildTarget`s within a package.
- Add `defaultGenerateFor` to `BuildeApplication` since builders can
  suggest reasonable defaults to reduce the boilerplat config for most
  packages.
- Make `createBuildActions` return a `Future` since it reads
  `build.yaml` files.
- Honor the default `generate_for` when generating build scripts.
- Add `auto_apply` and `generate_for` for the DDC bootstrap builder.
  Remove the hardcoded default `apply` call from the generated build
  script.