### PR TITLE
Log non-empty stderr on build_web_compilers test

### DIFF
--- a/build_web_compilers/test/build_test.dart
+++ b/build_web_compilers/test/build_test.dart
@@ -33,8 +33,10 @@ void main() {
 
     // 2 - run build - should be no output, since nothing should change
     var result = _runProc('dart', ['--checked', 'tool/build.dart', 'build']);
-    expect(result,
-        contains(new RegExp(r'Build: Succeeded after \S+ with \d+ outputs')));
+    expect(
+        result,
+        contains(
+            new RegExp(r'Build: Succeeded after \S+( \S+)? with \d+ outputs')));
 
     // 3 - get a list of modified `.g.dart` files - should still be empty
     expect(_changedGeneratedFiles(), isEmpty);

--- a/build_web_compilers/test/build_test.dart
+++ b/build_web_compilers/test/build_test.dart
@@ -62,9 +62,8 @@ String _runProc(String proc, List<String> args) {
     throw new ProcessException(
         proc, args, result.stderr as String, result.exitCode);
   }
-
-  print('stderr:');
-  print(result.stderr);
+  var stderr = result.stderr as String;
+  if (stderr.isNotEmpty) print('stderr: $stderr');
 
   return (result.stdout as String).trim();
 }

--- a/build_web_compilers/test/build_test.dart
+++ b/build_web_compilers/test/build_test.dart
@@ -63,5 +63,8 @@ String _runProc(String proc, List<String> args) {
         proc, args, result.stderr as String, result.exitCode);
   }
 
+  print('stderr:');
+  print(result.stderr);
+
   return (result.stdout as String).trim();
 }

--- a/build_web_compilers/tool/build.dart
+++ b/build_web_compilers/tool/build.dart
@@ -1,3 +1,9 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
@@ -16,7 +22,8 @@ main(List<String> arguments) async {
         generateFor: const InputSet(include: const ['lib/src/modules.dart'])),
   ];
   var args = arguments.toList()..add('--delete-conflicting-outputs');
-  await run(args, builders);
+  var result = await run(args, builders);
+  if (result != null && result != 0) exit(result);
 }
 
 const _assetIdTypeChecker = const TypeChecker.fromRuntime(AssetId);


### PR DESCRIPTION
Sometimes on Travis the build can be slow and our output format for the
time changes when it takes over 1 minute.