### PR TITLE
Add config support for mode options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,18 +50,10 @@ jobs:
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="build_config"
       dart: dev
-    - stage: analyze_and_format
-      script: ./tool/travis.sh dartanalyzer
-      env: PKG="build_config"
-      dart: stable
     - stage: unit_test
       script: ./tool/travis.sh test_0
       env: PKG="build_config"
       dart: dev
-    - stage: unit_test
-      script: ./tool/travis.sh test_0
-      env: PKG="build_config"
-      dart: stable
     - stage: analyze_and_format
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="build_modules"

--- a/build_config/.mono_repo.yml
+++ b/build_config/.mono_repo.yml
@@ -1,6 +1,5 @@
 dart:
   - dev
-  - stable
 
 stages:
   - analyze_and_format:
@@ -9,8 +8,5 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
       dart:
         - dev
-    - dartanalyzer: --fatal-infos --fatal-warnings .
-      dart:
-        - stable
   - unit_test:
     - test

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.2.6
+
+- Support options based on mode, add `devOptions` and `releaseOptions` on
+  `TargetBuilderConfig`.
+- Support applying default options based on builder definitions, add `option`,
+  `devOptions`, and `releaseOptions` to `TargetBuilderConfigDefaults`.
+- Ensure that `defaults` and `generateFor` fields are never null.
+- Add `InputSet.anything` to name the input sets that don't filter out any
+  assets.
+
+
 ## 0.2.5
 
 - Added `post_process_builders` section to `build.yaml`. See README.md for more

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -18,6 +18,8 @@ import 'pubspec.dart';
 /// Takes a list of strings in glob format for [include] and [exclude]. Matches
 /// the `glob()` function in skylark.
 class InputSet {
+  static const anything = const InputSet();
+
   /// The globs to include in the set.
   ///
   /// May be null or empty which means every possible path (like `'**'`).
@@ -96,7 +98,7 @@ class BuildConfig {
             .toSet(),
         package: packageName,
         key: defaultTarget,
-        sources: const InputSet(),
+        sources: InputSet.anything,
       )
     };
     return new BuildConfig(
@@ -186,8 +188,8 @@ class BuilderDefinition {
     this.appliesBuilders,
     this.isOptional,
     this.buildTo,
-    this.defaults,
-  });
+    TargetBuilderConfigDefaults defaults,
+  }) : defaults = defaults ?? const TargetBuilderConfigDefaults();
 
   @override
   String toString() => {
@@ -235,8 +237,8 @@ class PostProcessBuilderDefinition {
     @required this.inputExtensions,
     @required this.import,
     @required this.target,
-    this.defaults,
-  });
+    TargetBuilderConfigDefaults defaults,
+  }) : defaults = defaults ?? const TargetBuilderConfigDefaults();
 
   @override
   String toString() => {
@@ -252,8 +254,19 @@ class PostProcessBuilderDefinition {
 /// corresponding key for [TargetBuilderConfig].
 class TargetBuilderConfigDefaults {
   final InputSet generateFor;
+  final BuilderOptions options;
+  final BuilderOptions devOptions;
+  final BuilderOptions releaseOptions;
 
-  TargetBuilderConfigDefaults({this.generateFor});
+  const TargetBuilderConfigDefaults({
+    InputSet generateFor,
+    BuilderOptions options,
+    BuilderOptions devOptions,
+    BuilderOptions releaseOptions,
+  })  : generateFor = generateFor ?? InputSet.anything,
+        options = options ?? BuilderOptions.empty,
+        devOptions = devOptions ?? BuilderOptions.empty,
+        releaseOptions = releaseOptions ?? BuilderOptions.empty;
 }
 
 enum AutoApply { none, dependents, allPackages, rootPackage }
@@ -287,7 +300,7 @@ class BuildTarget {
   BuildTarget({
     @required this.package,
     @required this.key,
-    this.sources: const InputSet(),
+    this.sources: InputSet.anything,
     this.dependencies,
     this.builders: const {},
   });
@@ -326,18 +339,33 @@ class TargetBuilderConfig {
   /// builder.
   ///
   /// The `options` key in the configuration.
+  ///
+  /// Individual keys may be overridden by either [devOptions] or
+  /// [releaseOptions].
   final BuilderOptions options;
+
+  /// Overrides for [options] in dev mode.
+  final BuilderOptions devOptions;
+
+  /// Overrides for [options] in release mode.
+  final BuilderOptions releaseOptions;
 
   TargetBuilderConfig({
     this.isEnabled,
     this.generateFor,
-    this.options: const BuilderOptions(const {}),
-  });
+    BuilderOptions options,
+    BuilderOptions devOptions,
+    BuilderOptions releaseOptions,
+  })  : options = options ?? BuilderOptions.empty,
+        devOptions = devOptions ?? BuilderOptions.empty,
+        releaseOptions = releaseOptions ?? BuilderOptions.empty;
 
   @override
   String toString() => {
         'isEnabled': isEnabled,
         'generateFor': generateFor,
-        'options': options.config
+        'options': options.config,
+        'devOptions': devOptions.config,
+        'releaseOptions': releaseOptions.config,
       }.toString();
 }

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.2.6-dev
+version: 0.2.6
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.2.5
+version: 0.2.6-dev
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config
@@ -8,7 +8,7 @@ environment:
   sdk: '>=1.22.1 <2.0.0'
 
 dependencies:
-  build: ">=0.11.2 <0.13.0"
+  build: ^0.12.1
   meta: ^1.1.0
   path: ^1.4.0
   yaml: ^2.1.11

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -56,7 +56,10 @@ void main() {
         runsBefore: ['foo_builder|foo_builder'].toSet(),
         appliesBuilders: ['foo_builder|foo_builder'].toSet(),
         defaults: new TargetBuilderConfigDefaults(
-            generateFor: new InputSet(include: ['lib/**'])),
+          generateFor: const InputSet(include: const ['lib/**']),
+          options: const BuilderOptions(const {'foo': 'bar'}),
+          releaseOptions: const BuilderOptions(const {'baz': 'bop'}),
+        ),
       ),
     });
     expectPostProcessBuilderDefinitions(
@@ -69,7 +72,10 @@ void main() {
         key: 'example|p',
         target: 'example:example',
         defaults: new TargetBuilderConfigDefaults(
-            generateFor: new InputSet(include: ['web/**'])),
+          generateFor: const InputSet(include: const ['web/**']),
+          options: const BuilderOptions(const {'foo': 'bar'}),
+          releaseOptions: const BuilderOptions(const {'baz': 'bop'}),
+        ),
       ),
     });
   });
