### PR TITLE
Handle module cycles

### DIFF
--- a/build_modules/build.yaml
+++ b/build_modules/build.yaml
@@ -1,21 +1,15 @@
 builders:
-  meta_module:
-    import: "package:build_modules/builders.dart"
-    builder_factories:
-      - metaModuleBuilder
-    build_extensions:
-      $lib$:
-        - .meta_module
-    is_optional: True
-    auto_apply: all_packages
-    required_inputs: [".dart"]
   modules:
     import: "package:build_modules/builders.dart"
     builder_factories:
+      - metaModuleBuilder
+      - metaModuleCleanBuilder
       - moduleBuilder
       - unlinkedSummaryBuilder
       - linkedSummaryBuilder
     build_extensions:
+      $lib$:
+        - .meta_module
       .dart:
         - .module
         - .linked.sum
@@ -25,4 +19,4 @@ builders:
     defaults:
       options:
         strategy: 'coarse'
-    required_inputs: [".dart", ".meta_module"]
+    required_inputs: [".dart"]

--- a/build_modules/lib/builders.dart
+++ b/build_modules/lib/builders.dart
@@ -5,9 +5,12 @@
 import 'package:build/build.dart';
 import 'package:build_modules/build_modules.dart';
 import 'package:build_modules/src/meta_module_builder.dart';
+import 'package:build_modules/src/meta_module_clean_builder.dart';
 
 Builder moduleBuilder(BuilderOptions options) =>
     new ModuleBuilder.forOptions(options);
 Builder unlinkedSummaryBuilder(_) => const UnlinkedSummaryBuilder();
 Builder linkedSummaryBuilder(_) => const LinkedSummaryBuilder();
 Builder metaModuleBuilder(_) => const MetaModuleBuilder();
+Builder metaModuleCleanBuilder(BuilderOptions options) =>
+    const MetaModuleCleanBuilder();

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -330,6 +330,8 @@ class MetaModule extends Object with _$MetaModuleSerializerMixin {
       modules.addAll(
           await _computeModules(reader, assetsByTopLevel[key], key == 'lib'));
     }
+    // Deterministically output the modules.
+    modules.sort((a, b) => a.primarySource.compareTo(b.primarySource));
     return new MetaModule(modules);
   }
 }

--- a/build_modules/lib/src/meta_module_clean_builder.dart
+++ b/build_modules/lib/src/meta_module_clean_builder.dart
@@ -58,7 +58,11 @@ Future<Set<Module>> _transitiveModules(BuildStep buildStep, AssetId metaAsset,
   return dependentModules;
 }
 
