### PR TITLE
Prepare to publish build_resolvers

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0+1
+
+- Switch to `firstWhere(orElse)` for compatibility with the SDK dev.45
+
 # 0.2.0
 
 - Removed locking between uses of the Resolver and added a mandatory `reset`

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 0.2.0
+version: 0.2.0+1
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers


### PR DESCRIPTION
This will unblock the build_test Travis since it is currently pulling in
a version of this package that is not compatible with the latest SDK.