### PR TITLE
Catch errors parsing build.yaml

### DIFF
--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -10,6 +10,7 @@ export 'src/asset/writer.dart';
 export 'src/entrypoint/run.dart' show run;
 export 'src/generate/build.dart';
 export 'src/generate/build_result.dart';
+export 'src/generate/exceptions.dart' show CannotBuildException;
 export 'src/generate/performance_tracker.dart'
     show BuildPerformance, BuilderActionPerformance, BuildPhasePerformance;
 export 'src/package_graph/apply_builders.dart'

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -50,8 +50,14 @@ Future<Iterable<Expression>> _findBuilderApplications(String configKey) async {
     if (buildConfigOverrides.containsKey(package.name)) {
       return buildConfigOverrides[package.name];
     }
-    return BuildConfig.fromBuildConfigDir(
-        package.name, package.dependencies.map((n) => n.name), package.path);
+    try {
+      return await BuildConfig.fromBuildConfigDir(
+          package.name, package.dependencies.map((n) => n.name), package.path);
+    } catch (e) {
+      // During the build an error will be logged
+      return new BuildConfig.useDefault(
+          package.name, package.dependencies.map((n) => n.name));
+    }
   }
 
   bool _isValidDefinition(dynamic definition) {

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -53,7 +53,7 @@ Future<Iterable<Expression>> _findBuilderApplications(String configKey) async {
     try {
       return await BuildConfig.fromBuildConfigDir(
           package.name, package.dependencies.map((n) => n.name), package.path);
-    } catch (e) {
+    } on ArgumentError catch (_) {
       // During the build an error will be logged
       return new BuildConfig.useDefault(
           package.name, package.dependencies.map((n) => n.name));

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -54,7 +54,7 @@ Future<Iterable<Expression>> _findBuilderApplications(String configKey) async {
       return await BuildConfig.fromBuildConfigDir(
           package.name, package.dependencies.map((n) => n.name), package.path);
     } on ArgumentError catch (_) {
-      // During the build an error will be logged
+      // During the build an error will be logged.
       return new BuildConfig.useDefault(
           package.name, package.dependencies.map((n) => n.name));
     }

--- a/build_runner/lib/src/entrypoint/run.dart
+++ b/build_runner/lib/src/entrypoint/run.dart
@@ -8,6 +8,7 @@ import 'package:args/command_runner.dart';
 import 'package:io/ansi.dart' as ansi;
 import 'package:io/io.dart' show ExitCode;
 
+import '../generate/exceptions.dart';
 import '../package_graph/apply_builders.dart';
 import 'runner.dart';
 
@@ -26,5 +27,8 @@ Future<int> run(List<String> args, List<BuilderApplication> builders) async {
     print('');
     print(e.usage);
     return ExitCode.usage.code;
+  } on CannotBuildException {
+    // A message should have already been logged.
+    return ExitCode.config.code;
   }
 }

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -62,6 +62,7 @@ Future<ServeHandler> watch(
 }) async {
   builderConfigOverrides ??= const {};
   packageGraph ??= new PackageGraph.forThisPackage();
+
   var environment = new OverrideableEnvironment(
       new IOEnvironment(packageGraph, assumeTty),
       reader: reader,

--- a/build_runner/lib/src/package_graph/target_graph.dart
+++ b/build_runner/lib/src/package_graph/target_graph.dart
@@ -55,7 +55,7 @@ Future<BuildConfig> _packageBuildConfig(PackageNode package) async {
   try {
     return await BuildConfig.fromBuildConfigDir(
         package.name, dependencyNames, package.path);
-  } catch (e) {
+  } on ArgumentError catch (e) {
     throw new BuildConfigParseException(package.name, e);
   }
 }

--- a/build_runner/lib/src/package_graph/target_graph.dart
+++ b/build_runner/lib/src/package_graph/target_graph.dart
@@ -52,6 +52,17 @@ Future<BuildConfig> _packageBuildConfig(PackageNode package) async {
   if (package.path == null) {
     return new BuildConfig.useDefault(package.name, dependencyNames);
   }
-  return BuildConfig.fromBuildConfigDir(
-      package.name, dependencyNames, package.path);
+  try {
+    return await BuildConfig.fromBuildConfigDir(
+        package.name, dependencyNames, package.path);
+  } catch (e) {
+    throw new BuildConfigParseException(package.name, e);
+  }
+}
+
+class BuildConfigParseException {
+  final String packageName;
+  final dynamic exception;
+
+  BuildConfigParseException(this.packageName, this.exception);
 }


### PR DESCRIPTION
Towards #1426 

Instead of a stack trace the build will fail with an error message.