### PR TITLE
Allow same-package non-hidden to hidden reads

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -10,6 +10,8 @@
   https://github.com/dart-lang/build/issues/1033.
 - The experimental `create_merged_dir` binary is now removed, it can't be easily
   supported any more and has been replaced by the `--output` option.
+- Builders which write to `source` are no longer guaranteed to run before
+  builders which write to `cache`.
 - Honors `runs_before` configuration from in Builder definitions.
 
 ## 0.7.11+1

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -38,8 +38,8 @@ class SingleStepReader implements AssetReader {
 
   /// Whether the action using this reader writes to the generated directory.
   ///
-  /// Actions which do not hide their outptus may not read assets produced by
-  /// actions which do hide their outputs.
+  /// Actions which do not hide their outptus may not read assets produced in
+  /// other packages by actions which do hide their outputs.
   final bool _outputsHidden;
 
   SingleStepReader(this._delegate, this._assetGraph, this._phaseNumber,
@@ -71,7 +71,9 @@ class SingleStepReader implements AssetReader {
     if (node.isGenerated) {
       final generatedNode = node as GeneratedAssetNode;
       if (generatedNode.phaseNumber >= _phaseNumber) return false;
-      if (!_outputsHidden && generatedNode.isHidden) return false;
+      if (!_outputsHidden &&
+          generatedNode.isHidden &&
+          node.id.package != _primaryPackage) return false;
       return doAfter(
           _ensureAssetIsBuilt(node.id), (_) => generatedNode.wasOutput);
     }

--- a/build_runner/lib/src/build_script_generate/builder_ordering.dart
+++ b/build_runner/lib/src/build_script_generate/builder_ordering.dart
@@ -9,18 +9,10 @@ import 'package:graphs/graphs.dart';
 /// [BuilderDefinition.requiredInputs] will come after any builder which
 /// produces a desired output.
 ///
-/// Builders will be put in the following order:
-/// - Builders which write to the source tree
-/// - Builders which write to the build cache
-///
-/// Within each block any ordering constraints determined by `required_inputs`
-/// or `runs_before` are upheld.
+/// Builders will be ordered such that their `required_inputs` and `runs_before`
+/// constraints are met, but the rest of the ordering is arbitrary.
 Iterable<BuilderDefinition> findBuilderOrder(
-        Iterable<BuilderDefinition> builders) =>
-    _findOrder(builders.where((b) => b.buildTo == BuildTo.source)).followedBy(
-        _findOrder(builders.where((b) => b.buildTo == BuildTo.cache)));
-
-List<BuilderDefinition> _findOrder(Iterable<BuilderDefinition> builders) {
+    Iterable<BuilderDefinition> builders) {
   Iterable<BuilderDefinition> dependencies(BuilderDefinition parent) =>
       builders.where((child) =>
           _hasInputDependency(parent, child) || _mustRunBefore(parent, child));

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -361,8 +361,28 @@ void main() {
             });
       });
 
-      test('disallows reading hidden outputs to create a non-hidden output',
-          () async {
+      test(
+          'disallows reading hidden outputs from another package to create '
+          'a non-hidden output', () async {
+        await testBuilders(
+            [
+              apply('hidden_on_b', [(_) => new TestBuilder()], toPackage('b'),
+                  hideOutput: true),
+              applyToRoot(new TestBuilder(
+                  buildExtensions: appendExtension('.clone'),
+                  build: writeCanRead(makeAssetId('b|lib/b.txt.copy'))))
+            ],
+            {'a|lib/a.txt': 'a', 'b|lib/b.txt': 'b'},
+            packageGraph: packageGraph,
+            outputs: {
+              r'$$b|lib/b.txt.copy': 'b',
+              r'a|lib/a.txt.clone': 'false',
+            });
+      });
+
+      test(
+          'allows reading hidden outputs from same package to create '
+          'a non-hidden output', () async {
         await testBuilders(
             [
               applyToRoot(new TestBuilder(), hideOutput: true),
@@ -374,7 +394,7 @@ void main() {
             packageGraph: packageGraph,
             outputs: {
               r'$$a|lib/a.txt.copy': 'a',
-              r'a|lib/a.txt.clone': 'false',
+              r'a|lib/a.txt.clone': 'true',
             });
       });
 


### PR DESCRIPTION
Closes #1055

Solves a use where it takes multiple Builder steps to arrive at a source
output but only the final step needs to be published.