### PR TITLE
Add extra newlines in watch instead of build

### DIFF
--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -162,7 +162,7 @@ class BuildImpl {
     }
     if (result.status == BuildStatus.success) {
       _logger.info('Succeeded after ${humanReadable(watch.elapsed)} with '
-          '${result.outputs.length} outputs\n\n');
+          '${result.outputs.length} outputs\n');
     } else {
       if (result.exception is FatalBuildException) {
         // TODO(???) Really bad idea. Should not set exit codes in libraries!

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -168,6 +168,7 @@ class WatchImpl implements BuildState {
 
     Future<BuildResult> doBuild(List<List<AssetChange>> changes) async {
       assert(build != null);
+      _logger.info('\nStarting Build');
       var mergedChanges = _collectChanges(changes);
 
       _expectedDeletes.clear();

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -30,9 +30,7 @@ void stdIOLogListener(LogRecord record, {bool verbose}) {
   }
   var header = '$eraseLine$level ${record.loggerName}: $headerMessage';
   var lines = blankLineCount > 0
-      ? (<Object>[]
-        ..addAll(new Iterable.generate(blankLineCount, (_) => ''))
-        ..add(header))
+      ? (new List<Object>.generate(blankLineCount, (_) => '')..add(header))
       : <Object>[header];
 
   if (record.error != null) {

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -21,8 +21,19 @@ void stdIOLogListener(LogRecord record, {bool verbose}) {
   }
   final level = color.wrap('[${record.level}]');
   final eraseLine = ansiOutputEnabled && !verbose ? '\x1b[2K\r' : '';
-  var header = '$eraseLine$level ${record.loggerName}: ${record.message}';
-  var lines = <Object>[header];
+  var headerMessage = record.message;
+  var blankLineCount = 0;
+  if (headerMessage.startsWith('\n')) {
+    blankLineCount =
+        headerMessage.split('\n').takeWhile((line) => line.isEmpty).length;
+    headerMessage = headerMessage.substring(blankLineCount);
+  }
+  var header = '$eraseLine$level ${record.loggerName}: $headerMessage';
+  var lines = blankLineCount > 0
+      ? (<Object>[]
+        ..addAll(new Iterable.generate(blankLineCount, (_) => ''))
+        ..add(header))
+      : <Object>[header];
 
   if (record.error != null) {
     lines.add(record.error);


### PR DESCRIPTION
Fixes #567

Now a single build does not have any blank lines while a watch retains
the a blank line between builds.

Add special handling for message that start with one or more newlines to
our default logger.