### PR TITLE
Fix prompt when assumeTty is false

### DIFF
--- a/build_runner/lib/src/environment/io_environment.dart
+++ b/build_runner/lib/src/environment/io_environment.dart
@@ -32,7 +32,7 @@ class IOEnvironment implements BuildEnvironment {
   final bool _verbose;
 
   IOEnvironment(PackageGraph packageGraph, bool assumeTty, {bool verbose})
-      : _isInteractive = assumeTty ?? _canPrompt(),
+      : _isInteractive = assumeTty ? true : _canPrompt(),
         _assumeTty = assumeTty,
         _verbose = verbose ?? false,
         reader = new FileBasedAssetReader(packageGraph),

--- a/build_runner/lib/src/environment/io_environment.dart
+++ b/build_runner/lib/src/environment/io_environment.dart
@@ -32,7 +32,7 @@ class IOEnvironment implements BuildEnvironment {
   final bool _verbose;
 
   IOEnvironment(PackageGraph packageGraph, bool assumeTty, {bool verbose})
-      : _isInteractive = assumeTty ? true : _canPrompt(),
+      : _isInteractive = assumeTty == true || _canPrompt(),
         _assumeTty = assumeTty,
         _verbose = verbose ?? false,
         reader = new FileBasedAssetReader(packageGraph),

--- a/build_runner/test/environment/io_environment_test.dart
+++ b/build_runner/test/environment/io_environment_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import "package:async/async.dart";
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  Process process;
+  StreamQueue<String> stdoutLines;
+
+  setUpAll(() async {
+    process = await Process.start(Platform.resolvedExecutable,
+        [p.join('test', 'environment', 'simple_prompt.dart')]);
+    stdoutLines = new StreamQueue(process.stdout
+        .transform(new Utf8Decoder())
+        .transform(new LineSplitter()));
+  });
+
+  test('Can give the user interactive prompts', () async {
+    await expectEmits(stdoutLines, contains('Select an option!'));
+    await expectEmits(stdoutLines, contains('1 - a'));
+    await expectEmits(stdoutLines, contains('2 - b'));
+    await expectEmits(stdoutLines, contains('3 - c'));
+
+    process.stdin.writeln('4');
+    expect(await stdoutLines.next, contains('Unrecognized option 4'));
+
+    process.stdin.writeln('3');
+    await expectEmits(stdoutLines, contains('2'));
+    await process.exitCode;
+  });
+}
+
+Future<Null> expectEmits(StreamQueue<String> stream, Matcher line) async {
+  while (true) {
+    if (line.matches(await stream.next, null)) {
+      return;
+    }
+  }
+}

--- a/build_runner/test/environment/simple_prompt.dart
+++ b/build_runner/test/environment/simple_prompt.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build_runner/build_runner.dart';
+import 'package:logging/logging.dart';
+
+import 'package:build_runner/src/environment/io_environment.dart';
+
+main() async {
+  var env = new IOEnvironment(new PackageGraph.forThisPackage(), true);
+  var result = await env.prompt('Select an option!', ['a', 'b', 'c']);
+  Logger.root.onRecord.listen(env.onLog);
+  new Logger('Simple Logger').info(result);
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/826.

I added a basic test but I couldn't think of how to reasonable test this exact scenario actually, lmk if you have any ideas. The real bug was when you are connected to a terminal but don't pass --assume-tty, but we can't replicate that with package:test in a way that I can think of.
  