### PR TITLE
Add a verbose mode

### DIFF
--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -18,6 +18,7 @@ const _lowResourcesMode = 'low-resources-mode';
 const _failOnSevere = 'fail-on-severe';
 const _hostname = 'hostname';
 const _output = 'output';
+const _verbose = 'verbose';
 
 final _pubBinary = Platform.isWindows ? 'pub.bat' : 'pub';
 
@@ -56,12 +57,15 @@ class _SharedOptions {
   /// created.
   final String outputDir;
 
+  final bool verbose;
+
   _SharedOptions._({
     @required this.assumeTty,
     @required this.deleteFilesByDefault,
     @required this.failOnSevere,
     @required this.enableLowResourcesMode,
     @required this.outputDir,
+    @required this.verbose,
   });
 
   factory _SharedOptions.fromParsedArgs(ArgResults argResults) {
@@ -71,6 +75,7 @@ class _SharedOptions {
       failOnSevere: argResults[_failOnSevere] as bool,
       enableLowResourcesMode: argResults[_lowResourcesMode] as bool,
       outputDir: argResults[_output] as String,
+      verbose: argResults[_verbose] as bool,
     );
   }
 }
@@ -88,6 +93,7 @@ class _ServeOptions extends _SharedOptions {
     @required bool failOnSevere,
     @required bool enableLowResourcesMode,
     @required String outputDir,
+    @required bool verbose,
   })
       : super._(
           assumeTty: assumeTty,
@@ -95,6 +101,7 @@ class _ServeOptions extends _SharedOptions {
           failOnSevere: failOnSevere,
           enableLowResourcesMode: enableLowResourcesMode,
           outputDir: outputDir,
+          verbose: verbose,
         );
 
   factory _ServeOptions.fromParsedArgs(ArgResults argResults) {
@@ -119,6 +126,7 @@ class _ServeOptions extends _SharedOptions {
       failOnSevere: argResults[_failOnSevere] as bool,
       enableLowResourcesMode: argResults[_lowResourcesMode] as bool,
       outputDir: argResults[_output] as String,
+      verbose: argResults[_verbose] as bool,
     );
   }
 }
@@ -167,7 +175,12 @@ abstract class _BaseCommand extends Command {
           negatable: true,
           defaultsTo: false)
       ..addOption(_output,
-          help: 'A directory to write the result of a build to.', abbr: 'o');
+          help: 'A directory to write the result of a build to.', abbr: 'o')
+      ..addFlag('verbose',
+          abbr: 'v',
+          defaultsTo: false,
+          negatable: false,
+          help: 'Enables verbose logging.');
   }
 
   /// Must be called inside [run] so that [argResults] is non-null.
@@ -194,7 +207,8 @@ class _BuildCommand extends _BaseCommand {
         deleteFilesByDefault: options.deleteFilesByDefault,
         enableLowResourcesMode: options.enableLowResourcesMode,
         assumeTty: options.assumeTty,
-        outputDir: options.outputDir);
+        outputDir: options.outputDir,
+        verbose: options.verbose);
   }
 }
 
@@ -216,7 +230,8 @@ class _WatchCommand extends _BaseCommand {
         deleteFilesByDefault: options.deleteFilesByDefault,
         enableLowResourcesMode: options.enableLowResourcesMode,
         assumeTty: options.assumeTty,
-        outputDir: options.outputDir);
+        outputDir: options.outputDir,
+        verbose: options.verbose);
     await handler.currentBuild;
     await handler.buildResults.drain();
   }
@@ -248,7 +263,8 @@ class _ServeCommand extends _WatchCommand {
         deleteFilesByDefault: options.deleteFilesByDefault,
         enableLowResourcesMode: options.enableLowResourcesMode,
         assumeTty: options.assumeTty,
-        outputDir: options.outputDir);
+        outputDir: options.outputDir,
+        verbose: options.verbose);
     var servers = await Future.wait(options.serveTargets.map((target) =>
         serve(handler.handlerFor(target.dir), options.hostName, target.port)));
     await handler.currentBuild;
@@ -289,7 +305,8 @@ class _TestCommand extends _BaseCommand {
         deleteFilesByDefault: options.deleteFilesByDefault,
         enableLowResourcesMode: options.enableLowResourcesMode,
         assumeTty: options.assumeTty,
-        outputDir: outputDir);
+        outputDir: outputDir,
+        verbose: options.verbose);
 
     // Run the tests!
     await _runTests(outputDir);

