### PR TITLE
Use log labels which all have the same width

### DIFF
--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -10,15 +10,7 @@ import 'package:logging/logging.dart';
 
 void stdIOLogListener(LogRecord record, {bool verbose}) {
   verbose ??= false;
-  AnsiCode color;
-  if (record.level < Level.WARNING) {
-    color = cyan;
-  } else if (record.level < Level.SEVERE) {
-    color = yellow;
-  } else {
-    color = red;
-  }
-  final level = color.wrap('[${record.level}]');
+  final level = _levelLabel(record.level);
   final eraseLine = ansiOutputEnabled && !verbose ? '\x1b[2K\r' : '';
   var headerMessage = record.message;
   var blankLineCount = 0;
@@ -56,6 +48,24 @@ void stdIOLogListener(LogRecord record, {bool verbose}) {
   } else {
     stdout.write(message);
   }
+}
+
+String _levelLabel(Level level) => _levelColor(level).wrap(_levelName(level));
+
+/// Reduce possible levels to the groups we care about and make sure names are 6
+/// characters.
+String _levelName(Level level) {
+  if (level < Level.CONFIG) return '[ FINE ]';
+  if (level < Level.WARNING) return '[ INFO ]';
+  if (level < Level.SEVERE) return '[ WARN ]';
+  return '[SEVERE]';
+}
+
+AnsiCode _levelColor(Level level) {
+  if (level < Level.CONFIG) return lightBlue;
+  if (level < Level.WARNING) return cyan;
+  if (level < Level.SEVERE) return yellow;
+  return red;
 }
 
 /// Filter out the Logger names known to come from `build_runner` and splits the


### PR DESCRIPTION
Closes #1153

Since `SEVERE` doesn't have a nice way to shorten it we'll pad
everything to 6 characters.

- Don't use the labels or levels coming from the logging package, bucket
  things into 4 levels which are more sensible.
- Add a different color for `FINE` logs.