### PR TITLE
Add a warning when serving with no files

### DIFF
--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -20,7 +20,6 @@ import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../generate/build.dart';
 import '../generate/build_result.dart';
-import '../generate/options.dart' show defaultRootPackageWhitelist;
 import '../logging/logging.dart';
 import '../logging/std_io_logging.dart';
 import '../package_graph/apply_builders.dart';

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -20,6 +20,7 @@ import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../generate/build.dart';
 import '../generate/build_result.dart';
+import '../generate/options.dart' show defaultRootPackageWhitelist;
 import '../logging/logging.dart';
 import '../logging/std_io_logging.dart';
 import '../package_graph/apply_builders.dart';

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -98,10 +98,9 @@ class ServeHandler implements BuildState {
   }
 
   void _warnForEmptyDirectory(String rootDir) {
-    if (_state.assetGraph
+    if (!_state.assetGraph
         .packageNodes(_rootPackage)
-        .where((n) => n.id.path.startsWith('$rootDir/'))
-        .isEmpty) {
+        .any((n) => n.id.path.startsWith('$rootDir/'))) {
       _logger.warning('Requested a server for `$rootDir` but this directory '
           'has no assets in the build. You may need to add some sources or '
           'include this directory in some target in your `build.yaml`');

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -33,7 +33,7 @@ void main() {
     assetGraph =
         await AssetGraph.build([], new Set(), new Set(), packageGraph, reader);
     watchImpl = new MockWatchImpl(
-        new FinalizedReader(reader, assetGraph), packageGraph);
+        new FinalizedReader(reader, assetGraph), packageGraph, assetGraph);
     serveHandler = await createServeHandler(watchImpl);
     watchImpl.addFutureResult(
         new Future.value(new BuildResult(BuildStatus.success, [])));
@@ -167,7 +167,7 @@ void main() {
 
 class MockWatchImpl implements WatchImpl {
   @override
-  final AssetGraph assetGraph = null;
+  final AssetGraph assetGraph;
 
   Future<BuildResult> _currentBuild;
   @override
@@ -194,7 +194,7 @@ class MockWatchImpl implements WatchImpl {
     _futureBuildResultsController.add(result);
   }
 
-  MockWatchImpl(FinalizedReader reader, this.packageGraph)
+  MockWatchImpl(FinalizedReader reader, this.packageGraph, this.assetGraph)
       : this.reader = new Future.value(reader) {
     _futureBuildResultsController.stream.listen((futureBuildResult) {
       if (_currentBuild != null) {


### PR DESCRIPTION
Closes #1091

The error message is somewhat vague because it isn't trivial to tell
_why_ a directory has no assets. We're mostly trying to make it easier
to tell that there is something wrong before getting confused that every
single request is 404ing.