### PR TITLE
Release 0.7.2 with the test command

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,13 +1,10 @@
-## 0.7.3
-
-- Added the `test` command to the `build_runner` binary.
-
 ## 0.7.2
 
 - Added the flag `--fail-on-severe`, which defaults to `false`. In a future
   version this will default to `true`, which means that logging a message via
   `log.severe` will fail the build instead of just printing to the terminal.
   This would match the current behavior in `bazel_codegen`. 
+- Added the `test` command to the `build_runner` binary.
 
 ## 0.7.1+1
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.3
+
+- Added the `test` command to the `build_runner` binary.
+
 ## 0.7.2
 
 - Added the flag `--fail-on-severe`, which defaults to `false`. In a future

--- a/build_runner/README.md
+++ b/build_runner/README.md
@@ -27,6 +27,7 @@ tools such as [Bazel][].
 
 * [Installation](#installation)
 * [Usage](#usage)
+  * [Built-in commands](#built-in-commands)
   * [Inputs](#inputs)
   * [Outputs](#outputs)
   * [Source control](#source-control)

--- a/build_runner/README.md
+++ b/build_runner/README.md
@@ -54,8 +54,58 @@ Builder to decide whether the build needs to be customized. If it does you may
 also provide a `build.yaml` with the configuration. See the
 `package:build_config` README for more information on this file.
 
-Run `pub run build_runner serve` to start up a development server. To have web
-code compiled with DDC add a `dev_dependency` on `build_web_compilers`.
+To have web code compiled to js add a `dev_dependency` on `build_web_compilers`.
+
+### Built-in Commands
+
+The `build_runner` package exposes a binary by the same name, which can be
+invoked using `pub run build_runner <command>`.
+
+The available commands are `build`, `watch`, `serve`, and `test`.
+
+- `build`: Runs a single build and exits.
+- `watch`: Runs a persistent build server that watches the files system for
+  edits and does rebuilds as necessary.
+- `serve`: Same as `watch`, but runs a development server as well.
+  - By default this serves the `web` and `test` directories, on port `8080` and
+    `8081` respectively. See below for how to configure this.
+- `test`: Runs a single build, creates a merged output directory, and then runs
+  `pub run test --precompiled <merged-output-dir>`. See below for instructions
+  on passing custom args to the test command.
+
+#### Command Line Options
+
+All the above commands support the following arguments:
+
+- `--help`: Print usage information for the command.
+- `--assume-tty`: Enables colors and interactive input when the script does not
+  appear to be running directly in a terminal, for instance when it is a
+  subprocess.
+- `--delete-conflicting-outputs`: Assume conflicting outputs in the users
+  package are from previous builds, and skip the user prompt that would usually
+  be provided.
+- `--[no-]fail-on-severe`: Whether to consider the build a failure on an error
+  logged. By default this is false.
+
+Some commands also have additional options:
+
+##### serve
+
+- `--hostname`: The host to run the server on.
+
+Trailing args of the form `<directory>:<port>` are supported to customize what
+directories are served, and on what ports.
+
+For example to serve the `example` and `web` directories on ports 8000 and 8001
+you would do `pub run build_runner serve example:8000 web:8001`.
+
+##### test
+
+The test command will forward any arguments after an empty `--` arg to the
+`pub run test` command.
+
+For example if you wanted to pass `-p chrome` you would do
+`pub run build_runner test -- -p chrome`.
 
 ### Inputs
 

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -9,20 +9,40 @@ import 'package:io/io.dart';
 import 'package:logging/logging.dart';
 
 import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
+import 'package:build_runner/src/entrypoint/options.dart';
 import 'package:build_runner/src/logging/std_io_logging.dart';
 
 Future<Null> main(List<String> args) async {
   var logListener = Logger.root.onRecord.listen(stdIOLogListener);
   await ensureBuildScript();
   var dart = Platform.resolvedExecutable;
+
+  // Use the actual command runner to parse the args and immediately print the
+  // usage information if there is no command provided or the help command was
+  // explicitly invoked.
+  var commandRunner = new BuildCommandRunner([]);
+  var parsedArgs = commandRunner.parse(args);
+  var commandName = parsedArgs.command?.name;
+  if (commandName == null || commandName == 'help') {
+    commandRunner.printUsage();
+    return;
+  }
+
+  // The actual args we will pass to the generated entrypoint script.
   final innerArgs = [scriptLocation]..addAll(args);
+
+  // For commands that support the `assume-tty` flag, we want to force the right
+  // setting unless it was explicitly provided.
+  var command = commandRunner.commands[commandName];
+  var commandParser = command.argParser;
   if (stdioType(stdin) == StdioType.TERMINAL &&
-      !args.any((a) => a.contains('assume-tty')) &&
-      args.isNotEmpty) {
+      commandParser.options.containsKey('assume-tty') &&
+      !args.any((a) => a.contains('assume-tty'))) {
     // We want to insert this as the first arg after the command, trailing args
     // might get forwarded elsewhere (such as package:test).
-    innerArgs.insert(2, '--assume-tty');
+    innerArgs.insert(innerArgs.indexOf(commandName) + 1, '--assume-tty');
   }
+
   var buildRun = await new ProcessManager().spawn(dart, innerArgs);
   await buildRun.exitCode;
   await ProcessManager.terminateStdIn();

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.3
+version: 0.7.2
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.2
+version: 0.7.3
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
- updated the readme to highlight all the commands supported by the build_runner executable
- also fixed using the `--help` flag or `help` command, and generally made the addition of `--assume-tty` more robust.