### PR TITLE
Add excludes to FileDeletingBuilder

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.12.5
+
+- Add exclude support to `FileDeletingBuilder`.
+
 ## 0.12.4
 
-- Add `FileDeletingBuilder`
+- Add `FileDeletingBuilder`.
 - Add `PostProcesBuilderFactory` typedef.
 
 ## 0.12.3

--- a/build/lib/src/builder/file_deleting_builder.dart
+++ b/build/lib/src/builder/file_deleting_builder.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:glob/glob.dart';
+
 import 'post_process_build_step.dart';
 import 'post_process_builder.dart';
 
@@ -14,12 +16,20 @@ class FileDeletingBuilder implements PostProcessBuilder {
   final List<String> inputExtensions;
 
   final bool isEnabled;
+  final List<Glob> exclude;
 
-  const FileDeletingBuilder(this.inputExtensions, {this.isEnabled: true});
+  const FileDeletingBuilder(this.inputExtensions, {this.isEnabled: true})
+      : exclude = const [];
+
+  FileDeletingBuilder.withExcludes(
+      this.inputExtensions, Iterable<String> exclude,
+      {this.isEnabled: true})
+      : exclude = exclude?.map((s) => new Glob(s))?.toList() ?? const [];
 
   @override
   FutureOr<Null> build(PostProcessBuildStep buildStep) {
     if (!isEnabled) return null;
+    if (exclude.any((g) => g.matches(buildStep.inputId.path))) return null;
     buildStep.deletePrimaryInput();
     return null;
   }

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.12.4
+version: 0.12.5
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build


### PR DESCRIPTION
Towards #1308

Angular will want to use this builder, but will need the ability to
exclude certain files from being removed.

See discussion at https://github.com/dart-lang/angular/issues/1282