### PR TITLE
Use AnalyzerResolver from build_test

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.1+1
+
+- Replace `BarbackResolvers` with `AnalyzerResolvers` from `build_resolvers` by
+  default.
+
 ## 0.10.1
 
 - Allow overriding the `Resolvers` used for `resolve*` utilities.

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:build/build.dart';
-import 'package:build_barback/build_barback.dart';
+import 'package:build_resolvers/build_resolvers.dart';
 import 'package:package_resolver/package_resolver.dart';
 
 import 'in_memory_reader.dart';
@@ -27,7 +27,7 @@ Future<T> resolveSource<T>(
   AssetId inputId,
   PackageResolver resolver,
   Future<Null> tearDown,
-  Resolvers resolvers: const BarbackResolvers(),
+  Resolvers resolvers,
 }) {
   inputId ??= new AssetId('_resolve_source', 'lib/_resolve_source.dart');
   return _resolveAssets(
@@ -119,7 +119,7 @@ Future<T> resolveSources<T>(
   String resolverFor,
   String rootPackage,
   Future<Null> tearDown,
-  Resolvers resolvers: const BarbackResolvers(),
+  Resolvers resolvers,
 }) {
   if (inputs == null || inputs.isEmpty) {
     throw new ArgumentError.value(inputs, 'inputs', 'Must be a non-empty Map');
@@ -141,7 +141,7 @@ Future<T> resolveAsset<T>(
   FutureOr<T> action(Resolver resolver), {
   PackageResolver resolver,
   Future<Null> tearDown,
-  Resolvers resolvers: const BarbackResolvers(),
+  Resolvers resolvers,
 }) {
   return _resolveAssets(
     {
@@ -197,7 +197,7 @@ Future<T> _resolveAssets<T>(
     inputAssets.keys,
     new MultiAssetReader([inMemory, assetReader]),
     new InMemoryAssetWriter(),
-    resolvers,
+    resolvers ?? new AnalyzerResolvers(),
   );
   return resolveBuilder.onDone.future;
 }

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -4,10 +4,10 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:test/test.dart';
 import 'package:build/build.dart';
-import 'package:build_barback/build_barback.dart';
+import 'package:build_resolvers/build_resolvers.dart';
 import 'package:logging/logging.dart';
+import 'package:test/test.dart';
 
 import 'assets.dart';
 import 'in_memory_reader.dart';
@@ -134,7 +134,7 @@ Future testBuilder(
   var logger = new Logger('testBuilder');
   var logSubscription = logger.onRecord.listen(onLog);
   await runBuilder(
-      builder, inputIds, reader, writerSpy, const BarbackResolvers(),
+      builder, inputIds, reader, writerSpy, new AnalyzerResolvers(),
       logger: logger);
   await logSubscription.cancel();
   var actualOutputs = writerSpy.assetsWritten;

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.1
+version: 0.10.1+1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
@@ -12,6 +12,7 @@ dependencies:
   build: ^0.12.0
   build_barback: ">=0.5.0+1 <0.6.0"
   build_config: ^0.2.0
+  build_resolvers: ^0.2.0
   collection: ^1.14.0
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0


### PR DESCRIPTION
This gets us closer to being able to drop the `build_barback`
dependency, though that is still necessary because of the package:test
Transformer wrapping.