### PR TITLE
Update --output if source with no outputs changes

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -4,7 +4,9 @@
 - `pub run build_runner` exits with a error when invoked with an unsupported
   command.
 - Bug Fix: Update outputs in merged directory for sources which are not used
-  during the build.
+  during the build. For example if `web/index.html` is not read to produce any
+  generated outputs changes to this file will now get picked up during `pub run
+  build_runner watch --output build`.
 
 ## 0.8.0
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Improved the layout of `/$perf`, especially after browser window resize.
 - `pub run build_runner` exits with a error when invoked with an unsupported
   command.
+- Bug Fix: Update outputs in merged directory for sources which are not used
+  during the build.
 
 ## 0.8.0
 

--- a/build_runner/lib/src/generate/create_merged_dir.dart
+++ b/build_runner/lib/src/generate/create_merged_dir.dart
@@ -94,6 +94,7 @@ Future<bool> createMergedOutputDir(
     for (var node in assetGraph.allNodes) {
       if (_shouldSkipNode(node, buildPhases)) continue;
       originalOutputAssets.add(node.id);
+      node.lastKnownDigest ??= await reader.digest(node.id);
       outputAssets
           .add(await _writeAsset(node.id, outputDir, packageGraph, reader));
       if (node is GeneratedAssetNode) {


### PR DESCRIPTION
Fixes #1095

We use the presence of a digest as an indication that a source file has
an impact on the build.

- Ensure the digest is tracked for any asset which is copied to the
  merged output directory.
- Add a regession test which fails due to a timeout before the change
  and passes after.