### PR TITLE
Add runs_before Builder config and use it for ordering

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+- Add support for `runs_before` in `BuilderDefinition`.
+
 ## 0.2.3
 
 - Expose key normalization methods publicly, these include:

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -79,17 +79,8 @@ the following keys:
   - `"all_packages"`: Apply this Builder to all packages in the transitive
     dependency graph.
   - `"root_package"`; Apply this Builder only to the top-level package.
-- **required_inputs**: Optional, list of extensions. If a Builder must see every
-  input with one or more file extensions they can be specified here and it will
-  be guaranteed to run after any Builder which might produce an output of that
-  type. For instance a compiler must run after any Builder which can produce
-  `.dart` outputs or those libraries can't be compiled. This option should be
-  rare. Defaults to an empty list.
-- **runs_before**: Optional, list of Builder keys. If a Builder is producing
-  outputs which are intended to be inputs to other Builders they may be
-  specified here. This guarantees that the specified Builders will be ordered
-  later than this one. This will not cause Builders to be applied if they would
-  not otherwise run, it only affects ordering.
+- **required_inputs**: Optional, see [adjusting builder ordering][]
+- **runs_before**: Optional, see [adjusting builder ordering][]
 - **is_optional**: Optional, boolean. Specifies whether a Builder can be run
   lazily, such that it won't execute until one of it's outputs is requested by a
   later Builder. This option should be rare. Defaults to `False`.
@@ -129,6 +120,28 @@ builders:
     build_extensions: {".dart": [".my_package.dart"]}
     auto_apply: dependents
 ```
+
+[adjusting builder ordering][#adjusting_builder_odering]
+
+### Adjusting Builder Ordering
+
+Both `required_inputs` and `runs_before` can be used to tweak the order that
+Builders run in on a given target. These work by indicating a given builder is a
+_dependency_ of another. The resulting dependency graph must not have cycles and
+these options should be used rarely.
+
+- **required_inputs**: Optional, list of extensions, defaults to empty list. If
+  a Builder must see every input with one or more file extensions they can be
+  specified here and it will be guaranteed to run after any Builder which might
+  produce an output of that type. For instance a compiler must run after any
+  Builder which can produce `.dart` outputs or those libraries can't be
+  compiled. A Builder may not specify that it requires an output that it also
+  produces since this would be a self-cycle.
+- **runs_before**: Optional, list of Builder keys. If a Builder is producing
+  outputs which are intended to be inputs to other Builders they may be
+  specified here. This guarantees that the specified Builders will be ordered
+  later than this one. This will not cause Builders to be applied if they would
+  not otherwise run, it only affects ordering.
 
 # Publishing `build.yaml` files
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -121,7 +121,7 @@ builders:
     auto_apply: dependents
 ```
 
-[adjusting builder ordering]: #adjusting_builder_odering
+[adjusting builder ordering]: #adjusting-builder-odering
 
 ### Adjusting Builder Ordering
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -121,7 +121,7 @@ builders:
     auto_apply: dependents
 ```
 
-[adjusting builder ordering]: #adjusting-builder-odering
+[adjusting builder ordering]: #adjusting-builder-ordering
 
 ### Adjusting Builder Ordering
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -85,6 +85,11 @@ the following keys:
   type. For instance a compiler must run after any Builder which can produce
   `.dart` outputs or those libraries can't be compiled. This option should be
   rare. Defaults to an empty list.
+- **runs_before**: Optional, list of Builder keys. If a Builder is producing
+  outputs which are intended to be inputs to other Builders they may be
+  specified here. This guarantees that the specified Builders will be ordered
+  later than this one. This will not cause Builders to be applied if they would
+  not otherwise run, it only affects ordering.
 - **is_optional**: Optional, boolean. Specifies whether a Builder can be run
   lazily, such that it won't execute until one of it's outputs is requested by a
   later Builder. This option should be rare. Defaults to `False`.

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -121,7 +121,7 @@ builders:
     auto_apply: dependents
 ```
 
