### PR TITLE
Correctly create shared modules

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2+2
+
+- Fix an issue where modules were unnecessarily being built with DDC.
+  [#1375](https://github.com/dart-lang/build/issues/1375).
+
 ## 0.2.2+1
 
 - Fix an issue with new files causing subsequent build failures

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 0.2.2+1
+version: 0.2.2+2
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_modules/test/meta_module_test.dart
+++ b/build_modules/test/meta_module_test.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
+import 'dart:convert';
 import 'package:build/build.dart';
 import 'package:build_modules/src/modules.dart';
 import 'package:build_modules/src/meta_module.dart';
@@ -45,8 +45,9 @@ void main() {
     var d = new AssetId('myapp', 'lib/src/d.dart');
 
     var expectedModules = [
-      matchesModule(new Module(b, [b, d, c], [])),
       matchesModule(new Module(a, [a], [b, c])),
+      matchesModule(new Module(b, [b], [c])),
+      matchesModule(new Module(c, [c, d], [])),
     ];
 
     var meta = await MetaModule.forAssets(reader, assets);
@@ -116,8 +117,9 @@ void main() {
     var f = new AssetId('myapp', 'lib/src/f.dart');
 
     var expectedModules = [
-      matchesModule(new Module(a, [a, c, g, f, e], [])),
+      matchesModule(new Module(a, [a, c], [g, e])),
       matchesModule(new Module(b, [b, d], [c, e, g])),
+      matchesModule(new Module(e, [e, g, f], [])),
     ];
 
     var meta = await MetaModule.forAssets(reader, assets);
@@ -208,9 +210,12 @@ void main() {
     var f = new AssetId('myapp', 'lib/src/f.dart');
 
     var expectedModules = [
-      matchesModule(new Module(a, [a, d, e, f], [])),
+      matchesModule(new Module(a, [a], [d, e, f])),
       matchesModule(new Module(b, [b], [d, e])),
       matchesModule(new Module(c, [c], [d, f])),
+      matchesModule(new Module(d, [d], [])),
+      matchesModule(new Module(e, [e], [d])),
+      matchesModule(new Module(f, [f], [d])),
     ];
 
     var meta = await MetaModule.forAssets(reader, assets);
@@ -300,8 +305,9 @@ void main() {
     var d = new AssetId('myapp', 'web/d.dart');
 
     var expectedModules = [
-      matchesModule(new Module(b, [b, d, c], [])),
       matchesModule(new Module(a, [a], [b, c])),
+      matchesModule(new Module(b, [b], [c])),
+      matchesModule(new Module(c, [c, d], [])),
     ];
 
     var meta = await MetaModule.forAssets(reader, assets);
@@ -340,7 +346,8 @@ void main() {
     var e = new AssetId('myapp', 'web/e.dart');
 
     var expectedModules = [
-      matchesModule(new Module(a, [a, b, c, d], [])),
+      matchesModule(new Module(a, [a, b], [c])),
+      matchesModule(new Module(c, [c, d], [])),
       matchesModule(new Module(e, [e], [d])),
     ];
 

--- a/build_modules/test/meta_module_test.dart
+++ b/build_modules/test/meta_module_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import 'dart:convert';
 import 'package:build/build.dart';
 import 'package:build_modules/src/modules.dart';
 import 'package:build_modules/src/meta_module.dart';

--- a/build_modules/test/meta_module_test.dart
+++ b/build_modules/test/meta_module_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'package:build/build.dart';
 import 'package:build_modules/src/modules.dart';
 import 'package:build_modules/src/meta_module.dart';


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/1375

We weren't creating a shared module for resources that were used from multiple entry points. Now create a module for those resources.