### PR TITLE
build_modules: require at least source_gen ^0.7.5

### DIFF
--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 0.1.0+2
+version: 0.1.1-dev
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build
@@ -26,7 +26,7 @@ dev_dependencies:
   build_runner: ^0.7.0
   build_test: ^0.10.0
   json_serializable: ^0.3.0
-  source_gen: ^0.7.0
+  source_gen: ^0.7.5
   test: ^0.12.24
   a:
     path: test/fixtures/a

--- a/build_modules/tool/build.dart
+++ b/build_modules/tool/build.dart
@@ -18,7 +18,7 @@ main(List<String> arguments) async {
         new PartBuilder([
           new JsonSerializableGenerator.withDefaultHelpers(
               [const _AssetIdTypeHelper()])
-        ], requireLibraryDirective: false),
+        ]),
         generateFor: const InputSet(include: const ['lib/src/modules.dart'])),
   ];
   var args = arguments.toList()..add('--delete-conflicting-outputs');


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/992