### PR TITLE
release build_web_compilers

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.7+2
+
+- Fix sdk stack trace folding in the browser console and package:test.
+
 # 0.3.7+1
 
 - Add missing dependency on the `pool` package.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.3.7+1
+version: 0.3.7+2
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers

--- a/e2e_example/test/test_integration_test.dart
+++ b/e2e_example/test/test_integration_test.dart
@@ -22,7 +22,7 @@ void main() {
     expect(result.stdout,
         matches(new RegExp(r'hello_world_test.dart [\d]+:[\d]+')));
     expect(result.stdout, isNot(contains('.js')));
-  }, skip: 'https://github.com/dart-lang/sdk/issues/32389');
+  });
 
   group('file edits', () {
     setUp(() async {


### PR DESCRIPTION
also stop skipping the stack trace test since it passes now, yay!