### PR TITLE
Remove `default` target and normalize names

### DIFF
--- a/build_config/README.md
+++ b/build_config/README.md
@@ -10,13 +10,10 @@ can be broken up into multiple 'targets'. Targets are configured in the
 keys.
 
 - **name**: String, Required. The name of the target within the package. Targets
-  can be referred to by `'$packageName:$targetName'` keys. If the target is the
-  default target for the package it can also be referred to as just
-  `'$packageName'`. Usually the 'default' target will use the package name as
-  the target name.
-- **default**: Boolean, Optional. Whether this is the default target within the
-  package. If there is only one target in the package this can be omitted,
-  otherwise exactly 1 target must specify `default: True`.
+  can be referred to by `'$packageName:$targetName'` keys. If the target has the
+  same name as the package it can also be referred to as `'$packageName'`, at
+  least one target must use the package name so that other packages which depend
+  on this one can pick it up as a dependency.
 - **sources**: List of Strings or Map, Optional. The set of files within the
   package which make up this target. Files are specified using glob syntax. If a
   List of Strings is used they are considered the 'include' globs. If a Map is

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -92,6 +92,7 @@ class BuildConfig {
             .map((dep) => normalizeTargetKeyUsage(dep, packageName))
             .toSet(),
         package: packageName,
+        key: defaultTarget,
         sources: const InputSet(),
       )
     };
