### PR TITLE
crawl transitive modules in parallel

### DIFF
--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   build: ^0.12.0
   build_config: ^0.2.1
   cli_util: ^0.1.2
+  graphs: ^0.1.1
   json_annotation: ^0.2.2
   logging: ^0.11.2
   path: ^1.4.2


### PR DESCRIPTION
Previous implementation is serialized across file IO because we aren't
doing any work during `await reader.canRead` or `await
reader.readAsString`. `crawlAsync` implements a more aggressive
algorithm which attempts resolves nodes in parallel when possible.