### PR TITLE
Fix recording of input digests on the asset graph

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 0.8.3-dev
+## 0.8.3
 
 - Clean and summarize stack traces printed with `--verbose`.
 - Added a `clean` command which deletes generated to source files and the entire
   build cache directory.
+- Bug Fix: Use the same order to compute the digest of input files to a build
+  step when writing it as when comparing it. Previously builds would not be
+  pruned as efficiently as they can be because the inputs erroneously looked
+  different.
 
 ## 0.8.2+2
 - The `.packages` file is now always created in the root of the output directory

--- a/build_runner/lib/src/asset/reader.dart
+++ b/build_runner/lib/src/asset/reader.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:build/build.dart';
@@ -29,7 +30,7 @@ abstract class RunnerAssetReader implements MultiPackageAssetReader {}
 /// tracking.
 class SingleStepReader implements AssetReader {
   final AssetGraph _assetGraph;
-  final _assetsRead = new Set<AssetId>();
+  final _assetsRead = new SplayTreeSet<AssetId>();
   final AssetReader _delegate;
   final _globsRan = new Set<Glob>();
   final int _phaseNumber;
@@ -45,6 +46,7 @@ class SingleStepReader implements AssetReader {
   SingleStepReader(this._delegate, this._assetGraph, this._phaseNumber,
       this._outputsHidden, this._primaryPackage, this._runPhaseForInput);
 
+  /// The assets read during this step in sorted order.
   Set<AssetId> get assetsRead => _assetsRead;
 
   /// The [Glob]s which have been searched with [findAssets].

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.8.3-dev
+version: 0.8.3
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Depending on the order that inputs were read we could compute a
different `previousInputsDigest` than we would with identical inputs on
the next build. This would cause more actions to be run than necessary -
though it only impacts the case where all inputs were identical which is
relatively rare in practice, however upcoming changes to the module
strategy will make it much more likely.

- Store read assets in a sorted set which matches the way we store
inputs on the asset graph.
- Don't always include the primary input as if it was read - if the
build step doesn't read the primary input we can assume it does not
depend on rerunning when the content changes.
- Pull the digest computation out of the loop since we can always run it
against  the first output's node.