### PR TITLE
Add back DependencyType to PackageNode

### DIFF
--- a/build_runner/test/common/package_graphs.dart
+++ b/build_runner/test/common/package_graphs.dart
@@ -15,8 +15,8 @@ PackageGraph buildPackageGraph(Map<PackageNode, Iterable<String>> packages) {
   return new PackageGraph.fromRoot(root);
 }
 
-PackageNode package(String packageName, {String path}) =>
-    new PackageNode(packageName, path);
+PackageNode package(String packageName, {String path, DependencyType type}) =>
+    new PackageNode(packageName, path, type);
 
 PackageNode rootPackage(String packageName, {String path}) =>
-    new PackageNode(packageName, path, isRoot: true);
+    new PackageNode(packageName, path, DependencyType.path, isRoot: true);

--- a/build_runner/test/package_graph/package_graph_test.dart
+++ b/build_runner/test/package_graph/package_graph_test.dart
@@ -17,7 +17,7 @@ void main() {
       });
 
       test('root', () {
-        expectPkg(graph.root, 'build_runner', './');
+        expectPkg(graph.root, 'build_runner', './', DependencyType.path);
       });
     });
 
@@ -42,13 +42,13 @@ void main() {
       });
 
       test('root', () {
-        expectPkg(graph.root, 'basic_pkg', basicPkgPath,
+        expectPkg(graph.root, 'basic_pkg', basicPkgPath, DependencyType.path,
             [graph['a'], graph['b'], graph['c'], graph['d']]);
       });
 
       test('dependency', () {
-        expectPkg(
-            graph['a'], 'a', '$basicPkgPath/pkg/a', [graph['b'], graph['c']]);
+        expectPkg(graph['a'], 'a', '$basicPkgPath/pkg/a', DependencyType.pub,
+            [graph['b'], graph['c']]);
       });
     });
 
@@ -73,12 +73,14 @@ void main() {
       test('dev deps are contained in deps of root pkg, but not others', () {
         // Package `b` shows as a dep because this is the root package.
         expectPkg(graph.root, 'with_dev_deps', withDevDepsPkgPath,
-            [graph['a'], graph['b']]);
+            DependencyType.path, [graph['a'], graph['b']]);
 
         // Package `c` does not appear because this is not the root package.
-        expectPkg(graph['a'], 'a', '$withDevDepsPkgPath/pkg/a', []);
+        expectPkg(graph['a'], 'a', '$withDevDepsPkgPath/pkg/a',
+            DependencyType.pub, []);
 
-        expectPkg(graph['b'], 'b', '$withDevDepsPkgPath/pkg/b', []);
+        expectPkg(graph['b'], 'b', '$withDevDepsPkgPath/pkg/b',
+            DependencyType.pub, []);
 
         expect(graph['c'], isNull);
       });
@@ -107,10 +109,10 @@ void main() {
     });
 
     test('custom creation via fromRoot', () {
-      var a = new PackageNode('a', null, isRoot: true);
-      var b = new PackageNode('b', null);
-      var c = new PackageNode('c', null);
-      var d = new PackageNode('d', null);
+      var a = new PackageNode('a', null, DependencyType.path, isRoot: true);
+      var b = new PackageNode('b', null, null);
+      var c = new PackageNode('c', null, null);
+      var d = new PackageNode('d', null, null);
       a.dependencies.addAll([b, d]);
       b.dependencies.add(c);
       var graph = new PackageGraph.fromRoot(a);
@@ -136,10 +138,12 @@ void main() {
 }
 
 void expectPkg(PackageNode node, String name, String location,
+    DependencyType dependencyType,
     [Iterable<PackageNode> dependencies]) {
   location = p.absolute(location);
   expect(node.name, name);
   expect(node.path, location);
+  expect(node.dependencyType, dependencyType);
   if (dependencies != null) {
     expect(node.dependencies, unorderedEquals(dependencies));
   }

--- a/build_runner/test/watcher/asset_change_test.dart
+++ b/build_runner/test/watcher/asset_change_test.dart
@@ -33,7 +33,7 @@ void main() {
       final pkgBar = p.join('/', 'foo', 'bar');
       final barFile =
           p.join(p.relative(pkgBar, from: p.current), 'lib', 'bar.dart');
-      final nodeBar = new PackageNode('bar', pkgBar);
+      final nodeBar = new PackageNode('bar', pkgBar, null);
 
       final event = new WatchEvent(ChangeType.ADD, barFile);
       final change = new AssetChange.fromEvent(nodeBar, event);
@@ -46,7 +46,7 @@ void main() {
       final pkgBar = p.join('/', 'foo', 'bar');
       final barFile = p.join('/', 'foo', 'bar', 'lib', 'bar.dart');
 
-      final nodeBar = new PackageNode('bar', pkgBar);
+      final nodeBar = new PackageNode('bar', pkgBar, null);
       final event = new WatchEvent(ChangeType.ADD, barFile);
       final change = new AssetChange.fromEvent(nodeBar, event);
 

--- a/build_runner/test/watcher/node_watcher_test.dart
+++ b/build_runner/test/watcher/node_watcher_test.dart
@@ -41,7 +41,7 @@ void main() {
     }
 
     test('should emit a changed asset', () async {
-      var node = new PackageNode('a', p.join(tmpDir.path, 'a'));
+      var node = new PackageNode('a', p.join(tmpDir.path, 'a'), null);
       var nodeWatcher = new PackageNodeWatcher(node);
 
       initFiles(node);
@@ -70,7 +70,7 @@ void main() {
 
     test('should also respect relative watch URLs', () async {
       var node = new PackageNode(
-          'a', p.relative(p.join(tmpDir.path, 'a'), from: p.current));
+          'a', p.relative(p.join(tmpDir.path, 'a'), from: p.current), null);
       var nodeWatcher = new PackageNodeWatcher(node);
 
       initFiles(node);


### PR DESCRIPTION
We want to use this to reduce the number of watchers we set up.

- Add back the enum, without the prefix `Package`
- Track dependency type when crawling deps
- Update constructor calls in tests