### PR TITLE
Reimplement findAssets in PackageAssetReader

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.2+1
+
+- Add back an implementation of `findAssets` in `PackageAssetReader`.
+
 ## 0.10.2
 
 - Added a `DebugIndexBuilder`, which by default generates a `test/index.html`

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -110,7 +110,7 @@ class PackageAssetReader extends AssetReader
           .list(recursive: true)
           .where((e) => e is File)
           .map((f) => p.relative(f.path, from: Directory.current.path))
-          .where((p) => !p.startsWith('packages/'))));
+          .where((p) => !(p.startsWith('packages/') || p.startsWith('lib/')))));
     }
     return packageFiles.where(glob.matches).map((p) => new AssetId(package, p));
   }

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.2
+version: 0.10.2+1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
@@ -14,6 +14,7 @@ dependencies:
   build_config: ^0.2.0
   build_resolvers: ^0.2.0
   collection: ^1.14.0
+  stream_transform: ^0.0.11
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0
   html: ">=0.9.0 <=0.14.0"

--- a/build_test/test/package_reader_test.dart
+++ b/build_test/test/package_reader_test.dart
@@ -11,6 +11,7 @@ void main() {
   group('$PackageAssetReader', () {
     PackageAssetReader reader;
 
+    final buildAsset = new AssetId('build', 'lib/build.dart');
     final buildTest = new AssetId('build_test', 'lib/build_test.dart');
     final buildMissing = new AssetId('build_test', 'lib/build_missing.dart');
     final thisFile = new AssetId('build_test', 'test/package_reader_test.dart');
@@ -34,9 +35,20 @@ void main() {
       expect(await reader.canRead(buildMissing), isFalse);
     });
 
-    test('does not support findAssets', () {
-      expect(() => reader.findAssets(new Glob('lib/*.dart')),
-          throwsUnsupportedError);
+    test('should be able to use `findAssets` for files in lib', () {
+      expect(
+          reader.findAssets(new Glob('lib/*.dart')), emitsThrough(buildTest));
+    });
+
+    test('should be able to use `findAssets` for files in test', () {
+      expect(
+          reader.findAssets(new Glob('test/*.dart')), emitsThrough(thisFile));
+    });
+
+    test('should be able to use `findAssets` for files in non-root packages',
+        () {
+      expect(reader.findAssets(new Glob('lib/*.dart'), package: 'build'),
+          emitsThrough(buildAsset));
     });
   });
 


### PR DESCRIPTION
This was removed because I (incorrectly) thought there were no usages
and it was hard to support. Add it back in with a hack of listing all
the files in the searched package, reconsituting a "lib/" structure, and
then running the glob against it.

This is potentially much less performant for large packages and narrow
globs since we always list all files instead of just listing the glob.