### PR TITLE
remove build_barback dependency

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.2+3
+
+- Remove package:build_barback dependency, and use public apis from package:test
+  to directly do the bootstrapping instead of wrapping the transformer.
+
 ## 0.10.2+2
 
 - Avoid looking for files from `Uri.path` paths.
@@ -87,7 +92,7 @@ test('multiple assets, some mock, some on disk', () async {
   expect(type, isNotNull);
   expect(type.supertype.name, 'Example');
 });
-```  
+```
 
 ## 0.9.2
 
@@ -103,7 +108,7 @@ test('multiple assets, some mock, some on disk', () async {
 
 - Added the `TestBootstrapBuilder` under the `builder.dart` library. This can
   be used to bootstrap tests similar to the `test/pub_serve` Transformer.
-  - **Known Issue**: Custom html files are not supported.  
+  - **Known Issue**: Custom html files are not supported.
 - **Breaking**: All `AssetReader#findAssets` implementations now return a
   `Stream<AssetId>` to match the latest `build` package.
 - **Breaking**: The `DatedValue`, `DatedString`, and `DatedBytes` apis are now
@@ -126,7 +131,7 @@ test('multiple assets, some mock, some on disk', () async {
 - `InMemoryAssetReader`, `MultiAssetReader`, `StubAssetReader` and
   `PackageAssetReader` now implement the `MultiPackageAssetReader` interface.
 - `testBuilder` now supports `Builder`s that call `findAssets` in non-root
-  packages. 
+  packages.
 - Added a `GlobbingBuilder` which globs files in a package.
 - Added the `RecordingAssetReader` interface, which adds the
   `Iterable<AssetId> get assetsRead` getter.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.2+2
+version: 0.10.2+3
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
@@ -10,7 +10,6 @@ environment:
 dependencies:
   async: ">=1.2.0 <3.0.0"
   build: ^0.12.0
-  build_barback: ">=0.5.0+1 <0.6.0"
   build_config: ^0.2.0
   build_resolvers: ^0.2.0
   collection: ^1.14.0
@@ -22,7 +21,7 @@ dependencies:
   matcher: ^0.12.0
   package_resolver: ^1.0.2
   path: ^1.4.1
-  test: ^0.12.0
+  test: ^0.12.36
   watcher: ^0.9.7
 
 dev_dependencies:


### PR DESCRIPTION
Copy the logic from the package:test transformer instead of wrapping it, but use the public entrypoints.