### PR TITLE
Default isEnabled to true

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -4,6 +4,8 @@
   Builders which want to operate on the source tree will need to explicitly opt
   in. Allow this regardless of the value of `autoApply` and the build system
   will need to filter out the builders that can't run.
+- By default including any configuration for a Builder within a BuildTarget will
+  enabled that builder.
 
 ## 0.2.0
 

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -250,7 +250,9 @@ class TargetBuilderConfig {
   /// Overrides the setting of whether the Builder would run on this target.
   ///
   /// Builders may run on this target by default based on the `apply_to`
-  /// argument. If this value is set it overrides the default.
+  /// argument, set to `false` to disable a Builder which would otherwise run.
+  ///
+  /// By default including a config for a Builder enables that builder.
   final bool isEnabled;
 
   /// Sources to use as inputs for this Builder in glob format.

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -260,7 +260,7 @@ Map<String, TargetBuilderConfig> _readBuildersOrThrow(
         defaultValue: {});
 
     final isEnabled =
-        _readBoolOrThrow(builderConfig, _enabled, allowNull: true);
+        _readBoolOrThrow(builderConfig, _enabled, defaultValue: true);
 
     final generateFor =
         _readInputSetOrThrow(builderConfig, _generateFor, allowNull: true);

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -14,8 +14,10 @@ void main() {
       'example:a': new BuildTarget(
         builders: {
           'b|b': new TargetBuilderConfig(
+              isEnabled: true,
               generateFor: new InputSet(include: ['lib/a.dart'])),
           'example|h': new TargetBuilderConfig(
+              isEnabled: true,
               options: new BuilderOptions({'foo': 'bar'})),
         },
         dependencies: ['b:b', 'c:d'].toSet(),

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -17,8 +17,7 @@ void main() {
               isEnabled: true,
               generateFor: new InputSet(include: ['lib/a.dart'])),
           'example|h': new TargetBuilderConfig(
-              isEnabled: true,
-              options: new BuilderOptions({'foo': 'bar'})),
+              isEnabled: true, options: new BuilderOptions({'foo': 'bar'})),
         },
         dependencies: ['b:b', 'c:d'].toSet(),
         package: 'example',


### PR DESCRIPTION
We can't think of a situation in which you would want to provide
configuration options to a Builder wihout enabling it.