### PR TITLE
Return exit codes from `run`, and send them to the parent isolate.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,6 +6,8 @@ analyzer:
     unused_local_variable: error
     dead_code: error
     override_on_non_overriding_method: error
+  exclude:
+    - "test/goldens/generated_build_script.dart"
 linter:
   rules:
     # Errors

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.7-dev
+## 0.7.7
 
 - The top level `run` method now returns an `int` which represents an `exitCode`
   for the command that was executed.

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.7-dev
+
+- The top level `run` method now returns an `int` which represents an `exitCode`
+  for the command that was executed.
+  - For now we still set the exitCode manually as well but this will likely
+    change in the next breaking release. In manual scripts you should `await`
+    the call to `run` and assign that to `exitCode` to be future-proofed.
+
 ## 0.7.6
 
 - Update to package:build version `0.12.0`.

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -327,9 +327,12 @@ class _TestCommand extends _BaseCommand {
         return 1;
       }
 
-      // **Note**: We must have the await, otherwise the finally branch runs
-      // before this future is done.
-      return await _runTests(outputDir);
+      var testExitCode = await _runTests(outputDir);
+      if (testExitCode != 0) {
+        // No need to log - should see failed tests in the console.
+        exitCode = testExitCode;
+      }
+      return testExitCode;
     } finally {
       // Clean up the output dir if one wasn't explicitly asked for.
       if (options.outputDir == null && outputDir != null) {

--- a/build_runner/lib/src/entrypoint/run.dart
+++ b/build_runner/lib/src/entrypoint/run.dart
@@ -10,7 +10,7 @@ import 'options.dart';
 
 /// A common entrypoint to parse command line arguments and build or serve with
 /// [builders].
-Future run(List<String> args, List<BuilderApplication> builders) async {
+Future<int> run(List<String> args, List<BuilderApplication> builders) {
   var runner = new BuildCommandRunner(builders);
-  await runner.run(args);
+  return runner.run(args);
 }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.7-dev
+version: 0.7.7
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.6
+version: 0.7.7-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/e2e_example/test/common/utils.dart
+++ b/e2e_example/test/common/utils.dart
@@ -206,6 +206,7 @@ Future<Null> expectTestsFail({bool useManualScript}) async {
   var result =
       useManualScript ? await _runManualTests() : await _runAutoTests();
   expect(result.stdout, contains('Some tests failed'));
+  expect(result.exitCode, isNot(0));
 }
 
 Future<Null> expectTestsPass(

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -3,6 +3,7 @@ import 'package:provides_builder/builders.dart' as _i2;
 import 'package:build_test/builder.dart' as _i3;
 import 'package:build_config/build_config.dart' as _i4;
 import 'package:build_web_compilers/builders.dart' as _i5;
+import 'dart:isolate' as _i6;
 
 final _builders = [
   _i1.apply('provides_builder|some_not_applied_builder', [_i2.notApplied],
@@ -33,4 +34,7 @@ final _builders = [
           include: const ['web/**', 'test/**_test.dart'],
           exclude: const ['test/**.node_test.dart', 'test/**.vm_test.dart']))
 ];
-main(List<String> args) => _i1.run(args, _builders);
+main(List<String> args, [_i6.SendPort sendPort]) async {
+  var result = await _i1.run(args, _builders);
+  sendPort?.send(result);
+}

--- a/e2e_example/tool/build.dart
+++ b/e2e_example/tool/build.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:build/build.dart';
 import 'package:build_web_compilers/build_web_compilers.dart';
@@ -38,7 +39,7 @@ Future main(List<String> args) async {
             include: const ['web/**', 'test/**.browser_test.dart']))
   ];
 
-  await run(args, builders);
+  exitCode = await run(args, builders);
 }
 
 class ThrowingBuilder extends Builder {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/874

cc @chalin