### PR TITLE
release build_runner 0.7.11

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.11-dev
+## 0.7.11
 
 - Performance tracking is now disabled by default, and you must pass the
   `--track-performance` flag to enable it.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.11-dev
+version: 0.7.11
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
Going to wait on https://github.com/dart-lang/build/pull/1027 and then merge this and release