### PR TITLE
Record errors synchronously, fix up the --fail-on-severe logic a bit

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 0.7.9-dev
+
+### New Features
+
+- Added command line args to override config for builders globally. The format
+  is `--define "<builder_key>=<option>=<value>"`. As an example, enabling the
+  dart2js compiler for the `build_web_compilers|entrypoint` builder would look
+  like this: `--define "build_web_compilers|entrypoint=compiler=dart2js"`.
+
+### Bug Fixes
+
+- Fixed an issue with mixed mode builds, see
+  https://github.com/dart-lang/build/issues/924.
+- Fixed some issues with exit codes and --fail-on-severe, although there are
+  still some outstanding problems. See
+  https://github.com/dart-lang/build/issues/910 for status updates.
+- Fixed an issue where the process would hang on exceptions, see
+  https://github.com/dart-lang/build/issues/883.
+- Fixed an issue with etags not getting updated for source files that weren't
+  inputs to any build actions, https://github.com/dart-lang/build/issues/894.
+- Fixed an issue with hidden .DS_Store files on mac in the generated directory,
+  https://github.com/dart-lang/build/issues/902.
+- Fixed test output so it will use the compact reporter,
+  https://github.com/dart-lang/build/issues/821.
+
 ## 0.7.8
 
 - Add `--config` option to use a different `build.yaml` at build time.

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -112,7 +112,7 @@ class BuildImpl {
   final AssetGraph _assetGraph;
   final List<BuildAction> _buildActions;
   final bool _failOnSevere;
-  bool _severLogHandled = false;
+  bool _severeLogHandled = false;
   final OnDelete _onDelete;
   final PackageGraph _packageGraph;
   final AssetReader _reader;
@@ -147,14 +147,14 @@ class BuildImpl {
 
   Future<BuildResult> run(Map<AssetId, ChangeType> updates) async {
     var watch = new Stopwatch()..start();
-    _severLogHandled = false;
+    _severeLogHandled = false;
     _lazyPhases.clear();
     if (updates.isNotEmpty) {
       await _updateAssetGraph(updates);
     }
     var result = await _safeBuild(_resourceManager);
     if (_failOnSevere &&
-        _severLogHandled &&
+        _severeLogHandled &&
         result.status == BuildStatus.success) {
       result = new BuildResult(
         BuildStatus.failure,
@@ -361,7 +361,7 @@ class BuildImpl {
     await runBuilder(builder, [input], wrappedReader, wrappedWriter, _resolvers,
         logger: logger, resourceManager: resourceManager);
     if (logger.errorWasSeen) {
-      _severLogHandled = true;
+      _severeLogHandled = true;
     }
 
     // Reset the state for all the `builderOutputs` nodes based on what was

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -42,9 +42,6 @@ class BuildOptions {
   // For testing only, skips the build script updates check.
   bool skipBuildScriptCheck;
 
-  // For internal use only, flipped when a severe log occurred.
-  bool severeLogHandled = false;
-
   BuildOptions(BuildEnvironment environment,
       {@required this.packageGraph,
       BuildConfig rootPackageConfig,
@@ -67,12 +64,7 @@ class BuildOptions {
 
     Logger.root.level = logLevel;
 
-    logListener = Logger.root.onRecord.listen((r) {
-      if (r.level == Level.SEVERE) {
-        severeLogHandled = true;
-      }
-      environment.onLog(r);
-    });
+    logListener = Logger.root.onRecord.listen(environment.onLog);
 
     /// Set up other defaults.
     debounceDelay ??= const Duration(milliseconds: 250);

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -227,17 +227,6 @@ class WatchImpl implements BuildState {
         .transform(asyncMapBuffer(_recordCurrentBuild(doBuild)))
         .listen((BuildResult result) {
           if (controller.isClosed) return;
-          if (result.status != BuildStatus.failure &&
-              options.failOnSevere &&
-              options.severeLogHandled) {
-            options.severeLogHandled = false;
-            result = new BuildResult(
-              BuildStatus.failure,
-              result.outputs,
-              exception: 'A severe log was handled. See log for details',
-              performance: result.performance,
-            );
-          }
           controller.add(result);
         })
         .onDone(() async {

--- a/build_runner/lib/src/logging/error_recording_logger.dart
+++ b/build_runner/lib/src/logging/error_recording_logger.dart
@@ -57,7 +57,7 @@ class ErrorRecordingLogger implements Logger {
   @override
   void log(Level logLevel, message,
       [Object error, StackTrace stackTrace, Zone zone]) {
-    if (logLevel > Level.SEVERE) {
+    if (logLevel >= Level.SEVERE) {
       _errorWasSeen = true;
     }
     _delegate.log(logLevel, message, error, stackTrace, zone);

--- a/build_runner/lib/src/logging/error_recording_logger.dart
+++ b/build_runner/lib/src/logging/error_recording_logger.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
+class ErrorRecordingLogger implements Logger {
+  final Logger _delegate;
+
+  bool _errorWasSeen = false;
+  bool get errorWasSeen => _errorWasSeen;
+
+  ErrorRecordingLogger(this._delegate);
+
+  @override
+  Level get level => _delegate.level;
+
+  @override
+  set level(Level level) => _delegate.level = level;
+
+  @override
+  Map<String, Logger> get children => _delegate.children;
+
+  @override
+  void clearListeners() => _delegate.clearListeners();
+
+  @override
+  void config(message, [Object error, StackTrace stackTrace]) =>
+      _delegate.config(message, error, stackTrace);
+
+  @override
+  void fine(message, [Object error, StackTrace stackTrace]) =>
+      _delegate.fine(message, error, stackTrace);
+
+  @override
+  void finer(message, [Object error, StackTrace stackTrace]) =>
+      _delegate.finer(message, error, stackTrace);
+
+  @override
+  void finest(message, [Object error, StackTrace stackTrace]) =>
+      _delegate.finest(message, error, stackTrace);
+
+  @override
+  String get fullName => _delegate.fullName;
+
+  @override
+  void info(message, [Object error, StackTrace stackTrace]) =>
+      _delegate.info(message, error, stackTrace);
+
+  @override
+  bool isLoggable(Level value) => _delegate.isLoggable(value);
+
+  @override
+  void log(Level logLevel, message,
+      [Object error, StackTrace stackTrace, Zone zone]) {
+    if (logLevel > Level.SEVERE) {
+      _errorWasSeen = true;
+    }
+    _delegate.log(logLevel, message, error, stackTrace, zone);
+  }
+
+  @override
+  String get name => _delegate.name;
+
+  @override
+  Stream<LogRecord> get onRecord => _delegate.onRecord;
+
+  @override
+  Logger get parent => _delegate.parent;
+
+  @override
+  void severe(message, [Object error, StackTrace stackTrace]) {
+    _errorWasSeen = true;
+    _delegate.severe(message, error, stackTrace);
+  }
+
+  @override
+  void shout(message, [Object error, StackTrace stackTrace]) {
+    _errorWasSeen = true;
+    _delegate.shout(message, error, stackTrace);
+  }
+
+  @override
+  void warning(message, [Object error, StackTrace stackTrace]) =>
+      _delegate.warning(message, error, stackTrace);
+}

--- a/build_runner/lib/src/logging/error_recording_logger.dart
+++ b/build_runner/lib/src/logging/error_recording_logger.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 
+/// A delegating [Logger] that records if any logs of level >= [Level.SEVERE]
+/// were seen.
 class ErrorRecordingLogger implements Logger {
   final Logger _delegate;
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.8
+version: 0.7.9-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_runner/test/generate/build_error_test.dart
+++ b/build_runner/test/generate/build_error_test.dart
@@ -47,7 +47,7 @@ void main() {
     );
   });
 
-  test('should fail if a servere logged and failOnSevere is set', () async {
+  test('should fail if a severe logged and failOnSevere is set', () async {
     await testBuilders(
       [applyToRoot(new _LoggingBuilder(Level.SEVERE))],
       {

--- a/e2e_example/test/build_integration_test.dart
+++ b/e2e_example/test/build_integration_test.dart
@@ -21,11 +21,13 @@ void main() {
     test('causes builds to return a non-zero exit code on errors', () async {
       var result = await runAutoBuild(trailingArgs: ['--fail-on-severe']);
       expect(result.exitCode, isNot(0));
+      expect(result.stderr, contains('Build: Failed'));
     });
 
     test('causes tests to return a non-zero exit code on errors', () async {
       var result = await runAutoTests(buildArgs: ['--fail-on-severe']);
       expect(result.exitCode, isNot(0));
+      expect(result.stderr, contains('Build: Failed'));
       expect(result.stdout, contains('Skipping tests due to build failure'));
     });
   });


### PR DESCRIPTION
Resolves 2 of the 3 remaining parts of https://github.com/dart-lang/build/issues/910, and lays some groundwork for the last part.

Also updated the changelog to contain a bunch of missing entries from the past week.