### PR TITLE
Don't serve optional assets unused in the build

### DIFF
--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -19,6 +19,7 @@ import '../asset/reader.dart';
 import '../asset/writer.dart';
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
+import '../asset_graph/optional_output_tracker.dart';
 import '../environment/build_environment.dart';
 import '../environment/io_environment.dart';
 import '../environment/overridable_environment.dart';
@@ -281,8 +282,10 @@ class WatchImpl implements BuildState {
           true,
           packageGraph.root.name,
           null);
-      var finalizedReader =
-          new FinalizedReader(singleStepReader, _buildDefinition.assetGraph);
+      var finalizedReader = new FinalizedReader(
+          singleStepReader,
+          _buildDefinition.assetGraph,
+          new OptionalOutputTracker(_buildDefinition.assetGraph, buildPhases));
       _readerCompleter.complete(finalizedReader);
       _assetGraph = _buildDefinition.assetGraph;
       build = await BuildImpl.create(_buildDefinition, options, buildPhases,

--- a/build_runner/test/asset/finalized_reader_test.dart
+++ b/build_runner/test/asset/finalized_reader_test.dart
@@ -5,6 +5,7 @@
 import 'package:build_runner/src/asset/finalized_reader.dart';
 import 'package:build_runner/src/asset_graph/graph.dart';
 import 'package:build_runner/src/asset_graph/node.dart';
+import 'package:build_runner/src/asset_graph/optional_output_tracker.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -30,7 +31,8 @@ void main() {
       var delegate = new InMemoryAssetReader();
       delegate.assets.addAll({notDeleted.id: [], deleted.id: []});
 
-      reader = new FinalizedReader(delegate, graph);
+      reader = new FinalizedReader(
+          delegate, graph, new OptionalOutputTracker(graph, []));
     });
 
     test('can not read deleted files', () async {

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'package:build_runner/src/asset/finalized_reader.dart';
 import 'package:build_runner/src/asset_graph/graph.dart';
 import 'package:build_runner/src/asset_graph/node.dart';
+import 'package:build_runner/src/asset_graph/optional_output_tracker.dart';
 import 'package:build_runner/src/server/server.dart';
 
 import '../common/common.dart';
@@ -24,7 +25,8 @@ void main() {
     graph = await AssetGraph.build([], new Set(), new Set(),
         buildPackageGraph({rootPackage('foo'): []}), null);
     delegate = new InMemoryRunnerAssetReader();
-    reader = new FinalizedReader(delegate, graph);
+    reader = new FinalizedReader(
+        delegate, graph, new OptionalOutputTracker(graph, []));
     handler = new AssetHandler(reader, 'a');
   });
 

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -13,6 +13,7 @@ import 'package:build_runner/build_runner.dart';
 import 'package:build_runner/src/asset/finalized_reader.dart';
 import 'package:build_runner/src/asset_graph/graph.dart';
 import 'package:build_runner/src/asset_graph/node.dart';
+import 'package:build_runner/src/asset_graph/optional_output_tracker.dart';
 import 'package:build_runner/src/generate/build_result.dart';
 import 'package:build_runner/src/generate/performance_tracker.dart';
 import 'package:build_runner/src/generate/watch_impl.dart';
@@ -33,7 +34,10 @@ void main() {
     assetGraph =
         await AssetGraph.build([], new Set(), new Set(), packageGraph, reader);
     watchImpl = new MockWatchImpl(
-        new FinalizedReader(reader, assetGraph), packageGraph, assetGraph);
+        new FinalizedReader(
+            reader, assetGraph, new OptionalOutputTracker(assetGraph, [])),
+        packageGraph,
+        assetGraph);
     serveHandler = await createServeHandler(watchImpl);
     watchImpl.addFutureResult(
         new Future.value(new BuildResult(BuildStatus.success, [])));


### PR DESCRIPTION
Closes #1033

Use the `OptionalOutputTracker` in `FinalizedAssetReader` so the asset
handler sees these files as if they were not output.