### PR TITLE
rename DevCompilerBootstrapBuilder to WebEntrypointBuilder and move ddc logic to a separate file

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0-dev
+
+- Renamed `ddc_bootstrap` builder to `web_entrypoint`, the exposed class also
+  changed from `DevCompilerBootstrapBuilder` to `WebEntrypointBuilder`.
+
 # 0.1.1
 
 - Mark `ddc_bootstrap` builder with `build_to: cache`.

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,7 +1,11 @@
 # 0.2.0-dev
 
+## Breaking Changes
+
 - Renamed `ddc_bootstrap` builder to `web_entrypoint`, the exposed class also
   changed from `DevCompilerBootstrapBuilder` to `WebEntrypointBuilder`.
+- Renamed `jsBootstrapExtension` to `ddcBootstrapExtension` since it is only
+  required when using the dev compiler.
 
 # 0.1.1
 

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -18,10 +18,10 @@ builders:
     is_optional: True
     auto_apply: all_packages
     required_inputs: [".dart"]
-  ddc_bootstrap:
+  web_entrypoint:
     target: "build_web_compilers"
     import: "package:build_web_compilers/builders.dart"
-    builder_factories: ["devCompilerBootstrapBuilder"]
+    builder_factories: ["webEntrypointBuilder"]
     build_extensions:
       .dart:
         - .dart.bootstrap.js

--- a/build_web_compilers/lib/build_web_compilers.dart
+++ b/build_web_compilers/lib/build_web_compilers.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/dev_compiler_bootstrap_builder.dart'
-    show DevCompilerBootstrapBuilder, bootstrapJsExtension;
 export 'src/dev_compiler_builder.dart'
     show
         DevCompilerBuilder,
@@ -17,3 +15,5 @@ export 'src/summary_builder.dart'
         UnlinkedSummaryBuilder,
         linkedSummaryExtension,
         unlinkedSummaryExtension;
+export 'src/web_entrypoint_builder.dart'
+    show WebEntrypointBuilder, ddcBootstrapExtension;

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -9,4 +9,4 @@ Builder moduleBuilder(_) => const ModuleBuilder();
 Builder unlinkedSummaryBuilder(_) => const UnlinkedSummaryBuilder();
 Builder linkedSummaryBuilder(_) => const LinkedSummaryBuilder();
 Builder devCompilerBuilder(_) => const DevCompilerBuilder();
-Builder devCompilerBootstrapBuilder(_) => const DevCompilerBootstrapBuilder();
+Builder webEntrypointBuilder(_) => const WebEntrypointBuilder();

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:analyzer/analyzer.dart';
+import 'package:build/build.dart';
+
+import 'dev_compiler_bootstrap.dart';
+
+const ddcBootstrapExtension = '.dart.bootstrap.js';
+const jsEntrypointExtension = '.dart.js';
+const jsEntrypointSourceMapExtension = '.dart.js.map';
+
+class WebEntrypointBuilder implements Builder {
+  const WebEntrypointBuilder();
+
+  @override
+  final buildExtensions = const {
+    '.dart': const [
+      ddcBootstrapExtension,
+      jsEntrypointExtension,
+      jsEntrypointSourceMapExtension
+    ],
+  };
+
+  @override
+  Future<Null> build(BuildStep buildStep) async {
+    var dartEntrypointId = buildStep.inputId;
+    var isAppEntrypoint = await _isAppEntryPoint(dartEntrypointId, buildStep);
+    if (!isAppEntrypoint) return;
+    await bootstrapDdc(buildStep);
+  }
+}
+
+/// Returns whether or not [dartId] is an app entrypoint (basically, whether
+/// or not it has a `main` function).
+Future<bool> _isAppEntryPoint(AssetId dartId, AssetReader reader) async {
+  assert(dartId.extension == '.dart');
+  // Skip reporting errors here, dartdevc will report them later with nicer
+  // formatting.
+  var parsed = parseCompilationUnit(await reader.readAsString(dartId),
+      suppressErrors: true);
+  // Allow two or fewer arguments so that entrypoints intended for use with
+  // [spawnUri] get counted.
+  //
+  // TODO: This misses the case where a Dart file doesn't contain main(),
+  // but has a part that does, or it exports a `main` from another library.
+  return parsed.declarations.any((node) {
+    return node is FunctionDeclaration &&
+        node.name.name == "main" &&
+        node.functionExpression.parameters.parameters.length <= 2;
+  });
+}

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.1.1
+version: 0.2.0-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -54,7 +54,7 @@ main() {
         isNot(contains('lib/a')),
       ])),
     };
-    await testBuilder(new DevCompilerBootstrapBuilder(), assets,
+    await testBuilder(new WebEntrypointBuilder(), assets,
         outputs: expectedOutputs);
   });
 }

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -27,8 +27,8 @@ final _builders = [
       _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true),
-  _i1.apply('build_web_compilers|ddc_bootstrap',
-      [_i5.devCompilerBootstrapBuilder], _i1.toRoot(),
+  _i1.apply('build_web_compilers|web_entrypoint', [_i5.webEntrypointBuilder],
+      _i1.toRoot(),
       hideOutput: true,
       defaultGenerateFor: const _i4.InputSet(
           include: const ['web/**', 'test/**.browser_test.dart']))

--- a/e2e_example/tool/build.dart
+++ b/e2e_example/tool/build.dart
@@ -32,7 +32,7 @@ Future main(List<String> args) async {
         isOptional: true,
         hideOutput: true),
     apply('build_web_compilers|ddc_bootstrap',
-        [(_) => new DevCompilerBootstrapBuilder()], toRoot(),
+        [(_) => new WebEntrypointBuilder()], toRoot(),
         hideOutput: true,
         defaultGenerateFor: const InputSet(
             include: const ['web/**', 'test/**.browser_test.dart']))


### PR DESCRIPTION
This lays the groundwork for supporting both dart2js and ddc with the same builder (now called `WebEntrypointBuilder`).