### PR TITLE
Include stack trace in log

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.2
+
+- Include stack trace in log for exceptions throw by builders.
+
 ## 0.12.1
 
 - Add `BuilderOptions.empty` and `BuilderOptions.overrideWith`.

--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -24,7 +24,7 @@ Future<T> scopeLogAsync<T>(Future<T> fn(), Logger log) {
       }),
       zoneValues: {logKey: log},
       onError: (Object e, StackTrace s) {
-        log.severe('', e);
+        log.severe('', e, s);
         if (done.isCompleted) return;
         done.completeError(e, s);
       }).then((result) {

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.12.1
+version: 0.12.2
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build


### PR DESCRIPTION
Fixes #1299

The stack trace is only logged by `build_runner` with `--verbose` but we
should always pass it along.