### PR TITLE
Change or remove `text/javascript`

### DIFF
--- a/build_runner/lib/src/server/graph_viz.html
+++ b/build_runner/lib/src/server/graph_viz.html
@@ -8,7 +8,7 @@ BSD-style license that can be found in the LICENSE file.
 <head>
     <meta charset="utf-8">
     <title>Asset Graph visualization</title>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.css" rel="stylesheet" type="text/css" />
     <style type="text/css">
         #container {

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -219,8 +219,8 @@ String _renderPerformance(BuildPerformance performance, bool hideSkipped) {
     return '''
   <html>
     <head>
-      <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-      <script type="text/javascript">
+      <script src="https://www.gstatic.com/charts/loader.js"></script>
+      <script>
         google.charts.load('current', {'packages':['timeline']});
         google.charts.setOnLoadCallback(drawChart);
         function drawChart() {

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -128,7 +128,7 @@ When the development process included `dartium` HTML files typically referenced
 `main.dart` and used a transformer to rewrite to `main.dart.js` for deployment.
 The new development process uses DDC and so always compiles to javascript. Any
 script tags should be manually rewritten to always reference `*.dart.js` with a
-`type` of `text/javascript` rather than `application/dart`.
+`type` of `application/javascript` rather than `application/dart`.
 `dart_to_js_script_rewriter` and `browser` dependencies can be dropped.
 
 


### PR DESCRIPTION
According to https://www.iana.org/assignments/media-types/text/javascript the
value should be `application/javascript` rather than `text/javascript`,
but this is also the assumed default so it can be removed altogether.