### PR TITLE
move the .packages file to the root directory always

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.2+2
+- The `.packages` file is now always created in the root of the output directory
+  instead of under each top level directory.
+
 ## 0.8.2+1
 - Bug Fix: Correctly parse Window's paths with new `--output` semantics.
 

--- a/build_runner/lib/src/generate/create_merged_dir.dart
+++ b/build_runner/lib/src/generate/create_merged_dir.dart
@@ -108,25 +108,19 @@ Future<bool> _createMergedOutputDir(
         await _ensureInputs(node);
       }
     }
-
     outputAssets.addAll(
         await _createMissingTestHtmlFiles(outputPath, packageGraph.root.name));
 
     var packagesFileContent = packageGraph.allPackages.keys
         .map((p) => '$p:packages/$p/')
         .join('\r\n');
+    var packagesAsset = new AssetId(packageGraph.root.name, '.packages');
+    _writeAsString(outputDir, packagesAsset, packagesFileContent);
+    outputAssets.add(packagesAsset);
 
-    if (root != null) {
-      var packagesAsset = new AssetId(packageGraph.root.name, '.packages');
-      _writeAsString(outputDir, packagesAsset, packagesFileContent);
-      outputAssets.add(packagesAsset);
-    } else {
+    if (root == null) {
       for (var dir
           in _findRootDirs(outputPath, assetGraph, packageGraph, buildPhases)) {
-        var packagesAsset =
-            new AssetId(packageGraph.root.name, p.url.join(dir, '.packages'));
-        _writeAsString(outputDir, packagesAsset, packagesFileContent);
-        outputAssets.add(packagesAsset);
         var link = new Link(p.join(outputDir.path, dir, 'packages'));
         if (!link.existsSync()) {
           link.createSync(p.join('..', 'packages'), recursive: true);

--- a/build_runner/lib/src/generate/create_merged_dir.dart
+++ b/build_runner/lib/src/generate/create_merged_dir.dart
@@ -108,6 +108,7 @@ Future<bool> _createMergedOutputDir(
         await _ensureInputs(node);
       }
     }
+
     outputAssets.addAll(
         await _createMissingTestHtmlFiles(outputPath, packageGraph.root.name));
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.8.2+1
+version: 0.8.2+2
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner

--- a/build_runner/test/generate/create_merged_dir_test.dart
+++ b/build_runner/test/generate/create_merged_dir_test.dart
@@ -271,7 +271,7 @@ void _expectAllFiles(Directory dir) {
     'packages/b/c.txt.copy': 'c',
     'web/b.txt': 'b',
     'web/b.txt.copy': 'b',
-    'web/.packages': 'a:packages/a/\r\nb:packages/b/\r\n\$sdk:packages/\$sdk/',
+    '.packages': 'a:packages/a/\r\nb:packages/b/\r\n\$sdk:packages/\$sdk/',
   };
   _expectFiles(expectedFiles, dir);
 }


### PR DESCRIPTION
This is required for the node/vm --precompiled support.