### PR TITLE
Removed node failure cleanup

### DIFF
--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -193,6 +193,7 @@ class AssetGraph {
       }
       var builderOptionsNode = get(node.builderOptionsId);
       builderOptionsNode.outputs.remove(id);
+      markActionSucceeded(node.phaseNumber, node.primaryInput);
     }
     _nodesByPackage[id.package].remove(id.path);
     return removedIds;

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -137,8 +137,8 @@ void main() {
       });
 
       group('failedActions/markActionFailed/markActionSucceeded', () {
-        var aTxt = makeAssetId('a|lib/a.txt');
-        var bTxt = makeAssetId('a|lib/b.txt');
+        var aTxt = makeAssetId('foo|lib/a.txt');
+        var bTxt = makeAssetId('foo|lib/b.txt');
 
         test('basic functionality', () {
           expect(graph.failedActions, isEmpty);
@@ -155,9 +155,20 @@ void main() {
           expect(graph.failedActions, isEmpty);
         });
 
-        test('deleted nodes remove their failures', () {
-          graph.add(new SourceAssetNode(aTxt));
+        test('deleted nodes remove their failures', () async {
+          graph = await AssetGraph.build([
+            new BuildAction(
+                new TestBuilder(
+                    buildExtensions: appendExtension('.copy', from: '.txt')),
+                'foo'),
+            new BuildAction(
+                new TestBuilder(
+                    buildExtensions: appendExtension('.clone', from: '.txt')),
+                'foo'),
+          ], [aTxt, bTxt].toSet(), new Set(), fooPackageGraph, digestReader);
           graph.markActionFailed(0, aTxt);
+          graph.markActionFailed(1, aTxt);
+          expect(graph.failedActions, isNotEmpty);
           graph.remove(aTxt);
           expect(graph.failedActions, isEmpty);
         });

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -136,21 +136,31 @@ void main() {
             throwsA(assetGraphVersionException));
       });
 
-      test('failedActions/markActionFailed/markActionSucceeded', () {
-        expect(graph.failedActions, isEmpty);
+      group('failedActions/markActionFailed/markActionSucceeded', () {
         var aTxt = makeAssetId('a|lib/a.txt');
-        graph.markActionFailed(1, aTxt);
-        expect(graph.failedActions[1], equals([aTxt]));
         var bTxt = makeAssetId('a|lib/b.txt');
-        graph.markActionFailed(1, bTxt);
-        expect(graph.failedActions[1], unorderedEquals([aTxt, bTxt]));
-        graph.markActionSucceeded(1, aTxt);
-        expect(graph.failedActions[1], equals([bTxt]));
-        graph.markActionFailed(2, bTxt);
-        expect(graph.failedActions[2], equals([bTxt]));
-        graph.markActionSucceeded(1, bTxt);
-        graph.markActionSucceeded(2, bTxt);
-        expect(graph.failedActions, isEmpty);
+
+        test('basic functionality', () {
+          expect(graph.failedActions, isEmpty);
+          graph.markActionFailed(1, aTxt);
+          expect(graph.failedActions[1], equals([aTxt]));
+          graph.markActionFailed(1, bTxt);
+          expect(graph.failedActions[1], unorderedEquals([aTxt, bTxt]));
+          graph.markActionSucceeded(1, aTxt);
+          expect(graph.failedActions[1], equals([bTxt]));
+          graph.markActionFailed(2, bTxt);
+          expect(graph.failedActions[2], equals([bTxt]));
+          graph.markActionSucceeded(1, bTxt);
+          graph.markActionSucceeded(2, bTxt);
+          expect(graph.failedActions, isEmpty);
+        });
+
+        test('deleted nodes remove their failures', () {
+          graph.add(new SourceAssetNode(aTxt));
+          graph.markActionFailed(0, aTxt);
+          graph.remove(aTxt);
+          expect(graph.failedActions, isEmpty);
+        });
       });
     });
 


### PR DESCRIPTION
Previously if you had a failure to produce some output based on an input and the input was later deleted then those failures did not get cleaned up.