### PR TITLE
Work towards fixing ddc source maps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Dart command line",
+            "type": "dart-cli",
+            "request": "launch",
+            "program": "${workspaceRoot}/bin/main.dart"
+        },
+        {
+            "name": "E2E example build",
+            "type": "dart-cli",
+            "request": "launch",
+            "program": "${workspaceRoot}/e2e_example/.dart_tool/build/entrypoint/build.dart",
+            "cwd": "${workspaceRoot}/e2e_example",
+            "args": [
+                "build"
+            ]
+        }
+    ]
+}

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -183,7 +183,6 @@ var _currentDirectory = (function () {
 /// Sets up `window.$dartLoader` based on [modulePaths].
 String _dartLoaderSetup(Map<String, String> modulePaths) => '''
 $_currentDirectoryScript
-$_baseUrlScript
 let modulePaths = ${const JsonEncoder.withIndent(" ").convert(modulePaths)};
 if(!window.\$dartLoader) {
    window.\$dartLoader = {

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -183,6 +183,7 @@ var _currentDirectory = (function () {
 /// Sets up `window.$dartLoader` based on [modulePaths].
 String _dartLoaderSetup(Map<String, String> modulePaths) => '''
 $_currentDirectoryScript
+$_baseUrlScript
 let modulePaths = ${const JsonEncoder.withIndent(" ").convert(modulePaths)};
 if(!window.\$dartLoader) {
    window.\$dartLoader = {
@@ -198,7 +199,7 @@ for (let moduleName of Object.getOwnPropertyNames(modulePaths)) {
   if (modulePath != moduleName) {
     customModulePaths[moduleName] = modulePath;
   }
-  var src = _currentDirectory + modulePath + '.js';
+  var src = window.location.origin + '/' + modulePath + '.js';
   // dartdevc only strips the final extension when adding modules to source
   // maps, so we need to do the same.
   if (moduleName != 'dart_sdk') {

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -178,7 +178,7 @@ var _currentDirectory = (function () {
 
 /// Sets up `window.$dartLoader` based on [modulePaths].
 String _dartLoaderSetup(Map<String, String> modulePaths) => '''
-$_currentDirectoryScript
+$_baseUrlScript
 let modulePaths = ${const JsonEncoder.withIndent(" ").convert(modulePaths)};
 if(!window.\$dartLoader) {
    window.\$dartLoader = {
@@ -188,7 +188,7 @@ if(!window.\$dartLoader) {
    };
 }
 let customModulePaths = {};
-window.\$dartLoader.rootDirectories.push(_currentDirectory);
+window.\$dartLoader.rootDirectories.push(window.location.origin + baseUrl);
 for (let moduleName of Object.getOwnPropertyNames(modulePaths)) {
   let modulePath = modulePaths[moduleName];
   if (modulePath != moduleName) {

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -218,12 +218,14 @@ for (let moduleName of Object.getOwnPropertyNames(modulePaths)) {
 ///
 /// Posts a message to the window when done.
 final _initializeTools = '''
+$_baseUrlScript
   dart_sdk._debugger.registerDevtoolsFormatter();
   if (window.\$dartStackTraceUtility && !window.\$dartStackTraceUtility.ready) {
     window.\$dartStackTraceUtility.ready = true;
     let dart = dart_sdk.dart;
     window.\$dartStackTraceUtility.setSourceMapProvider(
       function(url) {
+        url = url.replace(baseUrl, '/');
         var module = window.\$dartLoader.urlToModuleId.get(url);
         if (!module) return null;
         return dart.getSourceMap(module);

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -199,6 +199,11 @@ for (let moduleName of Object.getOwnPropertyNames(modulePaths)) {
     customModulePaths[moduleName] = modulePath;
   }
   var src = _currentDirectory + modulePath + '.js';
+  // dartdevc only strips the final extension when adding modules to source
+  // maps, so we need to do the same.
+  if (moduleName != 'dart_sdk') {
+    moduleName += '${p.withoutExtension(jsModuleExtension)}';
+  }
   if (window.\$dartLoader.moduleIdToUrl.has(moduleName)) {
     continue;
   }

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -81,10 +81,6 @@ Future<Null> bootstrapDdc(BuildStep buildStep,
   await buildStep.writeAsString(
       dartEntrypointId.changeExtension(jsEntrypointExtension),
       entrypointJsContent);
-  await buildStep.writeAsString(
-      dartEntrypointId.changeExtension(jsEntrypointSourceMapExtension),
-      '{"version":3,"sourceRoot":"","sources":[],"names":[],"mappings":"",'
-      '"file":""}');
 }
 
 /// Ensures that all transitive js modules for [module] are available and built.

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -41,7 +41,6 @@ main() {
     // things actually work.
     var expectedOutputs = {
       'a|web/index.dart.js': decodedMatches(contains('index.dart.bootstrap')),
-      'a|web/index.dart.js.map': anything,
       'a|web/index.dart.bootstrap.js': decodedMatches(allOf([
         // Maps non-lib modules to remove the top level dir.
         contains('"web/index": "index.ddc"'),


### PR DESCRIPTION
Towards https://github.com/dart-lang/build/issues/916 and https://github.com/dart-lang/angular/issues/871.

After this we are now getting an empty stack trace in the console, but stack traces in the browser work as expected. The console logging for package:test looks like a package:test issue where it is trying to re-map the already mapped stack trace, going to pass that part off to @grouma for further investigation. 

This is pretty difficult to write a test for, we will need to set up webdriver I think. I filed https://github.com/dart-lang/build/issues/1021 to track adding that test as a followup.