### PR TITLE
Add support for IPv4 loopback

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,7 +1,12 @@
-## 0.7.13-prerelease
+## 0.7.13
 
 - Fix a bug where a chain of `Builder`s would fail to run on some outputs from
   previous steps when the generated asset did not match the target's `sources`.
+- Added support for serving on IPv4 loopback when the server hostname is
+  'localhost' (the default).
+- Added support for serving on any connection (both IPv4 and IPv6) when the
+  hostname is 'any'.
+- Improved stdout output.
 
 ## 0.7.12
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.13-prerelease
+version: 0.7.13
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -22,6 +22,7 @@ dependencies:
   dart_style: ^1.0.0
   glob: ^1.1.0
   graphs: ^0.1.0
+  http_multi_server: ^2.0.0
   io: ^0.3.0
   logging: ^0.11.2
   meta: ^1.1.0


### PR DESCRIPTION
Closes #1103

- Add dependnecy on `http_multi_server` and use it when hostname is
  'localhost'.
- Listen on any connection when hostname is 'any'.