### PR TITLE
Remember failures from previous builds

### DIFF
--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -22,6 +22,12 @@ part 'serialization.dart';
 
 /// All the [AssetId]s involved in a build, and all of their outputs.
 class AssetGraph {
+  /// All the [AssetId]s that failed the last time they were ran.
+  ///
+  /// See [markFailed] and [markSucceeded] for more info.
+  final Set<AssetId> _failedAssets;
+  Iterable<AssetId> get failedAssets => _failedAssets;
+
   /// All the [AssetNode]s in the graph, indexed by package and then path.
   final _nodesByPackage = <String, Map<String, AssetNode>>{};
 
@@ -31,7 +37,8 @@ class AssetGraph {
   /// the new [BuildAction]s and throw away the graph if it doesn't.
   final Digest buildActionsDigest;
 
-  AssetGraph._(this.buildActionsDigest);
+  AssetGraph._(this.buildActionsDigest, {Set<AssetId> failedAssets})
+      : _failedAssets = failedAssets ?? new Set<AssetId>();
 
   /// Deserializes this graph.
   factory AssetGraph.deserialize(List<int> serializedGraph) =>
@@ -69,6 +76,16 @@ class AssetGraph {
     var pkg = _nodesByPackage[id?.package];
     if (pkg == null) return null;
     return pkg[id.path];
+  }
+
+  /// Marks [id] as having failed, by adding it to [failedAssets].
+  void markFailed(AssetId id) {
+    _failedAssets.add(id);
+  }
+
+  /// Marks [id] as having succeeded, removing it from [failedAssets].
+  void markSucceeded(AssetId id) {
+    _failedAssets.remove(id);
   }
 
   /// Adds [node] to the graph if it doesn't exist.

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -89,7 +89,12 @@ class AssetGraph {
   /// Marks an action in [phaseNumber] with [primaryInputId] as having
   /// succeeded.
   void markActionSucceeded(int phaseNumber, AssetId primaryInputId) {
-    _failedActions[phaseNumber]?.remove(primaryInputId);
+    var phaseSet = _failedActions[phaseNumber];
+    if (phaseSet == null) return;
+    phaseSet.remove(primaryInputId);
+    if (phaseSet.isEmpty) {
+      _failedActions.remove(phaseNumber);
+    }
   }
 
   /// Adds [node] to the graph if it doesn't exist.

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -59,12 +59,14 @@ class _AssetGraphDeserializer {
     }
 
     // Read all the currently failing actions.
-    _serializedGraph['failedActions']
-        .forEach((int phase, List<int> serializedIds) {
+    var serializedFailedActions = _serializedGraph['failedActions'] as List;
+    for (int i = 0; i < serializedFailedActions.length; i += 2) {
+      var phase = serializedFailedActions[i] as int;
+      var serializedIds = serializedFailedActions[i + 1] as List<int>;
       graph._failedActions[phase] = serializedIds
           .map((serializedId) => _idToAssetId[serializedId])
           .toSet();
-    });
+    }
 
     return graph;
   }
@@ -174,11 +176,12 @@ class _AssetGraphSerializer {
     }
   }
 
-  Map<int, Iterable<int>> _serializeFailedActions(
-      Map<int, Iterable<AssetId>> failedActions) {
-    var serialized = <int, Iterable<int>>{};
+  List _serializeFailedActions(Map<int, Iterable<AssetId>> failedActions) {
+    var serialized = <dynamic>[];
     failedActions.forEach((phaseNum, assetIds) {
-      serialized[phaseNum] = assetIds.map((id) => _assetIdToId[id]).toList();
+      serialized
+        ..add(phaseNum)
+        ..add(assetIds.map((id) => _assetIdToId[id]).toList(growable: false));
     });
     return serialized;
   }

--- a/build_runner/lib/src/asset_graph/serialization.dart
+++ b/build_runner/lib/src/asset_graph/serialization.dart
@@ -8,7 +8,7 @@ part of 'graph.dart';
 ///
 /// This should be incremented any time the serialize/deserialize formats
 /// change.
-const _version = 16;
+const _version = 17;
 
 /// Deserializes an [AssetGraph] from a [Map].
 class _AssetGraphDeserializer {
@@ -57,6 +57,14 @@ class _AssetGraphDeserializer {
         generatedNode.inputs.add(node.id);
       }
     }
+
+    // Read all the currently failing actions.
+    _serializedGraph['failedActions']
+        .forEach((int phase, List<int> serializedIds) {
+      graph._failedActions[phase] = serializedIds
+          .map((serializedId) => _idToAssetId[serializedId])
+          .toSet();
+    });
 
     return graph;
   }
@@ -153,6 +161,7 @@ class _AssetGraphSerializer {
       'buildActionsDigest': _serializeDigest(_graph.buildActionsDigest),
       'packages': packages,
       'assetPaths': assetPaths,
+      'failedActions': _serializeFailedActions(_graph.failedActions),
     };
     return UTF8.encode(JSON.encode(result));
   }
@@ -163,6 +172,15 @@ class _AssetGraphSerializer {
     } else {
       return new _WrappedAssetNode(node, this);
     }
