### PR TITLE
Add dart2js deferred loading support

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.3.4-dev
 
+- Added support for dart2js deferred loading.
 - Added support for bootstrapping code in web workers with `dartdevc`.
 
 # 0.3.3

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -22,7 +22,6 @@ builders:
       .dart:
         - .dart.bootstrap.js
         - .dart.js
-        - .dart.js.info.json
         - .dart.js.map
         - .dart.js.tar.gz
     required_inputs:
@@ -41,3 +40,12 @@ builders:
         exclude:
           - test/**.node_test.dart
           - test/**.vm_test.dart
+    applies_builders:
+      - build_web_compilers|dart2js_archive_extractor
+post_process_builders:
+  dart2js_archive_extractor:
+    target: ":build_web_compilers"
+    import: "package:build_web_compilers/builders.dart"
+    builder_factory: dart2JsArchiveExtractor
+    input_extensions:
+      - .dart.js.tar.gz

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -24,6 +24,7 @@ builders:
         - .dart.js
         - .dart.js.info.json
         - .dart.js.map
+        - .dart.js.tar.gz
     required_inputs:
       - .dart
       - .ddc.js

--- a/build_web_compilers/lib/build_web_compilers.dart
+++ b/build_web_compilers/lib/build_web_compilers.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/archive_extractor.dart' show Dart2JsArchiveExtractor;
 export 'src/dev_compiler_builder.dart'
     show
         DevCompilerBuilder,

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -3,8 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
+import 'package:build_runner/build_runner.dart' show PostProcessBuilder;
 import 'package:build_web_compilers/build_web_compilers.dart';
 
 Builder devCompilerBuilder(_) => const DevCompilerBuilder();
 Builder webEntrypointBuilder(BuilderOptions options) =>
     new WebEntrypointBuilder.fromOptions(options);
+PostProcessBuilder dart2JsArchiveExtractor(_) => new Dart2JsArchiveExtractor();

--- a/build_web_compilers/lib/src/archive_extractor.dart
+++ b/build_web_compilers/lib/src/archive_extractor.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:archive/archive.dart';
+import 'package:build/build.dart';
+import 'package:build_runner/build_runner.dart'
+    show PostProcessBuildStep, PostProcessBuilder;
+import 'package:path/path.dart' as p;
+
+import 'web_entrypoint_builder.dart';
+
+class Dart2JsArchiveExtractor implements PostProcessBuilder {
+  @override
+  final inputExtensions = const [jsEntrypointArchiveExtension];
+
+  @override
+  Future<Null> build(PostProcessBuildStep buildStep) async {
+    var bytes = await buildStep.readInputAsBytes();
+    var archive = new TarDecoder().decodeBytes(bytes);
+    for (var file in archive.files) {
+      var inputId = buildStep.inputId;
+      var id = new AssetId(
+          inputId.package, p.url.join(p.url.dirname(inputId.path), file.name));
+      await buildStep.writeAsBytes(id, file.content as List<int>);
+    }
+  }
+}

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -13,9 +13,9 @@ import 'dart2js_bootstrap.dart';
 import 'dev_compiler_bootstrap.dart';
 
 const ddcBootstrapExtension = '.dart.bootstrap.js';
-const dumpInfoExtension = '.dart.js.info.json';
 const jsEntrypointExtension = '.dart.js';
 const jsEntrypointSourceMapExtension = '.dart.js.map';
+const jsEntrypointArchiveExtension = '.dart.js.tar.gz';
 
 /// Which compiler to use when compiling web entrypoints.
 enum WebCompiler {
@@ -90,9 +90,9 @@ class WebEntrypointBuilder implements Builder {
   final buildExtensions = const {
     '.dart': const [
       ddcBootstrapExtension,
-      dumpInfoExtension,
       jsEntrypointExtension,
-      jsEntrypointSourceMapExtension
+      jsEntrypointSourceMapExtension,
+      jsEntrypointArchiveExtension,
     ],
   };
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.30.0 <0.32.0"
+  archive: ^1.0.13
   bazel_worker: ^0.1.4
   build: ^0.12.0
   build_config: ^0.2.1

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -14,16 +14,22 @@ dependencies:
   build: ^0.12.0
   build_config: ^0.2.1
   build_modules: ^0.2.0
+  build_runner: ^0.8.0
   cli_util: ^0.1.2
   logging: ^0.11.2
   path: ^1.4.2
   scratch_space: ^0.0.1
 
 dev_dependencies:
-  build_runner: ^0.7.0
   build_test: ^0.10.0
   test: ^0.12.24
   a:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  build_config:
+    path: ../build_config
+  build_runner:
+    path: ../build_runner

--- a/build_web_compilers/test/dart2js_bootstrap_test.dart
+++ b/build_web_compilers/test/dart2js_bootstrap_test.dart
@@ -38,6 +38,7 @@ main() {
     var expectedOutputs = {
       'a|web/index.dart.js': decodedMatches(contains('world')),
       'a|web/index.dart.js.map': anything,
+      'a|web/index.dart.js.tar.gz': anything,
     };
     await testBuilder(new WebEntrypointBuilder(WebCompiler.Dart2Js), assets,
         outputs: expectedOutputs);
@@ -46,6 +47,7 @@ main() {
   test('works with --no-sourcemap', () async {
     var expectedOutputs = {
       'a|web/index.dart.js': anything,
+      'a|web/index.dart.js.tar.gz': anything,
     };
     await testBuilder(
         new WebEntrypointBuilder(WebCompiler.Dart2Js,

--- a/e2e_example/build.dart2js.yaml
+++ b/e2e_example/build.dart2js.yaml
@@ -11,6 +11,8 @@ targets:
           - web/sub/main.dart
           - test/hello_world_test.dart
           - test/hello_world_test.dart.browser_test.dart
+          - test/hello_world_deferred_test.dart
+          - test/hello_world_deferred_test.dart.browser_test.dart
           - test/hello_world_custom_html_test.dart
           - test/hello_world_custom_html_test.dart.browser_test.dart
           - test/other_test.dart.browser_test.dart

--- a/e2e_example/build.post_process.yaml
+++ b/e2e_example/build.post_process.yaml
@@ -10,6 +10,8 @@ targets:
           - web/sub/main.dart
           - test/hello_world_test.dart
           - test/hello_world_test.dart.browser_test.dart
+          - test/hello_world_deferred_test.dart
+          - test/hello_world_deferred_test.dart.browser_test.dart
           - test/hello_world_custom_html_test.dart
           - test/hello_world_custom_html_test.dart.browser_test.dart
           - test/other_test.dart.browser_test.dart

--- a/e2e_example/build.throws.yaml
+++ b/e2e_example/build.throws.yaml
@@ -4,3 +4,17 @@ targets:
       provides_builder|some_builder:
         options:
           throw_in_constructor: true
+      build_web_compilers|entrypoint:
+        generate_for:
+          - web/main.dart
+          - web/sub/main.dart
+          - test/hello_world_test.dart
+          - test/hello_world_test.dart.browser_test.dart
+          - test/hello_world_deferred_test.dart
+          - test/hello_world_deferred_test.dart.browser_test.dart
+          - test/hello_world_custom_html_test.dart
+          - test/hello_world_custom_html_test.dart.browser_test.dart
+          - test/other_test.dart.browser_test.dart
+          - test/subdir/subdir_test.dart
+          - test/subdir/subdir_test.dart.browser_test.dart
+

--- a/e2e_example/build.yaml
+++ b/e2e_example/build.yaml
@@ -7,6 +7,8 @@ targets:
           - web/sub/main.dart
           - test/hello_world_test.dart
           - test/hello_world_test.dart.browser_test.dart
+          - test/hello_world_deferred_test.dart
+          - test/hello_world_deferred_test.dart.browser_test.dart
           - test/hello_world_custom_html_test.dart
           - test/hello_world_custom_html_test.dart.browser_test.dart
           - test/other_test.dart.browser_test.dart

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -40,9 +40,12 @@ final _builders = [
       ], exclude: const [
         'test/**.node_test.dart',
         'test/**.vm_test.dart'
-      ])),
+      ]),
+      appliesBuilders: ['build_web_compilers|dart2js_archive_extractor']),
   _i1.applyPostProcess(
-      'provides_builder|some_post_process_builder', _i2.somePostProcessBuilder)
+      'provides_builder|some_post_process_builder', _i2.somePostProcessBuilder),
+  _i1.applyPostProcess('build_web_compilers|dart2js_archive_extractor',
+      _i6.dart2JsArchiveExtractor)
 ];
 main(List<String> args, [_i7.SendPort sendPort]) async {
   var result = await _i1.run(args, _builders);

--- a/e2e_example/test/hello_world_deferred_test.dart
+++ b/e2e_example/test/hello_world_deferred_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+import 'dart:html';
+
+import 'package:test/test.dart';
+
+import 'package:e2e_example/app.dart';
+
+import 'common/message.dart' deferred as m;
+
+void main() {
+  setUp(startApp);
+
+  tearDown(() {
+    document.body.innerHtml = '';
+  });
+
+  test('hello world', () async {
+    await m.loadLibrary();
+    expect(document.body.text, contains(m.message));
+  });
+}

--- a/e2e_example/test/serve_integration_test.dart
+++ b/e2e_example/test/serve_integration_test.dart
@@ -53,14 +53,14 @@ void main() {
       var nextBuild = nextSuccessfulBuild;
       await createFile(p.join('test', 'other_test.dart'), basicTestContents);
       await nextBuild;
-      await expectTestsPass(expectedNumRan: 4);
+      await expectTestsPass(expectedNumRan: 5);
     });
 
     test('delete test', () async {
       var nextBuild = nextSuccessfulBuild;
       await deleteFile(p.join('test', 'subdir', 'subdir_test.dart'));
       await nextBuild;
-      await expectTestsPass(expectedNumRan: 2);
+      await expectTestsPass(expectedNumRan: 3);
     });
 
     test('ddc errors can be fixed', () async {

--- a/e2e_example/web/main.dart
+++ b/e2e_example/web/main.dart
@@ -4,8 +4,9 @@
 
 import 'package:e2e_example/app.dart';
 
-import 'sub/message.dart';
+import 'sub/message.dart' deferred as message;
 
-void main() {
-  startApp(text: message);
+main() async {
+  await message.loadLibrary();
+  startApp(text: message.message);
 }


### PR DESCRIPTION
With this change dart2js now puts all the extra outputs (dump_info, deferred parts) in an archive file, which is extracted using one of the new `PostProcessBuilder` (`Dart2JsArchiveExtractor`) which is applied by the build_web_compilers|entrypoint builder.

To write unit tests we will need to create a series of helper utils for testing post process builders etc - that should happen but the provided e2e test should be sufficient for now.

Closes https://github.com/dart-lang/build/issues/814