### PR TITLE
Add nicer missing module reporting

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0-dev
+
+- `computeTransitiveDependencies` now throws a `MissingModulesException` instead
+  of logging a warning if it discovers a missing module.
+
 # 0.1.0+2
 
 - Fix a bug with the dart2js workers where the worker could hang if you try to

--- a/build_modules/lib/build_modules.dart
+++ b/build_modules/lib/build_modules.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/errors.dart' show MissingModulesException;
 export 'src/kernel_builder.dart'
     show KernelSummaryBuilder, kernelSummaryExtension, multiRootScheme;
 export 'src/module_builder.dart' show ModuleBuilder, moduleExtension;

--- a/build_modules/lib/src/errors.dart
+++ b/build_modules/lib/src/errors.dart
@@ -91,9 +91,11 @@ Future<String> _missingImportMessage(
   var parsed = parseDirectives(contents, suppressErrors: true);
   var import =
       parsed.directives.whereType<UriBasedDirective>().firstWhere((directive) {
-    var id = new AssetId.resolve(directive.uri.stringValue, from: sourceId);
+    var uriString = directive.uri.stringValue;
+    if (uriString.startsWith('dart:')) return false;
+    var id = new AssetId.resolve(uriString, from: sourceId);
     return id == missingId;
-  });
+  }, orElse: () => null);
   var lineInfo = parsed.lineInfo.getLocation(import.offset);
   return '`$import` from $sourceId at $lineInfo';
 }

--- a/build_modules/lib/src/errors.dart
+++ b/build_modules/lib/src/errors.dart
@@ -58,7 +58,7 @@ class MissingModulesException implements Exception {
       List<Module> transitiveModules,
       AssetReader reader) async {
     var buffer = new StringBuffer(
-        ' \n\nUnable to find modules for some sources, check the following '
+        ' Unable to find modules for some sources, check the following '
         'imports:\n\n');
 
     var checkedSourceDependencies = <AssetId, Set<AssetId>>{};

--- a/build_modules/lib/src/errors.dart
+++ b/build_modules/lib/src/errors.dart
@@ -2,7 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
+import 'package:analyzer/analyzer.dart';
 import 'package:build/build.dart';
+
+import 'modules.dart';
 
 /// An [Exception] that is thrown when a worker returns an error.
 abstract class _WorkerException implements Exception {
@@ -36,4 +41,59 @@ class KernelSummaryException extends _WorkerException {
 
   KernelSummaryException(AssetId summaryId, String error)
       : super(summaryId, error);
+}
+
+/// An [Exception] that is thrown when there are some missing modules.
+class MissingModulesException implements Exception {
+  final String message;
+
+  @override
+  String toString() => message;
+
+  MissingModulesException._(this.message);
+
+  static Future<MissingModulesException> create(
+      Module module,
+      Set<AssetId> missingSources,
+      List<Module> transitiveModules,
+      AssetReader reader) async {
+    var buffer = new StringBuffer(
+        ' \n\nUnable to find modules for some sources, check the following '
+        'imports:\n\n');
+
+    var checkedSourceDependencies = <AssetId, Set<AssetId>>{};
+    for (var module in transitiveModules) {
+      var missingIds = module.directDependencies.intersection(missingSources);
+      for (var missingId in missingIds) {
+        var checkedAlready = checkedSourceDependencies.putIfAbsent(
+            missingId, () => new Set<AssetId>());
+        for (var sourceId in module.sources) {
+          if (checkedAlready.contains(sourceId)) {
+            continue;
+          }
+          checkedAlready.add(sourceId);
+          var message =
+              await _missingImportMessage(sourceId, missingId, reader);
+          if (message != null) buffer.writeln(message);
+        }
+      }
+    }
+
+    return new MissingModulesException._(buffer.toString());
+  }
+}
+
+/// Checks if [sourceId] directly imports [missingId], and returns an error
+/// message if so.
+Future<String> _missingImportMessage(
+    AssetId sourceId, AssetId missingId, AssetReader reader) async {
+  var contents = await reader.readAsString(sourceId);
+  var parsed = parseDirectives(contents, suppressErrors: true);
+  var import =
+      parsed.directives.whereType<UriBasedDirective>().firstWhere((directive) {
+    var id = new AssetId.resolve(directive.uri.stringValue, from: sourceId);
+    return id == missingId;
+  });
+  var lineInfo = parsed.lineInfo.getLocation(import.offset);
+  return '`$import` from $sourceId at $lineInfo';
 }

--- a/build_modules/lib/src/summary_builder.dart
+++ b/build_modules/lib/src/summary_builder.dart
@@ -35,8 +35,8 @@ class UnlinkedSummaryBuilder implements Builder {
             as Map<String, dynamic>);
     try {
       await createUnlinkedSummary(module, buildStep);
-    } on AnalyzerSummaryException catch (e, s) {
-      log.warning('Error creating ${module.unlinkedSummaryId}:\n$e\n$s');
+    } on AnalyzerSummaryException catch (e) {
+      log.severe('Error creating ${module.unlinkedSummaryId}:\n$e');
     }
   }
 }