-[adjusting builder ordering][#adjusting_builder_odering]
+[adjusting builder ordering]: #adjusting_builder_odering
 
 ### Adjusting Builder Ordering
 

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -148,6 +148,10 @@ class BuilderDefinition {
   /// after this builder.
   final List<String> requiredInputs;
 
+  /// A list of Builder keys in `$package|$builder` format which should only be
+  /// run after this Builder.
+  final Set<String> runsBefore;
+
   /// Whether this Builder should be deferred until it's output is requested.
   ///
   /// Optional builders are lazy and will not run unless some later builder
@@ -169,6 +173,7 @@ class BuilderDefinition {
     @required this.target,
     this.autoApply,
     this.requiredInputs,
+    this.runsBefore,
     this.isOptional,
     this.buildTo,
     this.defaults,
@@ -182,6 +187,7 @@ class BuilderDefinition {
         'builderFactories': builderFactories,
         'buildExtensions': buildExtensions,
         'requiredInputs': requiredInputs,
+        'runsBefore': runsBefore,
         'isOptional': isOptional,
         'buildTo': buildTo,
         'defaults': defaults,

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -33,6 +33,7 @@ const _builderDefinitionOptions = const [
   _target,
   _autoApply,
   _requiredInputs,
+  _runsBefore,
   _isOptional,
   _buildTo,
   _defaults,
@@ -43,6 +44,7 @@ const _buildExtensions = 'build_extensions';
 const _target = 'target';
 const _autoApply = 'auto_apply';
 const _requiredInputs = 'required_inputs';
+const _runsBefore = 'runs_before';
 const _isOptional = 'is_optional';
 const _buildTo = 'build_to';
 const _defaults = 'defaults';
@@ -125,6 +127,10 @@ BuildConfig parseFromMap(String packageName,
     final requiredInputs = _readListOfStringsOrThrow(
         builderConfig, _requiredInputs,
         defaultValue: const []);
+    final runsBefore = _readListOfStringsOrThrow(builderConfig, _runsBefore,
+            defaultValue: const [])
+        .map((key) => normalizeBuilderKeyUsage(key, packageName))
+        .toSet();
     final isOptional =
         _readBoolOrThrow(builderConfig, _isOptional, defaultValue: false);
 
@@ -147,6 +153,7 @@ BuildConfig parseFromMap(String packageName,
       target: target,
       autoApply: autoApply,
       requiredInputs: requiredInputs,
+      runsBefore: runsBefore,
       isOptional: isOptional,
       buildTo: buildTo,
       defaults:

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -50,6 +50,7 @@ void main() {
         key: 'example|h',
         target: 'example:example',
         requiredInputs: ['.dart'],
+        runsBefore: ['foo_builder|foo_builder'].toSet(),
         defaults: new TargetBuilderConfigDefaults(
             generateFor: new InputSet(include: ['lib/**'])),
       ),
@@ -84,6 +85,7 @@ void main() {
         key: 'example|a',
         target: 'example:example',
         requiredInputs: const [],
+        runsBefore: new Set<String>(),
       ),
     });
   });
@@ -136,6 +138,7 @@ builders:
     target: ":example"
     auto_apply: dependents
     required_inputs: [".dart"]
+    runs_before: ["foo_builder"]
     is_optional: True
     defaults:
       generate_for: ["lib/**"]
@@ -168,6 +171,7 @@ class _BuilderDefinitionMatcher extends Matcher {
       equals(_expected.builderFactories).matches(item.builderFactories, _) &&
       equals(_expected.buildExtensions).matches(item.buildExtensions, _) &&
       equals(_expected.requiredInputs).matches(item.requiredInputs, _) &&
+      equals(_expected.runsBefore).matches(item.runsBefore, _) &&
       equals(_expected.defaults?.generateFor?.include)
           .matches(item.defaults?.generateFor?.include, _) &&
       equals(_expected.defaults?.generateFor?.exclude)

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -23,6 +23,8 @@ dependency_overrides:
     path: ../build_resolvers
   build_runner:
     path: ../build_runner
+  build_config:
+    path: ../build_config
 
 dev_dependencies:
   build_runner: ^0.7.0

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -10,6 +10,7 @@
   https://github.com/dart-lang/build/issues/1033.
 - The experimental `create_merged_dir` binary is now removed, it can't be easily
   supported any more and has been replaced by the `--output` option.
+- Honors `runs_before` configuration from in Builder definitions.
 
 ## 0.7.11+1
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
   build: ^0.12.0
-  build_config: ^0.2.3
+  build_config: ^0.2.4
   build_resolvers: ^0.2.0
   cli_util: ^0.1.2
   code_builder: ">2.3.0 <4.0.0"
@@ -42,3 +42,5 @@ dev_dependencies:
 dependency_overrides:
   build_resolvers:
     path: ../build_resolvers
+  build_config:
+    path: ../build_config

--- a/build_runner/test/build_script_generate/builder_ordering_test.dart
+++ b/build_runner/test/build_script_generate/builder_ordering_test.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:build_runner/src/build_script_generate/builder_ordering.dart';
+
+import '../common/build_configs.dart';
+
+void main() {
+  group('Builder ordering', () {
+    test('orders builders with `runs_before`', () async {
+      final buildConfigs = parseBuildConfigs({
+        'a': {
+          'builders': {
+            'runs_second': {
+              'builder_factories': [],
+              'build_extensions': {},
+              'target': '',
+              'import': '',
+            },
+            'runs_first': {
+              'builder_factories': [],
+              'build_extensions': {},
+              'target': '',
+              'import': '',
+              'runs_before': ['|runs_second'],
+            },
+          }
+        }
+      });
+      final orderedBuilders = findBuilderOrder(
+          buildConfigs.values.expand((v) => v.builderDefinitions.values));
+      final orderedKeys = orderedBuilders.map((b) => b.key);
+      expect(orderedKeys, ['a|runs_first', 'a|runs_second']);
+    });
+
+    test('orders builders with `required_inputs`', () async {
+      final buildConfigs = parseBuildConfigs({
+        'a': {
+          'builders': {
+            'runs_second': {
+              'builder_factories': [],
+              'build_extensions': {},
+              'target': '',
+              'import': '',
+              'required_inputs': ['.first_output'],
+            },
+            'runs_first': {
+              'builder_factories': [],
+              'build_extensions': {
+                '.anything': ['.first_output']
+              },
+              'target': '',
+              'import': '',
+            },
+          }
+        }
+      });
+      final orderedBuilders = findBuilderOrder(
+          buildConfigs.values.expand((v) => v.builderDefinitions.values));
+      final orderedKeys = orderedBuilders.map((b) => b.key);
+      expect(orderedKeys, ['a|runs_first', 'a|runs_second']);
+    });
+  });
+}

--- a/build_runner/test/build_script_generate/builder_ordering_test.dart
+++ b/build_runner/test/build_script_generate/builder_ordering_test.dart
@@ -63,5 +63,34 @@ void main() {
       final orderedKeys = orderedBuilders.map((b) => b.key);
       expect(orderedKeys, ['a|runs_first', 'a|runs_second']);
     });
+
+    test('disallows cycles', () async {
+      final buildConfigs = parseBuildConfigs({
+        'a': {
+          'builders': {
+            'builder_a': {
+              'builder_factories': [],
+              'build_extensions': {},
+              'target': '',
+              'import': '',
+              'required_inputs': ['.output_b'],
+              'runs_before': ['|builder_b'],
+            },
+            'builder_b': {
+              'builder_factories': [],
+              'build_extensions': {
+                '.anything': ['.output_b']
+              },
+              'target': '',
+              'import': '',
+            },
+          }
+        }
+      });
+      expect(
+          () => findBuilderOrder(
+              buildConfigs.values.expand((v) => v.builderDefinitions.values)),
+          throwsA(anything));
+    });
   });
 }

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -408,6 +408,7 @@ main() async {
       await d.dir('a', [
         await pubspec('a', currentIsolateDependencies: [
           'build',
+          'build_config',
           'build_resolvers',
           'build_runner',
         ]),

--- a/build_runner/test/generate/serve_integration_test.dart
+++ b/build_runner/test/generate/serve_integration_test.dart
@@ -17,8 +17,11 @@ main() {
 
     setUp(() async {
       await d.dir('a', [
-        await pubspec('a',
-            currentIsolateDependencies: ['build_resolvers', 'build_runner']),
+        await pubspec('a', currentIsolateDependencies: [
+          'build_config',
+          'build_resolvers',
+          'build_runner',
+        ]),
         d.dir('lib', [
           d.file('example.dart', "String hello = 'hello'"),
         ]),


### PR DESCRIPTION
Towards #1065

- Add `runs_before` parsing and include it in the test.
- Don't split builders into groups based on whether they have
  `requires_input`. This could slightly change ordering of some builders
  but not in a way that has any negative impact.
- Use `runs_before` to set dependencies for builders when ordering them.