### PR TITLE
Meta module tweaks

### DIFF
--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -123,7 +123,7 @@ Module _moduleForComponent(List<_AssetNode> componentNodes) {
 Map<AssetId, Module> _entryPointModules(
         Iterable<Module> modules, Set<AssetId> entrypoints) =>
     new Map.fromIterable(
-        modules.where((m) => m.sources.intersection(entrypoints).isNotEmpty),
+        modules.where((m) => m.sources.any(entrypoints.contains)),
         key: (m) => (m as Module).primarySource);
 
 /// Gets the local (same top level dir of the same package) transitive deps of
@@ -227,7 +227,7 @@ List<Module> _mergeModules(Iterable<Module> modules, Set<AssetId> entrypoints) {
 }
 
 Module _withConsistentPrimarySource(Module m) =>
-          new Module(m.sources.reduce(_min), m.sources, m.directDependencies);
+    new Module(m.sources.reduce(_min), m.sources, m.directDependencies);
 
 T _min<T extends Comparable<T>>(T a, T b) => a.compareTo(b) < 0 ? a : b;
 

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -174,10 +174,10 @@ Map<AssetId, Set<AssetId>> _findReverseEntrypointDeps(
 ///
 ///   * If it is an entrypoint module do not merge it.
 ///   * If it is not depended on my any entrypoint do not merge it.
-///   * If it is depended on by on entrypoint merge it into the entrypoint
-///     modules
+///   * If it is depended on by no entrypoint merge it into the entrypoint
+///   modules
 ///   * Else merge it into with others that are depended on by the same set of
-///     entrypoints
+///   entrypoints
 List<Module> _mergeModules(Iterable<Module> modules, Set<AssetId> entrypoints) {
   // Modules which have any entrypoing keyed by primary source.
   var entrypointModules = _entryPointModules(modules, entrypoints);

--- a/build_modules/lib/src/modules.dart
+++ b/build_modules/lib/src/modules.dart
@@ -148,6 +148,14 @@ class Module extends Object with _$ModuleSerializerMixin {
         (m) => m.directDependencies.map((s) => transitiveDeps[s]));
     return orderedModules.map((c) => c.single).toList();
   }
+
+  /// Add all of [other]'s source and dependencies to this module and keep this
+  /// module's primary source.
+  void merge(Module other) {
+    sources.addAll(other.sources);
+    directDependencies.addAll(other.directDependencies);
+    directDependencies.removeAll(sources);
+  }
 }
 
 /// Returns whether [library] owns the module for it's strongly connected import


### PR DESCRIPTION
- Avoid `(toList()..sort()).first`, use `reduce(_min)` instead.
- Add a `merge` method to `Module` so it can be used from multiple
  places.
- Don't make copies of collections that are unreferenced later.
- Use `Iterable<Module>` where possible instead of `Set<AssetId>` or
  `Map<AssetId, Module>`
- Keep separate collections for the different varieties of modules and
  concatenate them after merging.
- Change some for loops to `map` when we care more about the collection
  than the side effects.