### PR TITLE
Remove from _pendingWrites in whenComplete

### DIFF
--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.2+1
+
+- Fix a bug where failing to read an asset in serve mode could get the build
+  stuck.
+
 ## 0.0.2
 
 - Allow creating files at the root of the scratch space.

--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -27,7 +27,7 @@ class ScratchSpace {
   final Directory tempDir;
 
   // Assets which have a file created but are still being written to.
-  final _pendingWrites = <AssetId, Future<Null>>{};
+  final _pendingWrites = <AssetId, Future<void>>{};
 
   ScratchSpace._(this.tempDir)
       : packagesDir = new Directory(p.join(tempDir.path, 'packages'));
@@ -93,14 +93,13 @@ class ScratchSpace {
         if (pending != null) futures.add(pending);
       } else {
         file.createSync(recursive: true);
-        var done = () async {
-          var bytes = await reader.readAsBytes(id);
-          await _descriptorPool.withResource(() async {
-            await file.writeAsBytes(bytes);
-            // ignore: unawaited_futures
-            _pendingWrites.remove(id);
-          });
-        }();
+        var done = reader
+            .readAsBytes(id)
+            .then((bytes) =>
+                _descriptorPool.withResource(() => file.writeAsBytes(bytes)))
+            .whenComplete(() {
+          _pendingWrites.remove(id);
+        });
         _pendingWrites[id] = done;
         futures.add(done);
       }

--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -104,7 +104,7 @@ class ScratchSpace {
         futures.add(done);
       }
     }
-    return Future.wait(futures);
+    return Future.wait(futures, eagerError: true);
   }
 
   /// Returns the actual [File] in this environment corresponding to [id].

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scratch_space
-version: 0.0.2
+version: 0.0.2+1
 description: A tool to manage running external executables within package:build
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space


### PR DESCRIPTION
Previously if readAsString threw it could get the build stuck because
we'd never remove the pendingWrite Future and could get stuck waiting
forever.

Closes https://github.com/dart-lang/angular/issues/1259.