### PR TITLE
Update dev_compiler_bootstrap.dart to fix an issue

### DIFF
--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -312,7 +312,7 @@ var baseUrl = (function() {
     pathParts.shift();
   }
   var baseUrl;
-  if (pathParts.length > 1 && pathParts[1] == "test") {
+  if (pathParts.length > 1 || pathParts[1] == "test") {
     return "/" + pathParts.slice(0, 2).join("/") + "/";
   }
   return "/";


### PR DESCRIPTION
Fix for :
https://github.com/dart-lang/build/issues/1279

Before making changes (404 errors):
![baseurlerr](https://user-images.githubusercontent.com/8603858/38583336-4aede7e2-3d30-11e8-8b59-e12dd98bf808.png)

After making changes (no 404 errors):
![aftermakingchanges222](https://user-images.githubusercontent.com/8603858/38583647-4f6d225a-3d31-11e8-995c-50f6cee79a5a.png)

A comparison of both:
![baseurl2](https://user-images.githubusercontent.com/8603858/38583699-76b2b51e-3d31-11e8-87a9-af04355a7b30.png)






This will fix an issue where build_web_compilers is not able to correctly set value of `baseUrl` variable.