@@ -59,6 +59,8 @@ class LinkedSummaryBuilder implements Builder {
       await createLinkedSummary(module, buildStep);
     } on AnalyzerSummaryException catch (e, s) {
       log.warning('Error creating ${module.linkedSummaryId}:\n$e\n$s');
+    } on MissingModulesException catch (e) {
+      log.severe('$e');
     }
   }
 }

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 0.1.1-dev
+version: 0.2.0-dev
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_modules/test/fixtures/a/lib/a_imports_b_no_cycle.dart
+++ b/build_modules/test/fixtures/a/lib/a_imports_b_no_cycle.dart
@@ -1,0 +1,2 @@
+// ignore_for_file: unused_import
+import 'package:b/b_imports_a_no_cycle.dart';

--- a/build_modules/test/fixtures/b/lib/b_imports_a_no_cycle.dart
+++ b/build_modules/test/fixtures/b/lib/b_imports_a_no_cycle.dart
@@ -1,0 +1,2 @@
+// ignore_for_file: unused_import
+import 'package:a/a_no_cycle.dart';

--- a/build_modules/test/modules_test.dart
+++ b/build_modules/test/modules_test.dart
@@ -2,11 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
+import 'package:build_modules/src/errors.dart';
 import 'package:build_modules/src/modules.dart';
