### PR TITLE
Update dev_compiler_bootstrap.dart

### DIFF
--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -321,7 +321,7 @@ var baseUrl = (function () {
   // base href should start with "/"
   if (typeof document !== 'undefined') {
     var el = document.getElementsByTagName('base');
-    if (el && el[0] && el[0].href && el[0].href.startsWith('/')){
+    if (el && el[0] && el[0].getAttribute("href") && el[0].getAttribute("href").startsWith("/")){
     	return el[0].href;
     }
   }


### PR DESCRIPTION
Please see the difference between `el[0].href.startsWith("/");` and `el[0].getAttribute("href").startsWith("/")`

![screenshot_2018-04-27_19-17-19](https://user-images.githubusercontent.com/8603858/39365734-a6269e7a-4a4f-11e8-8038-edfc6ab90fa6.png)
