### PR TITLE
skip builders with relative imports that arent defined in the root package

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.10+1
+
+- Fix bug where relative imports in a dependencies build.yaml would break
+  all downstream users, https://github.com/dart-lang/build/issues/995.
+
 ## 0.7.10
 
 ### New Features

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -54,7 +54,12 @@ Future<Iterable<Expression>> _findBuilderApplications(String configKey) async {
 
   final builderDefinitions =
       (await Future.wait(orderedPackages.map(_packageBuildConfig)))
-          .expand((c) => c.builderDefinitions.values);
+          .expand((c) => c.builderDefinitions.values).where((definition) {
+            // Filter out builderDefinitions with relative imports that aren't
+            // from the root package, because they will never work.
+            if (definition.import.startsWith('package:')) return true;
+            return definition.package == packageGraph.root.name;
+          });
 
   final orderedBuilders = findBuilderOrder(builderDefinitions);
   builderApplications.addAll(orderedBuilders.map(_applyBuilder));

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.10
+version: 0.7.10+1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
Fixes the underlying issue for https://github.com/dart-lang/build/issues/995.

We still need to do more at some point (not importing builders which will never be applied) but this should catch this really basic case which can never work.