### PR TITLE
wait to create the build script until after checking for the help command

### DIFF
--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -14,8 +14,6 @@ import 'package:build_runner/src/logging/std_io_logging.dart';
 
 Future<Null> main(List<String> args) async {
   var logListener = Logger.root.onRecord.listen(stdIOLogListener);
-  await ensureBuildScript();
-  var dart = Platform.resolvedExecutable;
 
   // Use the actual command runner to parse the args and immediately print the
   // usage information if there is no command provided or the help command was
@@ -27,6 +25,9 @@ Future<Null> main(List<String> args) async {
     commandRunner.printUsage();
     return;
   }
+
+  await ensureBuildScript();
+  var dart = Platform.resolvedExecutable;
 
   // The actual args we will pass to the generated entrypoint script.
   final innerArgs = [scriptLocation]..addAll(args);


### PR DESCRIPTION
Previously we would do some work even before outputting the help command, start delaying that work until after that point.

related to https://github.com/dart-lang/build/issues/778