### PR TITLE
Use an Isolate rather than a subprocess

### DIFF
--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 
 import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
 import 'package:build_runner/src/entrypoint/options.dart';
@@ -31,7 +32,8 @@ Future<Null> main(List<String> args) async {
   scriptFile.writeAsStringSync(buildScript);
 
   var exitPort = new ReceivePort();
-  await Isolate.spawnUri(scriptFile.uri, args, null, onExit: exitPort.sendPort);
+  await Isolate.spawnUri(new Uri.file(p.absolute(scriptLocation)), args, null,
+      onExit: exitPort.sendPort);
   await exitPort.first;
   await logListener.cancel();
 }

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -3,12 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:build_config/build_config.dart';
 import 'package:build_runner/build_runner.dart';
-// ignore: undefined_hidden_name
-import 'package:code_builder/code_builder.dart' hide File;
+import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:graphs/graphs.dart';
 import 'package:logging/logging.dart';
@@ -20,13 +18,8 @@ import 'builder_ordering.dart';
 
 const scriptLocation = '$entryPointDir/build.dart';
 
-Future<Null> ensureBuildScript() async {
-  var log = new Logger('ensureBuildScript');
-  var scriptFile = new File(scriptLocation);
-  scriptFile.createSync(recursive: true);
-  await logTimedAsync(log, 'Generating build script',
-      () async => scriptFile.writeAsString(await _generateBuildScript()));
-}
+Future<String> generateBuildScript() => logTimedAsync(
+    new Logger('Entrypoint'), 'Generating build script', _generateBuildScript);
 
 Future<String> _generateBuildScript() async {
   final builders = await _findBuilderApplications();


### PR DESCRIPTION
We can avoid the `--assume-tty` hack since the Isolate sees the same TTY
as the VM. Leave that flag in for now as an option for higher levels of
wrapping scripts.

Only generate the String for the build script in
`build_script_generate.dart`. Handle writint it to a file in the main
method. This will open up the possibility of skipping the write to disk
and using a `data:` URI if we can solve the problem of build script
updates. If we can do that we can add a separate command to write the
build script to disk.