### PR TITLE
Drop dependency on analyzer

### DIFF
--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
   sdk: '>=2.0.0-dev.20 <2.0.0'
 
 dependencies:
-  analyzer: ">=0.27.1 <0.32.0"
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
   build: ^0.12.0


### PR DESCRIPTION
There are no imports in this package, we can rely on the dependenceis
from `build` and `build_resolvers`.