### PR TITLE
Drop unnecessary resolveAllLibraries parameter

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1-dev
+
+- Internal cleanup.
+
 # 0.1.0
 
 - Initial release as a migration from `code_transformers` with a near-identical

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 0.1.0
+version: 0.1.1-dev
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
This is only called from one place and always with a value of `false`.