### PR TITLE
Allow overriding Resolvers

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.1-dev
+
+- Allow overriding the `Resolvers` used for `resolve*` utilities.
+- Bug Fix: Don't call the `action` multiple times when there are multiple
+  sources passed to `resolve*`.
+
 ## 0.10.0
 
 - Added automatic generation of `.debug.html` files for all tests, which can

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -215,18 +215,13 @@ class _ResolveSourceBuilder<T> implements Builder {
 
   final onDone = new Completer<T>();
 
-  var hasStartedAction = false;
-
   _ResolveSourceBuilder(this._action, this._resolverFor, this._tearDown);
 
   @override
   Future<Null> build(BuildStep buildStep) async {
-    if (hasStartedAction) return;
-    hasStartedAction = true;
+    if (_resolverFor != buildStep.inputId) return;
     var result = await _action(buildStep.resolver);
-    if (_resolverFor == buildStep.inputId) {
-      onDone.complete(result);
-    }
+    onDone.complete(result);
     await _tearDown;
   }
 

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -119,7 +119,7 @@ Future<T> resolveSources<T>(
   String resolverFor,
   String rootPackage,
   Future<Null> tearDown,
-  Resolvers resolvers,
+  Resolvers resolvers: const BarbackResolvers(),
 }) {
   if (inputs == null || inputs.isEmpty) {
     throw new ArgumentError.value(inputs, 'inputs', 'Must be a non-empty Map');
@@ -141,7 +141,7 @@ Future<T> resolveAsset<T>(
   FutureOr<T> action(Resolver resolver), {
   PackageResolver resolver,
   Future<Null> tearDown,
-  Resolvers resolvers,
+  Resolvers resolvers: const BarbackResolvers(),
 }) {
   return _resolveAssets(
     {

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -27,6 +27,7 @@ Future<T> resolveSource<T>(
   AssetId inputId,
   PackageResolver resolver,
   Future<Null> tearDown,
+  Resolvers resolvers: const BarbackResolvers(),
 }) {
   inputId ??= new AssetId('_resolve_source', 'lib/_resolve_source.dart');
   return _resolveAssets(
@@ -38,6 +39,7 @@ Future<T> resolveSource<T>(
     resolver: resolver,
     resolverFor: inputId,
     tearDown: tearDown,
+    resolvers: resolvers,
   );
 }
 
@@ -117,6 +119,7 @@ Future<T> resolveSources<T>(
   String resolverFor,
   String rootPackage,
   Future<Null> tearDown,
+  Resolvers resolvers,
 }) {
   if (inputs == null || inputs.isEmpty) {
     throw new ArgumentError.value(inputs, 'inputs', 'Must be a non-empty Map');
@@ -128,6 +131,7 @@ Future<T> resolveSources<T>(
     resolver: resolver,
     resolverFor: new AssetId.parse(resolverFor ?? inputs.keys.first),
     tearDown: tearDown,
+    resolvers: resolvers,
   );
 }
 
@@ -137,6 +141,7 @@ Future<T> resolveAsset<T>(
   FutureOr<T> action(Resolver resolver), {
   PackageResolver resolver,
   Future<Null> tearDown,
+  Resolvers resolvers,
 }) {
   return _resolveAssets(
     {
@@ -147,6 +152,7 @@ Future<T> resolveAsset<T>(
     resolver: resolver,
     resolverFor: inputId,
     tearDown: tearDown,
+    resolvers: resolvers,
   );
 }
 
@@ -162,6 +168,7 @@ Future<T> _resolveAssets<T>(
   PackageResolver resolver,
   AssetId resolverFor,
   Future<Null> tearDown,
+  Resolvers resolvers,
 }) async {
   final syncResolver = await (resolver ?? PackageResolver.current).asSync;
   final assetReader = new PackageAssetReader(syncResolver, rootPackage);
@@ -190,7 +197,7 @@ Future<T> _resolveAssets<T>(
     inputAssets.keys,
     new MultiAssetReader([inMemory, assetReader]),
     new InMemoryAssetWriter(),
-    const BarbackResolvers(),
+    resolvers,
   );
   return resolveBuilder.onDone.future;
 }
@@ -208,11 +215,14 @@ class _ResolveSourceBuilder<T> implements Builder {
 
   final onDone = new Completer<T>();
 
+  var hasStartedAction = false;
+
   _ResolveSourceBuilder(this._action, this._resolverFor, this._tearDown);
 
   @override
   Future<Null> build(BuildStep buildStep) async {
-    if (onDone.isCompleted) return;
+    if (hasStartedAction) return;
+    hasStartedAction = true;
     var result = await _action(buildStep.resolver);
     if (_resolverFor == buildStep.inputId) {
       onDone.complete(result);

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.0
+version: 0.10.1-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
 


### PR DESCRIPTION
This will let us use these utilities to test new Resolver
implementations. Also fix a bug where the `action` was being called once
per input because the complete future wasn't called until the first
action finished.