### PR TITLE
Rename `serve` binary to `build_runner`

### DIFF
--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -11,13 +11,13 @@ import 'package:logging/logging.dart';
 import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
 import 'package:build_runner/src/logging/std_io_logging.dart';
 
-Future<Null> main() async {
+Future<Null> main(List<String> args) async {
   var logListener = Logger.root.onRecord.listen(stdIOLogListener);
   await ensureBuildScript();
   var dart = Platform.resolvedExecutable;
-  final args = [scriptLocation, 'serve'];
-  if (stdioType(stdin) == StdioType.TERMINAL) args.add('--assume-tty');
-  var buildRun = await new ProcessManager().spawn(dart, args);
+  final innerArgs = [scriptLocation]..addAll(args);
+  if (stdioType(stdin) == StdioType.TERMINAL) innerArgs.add('--assume-tty');
+  var buildRun = await new ProcessManager().spawn(dart, innerArgs);
   await buildRun.exitCode;
   await ProcessManager.terminateStdIn();
   await logListener.cancel();

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -16,7 +16,10 @@ Future<Null> main(List<String> args) async {
   await ensureBuildScript();
   var dart = Platform.resolvedExecutable;
   final innerArgs = [scriptLocation]..addAll(args);
-  if (stdioType(stdin) == StdioType.TERMINAL) innerArgs.add('--assume-tty');
+  if (stdioType(stdin) == StdioType.TERMINAL &&
+      !args.any((a) => a.contains('assume-tty'))) {
+    innerArgs.add('--assume-tty');
+  }
   var buildRun = await new ProcessManager().spawn(dart, innerArgs);
   await buildRun.exitCode;
   await ProcessManager.terminateStdIn();

--- a/e2e_example/test/common/utils.dart
+++ b/e2e_example/test/common/utils.dart
@@ -39,7 +39,7 @@ Future<Null> startManualServer(
         verbose: verbose,
         extraExpects: extraExpects);
 
-/// Runs `pub run build_runner:serve` in this package, and waits for the first
+/// Runs `pub run build_runner serve` in this package, and waits for the first
 /// build to complete.
 ///
 /// To ensure a clean build, set [ensureCleanBuild] to `true`.
@@ -52,7 +52,7 @@ Future<Null> startManualServer(
 /// setting [verbose] to `true`.
 Future<Null> startAutoServer(
         {bool ensureCleanBuild, bool verbose, List<Function> extraExpects}) =>
-    _startServer(_pubBinary, ['run', 'build_runner:serve'],
+    _startServer(_pubBinary, ['run', 'build_runner', 'serve'],
         ensureCleanBuild: ensureCleanBuild,
         verbose: verbose,
         extraExpects: extraExpects);


### PR DESCRIPTION
Pass through arguments rather than always assuming `serve` command.