### PR TITLE
Add sub-step tracking for time spent crawling imports

### DIFF
--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -29,6 +29,7 @@ import '../package_graph/apply_builders.dart';
 import '../package_graph/build_config_overrides.dart';
 import '../package_graph/package_graph.dart';
 import '../package_graph/target_graph.dart';
+import '../performance_tracking/performance_tracking_resolvers.dart';
 import '../util/constants.dart';
 import 'build_definition.dart';
 import 'build_result.dart';
@@ -364,8 +365,7 @@ class BuildImpl {
             phase, outputsHidden, input, resourceManager));
 
     if (!await tracker.track(
-        () => _buildShouldRun(builderOutputs, wrappedReader),
-        BuilderActionPhase.Setup)) {
+        () => _buildShouldRun(builderOutputs, wrappedReader), 'Setup')) {
       tracker.stop();
       return <AssetId>[];
     }
@@ -379,10 +379,10 @@ class BuildImpl {
     var wrappedWriter = new AssetWriterSpy(_writer);
     var logger = new ErrorRecordingLogger(new Logger('$builder on $input'));
     await tracker.track(
-        () => runBuilder(
-            builder, [input], wrappedReader, wrappedWriter, _resolvers,
+        () => runBuilder(builder, [input], wrappedReader, wrappedWriter,
+            new PerformanceTrackingResolvers(_resolvers, tracker),
             logger: logger, resourceManager: resourceManager),
-        BuilderActionPhase.Build);
+        'Build');
     if (logger.errorWasSeen) {
       _assetGraph.markActionFailed(phaseNumber, input);
     } else {
@@ -393,7 +393,7 @@ class BuildImpl {
     // read and written.
     await tracker.track(
         () => _setOutputsState(builderOutputs, wrappedReader, wrappedWriter),
-        BuilderActionPhase.Finalize);
+        'Finalize');
 
     tracker.stop();
     return wrappedWriter.assetsWritten;

--- a/build_runner/lib/src/generate/performance_tracker.dart
+++ b/build_runner/lib/src/generate/performance_tracker.dart
@@ -46,7 +46,7 @@ abstract class BuilderActionPerformance implements Timings {
 ///
 /// This is some slice of overall [BuilderActionPerformance].
 abstract class BuilderActionPhasePerformance implements Timings {
-  String get name;
+  String get label;
 }
 
 /// Internal class that tracks the [Timings] of an entire build.
@@ -126,8 +126,8 @@ class BuilderActionTracker extends TimeTracker
 
   BuilderActionTracker(this.primaryInput, this.builder);
 
-  FutureOr<T> track<T>(FutureOr<T> action(), String name) {
-    var tracker = new BuilderActionPhaseTracker(name);
+  FutureOr<T> track<T>(FutureOr<T> action(), String label) {
+    var tracker = new BuilderActionPhaseTracker(label);
     phases.add(tracker);
     tracker.start();
     var result = action();
@@ -149,9 +149,9 @@ class BuilderActionTracker extends TimeTracker
 class BuilderActionPhaseTracker extends TimeTracker
     implements BuilderActionPhasePerformance {
   @override
-  final String name;
+  final String label;
 
-  BuilderActionPhaseTracker(this.name);
+  BuilderActionPhaseTracker(this.label);
 }
 
 /// Internal base class for tracking the [Timings] of an arbitrary operation.

--- a/build_runner/lib/src/generate/performance_tracker.dart
+++ b/build_runner/lib/src/generate/performance_tracker.dart
@@ -42,11 +42,12 @@ abstract class BuilderActionPerformance implements Timings {
   Iterable<BuilderActionPhasePerformance> get phases;
 }
 
-/// The [Timings] of a particular [BuilderActionPhase].
+/// The [Timings] of a particular task within a builder action.
 ///
 /// This is some slice of overall [BuilderActionPerformance].
 abstract class BuilderActionPhasePerformance implements Timings {
-  BuilderActionPhase get phase;
+  // TODO give a different name
+  String get phase;
 }
 
 /// Internal class that tracks the [Timings] of an entire build.
@@ -113,17 +114,6 @@ class BuildPhaseTracker extends TimeTracker implements BuildPhasePerformance {
   }
 }
 
-/// The phases for running a [Builder] with a single primary input.
-enum BuilderActionPhase {
-  // Checking if the builder should run, possibly involves building other
-  // things lazily.
-  Setup,
-  // Actually running the builder, may involve building secondary inputs lazily.
-  Build,
-  // The finalizing step, updating the state of the asset graph etc.
-  Finalize,
-}
-
 /// Tracks the [Timings] of an indiviual [Builder] on a given primary input.
 class BuilderActionTracker extends TimeTracker
     implements BuilderActionPerformance {
@@ -137,7 +127,7 @@ class BuilderActionTracker extends TimeTracker
 
   BuilderActionTracker(this.primaryInput, this.builder);
 
-  FutureOr<T> track<T>(FutureOr<T> runPhase(), BuilderActionPhase phase) {
+  FutureOr<T> track<T>(FutureOr<T> runPhase(), String phase) {
     var tracker = new BuilderActionPhaseTracker(phase);
     phases.add(tracker);
     tracker.start();
@@ -154,13 +144,13 @@ class BuilderActionTracker extends TimeTracker
   }
 }
 
-/// Tracks the [Timings] of an indivual [BuilderActionPhase].
+/// Tracks the [Timings] of an indivual task.
 ///
 /// These represent a slice of the [BuilderActionPerformance].
 class BuilderActionPhaseTracker extends TimeTracker
     implements BuilderActionPhasePerformance {
   @override
-  final BuilderActionPhase phase;
+  final String phase;
 
   BuilderActionPhaseTracker(this.phase);
 }

--- a/build_runner/lib/src/generate/performance_tracker.dart
+++ b/build_runner/lib/src/generate/performance_tracker.dart
@@ -46,8 +46,7 @@ abstract class BuilderActionPerformance implements Timings {
 ///
 /// This is some slice of overall [BuilderActionPerformance].
 abstract class BuilderActionPhasePerformance implements Timings {
-  // TODO give a different name
-  String get phase;
+  String get name;
 }
 
 /// Internal class that tracks the [Timings] of an entire build.
@@ -127,11 +126,11 @@ class BuilderActionTracker extends TimeTracker
 
   BuilderActionTracker(this.primaryInput, this.builder);
 
-  FutureOr<T> track<T>(FutureOr<T> runPhase(), String phase) {
-    var tracker = new BuilderActionPhaseTracker(phase);
+  FutureOr<T> track<T>(FutureOr<T> action(), String name) {
+    var tracker = new BuilderActionPhaseTracker(name);
     phases.add(tracker);
     tracker.start();
-    var result = runPhase();
+    var result = action();
     if (result is Future<T>) {
       return result.then((actualResult) {
         tracker.stop();
@@ -150,9 +149,9 @@ class BuilderActionTracker extends TimeTracker
 class BuilderActionPhaseTracker extends TimeTracker
     implements BuilderActionPhasePerformance {
   @override
-  final String phase;
+  final String name;
 
-  BuilderActionPhaseTracker(this.phase);
+  BuilderActionPhaseTracker(this.name);
 }
 
 /// Internal base class for tracking the [Timings] of an arbitrary operation.

--- a/build_runner/lib/src/performance_tracking/performance_tracking_resolvers.dart
+++ b/build_runner/lib/src/performance_tracking/performance_tracking_resolvers.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+
+import '../generate/performance_tracker.dart';
+
+class PerformanceTrackingResolvers implements Resolvers {
+  final Resolvers _delegate;
+  final BuilderActionTracker _tracker;
+
+  PerformanceTrackingResolvers(this._delegate, this._tracker);
+
+  @override
+  Future<ReleasableResolver> get(BuildStep buildStep) =>
+      _tracker.track(() => _delegate.get(buildStep), 'ResolverGet')
+          as Future<ReleasableResolver>;
+}

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -146,9 +146,7 @@ class AssetHandler {
 String _renderPerformance(BuildPerformance performance, bool hideSkipped) {
   var rows = new StringBuffer();
   for (var action in performance.actions) {
-    if (hideSkipped &&
-        !action.phases
-            .any((phase) => phase.phase == BuilderActionPhase.Build)) {
+    if (hideSkipped && !action.phases.any((phase) => phase.phase == 'Build')) {
       continue;
     }
     var actionKey = '${action.builder.runtimeType}:${action.primaryInput}';
@@ -158,20 +156,7 @@ String _renderPerformance(BuildPerformance performance, bool hideSkipped) {
       var end = phase.stopTime.millisecondsSinceEpoch -
           performance.startTime.millisecondsSinceEpoch;
 
-      String phaseName;
-      switch (phase.phase) {
-        case BuilderActionPhase.Setup:
-          phaseName = 'setup';
-          break;
-        case BuilderActionPhase.Build:
-          phaseName = 'build';
-          break;
-        case BuilderActionPhase.Finalize:
-          phaseName = 'finalize';
-          break;
-      }
-
-      rows.writeln('          ["$actionKey", "$phaseName", $start, $end],');
+      rows.writeln('          ["$actionKey", "${phase.phase}", $start, $end],');
     }
   }
   if (performance.duration < new Duration(seconds: 1)) {

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -146,7 +146,7 @@ class AssetHandler {
 String _renderPerformance(BuildPerformance performance, bool hideSkipped) {
   var rows = new StringBuffer();
   for (var action in performance.actions) {
-    if (hideSkipped && !action.phases.any((phase) => phase.phase == 'Build')) {
+    if (hideSkipped && !action.phases.any((phase) => phase.name == 'Build')) {
       continue;
     }
     var actionKey = '${action.builder.runtimeType}:${action.primaryInput}';
@@ -156,7 +156,7 @@ String _renderPerformance(BuildPerformance performance, bool hideSkipped) {
       var end = phase.stopTime.millisecondsSinceEpoch -
           performance.startTime.millisecondsSinceEpoch;
 
-      rows.writeln('          ["$actionKey", "${phase.phase}", $start, $end],');
+      rows.writeln('          ["$actionKey", "${phase.name}", $start, $end],');
     }
   }
   if (performance.duration < new Duration(seconds: 1)) {

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -146,7 +146,7 @@ class AssetHandler {
 String _renderPerformance(BuildPerformance performance, bool hideSkipped) {
   var rows = new StringBuffer();
   for (var action in performance.actions) {
-    if (hideSkipped && !action.phases.any((phase) => phase.name == 'Build')) {
+    if (hideSkipped && !action.phases.any((phase) => phase.label == 'Build')) {
       continue;
     }
     var actionKey = '${action.builder.runtimeType}:${action.primaryInput}';
@@ -156,7 +156,7 @@ String _renderPerformance(BuildPerformance performance, bool hideSkipped) {
       var end = phase.stopTime.millisecondsSinceEpoch -
           performance.startTime.millisecondsSinceEpoch;
 
-      rows.writeln('          ["$actionKey", "${phase.name}", $start, $end],');
+      rows.writeln('          ["$actionKey", "${phase.label}", $start, $end],');
     }
   }
   if (performance.duration < new Duration(seconds: 1)) {

--- a/build_runner/test/generate/performance_tracker_test.dart
+++ b/build_runner/test/generate/performance_tracker_test.dart
@@ -77,13 +77,13 @@ main() {
           var actionTracker = tracker.startBuilderAction(input, builder);
           await actionTracker.track(() async {
             time = time.add(const Duration(seconds: 1));
-          }, BuilderActionPhase.Setup);
+          }, 'Setup');
           await actionTracker.track(() async {
             time = time.add(const Duration(seconds: 1));
-          }, BuilderActionPhase.Build);
+          }, 'Build');
           await actionTracker.track(() async {
             time = time.add(const Duration(seconds: 1));
-          }, BuilderActionPhase.Finalize);
+          }, 'Finalize');
           actionTracker.stop();
         }
         tracker.stop();
@@ -97,7 +97,6 @@ main() {
           var allPhases = action.phases.toList();
           for (int p = 0; p < 3; p++) {
             var phase = allPhases[p];
-            expect(phase.phase, BuilderActionPhase.values[p]);
             expect(phase.duration, new Duration(seconds: 1));
             expect(
                 phase.startTime,


### PR DESCRIPTION
This opens up a possibility to expose an API to allow builder authors to
track their own timings for the work they do.

Next step is to also track time spent in the AssetReader

- Change `phase` from an enum to a String (TODO: rename)
- Add a `PerformanceTrackingResolvers` so that the initial `get()`,
  which is where the import crawling happens, is tracked.