### PR TITLE
Clean build config

### DIFF
--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -74,7 +74,7 @@ const _builderConfigDefaultOptions = const [
 
 dynamic _convertYaml(dynamic node) {
   if (node is! YamlNode) {
-      return node;
+    return node;
   } else if (node is YamlMap) {
     return _convertYamlMap(node);
   } else if (node is YamlList) {
@@ -82,7 +82,7 @@ dynamic _convertYaml(dynamic node) {
   } else if (node is YamlScalar) {
     return node.value;
   } else {
-      throw new UnsupportedError('Unrecognized YamlNode: $node');
+    throw new UnsupportedError('Unrecognized YamlNode: $node');
   }
 }
 
@@ -98,20 +98,20 @@ List<dynamic> _convertYamlList(YamlList node) {
 Map<String, dynamic> _convertYamlMap(YamlMap node) {
   var map = <String, dynamic>{};
   node.forEach((key, value) {
-      if (key is YamlNode) {
-        key = key.value;
-      }
-      if (key is String) {
-        return map[key] = _convertYaml(value);
-      } else {
-        throw new UnsupportedError('only string keys are supported');
-      }  
+    if (key is YamlNode) {
+      key = key.value;
+    }
+    if (key is String) {
+      return map[key] = _convertYaml(value);
+    } else {
+      throw new UnsupportedError('only string keys are supported');
+    }
   });
   return map;
 }
 
 BuildConfig parseFromYaml(
-        String packageName, Iterable<String> dependencies, String configYaml) {
+    String packageName, Iterable<String> dependencies, String configYaml) {
   final parsed = loadYaml(configYaml) as YamlMap;
   final map = parsed == null ? <String, dynamic>{} : _convertYamlMap(parsed);
   return parseFromMap(packageName, dependencies, map);

--- a/build_config/lib/src/parse.dart
+++ b/build_config/lib/src/parse.dart
@@ -72,10 +72,50 @@ const _builderConfigDefaultOptions = const [
   _devOptions,
 ];
 
+dynamic _convertYaml(dynamic node) {
+  if (node is! YamlNode) {
+      return node;
+  } else if (node is YamlMap) {
+    return _convertYamlMap(node);
+  } else if (node is YamlList) {
+    return _convertYamlList(node);
+  } else if (node is YamlScalar) {
+    return node.value;
+  } else {
+      throw new UnsupportedError('Unrecognized YamlNode: $node');
+  }
+}
+
+List<dynamic> _convertYamlList(YamlList node) {
+  var list = <dynamic>[];
+  for (var item in node) {
+    list.add(_convertYaml(item));
+  }
+
+  return list;
+}
+
+Map<String, dynamic> _convertYamlMap(YamlMap node) {
+  var map = <String, dynamic>{};
+  node.forEach((key, value) {
+      if (key is YamlNode) {
+        key = key.value;
+      }
+      if (key is String) {
+        return map[key] = _convertYaml(value);
+      } else {
+        throw new UnsupportedError('only string keys are supported');
+      }  
+  });
+  return map;
+}
+
 BuildConfig parseFromYaml(
-        String packageName, Iterable<String> dependencies, String configYaml) =>
-    parseFromMap(packageName, dependencies,
-        loadYaml(configYaml) as Map<String, dynamic> ?? {});
+        String packageName, Iterable<String> dependencies, String configYaml) {
+  final parsed = loadYaml(configYaml) as YamlMap;
+  final map = parsed == null ? <String, dynamic>{} : _convertYamlMap(parsed);
+  return parseFromMap(packageName, dependencies, map);
+}
 
 BuildConfig parseFromMap(String packageName,
     Iterable<String> packageDependencies, Map<String, dynamic> config) {


### PR DESCRIPTION
Duplicate of https://github.com/dart-lang/build/pull/1295/files that just up front converts everything away from Yaml* to normal Map/List/etc.

Opening for posterity sake since I had already written it, not sure which is better really. I kind of like just making a total complete break from the yaml types though.