### PR TITLE
Add overrideWith to BuilderOptions

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.1
+
+- Add `BuilderOptions.empty` and `BuilderOptions.overrideWith`.
+
 ## 0.12.0+2
 
 - **Bug Fix** Correctly handle encoding `AssetId`s as `URI`s when they contain

--- a/build/lib/src/builder/builder.dart
+++ b/build/lib/src/builder/builder.dart
@@ -25,6 +25,9 @@ abstract class Builder {
 }
 
 class BuilderOptions {
+  /// A configuration with no options set.
+  static const empty = const BuilderOptions(const {});
+
   /// The configuration to apply to a given usage of a [Builder].
   ///
   /// A `Map` parsed from json or yaml. The value types will be `String`, `num`,
@@ -32,6 +35,17 @@ class BuilderOptions {
   final Map<String, dynamic> config;
 
   const BuilderOptions(this.config);
+
+  /// Returns a new set of options with keys from [other] overriding options in
+  /// this instance.
+  ///
+  /// Values are overridden at a per-key granularity. There is no value level
+  /// merging. [other] may be null or empty, in which case this instance is
+  /// returned directly.
+  BuilderOptions overrideWith(BuilderOptions other) =>
+      other == null || other.config.isEmpty
+          ? this
+          : new BuilderOptions({}..addAll(config)..addAll(other.config));
 }
 
 /// Creates a [Builder] honoring the configuation in [options].

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.12.0+2
+version: 0.12.1
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build

--- a/build/test/builder/builder_options_test.dart
+++ b/build/test/builder/builder_options_test.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuilderOptions', () {
+    test('overrides with non-empty options', () {
+      var defaults = const BuilderOptions(const {'foo': 'bar', 'baz': 'bop'});
+      var overridden = defaults.overrideWith(
+          const BuilderOptions(const {'baz': 'different', 'more': 'added'}));
+      expect(overridden.config,
+          {'foo': 'bar', 'baz': 'different', 'more': 'added'});
+    });
+
+    test('changes nothing when overriding with empty options', () {
+      var defaults = const BuilderOptions(const {'foo': 'bar', 'baz': 'bop'});
+      var overridden = defaults.overrideWith(BuilderOptions.empty);
+      expect(overridden, same(defaults));
+    });
+  });
+}


### PR DESCRIPTION
Towards #1109

As we add mode specific options we'll need to apply them in order and
override keys with lower precendence.

Also add a const empty version since it's a common defaul to avoid
`null`.