### PR TITLE
Add --log-requests flag

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.7.12-prerelease
 
+- Added the `--log-requests` flag to the `serve` command, which will log all
+  requests to the server.
 - Build actions using `findAssets` will be more smartly invalidated.
 - Added a warning if using `serve` mode but no directories were found to serve.
 - The `--output` option now only outputs files that were required for the latest

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -271,21 +271,15 @@ shelf.Handler _logRequests(shelf.Handler innerHandler) {
 
     return new Future.sync(() => innerHandler(request)).then((response) {
       var logFn = response.statusCode >= 500 ? _logger.warning : _logger.info;
-
       var msg = _getMessage(startTime, response.statusCode,
           request.requestedUri, request.method, watch.elapsed);
-
       logFn(msg);
-
       return response;
     }, onError: (error, stackTrace) {
       if (error is shelf.HijackException) throw error;
-
       var msg = _getMessage(
           startTime, 500, request.requestedUri, request.method, watch.elapsed);
-
       _logger.severe('$msg\r\n$error\r\n$stackTrace', true);
-
       throw error;
     });
   };


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/1058

There are some differences between this logging and pub serves logging:

- Requests are never collapsed
- It is more verbose (since its opt in, it seems likely people will be debugging and want as much info as possible)
- Only error codes >500 are considered errors (a 404 is not necessarily an error and this has caused spurious bug reports in the past with pub serve)