### PR TITLE
Revert "Use log labels which all have the same width (#1165)"

### DIFF
--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -10,7 +10,15 @@ import 'package:logging/logging.dart';
 
 void stdIOLogListener(LogRecord record, {bool verbose}) {
   verbose ??= false;
-  final level = _levelLabel(record.level);
+  AnsiCode color;
+  if (record.level < Level.WARNING) {
+    color = cyan;
+  } else if (record.level < Level.SEVERE) {
+    color = yellow;
+  } else {
+    color = red;
+  }
+  final level = color.wrap('[${record.level}]');
   final eraseLine = ansiOutputEnabled && !verbose ? '\x1b[2K\r' : '';
   var headerMessage = record.message;
   var blankLineCount = 0;
@@ -48,24 +56,6 @@ void stdIOLogListener(LogRecord record, {bool verbose}) {
   } else {
     stdout.write(message);
   }
-}
-
-String _levelLabel(Level level) => _levelColor(level).wrap(_levelName(level));
-
-/// Reduce possible levels to the groups we care about and make sure names are 6
-/// characters.
-String _levelName(Level level) {
-  if (level < Level.CONFIG) return '[ FINE ]';
-  if (level < Level.WARNING) return '[ INFO ]';
-  if (level < Level.SEVERE) return '[ WARN ]';
-  return '[SEVERE]';
-}
-
-AnsiCode _levelColor(Level level) {
-  if (level < Level.CONFIG) return lightBlue;
-  if (level < Level.WARNING) return cyan;
-  if (level < Level.SEVERE) return yellow;
-  return red;
 }
 
 /// Filter out the Logger names known to come from `build_runner` and splits the


### PR DESCRIPTION
This reverts commit f17b2f65892873824dcab895e0ef6daaf8f0d867.

This is breaking to things [like](https://github.com/furrary/livereload/blob/09272cc3613b9aab1a00cb91edd942be7cf9cdfe/lib/src/server/build_runner.dart#L130) [this](https://github.com/furrary/livereload/blob/09272cc3613b9aab1a00cb91edd942be7cf9cdfe/lib/src/logging.dart#L10). I don't think that means we should start considering our log output as unchangeable, but I'd like to have a high bar until we can address https://github.com/dart-lang/build/issues/1167