### PR TITLE
Add generate-build-script command

### DIFF
--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -50,7 +50,8 @@ const _generateCommand = 'generate-build-script';
 
 class _GenerateBuildScript extends Command {
   @override
-  final description = 'Generate a script to run builds and print the file path';
+  final description = 'Generate a script to run builds and print the file path '
+      'with no other logging. Useful for wrapping builds with other tools.';
 
   @override
   final name = _generateCommand;

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
+import 'package:args/command_runner.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
@@ -14,12 +15,11 @@ import 'package:build_runner/src/entrypoint/options.dart';
 import 'package:build_runner/src/logging/std_io_logging.dart';
 
 Future<Null> main(List<String> args) async {
-  var logListener = Logger.root.onRecord.listen(stdIOLogListener);
-
   // Use the actual command runner to parse the args and immediately print the
   // usage information if there is no command provided or the help command was
   // explicitly invoked.
-  var commandRunner = new BuildCommandRunner([]);
+  var commandRunner = new BuildCommandRunner([])
+    ..addCommand(new _GenerateBuildScript());
   var parsedArgs = commandRunner.parse(args);
   var commandName = parsedArgs.command?.name;
   if (commandName == null || commandName == 'help') {
@@ -27,13 +27,31 @@ Future<Null> main(List<String> args) async {
     return;
   }
 
+  StreamSubscription logListener;
+  if (commandName != _generateCommand) {
+    logListener = Logger.root.onRecord.listen(stdIOLogListener);
+  }
   var buildScript = await generateBuildScript();
   var scriptFile = new File(scriptLocation)..createSync(recursive: true);
   scriptFile.writeAsStringSync(buildScript);
+  if (commandName == _generateCommand) {
+    print(p.absolute(scriptLocation));
+    return;
+  }
 
   var exitPort = new ReceivePort();
   await Isolate.spawnUri(new Uri.file(p.absolute(scriptLocation)), args, null,
       onExit: exitPort.sendPort);
   await exitPort.first;
-  await logListener.cancel();
+  await logListener?.cancel();
+}
+
+const _generateCommand = 'generate-build-script';
+
+class _GenerateBuildScript extends Command {
+  @override
+  final description = 'Generate a script to run builds and print the file path';
+
+  @override
+  final name = _generateCommand;
 }


### PR DESCRIPTION
Closes #778

Wrapping entrypoints can use this to generate the build script and then
run it using `Isolate.spawnUri` and avoid workarounds like
`--assume-tty`.