### PR TITLE
Filter out non-hidden actions outside the root

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.1
+
+- Change the default for `BuilderDefinition.buildTo` to `BuildTo.cache`.
+  Builders which want to operate on the source tree will need to explicitly opt
+  in. Allow this regardless of the value of `autoApply` and the build system
+  will need to filter out the builders that can't run.
+
 ## 0.2.0
 
 - Add `build_to` option to Builder configuration.

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -89,10 +89,10 @@ the following keys:
   to. The possibilities are:
   - `"source"`: Outputs go to the source tree next to their primary inputs.
   - `"cache"`: Outputs go to a hidden build cache and won't be published.
-  Only builders which output to the build cache may run on primary inputs
-  outside the root package. Defaults to `"source"`, unless `auto_apply` is set
-  to either `"all_packages"` or `"dependents"` in which case it defaults to
-  `"cache"`.
+  The default is "cache". If a Builder specifies that it outputs to "source" it
+  will never run on any package other than the root - but does not necessarily
+  need to use the "root_package" value for "auto_apply". If it would otherwise
+  run on a non-root package it will be filtered out.
 - **defaults**: Optional: Default values to apply when a user does not specify
   the corresponding key in their `builders` section. May contain the following
   keys:

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -127,21 +127,14 @@ BuildConfig parseFromMap(String packageName,
     final isOptional =
         _readBoolOrThrow(builderConfig, _isOptional, defaultValue: false);
 
-    final mustBuildToCache =
-        autoApply == AutoApply.dependents || autoApply == AutoApply.allPackages;
     final buildTo = _readBuildToOrThrow(builderConfig, _buildTo,
-        defaultValue: mustBuildToCache ? BuildTo.cache : BuildTo.source);
+        defaultValue: BuildTo.cache);
 
     final defaultOptions = _readMapOrThrow(
         builderConfig, _defaults, _builderConfigDefaultOptions, 'defaults',
         defaultValue: {});
     final defaultGenerateFor =
         _readInputSetOrThrow(defaultOptions, _generateFor, allowNull: true);