@@ -167,6 +173,10 @@ builders:
     is_optional: True
     defaults:
       generate_for: ["lib/**"]
+      options:
+        foo: bar
+      release_options:
+        baz: bop
 post_process_builders:
   p:
     builder_factory: "createPostProcessBuilder"
@@ -175,6 +185,10 @@ post_process_builders:
     target: ":example"
     defaults:
       generate_for: ["web/**"]
+      options:
+        foo: bar
+      release_options:
+        baz: bop
 ''';
 
 var buildYamlNoTargets = '''
@@ -215,10 +229,8 @@ class _BuilderDefinitionMatcher extends Matcher {
       equals(_expected.requiredInputs).matches(item.requiredInputs, _) &&
       equals(_expected.runsBefore).matches(item.runsBefore, _) &&
       equals(_expected.appliesBuilders).matches(item.appliesBuilders, _) &&
-      equals(_expected.defaults?.generateFor?.include)
-          .matches(item.defaults?.generateFor?.include, _) &&
-      equals(_expected.defaults?.generateFor?.exclude)
-          .matches(item.defaults?.generateFor?.exclude, _) &&
+      new _TargetBuilderConfigDefaultsMatcher(_expected.defaults)
+          .matches(item.defaults, _) &&
       item.autoApply == _expected.autoApply &&
       item.isOptional == _expected.isOptional &&
       item.buildTo == _expected.buildTo &&
@@ -241,14 +253,33 @@ class _PostProcessBuilderDefinitionMatcher extends Matcher {
       item is PostProcessBuilderDefinition &&
       equals(_expected.builderFactory).matches(item.builderFactory, _) &&
       equals(_expected.inputExtensions).matches(item.inputExtensions, _) &&
-      equals(_expected.defaults?.generateFor?.include)
-          .matches(item.defaults?.generateFor?.include, _) &&
-      equals(_expected.defaults?.generateFor?.exclude)
-          .matches(item.defaults?.generateFor?.exclude, _) &&
+      new _TargetBuilderConfigDefaultsMatcher(_expected.defaults)
+          .matches(item.defaults, _) &&
       item.import == _expected.import &&
       item.key == _expected.key &&
       item.package == _expected.package &&
       item.target == _expected.target;
+
+  @override
+  Description describe(Description description) =>
+      description.addDescriptionOf(_expected);
+}
+
+class _TargetBuilderConfigDefaultsMatcher extends Matcher {
+  final TargetBuilderConfigDefaults _expected;
+  _TargetBuilderConfigDefaultsMatcher(this._expected);
+
+  @override
+  bool matches(item, _) =>
+      item is TargetBuilderConfigDefaults &&
+      equals(_expected.generateFor.include)
+          .matches(item.generateFor.include, _) &&
+      equals(_expected.generateFor.exclude)
+          .matches(item.generateFor.exclude, _) &&
+      equals(_expected.options.config).matches(item.options.config, _) &&
+      equals(_expected.devOptions.config).matches(item.devOptions.config, _) &&
+      equals(_expected.releaseOptions.config)
+          .matches(item.releaseOptions.config, _);
 
   @override
   Description describe(Description description) =>
@@ -315,7 +346,10 @@ class _BuilderConfigMatcher extends Matcher {
           .matches(item.generateFor?.include, _) &&
       equals(_expected.generateFor?.exclude)
           .matches(item.generateFor?.exclude, _) &&
-      equals(_expected.options.config).matches(item.options.config, _);
+      equals(_expected.options.config).matches(item.options.config, _) &&
+      equals(_expected.devOptions.config).matches(item.devOptions.config, _) &&
+      equals(_expected.releaseOptions.config)
+          .matches(item.releaseOptions.config, _);
 
   @override
   Description describe(Description description) =>

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -1,7 +1,7 @@
 import 'package:build_runner/build_runner.dart' as _i1;
 import 'package:provides_builder/builders.dart' as _i2;
-import 'package:build_test/builder.dart' as _i3;
-import 'package:build_config/build_config.dart' as _i4;
+import 'package:build_config/build_config.dart' as _i3;
+import 'package:build_test/builder.dart' as _i4;
 import 'package:build_modules/builders.dart' as _i5;
 import 'package:build_web_compilers/builders.dart' as _i6;
 import 'dart:isolate' as _i7;
@@ -9,30 +9,34 @@ import 'dart:isolate' as _i7;
 final _builders = [
   _i1.apply('provides_builder|some_not_applied_builder', [_i2.notApplied],
       _i1.toNoneByDefault(),
-      hideOutput: true),
+      hideOutput: true, defaultGenerateFor: const _i3.InputSet()),
   _i1.apply('provides_builder|some_builder', [_i2.someBuilder],
       _i1.toDependentsOf('provides_builder'),
       hideOutput: true,
+      defaultGenerateFor: const _i3.InputSet(),
       appliesBuilders: ['provides_builder|some_post_process_builder']),
   _i1.apply(
       'build_test|test_bootstrap',
-      [_i3.debugIndexBuilder, _i3.debugTestBuilder, _i3.testBootstrapBuilder],
+      [_i4.debugIndexBuilder, _i4.debugTestBuilder, _i4.testBootstrapBuilder],
       _i1.toRoot(),
       hideOutput: true,
-      defaultGenerateFor: const _i4.InputSet(include: const ['test/**'])),
+      defaultGenerateFor: const _i3.InputSet(include: const ['test/**'])),
   _i1.apply(
       'build_modules|modules',
       [_i5.moduleBuilder, _i5.unlinkedSummaryBuilder, _i5.linkedSummaryBuilder],
       _i1.toAllPackages(),
       isOptional: true,
-      hideOutput: true),
+      hideOutput: true,
+      defaultGenerateFor: const _i3.InputSet()),
   _i1.apply(
       'build_web_compilers|ddc', [_i6.devCompilerBuilder], _i1.toAllPackages(),
-      isOptional: true, hideOutput: true),
+      isOptional: true,
+      hideOutput: true,
+      defaultGenerateFor: const _i3.InputSet()),
   _i1.apply('build_web_compilers|entrypoint', [_i6.webEntrypointBuilder],
       _i1.toRoot(),
       hideOutput: true,
-      defaultGenerateFor: const _i4.InputSet(include: const [
+      defaultGenerateFor: const _i3.InputSet(include: const [
         'web/**',
         'test/**_test.dart',
         'example/**',
@@ -43,9 +47,11 @@ final _builders = [
       ]),
       appliesBuilders: ['build_web_compilers|dart2js_archive_extractor']),
   _i1.applyPostProcess(
-      'provides_builder|some_post_process_builder', _i2.somePostProcessBuilder),
+      'provides_builder|some_post_process_builder', _i2.somePostProcessBuilder,
+      defaultGenerateFor: const _i3.InputSet()),
   _i1.applyPostProcess('build_web_compilers|dart2js_archive_extractor',
-      _i6.dart2JsArchiveExtractor)
+      _i6.dart2JsArchiveExtractor,
+      defaultGenerateFor: const _i3.InputSet())
 ];
 main(List<String> args, [_i7.SendPort sendPort]) async {
   var result = await _i1.run(args, _builders);


### PR DESCRIPTION
Towards #1109

- Add `devOptions` and `releaseOptions` to target level builder config.
- Add `options`, `devOptions`, and `releaseOptions` to builder
  definition defaults so builder authors can recommend defaults per
  mode.
- Add `InputSet.anything` to give a name to the `const InputSet()`
  pattern.
- Ensure that `defaults`, all `options`, and `generateFor` fields are
  never null. This is behavior change that will be visible in
  `build_runner` but will only change the generated build script.
- Separate out a matcher for `TargetBuilderConfigDefaults` since it got
  more complext and is multiple times.