### PR TITLE
Add TestBuilder

### DIFF
--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -39,3 +39,7 @@ dev_dependencies:
   package_resolver: ^1.0.2
   test: ^0.12.0
   test_descriptor: ^1.0.0
+
+dependency_overrides:
+  build_test:
+    path: ../build_test

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   yaml: ^2.1.0
 
 dev_dependencies:
-  build_test: ^0.9.4
+  build_test: ^0.9.5
   package_resolver: ^1.0.2
   test: ^0.12.0
   test_descriptor: ^1.0.0

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -135,7 +135,8 @@ void main() {
     group('with buildActions', () {
       final buildActions = [
         new BuildAction(
-            new CopyBuilder(inputExtension: '.txt', extension: 'txt.copy'),
+            new TestBuilder(
+                buildExtensions: appendExtension('.copy', from: '.txt')),
             'foo',
             targetSources: const InputSet(exclude: const ['excluded.txt']))
       ];
@@ -286,7 +287,7 @@ void main() {
     test('overlapping build actions cause an error', () async {
       expect(
           () => AssetGraph.build(
-              new List.filled(2, new BuildAction(new CopyBuilder(), 'foo')),
+              new List.filled(2, new BuildAction(new TestBuilder(), 'foo')),
               [makeAssetId('foo|file')].toSet(),
               new Set(),
               fooPackageGraph,

--- a/build_runner/test/common/common.dart
+++ b/build_runner/test/common/common.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:build/build.dart';
-import 'package:build_test/build_test.dart';
 import 'package:crypto/crypto.dart';
 
 export 'package:build_runner/src/util/constants.dart';
@@ -22,15 +21,6 @@ export 'sdk.dart';
 export 'test_phases.dart';
 
 Digest computeDigest(String contents) => md5.convert(UTF8.encode(contents));
-
-class OverDeclaringCopyBuilder extends CopyBuilder {
-  OverDeclaringCopyBuilder({int numCopies: 1, String extension: 'copy'})
-      : super(numCopies: numCopies, extension: extension);
-
-  // Override to not actually output anything.
-  @override
-  Future build(BuildStep buildStep) async {}
-}
 
 class ExistsBuilder extends Builder {
   final AssetId idToCheck;

--- a/build_runner/test/generate/build_configuration_test.dart
+++ b/build_runner/test/generate/build_configuration_test.dart
@@ -13,8 +13,10 @@ import '../common/common.dart';
 
 void main() {
   test('uses builder options', () async {
-    Builder copyBuilder(BuilderOptions options) => new CopyBuilder(
-        inputExtension: options.config['inputExtension'] as String ?? '');
+    Builder copyBuilder(BuilderOptions options) => new TestBuilder(
+        buildExtensions: replaceExtension(
+            options.config['inputExtension'] as String, '.copy'));
+
     final buildConfigs = parseBuildConfigs({
       'a': {
         'targets': {

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -87,7 +87,7 @@ main() {
         await createFile(p.join('lib', 'a.txt'), 'a');
         await createFile(p.join('lib', 'b.txt'), 'b');
         var buildActions = [
-          new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+          new BuildAction(new TestBuilder(), 'a', hideOutput: true)
         ];
 
         var originalAssetGraph = await AssetGraph.build(
@@ -121,7 +121,7 @@ main() {
 
       test('for new sources and generated nodes', () async {
         var buildActions = [
-          new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+          new BuildAction(new TestBuilder(), 'a', hideOutput: true)
         ];
 
         var originalAssetGraph = await AssetGraph.build(buildActions,
@@ -146,7 +146,7 @@ main() {
       test('for changed sources', () async {
         await createFile(p.join('lib', 'a.txt'), 'a');
         var buildActions = [
-          new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+          new BuildAction(new TestBuilder(), 'a', hideOutput: true)
         ];
 
         var originalAssetGraph = await AssetGraph.build(
@@ -173,7 +173,8 @@ main() {
       test('retains non-output generated nodes', () async {
         await createFile(p.join('lib', 'test.txt'), 'a');
         var buildActions = [
-          new BuildAction(new OverDeclaringCopyBuilder(), 'a', hideOutput: true)
+          new BuildAction(new TestBuilder(build: (_, __) {}), 'a',
+              hideOutput: true)
         ];
 
         var originalAssetGraph = await AssetGraph.build(
@@ -198,8 +199,9 @@ main() {
       test('for changed BuilderOptions', () async {
         await createFile(p.join('lib', 'a.txt'), 'a');
         var buildActions = [
-          new BuildAction(new CopyBuilder(), 'a', hideOutput: true),
-          new BuildAction(new CopyBuilder(extension: 'clone'), 'a',
+          new BuildAction(new TestBuilder(), 'a', hideOutput: true),
+          new BuildAction(
+              new TestBuilder(buildExtensions: appendExtension('.clone')), 'a',
               targetSources: const InputSet(include: const ['**/*.txt']),
               hideOutput: true),
         ];
@@ -223,10 +225,11 @@ main() {
 
         // Same as before, but change the `BuilderOptions` for the first action.
         var newBuildActions = [
-          new BuildAction(new CopyBuilder(), 'a',
+          new BuildAction(new TestBuilder(), 'a',
               builderOptions: new BuilderOptions({'test': 'option'}),
               hideOutput: true),
-          new BuildAction(new CopyBuilder(extension: 'clone'), 'a',
+          new BuildAction(
+              new TestBuilder(buildExtensions: appendExtension('.clone')), 'a',
               targetSources: const InputSet(include: const ['**/*.txt']),
               hideOutput: true),
         ];
@@ -255,7 +258,8 @@ main() {
         await createFile(generatedId.path, 'a');
         var buildActions = [
           new BuildAction(
-              new CopyBuilder(inputExtension: '.txt', extension: 'txt.copy'),
+              new TestBuilder(
+                  buildExtensions: appendExtension('.copy', from: '.txt')),
               'a',
               hideOutput: true)
         ];
@@ -287,7 +291,7 @@ main() {
         var entryPoint =
             new AssetId('a', p.url.join(entryPointDir, 'build.dart'));
         var buildActions = [
-          new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+          new BuildAction(new TestBuilder(), 'a', hideOutput: true)
         ];
         var buildDefinition = await BuildDefinition.prepareWorkspace(
             environment, options, buildActions);
@@ -304,7 +308,7 @@ main() {
       await options.logListener.cancel();
 
       var buildActions = [
-        new BuildAction(new CopyBuilder(), 'a', hideOutput: true)
+        new BuildAction(new TestBuilder(), 'a', hideOutput: true)
       ];
       var logs = <LogRecord>[];
       environment = new OverrideableEnvironment(environment, onLog: logs.add);
@@ -319,7 +323,7 @@ main() {
       await createFile(
           assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
 
-      buildActions.add(new BuildAction(new CopyBuilder(), 'a',
+      buildActions.add(new BuildAction(new TestBuilder(), 'a',
           targetSources: const InputSet(include: const ['.copy']),
           hideOutput: true));
       logs.clear();
@@ -346,7 +350,7 @@ main() {
       await options.logListener.cancel();
 
       var buildActions = [
-        new BuildAction(new CopyBuilder(), 'a',
+        new BuildAction(new TestBuilder(), 'a',
             hideOutput: true,
             builderOptions: new BuilderOptions({'foo': 'bar'}))
       ];
@@ -364,7 +368,7 @@ main() {
           assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
 
       buildActions = [
-        new BuildAction(new CopyBuilder(), 'a',
+        new BuildAction(new TestBuilder(), 'a',
             hideOutput: true,
             builderOptions: new BuilderOptions({'baz': 'zap'}))
       ];

--- a/build_runner/test/generate/build_error_test.dart
+++ b/build_runner/test/generate/build_error_test.dart
@@ -19,7 +19,7 @@ void main() {
   test('fail if an output is on disk and !deleteFilesByDefault', () async {
     expect(
       testBuilders(
-        [applyToRoot(new CopyBuilder())],
+        [applyToRoot(new TestBuilder())],
         {
           'a|lib/a.dart': '',
           'a|lib/a.dart.copy': '',

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -18,7 +18,7 @@ import 'package:build_test/build_test.dart';
 
 main(List<String> args) async {
   await run(
-      args, [applyToRoot(new CopyBuilder())]);
+      args, [applyToRoot(new TestBuilder())]);
 }
 ''';
       setUp(() async {
@@ -270,9 +270,9 @@ import 'package:build_test/build_test.dart';
 
 main() async {
   await build([
-    applyToRoot(new CopyBuilder()),
-    applyToRoot(new CopyBuilder(
-        inputExtension: '.txt.copy', extension: 'txt.copy.copy')),
+    applyToRoot(new TestBuilder()),
+    applyToRoot(new TestBuilder(
+        buildExtensions: appendExtension('.copy', from: '.txt.copy'))),
   ]);
 }
 ''')

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -19,7 +19,7 @@ import '../common/package_graphs.dart';
 void main() {
   /// Basic phases/phase groups which get used in many tests
   final copyABuilderApplication = applyToRoot(
-      new CopyBuilder(inputExtension: '.txt', extension: 'txt.copy'));
+      new TestBuilder(buildExtensions: appendExtension('.copy', from: '.txt')));
   final globBuilder = new GlobbingBuilder(new Glob('**.txt'));
   final defaultBuilderOptions = const BuilderOptions(const {});
   final placeholders =
@@ -43,7 +43,8 @@ void main() {
 
       test('one phase, one builder, one-to-many outputs', () async {
         await testBuilders([
-          applyToRoot(new CopyBuilder(numCopies: 2))
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.copy', numCopies: 2)))
         ], {
           'a|web/a.txt': 'a',
           'a|lib/b.txt': 'b',
@@ -58,9 +59,17 @@ void main() {
       test('optional build actions don\'t run if their outputs aren\'t read',
           () async {
         await testBuilders([
-          apply('', [(_) => new CopyBuilder(extension: '1')], toRoot(),
+          apply(
+              '',
+              [(_) => new TestBuilder(buildExtensions: appendExtension('.1'))],
+              toRoot(),
               isOptional: true),
-          apply('a|only_on_1', [(_) => new CopyBuilder(inputExtension: '1')],
+          apply(
+              'a|only_on_1',
+              [
+                (_) => new TestBuilder(
+                    buildExtensions: appendExtension('.copy', from: '.1'))
+              ],
               toRoot(),
               isOptional: true),
         ], {
@@ -70,17 +79,27 @@ void main() {
 
       test('optional build actions do run if their outputs are read', () async {
         await testBuilders([
-          apply('', [(_) => new CopyBuilder(extension: '1')], toRoot(),
-              isOptional: true, hideOutput: false),
           apply(
               '',
-              [(_) => new CopyBuilder(inputExtension: '.1', extension: '2')],
+              [(_) => new TestBuilder(buildExtensions: appendExtension('.1'))],
               toRoot(),
               isOptional: true,
               hideOutput: false),
           apply(
               '',
-              [(_) => new CopyBuilder(inputExtension: '.2', extension: '3')],
+              [
+                (_) => new TestBuilder(
+                    buildExtensions: replaceExtension('.1', '.2'))
+              ],
+              toRoot(),
+              isOptional: true,
+              hideOutput: false),
+          apply(
+              '',
+              [
+                (_) => new TestBuilder(
+                    buildExtensions: replaceExtension('.2', '.3'))
+              ],
               toRoot(),
               hideOutput: false),
         ], {
@@ -95,10 +114,21 @@ void main() {
       test('multiple mixed build actions with custom build config', () async {
         var builders = [
           copyABuilderApplication,
-          apply('a|clone_txt', [(_) => new CopyBuilder(extension: 'clone')],
+          apply(
+              'a|clone_txt',
+              [
+                (_) =>
+                    new TestBuilder(buildExtensions: appendExtension('.clone'))
+              ],
               toRoot(),
-              isOptional: true, hideOutput: false),
-          apply('a|copy_web_clones', [(_) => new CopyBuilder(numCopies: 2)],
+              isOptional: true,
+              hideOutput: false),
+          apply(
+              'a|copy_web_clones',
+              [
+                (_) => new TestBuilder(
+                    buildExtensions: appendExtension('.copy', numCopies: 2))
+              ],
               toRoot(),
               hideOutput: false),
         ];
@@ -139,10 +169,11 @@ void main() {
       test('early step touches a not-yet-generated asset', () async {
         var copyId = new AssetId('a', 'lib/file.a.copy');
         var builders = [
-          applyToRoot(new CopyBuilder(
-              touchAsset: copyId, inputExtension: '.b', extension: 'b.copy')),
-          applyToRoot(
-              new CopyBuilder(inputExtension: '.a', extension: 'a.copy')),
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.b'),
+              extraWork: (buildStep, _) => buildStep.canRead(copyId))),
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.a'))),
           applyToRoot(new ExistsBuilder(copyId, inputExtension: '.a')),
         ];
         await testBuilders(builders, {
@@ -202,8 +233,8 @@ void main() {
         var writer = new InMemoryRunnerAssetWriter();
         await testBuilders([
           copyABuilderApplication,
-          applyToRoot(
-              new CopyBuilder(inputExtension: '.copy', extension: 'copy.clone'))
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.clone', from: '.copy')))
         ], {
           'a|web/a.txt': 'a',
           'a|web/a.txt.copy': 'a',
@@ -247,10 +278,9 @@ void main() {
             outputs: {'a|web/a.txt.copy': 'a'}, writer: writer);
 
         var blockingCompleter = new Completer<Null>();
-        var builder = new CopyBuilder(
-            blockUntil: blockingCompleter.future,
-            inputExtension: '.txt',
-            extension: 'txt.copy');
+        var builder = new TestBuilder(
+            buildExtensions: appendExtension('.copy', from: '.txt'),
+            extraWork: (_, __) => blockingCompleter.future);
         var done = testBuilders([applyToRoot(builder)], {'a|web/a.txt': 'b'},
             outputs: {'a|web/a.txt.copy': 'b'}, writer: writer);
 
@@ -278,7 +308,7 @@ void main() {
       });
       await testBuilders(
           [
-            apply('', [(_) => new CopyBuilder()], toPackage('b'),
+            apply('', [(_) => new TestBuilder()], toPackage('b'),
                 hideOutput: false)
           ],
           {'b|lib/b.txt': 'b'},
@@ -298,7 +328,7 @@ void main() {
       test('can output files in non-root packages', () async {
         await testBuilders(
             [
-              apply('', [(_) => new CopyBuilder()], toPackage('b'),
+              apply('', [(_) => new TestBuilder()], toPackage('b'),
                   hideOutput: true),
             ],
             {'b|lib/b.txt': 'b'},
@@ -311,9 +341,14 @@ void main() {
       test('handles mixed hidden and non-hidden outputs', () async {
         await testBuilders(
             [
-              apply('', [(_) => new CopyBuilder()], toRoot(),
+              apply('', [(_) => new TestBuilder()], toRoot(),
                   hideOutput: false),
-              apply('', [(_) => new CopyBuilder(extension: 'hiddencopy')],
+              apply(
+                  '',
+                  [
+                    (_) => new TestBuilder(
+                        buildExtensions: appendExtension('.hiddencopy'))
+                  ],
                   toRoot(),
                   hideOutput: true),
             ],
@@ -336,7 +371,7 @@ void main() {
           };
         await testBuilders(
             [
-              apply('', [(_) => new CopyBuilder()], toPackage('b'),
+              apply('', [(_) => new TestBuilder()], toPackage('b'),
                   hideOutput: true)
             ],
             {
@@ -353,7 +388,11 @@ void main() {
       var builders = [
         apply(
             '',
-            [(_) => new CopyBuilder(touchAsset: makeAssetId('b|lib/b.txt'))],
+            [
+              (_) => new TestBuilder(
+                  extraWork: (buildStep, _) =>
+                      buildStep.canRead(makeAssetId('b|lib/b.txt')))
+            ],
             toRoot(),
             hideOutput: false)
       ];
@@ -397,7 +436,7 @@ void main() {
 
     test('can glob files from packages with excludes applied', () async {
       await testBuilders(
-          [applyToRoot(new CopyBuilder())],
+          [applyToRoot(new TestBuilder())],
           {
             'a|lib/a/1.txt': '',
             'a|lib/a/2.txt': '',
@@ -423,7 +462,7 @@ void main() {
 
     test('can build on files outside the hardcoded whitelist', () async {
       await testBuilders(
-          [applyToRoot(new CopyBuilder())], {'a|test_files/a.txt': 'a'},
+          [applyToRoot(new TestBuilder())], {'a|test_files/a.txt': 'a'},
           overrideBuildConfig: parseBuildConfigs({
             'a': {
               'targets': {
@@ -441,8 +480,8 @@ void main() {
         apply(
             '',
             [
-              (_) => new CopyBuilder(
-                  copyFromAsset: makeAssetId('a|.dart_tool/any_file'))
+              (_) => new TestBuilder(
+                  build: copyFrom(makeAssetId('a|.dart_tool/any_file')))
             ],
             toRoot())
       ], {
@@ -462,7 +501,7 @@ void main() {
             throw 'Should not delete outside of package:a';
           }
         };
-      await testBuilders([applyToRoot(new CopyBuilder())],
+      await testBuilders([applyToRoot(new TestBuilder())],
           {'a|lib/a.txt': 'a', 'b|lib/b.txt': 'b', 'b|lib/b.txt.copy': 'b'},
           packageGraph: packageGraph,
           writer: writer,
@@ -474,10 +513,12 @@ void main() {
     test('Overdeclared outputs are not treated as inputs to later steps',
         () async {
       var builders = [
-        applyToRoot(new OverDeclaringCopyBuilder(
-            numCopies: 1, extension: 'unexpected')),
-        applyToRoot(new CopyBuilder(extension: 'expected')),
-        applyToRoot(new CopyBuilder()),
+        applyToRoot(new TestBuilder(
+            buildExtensions: appendExtension('.unexpected'),
+            build: (_, __) {})),
+        applyToRoot(
+            new TestBuilder(buildExtensions: appendExtension('.expected'))),
+        applyToRoot(new TestBuilder()),
       ];
       await testBuilders(builders, {
         'a|lib/a.txt': 'a',
@@ -621,8 +662,8 @@ void main() {
     test('graph/file system get cleaned up for deleted inputs', () async {
       var builders = [
         copyABuilderApplication,
-        applyToRoot(
-            new CopyBuilder(inputExtension: '.copy', extension: 'clone'))
+        applyToRoot(new TestBuilder(
+            buildExtensions: replaceExtension('.copy', '.clone')))
       ];
 
       // Initial build.
@@ -685,7 +726,7 @@ void main() {
 
     test('no outputs if no changed sources using `hideOutput: true`', () async {
       var builders = [
-        apply('', [(_) => new CopyBuilder()], toRoot(), hideOutput: true)
+        apply('', [(_) => new TestBuilder()], toRoot(), hideOutput: true)
       ];
 
       // Initial build.
@@ -709,10 +750,9 @@ void main() {
       // Initial build.
       var writer = new InMemoryRunnerAssetWriter();
       await testBuilders([
-        applyToRoot(new CopyBuilder(
-            copyFromAsset: makeAssetId('a|lib/file.b'),
-            inputExtension: '.a',
-            extension: 'a.copy')),
+        applyToRoot(new TestBuilder(
+            buildExtensions: appendExtension('.copy', from: '.a'),
+            build: copyFrom(makeAssetId('a|lib/file.b')))),
       ], {
         'a|lib/file.a': 'a',
         'a|lib/file.b': 'b',
@@ -727,10 +767,9 @@ void main() {
       writer.assets.clear();
 
       await testBuilders([
-        applyToRoot(new CopyBuilder(
-            copyFromAsset: makeAssetId('a|lib/file.c'),
-            inputExtension: '.a',
-            extension: 'a.copy')),
+        applyToRoot(new TestBuilder(
+            buildExtensions: appendExtension('.copy', from: '.a'),
+            build: copyFrom(makeAssetId('a|lib/file.c')))),
       ], {
         'a|lib/file.a': 'a',
         'a|lib/file.a.copy': 'b',
@@ -759,12 +798,11 @@ void main() {
 
     test('Ouputs aren\'t rebuilt if their inputs didn\'t change', () async {
       var builders = [
-        applyToRoot(new CopyBuilder(
-            copyFromAsset: new AssetId('a', 'lib/file.b'),
-            inputExtension: '.a',
-            extension: 'a.copy')),
-        applyToRoot(new CopyBuilder(
-            inputExtension: '.a.copy', extension: 'a.copy.copy')),
+        applyToRoot(new TestBuilder(
+            buildExtensions: appendExtension('.copy', from: '.a'),
+            build: copyFrom(makeAssetId('a|lib/file.b')))),
+        applyToRoot(new TestBuilder(
+            buildExtensions: appendExtension('.copy', from: '.a.copy'))),
       ];
 
       // Initial build.

--- a/build_runner/test/generate/performance_tracker_test.dart
+++ b/build_runner/test/generate/performance_tracker_test.dart
@@ -38,7 +38,7 @@ main() {
     test('can track multiple actions', () async {
       await scopeClock(fakeClock, () async {
         var packages = ['a', 'b', 'c'];
-        var builder = new CopyBuilder();
+        var builder = new TestBuilder();
         var actions = packages.map((p) => new BuildAction(builder, p)).toList();
 
         for (var action in actions) {

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -20,8 +20,6 @@ import '../common/package_graphs.dart';
 void main() {
   group('ServeHandler', () {
     InMemoryRunnerAssetWriter writer;
-    CopyBuilder copyBuilder;
-    BuilderApplication copyABuildApplication;
 
     setUp(() async {
       _terminateServeController = new StreamController();
@@ -30,9 +28,6 @@ void main() {
 # Fake packages file
 a:file://fake/pkg/path
 ''');
-
-      copyBuilder = new CopyBuilder();
-      copyABuildApplication = applyToRoot(copyBuilder);
     });
 
     tearDown(() async {
@@ -42,7 +37,7 @@ a:file://fake/pkg/path
 
     test('does basic builds', () async {
       var handler = await createHandler(
-          [copyABuildApplication], {'a|web/a.txt': 'a'}, writer);
+          [applyToRoot(new TestBuilder())], {'a|web/a.txt': 'a'}, writer);
       var results = new StreamQueue(handler.buildResults);
       var result = await results.next;
       checkBuild(result, outputs: {'a|web/a.txt.copy': 'a'}, writer: writer);
@@ -56,11 +51,15 @@ a:file://fake/pkg/path
     });
 
     test('blocks serving files until the build is done', () async {
+      var blockContainer = <Future>[];
       var buildBlocker1 = new Completer();
-      copyBuilder.blockUntil = buildBlocker1.future;
+      blockContainer.add(buildBlocker1.future);
 
-      var handler = await createHandler(
-          [copyABuildApplication], {'a|web/a.txt': 'a'}, writer);
+      var handler = await createHandler([
+        applyToRoot(new TestBuilder(extraWork: (_, __) => blockContainer.first))
+      ], {
+        'a|web/a.txt': 'a'
+      }, writer);
       var webHandler = handler.handlerFor('web');
       var results = new StreamQueue(handler.buildResults);
       // Give the build enough time to get started.
@@ -87,7 +86,7 @@ a:file://fake/pkg/path
       });
 
       /// Make an edit to force another build, and we should block again.
-      copyBuilder.blockUntil = buildBlocker2.future;
+      blockContainer[0] = buildBlocker2.future;
       await writer.writeAsString(makeAssetId('a|web/a.txt'), 'b');
       FakeWatcher.notifyWatchers(new WatchEvent(
           ChangeType.MODIFY, path.absolute('a', 'web', 'a.txt')));

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -51,12 +51,11 @@ a:file://fake/pkg/path
     });
 
     test('blocks serving files until the build is done', () async {
-      var blockContainer = <Future>[];
       var buildBlocker1 = new Completer();
-      blockContainer.add(buildBlocker1.future);
+      var nextBuildBlocker = buildBlocker1.future;
 
       var handler = await createHandler([
-        applyToRoot(new TestBuilder(extraWork: (_, __) => blockContainer.first))
+        applyToRoot(new TestBuilder(extraWork: (_, __) => nextBuildBlocker))
       ], {
         'a|web/a.txt': 'a'
       }, writer);
@@ -86,7 +85,7 @@ a:file://fake/pkg/path
       });
 
       /// Make an edit to force another build, and we should block again.
-      blockContainer[0] = buildBlocker2.future;
+      nextBuildBlocker = buildBlocker2.future;
       await writer.writeAsString(makeAssetId('a|web/a.txt'), 'b');
       FakeWatcher.notifyWatchers(new WatchEvent(
           ChangeType.MODIFY, path.absolute('a', 'web', 'a.txt')));

--- a/build_runner/test/generate/watch_integration_test.dart
+++ b/build_runner/test/generate/watch_integration_test.dart
@@ -21,7 +21,7 @@ import 'package:build_test/build_test.dart';
 
 main() async {
   await watch(
-    [applyToRoot(new CopyBuilder())], deleteFilesByDefault: true);
+    [applyToRoot(new TestBuilder())], deleteFilesByDefault: true);
 }
 ''';
 

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -25,7 +25,7 @@ import '../common/package_graphs.dart';
 void main() {
   /// Basic phases/phase groups which get used in many tests
   final copyABuildApplication = applyToRoot(
-      new CopyBuilder(inputExtension: '.txt', extension: 'txt.copy'));
+      new TestBuilder(buildExtensions: appendExtension('.copy', from: '.txt')));
   final defaultBuilderOptions = const BuilderOptions(const {});
   InMemoryRunnerAssetWriter writer;
 
@@ -321,7 +321,7 @@ a:file://fake/pkg/path
       test('rebuilds on file updates during first build', () async {
         var blocker = new Completer<Null>();
         var buildAction =
-            applyToRoot(new CopyBuilder(blockUntil: blocker.future));
+            applyToRoot(new TestBuilder(extraWork: (_, __) => blocker.future));
         var buildState =
             await startWatch([buildAction], {'a|web/a.txt': 'a'}, writer);
         var results = new StreamQueue(buildState.buildResults);
@@ -372,8 +372,8 @@ a:file://different/fake/pkg/path
       test('edits propagate through all phases', () async {
         var buildActions = [
           copyABuildApplication,
-          applyToRoot(
-              new CopyBuilder(inputExtension: '.copy', extension: 'copy.copy'))
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.copy')))
         ];
 
         var buildState =
@@ -398,8 +398,8 @@ a:file://different/fake/pkg/path
       test('adds propagate through all phases', () async {
         var buildActions = [
           copyABuildApplication,
-          applyToRoot(
-              new CopyBuilder(inputExtension: '.copy', extension: 'copy.copy'))
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.copy')))
         ];
 
         var buildState =
@@ -429,8 +429,8 @@ a:file://different/fake/pkg/path
       test('deletes propagate through all phases', () async {
         var buildActions = [
           copyABuildApplication,
-          applyToRoot(
-              new CopyBuilder(inputExtension: '.copy', extension: 'copy.copy'))
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.copy')))
         ];
 
         var buildState = await startWatch(
@@ -470,8 +470,8 @@ a:file://different/fake/pkg/path
       test('deleted generated outputs are regenerated', () async {
         var buildActions = [
           copyABuildApplication,
-          applyToRoot(
-              new CopyBuilder(inputExtension: '.copy', extension: 'copy.copy'))
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.copy')))
         ];
 
         var buildState =
@@ -506,10 +506,9 @@ a:file://different/fake/pkg/path
     group('secondary dependency', () {
       test('of an output file is edited', () async {
         var buildActions = [
-          applyToRoot(new CopyBuilder(
-              inputExtension: '.a',
-              extension: 'a.copy',
-              copyFromAsset: makeAssetId('a|web/file.b')))
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.a'),
+              build: copyFrom(makeAssetId('a|web/file.b'))))
         ];
 
         var buildState = await startWatch(
@@ -531,12 +530,11 @@ a:file://different/fake/pkg/path
           'of an output which is derived from another generated file is edited',
           () async {
         var buildActions = [
-          applyToRoot(
-              new CopyBuilder(inputExtension: '.a', extension: 'a.copy')),
-          applyToRoot(new CopyBuilder(
-              copyFromAsset: makeAssetId('a|web/file.b'),
-              inputExtension: '.a.copy',
-              extension: 'a.copy.copy'))
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.a'))),
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.a.copy'),
+              build: copyFrom(makeAssetId('a|web/file.b'))))
         ];
 
         var buildState = await startWatch(

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.5-dev
+
+- Deprecate `CopyBuilder` in favor of `TestBuilder` which takes closures to
+  change behavior rather than adding configuration for every possible
+  modification.
+
 ## 0.9.4
 
 - Added `InMemoryAssetReader.shareAssetCache` constructor. This is useful for the

--- a/build_test/lib/build_test.dart
+++ b/build_test/lib/build_test.dart
@@ -5,6 +5,7 @@
 export 'package:build/src/builder/logging.dart' show scopeLogAsync;
 
 export 'src/assets.dart';
+export 'src/builder.dart';
 export 'src/copy_builder.dart';
 export 'src/fake_watcher.dart';
 export 'src/globbing_builder.dart';

--- a/build_test/lib/src/builder.dart
+++ b/build_test/lib/src/builder.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+
+/// Copy the input asset to all possible output assets.
+void _defaultBehavior(
+        BuildStep buildStep, Map<String, List<String>> buildExtensions) =>
+    _copyToAll(buildStep, buildExtensions, (id) => id);
+
+void _copyToAll(BuildStep buildStep, Map<String, List<String>> buildExtensions,
+    AssetId Function(AssetId) readFrom) {
+  if (!buildExtensions.keys.any((e) => buildStep.inputId.path.endsWith(e))) {
+    throw new ArgumentError('Only expected inputs with extension in '
+        '${buildExtensions.keys.toList()} but got ${buildStep.inputId}');
+  }
+  for (final inputExtension in buildExtensions.keys) {
+    if (!buildStep.inputId.path.endsWith(inputExtension)) continue;
+    for (final outputExtension in buildExtensions[inputExtension]) {
+      final newPath = _replaceSuffix(
+          buildStep.inputId.path, inputExtension, outputExtension);
+      final id = new AssetId(buildStep.inputId.package, newPath);
+      buildStep.writeAsString(
+          id, buildStep.readAsString(readFrom(buildStep.inputId)));
+    }
+  }
+}
+
+FutureOr Function(BuildStep, Map<String, List<String>>) copyFrom(
+        AssetId assetId) =>
+    (buildStep, buildExtensions) =>
+        _copyToAll(buildStep, buildExtensions, (_) => assetId);
+
+Map<String, List<String>> appendExtension(String postFix,
+        {String from: '', int numCopies: 1}) =>
+    {
+      from: numCopies == 1
+          ? ['$from$postFix']
+          : new List.generate(numCopies, (i) => '$from$postFix.$i')
+    };
+
+Map<String, List<String>> replaceExtension(String from, String to) => {
+      from: [to]
+    };
+
+/// A [Builder] whose [build] method can be replaced with a closure.
+class TestBuilder implements Builder {
+  @override
+  final Map<String, List<String>> buildExtensions;
+
+  final FutureOr Function(BuildStep, Map<String, List<String>>) _build;
+  final FutureOr Function(BuildStep, Map<String, List<String>>) _extraWork;
+
+  /// A stream of all the [BuildStep.inputId]s that are seen.
+  ///
+  /// Events are added at the top of the [build] method.
+  final _buildInputsController = new StreamController<AssetId>.broadcast();
+  Stream<AssetId> get buildInputs => _buildInputsController.stream;
+
+  TestBuilder({
+    Map<String, List<String>> buildExtensions,
+    FutureOr Function(BuildStep, Map<String, List<String>>) build,
+    FutureOr Function(BuildStep, Map<String, List<String>>) extraWork,
+  })
+      : buildExtensions = buildExtensions ?? appendExtension('.copy'),
+        _build = build ?? _defaultBehavior,
+        _extraWork = extraWork;
+
+  @override
+  Future build(BuildStep buildStep) async {
+    if (buildStep.inputId.path.endsWith(r'$')) return;
+    _buildInputsController.add(buildStep.inputId);
+    await _build(buildStep, buildExtensions);
+    if (_extraWork != null) await _extraWork(buildStep, buildExtensions);
+  }
+}
+
+String _replaceSuffix(String path, String old, String replacement) =>
+    path.substring(0, path.length - old.length) + replacement;

--- a/build_test/lib/src/copy_builder.dart
+++ b/build_test/lib/src/copy_builder.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:build/build.dart';
 
+@Deprecated('Use TestBuilder instead')
 class CopyBuilder implements Builder {
   /// If > 1, then multiple copies will be output, using the copy number as an
   /// additional extension.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.9.4
+version: 0.9.5-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 environment:
-  sdk: ">=1.22.1 <2.0.0"
+  sdk: ">=2.0.0-dev <2.0.0"
 
 dependencies:
   async: ">=1.2.0 <3.0.0"

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 
 environment:
-  sdk: ">=2.0.0-dev <2.0.0"
+  sdk: ">=1.22.1 <2.0.0"
 
 dependencies:
   async: ">=1.2.0 <3.0.0"


### PR DESCRIPTION
The CopyBuilder has been hacked on long enough that it has some issues:
- No point of extensibility other than subclassing or adding new
  features directly.
- It isn't always clear from the constructor arguments what the behavior
  will be.
- inputExtension and extension are specified different - include the `.`
  for the input but not the output.

The TestBuilder replacement instead takes Function arguments to override
behavior and serves as a way to reduce boilerplate around the Builder
class with the same default behavior as the CopyBuilder.

- Mark CopyBuilder as deprecated
- Add TestBuilder with some quality of life help similar to CopyBuilder
  and allow overriding behavior by passing Function arguments.
- Add some utilities to give a nicer syntax for common behavior
  overrides.
- Update tests in `build_runner` to use the TestBuilder