### PR TITLE
Run with headless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ sudo: required
 addons:
   chrome: stable
 
-# Necessary for non-headless Chrome and Firefox to run
-before_install:
- - export DISPLAY=:99.0
- - sh -e /etc/init.d/xvfb start
- - "t=0; until (xdpyinfo -display :99 &> /dev/null || test $t -gt 10); do sleep 1; let t=$t+1; done"
-
 after_failure:
  - tool/report_failure.sh
 ##################

--- a/e2e_example/dart_test.yaml
+++ b/e2e_example/dart_test.yaml
@@ -6,4 +6,4 @@ concurrency: 1
 override_platforms:
   chrome:
     settings:
-      headless: false
+      headless: true


### PR DESCRIPTION
This will speed up our E2E tests slightly since https://github.com/dart-lang/test/issues/772 is now closed.