+  }
+
+  Map<int, Iterable<int>> _serializeFailedActions(
+      Map<int, Iterable<AssetId>> failedActions) {
+    var serialized = <int, Iterable<int>>{};
+    failedActions.forEach((phaseNum, assetIds) {
+      serialized[phaseNum] = assetIds.map((id) => _assetIdToId[id]).toList();
+    });
+    return serialized;
   }
 }
 

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -112,7 +112,6 @@ class BuildImpl {
   final AssetGraph _assetGraph;
   final List<BuildAction> _buildActions;
   final bool _failOnSevere;
-  bool _severeLogHandled = false;
   final OnDelete _onDelete;
   final PackageGraph _packageGraph;
   final AssetReader _reader;
@@ -147,19 +146,19 @@ class BuildImpl {
 
   Future<BuildResult> run(Map<AssetId, ChangeType> updates) async {
     var watch = new Stopwatch()..start();
-    _severeLogHandled = false;
     _lazyPhases.clear();
     if (updates.isNotEmpty) {
       await _updateAssetGraph(updates);
     }
     var result = await _safeBuild(_resourceManager);
     if (_failOnSevere &&
-        _severeLogHandled &&
+        _assetGraph.failedActions.isNotEmpty &&
         result.status == BuildStatus.success) {
       result = new BuildResult(
         BuildStatus.failure,
         result.outputs,
-        exception: 'A severe log was handled. See log for details',
+        exception:
+            'Some actions failed or were previously failing and not fixed.',
         performance: result.performance,
       );
     }
@@ -361,7 +360,9 @@ class BuildImpl {
     await runBuilder(builder, [input], wrappedReader, wrappedWriter, _resolvers,
         logger: logger, resourceManager: resourceManager);
     if (logger.errorWasSeen) {
-      _severeLogHandled = true;
+      _assetGraph.markActionFailed(phaseNumber, input);
+    } else {
+      _assetGraph.markActionSucceeded(phaseNumber, input);
     }
 
     // Reset the state for all the `builderOutputs` nodes based on what was

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -154,11 +154,13 @@ class BuildImpl {
     if (_failOnSevere &&
         _assetGraph.failedActions.isNotEmpty &&
         result.status == BuildStatus.success) {
+      int numFailing = _assetGraph.failedActions.values
+          .fold(0, (total, ids) => total + ids.length);
       result = new BuildResult(
         BuildStatus.failure,
         result.outputs,
-        exception:
-            'Some actions failed or were previously failing and not fixed.',
+        exception: 'There were $numFailing actions with SEVERE logs and '
+            '--fail-on-severe was passed.',
         performance: result.performance,
       );
     }

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -148,6 +148,9 @@ void main() {
         expect(graph.failedActions[1], equals([bTxt]));
         graph.markActionFailed(2, bTxt);
         expect(graph.failedActions[2], equals([bTxt]));
+        graph.markActionSucceeded(1, bTxt);
+        graph.markActionSucceeded(2, bTxt);
+        expect(graph.failedActions, isEmpty);
       });
     });
 

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -85,12 +85,16 @@ void main() {
         for (int n = 0; n < 5; n++) {
           var node = makeAssetNode();
           graph.add(node);
+          var phaseNum = n;
+          if (phaseNum % 2 == 0) {
+            graph.markActionFailed(phaseNum, node.id);
+          }
           for (int g = 0; g < 5 - n; g++) {
             var builderOptionsNode = new BuilderOptionsAssetNode(
                 makeAssetId(), md5.convert(UTF8.encode('test')));
 
             var generatedNode = new GeneratedAssetNode(makeAssetId(),
-                phaseNumber: 0,
+                phaseNumber: phaseNum,
                 primaryInput: node.id,
                 needsUpdate: g % 2 == 1,
                 wasOutput: g % 2 == 0,
@@ -119,6 +123,7 @@ void main() {
 
         var encoded = graph.serialize();
         var decoded = new AssetGraph.deserialize(encoded);
+        expect(decoded.failedActions, isNotEmpty);
         expect(graph, equalsAssetGraph(decoded));
       });
 
@@ -129,6 +134,20 @@ void main() {
         var encoded = UTF8.encode(JSON.encode(serialized));
         expect(() => new AssetGraph.deserialize(encoded),
             throwsA(assetGraphVersionException));
+      });
+
+      test('failedActions/markActionFailed/markActionSucceeded', () {
+        expect(graph.failedActions, isEmpty);
+        var aTxt = makeAssetId('a|lib/a.txt');
+        graph.markActionFailed(1, aTxt);
+        expect(graph.failedActions[1], equals([aTxt]));
+        var bTxt = makeAssetId('a|lib/b.txt');
+        graph.markActionFailed(1, bTxt);
+        expect(graph.failedActions[1], unorderedEquals([aTxt, bTxt]));
+        graph.markActionSucceeded(1, aTxt);
+        expect(graph.failedActions[1], equals([bTxt]));
+        graph.markActionFailed(2, bTxt);
+        expect(graph.failedActions[2], equals([bTxt]));
       });
     });
 


### PR DESCRIPTION
Further work towards https://github.com/dart-lang/build/issues/910, we will now remember all failures (regardless of --fail-on-severe flag), and if you provide that flag we will fail the build.

The current message is somewhat lacking, looks roughly like this:
```
[SEVERE] Build: Failed after 6.9s
There were 1 actions with `severe` logs and --fail-on-severe was passed
```
I added another action item to https://github.com/dart-lang/build/issues/910 to add a `--rerun-failing-actions` flag to get more information. I don't think its worth trying to store all the information about previous failures as it could get quite large if one failure caused a large number of other cascading failures.