-
-    if (mustBuildToCache && buildTo != BuildTo.cache) {
-      throw new ArgumentError('`hide_output` may not be set to `False` '
-          'when using `auto_apply: ${builderConfig[_autoApply]}`');
-    }
 
     final builderKey = normalizeBuilderKeyDefinition(builderName, packageName);
     builderDefinitions[builderKey] = new BuilderDefinition(

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.2.0
+version: 0.2.1-dev
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -37,7 +37,7 @@ void main() {
         builderFactories: ['createBuilder'],
         autoApply: AutoApply.dependents,
         isOptional: true,
-        buildTo: BuildTo.cache, // defaulted because of AutoApply.dependents
+        buildTo: BuildTo.cache,
         import: 'package:example/e.dart',
         buildExtensions: {
           '.dart': [
@@ -71,7 +71,7 @@ void main() {
         builderFactories: ['createBuilder'],
         autoApply: AutoApply.none,
         isOptional: false,
-        buildTo: BuildTo.source,
+        buildTo: BuildTo.cache,
         import: 'package:example/builder.dart',
         buildExtensions: {
           '.dart': [

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -23,6 +23,8 @@
   `List<BuilderApplication>`. See `apply` and `applyToRoot` to set these up.
 - Changed `apply` to take a single String argument - a Builder key from
   `package:build_config` rather than a separate package and builder name.
+- Changed the default value of `hideOutput` from `false` to `true` for `apply`.
+  With `applyToRoot` the value remains `false`.
 - There is now a whitelist of top level directories that will be used as a part
   of the build, and other files will be ignored. For now those directories
   include 'benchmark', 'bin', 'example', 'lib', 'test', 'tool', and 'web'.

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -92,6 +92,8 @@ Expression _applyBuilderWithFilter(
   }
   if (definition.buildTo == BuildTo.cache) {
     namedArgs['hideOutput'] = literalTrue;
+  } else {
+    namedArgs['hideOutput'] = literalFalse;
   }
   if (definition.defaults?.generateFor != null) {
     final inputSetArgs = <String, Expression>{};

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -39,7 +39,7 @@ PackageFilter toRoot() => (p) => p.isRoot;
 
 /// Apply [builder] to the root package.
 BuilderApplication applyToRoot(Builder builder) =>
-    new BuilderApplication._('', [(_) => builder], toRoot());
+    new BuilderApplication._('', [(_) => builder], toRoot(), hideOutput: false);
 
 /// Apply each builder from [builderFactories] to the packages matching
 /// [filter].
@@ -81,7 +81,8 @@ class BuilderApplication {
 
   const BuilderApplication._(
       this.builderKey, this.builderFactories, this.filter,
-      {this.isOptional, this.hideOutput, this.defaultGenerateFor});
+      {this.isOptional, bool hideOutput, this.defaultGenerateFor})
+      : hideOutput = hideOutput ?? true;
 }
 
 /// Creates a [BuildAction] to apply each builder in [builderApplications] to
@@ -126,6 +127,9 @@ Iterable<BuildAction> _createBuildActionsForBuilderInCycle(
   TargetBuilderConfig targetConfig(TargetNode node) =>
       node.target.builders[builderApplication.builderKey];
   bool shouldRun(TargetNode node) {
+    if (!builderApplication.hideOutput && !node.package.isRoot) {
+      return false;
+    }
     final builderConfig = targetConfig(node);
     if (builderConfig?.isEnabled != null) {
       return builderConfig.isEnabled;

--- a/build_runner/test/generate/build_configuration_test.dart
+++ b/build_runner/test/generate/build_configuration_test.dart
@@ -30,7 +30,8 @@ void main() {
     });
     await testBuilders(
         [
-          apply('a|optioned_builder', [copyBuilder], toRoot()),
+          apply('a|optioned_builder', [copyBuilder], toRoot(),
+              hideOutput: false),
         ],
         {
           'a|lib/file.nomatch': 'a',

--- a/build_runner/test/generate/build_error_test.dart
+++ b/build_runner/test/generate/build_error_test.dart
@@ -11,29 +11,6 @@ import '../common/common.dart';
 import '../common/package_graphs.dart';
 
 void main() {
-  test('fail with a nice error if the root package is not right', () async {
-    String error;
-    try {
-      await testBuilders(
-        [
-          apply('', [(_) => new CopyBuilder()], toPackage('not_root_package'))
-        ],
-        {},
-        packageGraph: buildPackageGraph({
-          rootPackage('root_package'): ['not_root_package'],
-          package('not_root_package'): [],
-        }),
-      );
-    } catch (e) {
-      // TODO: Write a throwsAWith(...) matcher?
-      error = e.toString();
-    } finally {
-      expect(error, isNotNull, reason: 'Did not throw!');
-      expect(error, contains('operate on package "not_root_package"'));
-      expect(error, contains('new BuilderApplication(..., toRoot())'));
-    }
-  });
-
   test('fail if an output is on disk and !deleteFilesByDefault', () async {
     expect(
       testBuilders(

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -71,17 +71,18 @@ void main() {
       test('optional build actions do run if their outputs are read', () async {
         await testBuilders([
           apply('', [(_) => new CopyBuilder(extension: '1')], toRoot(),
-              isOptional: true),
+              isOptional: true, hideOutput: false),
           apply(
               '',
               [(_) => new CopyBuilder(inputExtension: '.1', extension: '2')],
               toRoot(),
-              isOptional: true),
+              isOptional: true,
+              hideOutput: false),
           apply(
-            '',
-            [(_) => new CopyBuilder(inputExtension: '.2', extension: '3')],
-            toRoot(),
-          ),
+              '',
+              [(_) => new CopyBuilder(inputExtension: '.2', extension: '3')],
+              toRoot(),
+              hideOutput: false),
         ], {
           'a|web/a.txt': 'a'
         }, outputs: {
@@ -96,9 +97,10 @@ void main() {
           copyABuilderApplication,
           apply('a|clone_txt', [(_) => new CopyBuilder(extension: 'clone')],
               toRoot(),
-              isOptional: true),
+              isOptional: true, hideOutput: false),
           apply('a|copy_web_clones', [(_) => new CopyBuilder(numCopies: 2)],
-              toRoot()),
+              toRoot(),
+              hideOutput: false),
         ];
         var buildConfigs = parseBuildConfigs({
           'a': {
@@ -268,18 +270,20 @@ void main() {
       });
     });
 
-    test('can\'t output files in non-root packages', () async {
+    test('skips builders which would output files in non-root packages',
+        () async {
       final packageGraph = buildPackageGraph({
         rootPackage('a', path: 'a/'): ['b'],
         package('b', path: 'a/b'): []
       });
-      expect(
-          testBuilders([
-            apply('', [(_) => new CopyBuilder()], toPackage('b'))
-          ], {
-            'b|lib/b.txt': 'b'
-          }, packageGraph: packageGraph),
-          throwsA(anything));
+      await testBuilders(
+          [
+            apply('', [(_) => new CopyBuilder()], toPackage('b'),
+                hideOutput: false)
+          ],
+          {'b|lib/b.txt': 'b'},
+          packageGraph: packageGraph,
+          outputs: {});
     });
 
     group('with `hideOutput: true`', () {
@@ -307,7 +311,8 @@ void main() {
       test('handles mixed hidden and non-hidden outputs', () async {
         await testBuilders(
             [
-              apply('', [(_) => new CopyBuilder()], toRoot()),
+              apply('', [(_) => new CopyBuilder()], toRoot(),
+                  hideOutput: false),
               apply('', [(_) => new CopyBuilder(extension: 'hiddencopy')],
                   toRoot(),
                   hideOutput: true),
@@ -349,7 +354,8 @@ void main() {
         apply(
             '',
             [(_) => new CopyBuilder(touchAsset: makeAssetId('b|lib/b.txt'))],
-            toRoot())
+            toRoot(),
+            hideOutput: false)
       ];
       await testBuilders(builders, {
         'a|lib/a.txt': 'a',

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -6,7 +6,8 @@ import 'package:build_compilers/builders.dart' as _i5;
 
 final _builders = [
   _i1.apply('provides_builder|some_not_applied_builder', [_i2.notApplied],
-      _i1.toNoneByDefault()),
+      _i1.toNoneByDefault(),
+      hideOutput: true),
   _i1.apply('provides_builder|some_builder', [_i2.someBuilder],
       _i1.toDependentsOf('provides_builder'),
       hideOutput: true),


### PR DESCRIPTION
Previously this would be an error, but we want to be able to handle
cases like a `build.yaml` specifying `enable: true` for a Builder that
writes to the source tree, but then also being used as a dependency.

This is a small change for manual build scripts where instead of a
helpful exception an action would just not run.

- Allow BuildTo.source for non-root auto_apply in `build_config`
- Default `BuildTo` to `cache` always rather than depending on the value
  of `AutoApply`. Anything that writes to the source tree should be
  explicitly called out.
- Default `hideOutput` for most BuilderApplications to true to match the
  defaultin of `BuildTo`