### PR TITLE
Drop unnecessary test build scripts

### DIFF
--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -640,20 +640,6 @@ main() async {
         d.dir('web', [
           d.file('a.dart', 'void main() {}'),
         ]),
-        d.dir('tool', [
-          d.file('build.dart', '''
-import 'package:build_runner/build_runner.dart';
-import 'package:build_test/build_test.dart';
-
-main() async {
-  await build([
-    applyToRoot(new TestBuilder()),
-    applyToRoot(new TestBuilder(
-        buildExtensions: appendExtension('.copy', from: '.txt.copy'))),
-  ]);
-}
-''')
-        ]),
       ]).create();
 
       await pubGet('a');

--- a/build_runner/test/generate/serve_integration_test.dart
+++ b/build_runner/test/generate/serve_integration_test.dart
@@ -24,20 +24,6 @@ main() {
           'build_runner',
           'build_test',
         ]),
-        d.dir('tool', [
-          d.file('build.dart', '''
-import 'package:build_runner/build_runner.dart';
-import 'package:build_test/build_test.dart';
-
-main() async {
-  await build([
-    applyToRoot(new TestBuilder()),
-    applyToRoot(new TestBuilder(
-        buildExtensions: appendExtension('.copy', from: '.txt.copy'))),
-  ]);
-}
-''')
-        ]),
         d.dir('lib', [
           d.file('example.dart', "String hello = 'hello'"),
         ]),


### PR DESCRIPTION
These were erroneously added in tests that are using `pub run
build_runner`