### PR TITLE
Bump scratch_space SDK constraint

### DIFF
--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,14 +1,17 @@
 name: scratch_space
-version: 0.0.1+3
+version: 0.0.2-dev
 description: A tool to manage running external executables within package:build
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space
+
+environment:
+  sdk: '>=2.0.0-dev.9 <2.0.0'
+
 dependencies:
   build: '>=0.10.0 <0.13.0'
   path: ^1.1.0
   pool: ^1.0.0
+
 dev_dependencies:
   build_test: ^0.9.0
   test: ^0.12.0
-environment:
-  sdk: ">=1.21.0 <2.0.0"


### PR DESCRIPTION
This package started using the lowercase `utf8`. Even though it's only
used in a test we're no longer testing Travis with 1.x SDK and no
packages compatible with 1.x SDK will have a dependency on this.