### PR TITLE
Fix bug where empty build.yaml files failed to parse

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1+1
+
+- **Bug fix**: Empty build.yaml files no longer fail to parse.
+
 ## 0.2.1
 
 - Change the default for `BuilderDefinition.buildTo` to `BuildTo.cache`.

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -53,7 +53,7 @@ const _builderConfigDefaultOptions = const [
 BuildConfig parseFromYaml(
         String packageName, Iterable<String> dependencies, String configYaml) =>
     parseFromMap(packageName, dependencies,
-        loadYaml(configYaml) as Map<String, dynamic>);
+        loadYaml(configYaml) as Map<String, dynamic> ?? {});
 
 BuildConfig parseFromMap(String packageName,
     Iterable<String> packageDependencies, Map<String, dynamic> config) {

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.2.1
+version: 0.2.1+1
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -87,6 +87,19 @@ void main() {
       ),
     });
   });
+
+  test('build.yaml can be empty', () {
+    var buildConfig = new BuildConfig.parse('example', ['a', 'b'], '');
+    expectBuildTargets(buildConfig.buildTargets, {
+      'example:example': new BuildTarget(
+        dependencies: ['a:a', 'b:b'].toSet(),
+        package: 'example',
+        key: 'example:example',
+        sources: new InputSet(),
+      ),
+    });
+    expectBuilderDefinitions(buildConfig.builderDefinitions, {});
+  });
 }
 
 var buildYaml = '''


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/849