### PR TITLE
Update build_runner/generate/build_impl.dart

### DIFF
--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -221,6 +221,7 @@ class _SingleBuild {
       _logger.severe('Failed after ${humanReadable(watch.elapsed)}',
           result.exception, result.stackTrace);
     }
+    print("-----------------------------------------------------------------");
     return result;
   }
 


### PR DESCRIPTION
An attempt to fix :
https://github.com/dart-lang/build/issues/1269

Before adding : 
![scrrrrr](https://user-images.githubusercontent.com/8603858/38461865-f73033be-3af8-11e8-812c-32a83e1008a3.png)

After adding :
![scr2](https://user-images.githubusercontent.com/8603858/38461866-046c7c5e-3af9-11e8-8ba2-99b580cd4134.png)

Now it prints a separator whenever a build task is finished.