### PR TITLE
Cleanup dart2js outputs

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 0.3.8
 
-- Remove `.dart` source files from the output directory in release mode.
+- Remove `.dart` sources and `.js.map` files from the output directory in
+  release mode.
+- Clean up `.tar.gz` outputs produced by `Dart2Js.`
+- Don't output extra `Dart2Js` outputs other than deferred part files.
 
 # 0.3.7+3
 

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -54,6 +54,9 @@ post_process_builders:
   dart2js_archive_extractor:
     import: "package:build_web_compilers/builders.dart"
     builder_factory: dart2JsArchiveExtractor
+    defaults:
+      release_options:
+        filter_outputs: true
   dart_source_cleanup:
     import: "package:build_web_compilers/builders.dart"
     builder_factory: dartSourceCleanup

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -9,8 +9,10 @@ import 'package:build_web_compilers/build_web_compilers.dart';
 Builder devCompilerBuilder(_) => const DevCompilerBuilder();
 Builder webEntrypointBuilder(BuilderOptions options) =>
     new WebEntrypointBuilder.fromOptions(options);
-PostProcessBuilder dart2JsArchiveExtractor(_) => new Dart2JsArchiveExtractor();
+PostProcessBuilder dart2JsArchiveExtractor(BuilderOptions options) =>
+    new Dart2JsArchiveExtractor.fromOptions(options);
 PostProcessBuilder dartSourceCleanup(BuilderOptions options) =>
     (options.config['enabled'] as bool ?? false)
-        ? const FileDeletingBuilder(const ['.dart'])
-        : const FileDeletingBuilder(const ['.dart'], isEnabled: false);
+        ? const FileDeletingBuilder(const ['.dart', '.js.map'])
+        : const FileDeletingBuilder(const ['.dart', '.js.map'],
+            isEnabled: false);

--- a/e2e_example/test/goldens/generated_build_script.dart
+++ b/e2e_example/test/goldens/generated_build_script.dart
@@ -69,6 +69,8 @@ final _builders = [
       defaultGenerateFor: const _i4.InputSet()),
   _i1.applyPostProcess('build_web_compilers|dart2js_archive_extractor',
       _i6.dart2JsArchiveExtractor,
+      defaultReleaseOptions:
+          new _i7.BuilderOptions(_i8.json.decode('{"filter_outputs":true}')),
       defaultGenerateFor: const _i4.InputSet())
 ];
 main(List<String> args, [_i9.SendPort sendPort]) async {


### PR DESCRIPTION
Towards #1308

- Always remove the archive file, it's an artifact of the build process
  and not a useful output.
- Add a `filter_outputs` option which is enabled by default in release
  mode and only outputs .js files, omitting .js.deps.
- Clean up `.js.map` files along with Dart sources since that is what
  they map to.