### PR TITLE
add test that --define overrides build.yaml

### DIFF
--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -357,6 +357,90 @@ main(List<String> args) async {
         await expectBuildOutput(expectCopyInOutput: false);
       });
     });
+
+    group('--define overrides build.yaml', () {
+      String buildContent = '''
+import 'package:build/build.dart';
+import 'package:build_runner/build_runner.dart';
+import 'package:build_test/build_test.dart';
+
+main(List<String> args) async {
+  var buildApplications = [
+    apply(
+        'root|copy',
+        [
+          (options) {
+            var copyFromId = options.config['copy_from'];
+            var build = copyFromId != null ?
+                copyFrom(new AssetId.parse(copyFromId)) : null;
+            return new TestBuilder(
+              buildExtensions: appendExtension('.copy', from: '.txt'),
+              build: build);
+          }
+        ],
+        toRoot(),
+        hideOutput: false,
+        isOptional: false),
+  ];;
+  await run(args, buildApplications);
+}
+''';
+
+      /// Expects the build output based on [expectedContent].
+      Future<Null> expectBuildOutput(String expectedContent) async {
+        await d.dir('a', [
+          d.dir('web', [
+            d.file('a.txt', 'a'),
+            d.file('a.txt.copy', expectedContent),
+          ]),
+        ]).validate();
+      }
+
+      Future<Null> runBuild({List<String> extraArgs}) async {
+        extraArgs ??= [];
+        var buildArgs = ['build', '-o', 'build']..addAll(extraArgs);
+        var result = await runDart('a', 'tool/build.dart', args: buildArgs);
+        expect(result.exitCode, 0,
+            reason: '${result.stdout}\n${result.stderr}');
+        print('${result.stdout}\n${result.stderr}');
+      }
+
+      test('--define overrides build.yaml', () async {
+        await d.dir('a', [
+          await pubspec('a', currentIsolateDependencies: [
+            'build',
+            'build_config',
+            'build_resolvers',
+            'build_runner',
+            'build_test',
+          ]),
+          d.file('build.yaml', r'''
+targets:
+  $default:
+    builders:
+      root|copy:
+        options:
+          copy_from: a|web/b.txt
+'''),
+          d.dir('tool', [d.file('build.dart', buildContent)]),
+          d.dir('web', [
+            d.file('a.txt', 'a'),
+            d.file('b.txt', 'b'),
+            d.file('c.txt', 'c'),
+          ]),
+        ]).create();
+
+        await pubGet('a');
+
+        // Run a basic build with no --define config.
+        await runBuild();
+        await expectBuildOutput('b');
+
+        // Run another build but add the --define.
+        await runBuild(extraArgs: ['--define=root|copy=copy_from=a|web/c.txt']);
+        await expectBuildOutput('c');
+      });
+    });
   });
 
   group('regression tests', () {

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -257,7 +257,7 @@ class OverDeclaringGlobbingBuilder extends GlobbingBuilder {
     });
 
     group('--output with optional outputs', () {
-      String buildContent = '''
+      final buildContent = '''
 import 'package:build_runner/build_runner.dart';
 import 'package:build_test/build_test.dart';
 
@@ -359,7 +359,7 @@ main(List<String> args) async {
     });
 
     group('--define overrides build.yaml', () {
-      String buildContent = '''
+      final buildContent = '''
 import 'package:build/build.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:build_test/build_test.dart';

--- a/e2e_example/test/dart2js_integration_test.dart
+++ b/e2e_example/test/dart2js_integration_test.dart
@@ -18,7 +18,7 @@ void main() {
           usePrecompiled: true,
           useManualScript: false,
           args: ['--config=dart2js']);
-      await expectWasCompiledWithDart2Js();
+      await expectWasCompiledWithDart2Js(minified: false);
     }, onPlatform: {'windows': const Skip('flaky on windows')});
 
     test('via --define flag', () async {
@@ -29,17 +29,38 @@ void main() {
             '--define',
             'build_web_compilers|entrypoint=compiler=dart2js',
             '--define',
-            'build_web_compilers|entrypoint=dart2js_args=["--checked","--trust-primitives"]',
+            'build_web_compilers|entrypoint=dart2js_args=["--minify","--checked"]',
           ]);
-      await expectWasCompiledWithDart2Js();
+      await expectWasCompiledWithDart2Js(minified: true);
+    }, onPlatform: {'windows': const Skip('flaky on windows')});
+
+    test('--define overrides --config', () async {
+      await expectTestsPass(
+          usePrecompiled: true,
+          useManualScript: false,
+          args: [
+            '--config',
+            'dart2js',
+            '--define',
+            'build_web_compilers|entrypoint=compiler=dart2js',
+            '--define',
+            'build_web_compilers|entrypoint=dart2js_args=["--minify","--checked"]',
+          ]);
+      await expectWasCompiledWithDart2Js(minified: true);
     }, onPlatform: {'windows': const Skip('flaky on windows')});
   });
 }
 
-Future<Null> expectWasCompiledWithDart2Js() async {
+Future<Null> expectWasCompiledWithDart2Js({bool minified: false}) async {
   var jsFile =
       new File('.dart_tool/build/generated/e2e_example/web/main.dart.js');
   expect(await jsFile.exists(), isTrue);
   // sanity check that it was indeed compiled with dart2js
-  expect(await jsFile.readAsString(), contains('dart2js'));
+  var content = await jsFile.readAsString();
+  expect(content, contains('function generateAccessor('));
+  if (minified) {
+    expect(content, isNot(startsWith('//')));
+  } else {
+    expect(content, startsWith('//'));
+  }
 }


### PR DESCRIPTION
Added as a result of https://github.com/dart-lang/build/issues/1105, but it looks like we are already doing the right thing - cc @kevmoo.