+import 'package:build_modules/src/module_builder.dart';
 
 void main() {
   LibraryElement libCycle;
@@ -15,6 +20,8 @@ void main() {
   LibraryElement libCycleWithB;
   LibraryElement libCycleWithA;
   LibraryElement libDepOnNonSdk;
+  LibraryElement libAImportsBNoCycle;
+  LibraryElement libBImportsANoCycle;
   final assetCycle = makeAssetId('a|lib/a_cycle.dart');
   final assetSecondaryInCycle = makeAssetId('a|lib/a_secondary_in_cycle.dart');
   final assetPartInCycle = makeAssetId('a|lib/a_part_in_cycle.dart');
@@ -23,6 +30,8 @@ void main() {
   final assetCycleWithA = makeAssetId('b|lib/b_cycle_with_a.dart');
   final assetDepOnNonSdk = makeAssetId('a|lib/a_dep_on_non_sdk.dart');
   final assetNonSdk = makeAssetId('a|lib/a_non_sdk.dart');
+  final assetAImportsBNoCycle = makeAssetId('a|lib/a_imports_b_no_cycle.dart');
+  final assetBImportsANoCycle = makeAssetId('b|lib/b_imports_a_no_cycle.dart');
 
   setUpAll(() async {
     await resolveAsset(assetCycle, (resolver) async {
@@ -38,6 +47,12 @@ void main() {
     });
     await resolveAsset(assetDepOnNonSdk, (resolver) async {
       libDepOnNonSdk = await resolver.libraryFor(assetDepOnNonSdk);
+    });
+    await resolveAsset(assetAImportsBNoCycle, (resolver) async {
+      libAImportsBNoCycle = await resolver.libraryFor(assetAImportsBNoCycle);
+    });
+    await resolveAsset(assetBImportsANoCycle, (resolver) async {
+      libBImportsANoCycle = await resolver.libraryFor(assetBImportsANoCycle);
     });
   });
 
@@ -97,6 +112,62 @@ void main() {
       test('Does not mark library with later alpha sort as primary', () {
         expect(isPrimary(libCycleWithA), false);
       });
+    });
+  });
+
+  group('computeTransitiveDeps', () {
+    Module rootModule;
+    Module immediateDep;
+    Module transitiveDep;
+    InMemoryAssetReader reader;
+
+    setUp(() {
+      rootModule = new Module.forLibrary(libAImportsBNoCycle);
+      immediateDep = new Module.forLibrary(libBImportsANoCycle);
+      transitiveDep = new Module.forLibrary(libNoCycle);
+      reader = new InMemoryAssetReader();
+      reader.cacheStringAsset(
+          assetAImportsBNoCycle,
+          new File('test/fixtures/a/lib/a_imports_b_no_cycle.dart')
+              .readAsStringSync());
+      reader.cacheStringAsset(
+          assetBImportsANoCycle,
+          new File('test/fixtures/b/lib/b_imports_a_no_cycle.dart')
+              .readAsStringSync());
+    });
+
+    test('finds transitive deps', () async {
+      reader.cacheStringAsset(
+          assetBImportsANoCycle.changeExtension(moduleExtension),
+          JSON.encode(immediateDep.toJson()));
+      reader.cacheStringAsset(assetNoCycle.changeExtension(moduleExtension),
+          JSON.encode(transitiveDep.toJson()));
+
+      var transitiveDeps =
+          await rootModule.computeTransitiveDependencies(reader);
+      expect(
+          transitiveDeps.map((m) => m.primarySource),
+          unorderedEquals(
+              [immediateDep.primarySource, transitiveDep.primarySource]));
+    });
+
+    test('missing modules report nice errors', () {
+      reader.cacheStringAsset(
+          assetBImportsANoCycle.changeExtension(moduleExtension),
+          JSON.encode(immediateDep.toJson()));
+      expect(
+          () => rootModule.computeTransitiveDependencies(reader),
+          allOf(throwsA(new isInstanceOf<MissingModulesException>()), throwsA(
+            predicate<MissingModulesException>(
+              (error) {
+                return error.message.contains('''
+Unable to find modules for some sources, check the following imports:
+
+`import 'package:a/a_no_cycle.dart';` from b|lib/b_imports_a_no_cycle.dart at 2:1
+''');
+              },
+            ),
+          )));
     });
   });
 }

