### PR TITLE
Allow overriding `build.yaml` for other packages

### DIFF
--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -22,6 +22,7 @@ import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../logging/logging.dart';
 import '../package_graph/apply_builders.dart';
+import '../package_graph/build_config_overrides.dart';
 import '../package_graph/package_graph.dart';
 import '../util/constants.dart';
 import 'build_definition.dart';
@@ -62,6 +63,7 @@ Future<BuildResult> build(
       enableLowResourcesMode: enableLowResourcesMode);
   var terminator = new Terminator(terminateEventStream);
 
+  overrideBuildConfig ??= await findBuildConfigOverrides(options.packageGraph);
   final buildActions = await createBuildActions(options.packageGraph, builders,
       overrideBuildConfig: overrideBuildConfig);
 

--- a/build_runner/lib/src/package_graph/build_config_overrides.dart
+++ b/build_runner/lib/src/package_graph/build_config_overrides.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:build_config/build_config.dart';
+import 'package:glob/glob.dart';
+import 'package:path/path.dart' as p;
+
+import 'package_graph.dart';
+
+Future<Map<String, BuildConfig>> findBuildConfigOverrides(
+    PackageGraph packageGraph) async {
+  final configs = <String, BuildConfig>{};
+  final configFiles = await new Glob('*.build.yaml').list().toList();
+  for (final file in configFiles) {
+    if (file is File) {
+      final packageName = p.basename(file.path).split('.').first;
+      final packageNode = packageGraph.allPackages[packageName];
+      final yaml = await file.readAsString();
+      final config = new BuildConfig.parse(
+          packageName, packageNode.dependencies.map((n) => n.name), yaml);
+      configs[packageName] = config;
+    }
+  }
+  return configs;
+}

--- a/build_runner/lib/src/package_graph/build_config_overrides.dart
+++ b/build_runner/lib/src/package_graph/build_config_overrides.dart
@@ -14,8 +14,8 @@ import 'package_graph.dart';
 Future<Map<String, BuildConfig>> findBuildConfigOverrides(
     PackageGraph packageGraph) async {
   final configs = <String, BuildConfig>{};
-  final configFiles = await new Glob('*.build.yaml').list().toList();
-  for (final file in configFiles) {
+  final configFiles = new Glob('*.build.yaml').list();
+  await for (final file in configFiles) {
     if (file is File) {
       final packageName = p.basename(file.path).split('.').first;
       final packageNode = packageGraph.allPackages[packageName];


### PR DESCRIPTION
While we're rolling this out, and likely into the future, it's handy to
be able to hack on another package's `build.yaml` without a path
override to a local copy of the package. Read files matching
`$packageName.build.yaml` and use them instead of the `build.yaml`
coming from the package.

- Add `build_config_overrides.dart` with a function to look for override
  config files in the current directory and parse them into a map.
- When generating the build script and creating build actions, first
  look for overrides and use them over the package provided config.