### PR TITLE
Use a 'builder label' for log messages

### DIFF
--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -298,8 +298,8 @@ class _SingleBuild {
       await _performanceTracker.trackBuildPhase(action, () async {
         var primaryInputs =
             await _matchingPrimaryInputs(phase, resourceManager);
-        outputs.addAll(await _runBuilder(phase, action.hideOutput,
-            action.builder, primaryInputs, resourceManager));
+        outputs.addAll(
+            await _runBuilder(phase, action, primaryInputs, resourceManager));
       });
     }
     await Future.forEach(
@@ -323,8 +323,8 @@ class _SingleBuild {
       var input = _assetGraph.get(node.primaryInput);
       if (input is GeneratedAssetNode) {
         if (input.state != GeneratedNodeState.upToDate) {
-          await _runLazyPhaseForInput(input.phaseNumber, input.isHidden,
-              input.primaryInput, resourceManager);
+          await _runLazyPhaseForInput(
+              input.phaseNumber, input.primaryInput, resourceManager);
         }
         if (!input.wasOutput) return;
       }
@@ -333,27 +333,22 @@ class _SingleBuild {
     return ids;
   }
 
-  /// Runs a normal [builder] with [primaryInputs] as inputs and returns only
-  /// the outputs that were newly created.
+  /// Runs a normal builder with [primaryInputs] as inputs and returns only the
+  /// outputs that were newly created.
   ///
   /// Does not return outputs that didn't need to be re-ran or were declared
   /// but not output.
-  Future<Iterable<AssetId>> _runBuilder(
-      int phaseNumber,
-      bool outputsHidden,
-      Builder builder,
-      Iterable<AssetId> primaryInputs,
-      ResourceManager resourceManager) async {
-    var outputLists = await Future.wait(primaryInputs.map((input) =>
-        _runForInput(
-            phaseNumber, outputsHidden, builder, input, resourceManager)));
+  Future<Iterable<AssetId>> _runBuilder(int phaseNumber, BuildAction action,
+      Iterable<AssetId> primaryInputs, ResourceManager resourceManager) async {
+    var outputLists = await Future.wait(primaryInputs.map(
+        (input) => _runForInput(phaseNumber, action, input, resourceManager)));
     return outputLists.fold<List<AssetId>>(
         <AssetId>[], (combined, next) => combined..addAll(next));
   }
 
   /// Lazily runs [phaseNumber] with [input] and [resourceManager].
-  Future<Iterable<AssetId>> _runLazyPhaseForInput(int phaseNumber,
-      bool outputsHidden, AssetId input, ResourceManager resourceManager) {
+  Future<Iterable<AssetId>> _runLazyPhaseForInput(
+      int phaseNumber, AssetId input, ResourceManager resourceManager) {
     return _lazyPhases.putIfAbsent('$phaseNumber|$input', () async {
       // First check if `input` is generated, and whether or not it was
       // actually output. If it wasn't then we just return an empty list here.
@@ -361,21 +356,22 @@ class _SingleBuild {
       if (inputNode is GeneratedAssetNode) {
         // Make sure the `inputNode` is up to date, and rebuild it if not.
         if (inputNode.state != GeneratedNodeState.upToDate) {
-          await _runLazyPhaseForInput(inputNode.phaseNumber, inputNode.isHidden,
-              inputNode.primaryInput, resourceManager);
+          await _runLazyPhaseForInput(
+              inputNode.phaseNumber, inputNode.primaryInput, resourceManager);
         }
         if (!inputNode.wasOutput) return <AssetId>[];
       }
 
       var action = _buildActions[phaseNumber];
 
-      return _runForInput(
-          phaseNumber, outputsHidden, action.builder, input, resourceManager);
+      return _runForInput(phaseNumber, action, input, resourceManager);
     });
   }
 
-  Future<Iterable<AssetId>> _runForInput(int phaseNumber, bool outputsHidden,
-      Builder builder, AssetId input, ResourceManager resourceManager) async {
+  Future<Iterable<AssetId>> _runForInput(int phaseNumber, BuildAction action,
+      AssetId input, ResourceManager resourceManager) async {
+    final builder = action.builder;
+    final outputsHidden = action.hideOutput;
     var tracker = _performanceTracker.startBuilderAction(input, builder);
 
     var builderOutputs = expectedOutputs(builder, input);
@@ -398,8 +394,7 @@ class _SingleBuild {
         phaseNumber,
         outputsHidden,
         input.package,
-        (phase, input) => _runLazyPhaseForInput(
-            phase, outputsHidden, input, resourceManager));
+        (phase, input) => _runLazyPhaseForInput(phase, input, resourceManager));
 
     if (!await tracker.track(
         () => _buildShouldRun(builderOutputs, wrappedReader), 'Setup')) {
@@ -414,7 +409,8 @@ class _SingleBuild {
     wrappedReader.assetsRead.clear();
 
     var wrappedWriter = new AssetWriterSpy(_writer);
-    var logger = new BuildForInputLogger(new Logger('$builder on $input'));
+    var logger = new BuildForInputLogger(
+        new Logger(_actionLoggerName(action, input, _packageGraph.root.name)));
     numActionsStarted++;
     await tracker.track(
         () => runBuilder(builder, [input], wrappedReader, wrappedWriter,
@@ -590,4 +586,12 @@ class _SingleBuild {
     _onDelete?.call(id);
     return _writer.delete(id);
   }
+}
+
+String _actionLoggerName(
+    BuildAction action, AssetId primaryInput, String rootPackageName) {
+  var asset = primaryInput.package == rootPackageName
+      ? primaryInput.path
+      : primaryInput.uri;
+  return '${action.builderLabel} on $asset';
 }

--- a/build_runner/lib/src/generate/phase.dart
+++ b/build_runner/lib/src/generate/phase.dart
@@ -122,7 +122,6 @@ String _simpleBuilderKey(String builderKey) {
   if (!builderKey.contains('|')) return builderKey;
   var parts = builderKey.split('|');
   if (parts[0] == parts[1]) return parts[0];
-  print('Not changing $builderKey because $parts');
   return builderKey;
 }
 

--- a/build_runner/lib/src/generate/phase.dart
+++ b/build_runner/lib/src/generate/phase.dart
@@ -16,6 +16,7 @@ class BuildAction {
   final Builder builder;
   final InputMatcher targetSources;
   final InputMatcher generateFor;
+  final String builderLabel;
 
   /// Whether to run lazily when an output is read.
   ///
@@ -37,6 +38,7 @@ class BuildAction {
   BuildAction._(this.package, this.builder, this.builderOptions,
       {@required this.targetSources,
       @required this.generateFor,
+      @required this.builderLabel,
       bool isOptional,
       bool hideOutput})
       : this.isOptional = isOptional ?? false,
@@ -56,6 +58,7 @@ class BuildAction {
   factory BuildAction(
     Builder builder,
     String package, {
+    String builderKey,
     InputSet targetSources,
     InputSet generateFor,
     BuilderOptions builderOptions,
@@ -66,11 +69,18 @@ class BuildAction {
         new InputMatcher(targetSources ?? const InputSet());
     var generateFormatcher = new InputMatcher(generateFor ?? const InputSet());
     builderOptions ??= const BuilderOptions(const {});
-    return new BuildAction._(package, builder, builderOptions,
-        targetSources: targetSourceMatcher,
-        generateFor: generateFormatcher,
-        isOptional: isOptional,
-        hideOutput: hideOutput);
+    return new BuildAction._(
+      package,
+      builder,
+      builderOptions,
+      targetSources: targetSourceMatcher,
+      generateFor: generateFormatcher,
+      builderLabel: builderKey == null || builderKey.isEmpty
+          ? _builderLabel(builder)
+          : _simpleBuilderKey(builderKey),
+      isOptional: isOptional,
+      hideOutput: hideOutput,
+    );
   }
 
   @override
@@ -96,6 +106,24 @@ class BuildAction {
         isOptional,
         hideOutput
       ]);
+}
+
+/// If we have no key find a human friendly name for the Builder.
+String _builderLabel(Builder builder) {
+  var label = '$builder';
+  if (label.startsWith('Instance of \'')) {
+    label = label.substring(13, label.length - 1);
+  }
+  return label;
+}
+
+/// Change "angular|angular" to "angular".
+String _simpleBuilderKey(String builderKey) {
+  if (!builderKey.contains('|')) return builderKey;
+  var parts = builderKey.split('|');
+  if (parts[0] == parts[1]) return parts[0];
+  print('Not changing $builderKey because $parts');
+  return builderKey;
 }
 
 final _deepEquals = const DeepCollectionEquality();

--- a/build_runner/lib/src/logging/build_for_input_logger.dart
+++ b/build_runner/lib/src/logging/build_for_input_logger.dart
@@ -60,15 +60,6 @@ class BuildForInputLogger implements Logger {
     if (logLevel >= Level.SEVERE) {
       _errorWasSeen = true;
     }
-    if (logLevel >= Level.WARNING) {
-      if (_delegate.isLoggable(logLevel)) {
-        var original = message;
-        if (message is Function) message = () => '\n${original()}';
-        if (message is String) {
-          message = '\n$message';
-        }
-      }
-    }
     _delegate.log(logLevel, message, error, stackTrace, zone);
   }
 

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -58,7 +58,8 @@ void stdIOLogListener(LogRecord record, {bool verbose}) {
   }
 }
 
-/// Filter out the Logger names known to come from `build_runner`.
+/// Filter out the Logger names known to come from `build_runner` and splits the
+/// header for levels >= WARNING.
 String _loggerName(LogRecord record, bool verbose) {
   var knownNames = const [
     'Entrypoint',
@@ -66,7 +67,8 @@ String _loggerName(LogRecord record, bool verbose) {
     'BuildDefinition',
     'Heartbeat'
   ];
+  var maybeSplit = record.level >= Level.WARNING ? '\n' : '';
   return verbose || !knownNames.contains(record.loggerName)
-      ? '${record.loggerName}:\n'
+      ? '${record.loggerName}:$maybeSplit'
       : '';
 }

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -27,7 +27,7 @@ void stdIOLogListener(LogRecord record, {bool verbose}) {
         headerMessage.split('\n').takeWhile((line) => line.isEmpty).length;
     headerMessage = headerMessage.substring(blankLineCount);
   }
-  var header = '$eraseLine$level ${record.loggerName}: $headerMessage';
+  var header = '$eraseLine$level ${_loggerName(record, verbose)}$headerMessage';
   var lines = blankLineCount > 0
       ? (new List<Object>.generate(blankLineCount, (_) => '')..add(header))
       : <Object>[header];
@@ -36,7 +36,7 @@ void stdIOLogListener(LogRecord record, {bool verbose}) {
     lines.add(record.error);
   }
 
-  if (record.stackTrace != null) {
+  if (record.stackTrace != null && verbose) {
     lines.add(record.stackTrace);
   }
 
@@ -56,4 +56,17 @@ void stdIOLogListener(LogRecord record, {bool verbose}) {
   } else {
     stdout.write(message);
   }
+}
+
+/// Filter out the Logger names known to come from `build_runner`.
+String _loggerName(LogRecord record, bool verbose) {
+  var knownNames = const [
+    'Entrypoint',
+    'Build',
+    'BuildDefinition',
+    'Heartbeat'
+  ];
+  return verbose || !knownNames.contains(record.loggerName)
+      ? '${record.loggerName}:\n'
+      : '';
 }

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -93,6 +93,8 @@ class BuilderApplication {
   final Iterable<String> appliesBuilders;
 
   /// A uniqe key for this builder.
+  ///
+  /// Ignored when null or empty.
   final String builderKey;
 
   final bool isOptional;
@@ -179,6 +181,7 @@ Iterable<BuildAction> _createBuildActionsForBuilderInCycle(
             builderOptions: options,
             targetSources: node.target.sources,
             generateFor: generateFor,
+            builderKey: builderApplication.builderKey,
             isOptional: builderApplication.isOptional,
             hideOutput: builderApplication.hideOutput);
       }));

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -60,10 +60,8 @@ main(List<String> args) async {
         var result = await runDart('a', 'tool/build.dart',
             args: ['build', '--delete-conflicting-outputs']);
         expect(result.exitCode, 0, reason: result.stderr as String);
-        expect(
-            result.stdout,
-            contains('BuildDefinition: Invalidating asset graph due to '
-                'build script update'));
+        expect(result.stdout,
+            contains('Invalidating asset graph due to build script update'));
         await d.dir('a', [
           d.dir('web', [d.file('a.txt.copy', 'a')])
         ]).validate();

--- a/build_runner/test/generate/watch_integration_test.dart
+++ b/build_runner/test/generate/watch_integration_test.dart
@@ -71,8 +71,7 @@ main() {
           d.dir('tool', [d.file('build.dart', '$originalBuildContent\n')])
         ]).create();
 
-        await nextStdErrLine(
-            'Watch: Terminating builds due to build script update');
+        await nextStdErrLine('Terminating builds due to build script update');
         expect(await process.exitCode, equals(0));
       });
     });
@@ -80,7 +79,7 @@ main() {
 }
 
 Future get nextSuccessfulBuild =>
-    stdOutLines.firstWhere((line) => line.contains('Build: Succeeded after'));
+    stdOutLines.firstWhere((line) => line.contains('Succeeded after'));
 
 Future nextStdErrLine(String message) =>
     stdErrLines.firstWhere((line) => line.contains(message));

--- a/e2e_example/test/build_integration_test.dart
+++ b/e2e_example/test/build_integration_test.dart
@@ -21,13 +21,13 @@ void main() {
     test('causes builds to return a non-zero exit code on errors', () async {
       var result = await runAutoBuild(trailingArgs: ['--fail-on-severe']);
       expect(result.exitCode, isNot(0));
-      expect(result.stderr, contains('Build: Failed'));
+      expect(result.stderr, contains('Failed'));
     });
 
     test('causes tests to return a non-zero exit code on errors', () async {
       var result = await runAutoTests(buildArgs: ['--fail-on-severe']);
       expect(result.exitCode, isNot(0));
-      expect(result.stderr, contains('Build: Failed'));
+      expect(result.stderr, contains('Failed'));
       expect(result.stdout, contains('Skipping tests due to build failure'));
     });
   });

--- a/e2e_example/test/common/utils.dart
+++ b/e2e_example/test/common/utils.dart
@@ -173,11 +173,11 @@ Future<Null> _resetGitClient() async {
 
 Future<Null> get nextSuccessfulBuild async {
   await _stdOutLines
-      .firstWhere((line) => line.contains('Build: Succeeded after'));
+      .firstWhere((line) => line.contains('Succeeded after'));
 }
 
 Future<Null> get nextFailedBuild async {
-  await _stdErrLines.firstWhere((line) => line.contains('Build: Failed after'));
+  await _stdErrLines.firstWhere((line) => line.contains('Failed after'));
 }
 
 Future<String> nextStdErrLine(String message) =>


### PR DESCRIPTION
Closes #1069

Replaces the builder `toString()` with a more relevant label, and
changes AssetIds to something more reconizable.

- Keep a `buildLabel` on `BuildAction`. Where possible this is a
  `builderKey`, but when that is missing or empty we fall back on the
  `toString` of the Builder.
- Normalize AssetIds to `package:` URIs for non-root packages, and file
  path for root package.
- Don't prefix newlines as messages are logged, these weren't working as
  implemented and would get swallowed by the StdIoLogger anyway.
- Hardcode known `build_runner` Logger names and don't print their name
  with messages.
- Always prefix messages from Builders (loggers with names we don't
  recognize) with a newline. This works well in the WARNING and SEVERE
  case but might not work as well for other messages - we can revist if
  necessary.
- Don't print stack traces unless verbose logging is enabled.