--- a/build_modules/test/summary_builder_test.dart
+++ b/build_modules/test/summary_builder_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build_test/build_test.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import 'package:build_modules/build_modules.dart';
@@ -13,60 +14,89 @@ import 'util.dart';
 main() {
   Map<String, dynamic> assets;
 
-  setUp(() async {
-    assets = {
-      'build_modules|lib/src/analysis_options.default.yaml': '',
-      'b|lib/b.dart': '''final world = 'world';''',
-      'a|lib/a.dart': '''
+  group('basic project', () {
+    setUp(() async {
+      assets = {
+        'build_modules|lib/src/analysis_options.default.yaml': '',
+        'b|lib/b.dart': '''final world = 'world';''',
+        'a|lib/a.dart': '''
         import 'package:b/b.dart';
         final hello = world;
       ''',
-      'a|web/index.dart': '''
+        'a|web/index.dart': '''
         import "package:a/a.dart";
         main() {
           print(hello);
         }
       ''',
-    };
+      };
 
-    // Set up all the other required inputs for this test.
-    await testBuilderAndCollectAssets(new ModuleBuilder(), assets);
+      // Set up all the other required inputs for this test.
+      await testBuilderAndCollectAssets(new ModuleBuilder(), assets);
+    });
+
+    test("can output unlinked analyzer summaries for modules under lib and web",
+        () async {
+      var expectedOutputs = <String, Matcher>{
+        'b|lib/b.unlinked.sum': new HasUnlinkedUris(['package:b/b.dart']),
+        'a|lib/a.unlinked.sum': new HasUnlinkedUris(['package:a/a.dart']),
+        'a|web/index.unlinked.sum':
+            new HasUnlinkedUris([endsWith('web/index.dart')]),
+      };
+      await testBuilder(new UnlinkedSummaryBuilder(), assets,
+          outputs: expectedOutputs);
+    });
+
+    test("can output linked analyzer summaries for modules under lib and web",
+        () async {
+      // Build the unlinked summaries first.
+      await testBuilderAndCollectAssets(new UnlinkedSummaryBuilder(), assets);
+
+      // Actual test for LinkedSummaryBuilder;
+      var expectedOutputs = <String, Matcher>{
+        'b|lib/b.linked.sum': allOf(new HasLinkedUris(['package:b/b.dart']),
+            new HasUnlinkedUris(['package:b/b.dart'])),
+        'a|lib/a.linked.sum': allOf(
+            new HasLinkedUris(
+                unorderedEquals(['package:b/b.dart', 'package:a/a.dart'])),
+            new HasUnlinkedUris(['package:a/a.dart'])),
+        'a|web/index.linked.sum': allOf(
+            new HasLinkedUris(unorderedEquals([
+              'package:b/b.dart',
+              'package:a/a.dart',
+              endsWith('web/index.dart')
+            ])),
+            new HasUnlinkedUris([endsWith('web/index.dart')])),
+      };
+      await testBuilder(new LinkedSummaryBuilder(), assets,
+          outputs: expectedOutputs);
+    });
   });
 
-  test("can output unlinked analyzer summaries for modules under lib and web",
-      () async {
-    var expectedOutputs = <String, Matcher>{
-      'b|lib/b.unlinked.sum': new HasUnlinkedUris(['package:b/b.dart']),
-      'a|lib/a.unlinked.sum': new HasUnlinkedUris(['package:a/a.dart']),
-      'a|web/index.unlinked.sum':
-          new HasUnlinkedUris([endsWith('web/index.dart')]),
-    };
-    await testBuilder(new UnlinkedSummaryBuilder(), assets,
-        outputs: expectedOutputs);
-  });
+  group('linked summaries with missing imports', () {
+    setUp(() async {
+      assets = {
+        'build_modules|lib/src/analysis_options.default.yaml': '',
+        'a|web/index.dart': 'import "package:a/a.dart";',
+      };
 
-  test("can output linked analyzer summaries for modules under lib and web",
-      () async {
-    // Build the unlinked summaries first.
-    await testBuilderAndCollectAssets(new UnlinkedSummaryBuilder(), assets);
+      // Set up all the other required inputs for this test.
+      await testBuilderAndCollectAssets(new ModuleBuilder(), assets);
+      await testBuilderAndCollectAssets(new UnlinkedSummaryBuilder(), assets);
+    });
 
-    // Actual test for LinkedSummaryBuilder;
-    var expectedOutputs = <String, Matcher>{
-      'b|lib/b.linked.sum': allOf(new HasLinkedUris(['package:b/b.dart']),
-          new HasUnlinkedUris(['package:b/b.dart'])),
-      'a|lib/a.linked.sum': allOf(
-          new HasLinkedUris(
-              unorderedEquals(['package:b/b.dart', 'package:a/a.dart'])),
-          new HasUnlinkedUris(['package:a/a.dart'])),
-      'a|web/index.linked.sum': allOf(
-          new HasLinkedUris(unorderedEquals([
-            'package:b/b.dart',
-            'package:a/a.dart',
-            endsWith('web/index.dart')
-          ])),
-          new HasUnlinkedUris([endsWith('web/index.dart')])),
-    };
-    await testBuilder(new LinkedSummaryBuilder(), assets,
-        outputs: expectedOutputs);
+    test('print an error if there are any missing transitive modules',
+        () async {
+      var expectedOutputs = <String, Matcher>{};
+      var logs = <LogRecord>[];
+      await testBuilder(new LinkedSummaryBuilder(), assets,
+          outputs: expectedOutputs, onLog: logs.add);
+      expect(
+          logs,
+          contains(predicate<LogRecord>((record) =>
+              record.level == Level.SEVERE &&
+              record.message
+                  .contains('Unable to find modules for some sources'))));
+    });
   });
 }

--- a/build_modules/test/summary_builder_test.dart
+++ b/build_modules/test/summary_builder_test.dart
@@ -35,7 +35,7 @@ main() {
       await testBuilderAndCollectAssets(new ModuleBuilder(), assets);
     });
 
