### PR TITLE
Add --output flag which creates a merged output dir

### DIFF
--- a/build_runner/bin/create_merged_dir.dart
+++ b/build_runner/bin/create_merged_dir.dart
@@ -7,120 +7,61 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:build/build.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:build_runner/src/asset/build_cache.dart';
 import 'package:build_runner/src/asset/file_based.dart';
 import 'package:build_runner/src/asset_graph/graph.dart';
-import 'package:build_runner/src/asset_graph/node.dart';
+import 'package:build_runner/src/generate/create_merged_dir.dart';
 import 'package:build_runner/src/package_graph/package_graph.dart';
 import 'package:build_runner/src/util/constants.dart';
+import 'package:build_runner/src/logging/logging.dart';
+import 'package:build_runner/src/logging/std_io_logging.dart';
+import 'package:logging/logging.dart';
 
 AssetGraph assetGraph;
 PackageGraph packageGraph;
+final logger = new Logger('CreateMergedDir');
 
 Future main(List<String> args) async {
-  stdout.writeln(
-      'Warning: this tool is unsupported and usage may change at any time, '
-      'use at your own risk.\n\n');
+  Logger.root.onRecord.listen(stdIOLogListener);
+  logger.warning('This tool is deprecated, please use the --output=dir option '
+      'from the normal build/serve/watch commands.');
 
   var parsedArgs = argParser.parse(args);
 
   var scriptPath = parsedArgs['script'] as String;
   if (scriptPath == null) {
-    throw new ArgumentError.notNull('--script');
+    logger.severe('Missing required arg --script');
+    exit(1);
   }
 
   var scriptFile = new File(scriptPath);
   if (!scriptFile.existsSync()) {
-    throw new ArgumentError(
-        'Expected a build script at $scriptPath but didn\'t find one.');
+    logger
+        .severe('Expected a build script at $scriptPath but didn\'t find one.');
+    exit(1);
   }
 
   var assetGraphFile = new File(assetGraphPathFor(p.absolute(scriptPath)));
   if (!assetGraphFile.existsSync()) {
-    throw new ArgumentError(
+    logger.severe(
         'Unable to find AssetGraph for $scriptPath at ${assetGraphFile.path}');
+    exit(1);
   }
 
-  var outputDir = new Directory(parsedArgs['output-dir'] as String);
-  if (outputDir.existsSync()) {
-    stdout.writeln('Deleting existing output dir `$outputDir`');
-    outputDir.deleteSync(recursive: true);
-  }
-  outputDir.createSync(recursive: true);
-
-  stdout.writeln('Loading asset graph at ${assetGraphFile.path}...');
-
-  assetGraph = new AssetGraph.deserialize(
-      JSON.decode(assetGraphFile.readAsStringSync()) as Map);
+  await logTimedAsync(logger, 'Loading asset graph at ${assetGraphFile.path}',
+      () async {
+    assetGraph = new AssetGraph.deserialize(
+        JSON.decode(await assetGraphFile.readAsString()) as Map);
+  });
 
   packageGraph = new PackageGraph.forThisPackage();
-
-  stdout.writeln('Creating output dir at ${outputDir.path}...');
-  var rootDirs = new Set<String>();
-  for (var node in assetGraph.packageNodes(packageGraph.root.name)) {
-    var parts = p.url.split(node.id.path);
-    if (parts.length == 1) continue;
-    var dir = parts.first;
-    if (dir == outputDir.path) continue;
-    rootDirs.add(parts.first);
-  }
-
   var reader = new BuildCacheReader(new FileBasedAssetReader(packageGraph),
       assetGraph, packageGraph.root.name);
 
-  for (var node in assetGraph.allNodes) {
-    if (!node.isReadable) continue;
-    if (node is GeneratedAssetNode && !node.wasOutput) continue;
-    if (node.id.path == '.packages') continue;
-    var assetPaths = <String>[];
-    if (node.id.path.startsWith('lib')) {
-      assetPaths.add(p.url.join(
-          'packages', node.id.package, node.id.path.substring('lib/'.length)));
-    } else {
-      assetPaths.add(node.id.path);
-    }
-    for (var path in assetPaths) {
-      var outputId = new AssetId(packageGraph.root.name, path);
-      writeAsBytes(outputDir, outputId, await reader.readAsBytes(node.id));
-    }
-  }
-
-  var packagesFileContent =
-      packageGraph.allPackages.keys.map((p) => '$p:packages/$p/').join('\r\n');
-  for (var dir in rootDirs) {
-    writeAsString(
-        outputDir,
-        new AssetId(packageGraph.root.name, p.url.join(dir, '.packages')),
-        packagesFileContent);
-    var link = new Link(p.join(outputDir.path, dir, 'packages'));
-    link.createSync(p.join('..', 'packages'), recursive: true);
-  }
-}
-
-void writeAsBytes(Directory outputDir, AssetId id, List<int> bytes) {
-  var file = fileFor(outputDir, id);
-  file.writeAsBytesSync(bytes);
-}
-
-void writeAsString(Directory outputDir, AssetId id, String contents) {
-  var file = fileFor(outputDir, id);
-  file.writeAsStringSync(contents);
-}
-
-File fileFor(Directory outputDir, AssetId id) {
-  String relativePath;
-  if (id.path.startsWith('lib')) {
-    relativePath =
-        p.join('packages', id.package, p.joinAll(p.url.split(id.path).skip(1)));
-  } else {
-    relativePath = id.path;
-  }
-  var file = new File(p.join(outputDir.path, relativePath));
-  file.createSync(recursive: true);
-  return file;
+  await createMergedOutputDir(
+      parsedArgs['output-dir'] as String, assetGraph, packageGraph, reader);
 }
 
 final argParser = new ArgParser()

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -2,15 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
-import 'package:glob/glob.dart';
 import 'package:io/io.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p;
 import 'package:shelf/shelf_io.dart';
 
 import 'package:build_runner/build_runner.dart';
@@ -279,76 +276,34 @@ class _TestCommand extends _BaseCommand {
   @override
   Future<Null> run() async {
     var options = _readOptions();
+    // We always need an output dir when running tests, so we create a tmp dir
+    // if the user didn't specify one.
+    var outputDir = options.outputDir ??
+        Directory.systemTemp
+            .createTempSync('build_runner_test')
+            .absolute
+            .uri
+            .toFilePath();
     await build(builderApplications,
         deleteFilesByDefault: options.deleteFilesByDefault,
         enableLowResourcesMode: options.enableLowResourcesMode,
-        assumeTty: options.assumeTty);
-
-    // Create the merged output directory.
-    String precompiledPath = await _createMergedDir();
-
-    // Create missing *_test.html files.
-    await _createMissingHtmlFiles(precompiledPath);
+        assumeTty: options.assumeTty,
+        outputDir: outputDir);
 
     // Run the tests!
-    await _runTests(precompiledPath);
+    await _runTests(outputDir);
+
+    // Clean up the output dir if one wasn't explicitly asked for.
+    if (options.outputDir == null) {
+      await new Directory(outputDir).delete(recursive: true);
+    }
 
     await ProcessManager.terminateStdIn();
   }
 
-  /// Creates a merged directory for the current build script.
-  Future<String> _createMergedDir() async {
-    var tmpDir = await Directory.systemTemp.createTemp('build_runner_test');
-    var tmpDirPath = tmpDir.absolute.uri.toFilePath();
-    var scriptLocation = Platform.script.toFilePath();
-    var process = await new ProcessManager().spawn(_pubBinary, [
-      'run',
-      'build_runner:create_merged_dir',
-      '--script',
-      scriptLocation,
-      '--output-dir',
-      tmpDirPath,
-    ]);
-
-    var processExitCode = await process.exitCode;
-    if (processExitCode != 0) {
-      print('Error creating merged dir! :(');
-      exit(processExitCode);
-    }
-    return tmpDirPath;
-  }
-
-  /// Creates html files for tests in [tmpDirPath] that are missing them.
-  Future<Null> _createMissingHtmlFiles(String tmpDirPath) async {
-    var dartBrowserTestSuffix = '_test.dart.browser_test.dart';
-    var htmlTestSuffix = '_test.html';
-    var dartFiles =
-        new Glob('test/**$dartBrowserTestSuffix').list(root: tmpDirPath);
-    await for (var file in dartFiles) {
-      var dartPath = p.relative(file.path, from: tmpDirPath);
-      var htmlPath = dartPath.substring(
-              0, dartPath.length - dartBrowserTestSuffix.length) +
-          htmlTestSuffix;
-      var htmlFile = new File(p.join(tmpDirPath, htmlPath));
-      if (!await htmlFile.exists()) {
-        var originalDartPath = p.basename(dartPath.substring(
-            0, dartPath.length - '.browser_test.dart'.length));
-        await htmlFile.writeAsString('''
-<!DOCTYPE html>
-<html>
-<head>
-  <title>${HTML_ESCAPE.convert(htmlPath)} Test</title>
-  <link rel="x-dart-test"
-        href="${HTML_ESCAPE.convert(originalDartPath)}">
-  <script src="packages/test/dart.js"></script>
-</head>
-</html>''');
-      }
-    }
-  }
-
   /// Runs tests using [precompiledPath] as the precompiled test directory.
   Future<Null> _runTests(String precompiledPath) async {
+    stdout.writeln('Running tests...\n');
     var extraTestArgs = argResults.rest;
     var testProcess = await new ProcessManager().spawn(
         _pubBinary,
@@ -361,7 +316,7 @@ class _TestCommand extends _BaseCommand {
     var testExitCode = await testProcess.exitCode;
     if (testExitCode != 0) {
       // No need to log - should see failed tests in the console.
-      exit(testExitCode);
+      exitCode = testExitCode;
     }
   }
 }

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -52,7 +52,8 @@ class _SharedOptions {
 
   final bool enableLowResourcesMode;
 
-  /// Path to the merged output directory, if applicable.
+  /// Path to the merged output directory, or null if no directory should be
+  /// created.
   final String outputDir;
 
   _SharedOptions._({

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -40,6 +40,9 @@ import 'watch_impl.dart' as watch_impl;
 /// By default the [ProcessSignal.SIGINT] stream is used. In this mode, it
 /// will simply consume the first event and allow the build to continue.
 /// Multiple termination events will cause a normal shutdown.
+///
+/// If [outputDir] is supplied then after each build a merged output directory
+/// will be created containing all original sources and built sources.
 Future<BuildResult> build(List<BuilderApplication> builders,
         {bool deleteFilesByDefault,
         bool failOnSevere,
@@ -50,7 +53,8 @@ Future<BuildResult> build(List<BuilderApplication> builders,
         Level logLevel,
         onLog(LogRecord record),
         Stream terminateEventStream,
-        bool enableLowResourcesMode}) =>
+        bool enableLowResourcesMode,
+        String outputDir}) =>
     build_impl.build(builders,
         assumeTty: assumeTty,
         deleteFilesByDefault: deleteFilesByDefault,
@@ -61,7 +65,8 @@ Future<BuildResult> build(List<BuilderApplication> builders,
         logLevel: logLevel,
         onLog: onLog,
         terminateEventStream: terminateEventStream,
-        enableLowResourcesMode: enableLowResourcesMode);
+        enableLowResourcesMode: enableLowResourcesMode,
+        outputDir: outputDir);
 
 /// Same as [build], except it watches the file system and re-runs builds
 /// automatically.
@@ -81,8 +86,11 @@ Future<BuildResult> build(List<BuilderApplication> builders,
 /// The [terminateEventStream] is a stream which can send termination events.
 /// By default the [ProcessSignal.SIGINT] stream is used. In this mode, the
 /// first event will allow any ongoing builds to finish, and then the program
-///  will complete normally. Subsequent events are not handled (and will
-///  typically cause a shutdown).
+/// will complete normally. Subsequent events are not handled (and will
+/// typically cause a shutdown).
+///
+/// If [outputDir] is supplied then after each build a merged output directory
+/// will be created containing all original sources and built sources.
 Future<ServeHandler> watch(List<BuilderApplication> builders,
         {bool deleteFilesByDefault,
         bool failOnSevere,
@@ -95,7 +103,8 @@ Future<ServeHandler> watch(List<BuilderApplication> builders,
         Duration debounceDelay,
         DirectoryWatcherFactory directoryWatcherFactory,
         Stream terminateEventStream,
-        bool enableLowResourcesMode}) =>
+        bool enableLowResourcesMode,
+        String outputDir}) =>
     watch_impl.watch(builders,
         assumeTty: assumeTty,
         deleteFilesByDefault: deleteFilesByDefault,
@@ -108,4 +117,5 @@ Future<ServeHandler> watch(List<BuilderApplication> builders,
         debounceDelay: debounceDelay,
         directoryWatcherFactory: directoryWatcherFactory,
         terminateEventStream: terminateEventStream,
-        enableLowResourcesMode: enableLowResourcesMode);
+        enableLowResourcesMode: enableLowResourcesMode,
+        outputDir: outputDir);

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -30,6 +30,7 @@ import '../package_graph/package_graph.dart';
 import '../util/constants.dart';
 import 'build_definition.dart';
 import 'build_result.dart';
+import 'create_merged_dir.dart';
 import 'exceptions.dart';
 import 'fold_frames.dart';
 import 'heartbeat.dart';
@@ -54,6 +55,7 @@ Future<BuildResult> build(
   bool skipBuildScriptCheck,
   bool enableLowResourcesMode,
   Map<String, BuildConfig> overrideBuildConfig,
+  String outputDir,
 }) async {
   packageGraph ??= new PackageGraph.forThisPackage();
   var environment = new OverrideableEnvironment(
@@ -67,7 +69,8 @@ Future<BuildResult> build(
       packageGraph: packageGraph,
       logLevel: logLevel,
       skipBuildScriptCheck: skipBuildScriptCheck,
-      enableLowResourcesMode: enableLowResourcesMode);
+      enableLowResourcesMode: enableLowResourcesMode,
+      outputDir: outputDir);
   var terminator = new Terminator(terminateEventStream);
 
   overrideBuildConfig ??= await findBuildConfigOverrides(options.packageGraph);
@@ -85,8 +88,8 @@ Future<BuildResult> singleBuild(BuildEnvironment environment,
     BuildOptions options, List<BuildAction> buildActions) async {
   var buildDefinition = await BuildDefinition.prepareWorkspace(
       environment, options, buildActions);
-  var result =
-      (await BuildImpl.create(buildDefinition, buildActions)).firstBuild;
+  var result = (await BuildImpl.create(buildDefinition, options, buildActions))
+      .firstBuild;
   await buildDefinition.resourceManager.beforeExit();
   if (result.status == BuildStatus.success &&
       options.failOnSevere &&
@@ -114,21 +117,24 @@ class BuildImpl {
   final _resolvers = const BarbackResolvers();
   final ResourceManager _resourceManager;
   final RunnerAssetWriter _writer;
+  final String _outputDir;
 
-  BuildImpl._(BuildDefinition buildDefinition, this._buildActions)
+  BuildImpl._(
+      BuildDefinition buildDefinition, BuildOptions options, this._buildActions)
       : _packageGraph = buildDefinition.packageGraph,
-        _reader = buildDefinition.enableLowResourcesMode
+        _reader = options.enableLowResourcesMode
             ? buildDefinition.reader
             : new CachingAssetReader(buildDefinition.reader),
         _writer = buildDefinition.writer,
         _assetGraph = buildDefinition.assetGraph,
         _resourceManager = buildDefinition.resourceManager,
-        _onDelete = buildDefinition.onDelete;
+        _onDelete = buildDefinition.onDelete,
+        _outputDir = options.outputDir;
 
-  static Future<BuildImpl> create(
-      BuildDefinition buildDefinition, List<BuildAction> buildActions,
+  static Future<BuildImpl> create(BuildDefinition buildDefinition,
+      BuildOptions options, List<BuildAction> buildActions,
       {void onDelete(AssetId id)}) async {
-    var build = new BuildImpl._(buildDefinition, buildActions);
+    var build = new BuildImpl._(buildDefinition, options, buildActions);
 
     build._firstBuild = await build.run({});
     return build;
@@ -138,11 +144,14 @@ class BuildImpl {
     var watch = new Stopwatch()..start();
     _lazyPhases.clear();
     if (updates.isNotEmpty) {
-      await logTimedAsync(
-          _logger, 'Updating asset graph', () => _updateAssetGraph(updates));
+      await _updateAssetGraph(updates);
     }
     var result = await _safeBuild(_resourceManager);
     await _resourceManager.disposeAll();
+    if (_outputDir != null) {
+      await createMergedOutputDir(
+          _outputDir, _assetGraph, _packageGraph, _reader);
+    }
     if (result.status == BuildStatus.success) {
       _logger.info('Succeeded after ${watch.elapsedMilliseconds}ms with '
           '${result.outputs.length} outputs\n\n');
@@ -158,11 +167,13 @@ class BuildImpl {
   }
 
   Future<Null> _updateAssetGraph(Map<AssetId, ChangeType> updates) async {
-    var invalidated = await _assetGraph.updateAndInvalidate(
-        _buildActions, updates, _packageGraph.root.name, _delete, _reader);
-    if (_reader is CachingAssetReader) {
-      (_reader as CachingAssetReader).invalidate(invalidated);
-    }
+    await logTimedAsync(_logger, 'Updating asset graph', () async {
+      var invalidated = await _assetGraph.updateAndInvalidate(
+          _buildActions, updates, _packageGraph.root.name, _delete, _reader);
+      if (_reader is CachingAssetReader) {
+        (_reader as CachingAssetReader).invalidate(invalidated);
+      }
+    });
   }
 
   /// Runs a build inside a zone with an error handler and stack chain

--- a/build_runner/lib/src/generate/create_merged_dir.dart
+++ b/build_runner/lib/src/generate/create_merged_dir.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+
+import '../asset_graph/graph.dart';
+import '../asset_graph/node.dart';
+import '../logging/logging.dart';
+import '../package_graph/package_graph.dart';
+
+final _logger = new Logger('CreateOutputDir');
+
+/// Creates a merged output directory for a build at [outputPath].
+Future<Null> createMergedOutputDir(String outputPath, AssetGraph assetGraph,
+    PackageGraph packageGraph, AssetReader reader) async {
+  var outputDir = new Directory(outputPath);
+  if (await outputDir.exists()) {
+    await logTimedAsync(_logger, 'Deleting existing output dir `$outputPath`',
+        () => outputDir.delete(recursive: true));
+  }
+  await logTimedAsync(_logger, 'Creating merged output dir at $outputPath',
+      () async {
+    await outputDir.create(recursive: true);
+    var rootDirs = new Set<String>();
+
+    for (var node in assetGraph.packageNodes(packageGraph.root.name)) {
+      if (_shouldSkipNode(node)) continue;
+      var parts = p.url.split(node.id.path);
+      if (parts.length == 1) continue;
+      var dir = parts.first;
+      if (dir == outputPath || dir == 'lib') continue;
+      rootDirs.add(parts.first);
+    }
+
+    for (var node in assetGraph.allNodes) {
+      if (_shouldSkipNode(node)) continue;
+      var assetPaths = <String>[];
+      if (node.id.path.startsWith('lib')) {
+        assetPaths.add(p.url.join('packages', node.id.package,
+            node.id.path.substring('lib/'.length)));
+      } else {
+        assetPaths.add(node.id.path);
+      }
+      for (var path in assetPaths) {
+        var outputId = new AssetId(packageGraph.root.name, path);
+        _writeAsBytes(outputDir, outputId, await reader.readAsBytes(node.id));
+      }
+    }
+
+    var packagesFileContent = packageGraph.allPackages.keys
+        .map((p) => '$p:packages/$p/')
+        .join('\r\n');
+    for (var dir in rootDirs) {
+      _writeAsString(
+          outputDir,
+          new AssetId(packageGraph.root.name, p.url.join(dir, '.packages')),
+          packagesFileContent);
+      var link = new Link(p.join(outputDir.path, dir, 'packages'));
+      link.createSync(p.join('..', 'packages'), recursive: true);
+    }
+  });
+}
+
+bool _shouldSkipNode(AssetNode node) {
+  if (!node.isReadable) return true;
+  if (node is InternalAssetNode) return true;
+  if (node is GeneratedAssetNode && !node.wasOutput) return true;
+  if (node.id.path == '.packages') return true;
+  return false;
+}
+
+void _writeAsBytes(Directory outputDir, AssetId id, List<int> bytes) {
+  var file = _fileFor(outputDir, id);
+  file.writeAsBytesSync(bytes);
+}
+
+void _writeAsString(Directory outputDir, AssetId id, String contents) {
+  var file = _fileFor(outputDir, id);
+  file.writeAsStringSync(contents);
+}
+
+File _fileFor(Directory outputDir, AssetId id) {
+  String relativePath;
+  if (id.path.startsWith('lib')) {
+    relativePath =
+        p.join('packages', id.package, p.joinAll(p.url.split(id.path).skip(1)));
+  } else {
+    relativePath = id.path;
+  }
+  var file = new File(p.join(outputDir.path, relativePath));
+  file.createSync(recursive: true);
+  return file;
+}

--- a/build_runner/lib/src/generate/create_merged_dir.dart
+++ b/build_runner/lib/src/generate/create_merged_dir.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -17,6 +17,7 @@ class BuildOptions {
   bool deleteFilesByDefault;
   bool failOnSevere;
   bool enableLowResourcesMode;
+  final String outputDir;
 
   // Watch mode options.
   Duration debounceDelay;
@@ -34,7 +35,8 @@ class BuildOptions {
       Level logLevel,
       this.packageGraph,
       this.skipBuildScriptCheck,
-      this.enableLowResourcesMode}) {
+      this.enableLowResourcesMode,
+      this.outputDir}) {
     // Set up logging
     logLevel ??= Level.INFO;
 

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:logging/logging.dart';

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -51,6 +51,7 @@ Future<ServeHandler> watch(
   bool skipBuildScriptCheck,
   bool enableLowResourcesMode,
   Map<String, BuildConfig> overrideBuildConfig,
+  String outputDir,
 }) async {
   packageGraph ??= new PackageGraph.forThisPackage();
   var environment = new OverrideableEnvironment(
@@ -66,7 +67,8 @@ Future<ServeHandler> watch(
       logLevel: logLevel,
       debounceDelay: debounceDelay,
       skipBuildScriptCheck: skipBuildScriptCheck,
-      enableLowResourcesMode: enableLowResourcesMode);
+      enableLowResourcesMode: enableLowResourcesMode,
+      outputDir: outputDir);
   var terminator = new Terminator(terminateEventStream);
 
   overrideBuildConfig ??= await findBuildConfigOverrides(options.packageGraph);
@@ -241,7 +243,7 @@ class WatchImpl implements BuildState {
           packageGraph.root.name,
           null));
       _assetGraph = _buildDefinition.assetGraph;
-      build = await BuildImpl.create(_buildDefinition, buildActions,
+      build = await BuildImpl.create(_buildDefinition, options, buildActions,
           onDelete: _expectedDeletes.add);
 
       // It is possible this is already closed if the user kills the process


### PR DESCRIPTION
This also always does the magic for package:test to create html files where they are missing.

Closes https://github.com/dart-lang/build/issues/810.