### PR TITLE
Catch exceptions and mark builds as failures

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -7,6 +7,9 @@
   during the build. For example if `web/index.html` is not read to produce any
   generated outputs changes to this file will now get picked up during `pub run
   build_runner watch --output build`.
+- Don't allow a thrown exception from a Builder to take down the entire build
+  process - instead record it as a failed action. The overall build will still
+  be marked as a failure, but it won't crash the process.
 
 ## 0.8.0
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.8.1-dev
+version: 0.8.1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Fixes #1207

Catch exceptions and use them to mark individual actions as failures
rather than allowing the exception to bubble up and stop the entire
build.

Move the handling for `--fail-on-severe` to whether or not we mark an
action as failing rather than whether or not we treat failed actions as
a build failure.