### PR TITLE
Log a warning when pbr serve is used w/o build_web_compilers.

### DIFF
--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -493,8 +493,6 @@ void _ensureBuildWebCompilersDependency(PackageGraph packageGraph, Logger log) {
       build_runner: any
       build_test: any
       build_web_compilers: any''');
-  } else {
-    log.warning('YAY!');
   }
 }
 

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -524,16 +524,15 @@ main() async {
 
       await pubGet('a');
       var result = await startPub('a', 'run', args: ['build_runner', 'serve']);
+      addTearDown(result.kill);
       var error = 'Missing dev dependency on package:build_web_compilers';
 
       await for (final log in result.stdout.transform(UTF8.decoder)) {
         if (log.contains(error)) {
-          result.kill();
           return;
         }
       }
 
-      result.kill();
       fail('No warning issued when running the "serve" command');
     });
   });

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -506,7 +506,7 @@ main() async {
       expect(result.exitCode, isNot(0),
           reason: 'build should fail due to missing build_test dependency');
       expect(result.stdout,
-          contains('Missing dev dependecy on package:build_test'));
+          contains('Missing dev dependency on package:build_test'));
     });
 
     test('Missing build_web_compilers dependency warns the user', () async {


### PR DESCRIPTION
Closes #1124.

A strictly "better" version of this would see if there is at least a single Dart file being potentially served (i.e. this isn't an entirely static site or plain JavaScript), but I imagine that's quite rare - and it's just a warning.

... sorry for the wacky test, I just couldn't find the matcher that works.