### PR TITLE
Update create_merged_dir to use a manifest file

### DIFF
--- a/build_runner/bin/create_merged_dir.dart
+++ b/build_runner/bin/create_merged_dir.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as p;
 import 'package:build_runner/src/asset/build_cache.dart';
 import 'package:build_runner/src/asset/file_based.dart';
 import 'package:build_runner/src/asset_graph/graph.dart';
+import 'package:build_runner/src/environment/io_environment.dart';
 import 'package:build_runner/src/generate/create_merged_dir.dart';
 import 'package:build_runner/src/package_graph/package_graph.dart';
 import 'package:build_runner/src/util/constants.dart';
@@ -58,8 +59,8 @@ Future main(List<String> args) async {
   var reader = new BuildCacheReader(new FileBasedAssetReader(packageGraph),
       assetGraph, packageGraph.root.name);
 
-  await createMergedOutputDir(
-      parsedArgs['output-dir'] as String, assetGraph, packageGraph, reader);
+  await createMergedOutputDir(parsedArgs['output-dir'] as String, assetGraph,
+      packageGraph, reader, new IOEnvironment(packageGraph, false));
 }
 
 final argParser = new ArgParser()

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -44,6 +44,8 @@ class BuildDefinition {
 
   final OnDelete onDelete;
 
+  final BuildEnvironment environment;
+
   BuildDefinition._(
       this.assetGraph,
       this.reader,
@@ -53,7 +55,8 @@ class BuildDefinition {
       this.resourceManager,
       this.buildScriptUpdates,
       this.enableLowResourcesMode,
-      this.onDelete);
+      this.onDelete,
+      this.environment);
 
   static Future<BuildDefinition> prepareWorkspace(BuildEnvironment environment,
           BuildOptions options, List<BuildAction> buildActions,
@@ -137,7 +140,8 @@ class _Loader {
         new ResourceManager(),
         buildScriptUpdates,
         _options.enableLowResourcesMode,
-        _onDelete);
+        _onDelete,
+        _environment);
   }
 
   /// Checks that the [_buildActions] are valid based on whether they are

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -120,6 +120,7 @@ class BuildImpl {
   final RunnerAssetWriter _writer;
   final String _outputDir;
   final bool _verbose;
+  final BuildEnvironment _environment;
 
   BuildImpl._(
       BuildDefinition buildDefinition, BuildOptions options, this._buildActions)
@@ -133,7 +134,8 @@ class BuildImpl {
         _onDelete = buildDefinition.onDelete,
         _outputDir = options.outputDir,
         _verbose = options.verbose,
-        _failOnSevere = options.failOnSevere;
+        _failOnSevere = options.failOnSevere,
+        _environment = buildDefinition.environment;
 
   static Future<BuildImpl> create(BuildDefinition buildDefinition,
       BuildOptions options, List<BuildAction> buildActions,
@@ -164,7 +166,7 @@ class BuildImpl {
     }
     if (_outputDir != null && result.status == BuildStatus.success) {
       if (!await createMergedOutputDir(
-          _outputDir, _assetGraph, _packageGraph, _reader)) {
+          _outputDir, _assetGraph, _packageGraph, _reader, _environment)) {
         result = _convertToFailure(
             result, 'Failed to create merged output directory.');
       }

--- a/build_runner/lib/src/generate/create_merged_dir.dart
+++ b/build_runner/lib/src/generate/create_merged_dir.dart
@@ -17,18 +17,45 @@ import '../logging/logging.dart';
 import '../package_graph/package_graph.dart';
 
 final _logger = new Logger('CreateOutputDir');
+const _manifestName = '.build.manifest';
+const _manifestSeparator = '\n';
 
 /// Creates a merged output directory for a build at [outputPath].
-Future<Null> createMergedOutputDir(String outputPath, AssetGraph assetGraph,
+///
+/// Returns whether it succeeded or not.
+Future<bool> createMergedOutputDir(String outputPath, AssetGraph assetGraph,
     PackageGraph packageGraph, AssetReader reader) async {
   var outputDir = new Directory(outputPath);
-  if (await outputDir.exists()) {
-    await logTimedAsync(_logger, 'Deleting existing output dir `$outputPath`',
-        () => outputDir.delete(recursive: true));
+  var outputDirExists = await outputDir.exists();
+  if (outputDirExists) {
+    var manifestFile = new File(p.join(outputPath, _manifestName));
+    if (!await manifestFile.exists()) {
+      _logger.severe(
+          'Found existing output directory `$outputPath` but no manifest file, '
+          'skipping creation of output directory. If you would like to output '
+          'to this directory please delete it first, and then re-run.');
+      return false;
+    }
+
+    var previousOutputs = logTimedSync(
+        _logger,
+        'Reading manifest at ${manifestFile.path}',
+        () => manifestFile.readAsStringSync().split(_manifestSeparator));
+
+    logTimedSync(_logger, 'Deleting previous outputs in `$outputPath`', () {
+      for (var path in previousOutputs) {
+        var file = new File(p.join(outputPath, path));
+        if (file.existsSync()) file.deleteSync();
+      }
+    });
   }
+
+  var outputAssets = new Set<AssetId>();
   await logTimedAsync(_logger, 'Creating merged output dir `$outputPath`',
       () async {
-    await outputDir.create(recursive: true);
+    if (!outputDirExists) {
+      await outputDir.create(recursive: true);
+    }
     var rootDirs = new Set<String>();
 
     for (var node in assetGraph.packageNodes(packageGraph.root.name)) {
@@ -42,33 +69,57 @@ Future<Null> createMergedOutputDir(String outputPath, AssetGraph assetGraph,
 
     for (var node in assetGraph.allNodes) {
       if (_shouldSkipNode(node)) continue;
-      var assetPaths = <String>[];
+      String assetPath;
       if (node.id.path.startsWith('lib')) {
-        assetPaths.add(p.url.join('packages', node.id.package,
-            node.id.path.substring('lib/'.length)));
+        assetPath = p.url.join(
+            'packages', node.id.package, node.id.path.substring('lib/'.length));
       } else {
-        assetPaths.add(node.id.path);
+        assetPath = node.id.path;
       }
-      for (var path in assetPaths) {
-        var outputId = new AssetId(packageGraph.root.name, path);
+
+      var outputId = new AssetId(packageGraph.root.name, assetPath);
+      try {
         _writeAsBytes(outputDir, outputId, await reader.readAsBytes(node.id));
+        outputAssets.add(outputId);
+      } on AssetNotFoundException catch (e, __) {
+        if (p.basename(node.id.path).startsWith('.')) {
+          _logger.fine('Skipping missing hidden file ${node.id.path}');
+        } else {
+          _logger.severe(
+              'Missing asset ${e.assetId}, it may have been deleted during the '
+              'build. Please try rebuilding and if you continue to see the '
+              'error then file a bug at '
+              'https://github.com/dart-lang/build/issues/new.');
+          rethrow;
+        }
       }
     }
 
-    await _createMissingTestHtmlFiles(outputPath);
+    outputAssets.addAll(
+        await _createMissingTestHtmlFiles(outputPath, packageGraph.root.name));
 
     var packagesFileContent = packageGraph.allPackages.keys
         .map((p) => '$p:packages/$p/')
         .join('\r\n');
     for (var dir in rootDirs) {
-      _writeAsString(
-          outputDir,
-          new AssetId(packageGraph.root.name, p.url.join(dir, '.packages')),
-          packagesFileContent);
+      var packagesAsset =
+          new AssetId(packageGraph.root.name, p.url.join(dir, '.packages'));
+      _writeAsString(outputDir, packagesAsset, packagesFileContent);
+      outputAssets.add(packagesAsset);
       var link = new Link(p.join(outputDir.path, dir, 'packages'));
-      link.createSync(p.join('..', 'packages'), recursive: true);
+      if (!link.existsSync()) {
+        link.createSync(p.join('..', 'packages'), recursive: true);
+      }
     }
   });
+
+  logTimedSync(_logger, 'Writing asset manifest', () {
+    var content = outputAssets.map((id) => id.path).join(_manifestSeparator);
+    _writeAsString(
+        outputDir, new AssetId(packageGraph.root.name, _manifestName), content);
+  });
+
+  return true;
 }
 
 bool _shouldSkipNode(AssetNode node) {
@@ -106,13 +157,15 @@ File _fileFor(Directory outputDir, AssetId id) {
 ///
 /// This only exists as a hack until we have something like
 /// https://github.com/dart-lang/build/issues/508.
-Future<Null> _createMissingTestHtmlFiles(String outputDir) async {
-  if (!await new Directory(p.join(outputDir, 'test')).exists()) return;
+Future<List<AssetId>> _createMissingTestHtmlFiles(
+    String outputDir, String rootPackage) async {
+  if (!await new Directory(p.join(outputDir, 'test')).exists()) return [];
 
   var dartBrowserTestSuffix = '_test.dart.browser_test.dart';
   var htmlTestSuffix = '_test.html';
   var dartFiles =
       new Glob('test/**$dartBrowserTestSuffix').list(root: outputDir);
+  var outputAssets = <AssetId>[];
   await for (var file in dartFiles) {
     var dartPath = p.relative(file.path, from: outputDir);
     var htmlPath =
@@ -132,6 +185,8 @@ Future<Null> _createMissingTestHtmlFiles(String outputDir) async {
   <script src="packages/test/dart.js"></script>
 </head>
 </html>''');
+      outputAssets.add(new AssetId(rootPackage, htmlPath));
     }
   }
+  return outputAssets;
 }

--- a/build_runner/test/common/test_environment.dart
+++ b/build_runner/test/common/test_environment.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
+import 'package:build_runner/src/asset/reader.dart';
+import 'package:build_runner/src/asset/writer.dart';
+import 'package:build_runner/src/environment/build_environment.dart';
+import 'package:build_runner/src/generate/directory_watcher_factory.dart';
+
+import 'common.dart';
+
+/// A [BuildEnvironment] for testing.
+///
+/// Defaults to using an [InMemoryRunnerAssetReader] and
+/// [InMemoryRunnerAssetWriter].
+///
+/// To handle prompts you must first set `nextPromtResponse`. Alternatively
+/// you can set `throwOnPrompt` to `true` to emulate a
+/// [NonInteractiveBuildException].
+class TestBuildEnvironment implements BuildEnvironment {
+  @override
+  final RunnerAssetReader reader;
+  @override
+  final RunnerAssetWriter writer;
+  @override
+  DirectoryWatcherFactory get directoryWatcherFactory =>
+      (path) => new FakeWatcher(path);
+
+  /// If true, this will throw a [NonInteractiveBuildException] for all calls to
+  /// [prompt].
+  final bool throwOnPrompt;
+
+  final logRecords = <LogRecord>[];
+
+  /// The next response for calls to [prompt]. Must be set before calling
+  /// [prompt].
+  set nextPromptResponse(int next) {
+    assert(_nextPromptResponse == null);
+    _nextPromptResponse = next;
+  }
+
+  int _nextPromptResponse;
+
+  TestBuildEnvironment(
+      {RunnerAssetReader reader,
+      RunnerAssetWriter writer,
+      this.throwOnPrompt: false})
+      : this.reader = reader ?? new InMemoryRunnerAssetReader(),
+        this.writer = writer ?? new InMemoryRunnerAssetWriter();
+
+  @override
+  void onLog(LogRecord record) => logRecords.add(record);
+
+  /// Prompt the user for input.
+  ///
+  /// The message and choices are displayed to the user and the index of the
+  /// chosen option is returned.
+  ///
+  /// If this environmment is non-interactive (such as when running in a test)
+  /// this method should throw [NonInteractiveBuildException].
+  @override
+  Future<int> prompt(String message, List<String> choices) {
+    if (throwOnPrompt) throw new NonInteractiveBuildException();
+
+    assert(_nextPromptResponse != null);
+    return new Future.value(_nextPromptResponse);
+  }
+}

--- a/build_runner/test/common/test_environment.dart
+++ b/build_runner/test/common/test_environment.dart
@@ -18,7 +18,7 @@ import 'common.dart';
 /// Defaults to using an [InMemoryRunnerAssetReader] and
 /// [InMemoryRunnerAssetWriter].
 ///
-/// To handle prompts you must first set `nextPromtResponse`. Alternatively
+/// To handle prompts you must first set `nextPromptResponse`. Alternatively
 /// you can set `throwOnPrompt` to `true` to emulate a
 /// [NonInteractiveBuildException].
 class TestBuildEnvironment implements BuildEnvironment {

--- a/build_runner/test/generate/create_merged_dir_test.dart
+++ b/build_runner/test/generate/create_merged_dir_test.dart
@@ -1,0 +1,160 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:build_runner/src/asset_graph/graph.dart';
+import 'package:build_runner/src/asset_graph/node.dart';
+import 'package:build_runner/src/generate/create_merged_dir.dart';
+import 'package:build_runner/src/generate/phase.dart';
+
+import '../common/common.dart';
+import '../common/package_graphs.dart';
+import '../common/test_environment.dart';
+
+main() {
+  group('createMergedDir', () {
+    AssetGraph graph;
+    final actions = [
+      new BuildAction(
+          new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.txt')),
+          'a'),
+      new BuildAction(
+          new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.txt')),
+          'b')
+    ];
+    final sources = {
+      makeAssetId('a|lib/a.txt'): 'a',
+      makeAssetId('a|web/b.txt'): 'b',
+      makeAssetId('b|lib/c.txt'): 'c',
+    };
+    final packageGraph = buildPackageGraph({
+      rootPackage('a'): ['b'],
+      package('b'): []
+    });
+    Directory tmpDir;
+    TestBuildEnvironment environment;
+    InMemoryRunnerAssetReader assetReader;
+
+    setUp(() async {
+      assetReader = new InMemoryRunnerAssetReader(sources);
+      environment = new TestBuildEnvironment(reader: assetReader);
+      graph = await AssetGraph.build(actions, sources.keys.toSet(),
+          new Set<AssetId>(), packageGraph, assetReader);
+      for (var id in graph.outputs) {
+        var node = graph.get(id) as GeneratedAssetNode;
+        node.wasOutput = true;
+        assetReader.cacheStringAsset(id, sources[node.primaryInput]);
+      }
+      tmpDir = await Directory.systemTemp.createTemp('build_tests');
+    });
+
+    tearDown(() async {
+      await tmpDir.delete(recursive: true);
+    });
+
+    test('creates a valid merged output directory', () async {
+      var success = await createMergedOutputDir(
+          tmpDir.path, graph, packageGraph, assetReader, environment);
+      expect(success, isTrue);
+
+      _expectAllFiles(tmpDir);
+    });
+
+    test('doesnt write files that werent output', () async {
+      var node =
+          graph.get(new AssetId('b', 'lib/c.txt.copy')) as GeneratedAssetNode;
+      node.wasOutput = false;
+
+      var success = await createMergedOutputDir(
+          tmpDir.path, graph, packageGraph, assetReader, environment);
+      expect(success, isTrue);
+
+      var file = new File(p.join(tmpDir.path, 'packages/b/c.txt.copy'));
+      expect(file.existsSync(), isFalse);
+    });
+
+    group('existing output dir handling', () {
+      File garbageFile;
+      setUp(() {
+        garbageFile = new File(p.join(tmpDir.path, 'garbage_file.txt'));
+        garbageFile.createSync();
+      });
+
+      test('fails in non-interactive mode', () async {
+        environment =
+            new TestBuildEnvironment(reader: assetReader, throwOnPrompt: true);
+        var success = await createMergedOutputDir(
+            tmpDir.path, graph, packageGraph, assetReader, environment);
+        expect(success, isFalse);
+      });
+
+      test('can skip creating the directory', () async {
+        environment.nextPromptResponse = 0;
+        var success = await createMergedOutputDir(
+            tmpDir.path, graph, packageGraph, assetReader, environment);
+        expect(success, isFalse,
+            reason: 'Skipping creation of the directory should be considered a '
+                'failure.');
+
+        expect(garbageFile.existsSync(), isTrue,
+            reason: 'Should not delete existing files.');
+        var file = new File(p.join(tmpDir.path, 'web/b.txt'));
+        expect(file.existsSync(), isFalse,
+            reason: 'Should not copy any files.');
+      });
+
+      test('can delete the entire existing directory', () async {
+        environment.nextPromptResponse = 1;
+        var success = await createMergedOutputDir(
+            tmpDir.path, graph, packageGraph, assetReader, environment);
+        expect(success, isTrue);
+
+        expect(garbageFile.existsSync(), isFalse);
+        _expectAllFiles(tmpDir);
+      });
+
+      test('can merge into the existing directory', () async {
+        environment.nextPromptResponse = 2;
+        var success = await createMergedOutputDir(
+            tmpDir.path, graph, packageGraph, assetReader, environment);
+        expect(success, isTrue);
+
+        expect(garbageFile.existsSync(), isTrue,
+            reason: 'Existing files should be left alone.');
+        _expectAllFiles(tmpDir);
+      });
+    });
+  });
+}
+
+void _expectAllFiles(Directory dir) {
+  var expectedFiles = <String, dynamic>{
+    'packages/a/a.txt': 'a',
+    'packages/a/a.txt.copy': 'a',
+    'packages/b/c.txt': 'c',
+    'packages/b/c.txt.copy': 'c',
+    'web/b.txt': 'b',
+    'web/b.txt.copy': 'b',
+    'web/.packages': '''
+a:packages/a/\r
+b:packages/b/\r
+\$sdk:packages/\$sdk/''',
+  };
+  expectedFiles['.build.manifest'] =
+      allOf(expectedFiles.keys.map(contains).toList());
+  expectedFiles.forEach((path, content) {
+    var file = new File(p.join(dir.path, path));
+    expect(file.existsSync(), isTrue, reason: 'Missing file at $path.');
+    expect(file.readAsStringSync(), content,
+        reason: 'Incorrect content for file at $path');
+  });
+}


### PR DESCRIPTION
If the manifest doesn't exist in the target directory you get this prompt:

```
Found existing output directory `build` but no manifest file. Please choose one of the following options:
1 - Skip creating the output directory
2 - Delete the existing directory entirely
3 - Leave the directory in place and write over any existing files
```

Should fix https://github.com/dart-lang/build/issues/927