### PR TITLE
Require build_extensions again

### DIFF
--- a/build_config/README.md
+++ b/build_config/README.md
@@ -67,6 +67,9 @@ the following keys:
 - **builder_factories**: A `List<String>` which contains the names of the
   top-level methods in the imported library which are a function fitting the
   typedef `Builder factoryName(BuilderOptions options)`.
+- **build_extensions**: Required. A map from input extension to the list of
+  output extensions that may be created for that input. This must match the
+  merged `buildExtensions` maps from each `Builder` in `builder_factories`.
 - **auto_apply**: Optional. The packages which should have this builder
   automatically to applied. Defaults to `'none'` The possibilities are:
   - `"none"`: Never apply this Builder unless it is manually configured
@@ -104,6 +107,7 @@ builders:
   my_builder:
     import: "package:my_package/builder.dart"
     builder_factories: ["myBuilder"]
+    build_extensions: {".dart": [".my_package.dart"]}
     auto_apply: dependents
 ```
 
@@ -145,6 +149,7 @@ builders:
   regular_builder:
     import: "package:my_package/builder.dart"
     builder_factories: ["myBuilder"]
+    build_extensions: {".dart": [".tar.gz"]}
     auto_apply: dependents
     apply_builders: ["|archive_extract_builder"]
 post_process_builders:

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -141,9 +141,6 @@ class BuilderDefinition {
 
   /// A map from input extension to the output extensions created for matching
   /// inputs.
-  ///
-  /// May be null or unreliable and should not be used.
-  @deprecated
   final Map<String, List<String>> buildExtensions;
 
   /// The name of the dart_library target that contains `import`.
@@ -185,8 +182,8 @@ class BuilderDefinition {
     @required this.package,
     @required this.key,
     @required this.builderFactories,
+    @required this.buildExtensions,
     @required this.import,
-    this.buildExtensions,
     this.target,
     this.autoApply,
     this.requiredInputs,
@@ -202,6 +199,7 @@ class BuilderDefinition {
         'autoApply': autoApply,
         'import': import,
         'builderFactories': builderFactories,
+        'buildExtensions': buildExtensions,
         'requiredInputs': requiredInputs,
         'runsBefore': runsBefore,
         'isOptional': isOptional,

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -249,7 +249,7 @@ BuildConfig parseFromMap(String packageName,
 Map<String, List<String>> _readBuildExtensions(Map<String, dynamic> options) {
   var value = options[_buildExtensions];
   if (value == null) {
-    throw new ArgumentError('Missing configuratino for build_extensions');
+    throw new ArgumentError('Missing configuration for build_extensions');
   }
   if (value is! Map<String, List<String>>) {
     throw new ArgumentError('Invalid value for build_extensions, '

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -249,7 +249,7 @@ BuildConfig parseFromMap(String packageName,
 Map<String, List<String>> _readBuildExtensions(Map<String, dynamic> options) {
   var value = options[_buildExtensions];
   if (value == null) {
-    return null;
+    throw new ArgumentError('Missing configuratino for build_extensions');
   }
   if (value is! Map<String, List<String>>) {
     throw new ArgumentError('Invalid value for build_extensions, '

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.2.6
+version: 0.2.6+1
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -43,6 +43,12 @@ void main() {
         isOptional: true,
         buildTo: BuildTo.cache,
         import: 'package:example/e.dart',
+        buildExtensions: {
+          '.dart': [
+            '.g.dart',
+            '.json',
+          ]
+        },
         package: 'example',
         key: 'example|h',
         requiredInputs: ['.dart'],
@@ -89,6 +95,12 @@ void main() {
         isOptional: false,
         buildTo: BuildTo.cache,
         import: 'package:example/builder.dart',
+        buildExtensions: {
+          '.dart': [
+            '.g.dart',
+            '.json',
+          ]
+        },
         package: 'example',
         key: 'example|a',
         requiredInputs: const [],
@@ -148,6 +160,7 @@ builders:
   h:
     builder_factories: ["createBuilder"]
     import: package:example/e.dart
+    build_extensions: {".dart": [".g.dart", ".json"]}
     auto_apply: dependents
     required_inputs: [".dart"]
     runs_before: ["foo_builder"]
@@ -176,6 +189,7 @@ builders:
   a:
     builder_factories: ["createBuilder"]
     import: package:example/builder.dart
+    build_extensions: {".dart": [".g.dart", ".json"]}
 ''';
 
 void expectBuilderDefinitions(Map<String, BuilderDefinition> actual,
@@ -203,6 +217,7 @@ class _BuilderDefinitionMatcher extends Matcher {
   bool matches(item, _) =>
       item is BuilderDefinition &&
       equals(_expected.builderFactories).matches(item.builderFactories, _) &&
+      equals(_expected.buildExtensions).matches(item.buildExtensions, _) &&
       equals(_expected.requiredInputs).matches(item.requiredInputs, _) &&
       equals(_expected.runsBefore).matches(item.runsBefore, _) &&
       equals(_expected.appliesBuilders).matches(item.appliesBuilders, _) &&

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -39,3 +39,7 @@ dev_dependencies:
   package_resolver: ^1.0.2
   test: ^0.12.0
   test_descriptor: ^1.0.0
+
+dependency_overrides:
+  build_config:
+    path: ../build_config


### PR DESCRIPTION
Partially rolls back 265432a7c39c5b93d2bab8c2e945b1fd9dc8767e

I forgot that these _are_ used by `build_runner` since they can impact
the order we run builders in because of `required_inputs`.