### PR TITLE
Eagerly find assets matching glob

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.13+1
+
+- Fix a concurrent modification error when using `listAssets` when an asset
+  could be written.
+
 ## 0.7.13
 
 - Fix a bug where a chain of `Builder`s would fail to run on some outputs from

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -138,7 +138,8 @@ class SingleStepReader implements AssetReader {
     _globsRan.add(glob);
     var potentialMatches = _assetGraph
         .packageNodes(_primaryPackage)
-        .where((n) => glob.matches(n.id.path));
+        .where((n) => glob.matches(n.id.path))
+        .toList();
     for (var node in potentialMatches) {
       if (await _isReadableNode(node)) yield node.id;
     }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.7.13
+version: 0.7.13+1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Fixes #1128

Since there is async work to check for readable nodes a new asset might
get created which changes the original Map keys we're iterating over.
That asset would never be readable in this context so eagerly find
assets matching the glob before starting the async checks.