### PR TITLE
use polling watcher on windows

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.11+1
+
+- Switch to use a `PollingDirectoryWatcher` on windows, which should fix file
+  watching with the `--output` option. Follow along at
+  https://github.com/dart-lang/watcher/issues/52 for more details.
+
 ## 0.7.11
 
 - Performance tracking is now disabled by default, and you must pass the

--- a/build_runner/lib/src/generate/directory_watcher_factory.dart
+++ b/build_runner/lib/src/generate/directory_watcher_factory.dart
@@ -1,9 +1,17 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
 import 'package:watcher/watcher.dart';
 
 typedef DirectoryWatcher DirectoryWatcherFactory(String path);
 
 DirectoryWatcher defaultDirectoryWatcherFactory(String path) =>
-    new DirectoryWatcher(path);
+    // TODO: Use `DirectoryWatcher` on windows. See the following issues:
+    // - https://github.com/dart-lang/build/issues/1031
+    // - https://github.com/dart-lang/watcher/issues/52
+    Platform.isWindows
+        ? new PollingDirectoryWatcher(path)
+        : new DirectoryWatcher(path);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.11
+version: 0.7.11+1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/1031 in a roundabout way, we can revert this once https://github.com/dart-lang/watcher/issues/52 is resolved.