### PR TITLE
Don't add watchers to hosted dependencies

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.8
+## 0.7.7+1
 
 - Avoid watching hosted dependencies for file changes.
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.8
+
+- Avoid watching hosted dependencies for file changes.
+
 ## 0.7.7
 
 - The top level `run` method now returns an `int` which represents an `exitCode`

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -68,9 +68,14 @@ class PackageGraphWatcher {
     final subscriptions = <StreamSubscription>[];
     var allWatchers = <PackageNodeWatcher>[];
     _graph.allPackages.forEach((name, node) {
+      if (node.dependencyType == DependencyType.pub ||
+          node.dependencyType == DependencyType.hosted ||
+          node.dependencyType == DependencyType.github) {
+        return;
+      }
       final nestedPackages = _nestedPaths(node);
       _logger.fine('Setting up watcher at ${node.path}');
-      var nodeWatcher = _strategy(node);
+      final nodeWatcher = _strategy(node);
       allWatchers.add(nodeWatcher);
       subscriptions.add(nodeWatcher.watch().listen((event) {
         // TODO: Consider a faster filtering strategy.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.8
+version: 0.7.7+1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.7
+version: 0.7.8
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
Closes #868

We don't expect files in `pub`, `hosted`, or `github` dependencies to
ever change locally.