### PR TITLE
Update dev_compiler_bootstrap to detect baseUrl 

### DIFF
--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -317,8 +317,12 @@ var baseUrl = (function () {
   // base href should start with "/"
   if (typeof document !== 'undefined') {
     var el = document.getElementsByTagName('base');
-    if (el && el[0] && el[0].href && el[0].href.startsWith('/')){
-    	return el[0].href;
+    if (el && el[0] && el[0].href){
+      var a = document.createElement('a');
+      a.href=el[0].href;
+      if(a && a.pathname && a.pathname.startsWith("/")){
+        return el[0].href;
+      }
     }
   }
   // Attempt to detect --precompiled mode for tests, and set the base url

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.3.7+3
+version: 0.3.7+4
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
When base href  is `<base href="/abc/">`, 
`el[0].href` 
evaluates to 
`http://example.com/abc/`.

`el[0].href.startsWith("/")`
evaluates to,
`"http://example.com/abc/".startsWith("/")` 
evaluates to,
`false`

This will split `el[0].href` into correct pathname and implement correct checking
```js
var a = document.createElement('a');
a.href=el[0].href;
if(a && a.pathname && a.pathname.startsWith("/")){
  return el[0].href;
}
```