### PR TITLE
Allow `$default` as a target name

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.2.1+1
+## 0.2.2
 
 - **Bug fix**: Empty build.yaml files no longer fail to parse.
+- Allow `$default` as a target name to get he package name automatically filled
+  in.
 
 ## 0.2.1
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -11,7 +11,10 @@ for that target. Targets can be referred to in
 `'$definingPackageName:$targetname'`. When the target name matches the package
 name it can also be referred to as just the package name. One target in every
 package _must_ use the package name so that consumers will use it by default.
-Each target may also contain the following keys.
+In the `build.yaml` file this target can be defined with the key `$default` or
+with the name of the package.
+
+Each target may also contain the following keys:
 
 - **sources**: List of Strings or Map, Optional. The set of files within the
   package which make up this target. Files are specified using glob syntax. If a

--- a/build_config/lib/src/key_normalization.dart
+++ b/build_config/lib/src/key_normalization.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+const _defaultTargetNamePlaceholder = r'$default';
+
 String normalizeBuilderKeyDefinition(String builderKey, String packageName) =>
     _normalizeDefinition(builderKey, packageName, '|');
 
@@ -9,7 +11,9 @@ String normalizeBuilderKeyUsage(String builderKey, String packageName) =>
     _normalizeUsage(builderKey, packageName, '|');
 
 String normalizeTargetKeyDefinition(String targetKey, String packageName) =>
-    _normalizeDefinition(targetKey, packageName, ':');
+    targetKey == _defaultTargetNamePlaceholder
+        ? '$packageName:$packageName'
+        : _normalizeDefinition(targetKey, packageName, ':');
 
 String normalizeTargetKeyUsage(String targetKey, String packageName) =>
     _normalizeUsage(targetKey, packageName, ':');

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -103,7 +103,8 @@ BuildConfig parseFromMap(String packageName,
   }
 
   if (!buildTargets.containsKey(defaultTarget)) {
-    throw new ArgumentError('Must specify a target with the name $packageName');
+    throw new ArgumentError('Must specify a target with the name '
+        '$packageName or `\$default`');
   }
 
   final Map<String, Map> builderConfigs =

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.2.1+1
+version: 0.2.2
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -102,7 +102,7 @@ void main() {
   });
 }
 
-var buildYaml = '''
+var buildYaml = r'''
 targets:
   a:
     builders:
@@ -118,7 +118,7 @@ targets:
     sources:
       - "lib/a.dart"
       - "lib/src/a/**"
-  example:
+  $default:
     dependencies:
       - f
       - :a


### PR DESCRIPTION
Closes #864

This makes some simple cases of configuring builders for the entire
package able to get copied directly rather than rewriting the target nam
for each package.