### PR TITLE
Improve error when a dependency is missing

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.9
+
+- Improve error message when a dependency has a bad `build.yaml` with a missing
+  dependency.
+
 ## 0.8.8
 
 - Improve search behavior on the `/$graph` page. Users can now query for

--- a/build_runner/lib/src/package_graph/apply_builders.dart
+++ b/build_runner/lib/src/package_graph/apply_builders.dart
@@ -227,6 +227,10 @@ class BuilderApplication {
 
 final _logger = new Logger('ApplyBuilders');
 
+class _MissingDependency {
+  const _MissingDependency();
+}
+
 /// Creates a [BuildPhase] to apply each builder in [builderApplications] to
 /// each target in [targetGraph] such that all builders are run for dependencies
 /// before moving on to later packages.
@@ -255,11 +259,11 @@ Future<List<BuildPhase>> createBuildPhases(
                 _logger
                     .severe('${node.target.key} declares a dependency on $key '
                         'but it does not exist');
-                throw new Exception();
+                throw const _MissingDependency();
               }
               return targetGraph.allModules[key];
             })?.where((n) => n != null));
-  } catch (_) {
+  } on _MissingDependency {
     return [];
   }
   final applyWith = _applyWith(builderApplications);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.8.8
+version: 0.8.9-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner

--- a/build_runner/test/package_graph/apply_builders_test.dart
+++ b/build_runner/test/package_graph/apply_builders_test.dart
@@ -7,6 +7,7 @@ import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
 import 'package:test/test.dart';
 
+import 'package:build_runner/src/generate/exceptions.dart';
 import 'package:build_runner/src/generate/phase.dart';
 import 'package:build_runner/src/package_graph/apply_builders.dart';
 import 'package:build_runner/src/package_graph/target_graph.dart';
@@ -97,9 +98,9 @@ void main() {
         apply('b|cool_builder', [(options) => new CoolBuilder(options)],
             toAllPackages()),
       ];
-      var phases =
-          await createBuildPhases(targetGraph, builderApplications, {}, false);
-      expect(phases, isEmpty);
+      expect(
+          () => createBuildPhases(targetGraph, builderApplications, {}, false),
+          throwsA(new isInstanceOf<CannotBuildException>()));
     });
   });
 }


### PR DESCRIPTION
Towards #1426

Instead of a stack trace we will now see:

[SEVERE] angular_tour_of_heroes:angular_tour_of_heroes declares a dependency on pageloader:pageloader but it does not exist
[SEVERE] Nothing can be built, yet a build was requested.