### PR TITLE
Use isInSystemLibrary instead of isInSdk

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0+1
+
+- Fix a bug with imports to libraries that have names starting with `dart.`
+
 # 0.1.0
 
 - Split from `build_web_compilers`.

--- a/build_modules/lib/src/modules.dart
+++ b/build_modules/lib/src/modules.dart
@@ -162,13 +162,10 @@ Iterable<LibraryElement> _cycleDependencies(
 /// [library].
 ///
 /// There may be duplicates.
-Iterable<LibraryElement> _libraryDependencies(LibraryElement library) =>
-    [library.importedLibraries, library.exportedLibraries]
-        .expand((l) => l)
-        // TODO: `isInSdk` returns false for some dart: libraries, can remove
-        // the `dart` scheme check once
-        // https://github.com/dart-lang/sdk/issues/31045 is fixed.
-        .where((l) => !l.isInSdk && l.source.uri.scheme != 'dart');
+Iterable<LibraryElement> _libraryDependencies(LibraryElement library) => [
+      library.importedLibraries,
+      library.exportedLibraries
+    ].expand((l) => l).where((l) => !l.source.isInSystemLibrary);
 
 /// All sources for a library cycle, including part files.
 Iterable<Uri> _cycleSources(Iterable<LibraryElement> libraries) =>

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 0.1.0
+version: 0.1.0+1
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_modules/test/fixtures/a/lib/a_dep_on_non_sdk.dart
+++ b/build_modules/test/fixtures/a/lib/a_dep_on_non_sdk.dart
@@ -1,0 +1,2 @@
+// ignore_for_file: unused_import
+import 'package:a/a_non_sdk.dart';

--- a/build_modules/test/fixtures/a/lib/a_non_sdk.dart
+++ b/build_modules/test/fixtures/a/lib/a_non_sdk.dart
@@ -1,0 +1,1 @@
+library dart.pkg.not_in_sdk;

--- a/build_modules/test/modules_test.dart
+++ b/build_modules/test/modules_test.dart
@@ -70,7 +70,8 @@ void main() {
     test('Includes libraries that have names starting with "dart."', () {
       // https://github.com/dart-lang/sdk/issues/31045
       // `library.isInSdk` is broken - we shouldn't use it
-      var dependencies = new Module.forLibrary(libDepOnNonSdk).directDependencies;
+      var dependencies =
+          new Module.forLibrary(libDepOnNonSdk).directDependencies;
       expect(dependencies, unorderedEquals([assetNonSdk]));
     });
   });

--- a/build_modules/test/modules_test.dart
+++ b/build_modules/test/modules_test.dart
@@ -14,12 +14,15 @@ void main() {
   LibraryElement libNoCycle;
   LibraryElement libCycleWithB;
   LibraryElement libCycleWithA;
+  LibraryElement libDepOnNonSdk;
   final assetCycle = makeAssetId('a|lib/a_cycle.dart');
   final assetSecondaryInCycle = makeAssetId('a|lib/a_secondary_in_cycle.dart');
   final assetPartInCycle = makeAssetId('a|lib/a_part_in_cycle.dart');
   final assetNoCycle = makeAssetId('a|lib/a_no_cycle.dart');
   final assetCycleWithB = makeAssetId('a|lib/a_cycle_with_b.dart');
   final assetCycleWithA = makeAssetId('b|lib/b_cycle_with_a.dart');
+  final assetDepOnNonSdk = makeAssetId('a|lib/a_dep_on_non_sdk.dart');
+  final assetNonSdk = makeAssetId('a|lib/a_non_sdk.dart');
 
   setUpAll(() async {
     await resolveAsset(assetCycle, (resolver) async {
@@ -32,6 +35,9 @@ void main() {
     await resolveAsset(assetCycleWithB, (resolver) async {
       libCycleWithB = await resolver.libraryFor(assetCycleWithB);
       libCycleWithA = await resolver.libraryFor(assetCycleWithA);
+    });
+    await resolveAsset(assetDepOnNonSdk, (resolver) async {
+      libDepOnNonSdk = await resolver.libraryFor(assetDepOnNonSdk);
     });
   });
 
@@ -59,6 +65,13 @@ void main() {
     test('Chooses primary from cycle for dependency', () {
       var dependencies = new Module.forLibrary(libCycle).directDependencies;
       expect(dependencies, unorderedEquals([assetCycleWithB]));
+    });
+
+    test('Includes libraries that have names starting with "dart."', () {
+      // https://github.com/dart-lang/sdk/issues/31045
+      // `library.isInSdk` is broken - we shouldn't use it
+      var dependencies = new Module.forLibrary(libDepOnNonSdk).directDependencies;
+      expect(dependencies, unorderedEquals([assetNonSdk]));
     });
   });
 


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/31045 - isInSdk is broken

Add a regression test to indicate exactly what is wrong with the old
version.