### PR TITLE
update serve usage to mention directory/port trailing args

### DIFF
--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -314,7 +314,7 @@ class _ServeCommand extends _WatchCommand {
   }
 
   @override
-  String get invocation => '${super.invocation} [directory[:port]] ...';
+  String get invocation => '${super.invocation} [directory[:port]]...';
 
   @override
   String get name => 'serve';

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -314,7 +314,7 @@ class _ServeCommand extends _WatchCommand {
   }
 
   @override
-  String get invocation => '${super.invocation} [directory[:port]]...';
+  String get invocation => '${super.invocation} [<directory>[:<port>]]...';
 
   @override
   String get name => 'serve';

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -141,16 +141,17 @@ class _ServeOptions extends _SharedOptions {
   factory _ServeOptions.fromParsedArgs(
       ArgResults argResults, String rootPackage) {
     var serveTargets = <_ServeTarget>[];
+    int nextDefaultPort = 8080;
     for (var arg in argResults.rest) {
       var parts = arg.split(':');
       var path = parts.first;
-      var port = parts.length == 2 ? int.parse(parts[1]) : 8080;
+      var port = parts.length == 2 ? int.parse(parts[1]) : nextDefaultPort++;
       serveTargets.add(new _ServeTarget(path, port));
     }
     if (serveTargets.isEmpty) {
       serveTargets.addAll([
-        new _ServeTarget('web', 8080),
-        new _ServeTarget('test', 8081),
+        new _ServeTarget('web', nextDefaultPort++),
+        new _ServeTarget('test', nextDefaultPort++),
       ]);
     }
     return new _ServeOptions._(

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -313,6 +313,9 @@ class _ServeCommand extends _WatchCommand {
   }
 
   @override
+  String get invocation => '${super.invocation} [directory[:port]] ...';
+
+  @override
   String get name => 'serve';
 
   @override


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/1005

I didn't see a 100% clear standard on how to represent this arg (specifically, the optional `:port` part) in a usage statement, this seems to be fairly reasonable though.

I also fixed it so you can provide a series of dirs with no ports and won't get an error.