-Module _cleanModule(
+/// Merges the modules in a strongly connected component.
+///
+/// Note this will clean the module dependencies as the merge happens.
+/// The result will be that all dependencies are primary sources.
+Module _mergeComponent(
     List<Module> connectedComponent, Map<AssetId, Module> assetToModule) {
   var sources = new Set<AssetId>();
   var deps = new Set<AssetId>();
@@ -106,7 +110,7 @@ class MetaModuleCleanBuilder implements Builder {
     var cleanModules = new SplayTreeSet<Module>(
         (a, b) => a.primarySource.compareTo(b.primarySource));
     for (var connectedComponent in connectedComponents) {
-      var cleanModule = _cleanModule(connectedComponent, assetToModule);
+      var cleanModule = _mergeComponent(connectedComponent, assetToModule);
       for (var source in cleanModule.sources) {
         if (source.package == buildStep.inputId.package) {
           cleanModules.add(cleanModule);

--- a/build_modules/lib/src/meta_module_clean_builder.dart
+++ b/build_modules/lib/src/meta_module_clean_builder.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:graphs/graphs.dart';
+
+import 'package:build/build.dart';
+import 'meta_module.dart';
+import 'meta_module_builder.dart';
+import 'modules.dart';
+
+/// The extension for serialized clean meta module assets.
+const metaModuleCleanExtension = '.meta_module_clean';
+
+/// Map of [AssetId] to corresponding primary [AssetId] within the same
+/// [Module].
+final _assetToModule =
+    new Resource<Map<AssetId, Module>>(() => {}, dispose: (map) => map.clear());
+
+/// Returns a set of all modules transitvely reachable from the provided meta
+/// module asset.
+Future<Set<Module>> _transitiveModules(BuildStep buildStep, AssetId metaAsset,
+    Map<AssetId, Module> assetToModule) async {
+  var dependentModules = new Set<Module>();
+  // Ensures we only process a meta file once.
+  var seenMetas = new Set<AssetId>()..add(metaAsset);
+  var meta = new MetaModule.fromJson(
+      json.decode(await buildStep.readAsString(buildStep.inputId))
+          as Map<String, dynamic>);
+  var nextModules = <Module>[];
+  nextModules.addAll(meta.modules);
+  while (nextModules.isNotEmpty) {
+    var module = nextModules.removeLast();
+    dependentModules.add(module);
+    for (var source in module.sources) {
+      assetToModule[source] = module;
+    }
+    for (var dep in module.directDependencies) {
+      var depMetaAsset = new AssetId(dep.package, 'lib/$metaModuleExtension');
+      if (!seenMetas.contains(depMetaAsset)) {
+        seenMetas.add(depMetaAsset);
+        if (await buildStep.canRead(depMetaAsset)) {
+          var depMeta = new MetaModule.fromJson(
+              json.decode(await buildStep.readAsString(depMetaAsset))
+                  as Map<String, dynamic>);
+          nextModules.addAll(depMeta.modules);
+        } else {
+          log.info('Unable to find meta module for dependency: $dep '
+              'Are you missing a dependency on package:${dep.package}?');
+        }
+      }
+    }
+  }
+  return dependentModules;
+}
+
+Module _cleanModule(
+    List<Module> connectedComponent, Map<AssetId, Module> assetToModule) {
+  var sources = new Set<AssetId>();
+  var deps = new Set<AssetId>();
+  // Sort the modules to deterministicly select the primary source.
+  var components = new SplayTreeSet<Module>(
+      (a, b) => a.primarySource.compareTo(b.primarySource))
+    ..addAll(connectedComponent);
+  var primarySource = components.first.primarySource;
+  for (var module in connectedComponent) {
+    sources.addAll(module.sources);
+    for (var dep in module.directDependencies) {
+      var depModule = assetToModule[dep];
+      if (depModule == null) continue;
+      // This dep is now merged into sources so skip it.
+      if (!components.contains(depModule)) deps.add(depModule.primarySource);
+    }
+  }
+  return new Module(primarySource, sources, deps);
+}
+
+/// Creates `.meta_module_clean` file for any Dart library.
+///
+/// This file contains information about the full computed
+/// module structure for the package with cleaned dependencies.
+class MetaModuleCleanBuilder implements Builder {
+  const MetaModuleCleanBuilder();
+
+  @override
+  final buildExtensions = const {
+    '$metaModuleExtension': const [metaModuleCleanExtension]
+  };
+
+  @override
+  Future build(BuildStep buildStep) async {
+    var assetToModule = await buildStep.fetchResource(_assetToModule);
+    var modules =
+        await _transitiveModules(buildStep, buildStep.inputId, assetToModule);
+    var connectedComponents = stronglyConnectedComponents<AssetId, Module>(
+        modules,
+        (m) => m.primarySource,
+        (m) => m.directDependencies
+            .map((d) => assetToModule[d])
+            .where((d) => d != null));
+    // Ensure deterministic output by sorting the modules.
+    var cleanModules = new SplayTreeSet<Module>(
+        (a, b) => a.primarySource.compareTo(b.primarySource));
+    for (var connectedComponent in connectedComponents) {
+      var cleanModule = _cleanModule(connectedComponent, assetToModule);
+      for (var source in cleanModule.sources) {
+        if (source.package == buildStep.inputId.package) {
+          cleanModules.add(cleanModule);
+          break;
+        }
+      }
+    }
+    return buildStep.writeAsString(
+        new AssetId(buildStep.inputId.package, 'lib/$metaModuleCleanExtension'),
+        json.encode(new MetaModule(cleanModules.toList())));
+  }
+}

--- a/build_modules/lib/src/module_builder.dart
+++ b/build_modules/lib/src/module_builder.dart
@@ -30,7 +30,7 @@ final _assetToPrimary = new Resource<Map<AssetId, AssetId>>(() => {},
 /// Updates dependencies from the provided [Module] so that they point to the
 /// primary resource of the dependencies corresponding [Module].
 ///
-/// Note that this will process the clean meata modules for the module
+/// Note that this will process the clean meta modules for the module
 /// dependencies if necessary.
 Future<Module> _cleanModuleDeps(
     BuildStep buildStep,

--- a/build_modules/test/meta_module_clean_builder_test.dart
+++ b/build_modules/test/meta_module_clean_builder_test.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'package:build/build.dart';
+import 'package:build_modules/src/meta_module_clean_builder.dart';
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+import 'package:build_modules/build_modules.dart';
+import 'package:build_modules/src/meta_module.dart';
+
+import 'matchers.dart';
+
+main() {
+  test('unconnected components stay disjoint', () async {
+    var assetA = new AssetId('a', 'lib/a.dart');
+    var assetB = new AssetId('b', 'lib/b.dart');
+    var moduleA = new Module(assetA, [assetA], []);
+    var moduleB = new Module(assetB, [assetB], []);
+
+    var metaA = new MetaModule([moduleA]);
+    var metaB = new MetaModule([moduleB]);
+
+    await testBuilder(new MetaModuleCleanBuilder(), {
+      'a|lib/.meta_module': json.encode(metaA),
+      'b|lib/.meta_module': json.encode(metaB),
+      'a|lib/a.dart': 'import "package:b/b.dart"',
+      'b|lib/b.dart': 'import "package:a/a.dart"',
+    }, outputs: {
+      'a|lib/.meta_module_clean': encodedMatchesMetaModule(metaA),
+      'b|lib/.meta_module_clean': encodedMatchesMetaModule(metaB),
+    });
+  });
+
+  test('can handle cycles', () async {
+    var assetA = new AssetId('a', 'lib/a.dart');
+    var assetB = new AssetId('b', 'lib/b.dart');
+    var moduleA = new Module(assetA, [assetA], [assetB]);
+    var moduleB = new Module(assetB, [assetB], [assetA]);
+
+    var metaA = new MetaModule([moduleA]);
+    var metaB = new MetaModule([moduleB]);
+    var clean = new MetaModule([
+      new Module(assetA, [assetA, assetB], [])
+    ]);
+
+    await testBuilder(new MetaModuleCleanBuilder(), {
+      'a|lib/.meta_module': json.encode(metaA),
+      'b|lib/.meta_module': json.encode(metaB),
+      'a|lib/a.dart': 'import "package:b/b.dart"',
+      'b|lib/b.dart': 'import "package:a/a.dart"',
+    }, outputs: {
+      'a|lib/.meta_module_clean': encodedMatchesMetaModule(clean),
+      'b|lib/.meta_module_clean': encodedMatchesMetaModule(clean),
+    });
+  });
+}

--- a/build_modules/test/module_builder_test.dart
+++ b/build_modules/test/module_builder_test.dart
@@ -42,7 +42,7 @@ main() {
     var moduleA = new Module(assetA, [assetA], <AssetId>[]);
     var meta = new MetaModule([moduleA]);
     await testBuilder(new ModuleBuilder(isCourse: true), {
-      'a|lib/.meta_module': json.encode(meta),
+      'a|lib/.meta_module_clean': json.encode(meta),
       'a|lib/a.dart': '',
     }, outputs: {
       'a|lib/a.module': encodedMatchesModule(moduleA),

--- a/build_modules/test/summary_builder_test.dart
+++ b/build_modules/test/summary_builder_test.dart
@@ -29,8 +29,8 @@ main() {
       ]);
       assets = {
         'build_modules|lib/src/analysis_options.default.yaml': '',
-        'a|lib/.meta_module': json.encode(ameta),
-        'b|lib/.meta_module': json.encode(bmeta),
+        'a|lib/.meta_module_clean': json.encode(ameta),
+        'b|lib/.meta_module_clean': json.encode(bmeta),
         'b|lib/b.dart': '''final world = 'world';''',
         'a|lib/a.dart': '''
         import 'package:b/b.dart';


### PR DESCRIPTION
- Introduce new MetaModuleCleanBuilder which outputs a .meta_module_clean
- This new output contains a list of cleaned modules with cyclic modules merged into one

I'm seeing even further performance benefits with this approach. Curious how it will impact the Wrike folks.

Towards https://github.com/dart-lang/build/issues/1186