@@ -119,7 +120,11 @@ class BuildConfig {
 }
 
 class BuilderDefinition {
+  /// The package which provides this Builder.
   final String package;
+
+  /// A unique key for this Builder in `'$package|$builder'` format.
+  final String key;
 
   /// The names of the top-level methods in [import] from args -> Builder.
   final List<String> builderFactories;
@@ -156,11 +161,12 @@ class BuilderDefinition {
   final TargetBuilderConfigDefaults defaults;
 
   BuilderDefinition({
-    this.builderFactories,
-    this.buildExtensions,
-    this.import,
-    this.package,
-    this.target,
+    @required this.package,
+    @required this.key,
+    @required this.builderFactories,
+    @required this.buildExtensions,
+    @required this.import,
+    @required this.target,
     this.autoApply,
     this.requiredInputs,
     this.isOptional,
@@ -206,6 +212,9 @@ class BuildTarget {
 
   final String package;
 
+  /// A unique key for this target in `'$package:$target'` format.
+  final String key;
+
   final InputSet sources;
 
   /// A map from builder key to the configuration used for this target.
@@ -216,7 +225,8 @@ class BuildTarget {
   final Map<String, TargetBuilderConfig> builders;
 
   BuildTarget({
-    this.package,
+    @required this.package,
+    @required this.key,
     this.sources: const InputSet(),
     this.dependencies,
     this.builders: const {},

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -9,6 +9,7 @@ import 'package:build/build.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
+import 'key_normalization.dart';
 import 'parse.dart';
 import 'pubspec.dart';
 
@@ -86,8 +87,9 @@ class BuildConfig {
       String packageName, Iterable<String> dependencies) {
     final buildTargets = {
       packageName: new BuildTarget(
-        dependencies: dependencies,
-        isDefault: true,
+        dependencies: dependencies
+            .map((dep) => normalizeTargetKey(dep, packageName))
+            .toSet(),
         name: packageName,
         package: packageName,
         sources: const InputSet(),
@@ -114,9 +116,6 @@ class BuildConfig {
     @required this.buildTargets,
     this.builderDefinitions: const {},
   });
-
-  BuildTarget get defaultBuildTarget =>
-      buildTargets.values.singleWhere((l) => l.isDefault);
 }
 
 class BuilderDefinition {
@@ -193,7 +192,7 @@ enum BuildTo {
 }
 
 class BuildTarget {
-  final Iterable<String> dependencies;
+  final Set<String> dependencies;
 
   final String name;
 
@@ -208,34 +207,21 @@ class BuildTarget {
   /// those which have configuration customized against the default.
   final Map<String, TargetBuilderConfig> builders;
 
-  /// Whether or not this is the default dart library for the package.
-  final bool isDefault;
-
   BuildTarget({
     this.name,
     this.package,
     this.sources: const InputSet(),
     this.dependencies,
     this.builders: const {},
-    this.isDefault: false,
   });
-
-  factory BuildTarget.asDefault(BuildTarget other) => new BuildTarget(
-        isDefault: true,
-        name: other.name,
-        package: other.package,
-        sources: other.sources,
-        dependencies: other.dependencies,
-        builders: other.builders,
-      );
 
   @override
   String toString() => {
         'package': package,
         'name': name,
-        'isDefault': isDefault,
         'sources': sources,
-        'builders': builders
+        'dependencies': dependencies,
+        'builders': builders,
       }.toString();
 }
 

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -89,9 +89,8 @@ class BuildConfig {
     final buildTargets = {
       defaultTarget: new BuildTarget(
         dependencies: dependencies
-            .map((dep) => normalizeTargetKey(dep, packageName))
+            .map((dep) => normalizeTargetKeyUsage(dep, packageName))
             .toSet(),
-        name: defaultTarget,
         package: packageName,
         sources: const InputSet(),
       )
@@ -120,8 +119,6 @@ class BuildConfig {
 }
 
 class BuilderDefinition {
-  final String name;
-
   final String package;
 
   /// The names of the top-level methods in [import] from args -> Builder.
@@ -162,7 +159,6 @@ class BuilderDefinition {
     this.builderFactories,
     this.buildExtensions,
     this.import,
-    this.name,
     this.package,
     this.target,
     this.autoApply,
@@ -171,6 +167,19 @@ class BuilderDefinition {
     this.buildTo,
     this.defaults,
   });
+
+  @override
+  String toString() => {
+        'target': target,
+        'autoApply': autoApply,
+        'import': import,
+        'builderFactories': builderFactories,
+        'buildExtensions': buildExtensions,
+        'requiredInputs': requiredInputs,
+        'isOptional': isOptional,
+        'buildTo': buildTo,
+        'defaults': defaults,
+      }.toString();
 }
 
 /// Default values that builder authors can specify when users don't fill in the
@@ -195,8 +204,6 @@ enum BuildTo {
 class BuildTarget {
   final Set<String> dependencies;
 
-  final String name;
-
   final String package;
 
   final InputSet sources;
@@ -209,7 +216,6 @@ class BuildTarget {
   final Map<String, TargetBuilderConfig> builders;
 
   BuildTarget({
-    this.name,
     this.package,
     this.sources: const InputSet(),
     this.dependencies,
@@ -219,7 +225,6 @@ class BuildTarget {
   @override
   String toString() => {
         'package': package,
-        'name': name,
         'sources': sources,
         'dependencies': dependencies,
         'builders': builders,

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -85,12 +85,13 @@ class BuildConfig {
   /// The default config if you have no `build.yaml` file.
   factory BuildConfig.useDefault(
       String packageName, Iterable<String> dependencies) {
+    final defaultTarget = '$packageName:$packageName';
     final buildTargets = {
-      packageName: new BuildTarget(
+      defaultTarget: new BuildTarget(
         dependencies: dependencies
             .map((dep) => normalizeTargetKey(dep, packageName))
             .toSet(),
-        name: packageName,
+        name: defaultTarget,
         package: packageName,
         sources: const InputSet(),
       )

--- a/build_config/lib/src/key_normalization.dart
+++ b/build_config/lib/src/key_normalization.dart
@@ -2,13 +2,25 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-String normalizeBuilderKey(String builderKey, String packageName) {
+String normalizeBuilderKeyDefinition(String builderKey, String packageName) {
+  if (builderKey.startsWith('|')) return '$packageName$builderKey';
+  if (!builderKey.contains('|')) return '$packageName|$builderKey';
+  return builderKey;
+}
+
+String normalizeBuilderKeyUsage(String builderKey, String packageName) {
   if (builderKey.startsWith('|')) return '$packageName$builderKey';
   if (!builderKey.contains('|')) return '$builderKey|$builderKey';
   return builderKey;
 }
 
-String normalizeTargetKey(String targetKey, String packageName) {
+String normalizeTargetKeyDefinition(String targetKey, String packageName) {
+  if (targetKey.startsWith(':')) return '$packageName$targetKey';
+  if (!targetKey.contains(':')) return '$packageName:$targetKey';
+  return targetKey;
+}
+
+String normalizeTargetKeyUsage(String targetKey, String packageName) {
   if (targetKey.startsWith(':')) return '$packageName$targetKey';
   if (!targetKey.contains(':')) return '$targetKey:$targetKey';
   return targetKey;

--- a/build_config/lib/src/key_normalization.dart
+++ b/build_config/lib/src/key_normalization.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+String normalizeBuilderKey(String builderKey, String packageName) {
+  if (builderKey.startsWith('|')) return '$packageName$builderKey';
+  if (!builderKey.contains('|')) return '$builderKey|$builderKey';
+  return builderKey;
+}
+
+String normalizeTargetKey(String targetKey, String packageName) {
+  if (targetKey.startsWith(':')) return '$packageName$targetKey';
+  if (!targetKey.contains(':')) return '$targetKey:$targetKey';
+  return targetKey;
+}

--- a/build_config/lib/src/key_normalization.dart
+++ b/build_config/lib/src/key_normalization.dart
@@ -20,6 +20,9 @@ String normalizeTargetKeyUsage(String targetKey, String packageName) =>
 /// builder named after a package (which is not this package). If [name] starts
 /// with the separator we assume it's referring to a target within the package
 /// it's used from.
+///
+/// For example: If I depend on `angular` from `my_package` it is treated as a
+/// dependency on the globally unique `angular:angular`.
 String _normalizeUsage(String name, String packageName, String separator) {
   if (name.startsWith(separator)) return '$packageName$name';
   if (!name.contains(separator)) return '$name|$name';
@@ -30,6 +33,9 @@ String _normalizeUsage(String name, String packageName, String separator) {
 ///
 /// The result is always '$packageName$separator$name since at definition the
 /// key must be referring to something within [packageName].
+///
+/// For example: If I expose a builder `my_builder` within `my_package` it is
+/// turned into the globally unique `my_package|my_builder`.
 String _normalizeDefinition(String name, String packageName, String separator) {
   if (name.startsWith(separator)) return '$packageName$name';
   if (!name.contains(separator)) return '$packageName$separator$name';

--- a/build_config/lib/src/key_normalization.dart
+++ b/build_config/lib/src/key_normalization.dart
@@ -25,7 +25,7 @@ String normalizeTargetKeyUsage(String targetKey, String packageName) =>
 /// dependency on the globally unique `angular:angular`.
 String _normalizeUsage(String name, String packageName, String separator) {
   if (name.startsWith(separator)) return '$packageName$name';
-  if (!name.contains(separator)) return '$name|$name';
+  if (!name.contains(separator)) return '$name$separator$name';
   return name;
 }
 

--- a/build_config/lib/src/key_normalization.dart
+++ b/build_config/lib/src/key_normalization.dart
@@ -2,26 +2,36 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-String normalizeBuilderKeyDefinition(String builderKey, String packageName) {
-  if (builderKey.startsWith('|')) return '$packageName$builderKey';
-  if (!builderKey.contains('|')) return '$packageName|$builderKey';
-  return builderKey;
+String normalizeBuilderKeyDefinition(String builderKey, String packageName) =>
+    _normalizeDefinition(builderKey, packageName, '|');
+
+String normalizeBuilderKeyUsage(String builderKey, String packageName) =>
+    _normalizeUsage(builderKey, packageName, '|');
+
+String normalizeTargetKeyDefinition(String targetKey, String packageName) =>
+    _normalizeDefinition(targetKey, packageName, ':');
+
+String normalizeTargetKeyUsage(String targetKey, String packageName) =>
+    _normalizeUsage(targetKey, packageName, ':');
+
+/// Gives a full unique key for [name] used from [packageName].
+///
+/// If [name] omits the separator we assume it's referring to a target or
+/// builder named after a package (which is not this package). If [name] starts
+/// with the separator we assume it's referring to a target within the package
+/// it's used from.
+String _normalizeUsage(String name, String packageName, String separator) {
+  if (name.startsWith(separator)) return '$packageName$name';
+  if (!name.contains(separator)) return '$name|$name';
+  return name;
 }
 
-String normalizeBuilderKeyUsage(String builderKey, String packageName) {
-  if (builderKey.startsWith('|')) return '$packageName$builderKey';
-  if (!builderKey.contains('|')) return '$builderKey|$builderKey';
-  return builderKey;
-}
-
-String normalizeTargetKeyDefinition(String targetKey, String packageName) {
-  if (targetKey.startsWith(':')) return '$packageName$targetKey';
-  if (!targetKey.contains(':')) return '$packageName:$targetKey';
-  return targetKey;
-}
-
-String normalizeTargetKeyUsage(String targetKey, String packageName) {
-  if (targetKey.startsWith(':')) return '$packageName$targetKey';
-  if (!targetKey.contains(':')) return '$targetKey:$targetKey';
-  return targetKey;
+/// Gives a full unique key for [name] definied within [packageName].
+///
+/// The result is always '$packageName$separator$name since at definition the
+/// key must be referring to something within [packageName].
+String _normalizeDefinition(String name, String packageName, String separator) {
+  if (name.startsWith(separator)) return '$packageName$name';
+  if (!name.contains(separator)) return '$packageName$separator$name';
+  return name;
 }

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -79,28 +79,30 @@ BuildConfig parseFromMap(String packageName,
     final sources = _readInputSetOrThrow(targetConfig, _sources,
         defaultValue: const InputSet());
 
-    buildTargets[targetName] = new BuildTarget(
+    final targetKey = normalizeTargetKey(targetName, packageName);
+    buildTargets[targetKey] = new BuildTarget(
       builders: builders,
       dependencies: dependencies,
-      name: targetName,
+      name: targetKey,
       package: packageName,
       sources: sources,
     );
   }
 
+  final defaultTarget = '$packageName:$packageName';
   if (buildTargets.isEmpty) {
     // Add the default dart library if there are no targets discovered.
-    buildTargets[packageName] = new BuildTarget(
+    buildTargets[defaultTarget] = new BuildTarget(
       dependencies: packageDependencies
           .map((dep) => normalizeTargetKey(dep, packageName))
           .toSet(),
-      name: packageName,
+      name: defaultTarget,
       package: packageName,
       sources: const InputSet(),
     );
   }
 
-  if (!buildTargets.containsKey(packageName)) {
+  if (!buildTargets.containsKey(defaultTarget)) {
     throw new ArgumentError('Must specify a target with the name $packageName');
   }
 
@@ -140,11 +142,12 @@ BuildConfig parseFromMap(String packageName,
           'when using `auto_apply: ${builderConfig[_autoApply]}`');
     }
 
-    builderDefinitions[builderName] = new BuilderDefinition(
+    final builderKey = normalizeBuilderKey(builderName, packageName);
+    builderDefinitions[builderKey] = new BuilderDefinition(
       builderFactories: builderFactories,
       import: import,
       buildExtensions: buildExtensions,
-      name: builderName,
+      name: builderKey,
       package: packageName,
       target: target,
       autoApply: autoApply,

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -73,17 +73,16 @@ BuildConfig parseFromMap(String packageName,
 
     final dependencies = _readListOfStringsOrThrow(targetConfig, _dependencies,
             defaultValue: packageDependencies)
-        .map((dep) => normalizeTargetKey(dep, packageName))
+        .map((dep) => normalizeTargetKeyUsage(dep, packageName))
         .toSet();
 
     final sources = _readInputSetOrThrow(targetConfig, _sources,
         defaultValue: const InputSet());
 
-    final targetKey = normalizeTargetKey(targetName, packageName);
+    final targetKey = normalizeTargetKeyDefinition(targetName, packageName);
     buildTargets[targetKey] = new BuildTarget(
       builders: builders,
       dependencies: dependencies,
-      name: targetKey,
       package: packageName,
       sources: sources,
     );
@@ -94,9 +93,8 @@ BuildConfig parseFromMap(String packageName,
     // Add the default dart library if there are no targets discovered.
     buildTargets[defaultTarget] = new BuildTarget(
       dependencies: packageDependencies
-          .map((dep) => normalizeTargetKey(dep, packageName))
+          .map((dep) => normalizeTargetKeyUsage(dep, packageName))
           .toSet(),
-      name: defaultTarget,
       package: packageName,
       sources: const InputSet(),
     );
@@ -142,12 +140,11 @@ BuildConfig parseFromMap(String packageName,
           'when using `auto_apply: ${builderConfig[_autoApply]}`');
     }
 
-    final builderKey = normalizeBuilderKey(builderName, packageName);
+    final builderKey = normalizeBuilderKeyDefinition(builderName, packageName);
     builderDefinitions[builderKey] = new BuilderDefinition(
       builderFactories: builderFactories,
       import: import,
       buildExtensions: buildExtensions,
-      name: builderKey,
       package: packageName,
       target: target,
       autoApply: autoApply,
@@ -280,7 +277,7 @@ Map<String, TargetBuilderConfig> _readBuildersOrThrow(
       }
       parsedOptions = new BuilderOptions(options as Map<String, dynamic>);
     }
-    parsedConfigs[normalizeBuilderKey(builderKey, packageName)] =
+    parsedConfigs[normalizeBuilderKeyUsage(builderKey, packageName)] =
         new TargetBuilderConfig(
       isEnabled: isEnabled,
       generateFor: generateFor,

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -84,6 +84,7 @@ BuildConfig parseFromMap(String packageName,
       builders: builders,
       dependencies: dependencies,
       package: packageName,
+      key: targetKey,
       sources: sources,
     );
   }
@@ -96,6 +97,7 @@ BuildConfig parseFromMap(String packageName,
           .map((dep) => normalizeTargetKeyUsage(dep, packageName))
           .toSet(),
       package: packageName,
+      key: defaultTarget,
       sources: const InputSet(),
     );
   }
@@ -142,6 +144,7 @@ BuildConfig parseFromMap(String packageName,
 
     final builderKey = normalizeBuilderKeyDefinition(builderName, packageName);
     builderDefinitions[builderKey] = new BuilderDefinition(
+      key: builderKey,
       builderFactories: builderFactories,
       import: import,
       buildExtensions: buildExtensions,

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -117,7 +117,8 @@ BuildConfig parseFromMap(String packageName,
         _readListOfStringsOrThrow(builderConfig, _builderFactories);
     final import = _readStringOrThrow(builderConfig, _import);
     final buildExtensions = _readBuildExtensions(builderConfig);
-    final target = _readStringOrThrow(builderConfig, _target);
+    final target = normalizeTargetKeyUsage(
+        _readStringOrThrow(builderConfig, _target), packageName);
     final autoApply = _readAutoApplyOrThrow(builderConfig, _autoApply,
         defaultValue: AutoApply.none);
     final requiredInputs = _readListOfStringsOrThrow(

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -20,11 +20,13 @@ void main() {
         },
         dependencies: ['b:b', 'c:d'].toSet(),
         package: 'example',
+        key: 'example:a',
         sources: new InputSet(include: ['lib/a.dart', 'lib/src/a/**']),
       ),
       'example:example': new BuildTarget(
         dependencies: ['f:f', 'example:a'].toSet(),
         package: 'example',
+        key: 'example:example',
         sources: new InputSet(
             include: ['lib/e.dart', 'lib/src/e/**'],
             exclude: ['lib/src/e/g.dart']),
@@ -44,6 +46,7 @@ void main() {
           ]
         },
         package: 'example',
+        key: 'example|h',
         target: 'e',
         requiredInputs: ['.dart'],
         defaults: new TargetBuilderConfigDefaults(
@@ -59,6 +62,7 @@ void main() {
       'example:example': new BuildTarget(
         dependencies: ['a:a', 'b:b'].toSet(),
         package: 'example',
+        key: 'example:example',
         sources: new InputSet(),
       ),
     });
@@ -76,6 +80,7 @@ void main() {
           ]
         },
         package: 'example',
+        key: 'example|a',
         target: 'example',
         requiredInputs: const [],
       ),
@@ -157,6 +162,7 @@ class _BuilderDefinitionMatcher extends Matcher {
       item.isOptional == _expected.isOptional &&
       item.buildTo == _expected.buildTo &&
       item.import == _expected.import &&
+      item.key == _expected.key &&
       item.package == _expected.package &&
       item.target == _expected.target;
 

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -18,15 +18,14 @@ void main() {
           'a|h': new TargetBuilderConfig(
               options: new BuilderOptions({'foo': 'bar'})),
         },
-        dependencies: ['b', 'c:d'],
+        dependencies: ['b:b', 'c:d'].toSet(),
         name: 'a',
         package: 'example',
         sources: new InputSet(include: ['lib/a.dart', 'lib/src/a/**']),
       ),
-      'e': new BuildTarget(
-        dependencies: ['f', ':a'],
-        isDefault: true,
-        name: 'e',
+      'example': new BuildTarget(
+        dependencies: ['f:f', 'example:a'].toSet(),
+        name: 'example',
         package: 'example',
         sources: new InputSet(
             include: ['lib/e.dart', 'lib/src/e/**'],
@@ -61,8 +60,7 @@ void main() {
         new BuildConfig.parse('example', ['a', 'b'], buildYamlNoTargets);
     expectBuildTargets(buildConfig.buildTargets, {
       'example': new BuildTarget(
-        dependencies: ['a', 'b'],
-        isDefault: true,
+        dependencies: ['a:a', 'b:b'].toSet(),
         name: 'example',
         package: 'example',
         sources: new InputSet(),
@@ -106,8 +104,7 @@ targets:
     sources:
       - "lib/a.dart"
       - "lib/src/a/**"
-  e:
-    default: true
+  example:
     dependencies:
       - f
       - :a
@@ -191,7 +188,6 @@ class _BuildTargetMatcher extends Matcher {
       item is BuildTarget &&
       item.name == _expected.name &&
       item.package == _expected.package &&
-      item.isDefault == _expected.isDefault &&
       new _BuilderConfigsMatcher(_expected.builders)
           .matches(item.builders, _) &&
       equals(_expected.dependencies).matches(item.dependencies, _) &&

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -47,7 +47,7 @@ void main() {
         },
         package: 'example',
         key: 'example|h',
-        target: 'e',
+        target: 'example:example',
         requiredInputs: ['.dart'],
         defaults: new TargetBuilderConfigDefaults(
             generateFor: new InputSet(include: ['lib/**'])),
@@ -81,7 +81,7 @@ void main() {
         },
         package: 'example',
         key: 'example|a',
-        target: 'example',
+        target: 'example:example',
         requiredInputs: const [],
       ),
     });
@@ -119,7 +119,7 @@ builders:
     builder_factories: ["createBuilder"]
     import: package:example/e.dart
     build_extensions: {".dart": [".g.dart", ".json"]}
-    target: e
+    target: ":example"
     auto_apply: dependents
     required_inputs: [".dart"]
     is_optional: True

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -11,21 +11,19 @@ void main() {
   test('build.yaml can be parsed', () {
     var buildConfig = new BuildConfig.parse('example', ['a', 'b'], buildYaml);
     expectBuildTargets(buildConfig.buildTargets, {
-      'a': new BuildTarget(
+      'example:a': new BuildTarget(
         builders: {
           'b|b': new TargetBuilderConfig(
               generateFor: new InputSet(include: ['lib/a.dart'])),
-          'a|h': new TargetBuilderConfig(
+          'example|h': new TargetBuilderConfig(
               options: new BuilderOptions({'foo': 'bar'})),
         },
         dependencies: ['b:b', 'c:d'].toSet(),
-        name: 'a',
         package: 'example',
         sources: new InputSet(include: ['lib/a.dart', 'lib/src/a/**']),
       ),
-      'example': new BuildTarget(
+      'example:example': new BuildTarget(
         dependencies: ['f:f', 'example:a'].toSet(),
-        name: 'example',
         package: 'example',
         sources: new InputSet(
             include: ['lib/e.dart', 'lib/src/e/**'],
@@ -33,7 +31,7 @@ void main() {
       )
     });
     expectBuilderDefinitions(buildConfig.builderDefinitions, {
-      'h': new BuilderDefinition(
+      'example|h': new BuilderDefinition(
         builderFactories: ['createBuilder'],
         autoApply: AutoApply.dependents,
         isOptional: true,
@@ -45,7 +43,6 @@ void main() {
             '.json',
           ]
         },
-        name: 'h',
         package: 'example',
         target: 'e',
         requiredInputs: ['.dart'],
@@ -59,21 +56,19 @@ void main() {
     var buildConfig =
         new BuildConfig.parse('example', ['a', 'b'], buildYamlNoTargets);
     expectBuildTargets(buildConfig.buildTargets, {
-      'example': new BuildTarget(
+      'example:example': new BuildTarget(
         dependencies: ['a:a', 'b:b'].toSet(),
-        name: 'example',
         package: 'example',
         sources: new InputSet(),
       ),
     });
     expectBuilderDefinitions(buildConfig.builderDefinitions, {
-      'a': new BuilderDefinition(
+      'example|a': new BuilderDefinition(
         builderFactories: ['createBuilder'],
         autoApply: AutoApply.none,
         isOptional: false,
         buildTo: BuildTo.source,
         import: 'package:example/builder.dart',
-        name: 'a',
         buildExtensions: {
           '.dart': [
             '.g.dart',
@@ -92,7 +87,7 @@ var buildYaml = '''
 targets:
   a:
     builders:
-      a|h:
+      "|h":
         options:
           foo: bar
       b|b:
@@ -162,7 +157,6 @@ class _BuilderDefinitionMatcher extends Matcher {
       item.isOptional == _expected.isOptional &&
       item.buildTo == _expected.buildTo &&
       item.import == _expected.import &&
-      item.name == _expected.name &&
       item.package == _expected.package &&
       item.target == _expected.target;
 
@@ -186,7 +180,6 @@ class _BuildTargetMatcher extends Matcher {
   @override
   bool matches(item, _) =>
       item is BuildTarget &&
-      item.name == _expected.name &&
       item.package == _expected.package &&
       new _BuilderConfigsMatcher(_expected.builders)
           .matches(item.builders, _) &&

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -108,8 +108,7 @@ Expression _applyBuilderWithFilter(
             .constInstance([], inputSetArgs);
   }
   return refer('apply', 'package:build_runner/build_runner.dart').call([
-    literalString(definition.package),
-    literalString(definition.name),
+    literalString(definition.key),
     literalList(definition.builderFactories
         .map((f) => refer(f, definition.import))
         .toList()),

--- a/build_runner/lib/src/build_script_generate/builder_ordering.dart
+++ b/build_runner/lib/src/build_script_generate/builder_ordering.dart
@@ -25,7 +25,7 @@ List<BuilderDefinition> _findOrder(Iterable<BuilderDefinition> builders) {
   Iterable<BuilderDefinition> dependencies(BuilderDefinition parent) =>
       builders.where((child) => _hasInputDependency(parent, child));
   var components = stronglyConnectedComponents<String, BuilderDefinition>(
-      builders, _builderKey, dependencies);
+      builders, (b) => b.key, dependencies);
   return components.map((component) {
     if (component.length > 1) {
       throw new ArgumentError('Required input cycle for ${component.toList()}');
@@ -41,5 +41,3 @@ bool _hasInputDependency(BuilderDefinition parent, BuilderDefinition child) {
   return parent.requiredInputs
       .any((input) => childOutputs.any((output) => output.endsWith(input)));
 }
-
-String _builderKey(BuilderDefinition b) => '${b.package}|${b.name}';

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -39,7 +39,7 @@ PackageFilter toRoot() => (p) => p.isRoot;
 
 /// Apply [builder] to the root package.
 BuilderApplication applyToRoot(Builder builder) =>
-    new BuilderApplication._('', '', [(_) => builder], toRoot());
+    new BuilderApplication._('', [(_) => builder], toRoot());
 
 /// Apply each builder from [builderFactories] to the packages matching
 /// [filter].
@@ -52,11 +52,10 @@ BuilderApplication applyToRoot(Builder builder) =>
 /// read by a later builder, or is used as a primary input to a later builder.
 /// If no build actions read the output of an optional action, then it will
 /// never run.
-BuilderApplication apply(String providingPackage, String builderName,
+BuilderApplication apply(String builderKey,
         List<BuilderFactory> builderFactories, PackageFilter filter,
         {bool isOptional, bool hideOutput, InputSet defaultGenerateFor}) =>
-    new BuilderApplication._(
-        providingPackage, builderName, builderFactories, filter,
+    new BuilderApplication._(builderKey, builderFactories, filter,
         isOptional: isOptional,
         hideOutput: hideOutput,
         defaultGenerateFor: defaultGenerateFor);
@@ -68,17 +67,8 @@ class BuilderApplication {
   /// Determines whether a given package needs builder applied.
   final PackageFilter filter;
 
-  /// The package which provides this builder.
-  ///
-  /// Along with the [builderName] makes up a key that uniquely identifies the
-  /// builder.
-  final String providingPackage;
-
-  /// A name for this builder.
-  ///
-  /// Along with the [providingPackage] makes up a key that uniquely identifies the
-  /// builder.
-  final String builderName;
+  /// A uniqe key for this builder.
+  final String builderKey;
 
   final bool isOptional;
 
@@ -89,11 +79,9 @@ class BuilderApplication {
   /// not specify one.
   final InputSet defaultGenerateFor;
 
-  const BuilderApplication._(this.providingPackage, this.builderName,
-      this.builderFactories, this.filter,
+  const BuilderApplication._(
+      this.builderKey, this.builderFactories, this.filter,
       {this.isOptional, this.hideOutput, this.defaultGenerateFor});
-
-  String get builderKey => '$providingPackage|$builderName';
 }
 
 /// Creates a [BuildAction] to apply each builder in [builderApplications] to
@@ -114,7 +102,7 @@ Future<List<BuildAction>> createBuildActions(
       overrideBuildConfig: overrideBuildConfig);
   var cycles = stronglyConnectedComponents<String, TargetNode>(
       moduleGraph.allModules.values,
-      (node) => node.target.name,
+      (node) => node.target.key,
       (node) =>
           node.target.dependencies?.map((key) => moduleGraph.allModules[key]));
   return cycles

--- a/build_runner/lib/src/package_graph/target_graph.dart
+++ b/build_runner/lib/src/package_graph/target_graph.dart
@@ -26,7 +26,7 @@ class TargetGraph {
       final nodes = config.buildTargets.values
           .map((target) => new TargetNode(target, package));
       for (final node in nodes) {
-        modules[node.target.name] = node;
+        modules[node.target.key] = node;
       }
     }
     return new TargetGraph._(modules);
@@ -39,7 +39,7 @@ class TargetNode {
   TargetNode(this.target, this.package);
 
   @override
-  String toString() => '${package.name}:${target.name}';
+  String toString() => target.key;
 }
 
 Future<BuildConfig> _packageBuildConfig(PackageNode package) async {

--- a/build_runner/test/generate/build_configuration_test.dart
+++ b/build_runner/test/generate/build_configuration_test.dart
@@ -30,7 +30,7 @@ void main() {
     });
     await testBuilders(
         [
-          apply('a', 'optioned_builder', [copyBuilder], toRoot()),
+          apply('a|optioned_builder', [copyBuilder], toRoot()),
         ],
         {
           'a|lib/file.nomatch': 'a',

--- a/build_runner/test/generate/build_error_test.dart
+++ b/build_runner/test/generate/build_error_test.dart
@@ -16,8 +16,7 @@ void main() {
     try {
       await testBuilders(
         [
-          apply(
-              '', '', [(_) => new CopyBuilder()], toPackage('not_root_package'))
+          apply('', [(_) => new CopyBuilder()], toPackage('not_root_package'))
         ],
         {},
         packageGraph: buildPackageGraph({
@@ -38,9 +37,7 @@ void main() {
   test('fail if an output is on disk and !deleteFilesByDefault', () async {
     expect(
       testBuilders(
-        [
-          apply('', '', [(_) => new CopyBuilder()], toRoot())
-        ],
+        [applyToRoot(new CopyBuilder())],
         {
           'a|lib/a.dart': '',
           'a|lib/a.dart.copy': '',

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -58,9 +58,9 @@ void main() {
       test('optional build actions don\'t run if their outputs aren\'t read',
           () async {
         await testBuilders([
-          apply('', '', [(_) => new CopyBuilder(extension: '1')], toRoot(),
+          apply('', [(_) => new CopyBuilder(extension: '1')], toRoot(),
               isOptional: true),
-          apply('a', 'only_on_1', [(_) => new CopyBuilder(inputExtension: '1')],
+          apply('a|only_on_1', [(_) => new CopyBuilder(inputExtension: '1')],
               toRoot(),
               isOptional: true),
         ], {
@@ -70,16 +70,14 @@ void main() {
 
       test('optional build actions do run if their outputs are read', () async {
         await testBuilders([
-          apply('', '', [(_) => new CopyBuilder(extension: '1')], toRoot(),
+          apply('', [(_) => new CopyBuilder(extension: '1')], toRoot(),
               isOptional: true),
           apply(
-              '',
               '',
               [(_) => new CopyBuilder(inputExtension: '.1', extension: '2')],
               toRoot(),
               isOptional: true),
           apply(
-            '',
             '',
             [(_) => new CopyBuilder(inputExtension: '.2', extension: '3')],
             toRoot(),
@@ -96,10 +94,10 @@ void main() {
       test('multiple mixed build actions with custom build config', () async {
         var builders = [
           copyABuilderApplication,
-          apply('a', 'clone_txt', [(_) => new CopyBuilder(extension: 'clone')],
+          apply('a|clone_txt', [(_) => new CopyBuilder(extension: 'clone')],
               toRoot(),
               isOptional: true),
-          apply('a', 'copy_web_clones', [(_) => new CopyBuilder(numCopies: 2)],
+          apply('a|copy_web_clones', [(_) => new CopyBuilder(numCopies: 2)],
               toRoot()),
         ];
         var buildConfigs = parseBuildConfigs({
@@ -277,7 +275,7 @@ void main() {
       });
       expect(
           testBuilders([
-            apply('', '', [(_) => new CopyBuilder()], toPackage('b'))
+            apply('', [(_) => new CopyBuilder()], toPackage('b'))
           ], {
             'b|lib/b.txt': 'b'
           }, packageGraph: packageGraph),
@@ -296,7 +294,7 @@ void main() {
       test('can output files in non-root packages', () async {
         await testBuilders(
             [
-              apply('', '', [(_) => new CopyBuilder()], toPackage('b'),
+              apply('', [(_) => new CopyBuilder()], toPackage('b'),
                   hideOutput: true),
             ],
             {'b|lib/b.txt': 'b'},
@@ -309,8 +307,8 @@ void main() {
       test('handles mixed hidden and non-hidden outputs', () async {
         await testBuilders(
             [
-              apply('', '', [(_) => new CopyBuilder()], toRoot()),
-              apply('', '', [(_) => new CopyBuilder(extension: 'hiddencopy')],
+              apply('', [(_) => new CopyBuilder()], toRoot()),
+              apply('', [(_) => new CopyBuilder(extension: 'hiddencopy')],
                   toRoot(),
                   hideOutput: true),
             ],
@@ -333,7 +331,7 @@ void main() {
           };
         await testBuilders(
             [
-              apply('', '', [(_) => new CopyBuilder()], toPackage('b'),
+              apply('', [(_) => new CopyBuilder()], toPackage('b'),
                   hideOutput: true)
             ],
             {
@@ -349,7 +347,6 @@ void main() {
     test('can read files from external packages', () async {
       var builders = [
         apply(
-            '',
             '',
             [(_) => new CopyBuilder(touchAsset: makeAssetId('b|lib/b.txt'))],
             toRoot())
@@ -369,8 +366,8 @@ void main() {
       });
 
       var builders = [
-        apply('', '', [(_) => globBuilder], toRoot(), hideOutput: true),
-        apply('', '', [(_) => globBuilder], toPackage('b'), hideOutput: true),
+        apply('', [(_) => globBuilder], toRoot(), hideOutput: true),
+        apply('', [(_) => globBuilder], toPackage('b'), hideOutput: true),
       ];
 
       await testBuilders(
@@ -422,7 +419,6 @@ void main() {
       await testBuilders([
         apply(
             '',
-            '',
             [
               (_) => new CopyBuilder(
                   copyFromAsset: makeAssetId('a|.dart_tool/any_file'))
@@ -445,10 +441,7 @@ void main() {
             throw 'Should not delete outside of package:a';
           }
         };
-      await testBuilders(
-          [
-            apply('', '', [(_) => new CopyBuilder()], toRoot())
-          ],
+      await testBuilders([applyToRoot(new CopyBuilder())],
           {'a|lib/a.txt': 'a', 'b|lib/b.txt': 'b', 'b|lib/b.txt.copy': 'b'},
           packageGraph: packageGraph,
           writer: writer,
@@ -671,7 +664,7 @@ void main() {
 
     test('no outputs if no changed sources using `hideOutput: true`', () async {
       var builders = [
-        apply('', '', [(_) => new CopyBuilder()], toRoot(), hideOutput: true)
+        apply('', [(_) => new CopyBuilder()], toRoot(), hideOutput: true)
       ];
 
       // Initial build.

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -5,19 +5,18 @@ import 'package:build_config/build_config.dart' as _i4;
 import 'package:build_compilers/builders.dart' as _i5;
 
 final _builders = [
-  _i1.apply('provides_builder', 'some_not_applied_builder', [_i2.notApplied],
+  _i1.apply('provides_builder|some_not_applied_builder', [_i2.notApplied],
       _i1.toNoneByDefault()),
-  _i1.apply('provides_builder', 'some_builder', [_i2.someBuilder],
+  _i1.apply('provides_builder|some_builder', [_i2.someBuilder],
       _i1.toDependentsOf('provides_builder'),
       hideOutput: true),
   _i1.apply(
-      'build_test', 'test_bootstrap', [_i3.testBootstrapBuilder], _i1.toRoot(),
+      'build_test|test_bootstrap', [_i3.testBootstrapBuilder], _i1.toRoot(),
       isOptional: true,
       hideOutput: true,
       defaultGenerateFor: const _i4.InputSet(include: const ['test/**'])),
   _i1.apply(
-      'build_compilers',
-      'ddc',
+      'build_compilers|ddc',
       [
         _i5.moduleBuilder,
         _i5.unlinkedSummaryBuilder,
@@ -27,8 +26,8 @@ final _builders = [
       _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true),
-  _i1.apply('build_compilers', 'ddc_bootstrap',
-      [_i5.devCompilerBootstrapBuilder], _i1.toRoot(),
+  _i1.apply('build_compilers|ddc_bootstrap', [_i5.devCompilerBootstrapBuilder],
+      _i1.toRoot(),
       hideOutput: true,
       defaultGenerateFor: const _i4.InputSet(
           include: const ['web/**', 'test/**.browser_test.dart']))

--- a/e2e_example/tool/build.dart
+++ b/e2e_example/tool/build.dart
@@ -12,16 +12,15 @@ import 'package:build_test/builder.dart';
 
 Future main(List<String> args) async {
   var builders = [
-    apply('e2e_example', 'throwing_builder', [(_) => new ThrowingBuilder()],
+    apply('e2e_example|throwing_builder', [(_) => new ThrowingBuilder()],
         toRoot(),
         hideOutput: true),
-    apply('build_test', 'test_bootstrap', [(_) => new TestBootstrapBuilder()],
+    apply('build_test|test_bootstrap', [(_) => new TestBootstrapBuilder()],
         toRoot(),
         hideOutput: true,
         defaultGenerateFor: const InputSet(include: const ['test/**'])),
     apply(
-        'build_compilers',
-        'ddc',
+        'build_compilers|ddc',
         [
           (_) => new ModuleBuilder(),
           (_) => new UnlinkedSummaryBuilder(),
@@ -31,7 +30,7 @@ Future main(List<String> args) async {
         toAllPackages(),
         isOptional: true,
         hideOutput: true),
-    apply('build_compilers', 'ddc_bootstrap',
+    apply('build_compilers|ddc_bootstrap',
         [(_) => new DevCompilerBootstrapBuilder()], toRoot(),
         hideOutput: true,
         defaultGenerateFor: const InputSet(


### PR DESCRIPTION
- Remove `default` target, it now always matches the package name.
- Normalize target names in deps, and builder names in builder
  configuration. By normalizing at parse time we can avoid having to
  repeat the normalization logic at usage sites.