-    test("can output unlinked analyzer summaries for modules under lib and web",
+    test('can output unlinked analyzer summaries for modules under lib and web',
         () async {
       var expectedOutputs = <String, Matcher>{
         'b|lib/b.unlinked.sum': new HasUnlinkedUris(['package:b/b.dart']),
@@ -47,7 +47,7 @@ main() {
           outputs: expectedOutputs);
     });
 
-    test("can output linked analyzer summaries for modules under lib and web",
+    test('can output linked analyzer summaries for modules under lib and web',
         () async {
       // Build the unlinked summaries first.
       await testBuilderAndCollectAssets(new UnlinkedSummaryBuilder(), assets);

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -21,7 +21,7 @@ import '../asset_graph/node.dart';
 import '../environment/build_environment.dart';
 import '../environment/io_environment.dart';
 import '../environment/overridable_environment.dart';
-import '../logging/error_recording_logger.dart';
+import '../logging/build_for_input_logger.dart';
 import '../logging/human_readable_duration.dart';
 import '../logging/logging.dart';
 import '../package_graph/apply_builders.dart';
@@ -422,7 +422,7 @@ class _SingleBuild {
     wrappedReader.assetsRead.clear();
 
     var wrappedWriter = new AssetWriterSpy(_writer);
-    var logger = new ErrorRecordingLogger(new Logger('$builder on $input'));
+    var logger = new BuildForInputLogger(new Logger('$builder on $input'));
     numActionsStarted++;
     await tracker.track(
         () => runBuilder(builder, [input], wrappedReader, wrappedWriter,

--- a/build_runner/lib/src/logging/build_for_input_logger.dart
+++ b/build_runner/lib/src/logging/build_for_input_logger.dart
@@ -8,13 +8,13 @@ import 'package:logging/logging.dart';
 
 /// A delegating [Logger] that records if any logs of level >= [Level.SEVERE]
 /// were seen.
-class ErrorRecordingLogger implements Logger {
+class BuildForInputLogger implements Logger {
   final Logger _delegate;
 
   bool _errorWasSeen = false;
   bool get errorWasSeen => _errorWasSeen;
 
-  ErrorRecordingLogger(this._delegate);
+  BuildForInputLogger(this._delegate);
 
   @override
   Level get level => _delegate.level;
@@ -59,6 +59,15 @@ class ErrorRecordingLogger implements Logger {
       [Object error, StackTrace stackTrace, Zone zone]) {
     if (logLevel >= Level.SEVERE) {
       _errorWasSeen = true;
+    }
+    if (logLevel >= Level.WARNING) {
+      if (_delegate.isLoggable(logLevel)) {
+        var original = message;
+        if (message is Function) message = () => '\n${original()}';
+        if (message is String) {
+          message = '\n$message';
+        }
+      }
     }
     _delegate.log(logLevel, message, error, stackTrace, zone);
   }

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -27,9 +27,7 @@ void stdIOLogListener(LogRecord record, {bool verbose}) {
         headerMessage.split('\n').takeWhile((line) => line.isEmpty).length;
     headerMessage = headerMessage.substring(blankLineCount);
   }
-  var optionalNewline = record.level >= Level.WARNING ? '\n' : '';
-  var header = '$eraseLine$level ${record.loggerName}: $optionalNewline'
-      '$headerMessage';
+  var header = '$eraseLine$level ${record.loggerName}: $headerMessage';
   var lines = blankLineCount > 0
       ? (new List<Object>.generate(blankLineCount, (_) => '')..add(header))
       : <Object>[header];

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -27,7 +27,9 @@ void stdIOLogListener(LogRecord record, {bool verbose}) {
         headerMessage.split('\n').takeWhile((line) => line.isEmpty).length;
     headerMessage = headerMessage.substring(blankLineCount);
   }
-  var header = '$eraseLine$level ${record.loggerName}: $headerMessage';
+  var optionalNewline = record.level >= Level.WARNING ? '\n' : '';
+  var header = '$eraseLine$level ${record.loggerName}: $optionalNewline'
+      '$headerMessage';
   var lines = blankLineCount > 0
       ? (new List<Object>.generate(blankLineCount, (_) => '')..add(header))
       : <Object>[header];

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -42,13 +42,20 @@ class DevCompilerBuilder implements Builder {
     var module = new Module.fromJson(
         JSON.decode(await buildStep.readAsString(buildStep.inputId))
             as Map<String, dynamic>);
+
+    Future<Null> handleError(e) async {
+      await buildStep.writeAsString(
+          buildStep.inputId.changeExtension(jsModuleErrorsExtension), '$e');
+      log.severe('$e');
+    }
+
     try {
       await createDevCompilerModule(module, buildStep, useKernel,
           debugMode: !useKernel);
     } on DartDevcCompilationException catch (e) {
-      await buildStep.writeAsString(
-          buildStep.inputId.changeExtension(jsModuleErrorsExtension), '$e');
-      log.severe('', e);
+      await handleError(e);
+    } on MissingModulesException catch (e) {
+      await handleError(e);
     }
   }
 }

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:analyzer/analyzer.dart';
 import 'package:build/build.dart';
+import 'package:build_modules/build_modules.dart';
 
 import 'common.dart';
 import 'dart2js_bootstrap.dart';
@@ -99,10 +100,14 @@ class WebEntrypointBuilder implements Builder {
     var isAppEntrypoint = await _isAppEntryPoint(dartEntrypointId, buildStep);
     if (!isAppEntrypoint) return;
     if (webCompiler == WebCompiler.DartDevc) {
-      await bootstrapDdc(buildStep,
-          useKernel: useKernel,
-          buildRootAppSummary: buildRootAppSummary,
-          ignoreCastFailures: ignoreCastFailures);
+      try {
+        await bootstrapDdc(buildStep,
+            useKernel: useKernel,
+            buildRootAppSummary: buildRootAppSummary,
+            ignoreCastFailures: ignoreCastFailures);
+      } on MissingModulesException catch (e) {
+        log.severe('$e');
+      }
     } else if (webCompiler == WebCompiler.Dart2Js) {
       await bootstrapDart2Js(buildStep, dart2JsArgs);
     }

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   bazel_worker: ^0.1.4
   build: ^0.12.0
   build_config: ^0.2.1
-  build_modules: ^0.1.0
+  build_modules: ^0.2.0
   cli_util: ^0.1.2
   logging: ^0.11.2
   path: ^1.4.2
@@ -26,3 +26,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  build_modules:
+    path: ../build_modules

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -37,7 +37,7 @@ main() {
       await testBuilderAndCollectAssets(new LinkedSummaryBuilder(), assets);
     });
 
-    test("can compile ddc modules under lib and web", () async {
+    test('can compile ddc modules under lib and web', () async {
       var expectedOutputs = {
         'b|lib/b$jsModuleExtension': decodedMatches(contains('world')),
         'b|lib/b$jsSourceMapExtension': decodedMatches(contains('b.dart')),
@@ -66,7 +66,7 @@ main() {
         await testBuilderAndCollectAssets(new LinkedSummaryBuilder(), assets);
       });
 
-      test("reports useful messages", () async {
+      test('reports useful messages', () async {
         var expectedOutputs = {
           'a|web/index$jsModuleErrorsExtension': decodedMatches(
               allOf(contains('String'), contains('assigned'), contains('int'))),
@@ -95,7 +95,7 @@ main() {
         await testBuilderAndCollectAssets(new ModuleBuilder(), assets);
       });
 
-      test("reports useful messages", () async {
+      test('reports useful messages', () async {
         var expectedOutputs = {
           'a|web/index$jsModuleErrorsExtension': decodedMatches(
               contains('Unable to find modules for some sources')),

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build_test/build_test.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import 'package:build_web_compilers/build_web_compilers.dart';
@@ -13,39 +14,102 @@ import 'util.dart';
 main() {
   Map<String, dynamic> assets;
 
-  setUp(() async {
-    assets = {
-      'build_modules|lib/src/analysis_options.default.yaml': '',
-      'b|lib/b.dart': '''final world = 'world';''',
-      'a|lib/a.dart': '''
+  group('error free project', () {
+    setUp(() async {
+      assets = {
+        'build_modules|lib/src/analysis_options.default.yaml': '',
+        'b|lib/b.dart': '''final world = 'world';''',
+        'a|lib/a.dart': '''
         import 'package:b/b.dart';
         final hello = world;
       ''',
-      'a|web/index.dart': '''
+        'a|web/index.dart': '''
         import "package:a/a.dart";
         main() {
           print(hello);
         }
       ''',
-    };
+      };
 
-    // Set up all the other required inputs for this test.
-    await testBuilderAndCollectAssets(new ModuleBuilder(), assets);
-    await testBuilderAndCollectAssets(new UnlinkedSummaryBuilder(), assets);
-    await testBuilderAndCollectAssets(new LinkedSummaryBuilder(), assets);
+      // Set up all the other required inputs for this test.
+      await testBuilderAndCollectAssets(new ModuleBuilder(), assets);
+      await testBuilderAndCollectAssets(new UnlinkedSummaryBuilder(), assets);
+      await testBuilderAndCollectAssets(new LinkedSummaryBuilder(), assets);
+    });
+
+    test("can compile ddc modules under lib and web", () async {
+      var expectedOutputs = {
+        'b|lib/b$jsModuleExtension': decodedMatches(contains('world')),
+        'b|lib/b$jsSourceMapExtension': decodedMatches(contains('b.dart')),
+        'a|lib/a$jsModuleExtension': decodedMatches(contains('hello')),
+        'a|lib/a$jsSourceMapExtension': decodedMatches(contains('a.dart')),
+        'a|web/index$jsModuleExtension': decodedMatches(contains('main')),
+        'a|web/index$jsSourceMapExtension':
+            decodedMatches(contains('index.dart')),
+      };
+      await testBuilder(new DevCompilerBuilder(), assets,
+          outputs: expectedOutputs);
+    });
   });
 
-  test("can compile ddc modules under lib and web", () async {
-    var expectedOutputs = {
-      'b|lib/b$jsModuleExtension': decodedMatches(contains('world')),
-      'b|lib/b$jsSourceMapExtension': decodedMatches(contains('b.dart')),
-      'a|lib/a$jsModuleExtension': decodedMatches(contains('hello')),
-      'a|lib/a$jsSourceMapExtension': decodedMatches(contains('a.dart')),
-      'a|web/index$jsModuleExtension': decodedMatches(contains('main')),
-      'a|web/index$jsSourceMapExtension':
-          decodedMatches(contains('index.dart')),
-    };
-    await testBuilder(new DevCompilerBuilder(), assets,
-        outputs: expectedOutputs);
+  group('projects with errors due to', () {
+    group('invalid assignements', () {
+      setUp(() async {
+        assets = {
+          'build_modules|lib/src/analysis_options.default.yaml': '',
+          'a|web/index.dart': 'int x = "hello";',
+        };
+
+        // Set up all the other required inputs for this test.
+        await testBuilderAndCollectAssets(new ModuleBuilder(), assets);
+        await testBuilderAndCollectAssets(new UnlinkedSummaryBuilder(), assets);
+        await testBuilderAndCollectAssets(new LinkedSummaryBuilder(), assets);
+      });
+
+      test("reports useful messages", () async {
+        var expectedOutputs = {
+          'a|web/index$jsModuleErrorsExtension': decodedMatches(
+              allOf(contains('String'), contains('assigned'), contains('int'))),
+        };
+        var logs = <LogRecord>[];
+        await testBuilder(new DevCompilerBuilder(), assets,
+            outputs: expectedOutputs, onLog: logs.add);
+        expect(
+            logs,
+            contains(predicate<LogRecord>((record) =>
+                record.level == Level.SEVERE &&
+                record.message.contains('String') &&
+                record.message.contains('assigned') &&
+                record.message.contains('int'))));
+      });
+    });
+
+    group('invalid imports', () {
+      setUp(() async {
+        assets = {
+          'build_modules|lib/src/analysis_options.default.yaml': '',
+          'a|web/index.dart': "import 'package:a/a.dart'",
+        };
+
+        // Set up all the other required inputs for this test.
+        await testBuilderAndCollectAssets(new ModuleBuilder(), assets);
+      });
+
+      test("reports useful messages", () async {
+        var expectedOutputs = {
+          'a|web/index$jsModuleErrorsExtension': decodedMatches(
+              contains('Unable to find modules for some sources')),
+        };
+        var logs = <LogRecord>[];
+        await testBuilder(new DevCompilerBuilder(), assets,
+            outputs: expectedOutputs, onLog: logs.add);
+        expect(
+            logs,
+            contains(predicate<LogRecord>((record) =>
+                record.level == Level.SEVERE &&
+                record.message
+                    .contains('Unable to find modules for some sources'))));
+      });
+    });
   });
 }

--- a/e2e_example/pubspec.yaml
+++ b/e2e_example/pubspec.yaml
@@ -16,16 +16,18 @@ dependency_overrides:
     path: ../build
   build_barback:
     path: ../build_barback
-  build_web_compilers:
-    path: ../build_web_compilers
   build_config:
     path: ../build_config
+  build_modules:
+    path: ../build_modules
   build_resolvers:
     path: ../build_resolvers
   build_runner:
     path: ../build_runner
   build_test:
     path: ../build_test
+  build_web_compilers:
+    path: ../build_web_compilers
   scratch_space:
     path: ../scratch_space
 

--- a/e2e_example/test/serve_integration_test.dart
+++ b/e2e_example/test/serve_integration_test.dart
@@ -66,15 +66,15 @@ void main() {
     test('ddc errors can be fixed', () async {
       var path = p.join('test', 'common', 'message.dart');
       var error = nextStdErrLine('Error compiling dartdevc module:'
-          'e2e_example|test/hello_world_test.ddc.js');
+          'e2e_example|test/common/message.ddc.js');
       var nextBuild = nextSuccessfulBuild;
-      await deleteFile(path);
+      await replaceAllInFile(path, "'Hello World!'", '1');
       await error;
       await nextBuild;
       await expectTestsFail();
 
       nextBuild = nextSuccessfulBuild;
-      await createFile(path, "String get message => 'Hello World!';");
+      await replaceAllInFile(path, '1', "'Hello World!'");
       await nextBuild;
       await expectTestsPass();
     });


### PR DESCRIPTION
In normal workflows, with this change, you will now only see errors for invalid imports reported by the entrypoint builder, and they will look something like this:

```
[SEVERE] Instance of 'WebEntrypointBuilder' on e2e_example|web/main.dart:  

Unable to find modules for some sources, check the following imports:

`import 'missing.dart';` from e2e_example|web/sub/message.dart at 3:1
```

Fixes https://github.com/dart-lang/build/issues/1046