### PR TITLE
Use new frontend with Dart2Js

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.4+2
+
+- Create `.packages` file and use the new frontend with `dart2js`.
+
 # 0.3.4+1
 
 - Use `--use-old-frontend` with `dart2js` as a stopgap until we can add support

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:archive/archive.dart';
 import 'package:build/build.dart';
 import 'package:build_modules/build_modules.dart';
+import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' as p;
 import 'package:scratch_space/scratch_space.dart';
@@ -27,11 +28,12 @@ Future<Null> bootstrapDart2Js(
   var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
   await scratchSpace.ensureAssets(allSrcs, buildStep);
 
+  var packageFile = await _createPackageFile(allSrcs, buildStep, scratchSpace);
+
   var jsOutputId = dartEntrypointId.changeExtension(jsEntrypointExtension);
   var args = dart2JsArgs.toList()
     ..addAll([
-      '-ppackages',
-      '--use-old-frontend',
+      '--packages=$packageFile',
       '-o${jsOutputId.path}',
       dartEntrypointId.path,
     ]);
@@ -82,4 +84,30 @@ Future<Null> _copyIfExists(
   if (await file.exists()) {
     await scratchSpace.copyOutput(id, writer);
   }
+}
+
+/// Creates a `.packages` file unique to this entrypoint at the root of the
+/// scratch space and returns it's filename.
+///
+/// Since mulitple invocations of Dart2Js will share a scratch space and we only
+/// know the set of packages involved the current entrypoint we can't construct
+/// a `.packages` file that will work for all invocations of Dart2Js so a unique
+/// file is created for every entrypoint that is run.
+///
+/// The filename is based off the MD5 hash of the asset path so that files are
+/// unique regarless of situations like `web/foo/bar.dart` vs
+/// `web/foo-bar.dart`.
+Future<String> _createPackageFile(Iterable<AssetId> inputSources,
+    BuildStep buildStep, ScratchSpace scratchSpace) async {
+  var inputUri = buildStep.inputId.uri;
+  var packageFileName =
+      '.package-${md5.convert(inputUri.toString().codeUnits)}';
+  var packagesFile = scratchSpace
+      .fileFor(new AssetId(buildStep.inputId.package, packageFileName));
+  var packageNames = inputSources.map((s) => s.package).toSet();
+  var packagesFileContent =
+      packageNames.map((n) => '$n:packages/$n/').join('\n');
+  await packagesFile
+      .writeAsString('# Generated for $inputUri\n$packagesFileContent');
+  return packageFileName;
 }

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.3.4+1
+version: 0.3.4+2
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
@@ -16,6 +16,7 @@ dependencies:
   build_modules: ^0.2.0
   build_runner: ^0.8.0
   cli_util: ^0.1.2
+  crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0
   logging: ^0.11.2
   path: ^1.4.2

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   glob: ^1.1.0
   logging: ^0.11.2
   path: ^1.4.2
-  scratch_space: ^0.0.1
+  scratch_space: ^0.0.2
 
 dev_dependencies:
   build_test: ^0.10.0
@@ -29,3 +29,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  scratch_space:
+    path: ../scratch_space

--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+- Allow creating files at the root of the scratch space.
+
 ## 0.0.1+3
 
 - Allow package:build 0.12.0

--- a/scratch_space/lib/src/util.dart
+++ b/scratch_space/lib/src/util.dart
@@ -6,18 +6,12 @@ import 'package:path/path.dart' as p;
 
 /// Returns the top level directory in [uri].
 ///
-/// Throws an [ArgumentError] if [uri] is just a filename with no directory.
+/// Throws an [ArgumentError] if [uri] reaches above the top level directory.
 String topLevelDir(String uri) {
   var parts = p.url.split(p.url.normalize(uri));
-  String error;
-  if (parts.length == 1) {
-    error = 'The uri `$uri` does not contain a directory.';
-  } else if (parts.first == '..') {
-    error = 'The uri `$uri` reaches outside the root directory.';
+  if (parts.first == '..') {
+    throw new ArgumentError('Cannot compute top level dir for path `$uri` '
+        'which reaches outside the root directory.');
   }
-  if (error != null) {
-    throw new ArgumentError(
-        'Cannot compute top level dir for path `$uri`. $error');
-  }
-  return parts.first;
+  return parts.length == 1 ? null : parts.first;
 }

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scratch_space
-version: 0.0.2-dev
+version: 0.0.2
 description: A tool to manage running external executables within package:build
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space

--- a/scratch_space/test/scratch_space_test.dart
+++ b/scratch_space/test/scratch_space_test.dart
@@ -123,12 +123,11 @@ void main() {
         equals('package:a/src/a.dart'));
     expect(
         canonicalUriFor(new AssetId('a', 'web/a.dart')), equals('web/a.dart'));
+    expect(canonicalUriFor(new AssetId('a', 'a.dart')), equals('a.dart'));
 
-    expect(
-        () => canonicalUriFor(new AssetId('a', 'a.dart')), throwsArgumentError);
-    expect(() => canonicalUriFor(new AssetId('a', 'lib/../a.dart')),
+    expect(() => canonicalUriFor(new AssetId('a', 'lib/../../a.dart')),
         throwsArgumentError);
-    expect(() => canonicalUriFor(new AssetId('a', 'web/../a.dart')),
+    expect(() => canonicalUriFor(new AssetId('a', 'web/../../a.dart')),
         throwsArgumentError);
   });
 }

--- a/scratch_space/test/util_test.dart
+++ b/scratch_space/test/util_test.dart
@@ -19,8 +19,6 @@ main() {
           reason: 'Paths reaching outside the root dir should throw.');
       expect(() => topLevelDir('foo/../../bar.dart'), throwsArgumentError,
           reason: 'Paths reaching outside the root dir should throw.');
-      expect(() => topLevelDir('foo/../foo.dart'), throwsArgumentError,
-          reason: 'Normalized paths to the root directory should throw.');
     });
 
     test('allows without a top level directory', () {

--- a/scratch_space/test/util_test.dart
+++ b/scratch_space/test/util_test.dart
@@ -19,10 +19,12 @@ main() {
           reason: 'Paths reaching outside the root dir should throw.');
       expect(() => topLevelDir('foo/../../bar.dart'), throwsArgumentError,
           reason: 'Paths reaching outside the root dir should throw.');
-      expect(() => topLevelDir('foo.dart'), throwsArgumentError,
-          reason: 'Paths to the root directory should throw.');
       expect(() => topLevelDir('foo/../foo.dart'), throwsArgumentError,
           reason: 'Normalized paths to the root directory should throw.');
+    });
+
+    test('allows without a top level directory', () {
+      expect(topLevelDir('foo.dart'), null);
     });
   });
 }


### PR DESCRIPTION
- Allow creating files at the root of the scratchspace.
- Construct a .packages file for the entrypoint before invoking Dart2Js