### PR TITLE
Print terse stack traces for uncaught errors

### DIFF
--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -9,6 +9,7 @@ import 'dart:isolate';
 import 'package:args/command_runner.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+import 'package:stack_trace/stack_trace.dart';
 
 import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
 import 'package:build_runner/src/entrypoint/options.dart';
@@ -43,7 +44,13 @@ Future<Null> main(List<String> args) async {
   var errorPort = new ReceivePort();
   var messagePort = new ReceivePort();
   var errorListener = errorPort.listen((e) {
-    stderr.writeAll(e as List, '\n');
+    stderr.writeln('You have hit a bug in build_runner');
+    stderr.writeln('Please file an issue with reproduction steps at '
+        'https://github.com/dart-lang/build/issues');
+    final error = e[0];
+    final trace = e[1] as String;
+    stderr.writeln(error);
+    stderr.writeln(new Trace.parse(trace).terse);
     if (exitCode == 0) exitCode = 1;
   });
   await Isolate.spawnUri(

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -44,9 +44,9 @@ Future<Null> main(List<String> args) async {
   var errorPort = new ReceivePort();
   var messagePort = new ReceivePort();
   var errorListener = errorPort.listen((e) {
-    stderr.writeln('You have hit a bug in build_runner');
+    stderr.writeln('\n\nYou have hit a bug in build_runner');
     stderr.writeln('Please file an issue with reproduction steps at '
-        'https://github.com/dart-lang/build/issues');
+        'https://github.com/dart-lang/build/issues\n\n');
     final error = e[0];
     final trace = e[1] as String;
     stderr.writeln(error);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   path: ^1.1.0
   pool: ^1.0.0
   shelf: ">=0.6.5 <0.8.0"
+  stack_trace: ^1.9.0
   stream_transform: ^0.0.9
   watcher: ^0.9.7
   yaml: ^2.1.0


### PR DESCRIPTION
Closes #1135

Exceptions from Builders should be caught by a `runZoned` call. The only
exceptions we expect to escape the Isolate are bugs within build_runner.

- Add a message saying that an issue should be file.
- Parse the trace and print the Trace.terse version