### PR TITLE
Enable `delete` in PostProcessBuilders

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.8.2
 
+- Allow deleting files in the post process build step.
 - Bug Fix: Correctly include the default whitelist when multiple targets
   without include are provided.
 - Allow logging from within a build factory.

--- a/build_runner/lib/src/asset/finalized_reader.dart
+++ b/build_runner/lib/src/asset/finalized_reader.dart
@@ -17,8 +17,8 @@ class FinalizedReader implements AssetReader {
 
   @override
   Future<bool> canRead(AssetId id) async {
+    if (_assetGraph.get(id)?.isDeleted ?? true) return false;
     if (!await _delegate.canRead(id)) return false;
-    if (_assetGraph.get(id).isDeleted) return false;
     return true;
   }
 
@@ -29,8 +29,12 @@ class FinalizedReader implements AssetReader {
   Future<List<int>> readAsBytes(AssetId id) => _delegate.readAsBytes(id);
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding: utf8}) =>
-      _delegate.readAsString(id, encoding: encoding);
+  Future<String> readAsString(AssetId id, {Encoding encoding: utf8}) async {
+    if (_assetGraph.get(id)?.isDeleted ?? true) {
+      throw new AssetNotFoundException(id);
+    }
+    return _delegate.readAsString(id, encoding: encoding);
+  }
 
   @override
   Stream<AssetId> findAssets(Glob glob) => _delegate.findAssets(glob);

