### PR TITLE
Skip dart2js via --release

### DIFF
--- a/e2e_example/test/dart2js_integration_test.dart
+++ b/e2e_example/test/dart2js_integration_test.dart
@@ -56,7 +56,7 @@ void main() {
             '--output=$_outputDir',
           ]);
       await expectWasCompiledWithDart2Js(minified: true);
-    });
+    }, onPlatform: {'windows': const Skip('flaky on windows')});
 
     test('--define overrides --config', () async {
       await expectTestsPass(


### PR DESCRIPTION
The other dart2js are already skipped on Windows for being flaky