### PR TITLE
build: if there is no current Zone logger, return a default logger

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.6
+
+- `log` will now always return a `Logger` instance.
+
 ## 0.12.5
 
 - Add exclude support to `FileDeletingBuilder`.

--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -4,10 +4,12 @@ import 'package:logging/logging.dart';
 
 const Symbol logKey = #buildLog;
 
+final _default = new Logger('build.fallback');
+
 /// The log instance for the currently running BuildStep.
 ///
 /// Will be `null` when not running within a build.
-Logger get log => Zone.current[logKey] as Logger;
+Logger get log => Zone.current[logKey] as Logger ?? _default;
 
 /// Runs [fn] in an error handling [Zone].
 ///

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.12.5
+version: 0.12.6-dev
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/1377