--- a/build_runner/lib/src/asset/finalized_reader.dart
+++ b/build_runner/lib/src/asset/finalized_reader.dart
@@ -5,6 +5,7 @@ import 'package:build_runner/src/asset_graph/graph.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 
+/// An [AssetReader] which ignores deleted files.
 class FinalizedReader implements AssetReader {
   final AssetReader _delegate;
   final AssetGraph _assetGraph;

--- a/build_runner/lib/src/asset/finalized_reader.dart
+++ b/build_runner/lib/src/asset/finalized_reader.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:build/build.dart';
+import 'package:build_runner/src/asset_graph/graph.dart';
+import 'package:crypto/crypto.dart';
+import 'package:glob/glob.dart';
+
+class FinalizedReader implements AssetReader {
+  final AssetReader _delegate;
+  final AssetGraph _assetGraph;
+
+  FinalizedReader(
+    this._delegate,
+    this._assetGraph,
+  );
+
+  @override
+  Future<bool> canRead(AssetId id) async {
+    if (!await _delegate.canRead(id)) return false;
+    if (_assetGraph.get(id).isDeleted) return false;
+    return true;
+  }
+
+  @override
+  Future<Digest> digest(AssetId id) => _delegate.digest(id);
+
+  @override
+  Future<List<int>> readAsBytes(AssetId id) => _delegate.readAsBytes(id);
+
+  @override
+  Future<String> readAsString(AssetId id, {Encoding encoding: utf8}) =>
+      _delegate.readAsString(id, encoding: encoding);
+
+  @override
+  Stream<AssetId> findAssets(Glob glob) => _delegate.findAssets(glob);
+}

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -42,6 +42,9 @@ abstract class AssetNode {
   /// at this moment in time.
   bool get isReadable => true;
 
+  /// Whether the node is deleted and will be removed in the post process step.
+  bool isDeleted = false;
+
   /// Whether or not this node can be used as a primary input.
   ///
   /// Some nodes are valid primary inputs but are not readable (see

--- a/build_runner/lib/src/asset_graph/node.dart
+++ b/build_runner/lib/src/asset_graph/node.dart
@@ -42,7 +42,9 @@ abstract class AssetNode {
   /// at this moment in time.
   bool get isReadable => true;
 
-  /// Whether the node is deleted and will be removed in the post process step.
+  /// Whether the node is deleted.
+  ///
+  /// Deleted nodes are ignored in the final merge step and watch handlers.
   bool isDeleted = false;
 
   /// Whether or not this node can be used as a primary input.

--- a/build_runner/lib/src/builder/post_process_build_step.dart
+++ b/build_runner/lib/src/builder/post_process_build_step.dart
@@ -57,6 +57,12 @@ class PostProcessBuildStep {
     return done;
   }
 
+  /// Marks an asset for deletion in the post process step.
+  void delete(AssetId id) {
+    var node = _assetGraph.get(id);
+    node.isDeleted = true;
+  }
+
   /// Waits for work to finish and cleans up resources.
   ///
   /// This method should be called after a build has completed. After the

--- a/build_runner/lib/src/builder/post_process_build_step.dart
+++ b/build_runner/lib/src/builder/post_process_build_step.dart
@@ -58,8 +58,8 @@ class PostProcessBuildStep {
   }
 
   /// Marks an asset for deletion in the post process step.
-  void delete(AssetId id) {
-    var node = _assetGraph.get(id);
+  void deletePrimaryInput() {
+    var node = _assetGraph.get(inputId);
     node.isDeleted = true;
   }
 

--- a/build_runner/lib/src/generate/create_merged_dir.dart
+++ b/build_runner/lib/src/generate/create_merged_dir.dart
@@ -132,6 +132,7 @@ Future<bool> createMergedOutputDir(
 bool _shouldSkipNode(AssetNode node, List<BuildPhase> buildPhases,
     {bool skipOptional: true}) {
   if (!node.isReadable) return true;
+  if (node.isDeleted) return true;
   if (node is InternalAssetNode) return true;
   if (node is GeneratedAssetNode) {
     if (!node.wasOutput ||

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
+import 'package:build_runner/src/asset/finalized_reader.dart';
 import 'package:build_runner/src/watcher/asset_change.dart';
 import 'package:build_runner/src/watcher/graph_watcher.dart';
 import 'package:build_runner/src/watcher/node_watcher.dart';
@@ -264,13 +265,16 @@ class WatchImpl implements BuildState {
       _buildDefinition = await BuildDefinition.prepareWorkspace(
           environment, options, buildPhases,
           onDelete: _expectedDeletes.add);
-      _readerCompleter.complete(new SingleStepReader(
+      var singleStepReader = new SingleStepReader(
           _buildDefinition.reader,
           _buildDefinition.assetGraph,
           buildPhases.length,
           true,
           packageGraph.root.name,
-          null));
+          null);
+      var finalizedReader =
+          new FinalizedReader(singleStepReader, _buildDefinition.assetGraph);
+      _readerCompleter.complete(finalizedReader);
       _assetGraph = _buildDefinition.assetGraph;
       build = await BuildImpl.create(_buildDefinition, options, buildPhases,
           onDelete: _expectedDeletes.add);

--- a/build_runner/test/asset/finalized_reader_test.dart
+++ b/build_runner/test/asset/finalized_reader_test.dart
@@ -1,51 +1,14 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 @TestOn('vm')
-import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-
-import 'package:build/build.dart';
 import 'package:build_runner/src/asset/finalized_reader.dart';
 import 'package:build_runner/src/asset_graph/graph.dart';
 import 'package:build_runner/src/asset_graph/node.dart';
-import 'package:crypto/src/digest.dart';
-import 'package:glob/glob.dart';
+import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
-import 'package:build_runner/build_runner.dart';
-
 import '../common/common.dart';
-
-final PackageGraph packageGraph =
-    new PackageGraph.forPath('test/fixtures/basic_pkg');
-final String newLine = Platform.isWindows ? '\r\n' : '\n';
-
-class MockReader implements AssetReader {
-  @override
-  Future<bool> canRead(AssetId id) async => true;
-
-  @override
-  Future<Digest> digest(AssetId id) {
-    throw 'Not implemented.';
-  }
-
-  @override
-  Stream<AssetId> findAssets(Glob glob) {
-    throw 'Not implemented.';
-  }
-
-  @override
-  Future<List<int>> readAsBytes(AssetId id) {
-    throw 'Not implemented.';
-  }
-
-  @override
-  Future<String> readAsString(AssetId id, {Encoding encoding: utf8}) {
-    throw 'Not implemented.';
-  }
-}
 
 void main() {
   group('FinalizedReader', () {
@@ -64,7 +27,10 @@ void main() {
       graph.add(notDeleted);
       graph.add(deleted);
 
-      reader = new FinalizedReader(new MockReader(), graph);
+      var delegate = new InMemoryAssetReader();
+      delegate.assets.addAll({notDeleted.id: [], deleted.id: []});
+
+      reader = new FinalizedReader(delegate, graph);
     });
 
     test('can not read deleted files', () async {

--- a/build_runner/test/asset/finalized_reader_test.dart
+++ b/build_runner/test/asset/finalized_reader_test.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+@TestOn('vm')
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:build_runner/src/asset/finalized_reader.dart';
+import 'package:build_runner/src/asset_graph/graph.dart';
+import 'package:build_runner/src/asset_graph/node.dart';
+import 'package:crypto/src/digest.dart';
+import 'package:glob/glob.dart';
+import 'package:test/test.dart';
+
+import 'package:build_runner/build_runner.dart';
+
+import '../common/common.dart';
+
+final PackageGraph packageGraph =
+    new PackageGraph.forPath('test/fixtures/basic_pkg');
+final String newLine = Platform.isWindows ? '\r\n' : '\n';
+
+class MockReader implements AssetReader {
+  @override
+  Future<bool> canRead(AssetId id) async => true;
+
+  @override
+  Future<Digest> digest(AssetId id) {
+    throw 'Not implemented.';
+  }
+
+  @override
+  Stream<AssetId> findAssets(Glob glob) {
+    throw 'Not implemented.';
+  }
+
+  @override
+  Future<List<int>> readAsBytes(AssetId id) {
+    throw 'Not implemented.';
+  }
+
+  @override
+  Future<String> readAsString(AssetId id, {Encoding encoding: utf8}) {
+    throw 'Not implemented.';
+  }
+}
+
+void main() {
+  group('FinalizedReader', () {
+    FinalizedReader reader;
+    AssetNode notDeleted;
+    AssetNode deleted;
+
+    setUp(() async {
+      var graph = await AssetGraph.build([], new Set(), new Set(),
+          buildPackageGraph({rootPackage('foo'): []}), null);
+
+      notDeleted = makeAssetNode('a|web/a.txt', [], computeDigest('a'));
+      deleted = makeAssetNode('a|lib/b.txt', [], computeDigest('b'));
+      deleted.isDeleted = true;
+
+      graph.add(notDeleted);
+      graph.add(deleted);
+
+      reader = new FinalizedReader(new MockReader(), graph);
+    });
+
+    test('can not read deleted files', () async {
+      expect(await reader.canRead(notDeleted.id), true);
+      expect(await reader.canRead(deleted.id), false);
+    });
+  });
+}

--- a/build_runner/test/common/builders.dart
+++ b/build_runner/test/common/builders.dart
@@ -22,3 +22,15 @@ class CopyingPostProcessBuilder implements PostProcessBuilder {
         await buildStep.readInputAsString());
   }
 }
+
+class DeletePostProcessBuilder implements PostProcessBuilder {
+  @override
+  final inputExtensions = ['.txt'];
+
+  DeletePostProcessBuilder();
+
+  @override
+  Future<Null> build(PostProcessBuildStep buildStep) async {
+    buildStep.delete(buildStep.inputId);
+  }
+}

--- a/build_runner/test/common/builders.dart
+++ b/build_runner/test/common/builders.dart
@@ -31,6 +31,6 @@ class DeletePostProcessBuilder implements PostProcessBuilder {
 
   @override
   Future<Null> build(PostProcessBuildStep buildStep) async {
-    buildStep.delete(buildStep.inputId);
+    buildStep.deletePrimaryInput();
   }
 }

--- a/build_runner/test/generate/create_merged_dir_test.dart
+++ b/build_runner/test/generate/create_merged_dir_test.dart
@@ -71,6 +71,19 @@ main() {
       _expectAllFiles(tmpDir);
     });
 
+    test('doesnt write deleted files', () async {
+      var node =
+          graph.get(new AssetId('b', 'lib/c.txt.copy')) as GeneratedAssetNode;
+      node.isDeleted = true;
+
+      var success = await createMergedOutputDir(
+          tmpDir.path, graph, packageGraph, assetReader, environment, phases);
+      expect(success, isTrue);
+
+      var file = new File(p.join(tmpDir.path, 'packages/b/c.txt.copy'));
+      expect(file.existsSync(), isFalse);
+    });
+
     test('doesnt write files that werent output', () async {
       var node =
           graph.get(new AssetId('b', 'lib/c.txt.copy')) as GeneratedAssetNode;

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -32,7 +32,7 @@ void main() {
     delegate.cacheStringAsset(node.id, content);
   }
 
-  test('can not  read deleted nodes', () async {
+  test('can not read deleted nodes', () async {
     _addAsset('a|web/index.html', 'content', deleted: true);
     var response = await handler.handle(
         new Request('GET', Uri.parse('http://server.com/index.html')), 'web');


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/1010

Changes:
- Add a deleted field to AssetNode
- Add new `delete` method to PostProcessBuildStep
- Add new FinalizedReader which ignores deleted files. 
- Update AssetHandler to make use of new reader.
- Ignore deleted files in `createMergedDir`
- Corresponding tests for everything