### PR TITLE
Allow serving assets for failed builds

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Bug Fix: Correctly include the default whitelist when multiple targets
   without include are provided.
 - Allow logging from within a build factory.
+- Allow serving assets from successful build steps if the overall build fails.
 
 ## 0.8.1
 

--- a/build_runner/lib/src/asset/finalized_reader.dart
+++ b/build_runner/lib/src/asset/finalized_reader.dart
@@ -22,17 +22,17 @@ class FinalizedReader implements AssetReader {
   );
 
   /// Returns a reason why [id] is not readable, or null if it is readable.
-  Future<UnreadableAssetReason> canReadReason(AssetId id) async {
-    if (!_assetGraph.contains(id)) return UnreadableAssetReason.notFound;
+  Future<UnreadableReason> unreadableReason(AssetId id) async {
+    if (!_assetGraph.contains(id)) return UnreadableReason.notFound;
     var node = _assetGraph.get(id);
-    if (node.isDeleted) return UnreadableAssetReason.deleted;
-    if (!node.isReadable) return UnreadableAssetReason.assetType;
+    if (node.isDeleted) return UnreadableReason.deleted;
+    if (!node.isReadable) return UnreadableReason.assetType;
     if (node is GeneratedAssetNode) {
-      if (node.isFailure) return UnreadableAssetReason.failed;
-      if (!node.wasOutput) return UnreadableAssetReason.notOutput;
+      if (node.isFailure) return UnreadableReason.failed;
+      if (!node.wasOutput) return UnreadableReason.notOutput;
     }
     if (await _delegate.canRead(id)) return null;
-    return UnreadableAssetReason.unknown;
+    return UnreadableReason.unknown;
   }
 
   @override
@@ -60,7 +60,7 @@ class FinalizedReader implements AssetReader {
   Stream<AssetId> findAssets(Glob glob) => _delegate.findAssets(glob);
 }
 
-enum UnreadableAssetReason {
+enum UnreadableReason {
   notFound,
   notOutput,
   assetType,

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -144,8 +144,8 @@ class WatchImpl implements BuildState {
   /// Pending expected delete events from the build.
   final Set<AssetId> _expectedDeletes = new Set<AssetId>();
 
-  final _readerCompleter = new Completer<AssetReader>();
-  Future<AssetReader> get reader => _readerCompleter.future;
+  final _readerCompleter = new Completer<FinalizedReader>();
+  Future<FinalizedReader> get reader => _readerCompleter.future;
 
   WatchImpl(
       BuildEnvironment environment,

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -115,13 +115,13 @@ class AssetHandler {
   Future<shelf.Response> _handle(
       Map<String, String> requestHeaders, AssetId assetId) async {
     try {
-      var reason = await _reader.canReadReason(assetId);
-      if (reason != null) {
+      if (!await _reader.canRead(assetId)) {
+        var reason = await _reader.unreadableReason(assetId);
         switch (reason) {
-          case UnreadableAssetReason.failed:
+          case UnreadableReason.failed:
             return new shelf.Response.internalServerError(
                 body: 'Build failed for $assetId');
-          case UnreadableAssetReason.notOutput:
+          case UnreadableReason.notOutput:
             return new shelf.Response.notFound('$assetId was not output');
           default:
             return new shelf.Response.notFound('Not Found');

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -25,7 +25,7 @@ void main() {
         buildPackageGraph({rootPackage('foo'): []}), null);
     delegate = new InMemoryRunnerAssetReader();
     reader = new FinalizedReader(delegate, graph);
-    handler = new AssetHandler(reader, 'a', graph);
+    handler = new AssetHandler(reader, 'a');
   });
 
   void _addAsset(String id, String content, {bool deleted: false}) {

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -2,20 +2,28 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
 import 'package:build_runner/src/server/server.dart';
+import 'package:build_runner/src/asset_graph/graph.dart';
+import 'package:build_runner/src/asset_graph/node.dart';
 
 import '../common/common.dart';
 
 void main() {
   AssetHandler handler;
   InMemoryRunnerAssetReader reader;
+  AssetGraph assetGraph;
 
   setUp(() async {
     reader = new InMemoryRunnerAssetReader();
-    handler = new AssetHandler(reader, 'a');
+    final packageGraph = buildPackageGraph({rootPackage('a'): []});
+    assetGraph =
+        await AssetGraph.build([], new Set(), new Set(), packageGraph, reader);
+    handler = new AssetHandler(reader, 'a', assetGraph);
   });
 
   test('can read from the root package', () async {
@@ -60,5 +68,21 @@ void main() {
     var response = await handler.handle(
         new Request('GET', Uri.parse('http://server.com/sub')), 'web');
     expect(response.statusCode, 404);
+  });
+
+  test('Fails request for failed outputs', () async {
+    assetGraph.add(new GeneratedAssetNode(
+      makeAssetId('a|web/main.ddc.js'),
+      builderOptionsId: null,
+      phaseNumber: null,
+      state: GeneratedNodeState.upToDate,
+      isHidden: false,
+      wasOutput: true,
+      isFailure: true,
+      primaryInput: null,
+    ));
+    var response = await handler.handle(
+        new Request('GET', Uri.parse('http://server.com/main.ddc.js')), 'web');
+    expect(response.statusCode, HttpStatus.INTERNAL_SERVER_ERROR);
   });
 }

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -12,6 +12,7 @@ import 'package:test/test.dart';
 import 'package:build/build.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:build_runner/src/asset_graph/graph.dart';
+import 'package:build_runner/src/asset_graph/node.dart';
 import 'package:build_runner/src/generate/build_result.dart';
 import 'package:build_runner/src/generate/performance_tracker.dart';
 import 'package:build_runner/src/generate/watch_impl.dart';
@@ -24,11 +25,14 @@ void main() {
   ServeHandler serveHandler;
   InMemoryRunnerAssetReader reader;
   MockWatchImpl watchImpl;
+  AssetGraph assetGraph;
 
   setUp(() async {
     reader = new InMemoryRunnerAssetReader();
     final packageGraph = buildPackageGraph({rootPackage('a'): []});
-    watchImpl = new MockWatchImpl(reader, packageGraph);
+    assetGraph =
+        await AssetGraph.build([], new Set(), new Set(), packageGraph, reader);
+    watchImpl = new MockWatchImpl(reader, packageGraph, assetGraph);
     serveHandler = await createServeHandler(watchImpl);
     watchImpl.addFutureResult(
         new Future.value(new BuildResult(BuildStatus.success, [])));
@@ -61,22 +65,50 @@ void main() {
     expect(() => serveHandler.handlerFor('web/sub'), throwsArgumentError);
   });
 
-  test('serves an error page if there were build errors', () async {
-    var fakeException = 'Really bad error omg!';
-    var fakeStackTrace = 'My cool stack trace!';
-    watchImpl.addFutureResult(new Future.value(new BuildResult(
-        BuildStatus.failure, [],
-        exception: fakeException,
-        stackTrace: new StackTrace.fromString(fakeStackTrace))));
-    await new Future.value();
-    var response = await serveHandler.handlerFor('web')(
-        new Request('GET', Uri.parse('http://server.com/index.html')));
+  group('build failures', () {
+    setUp(() async {
+      reader.cacheStringAsset(makeAssetId('a|web/index.html'), '');
+      var fakeException = 'Really bad error omg!';
+      var fakeStackTrace = 'My cool stack trace!';
+      assetGraph.add(new GeneratedAssetNode(
+        makeAssetId('a|web/main.ddc.js'),
+        builderOptionsId: null,
+        phaseNumber: null,
+        state: GeneratedNodeState.upToDate,
+        isHidden: false,
+        wasOutput: true,
+        isFailure: true,
+        primaryInput: null,
+      ));
+      watchImpl.addFutureResult(new Future.value(new BuildResult(
+          BuildStatus.failure, [],
+          exception: fakeException,
+          stackTrace: new StackTrace.fromString(fakeStackTrace))));
+    });
 
-    expect(response.statusCode, HttpStatus.INTERNAL_SERVER_ERROR);
-    expect(
-        await response.readAsString(),
-        allOf(contains('Really&nbsp;bad&nbsp;error&nbsp;omg!'),
-            contains('My&nbsp;cool&nbsp;stack&nbsp;trace!')));
+    test('serves successful assets', () async {
+      var response = await serveHandler.handlerFor('web')(
+          new Request('GET', Uri.parse('http://server.com/index.html')));
+
+      expect(response.statusCode, HttpStatus.OK);
+    });
+
+    test('rejects requests for failed assets', () async {
+      var response = await serveHandler.handlerFor('web')(
+          new Request('GET', Uri.parse('http://server.com/main.ddc.js')));
+
+      expect(response.statusCode, HttpStatus.INTERNAL_SERVER_ERROR);
+    });
+
+    test('logs rejected requests', () async {
+      expect(
+          Logger.root.onRecord,
+          emitsThrough(predicate<LogRecord>((record) =>
+              record.message.contains('main.ddc.js') &&
+              record.level == Level.WARNING)));
+      await serveHandler.handlerFor('web', logRequests: true)(
+          new Request('GET', Uri.parse('http://server.com/main.ddc.js')));
+    });
   });
 
   test('logs requests if you ask it to', () async {
@@ -86,21 +118,6 @@ void main() {
         emitsThrough(predicate<LogRecord>((record) =>
             record.message.contains('index.html') &&
             record.level == Level.INFO)));
-    await serveHandler.handlerFor('web', logRequests: true)(
-        new Request('GET', Uri.parse('http://server.com/index.html')));
-
-    var fakeException = 'Really bad error omg!';
-    var fakeStackTrace = 'My cool stack trace!';
-    watchImpl.addFutureResult(new Future.value(new BuildResult(
-        BuildStatus.failure, [],
-        exception: fakeException,
-        stackTrace: new StackTrace.fromString(fakeStackTrace))));
-
-    expect(
-        Logger.root.onRecord,
-        emitsThrough(predicate<LogRecord>((record) =>
-            record.message.contains('index.html') &&
-            record.level == Level.WARNING)));
     await serveHandler.handlerFor('web', logRequests: true)(
         new Request('GET', Uri.parse('http://server.com/index.html')));
   });
@@ -140,7 +157,7 @@ void main() {
 
 class MockWatchImpl implements WatchImpl {
   @override
-  final AssetGraph assetGraph = null;
+  final AssetGraph assetGraph;
 
   Future<BuildResult> _currentBuild;
   @override
@@ -167,7 +184,7 @@ class MockWatchImpl implements WatchImpl {
     _futureBuildResultsController.add(result);
   }
 
-  MockWatchImpl(AssetReader reader, this.packageGraph)
+  MockWatchImpl(AssetReader reader, this.packageGraph, this.assetGraph)
       : this.reader = new Future.value(reader) {
     _futureBuildResultsController.stream.listen((futureBuildResult) {
       if (_currentBuild != null) {


### PR DESCRIPTION
Towards #1097

No longer refuse to server any assets if the overall build fails. Check
the asset node for individual requests and send an internal server error
if the build step producing that asset failed.

Add `canReadReason` to `FinalizedReader` to give more distinction than a boolean. We use this to determine whether to send a `500` or `404` for missing assets.

Take a `FinalizedReader` rather than generic `AssetReader` in `AssetHandler`.