### PR TITLE
Serialize AssetGraph to/from List<int>

### DIFF
--- a/build_runner/bin/create_merged_dir.dart
+++ b/build_runner/bin/create_merged_dir.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -52,8 +51,7 @@ Future main(List<String> args) async {
 
   await logTimedAsync(logger, 'Loading asset graph at ${assetGraphFile.path}',
       () async {
-    assetGraph = new AssetGraph.deserialize(
-        JSON.decode(await assetGraphFile.readAsString()) as Map);
+    assetGraph = new AssetGraph.deserialize(await assetGraphFile.readAsBytes());
   });
 
   packageGraph = new PackageGraph.forThisPackage();

--- a/build_runner/bin/graph_inspector.dart
+++ b/build_runner/bin/graph_inspector.dart
@@ -42,8 +42,7 @@ Future main(List<String> args) async {
   }
   stdout.writeln('Loading asset graph at ${assetGraphFile.path}...');
 
-  assetGraph = new AssetGraph.deserialize(
-      assetGraphFile.readAsBytesSync());
+  assetGraph = new AssetGraph.deserialize(assetGraphFile.readAsBytesSync());
   packageGraph = new PackageGraph.forThisPackage();
 
   var commandRunner = new CommandRunner(

--- a/build_runner/bin/graph_inspector.dart
+++ b/build_runner/bin/graph_inspector.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
@@ -44,7 +43,7 @@ Future main(List<String> args) async {
   stdout.writeln('Loading asset graph at ${assetGraphFile.path}...');
 
   assetGraph = new AssetGraph.deserialize(
-      JSON.decode(assetGraphFile.readAsStringSync()) as Map);
+      assetGraphFile.readAsBytesSync());
   packageGraph = new PackageGraph.forThisPackage();
 
   var commandRunner = new CommandRunner(

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -34,7 +34,7 @@ class AssetGraph {
   AssetGraph._(this.buildActionsDigest);
 
   /// Deserializes this graph.
-  factory AssetGraph.deserialize(Map serializedGraph) =>
+  factory AssetGraph.deserialize(List<int> serializedGraph) =>
       new _AssetGraphDeserializer(serializedGraph).deserialize();
 
   static Future<AssetGraph> build(
@@ -58,7 +58,7 @@ class AssetGraph {
     return graph;
   }
 
-  Map<String, dynamic> serialize() =>
+  List<int> serialize() =>
       new _AssetGraphSerializer(this).serialize();
 
   /// Checks if [id] exists in the graph.

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -58,8 +58,7 @@ class AssetGraph {
     return graph;
   }
 
-  List<int> serialize() =>
-      new _AssetGraphSerializer(this).serialize();
+  List<int> serialize() => new _AssetGraphSerializer(this).serialize();
 
   /// Checks if [id] exists in the graph.
   bool contains(AssetId id) =>

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -15,7 +15,8 @@ class _AssetGraphDeserializer {
   final _idToAssetId = <int, AssetId>{};
   final Map _serializedGraph;
 
-  _AssetGraphDeserializer(this._serializedGraph);
+  _AssetGraphDeserializer(List<int> bytes)
+      : _serializedGraph = JSON.decode(UTF8.decode(bytes)) as Map;
 
   /// Perform the deserialization, should only be called once.
   AssetGraph deserialize() {
@@ -129,7 +130,7 @@ class _AssetGraphSerializer {
   _AssetGraphSerializer(this._graph);
 
   /// Perform the serialization, should only be called once.
-  Map<String, dynamic> serialize() {
+  List<int> serialize() {
     /// Compute numeric identifiers for all asset ids.
     var next = 0;
     for (var node in _graph.allNodes) {
@@ -152,7 +153,7 @@ class _AssetGraphSerializer {
     });
     result['serializedAssetIds'] = serializedAssetIds;
 
-    return result;
+    return UTF8.encode(JSON.encode(result));
   }
 
   List _serializeNode(AssetNode node) {

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';
@@ -186,8 +185,7 @@ class _Loader {
     return logTimedAsync(_logger, 'Reading cached asset graph', () async {
       try {
         var cachedGraph = new AssetGraph.deserialize(
-            JSON.decode(await _environment.reader.readAsString(assetGraphId))
-                as Map);
+            await _environment.reader.readAsBytes(assetGraphId));
         if (computeBuildActionsDigest(_buildActions) !=
             cachedGraph.buildActionsDigest) {
           _logger.warning(

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -200,9 +200,9 @@ class BuildImpl {
       // Write out the dependency graph file.
       await logTimedAsync(_logger, 'Caching finalized dependency graph',
           () async {
-        await _writer.writeAsString(
+        await _writer.writeAsBytes(
             new AssetId(_packageGraph.root.name, assetGraphPath),
-            JSON.encode(_assetGraph.serialize()));
+            _assetGraph.serialize());
       });
 
       done.complete(result);

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -117,17 +117,9 @@ void main() {
           }
         }
 
-        var encoded = JSON.encode(graph.serialize());
-        var decoded = new AssetGraph.deserialize(JSON.decode(encoded) as Map);
+        var encoded = graph.serialize();
+        var decoded = new AssetGraph.deserialize(encoded);
         expect(graph, equalsAssetGraph(decoded));
-      });
-
-      test('Throws an AssetGraphVersionError if versions dont match up', () {
-        var serialized = graph.serialize();
-        serialized['version'] = -1;
-        var encoded = JSON.encode(serialized);
-        expect(() => new AssetGraph.deserialize(JSON.decode(encoded) as Map),
-            throwsA(assetGraphVersionException));
       });
     });
 

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -121,6 +121,15 @@ void main() {
         var decoded = new AssetGraph.deserialize(encoded);
         expect(graph, equalsAssetGraph(decoded));
       });
+
+      test('Throws an AssetGraphVersionError if versions dont match up', () {
+        var bytes = graph.serialize();
+        var serialized = JSON.decode(UTF8.decode(bytes));
+        serialized['version'] = -1;
+        var encoded = UTF8.encode(JSON.encode(serialized));
+        expect(() => new AssetGraph.deserialize(encoded),
+            throwsA(assetGraphVersionException));
+      });
     });
 
     group('with buildActions', () {

--- a/build_runner/test/generate/build_definition_test.dart
+++ b/build_runner/test/generate/build_definition_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';
@@ -36,11 +35,15 @@ main() {
     BuildEnvironment environment;
     String pkgARoot;
 
-    Future<Null> createFile(String path, String contents) async {
+    Future<Null> createFile(String path, dynamic contents) async {
       var file = new File(p.join(pkgARoot, path));
       expect(await file.exists(), isFalse);
       await file.create(recursive: true);
-      await file.writeAsString(contents);
+      if (contents is String) {
+        await file.writeAsString(contents);
+      } else {
+        await file.writeAsBytes(contents as List<int>);
+      }
       addTearDown(() async => await file.exists() ? await file.delete() : null);
     }
 
@@ -103,8 +106,7 @@ main() {
         generatedANode.wasOutput = true;
         generatedANode.needsUpdate = false;
 
-        await createFile(
-            assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
+        await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         await deleteFile(p.join('lib', 'b.txt'));
         var buildDefinition = await BuildDefinition.prepareWorkspace(
@@ -128,8 +130,7 @@ main() {
         var originalAssetGraph = await AssetGraph.build(buildActions,
             <AssetId>[].toSet(), new Set(), aPackageGraph, environment.reader);
 
-        await createFile(
-            assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
+        await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         await createFile(p.join('lib', 'a.txt'), 'a');
         var buildDefinition = await BuildDefinition.prepareWorkspace(
@@ -157,8 +158,7 @@ main() {
             aPackageGraph,
             environment.reader);
 
-        await createFile(
-            assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
+        await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         await modifyFile(p.join('lib', 'a.txt'), 'b');
         var buildDefinition = await BuildDefinition.prepareWorkspace(
@@ -189,8 +189,7 @@ main() {
             originalAssetGraph.get(generatedSrcId) as GeneratedAssetNode;
         generatedNode.wasOutput = false;
 
-        await createFile(
-            assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
+        await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         var buildDefinition = await BuildDefinition.prepareWorkspace(
             environment, options, buildActions);
@@ -221,8 +220,7 @@ main() {
           node.needsUpdate = false;
         }
 
-        await createFile(
-            assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
+        await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         // Same as before, but change the `BuilderOptions` for the first action.
         var newBuildActions = [
@@ -272,7 +270,7 @@ main() {
         expect(assetGraph.allNodes.map((node) => node.id),
             unorderedEquals(expectedIds));
 
-        await createFile(assetGraphPath, JSON.encode(assetGraph.serialize()));
+        await createFile(assetGraphPath, assetGraph.serialize());
 
         var buildDefinition = await BuildDefinition.prepareWorkspace(
             environment, options, buildActions);
@@ -321,8 +319,7 @@ main() {
       var originalAssetGraph = await AssetGraph.build(buildActions,
           <AssetId>[].toSet(), new Set(), aPackageGraph, environment.reader);
 
-      await createFile(
-          assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
+      await createFile(assetGraphPath, originalAssetGraph.serialize());
 
       buildActions.add(new BuildAction(new TestBuilder(), 'a',
           targetSources: const InputSet(include: const ['.copy']),
@@ -365,8 +362,7 @@ main() {
       var originalAssetGraph = await AssetGraph.build(buildActions,
           <AssetId>[].toSet(), new Set(), aPackageGraph, environment.reader);
 
-      await createFile(
-          assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
+      await createFile(assetGraphPath, originalAssetGraph.serialize());
 
       buildActions = [
         new BuildAction(new TestBuilder(), 'a',
@@ -416,8 +412,7 @@ main() {
       (originalAssetGraph.get(aTxtCopy) as GeneratedAssetNode).wasOutput = true;
       await createFile(aTxtCopy.path, 'hello');
 
-      await createFile(
-          assetGraphPath, JSON.encode(originalAssetGraph.serialize()));
+      await createFile(assetGraphPath, originalAssetGraph.serialize());
 
       buildActions.add(new BuildAction(new TestBuilder(), 'a',
           targetSources: const InputSet(include: const ['.copy']),

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
@@ -252,8 +251,7 @@ void main() {
 
         var graphId = makeAssetId('a|$assetGraphPath');
         expect(writer.assets, contains(graphId));
-        var cachedGraph = new AssetGraph.deserialize(
-            JSON.decode(UTF8.decode(writer.assets[graphId])) as Map);
+        var cachedGraph = new AssetGraph.deserialize(writer.assets[graphId]);
         expect(
             cachedGraph.allNodes.map((node) => node.id),
             unorderedEquals([
@@ -577,8 +575,7 @@ void main() {
 
     var graphId = makeAssetId('a|$assetGraphPath');
     expect(writer.assets, contains(graphId));
-    var cachedGraph = new AssetGraph.deserialize(
-        JSON.decode(UTF8.decode(writer.assets[graphId])) as Map);
+    var cachedGraph = new AssetGraph.deserialize(writer.assets[graphId]);
 
     var expectedGraph = await AssetGraph.build([], new Set(), new Set(),
         buildPackageGraph({rootPackage('a'): []}), null);
@@ -731,9 +728,8 @@ void main() {
           writer: writer);
 
       /// Should be deleted using the writer, and removed from the new graph.
-      var serialized = JSON.decode(
-          UTF8.decode(writer.assets[makeAssetId('a|$assetGraphPath')])) as Map;
-      var newGraph = new AssetGraph.deserialize(serialized);
+      var newGraph = new AssetGraph.deserialize(
+          writer.assets[makeAssetId('a|$assetGraphPath')]);
       var aNodeId = makeAssetId('a|lib/a.txt');
       var aCopyNodeId = makeAssetId('a|lib/a.txt.copy');
       var aCloneNodeId = makeAssetId('a|lib/a.txt.copy.clone');
@@ -821,8 +817,8 @@ void main() {
       }, writer: writer);
 
       // Read cached graph and validate.
-      var graph = new AssetGraph.deserialize(JSON.decode(
-          UTF8.decode(writer.assets[makeAssetId('a|$assetGraphPath')])) as Map);
+      var graph = new AssetGraph.deserialize(
+          writer.assets[makeAssetId('a|$assetGraphPath')]);
       var outputNode =
           graph.get(makeAssetId('a|lib/file.a.copy')) as GeneratedAssetNode;
       var fileANode = graph.get(makeAssetId('a|lib/file.a'));

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:async/async.dart';
 import 'package:build/build.dart';
@@ -242,10 +241,8 @@ a:file://fake/pkg/path
             outputs: {'a|web/b.txt.copy': 'b2', 'a|web/c.txt.copy': 'c'},
             writer: writer);
 
-        var serialized = JSON.decode(
-                UTF8.decode(writer.assets[makeAssetId('a|$assetGraphPath')]))
-            as Map;
-        var cachedGraph = new AssetGraph.deserialize(serialized);
+        var cachedGraph = new AssetGraph.deserialize(
+            writer.assets[makeAssetId('a|$assetGraphPath')]);
 
         var expectedGraph = await AssetGraph.build([], new Set(), new Set(),
             buildPackageGraph({rootPackage('a'): []}), null);


### PR DESCRIPTION
Helpful for #41

Centralizes all references to `JSON` within the serialization so that we
can update a single place to experiment with other serialization
formats.