### PR TITLE
Don't add source primary outputs for hidden inputs

### DIFF
--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -326,10 +326,13 @@ class AssetGraph {
         // We might have deleted some inputs during this loop, if they turned
         // out to be generated assets.
         if (!allInputs.contains(input)) continue;
+        var node = get(input);
+        if (!action.hideOutput && node is GeneratedAssetNode && node.isHidden) {
+          continue;
+        }
 
         var outputs = expectedOutputs(action.builder, input);
         phaseOutputs.addAll(outputs);
-        var node = get(input);
         node.primaryOutputs.addAll(outputs);
         node.outputs.addAll(outputs);
         allInputs.removeAll(_addGeneratedOutputs(

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -284,6 +284,22 @@ void main() {
       });
     });
 
+    test('non-hidden action following hidden action', () async {
+      final graph = await AssetGraph.build([
+        new BuildAction(
+            new TestBuilder(buildExtensions: appendExtension('.hidden')), 'foo',
+            hideOutput: true),
+        new BuildAction(
+            new TestBuilder(buildExtensions: appendExtension('.visible')),
+            'foo',
+            hideOutput: false)
+      ], [makeAssetId('foo|lib/file.txt')].toSet(), new Set<AssetId>(),
+          fooPackageGraph, digestReader);
+
+      expect(graph.outputs,
+          isNot(contains(makeAssetId('foo|lib/file.txt.hidden.visible'))));
+    });
+
     test('overlapping build actions cause an error', () async {
       expect(
           () => AssetGraph.build(


### PR DESCRIPTION
This situation should never happen with auto-gen build scripts since we
always order to-source Builders before to-cache Builders. For manual
build scripts ensure that we don't create primary outputs to source for
hidden inputs.