### PR TITLE
Add human readable Duration printing

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.5-dev
+
+- Add more human friendly duration printing.
+
 ## 0.7.4
 
 - Allows using files in any build targets in the root package as sources if they

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -23,6 +23,7 @@ import '../asset_graph/node.dart';
 import '../environment/build_environment.dart';
 import '../environment/io_environment.dart';
 import '../environment/overridable_environment.dart';
+import '../logging/human_readable_duration.dart';
 import '../logging/logging.dart';
 import '../package_graph/apply_builders.dart';
 import '../package_graph/build_config_overrides.dart';
@@ -147,14 +148,14 @@ class BuildImpl {
     var result = await _safeBuild(_resourceManager);
     await _resourceManager.disposeAll();
     if (result.status == BuildStatus.success) {
-      _logger.info('Succeeded after ${watch.elapsedMilliseconds}ms with '
+      _logger.info('Succeeded after ${humanReadable(watch.elapsed)} with '
           '${result.outputs.length} outputs\n\n');
     } else {
       if (result.exception is FatalBuildException) {
         // TODO(???) Really bad idea. Should not set exit codes in libraries!
         exitCode = 1;
       }
-      _logger.severe('Failed after ${watch.elapsedMilliseconds}ms',
+      _logger.severe('Failed after ${humanReadable(watch.elapsed)}',
           result.exception, result.stackTrace);
     }
     return result;

--- a/build_runner/lib/src/generate/heartbeat.dart
+++ b/build_runner/lib/src/generate/heartbeat.dart
@@ -5,7 +5,8 @@
 import 'dart:async';
 
 import 'package:logging/logging.dart';
-import 'package:millisecond/millisecond.dart' as ms;
+
+import '../logging/human_readable_duration.dart';
 
 var _logger = new Logger('Heartbeat');
 
@@ -66,11 +67,9 @@ class HeartbeatLogger {
   /// Logs a heartbeat message if [_intervalWatch] has been running for
   /// [waitDuration] or more.
   void _logIfDurationIsMet(_) {
-    if (_intervalWatch.elapsedMilliseconds < waitDuration.inMilliseconds) {
-      return;
-    }
+    if (_intervalWatch.elapsed < waitDuration) return;
 
-    var formattedTime = ms.format(_totalWatch.elapsedMilliseconds, long: true);
+    var formattedTime = humanReadable(_totalWatch.elapsed);
     _logger.info('... still running ($formattedTime so far)');
     _resetHeartbeat();
   }

--- a/build_runner/lib/src/logging/human_readable_duration.dart
+++ b/build_runner/lib/src/logging/human_readable_duration.dart
@@ -9,7 +9,7 @@
 ///
 /// Always attempts 2 'levels' of precision. Will show hours/minutes,
 /// minutes/seconds, seconds/tenths of a second, or milliseconds depending on
-/// the largets level that needs to be displayed.
+/// the largest level that needs to be displayed.
 String humanReadable(Duration duration) {
   if (duration < const Duration(seconds: 1)) {
     return '${duration.inMilliseconds}ms';

--- a/build_runner/lib/src/logging/human_readable_duration.dart
+++ b/build_runner/lib/src/logging/human_readable_duration.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Returns a human readable string for a duration.
+///
+/// Handles durations that span up to hours - this will not be a good fit for
+/// durations that are longer than days.
+///
+/// Always attempts 2 'levels' of precision. Will show hours/minutes,
+/// minutes/seconds, seconds/tenths of a second, or milliseconds depending on
+/// the largets level that needs to be displayed.
+String humanReadable(Duration duration) {
+  if (duration < const Duration(seconds: 1)) {
+    return '${duration.inMilliseconds}ms';
+  }
+  if (duration < const Duration(minutes: 1)) {
+    return '${(duration.inMilliseconds / 1000.0).toStringAsFixed(1)}s';
+  }
+  if (duration < const Duration(hours: 1)) {
+    final minutes = duration.inMinutes;
+    final remaining = duration - new Duration(minutes: minutes);
+    return '${minutes}m ${remaining.inSeconds}s';
+  }
+  final hours = duration.inHours;
+  final remaining = duration - new Duration(hours: hours);
+  return '${hours}h ${remaining.inMinutes}m';
+}

--- a/build_runner/lib/src/logging/logging.dart
+++ b/build_runner/lib/src/logging/logging.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 
 import 'package:logging/logging.dart';
 
+import 'human_readable_duration.dart';
+
 // Ensures on windows this message does not get overwritten by later logs.
 final _logSuffix = '${Platform.isWindows ? '' : '\n'}';
 
@@ -23,7 +25,7 @@ Future<T> logTimedAsync<T>(
   logger.log(level, '$description...');
   final result = await action();
   watch.stop();
-  final time = '${watch.elapsedMilliseconds}ms$_logSuffix';
+  final time = '${humanReadable(watch.elapsed)}$_logSuffix';
   logger.log(level, '$description completed, took $time');
   return result;
 }
@@ -41,7 +43,7 @@ T logTimedSync<T>(
   logger.log(level, '$description...');
   final result = action();
   watch.stop();
-  final time = '${watch.elapsedMilliseconds}ms$_logSuffix';
+  final time = '${humanReadable(watch.elapsed)}$_logSuffix';
   logger.log(level, '$description completed, took $time');
   return result;
 }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.4
+version: 0.7.5-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -25,7 +25,6 @@ dependencies:
   io: ^0.3.0
   logging: ^0.11.2
   meta: ^1.1.0
-  millisecond: ^0.1.0
   mime: ^0.9.3
   path: ^1.1.0
   pool: ^1.0.0


### PR DESCRIPTION
Closes #784

Since the build_runner use case is more constrained than a general
human-friendly duration printer we can use a very simple implementation.

- Add `humanReadable` with a simple implementation that fits our use
  case.
- Replace usage of `package:millisecond` with this method.
- Use this method in other places where we were printing milliseconds.