### PR TITLE
fix dart2js builder with --no-source-maps

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0+1
+
+- Fixed an issue with `dart2js` and the `--no-source-maps` flag.
+
 # 0.3.0
 
 ## Breaking changes

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -37,7 +37,10 @@ Future<Null> bootstrapDart2Js(
     await scratchSpace.copyOutput(jsOutputId, buildStep);
     var jsSourceMapId =
         dartEntrypointId.changeExtension(jsEntrypointSourceMapExtension);
-    await scratchSpace.copyOutput(jsSourceMapId, buildStep);
+    var jsSourceMapFile = scratchSpace.fileFor(jsSourceMapId);
+    if (await jsSourceMapFile.exists()) {
+      await scratchSpace.copyOutput(jsSourceMapId, buildStep);
+    }
   } else {
     log.severe(result.output);
   }

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.3.0
+version: 0.3.0+1
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build

--- a/build_web_compilers/test/dart2js_bootstrap_test.dart
+++ b/build_web_compilers/test/dart2js_bootstrap_test.dart
@@ -42,4 +42,15 @@ main() {
     await testBuilder(new WebEntrypointBuilder(WebCompiler.Dart2Js), assets,
         outputs: expectedOutputs);
   });
+
+  test('works with --no-sourcemap', () async {
+    var expectedOutputs = {
+      'a|web/index.dart.js': anything,
+    };
+    await testBuilder(
+        new WebEntrypointBuilder(WebCompiler.Dart2Js,
+            dart2JsArgs: ['--no-source-maps']),
+        assets,
+        outputs: expectedOutputs);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/987

The test requires https://github.com/dart-lang/build/pull/989 to pass, will re-run travis after that is submitted and published.