### PR TITLE
Allow building only specified directories

### DIFF
--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -156,9 +156,7 @@ class _SharedOptions {
     @required this.builderConfigOverrides,
     @required this.isReleaseBuild,
     @required this.buildDirs,
-  }) {
-    print('\n$buildDirs\n');
-  }
+  });
 
   factory _SharedOptions.fromParsedArgs(
       ArgResults argResults, String rootPackage, Command command,

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -404,6 +404,7 @@ class _BuildCommand extends _BuildRunnerCommand {
       isReleaseBuild: options.isReleaseBuild,
       trackPerformance: options.trackPerformance,
       skipBuildScriptCheck: options.skipBuildScriptCheck,
+      buildDirs: options.buildDirs,
     );
     if (result.status == BuildStatus.success) {
       return ExitCode.success.code;
@@ -441,6 +442,7 @@ class _WatchCommand extends _BuildRunnerCommand {
       verbose: options.verbose,
       builderConfigOverrides: options.builderConfigOverrides,
       isReleaseBuild: options.isReleaseBuild,
+      buildDirs: options.buildDirs,
     );
     if (handler == null) return ExitCode.config.code;
 
@@ -495,6 +497,7 @@ class _ServeCommand extends _WatchCommand {
       verbose: options.verbose,
       builderConfigOverrides: options.builderConfigOverrides,
       isReleaseBuild: options.isReleaseBuild,
+      buildDirs: options.buildDirs,
     );
 
     if (handler == null) return ExitCode.config.code;
@@ -584,6 +587,7 @@ class _TestCommand extends _BuildRunnerCommand {
         verbose: options.verbose,
         builderConfigOverrides: options.builderConfigOverrides,
         isReleaseBuild: options.isReleaseBuild,
+        buildDirs: options.buildDirs,
       );
 
       if (result.status == BuildStatus.failure) {

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -13,6 +13,7 @@ import 'package:http_multi_server/http_multi_server.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 import 'package:shelf/shelf_io.dart';
 
 import '../asset/file_based.dart';
@@ -139,6 +140,9 @@ class _SharedOptions {
 
   final bool isReleaseBuild;
 
+  /// The directories that should be built.
+  final List<String> buildDirs;
+
   _SharedOptions._({
     @required this.assumeTty,
     @required this.deleteFilesByDefault,
@@ -151,23 +155,39 @@ class _SharedOptions {
     @required this.verbose,
     @required this.builderConfigOverrides,
     @required this.isReleaseBuild,
-  });
+    @required this.buildDirs,
+  }) {
+    print('\n$buildDirs\n');
+  }
 
   factory _SharedOptions.fromParsedArgs(
-      ArgResults argResults, String rootPackage) {
+      ArgResults argResults, String rootPackage, Command command) {
+    var outputMap = _parseOutputMap(argResults);
+    var buildDirs = _buildDirsFromOutputMap(outputMap);
+    for (var arg in argResults.rest) {
+      var parts = p.split(arg);
+      if (parts.length > 1) {
+        throw new UsageException(
+            'Only top level directories are allowed as positional args',
+            command.usage);
+      }
+      buildDirs.add(arg);
+    }
+
     return new _SharedOptions._(
       assumeTty: argResults[_assumeTty] as bool,
       deleteFilesByDefault: argResults[_deleteFilesByDefault] as bool,
       failOnSevere: argResults[_failOnSevere] as bool,
       enableLowResourcesMode: argResults[_lowResourcesMode] as bool,
       configKey: argResults[_config] as String,
-      outputMap: _parseOutputMap(argResults),
+      outputMap: outputMap,
       trackPerformance: argResults[_trackPerformance] as bool,
       skipBuildScriptCheck: argResults[_skipBuildScriptCheck] as bool,
       verbose: argResults[_verbose] as bool,
       builderConfigOverrides:
           _parseBuilderConfigOverrides(argResults[_define], rootPackage),
       isReleaseBuild: argResults[_release] as bool,
+      buildDirs: buildDirs.toList(),
     );
   }
 }
@@ -193,6 +213,7 @@ class _ServeOptions extends _SharedOptions {
     @required bool verbose,
     @required Map<String, Map<String, dynamic>> builderConfigOverrides,
     @required bool isReleaseBuild,
+    @required List<String> buildDirs,
   }) : super._(
           assumeTty: assumeTty,
           deleteFilesByDefault: deleteFilesByDefault,
@@ -205,16 +226,27 @@ class _ServeOptions extends _SharedOptions {
           verbose: verbose,
           builderConfigOverrides: builderConfigOverrides,
           isReleaseBuild: isReleaseBuild,
+          buildDirs: buildDirs,
         );
 
   factory _ServeOptions.fromParsedArgs(
-      ArgResults argResults, String rootPackage) {
+      ArgResults argResults, String rootPackage, Command command) {
     var serveTargets = <_ServeTarget>[];
     var nextDefaultPort = 8080;
     for (var arg in argResults.rest) {
       var parts = arg.split(':');
       var path = parts.first;
-      var port = parts.length == 2 ? int.parse(parts[1]) : nextDefaultPort++;
+      if (parts.length > 2) {
+        throw new UsageException(
+            'Invalid format for positional argument to serve `$arg`'
+            ', expected <directory>:<port>.',
+            command.usage);
+      }
+      var port = parts.length == 2 ? int.tryParse(parts[1]) : nextDefaultPort++;
+      if (port == null) {
+        throw new UsageException(
+            'Unable to parse port number in `$arg`', command.usage);
+      }
       serveTargets.add(new _ServeTarget(path, port));
     }
     if (serveTargets.isEmpty) {
@@ -224,6 +256,11 @@ class _ServeOptions extends _SharedOptions {
         }
       }
     }
+
+    var outputMap = _parseOutputMap(argResults);
+    var buildDirs = _buildDirsFromOutputMap(outputMap)
+      ..addAll(serveTargets.map((t) => t.dir));
+
     return new _ServeOptions._(
       hostName: argResults[_hostname] as String,
       logRequests: argResults[_logRequests] as bool,
@@ -240,6 +277,7 @@ class _ServeOptions extends _SharedOptions {
       builderConfigOverrides:
           _parseBuilderConfigOverrides(argResults[_define], rootPackage),
       isReleaseBuild: argResults[_release] as bool,
+      buildDirs: buildDirs.toList(),
     );
   }
 }
@@ -327,20 +365,9 @@ abstract class _BuildRunnerCommand extends Command<int> {
   ///
   /// You may override this to return more specific options if desired, but they
   /// must extend [_SharedOptions].
-  _SharedOptions _readOptions({bool allowExtraArgs}) {
-    _checkExtraArgs(allowExtraArgs);
+  _SharedOptions _readOptions() {
     return new _SharedOptions.fromParsedArgs(
-        argResults, packageGraph.root.name);
-  }
-
-  /// Throws a [UsageException] if not [allowExtraArgs] and there are extra
-  /// unparsed args.
-  void _checkExtraArgs(bool allowExtraArgs) {
-    allowExtraArgs ??= false;
-    if (!allowExtraArgs && argResults.rest.isNotEmpty) {
-      throw new UsageException(
-          'Unrecognized arguments: ${argResults.rest}', usage);
-    }
+        argResults, packageGraph.root.name, this);
   }
 }
 
@@ -440,8 +467,8 @@ class _ServeCommand extends _WatchCommand {
       'builds based on file system updates.';
 
   @override
-  _ServeOptions _readOptions({bool allowExtraArgs}) =>
-      new _ServeOptions.fromParsedArgs(argResults, packageGraph.root.name);
+  _ServeOptions _readOptions() => new _ServeOptions.fromParsedArgs(
+      argResults, packageGraph.root.name, this);
 
   @override
   Future<int> run() async {
@@ -532,7 +559,7 @@ class _TestCommand extends _BuildRunnerCommand {
         .toFilePath();
     try {
       _ensureBuildTestDependency(packageGraph);
-      options = _readOptions(allowExtraArgs: true);
+      options = _readOptions();
       var outputMap = options.outputMap ?? {};
       outputMap.addAll({tempPath: null});
       var result = await build(
@@ -647,6 +674,15 @@ class _CleanCommand extends Command<int> {
 
     return 0;
   }
+}
+
+Set<String> _buildDirsFromOutputMap(Map<String, String> outputMap) {
+  var dirs = new Set<String>();
+  outputMap.forEach((k, v) {
+    if (v == null) return;
+    dirs.add(v);
+  });
+  return dirs;
 }
 
 void _ensureBuildTestDependency(PackageGraph packageGraph) {

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -66,7 +66,8 @@ Future<BuildResult> build(List<BuilderApplication> builders,
         bool skipBuildScriptCheck,
         bool verbose,
         bool isReleaseBuild,
-        Map<String, Map<String, dynamic>> builderConfigOverrides}) =>
+        Map<String, Map<String, dynamic>> builderConfigOverrides,
+        List<String> buildDirs}) =>
     build_impl.build(
       builders,
       assumeTty: assumeTty,
@@ -86,6 +87,7 @@ Future<BuildResult> build(List<BuilderApplication> builders,
       verbose: verbose,
       builderConfigOverrides: builderConfigOverrides,
       isReleaseBuild: isReleaseBuild,
+      buildDirs: buildDirs,
     );
 
 /// Same as [build], except it watches the file system and re-runs builds
@@ -131,7 +133,8 @@ Future<ServeHandler> watch(List<BuilderApplication> builders,
         bool skipBuildScriptCheck,
         bool verbose,
         bool isReleaseBuild,
-        Map<String, Map<String, dynamic>> builderConfigOverrides}) =>
+        Map<String, Map<String, dynamic>> builderConfigOverrides,
+        List<String> buildDirs}) =>
     watch_impl.watch(
       builders,
       assumeTty: assumeTty,
@@ -153,4 +156,5 @@ Future<ServeHandler> watch(List<BuilderApplication> builders,
       verbose: verbose,
       builderConfigOverrides: builderConfigOverrides,
       isReleaseBuild: isReleaseBuild,
+      buildDirs: buildDirs,
     );

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -40,6 +40,7 @@ class BuildOptions {
   final Map<String, String> outputMap;
   final bool trackPerformance;
   final bool verbose;
+  final List<String> buildDirs;
 
   // Watch mode options.
   Duration debounceDelay;
@@ -47,35 +48,39 @@ class BuildOptions {
   // For testing only, skips the build script updates check.
   bool skipBuildScriptCheck;
 
-  BuildOptions._(
-      {@required this.configKey,
-      @required this.debounceDelay,
-      @required this.deleteFilesByDefault,
-      @required this.enableLowResourcesMode,
-      @required this.failOnSevere,
-      @required this.logListener,
-      @required this.outputMap,
-      @required this.packageGraph,
-      @required List<String> rootPackageFilesWhitelist,
-      @required this.skipBuildScriptCheck,
-      @required this.trackPerformance,
-      @required this.verbose})
-      : this.rootPackageFilesWhitelist =
+  BuildOptions._({
+    @required this.configKey,
+    @required this.debounceDelay,
+    @required this.deleteFilesByDefault,
+    @required this.enableLowResourcesMode,
+    @required this.failOnSevere,
+    @required this.logListener,
+    @required this.outputMap,
+    @required this.packageGraph,
+    @required List<String> rootPackageFilesWhitelist,
+    @required this.skipBuildScriptCheck,
+    @required this.trackPerformance,
+    @required this.verbose,
+    @required this.buildDirs,
+  }) : this.rootPackageFilesWhitelist =
             new UnmodifiableListView(rootPackageFilesWhitelist);
 
-  factory BuildOptions(BuildEnvironment environment,
-      {String configKey,
-      Duration debounceDelay,
-      bool deleteFilesByDefault,
-      bool enableLowResourcesMode,
-      bool failOnSevere,
-      Level logLevel,
-      Map<String, String> outputMap,
-      @required PackageGraph packageGraph,
-      BuildConfig rootPackageConfig,
-      bool skipBuildScriptCheck,
-      bool trackPerformance,
-      bool verbose}) {
+  factory BuildOptions(
+    BuildEnvironment environment, {
+    String configKey,
+    Duration debounceDelay,
+    bool deleteFilesByDefault,
+    bool enableLowResourcesMode,
+    bool failOnSevere,
+    Level logLevel,
+    Map<String, String> outputMap,
+    @required PackageGraph packageGraph,
+    BuildConfig rootPackageConfig,
+    bool skipBuildScriptCheck,
+    bool trackPerformance,
+    bool verbose,
+    List<String> buildDirs,
+  }) {
     // Set up logging
     verbose ??= false;
     logLevel ??= verbose ? Level.ALL : Level.INFO;
@@ -96,6 +101,7 @@ class BuildOptions {
     skipBuildScriptCheck ??= false;
     enableLowResourcesMode ??= false;
     trackPerformance ??= false;
+    buildDirs ??= [];
 
     var mergedWhitelist = new Set<String>();
     if (rootPackageConfig == null) {
@@ -121,6 +127,7 @@ class BuildOptions {
         rootPackageFilesWhitelist: mergedWhitelist.toList(),
         skipBuildScriptCheck: skipBuildScriptCheck,
         trackPerformance: trackPerformance,
-        verbose: verbose);
+        verbose: verbose,
+        buildDirs: buildDirs);
   }
 }

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -62,6 +62,7 @@ Future<ServeHandler> watch(
   bool verbose,
   Map<String, Map<String, dynamic>> builderConfigOverrides,
   bool isReleaseBuild,
+  List<String> buildDirs,
 }) async {
   builderConfigOverrides ??= const {};
   packageGraph ??= new PackageGraph.forThisPackage();
@@ -87,7 +88,8 @@ Future<ServeHandler> watch(
       enableLowResourcesMode: enableLowResourcesMode,
       outputMap: outputMap,
       trackPerformance: trackPerformance,
-      verbose: verbose);
+      verbose: verbose,
+      buildDirs: buildDirs);
   var terminator = new Terminator(terminateEventStream);
 
   final buildPhases = await createBuildPhases(


### PR DESCRIPTION
Work towards https://github.com/dart-lang/build/issues/539.

Sending this out before adding tests to get general agreement on the strategy first.

Specifically, this has interesting interactions with the `-o` argument, and also somewhat with the `serve` positional args. I chose to resolve these using these rules:

- If `-o` is provided with a specific output directory, add that to the list of directories to build. So for example `pbr build web -o test:build` would build both `web` and `test`, but the output directory would only contain the hoisted files from `test`.
  - The possible weird edge case here is if you do this without a specified directory for -o `pbr build web -o build` that will still only build the `web` directory, but it won't hoist it in the output directory. I think this roughly correlates to the desired behavior in that case, but it might be a little surprising for some people.
- For `serve` it is more straightforward, I simply treat the serve targets as build directories. The only real difference is in serve mode you are allowed to add a port modifier. The `-o` argument is treated the same as above, so `pbr serve web:8080 -o test:build` would build both `web` and `test`, serve `web` on 8080, and create an output directory with the hoisted `test` directory.