### PR TITLE
Filter inputs based on source assets

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.13-prerelease
+
+- Fix a bug where a chain of `Builder`s would fail to run on some outputs from
+  previous steps when the generated asset did not match the target's `sources`.
+
 ## 0.7.12
 
 - Added the `--log-requests` flag to the `serve` command, which will log all

--- a/build_runner/lib/src/asset_graph/graph.dart
+++ b/build_runner/lib/src/asset_graph/graph.dart
@@ -217,6 +217,12 @@ class AssetGraph {
   Iterable<AssetId> get outputs =>
       allNodes.where((n) => n.isGenerated).map((n) => n.id);
 
+  /// All the generated outputs for a particular phase.
+  // TODO consider storing this directly
+  Iterable<GeneratedAssetNode> outputsForPhase(int phase) => allNodes
+      .where((n) => n is GeneratedAssetNode && n.phaseNumber == phase)
+      .cast<GeneratedAssetNode>();
+
   /// All the source files in the graph.
   Iterable<AssetId> get sources =>
       allNodes.where((n) => n is SourceAssetNode).map((n) => n.id);
@@ -341,6 +347,18 @@ class AssetGraph {
     return invalidatedIds;
   }
 
+  /// Crawl up primary inputs to see if the original Source file matches the
+  /// glob on [action].
+  bool _actionMatches(BuildAction action, AssetId input) {
+    if (input.package != action.package) return false;
+    if (!action.generateFor.matches(input)) return false;
+    var inputNode = get(input);
+    while (inputNode is GeneratedAssetNode) {
+      inputNode = get((inputNode as GeneratedAssetNode).primaryInput);
+    }
+    return action.targetSources.matches(inputNode.id);
+  }
+
   /// Returns a set containing [newSources] plus any new generated sources
   /// based on [buildActions], and updates this graph to contain all the
   /// new outputs.
@@ -359,15 +377,13 @@ class AssetGraph {
       var buildOptionsNodeId = builderOptionsIdForPhase(action.package, phase);
       var builderOptionsNode =
           get(buildOptionsNodeId) as BuilderOptionsAssetNode;
-      var inputs = allInputs.where(action.matches).toList();
+      var inputs =
+          allInputs.where((input) => _actionMatches(action, input)).toList();
       for (var input in inputs) {
         // We might have deleted some inputs during this loop, if they turned
         // out to be generated assets.
         if (!allInputs.contains(input)) continue;
         var node = get(input);
-        if (!action.hideOutput && node is GeneratedAssetNode && node.isHidden) {
-          continue;
-        }
         assert(node != null, 'The node from `$input` does not exist.');
 
         var outputs = expectedOutputs(action.builder, input);

--- a/build_runner/lib/src/generate/input_matcher.dart
+++ b/build_runner/lib/src/generate/input_matcher.dart
@@ -12,13 +12,7 @@ abstract class InputMatcher {
   /// Whether [input] is included in this set of assets.
   bool matches(AssetId input);
 
-  // Remove after https://github.com/dart-lang/linter/issues/863 fixed.
-  // ignore: avoid_unused_constructor_parameters
   factory InputMatcher(InputSet inputSet) = _GlobInputMatcher;
-
-  /// Returns a matcher on the intersection of all [matchers].
-  factory InputMatcher.allOf(Iterable<InputMatcher> matchers) =>
-      new _MultiMatcher(matchers.toList());
 }
 
 class _GlobInputMatcher implements InputMatcher {
@@ -73,27 +67,6 @@ class _GlobInputMatcher implements InputMatcher {
   @override
   int get hashCode =>
       _deepEquals.hash([_patterns(include), _patterns(exclude)]);
-}
-
-class _MultiMatcher implements InputMatcher {
-  final List<InputMatcher> delegates;
-
-  _MultiMatcher(this.delegates);
-
-  @override
-  matches(AssetId input) => delegates.every((d) => d.matches(input));
-
-  @override
-  String toString() => 'All of $delegates';
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      (other is _MultiMatcher &&
-          _deepEquals.equals(delegates, other.delegates));
-
-  @override
-  int get hashCode => _deepEquals.hash(delegates);
 }
 
 final _deepEquals = const DeepCollectionEquality();

--- a/build_runner/lib/src/generate/phase.dart
+++ b/build_runner/lib/src/generate/phase.dart
@@ -34,8 +34,7 @@ class BuildAction {
   /// the root.
   final bool hideOutput;
 
-  BuildAction._(
-      this.package, this.builder, this.builderOptions,
+  BuildAction._(this.package, this.builder, this.builderOptions,
       {@required this.targetSources,
       @required this.generateFor,
       bool isOptional,

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.12
+version: 0.7.13-prerelease
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner

--- a/build_runner/test/asset_graph/graph_test.dart
+++ b/build_runner/test/asset_graph/graph_test.dart
@@ -352,22 +352,6 @@ void main() {
       });
     });
 
-    test('non-hidden action following hidden action', () async {
-      final graph = await AssetGraph.build([
-        new BuildAction(
-            new TestBuilder(buildExtensions: appendExtension('.hidden')), 'foo',
-            hideOutput: true),
-        new BuildAction(
-            new TestBuilder(buildExtensions: appendExtension('.visible')),
-            'foo',
-            hideOutput: false)
-      ], [makeAssetId('foo|lib/file.txt')].toSet(), new Set<AssetId>(),
-          fooPackageGraph, digestReader);
-
-      expect(graph.outputs,
-          isNot(contains(makeAssetId('foo|lib/file.txt.hidden.visible'))));
-    });
-
     test('overlapping build actions cause an error', () async {
       expect(
           () => AssetGraph.build(
@@ -430,6 +414,29 @@ void main() {
             unorderedEquals([
               makeAssetId('foo|lib/1.txt'),
               makeAssetId('foo|lib/2.txt'),
+            ]));
+      });
+
+      test(
+          'allows running on generated inputs that do not match target '
+          'source globs', () async {
+        final graph = await AssetGraph.build([
+          new BuildAction(
+              new TestBuilder(
+                  buildExtensions: appendExtension('.1', from: '.txt')),
+              'foo'),
+          new BuildAction(
+              new TestBuilder(
+                  buildExtensions: appendExtension('.2', from: '.1')),
+              'foo',
+              targetSources: new InputSet(include: ['lib/*.txt'])),
+        ], [makeAssetId('foo|lib/1.txt')].toSet(), new Set<AssetId>(),
+            fooPackageGraph, digestReader);
+        expect(
+            graph.outputs,
+            unorderedEquals([
+              makeAssetId('foo|lib/1.txt.1'),
+              makeAssetId('foo|lib/1.txt.1.2')
             ]));
       });
     });

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -165,6 +165,29 @@ void main() {
             });
       });
 
+      test(
+          'allows running on generated inputs that do not match target '
+          'source globx', () async {
+        var builders = [
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.1', from: '.txt'))),
+          applyToRoot(new TestBuilder(
+              buildExtensions: appendExtension('.2', from: '.1')))
+        ];
+        var buildConfigs = parseBuildConfigs({
+          'a': {
+            'targets': {
+              r'$default': {
+                'sources': ['lib/*.txt']
+              }
+            }
+          }
+        });
+        await testBuilders(builders, {'a|lib/a.txt': 'a'},
+            overrideBuildConfig: buildConfigs,
+            outputs: {'a|lib/a.txt.1': 'a', 'a|lib/a.txt.1.2': 'a'});
+      });
+
       test('early step touches a not-yet-generated asset', () async {
         var copyId = new AssetId('a', 'lib/file.a.copy');
         var builders = [
@@ -369,14 +392,14 @@ void main() {
               apply('hidden_on_b', [(_) => new TestBuilder()], toPackage('b'),
                   hideOutput: true),
               applyToRoot(new TestBuilder(
-                  buildExtensions: appendExtension('.clone'),
+                  buildExtensions: appendExtension('.check_can_read'),
                   build: writeCanRead(makeAssetId('b|lib/b.txt.copy'))))
             ],
             {'a|lib/a.txt': 'a', 'b|lib/b.txt': 'b'},
             packageGraph: packageGraph,
             outputs: {
               r'$$b|lib/b.txt.copy': 'b',
-              r'a|lib/a.txt.clone': 'false',
+              r'a|lib/a.txt.check_can_read': 'false',
             });
       });
 
@@ -387,14 +410,15 @@ void main() {
             [
               applyToRoot(new TestBuilder(), hideOutput: true),
               applyToRoot(new TestBuilder(
-                  buildExtensions: appendExtension('.clone'),
+                  buildExtensions: appendExtension('.check_can_read'),
                   build: writeCanRead(makeAssetId('a|lib/a.txt.copy'))))
             ],
             {'a|lib/a.txt': 'a'},
             packageGraph: packageGraph,
             outputs: {
               r'$$a|lib/a.txt.copy': 'a',
-              r'a|lib/a.txt.clone': 'true',
+              r'a|lib/a.txt.copy.check_can_read': 'true',
+              r'a|lib/a.txt.check_can_read': 'true',
             });
       });
 


### PR DESCRIPTION
Fixes #1076
Fixes a missed case for #1055

Instead of checking whether the direct input to an action matches the
target sources and the generate_for, we need to check whether the
_original_ source was in the target and the _current_ input matches the
generate_for.

We had this check twice, once while building up the asset graph, and
once while doing the build. Shift instead to trusting that the outputs
for a given phase have already done necessary filtering and while
building only check the lazy phases and whether the input was written.

- Add `outputsForPhase` to `AssetGraph`. This immediately gets to the
  filtered and valid files that may be generated, and their
  `primaryInput` can point to the assets we should be running on.
  Initial naive implementation can be replaced with a cached version in
  a followup.
- Don't implement `matches` on `BuildAction`. Instead separately track
  the two types of Asset filtering so we can compare against different
  ids.
- Drop the `_MultiMatcher` since there is no longer any use.
- Fix or remove tests depending on the old behavior of not running
  to-source Builders on hidden primary inputs.
- Add regression tests both directly on graph building as well as
  through the overall build.