### PR TITLE
Deprecate target and extension config for builders

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.6
+
+- The `target` and `build_extensions` keys for builder definitions are now
+  optional and should be omitted in most cases since they are currently unused.
+
 ## 0.2.5
 
 - Added `post_process_builders` section to `build.yaml`. See README.md for more

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -62,16 +62,11 @@ Exposed `Builder`s are configured in the `builders` section of the `build.yaml`.
 This is a map of builder names to configuration. Each builder config may contain
 the following keys:
 
-- **target**: The name of the target which defines contains the `Builder` class
-  definition.
 - **import**: Required. The import uri that should be used to import the library
   containing the `Builder` class. This should always be a `package:` uri.
 - **builder_factories**: A `List<String>` which contains the names of the
   top-level methods in the imported library which are a function fitting the
   typedef `Builder factoryName(BuilderOptions options)`.
-- **build_extensions**: Required. A map from input extension to the list of
-  output extensions that may be created for that input. This must match the
-  merged `buildExtensions` maps from each `Builder` in `builder_factories`.
 - **auto_apply**: Optional. The packages which should have this builder
   automatically to applied. Defaults to `'none'` The possibilities are:
   - `"none"`: Never apply this Builder unless it is manually configured
@@ -105,22 +100,10 @@ the following keys:
 Example `builders` config:
 
 ```yaml
-targets:
-  # The target containing the builder sources.
-  _my_builder: # By convention, this is private
-    sources:
-      - "lib/src/builder/**/*.dart"
-      - "lib/builder.dart"
-    dependencies:
-      - "build"
-      - "source_gen"
 builders:
-  # The actual builder config.
   my_builder:
-    target: ":_my_builder"
     import: "package:my_package/builder.dart"
     builder_factories: ["myBuilder"]
-    build_extensions: {".dart": [".my_package.dart"]}
     auto_apply: dependents
 ```
 
@@ -138,8 +121,6 @@ Exposed `PostProcessBuilder`s are configured in the `post_process_builders`
 section of the  `build.yaml`. This is a map of builder names to configuration.
 Each post process builder config may contain the following keys:
 
-- **target**: The name of the target which defines contains the `Builder` class
-  definition.
 - **import**: Required. The import uri that should be used to import the library
   containing the `Builder` class. This should always be a `package:` uri.
 - **builder_factory**: A `String` which contains the name of the top-level
@@ -164,7 +145,6 @@ builders:
   regular_builder:
     import: "package:my_package/builder.dart"
     builder_factories: ["myBuilder"]
