### PR TITLE
Prepare to publish build_config 0.2.0

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -8,8 +8,8 @@
 - Add `TargetBuilderConfigDefaults` class for Builder authors to provide default
   configuration.
 - Add `InputSet` and change `sources` and `generate_for` to use it.
-- Remove `BuildTarget.isDefault`. The default will be determined by the target
-  which matches the package name.
+- Remove `BuildTarget.isDefault` and related config parsing. The default will be
+  determined by the target which matches the package name.
 - Normalize Target and Builder names so they are scoped to the package they are
   defined in.
 

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0-dev
+## 0.2.0
 
 - Add `build_to` option to Builder configuration.
 - Add `BuildConfig.fromBuildConfigDir` for cases where the package name and
@@ -8,6 +8,10 @@
 - Add `TargetBuilderConfigDefaults` class for Builder authors to provide default
   configuration.
 - Add `InputSet` and change `sources` and `generate_for` to use it.
+- Remove `BuildTarget.isDefault`. The default will be determined by the target
+  which matches the package name.
+- Normalize Target and Builder names so they are scoped to the package they are
+  defined in.
 
 ### Breaking
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -6,14 +6,13 @@ file, which describes your configuration.
 ## Dividing a package into Build targets
 When a `Builder` should be applied to a subset of files in a package the package
 can be broken up into multiple 'targets'. Targets are configured in the
-`targets` section of the `build.yaml`. Each target may contain the following
-keys.
+`targets` section of the `build.yaml`. The key for each target makes up the name
+for that target. Targets can be referred to in
+`'$definingPackageName:$targetname'`. When the target name matches the package
+name it can also be referred to as just the package name. One target in every
+package _must_ use the package name so that consumers will use it by default.
+Each target may also contain the following keys.
 
-- **name**: String, Required. The name of the target within the package. Targets
-  can be referred to by `'$packageName:$targetName'` keys. If the target has the
-  same name as the package it can also be referred to as `'$packageName'`, at
-  least one target must use the package name so that other packages which depend
-  on this one can pick it up as a dependency.
 - **sources**: List of Strings or Map, Optional. The set of files within the
   package which make up this target. Files are specified using glob syntax. If a
   List of Strings is used they are considered the 'include' globs. If a Map is
@@ -50,6 +49,10 @@ configuration may have the following keys:
 If users of your package need to apply some code generation to their package,
 then you can define `Builder`s and have those applied to packages with a
 dependency on yours.
+
+The key for a Builder will be normalized so that consumers of the builder can
+refer to it in `'$definingPackageName|$builderName'` format. If the builder name
+matches the package name it can also be referred to with just the package name.
 
 Exposed `Builder`s are configured in the `builders` section of the `build.yaml`.
 This is a map of builder names to configuration. Each builder config may contain
@@ -118,3 +121,12 @@ builders:
     build_extensions: {".dart": [".my_package.dart"]}
     auto_apply: dependents
 ```
+
+# Publishing `build.yaml` files
+
+`build.yaml` configuration should be published to pub with the package and
+checked in to source control. Whenever a package is published with a
+`build.yaml` it should mark a `dependency` on `build_config` to ensure that
+the package consuming the config has a compatible versions. Breaking version
+changes which do not impact the configuration file format will be clearly marked
+in the changelog.

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -127,6 +127,6 @@ builders:
 `build.yaml` configuration should be published to pub with the package and
 checked in to source control. Whenever a package is published with a
 `build.yaml` it should mark a `dependency` on `build_config` to ensure that
-the package consuming the config has a compatible versions. Breaking version
+the package consuming the config has a compatible version. Breaking version
 changes which do not impact the configuration file format will be clearly marked
 in the changelog.

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.2.0-dev
+version: 0.2.0
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   build: ^0.11.2
+  meta: ^1.1.0
   path: ^1.4.0
   yaml: ^2.1.11
 


### PR DESCRIPTION
- Fix the BuildTarget description in the README.
- Add notes about how to refer to Builders and Targets by key.
- Add a note about publishing with a `build.yaml` and a dependency on
  this package.
- Add missing changelog entries.
- Add missing dependnecy on `package:meta`.
- Drop `-dev` from the version.