--- a/build_runner/lib/src/environment/io_environment.dart
+++ b/build_runner/lib/src/environment/io_environment.dart
@@ -29,10 +29,12 @@ class IOEnvironment implements BuildEnvironment {
 
   final bool _isInteractive;
   final bool _assumeTty;
+  final bool _verbose;
 
-  IOEnvironment(PackageGraph packageGraph, bool assumeTty)
+  IOEnvironment(PackageGraph packageGraph, bool assumeTty, {bool verbose})
       : _isInteractive = assumeTty ?? _canPrompt(),
         _assumeTty = assumeTty,
+        _verbose = verbose ?? false,
         reader = new FileBasedAssetReader(packageGraph),
         writer = new FileBasedAssetWriter(packageGraph),
         directoryWatcherFactory = defaultDirectoryWatcherFactory;
@@ -40,7 +42,7 @@ class IOEnvironment implements BuildEnvironment {
   @override
   void onLog(LogRecord record) {
     overrideAnsiOutput(_assumeTty == true || ansiOutputEnabled, () {
-      stdIOLogListener(record);
+      stdIOLogListener(record, verbose: _verbose);
     });
   }
 

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -43,6 +43,10 @@ import 'watch_impl.dart' as watch_impl;
 ///
 /// If [outputDir] is supplied then after each build a merged output directory
 /// will be created containing all original sources and built sources.
+///
+/// If [verbose] is `true` then verbose logging will be enabled. This changes
+/// the default [logLevel] to [Level.ALL] and removes stack frame folding, among
+/// other things.
 Future<BuildResult> build(List<BuilderApplication> builders,
         {bool deleteFilesByDefault,
         bool failOnSevere,
@@ -54,7 +58,8 @@ Future<BuildResult> build(List<BuilderApplication> builders,
         onLog(LogRecord record),
         Stream terminateEventStream,
         bool enableLowResourcesMode,
-        String outputDir}) =>
+        String outputDir,
+        bool verbose}) =>
     build_impl.build(builders,
         assumeTty: assumeTty,
         deleteFilesByDefault: deleteFilesByDefault,
@@ -66,7 +71,8 @@ Future<BuildResult> build(List<BuilderApplication> builders,
         onLog: onLog,
         terminateEventStream: terminateEventStream,
         enableLowResourcesMode: enableLowResourcesMode,
-        outputDir: outputDir);
+        outputDir: outputDir,
+        verbose: verbose);
 
 /// Same as [build], except it watches the file system and re-runs builds
 /// automatically.
@@ -104,7 +110,8 @@ Future<ServeHandler> watch(List<BuilderApplication> builders,
         DirectoryWatcherFactory directoryWatcherFactory,
         Stream terminateEventStream,
         bool enableLowResourcesMode,
-        String outputDir}) =>
+        String outputDir,
+        bool verbose}) =>
     watch_impl.watch(builders,
         assumeTty: assumeTty,
         deleteFilesByDefault: deleteFilesByDefault,
@@ -118,4 +125,5 @@ Future<ServeHandler> watch(List<BuilderApplication> builders,
         directoryWatcherFactory: directoryWatcherFactory,
         terminateEventStream: terminateEventStream,
         enableLowResourcesMode: enableLowResourcesMode,
-        outputDir: outputDir);
+        outputDir: outputDir,
+        verbose: verbose);

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -32,6 +32,7 @@ class BuildOptions {
   bool failOnSevere;
   bool enableLowResourcesMode;
   final String outputDir;
+  bool verbose;
 
   // Watch mode options.
   Duration debounceDelay;
@@ -51,9 +52,10 @@ class BuildOptions {
       Level logLevel,
       this.skipBuildScriptCheck,
       this.enableLowResourcesMode,
-      this.outputDir}) {
+      this.outputDir,
+      this.verbose}) {
     // Set up logging
-    logLevel ??= Level.INFO;
+    logLevel ??= verbose ? Level.ALL : Level.INFO;
 
     // Invalid to have Level.OFF but want severe logs to fail the build.
     if (logLevel == Level.OFF && failOnSevere == true) {
@@ -75,6 +77,7 @@ class BuildOptions {
     failOnSevere ??= false;
     skipBuildScriptCheck ??= false;
     enableLowResourcesMode ??= false;
+    verbose ??= false;
 
     if (rootPackageConfig == null ||
         (rootPackageConfig.buildTargets.length == 1 &&

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -54,6 +54,7 @@ Future<ServeHandler> watch(
   bool enableLowResourcesMode,
   Map<String, BuildConfig> overrideBuildConfig,
   String outputDir,
+  bool verbose,
 }) async {
   packageGraph ??= new PackageGraph.forThisPackage();
   final targetGraph = await TargetGraph.forPackageGraph(packageGraph,
@@ -73,7 +74,8 @@ Future<ServeHandler> watch(
       debounceDelay: debounceDelay,
       skipBuildScriptCheck: skipBuildScriptCheck,
       enableLowResourcesMode: enableLowResourcesMode,
-      outputDir: outputDir);
+      outputDir: outputDir,
+      verbose: verbose);
   var terminator = new Terminator(terminateEventStream);
 
   overrideBuildConfig ??= await findBuildConfigOverrides(options.packageGraph);

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -9,7 +9,8 @@ import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
 import 'package:stack_trace/stack_trace.dart';
 
-void stdIOLogListener(LogRecord record) {
+void stdIOLogListener(LogRecord record, {bool verbose}) {
+  verbose ??= false;
   AnsiCode color;
   if (record.level < Level.WARNING) {
     color = cyan;
@@ -19,9 +20,8 @@ void stdIOLogListener(LogRecord record) {
     color = red;
   }
   final level = color.wrap('[${record.level}]');
-  var header = '${ansiOutputEnabled ? '\x1b[2K\r' : ''}'
-      '$level ${record.loggerName}: '
-      '${record.message}';
+  final eraseLine = ansiOutputEnabled && !verbose ? '\x1b[2K\r' : '';
+  var header = '$eraseLine$level ${record.loggerName}: ${record.message}';
   var lines = <Object>[header];
 
   if (record.error != null) {
@@ -42,7 +42,7 @@ void stdIOLogListener(LogRecord record) {
   // isn't multiline unless we see > 2 lines.
   var multiLine = LineSplitter.split(message.toString()).length > 2;
 
-  if (record.level > Level.INFO || !ansiOutputEnabled || multiLine) {
+  if (record.level > Level.INFO || !ansiOutputEnabled || multiLine || verbose) {
     // Add an extra line to the output so the last line isn't written over.
     message.writeln('');
   }

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -85,6 +85,7 @@ Future<BuildResult> testBuilders(
   bool deleteFilesByDefault: true,
   bool enableLowResourcesMode: false,
   Map<String, BuildConfig> overrideBuildConfig,
+  bool verbose: false,
 }) async {
   writer ??= new InMemoryRunnerAssetWriter();
   reader ??= new InMemoryRunnerAssetReader.shareAssetCache(writer.assets,
@@ -113,6 +114,7 @@ Future<BuildResult> testBuilders(
     skipBuildScriptCheck: true,
     enableLowResourcesMode: enableLowResourcesMode,
     overrideBuildConfig: overrideBuildConfig,
+    verbose: verbose,
   );
 
   if (checkBuildStatus) {

--- a/build_runner/test/generate/stack_trace_test.dart
+++ b/build_runner/test/generate/stack_trace_test.dart
@@ -23,24 +23,42 @@ const _badOutput = r'''
 //
 // Regression test for https://github.com/dart-lang/build/issues/427.
 void main() {
-  test('should throw a readable/terse stack trace', () async {
-    final result = await testBuilders([
-      applyToRoot(new BadCodeBuilder())
-    ], {
+  group('stack traces', () {
+    final builderApplications = [applyToRoot(new BadCodeBuilder())];
+    final inputs = {
       'a|lib/a.dart': 'class Foo {}',
-    }, outputs: {
-      'a|lib/a.g.dart': _badOutput
-    }, checkBuildStatus: false);
+    };
+    final outputs = {'a|lib/a.g.dart': _badOutput};
 
-    expect(result.status, BuildStatus.failure,
-        reason: 'Dartfmt should fail due to invalid code emitted');
-    final trace = new Trace.from(result.stackTrace);
-    expect(trace.frames.map((f) => f.package), contains('dart_style'),
-        reason: 'Should have failed due to a dartfmt error');
-    expect(trace.toString(), trace.terse.toString(), reason: 'Should be terse');
-    expect(trace.foldFrames((f) => f.package == 'build_runner').toString(),
-        trace.toString(),
-        reason: 'Should fold build package frames');
+    test('should be folded/terse by default', () async {
+      final result = await testBuilders(builderApplications, inputs,
+          outputs: outputs, checkBuildStatus: false);
+      expect(result.status, BuildStatus.failure,
+          reason: 'Dartfmt should fail due to invalid code emitted');
+      final trace = new Trace.from(result.stackTrace);
+      expect(trace.frames.map((f) => f.package), contains('dart_style'),
+          reason: 'Should have failed due to a dartfmt error');
+      expect(trace.toString(), trace.terse.toString(),
+          reason: 'Should be terse');
+      expect(trace.foldFrames((f) => f.package == 'build_runner').toString(),
+          trace.toString(),
+          reason: 'Should fold build package frames');
+    });
+
+    test('should not be folded/terse in verbose mode', () async {
+      final result = await testBuilders(builderApplications, inputs,
+          outputs: outputs, checkBuildStatus: false, verbose: true);
+      expect(result.status, BuildStatus.failure,
+          reason: 'Dartfmt should fail due to invalid code emitted');
+      final trace = new Trace.from(result.stackTrace);
+      expect(trace.frames.map((f) => f.package), contains('dart_style'),
+          reason: 'Should have failed due to a dartfmt error');
+      expect(trace.toString(), isNot(trace.terse.toString()),
+          reason: 'Should not be terse');
+      expect(trace.foldFrames((f) => f.package == 'build_runner').toString(),
+          isNot(trace.toString()),
+          reason: 'Should not fold build package frames');
+    });
   });
 }
 


### PR DESCRIPTION
Adds the --verbose flag (with -v shorthand). This stops using folded/terse stack traces, sets the default log level to Level.ALL, and stops overwriting all logs < Level.INFO. 