-    build_extensions: {".dart": [".tar.gz"]}
     auto_apply: dependents
     apply_builders: ["|archive_extract_builder"]
 post_process_builders:

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -139,9 +139,15 @@ class BuilderDefinition {
 
   /// A map from input extension to the output extensions created for matching
   /// inputs.
+  ///
+  /// May be null or unreliable and should not be used.
+  @deprecated
   final Map<String, List<String>> buildExtensions;
 
   /// The name of the dart_library target that contains `import`.
+  ///
+  /// May be null or unreliable and should not be used.
+  @deprecated
   final String target;
 
   /// Which packages should have this builder applied automatically.
@@ -177,9 +183,9 @@ class BuilderDefinition {
     @required this.package,
     @required this.key,
     @required this.builderFactories,
-    @required this.buildExtensions,
     @required this.import,
-    @required this.target,
+    this.buildExtensions,
+    this.target,
     this.autoApply,
     this.requiredInputs,
     this.runsBefore,
@@ -191,11 +197,9 @@ class BuilderDefinition {
 
   @override
   String toString() => {
-        'target': target,
         'autoApply': autoApply,
         'import': import,
         'builderFactories': builderFactories,
-        'buildExtensions': buildExtensions,
         'requiredInputs': requiredInputs,
         'runsBefore': runsBefore,
         'isOptional': isOptional,
@@ -221,9 +225,15 @@ class PostProcessBuilderDefinition {
   final String import;
 
   /// A list of input extensions for this builder.
+  ///
+  /// May be null or unreliable and should not be used.
+  @deprecated
   final Iterable<String> inputExtensions;
 
   /// The name of the dart_library target that contains `import`.
+  ///
+  /// May be null or unreliable and should not be used.
+  @deprecated
   final String target;
 
   final TargetBuilderConfigDefaults defaults;
@@ -232,18 +242,16 @@ class PostProcessBuilderDefinition {
     @required this.package,
     @required this.key,
     @required this.builderFactory,
-    @required this.inputExtensions,
     @required this.import,
-    @required this.target,
+    this.inputExtensions,
+    this.target,
     this.defaults,
   });
 
   @override
   String toString() => {
-        'target': target,
         'import': import,
         'builderFactory': builderFactory,
-        'inputExtensions': inputExtensions,
         'defaults': defaults,
       }.toString();
 }

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -118,11 +118,6 @@ BuildConfig parseFromMap(String packageName,
     );
   }
 
-  if (!buildTargets.containsKey(defaultTarget)) {
-    throw new ArgumentError('Must specify a target with the name '
-        '$packageName or `\$default`');
-  }
-
   final builderConfigs = config['builders'] as Map<String, Map> ?? {};
   for (var builderName in builderConfigs.keys) {
     final builderConfig = _readMapOrThrow(builderConfigs, builderName,
@@ -133,8 +128,7 @@ BuildConfig parseFromMap(String packageName,
         _readListOfStringsOrThrow(builderConfig, _builderFactories);
     final import = _readStringOrThrow(builderConfig, _import);
     final buildExtensions = _readBuildExtensions(builderConfig);
-    final target = normalizeTargetKeyUsage(
-        _readStringOrThrow(builderConfig, _target), packageName);
+    final target = _readStringOrThrow(builderConfig, _target, allowNull: true);
     final autoApply = _readAutoApplyOrThrow(builderConfig, _autoApply,
         defaultValue: AutoApply.none);
     final requiredInputs = _readListOfStringsOrThrow(
@@ -192,10 +186,10 @@ BuildConfig parseFromMap(String packageName,
 
     final builderFactory = _readStringOrThrow(builderConfig, _builderFactory);
     final import = _readStringOrThrow(builderConfig, _import);
-    final inputExtensions =
-        _readListOfStringsOrThrow(builderConfig, _inputExtensions);
-    final target = normalizeTargetKeyUsage(
-        _readStringOrThrow(builderConfig, _target), packageName);
+    final inputExtensions = _readListOfStringsOrThrow(
+        builderConfig, _inputExtensions,
+        allowNull: true);
+    final target = _readStringOrThrow(builderConfig, _target, allowNull: true);
     final defaultOptions = _readMapOrThrow(
         builderConfig, _defaults, _builderConfigDefaultOptions, 'defaults',
         defaultValue: {});
@@ -226,7 +220,7 @@ BuildConfig parseFromMap(String packageName,
 Map<String, List<String>> _readBuildExtensions(Map<String, dynamic> options) {
   var value = options[_buildExtensions];
   if (value == null) {
-    throw new ArgumentError('Missing configuratino for build_extensions');
+    return null;
   }
   if (value is! Map<String, List<String>>) {
     throw new ArgumentError('Invalid value for build_extensions, '

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.2.5
+version: 0.2.6-dev
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -43,15 +43,8 @@ void main() {
         isOptional: true,
         buildTo: BuildTo.cache,
         import: 'package:example/e.dart',
-        buildExtensions: {
-          '.dart': [
-            '.g.dart',
-            '.json',
-          ]
-        },
         package: 'example',
         key: 'example|h',
-        target: 'example:example',
         requiredInputs: ['.dart'],
         runsBefore: ['foo_builder|foo_builder'].toSet(),
         appliesBuilders: ['foo_builder|foo_builder'].toSet(),
@@ -64,10 +57,8 @@ void main() {
       'example|p': new PostProcessBuilderDefinition(
         builderFactory: 'createPostProcessBuilder',
         import: 'package:example/p.dart',
-        inputExtensions: ['.tar.gz', '.zip'],
         package: 'example',
         key: 'example|p',
-        target: 'example:example',
         defaults: new TargetBuilderConfigDefaults(
             generateFor: new InputSet(include: ['web/**'])),
       ),
@@ -92,15 +83,8 @@ void main() {
         isOptional: false,
         buildTo: BuildTo.cache,
         import: 'package:example/builder.dart',
-        buildExtensions: {
-          '.dart': [
-            '.g.dart',
-            '.json',
-          ]
-        },
         package: 'example',
         key: 'example|a',
-        target: 'example:example',
         requiredInputs: const [],
         runsBefore: new Set<String>(),
         appliesBuilders: new Set<String>(),
@@ -158,8 +142,6 @@ builders:
   h:
     builder_factories: ["createBuilder"]
     import: package:example/e.dart
-    build_extensions: {".dart": [".g.dart", ".json"]}
-    target: ":example"
     auto_apply: dependents
     required_inputs: [".dart"]
     runs_before: ["foo_builder"]
@@ -171,8 +153,6 @@ post_process_builders:
   p:
     builder_factory: "createPostProcessBuilder"
     import: package:example/p.dart
-    input_extensions: [".tar.gz", ".zip"]
-    target: ":example"
     defaults:
       generate_for: ["web/**"]
 ''';
@@ -182,8 +162,6 @@ builders:
   a:
     builder_factories: ["createBuilder"]
     import: package:example/builder.dart
-    build_extensions: {".dart": [".g.dart", ".json"]}
-    target: example
 ''';
 
 void expectBuilderDefinitions(Map<String, BuilderDefinition> actual,
@@ -211,7 +189,6 @@ class _BuilderDefinitionMatcher extends Matcher {
   bool matches(item, _) =>
       item is BuilderDefinition &&
       equals(_expected.builderFactories).matches(item.builderFactories, _) &&
-      equals(_expected.buildExtensions).matches(item.buildExtensions, _) &&
       equals(_expected.requiredInputs).matches(item.requiredInputs, _) &&
       equals(_expected.runsBefore).matches(item.runsBefore, _) &&
       equals(_expected.appliesBuilders).matches(item.appliesBuilders, _) &&
@@ -224,8 +201,7 @@ class _BuilderDefinitionMatcher extends Matcher {
       item.buildTo == _expected.buildTo &&
       item.import == _expected.import &&
       item.key == _expected.key &&
-      item.package == _expected.package &&
-      item.target == _expected.target;
+      item.package == _expected.package;
 
   @override
   Description describe(Description description) =>
@@ -240,15 +216,13 @@ class _PostProcessBuilderDefinitionMatcher extends Matcher {
   bool matches(item, _) =>
       item is PostProcessBuilderDefinition &&
       equals(_expected.builderFactory).matches(item.builderFactory, _) &&
-      equals(_expected.inputExtensions).matches(item.inputExtensions, _) &&
       equals(_expected.defaults?.generateFor?.include)
           .matches(item.defaults?.generateFor?.include, _) &&
       equals(_expected.defaults?.generateFor?.exclude)
           .matches(item.defaults?.generateFor?.exclude, _) &&
       item.import == _expected.import &&
       item.key == _expected.key &&
-      item.package == _expected.package &&
-      item.target == _expected.target;
+      item.package == _expected.package;
 
   @override
   Description describe(Description description) =>


### PR DESCRIPTION
Closes #1258

Deprecate the fields but continue to allow them to be parsed. Remove any
checks that required them. Remove these fields from the test.

After this change these fields _may_ be included, and if they are they
must be the right type, but they are otherwise ignored.