### PR TITLE
Avoid using `Uri.path`

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.2+2
+
+- Avoid looking for files from `Uri.path` paths.
+
 ## 0.10.2+1
 
 - Add back an implementation of `findAssets` in `PackageAssetReader`.

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -77,7 +77,7 @@ class PackageAssetReader extends AssetReader
   File _resolve(AssetId id) {
     final uri = id.uri;
     if (uri.isScheme('package')) {
-      return new File(_packageResolver.resolveUri(id.uri).path);
+      return new File.fromUri(_packageResolver.resolveUri(id.uri));
     }
     if (id.package == _rootPackage) {
       // TODO this assumes the cwd is the root package
@@ -99,11 +99,11 @@ class PackageAssetReader extends AssetReader
       throw new UnsupportedError('Unable to find package $package');
     }
 
-    var packageFiles = new Directory(packageLibDir.path)
+    var packageFiles = new Directory.fromUri(packageLibDir)
         .list(recursive: true)
         .where((e) => e is File)
-        .map(
-            (f) => p.join('lib', p.relative(f.path, from: packageLibDir.path)));
+        .map((f) =>
+            p.join('lib', p.relative(f.path, from: p.fromUri(packageLibDir))));
     if (package == _rootPackage) {
       // TODO this assumes the cwd is the root package
       packageFiles = packageFiles.transform(merge(Directory.current

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.2+1
+version: 0.10.2+2
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 


### PR DESCRIPTION
This may not work on windows, instead use `p.fromUri` or `File.fromUri`
as needed. Remaining paths are from `File`, `Directory`, or `AssetId`
instances which should be safe.