### PR TITLE
Split BuildOptions into BuildEnvironment

### DIFF
--- a/build_runner/lib/src/changes/build_script_updates.dart
+++ b/build_runner/lib/src/changes/build_script_updates.dart
@@ -9,8 +9,9 @@ import 'package:build/build.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
+import '../asset/reader.dart';
 import '../asset_graph/graph.dart';
-import '../generate/options.dart';
+import '../package_graph/package_graph.dart';
 
 class BuildScriptUpdates {
   final Set<AssetId> _allSources;
@@ -18,10 +19,10 @@ class BuildScriptUpdates {
 
   BuildScriptUpdates._(this._supportsIncrementalRebuilds, this._allSources);
 
-  static Future<BuildScriptUpdates> create(
-      BuildOptions options, AssetGraph graph) async {
+  static Future<BuildScriptUpdates> create(RunnerAssetReader reader,
+      PackageGraph packageGraph, AssetGraph graph) async {
     bool supportsIncrementalRebuilds = true;
-    var rootPackage = options.packageGraph.root.name;
+    var rootPackage = packageGraph.root.name;
     Set<AssetId> allSources;
     var logger = new Logger('BuildScriptUpdates');
     try {
@@ -41,7 +42,7 @@ class BuildScriptUpdates {
         // Make sure we are tracking changes for all ids in [allSources].
         for (var id in allSources) {
           var node = graph.get(id);
-          node.lastKnownDigest ??= await options.reader.digest(id);
+          node.lastKnownDigest ??= await reader.digest(id);
         }
       }
     } on ArgumentError catch (_) {

--- a/build_runner/lib/src/environment/build_environment.dart
+++ b/build_runner/lib/src/environment/build_environment.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
+import '../asset/reader.dart';
+import '../asset/writer.dart';
+import '../generate/directory_watcher_factory.dart';
+
+/// Utilities to interact with the environment in which a build is running.
+///
+/// All side effects and user interaction should go through the build
+/// environment. An IO based environment can write to disk and interact through
+/// stdout/stdin, while a theoretical web or remote environment might interact
+/// over HTTP.
+abstract class BuildEnvironment {
+  RunnerAssetReader get reader;
+  RunnerAssetWriter get writer;
+  DirectoryWatcherFactory get directoryWatcherFactory;
+
+  void onLog(LogRecord record);
+
+  /// Prompt the user for input.
+  ///
+  /// The message and choices are displayed to the user and the index of the
+  /// chosen option is returned.
+  ///
+  /// If this environmment is non-interactive (such as when running in a test)
+  /// this method should throw [NonInteractiveBuildException].
+  Future<int> prompt(String message, List<String> choices);
+}
+
+/// Thrown when the build attempts to prompt the users but no prompt is
+/// possible.
+class NonInteractiveBuildException implements Exception {}

--- a/build_runner/lib/src/environment/io_environment.dart
+++ b/build_runner/lib/src/environment/io_environment.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:io/ansi.dart';
+import 'package:logging/logging.dart';
+
+import '../asset/file_based.dart';
+import '../asset/reader.dart';
+import '../asset/writer.dart';
+import '../generate/directory_watcher_factory.dart';
+import '../logging/std_io_logging.dart';
+import '../package_graph/package_graph.dart';
+import 'build_environment.dart';
+
+/// A [BuildEnvironment] writing to disk and stdout.
+class IOEnvironment implements BuildEnvironment {
+  @override
+  final RunnerAssetReader reader;
+
+  @override
+  final RunnerAssetWriter writer;
+
+  @override
+  final DirectoryWatcherFactory directoryWatcherFactory;
+
+  final bool _isInteractive;
+  final bool _assumeTty;
+
+  IOEnvironment(PackageGraph packageGraph, bool assumeTty)
+      : _isInteractive = assumeTty ?? _canPrompt(),
+        _assumeTty = assumeTty,
+        reader = new FileBasedAssetReader(packageGraph),
+        writer = new FileBasedAssetWriter(packageGraph),
+        directoryWatcherFactory = defaultDirectoryWatcherFactory;
+
+  @override
+  void onLog(LogRecord record) {
+    overrideAnsiOutput(_assumeTty == true || ansiOutputEnabled, () {
+      stdIOLogListener(record);
+    });
+  }
+
+  @override
+  Future<int> prompt(String message, List<String> choices) async {
+    if (!_isInteractive) throw new NonInteractiveBuildException();
+    while (true) {
+      stdout.writeln('\n$message');
+      for (int i = 0, l = choices.length; i < l; i++) {
+        stdout.writeln('${i + 1} - ${choices[i]}');
+      }
+      final input = stdin.readLineSync();
+      final choice = int.parse(input, onError: (_) => -1);
+      if (choice > 0 && choice <= choices.length) return choice - 1;
+      stdout.writeln('Unrecognized option $input, '
+          'a number between 1 and ${choices.length} expected');
+    }
+  }
+}
+
+bool _canPrompt() =>
+    stdioType(stdin) == StdioType.TERMINAL &&
+    // Assume running inside a test if the code is running as a `data:` URI
+    Platform.script.scheme != 'data';

--- a/build_runner/lib/src/environment/overridable_environment.dart
+++ b/build_runner/lib/src/environment/overridable_environment.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
+import '../asset/reader.dart';
+import '../asset/writer.dart';
+import '../generate/directory_watcher_factory.dart';
+import 'build_environment.dart';
+
+/// A [BuildEnvironment] which can have individual features overridden.
+class OverrideableEnvironment implements BuildEnvironment {
+  final BuildEnvironment _default;
+
+  final RunnerAssetReader _reader;
+  final RunnerAssetWriter _writer;
+  final DirectoryWatcherFactory _directoryWatcherFactory;
+
+  final void Function(LogRecord) _onLog;
+
+  OverrideableEnvironment(
+    this._default, {
+    RunnerAssetReader reader,
+    RunnerAssetWriter writer,
+    DirectoryWatcherFactory directoryWatcherFactory,
+    void Function(LogRecord) onLog,
+  })
+      : _reader = reader,
+        _writer = writer,
+        _directoryWatcherFactory = directoryWatcherFactory,
+        _onLog = onLog;
+
+  @override
+  RunnerAssetReader get reader => _reader ?? _default.reader;
+
+  @override
+  RunnerAssetWriter get writer => _writer ?? _default.writer;
+
+  @override
+  DirectoryWatcherFactory get directoryWatcherFactory =>
+      _directoryWatcherFactory ?? _default.directoryWatcherFactory;
+
+  @override
+  void onLog(LogRecord record) {
+    if (_onLog != null) {
+      _onLog(record);
+    } else {
+      _default.onLog(record);
+    }
+  }
+
+  @override
+  Future<int> prompt(String message, List<String> choices) =>
+      _default.prompt(message, choices);
+}

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
 import 'package:watcher/watcher.dart';
 
 import '../asset/build_cache.dart';
@@ -19,6 +18,7 @@ import '../asset_graph/exceptions.dart';
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../changes/build_script_updates.dart';
+import '../environment/build_environment.dart';
 import '../logging/logging.dart';
 import '../package_graph/package_graph.dart';
 import '../util/constants.dart';
@@ -57,18 +57,20 @@ class BuildDefinition {
       this.enableLowResourcesMode,
       this.onDelete);
 
-  static Future<BuildDefinition> prepareWorkspace(
+  static Future<BuildDefinition> prepareWorkspace(BuildEnvironment environment,
           BuildOptions options, List<BuildAction> buildActions,
           {void onDelete(AssetId id)}) =>
-      new _Loader(options, buildActions, onDelete).prepareWorkspace();
+      new _Loader(environment, options, buildActions, onDelete)
+          .prepareWorkspace();
 }
 
 class _Loader {
   final List<BuildAction> _buildActions;
   final BuildOptions _options;
+  final BuildEnvironment _environment;
   final OnDelete _onDelete;
 
-  _Loader(this._options, this._buildActions, this._onDelete);
+  _Loader(this._environment, this._options, this._buildActions, this._onDelete);
 
   Future<BuildDefinition> prepareWorkspace() async {
     _checkBuildActions();
@@ -88,8 +90,8 @@ class _Loader {
           () => _updateAssetGraph(assetGraph, _buildActions, inputSources,
               cacheDirSources, internalSources));
 
-      buildScriptUpdates =
-          await BuildScriptUpdates.create(_options, assetGraph);
+      buildScriptUpdates = await BuildScriptUpdates.create(
+          _environment.reader, _options.packageGraph, assetGraph);
       if (!_options.skipBuildScriptCheck &&
           buildScriptUpdates.hasBeenUpdated(updates.keys.toSet())) {
         _logger.warning('Invalidating asset graph due to build script update');
@@ -104,9 +106,9 @@ class _Loader {
 
       await logTimedAsync(_logger, 'Building new asset graph', () async {
         assetGraph = await AssetGraph.build(_buildActions, inputSources,
-            internalSources, _options.packageGraph, _options.reader);
-        buildScriptUpdates =
-            await BuildScriptUpdates.create(_options, assetGraph);
+            internalSources, _options.packageGraph, _environment.reader);
+        buildScriptUpdates = await BuildScriptUpdates.create(
+            _environment.reader, _options.packageGraph, assetGraph);
         conflictingOutputs = assetGraph.outputs
             .where((n) => n.package == _options.packageGraph.root.name)
             .where(inputSources.contains)
@@ -123,16 +125,14 @@ class _Loader {
       await logTimedAsync(
           _logger,
           'Checking for unexpected pre-existing outputs.',
-          () => _initialBuildCleanup(
-              conflictingOutputs, _wrapWriter(_options.writer, assetGraph),
-              deleteFilesByDefault: _options.deleteFilesByDefault,
-              assumeTty: _options.assumeTty));
+          () => _initialBuildCleanup(conflictingOutputs,
+              _wrapWriter(_environment.writer, assetGraph)));
     }
 
     return new BuildDefinition._(
         assetGraph,
-        _wrapReader(_options.reader, assetGraph),
-        _wrapWriter(_options.writer, assetGraph),
+        _wrapReader(_environment.reader, assetGraph),
+        _wrapWriter(_environment.writer, assetGraph),
         _options.packageGraph,
         _options.deleteFilesByDefault,
         new ResourceManager(),
@@ -169,7 +169,9 @@ class _Loader {
 
   /// Returns all the internal sources, such as those under [entryPointDir].
   Future<Set<AssetId>> _findInternalSources() {
-    return _options.reader.findAssets(new Glob('$entryPointDir/**')).toSet();
+    return _environment.reader
+        .findAssets(new Glob('$entryPointDir/**'))
+        .toSet();
   }
 
   /// Attempts to read in an [AssetGraph] from disk, and returns `null` if it
@@ -177,14 +179,15 @@ class _Loader {
   Future<AssetGraph> _tryReadCachedAssetGraph() async {
     final assetGraphId =
         new AssetId(_options.packageGraph.root.name, assetGraphPath);
-    if (!await _options.reader.canRead(assetGraphId)) {
+    if (!await _environment.reader.canRead(assetGraphId)) {
       return null;
     }
 
     return logTimedAsync(_logger, 'Reading cached asset graph', () async {
       try {
-        var cachedGraph = new AssetGraph.deserialize(JSON
-            .decode(await _options.reader.readAsString(assetGraphId)) as Map);
+        var cachedGraph = new AssetGraph.deserialize(
+            JSON.decode(await _environment.reader.readAsString(assetGraphId))
+                as Map);
         if (computeBuildActionsDigest(_buildActions) !=
             cachedGraph.buildActionsDigest) {
           _logger.warning(
@@ -224,8 +227,8 @@ class _Loader {
         _buildActions,
         updates,
         _options.packageGraph.root.name,
-        (id) => _delete(id, _wrapWriter(_options.writer, assetGraph)),
-        _wrapReader(_options.reader, assetGraph));
+        (id) => _delete(id, _wrapWriter(_environment.writer, assetGraph)),
+        _wrapReader(_environment.reader, assetGraph));
     return updates;
   }
 
@@ -288,7 +291,7 @@ class _Loader {
       if (node == null) throw id;
       var originalDigest = node.lastKnownDigest;
       if (originalDigest == null) return;
-      var currentDigest = await _options.reader.digest(id);
+      var currentDigest = await _environment.reader.digest(id);
       if (currentDigest != originalDigest) {
         updates[id] = ChangeType.MODIFY;
       }
@@ -326,7 +329,8 @@ class _Loader {
 
   Stream<AssetId> _listAssetIds(PackageNode package) async* {
     for (final glob in _packageIncludes(package)) {
-      yield* _options.reader.findAssets(new Glob(glob), package: package.name);
+      yield* _environment.reader
+          .findAssets(new Glob(glob), package: package.name);
     }
   }
 
@@ -338,7 +342,7 @@ class _Loader {
 
   Stream<AssetId> _listGeneratedAssetIds() async* {
     var glob = new Glob('$generatedOutputDirectory/**');
-    await for (var id in _options.reader.findAssets(glob)) {
+    await for (var id in _environment.reader.findAssets(glob)) {
       var packagePath = id.path.substring(generatedOutputDirectory.length + 1);
       var firstSlash = packagePath.indexOf('/');
       var package = packagePath.substring(0, firstSlash);
@@ -350,12 +354,11 @@ class _Loader {
   /// Handles cleanup of pre-existing outputs for initial builds (where there is
   /// no cached graph).
   Future<Null> _initialBuildCleanup(
-      Set<AssetId> conflictingAssets, RunnerAssetWriter writer,
-      {@required bool deleteFilesByDefault, @required bool assumeTty}) async {
+      Set<AssetId> conflictingAssets, RunnerAssetWriter writer) async {
     if (conflictingAssets.isEmpty) return;
 
     // Skip the prompt if using this option.
-    if (deleteFilesByDefault) {
+    if (_options.deleteFilesByDefault) {
       _logger.info('Deleting ${conflictingAssets.length} declared outputs '
           'which already existed on disk.');
       await Future.wait(conflictingAssets.map((id) => _delete(id, writer)));
@@ -368,37 +371,28 @@ class _Loader {
         '`$cacheDir` folder was deleted, or you are submitting generated '
         'files to your source repository.');
 
-    // If not in a standard terminal then we just exit, since there is no way
-    // for the user to provide a yes/no answer.
-    bool runningInPubRunTest() => Platform.script.scheme == 'data';
-    if (!assumeTty &&
-        (stdioType(stdin) != StdioType.TERMINAL || runningInPubRunTest())) {
-      throw new UnexpectedExistingOutputsException(conflictingAssets);
-    }
-
-    // Give a little extra space after the last message, need to make it clear
-    // this is a prompt.
-    stdout.writeln();
     var done = false;
     while (!done) {
-      stdout.write('\nDelete these files (y/n) (or list them (l))?: ');
-      var input = stdin.readLineSync();
-      switch (input.toLowerCase()) {
-        case 'y':
-          stdout.writeln('Deleting files...');
-          done = true;
-          await Future.wait(conflictingAssets.map((id) => _delete(id, writer)));
-          break;
-        case 'n':
-          throw new UnexpectedExistingOutputsException(conflictingAssets);
-          break;
-        case 'l':
-          for (var output in conflictingAssets) {
-            stdout.writeln(output);
-          }
-          break;
-        default:
-          stdout.writeln('Unrecognized option $input, (y/n/l) expected.');
+      try {
+        var choice = await _environment.prompt('Delete these files?',
+            ['Delete', 'Cancel build', 'List conflicts']);
+        switch (choice) {
+          case 0:
+            _logger.info('Deleting files...');
+            done = true;
+            await Future
+                .wait(conflictingAssets.map((id) => _delete(id, writer)));
+            break;
+          case 1:
+            throw new UnexpectedExistingOutputsException(conflictingAssets);
+            break;
+          case 2:
+            _logger.info('Conflicts:\n${conflictingAssets.join('\n')}');
+            // Logging should be sync :(
+            await new Future(() {});
+        }
+      } on NonInteractiveBuildException {
+        throw new UnexpectedExistingOutputsException(conflictingAssets);
       }
     }
   }

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -20,6 +20,9 @@ import '../asset/reader.dart';
 import '../asset/writer.dart';
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
+import '../environment/build_environment.dart';
+import '../environment/io_environment.dart';
+import '../environment/overridable_environment.dart';
 import '../logging/logging.dart';
 import '../package_graph/apply_builders.dart';
 import '../package_graph/build_config_overrides.dart';
@@ -52,15 +55,17 @@ Future<BuildResult> build(
   bool enableLowResourcesMode,
   Map<String, BuildConfig> overrideBuildConfig,
 }) async {
-  var options = new BuildOptions(
-      assumeTty: assumeTty,
+  packageGraph ??= new PackageGraph.forThisPackage();
+  var environment = new OverrideableEnvironment(
+      new IOEnvironment(packageGraph, assumeTty),
+      reader: reader,
+      writer: writer,
+      onLog: onLog);
+  var options = new BuildOptions(environment,
       deleteFilesByDefault: deleteFilesByDefault,
       failOnSevere: failOnSevere,
       packageGraph: packageGraph,
-      reader: reader,
-      writer: writer,
       logLevel: logLevel,
-      onLog: onLog,
       skipBuildScriptCheck: skipBuildScriptCheck,
       enableLowResourcesMode: enableLowResourcesMode);
   var terminator = new Terminator(terminateEventStream);
@@ -69,17 +74,17 @@ Future<BuildResult> build(
   final buildActions = await createBuildActions(options.packageGraph, builders,
       overrideBuildConfig: overrideBuildConfig);
 
-  var result = await singleBuild(options, buildActions);
+  var result = await singleBuild(environment, options, buildActions);
 
   await terminator.cancel();
   await options.logListener.cancel();
   return result;
 }
 
-Future<BuildResult> singleBuild(
+Future<BuildResult> singleBuild(BuildEnvironment environment,
     BuildOptions options, List<BuildAction> buildActions) async {
-  var buildDefinition =
-      await BuildDefinition.prepareWorkspace(options, buildActions);
+  var buildDefinition = await BuildDefinition.prepareWorkspace(
+      environment, options, buildActions);
   var result =
       (await BuildImpl.create(buildDefinition, buildActions)).firstBuild;
   await buildDefinition.resourceManager.beforeExit();

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -3,32 +3,23 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
 
-import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
 
-import '../asset/file_based.dart';
-import '../asset/reader.dart';
-import '../asset/writer.dart';
-import '../logging/std_io_logging.dart';
+import '../environment/build_environment.dart';
 import '../package_graph/package_graph.dart';
-import 'directory_watcher_factory.dart';
 
 /// Manages setting up consistent defaults for all options and build modes.
 class BuildOptions {
   // Build mode options.
   StreamSubscription logListener;
   PackageGraph packageGraph;
-  RunnerAssetReader reader;
-  RunnerAssetWriter writer;
 
   bool deleteFilesByDefault;
   bool failOnSevere;
   bool enableLowResourcesMode;
-  bool assumeTty;
 
   // Watch mode options.
   Duration debounceDelay;
-  DirectoryWatcherFactory directoryWatcherFactory;
 
   // For testing only, skips the build script updates check.
   bool skipBuildScriptCheck;
@@ -36,17 +27,12 @@ class BuildOptions {
   // For internal use only, flipped when a severe log occurred.
   bool severeLogHandled = false;
 
-  BuildOptions(
+  BuildOptions(BuildEnvironment environment,
       {this.debounceDelay,
-      this.assumeTty,
       this.deleteFilesByDefault,
       this.failOnSevere,
-      this.directoryWatcherFactory,
       Level logLevel,
-      onLog(LogRecord record),
       this.packageGraph,
-      this.reader,
-      this.writer,
       this.skipBuildScriptCheck,
       this.enableLowResourcesMode}) {
     // Set up logging
@@ -59,23 +45,16 @@ class BuildOptions {
 
     Logger.root.level = logLevel;
 
-    overrideAnsiOutput(assumeTty == true || ansiOutputEnabled, () {
-      onLog ??= stdIOLogListener;
-      logListener = Logger.root.onRecord.listen((r) {
-        if (r.level == Level.SEVERE) {
-          severeLogHandled = true;
-        }
-        onLog(r);
-      });
+    logListener = Logger.root.onRecord.listen((r) {
+      if (r.level == Level.SEVERE) {
+        severeLogHandled = true;
+      }
+      environment.onLog(r);
     });
 
     /// Set up other defaults.
     debounceDelay ??= const Duration(milliseconds: 250);
     packageGraph ??= new PackageGraph.forThisPackage();
-    reader ??= new FileBasedAssetReader(packageGraph);
-    writer ??= new FileBasedAssetWriter(packageGraph);
-    directoryWatcherFactory ??= defaultDirectoryWatcherFactory;
-    assumeTty ??= false;
     deleteFilesByDefault ??= false;
     failOnSevere ??= false;
     skipBuildScriptCheck ??= false;

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -16,6 +16,9 @@ import '../asset/reader.dart';
 import '../asset/writer.dart';
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
+import '../environment/build_environment.dart';
+import '../environment/io_environment.dart';
+import '../environment/overridable_environment.dart';
 import '../package_graph/apply_builders.dart';
 import '../package_graph/build_config_overrides.dart';
 import '../package_graph/package_graph.dart';
@@ -48,17 +51,19 @@ Future<ServeHandler> watch(
   bool enableLowResourcesMode,
   Map<String, BuildConfig> overrideBuildConfig,
 }) async {
-  var options = new BuildOptions(
-      assumeTty: assumeTty,
+  packageGraph ??= new PackageGraph.forThisPackage();
+  var environment = new OverrideableEnvironment(
+      new IOEnvironment(packageGraph, assumeTty),
+      reader: reader,
+      writer: writer,
+      directoryWatcherFactory: directoryWatcherFactory,
+      onLog: onLog);
+  var options = new BuildOptions(environment,
       deleteFilesByDefault: deleteFilesByDefault,
       failOnSevere: failOnSevere,
       packageGraph: packageGraph,
-      reader: reader,
-      writer: writer,
       logLevel: logLevel,
-      onLog: onLog,
       debounceDelay: debounceDelay,
-      directoryWatcherFactory: directoryWatcherFactory,
       skipBuildScriptCheck: skipBuildScriptCheck,
       enableLowResourcesMode: enableLowResourcesMode);
   var terminator = new Terminator(terminateEventStream);
@@ -67,7 +72,8 @@ Future<ServeHandler> watch(
   final buildActions = await createBuildActions(options.packageGraph, builders,
       overrideBuildConfig: overrideBuildConfig);
 
-  var watch = runWatch(options, buildActions, terminator.shouldTerminate);
+  var watch =
+      runWatch(environment, options, buildActions, terminator.shouldTerminate);
 
   // ignore: unawaited_futures
   watch.buildResults.drain().then((_) async {
@@ -86,9 +92,9 @@ Future<ServeHandler> watch(
 ///
 /// The [BuildState.buildResults] stream will end after the final build has been
 /// run.
-WatchImpl runWatch(
-        BuildOptions options, List<BuildAction> buildActions, Future until) =>
-    new WatchImpl(options, buildActions, until);
+WatchImpl runWatch(BuildEnvironment environment, BuildOptions options,
+        List<BuildAction> buildActions, Future until) =>
+    new WatchImpl(environment, options, buildActions, until);
 
 typedef Future<BuildResult> _BuildAction(List<List<AssetChange>> changes);
 
@@ -114,11 +120,13 @@ class WatchImpl implements BuildState {
   final _readerCompleter = new Completer<DigestAssetReader>();
   Future<DigestAssetReader> get reader => _readerCompleter.future;
 
-  WatchImpl(BuildOptions options, List<BuildAction> buildActions, Future until)
-      : _directoryWatcherFactory = options.directoryWatcherFactory,
+  WatchImpl(BuildEnvironment environment, BuildOptions options,
+      List<BuildAction> buildActions, Future until)
+      : _directoryWatcherFactory = environment.directoryWatcherFactory,
         _debounceDelay = options.debounceDelay,
         packageGraph = options.packageGraph {
-    buildResults = _run(options, buildActions, until).asBroadcastStream();
+    buildResults =
+        _run(environment, options, buildActions, until).asBroadcastStream();
   }
 
   @override
@@ -129,8 +137,8 @@ class WatchImpl implements BuildState {
   /// Only one build will run at a time, and changes are batched.
   ///
   /// File watchers are scheduled synchronously.
-  Stream<BuildResult> _run(
-      BuildOptions options, List<BuildAction> buildActions, Future until) {
+  Stream<BuildResult> _run(BuildEnvironment environment, BuildOptions options,
+      List<BuildAction> buildActions, Future until) {
     var fatalBuildCompleter = new Completer();
     var firstBuildCompleter = new Completer<BuildResult>();
     currentBuild = firstBuildCompleter.future;
@@ -202,7 +210,7 @@ class WatchImpl implements BuildState {
     // stream synchronously.
     () async {
       _buildDefinition = await BuildDefinition.prepareWorkspace(
-          options, buildActions,
+          environment, options, buildActions,
           onDelete: _expectedDeletes.add);
       _readerCompleter.complete(new SingleStepReader(
           _buildDefinition.reader,


### PR DESCRIPTION
Fixes #803

Takes some of the `dart:io` specific pieces and hides them behind and
interface. The visible difference is a change in the way the 'delete
conflicts' prompt is shown to the user.

- Add `BuildEnvironment` interface, and an IO backed implementation as
  well as one that have individual pieces overridden.
- Remove anything that defaults to io implementations from
  `BuildOptions`.