### PR TITLE
Disable common splitting for --define

### DIFF
--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -218,6 +218,7 @@ abstract class BuildRunnerCommand extends Command<int> {
           help: 'Enables verbose logging.')
       ..addOption(_define,
           allowMultiple: true,
+          splitCommas: false,
           help: 'Sets the global `options` config for a builder by key.');
   }
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.9
+version: 0.7.10-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/e2e_example/test/dart2js_integration_test.dart
+++ b/e2e_example/test/dart2js_integration_test.dart
@@ -29,7 +29,7 @@ void main() {
             '--define',
             'build_web_compilers|entrypoint=compiler=dart2js',
             '--define',
-            'build_web_compilers|entrypoint=dart2js_args=["--checked"]',
+            'build_web_compilers|entrypoint=dart2js_args=["--checked","--trust-primitives"]',
           ]);
       await expectWasCompiledWithDart2Js();
     }, onPlatform: {'windows': const Skip('flaky on windows')});


### PR DESCRIPTION
Allows valid JSON as an argument

Fixes https://github.com/dart-lang/build/issues/949