### PR TITLE
Update dev_compiler_bootstrap to detect baseUrl

### DIFF
--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -314,7 +314,6 @@ var baseUrl = (function() {
   if(baseTag && baseTag[0] && baseTag[0].href){
     return baseTag[0].href;
   }
-
   var pathParts = location.pathname.split("/");
   if (pathParts[0] == "") {
     pathParts.shift();

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -310,6 +310,12 @@ final _baseUrlScript = '''
 // Attempt to detect --precompiled mode for tests, and set the base url
 // appropriately, otherwise set it to "/".
 var baseUrl = (function() {
+  if(document.getElementsByTagName("base")){
+  if(document.getElementsByTagName("base")[0]){
+  if(document.getElementsByTagName("base")[0].href){
+    return document.getElementsByTagName("base")[0].href;
+  }}}
+
   var pathParts = location.pathname.split("/");
   if (pathParts[0] == "") {
     pathParts.shift();

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -310,11 +310,10 @@ final _baseUrlScript = '''
 // Attempt to detect --precompiled mode for tests, and set the base url
 // appropriately, otherwise set it to "/".
 var baseUrl = (function() {
-  if(document.getElementsByTagName("base")){
-  if(document.getElementsByTagName("base")[0]){
-  if(document.getElementsByTagName("base")[0].href){
-    return document.getElementsByTagName("base")[0].href;
-  }}}
+  var baseTag = document.getElementsByTagName("base");
+  if(baseTag && baseTag[0] && baseTag[0].href){
+    return baseTag[0].href;
+  }
 
   var pathParts = location.pathname.split("/");
   if (pathParts[0] == "") {


### PR DESCRIPTION
Partial fix for https://github.com/dart-lang/build/issues/1087

This will attempt to detect `baseUrl` using `<base href="/">` html element.

Most angular dart apps specify base href using `<base href="/">`, so this will work for them without any issues.

Works with both `routerProviders` , `routerProvidersHash`