### PR TITLE
Export build_script_generate.dart

### DIFF
--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -4,7 +4,8 @@
 export 'src/asset/file_based.dart';
 export 'src/asset/reader.dart' show RunnerAssetReader;
 export 'src/asset/writer.dart';
-export 'src/build_script_generate/build_script_generate.dart';
+export 'src/build_script_generate/build_script_generate.dart'
+    show generateBuildScript, scriptLocation;
 export 'src/entrypoint/run.dart' show run;
 export 'src/generate/build.dart';
 export 'src/generate/build_result.dart';

--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -4,6 +4,7 @@
 export 'src/asset/file_based.dart';
 export 'src/asset/reader.dart' show RunnerAssetReader;
 export 'src/asset/writer.dart';
+export 'src/build_script_generate/build_script_generate.dart';
 export 'src/entrypoint/run.dart' show run;
 export 'src/generate/build.dart';
 export 'src/generate/build_result.dart';


### PR DESCRIPTION
Allow wrapping scripts to directly call generateBuildScript() without having to run build_runner as a process.