### PR TITLE
Refactor watch_impl

### DIFF
--- a/build_runner/lib/src/asset/finalized_reader.dart
+++ b/build_runner/lib/src/asset/finalized_reader.dart
@@ -19,6 +19,11 @@ class FinalizedReader implements AssetReader {
   final AssetGraph _assetGraph;
   final OptionalOutputTracker _optionalOutputTracker;
 
+  /// Clears the cache of which assets were required.
+  void reset() {
+    _optionalOutputTracker.reset();
+  }
+
   FinalizedReader(
       this._delegate, this._assetGraph, this._optionalOutputTracker);
 

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -9,6 +9,8 @@ import 'dart:io';
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
 import 'package:build_resolvers/build_resolvers.dart';
+import 'package:build_runner/src/asset/finalized_reader.dart';
+import 'package:build_runner/src/changes/build_script_updates.dart';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
 import 'package:logging/logging.dart';
@@ -93,29 +95,32 @@ Future<BuildResult> build(
       buildDirs: buildDirs);
   var terminator = new Terminator(terminateEventStream);
 
-  final buildPhases = await createBuildPhases(
-      targetGraph, builders, builderConfigOverrides, isReleaseBuild ?? false);
-
-  BuildResult result;
-  if (buildPhases.isEmpty) {
-    _logger.severe('Nothing can be built, yet a build was requested.');
-    result = new BuildResult(BuildStatus.failure, []);
-  } else {
-    result = await _singleBuild(environment, options, buildPhases);
-  }
+  var result = await _singleBuild(options, environment, builders,
+      builderConfigOverrides, overrideBuildConfig,
+      isReleaseBuild: isReleaseBuild ?? false);
 
   await terminator.cancel();
   await options.logListener.cancel();
   return result;
 }
 
-Future<BuildResult> _singleBuild(BuildEnvironment environment,
-    BuildOptions options, List<BuildPhase> buildPhases) async {
-  var buildDefinition =
-      await BuildDefinition.prepareWorkspace(environment, options, buildPhases);
-  var result = (await BuildImpl.create(buildDefinition, options, buildPhases))
-      .firstBuild;
-  await buildDefinition.resourceManager.beforeExit();
+Future<BuildResult> _singleBuild(
+    BuildOptions options,
+    BuildEnvironment environment,
+    List<BuilderApplication> builders,
+    Map<String, Map<String, dynamic>> builderConfigOverrides,
+    Map<String, BuildConfig> overrideBuildConfig,
+    {bool isReleaseBuild: false}) async {
+  var build = await BuildImpl.create(
+    options,
+    environment,
+    builders,
+    builderConfigOverrides,
+    overrideBuildConfig,
+  );
+  if (build == null) return new BuildResult(BuildStatus.failure, []);
+  var result = build.firstBuild;
+  await build.beforeExit();
   return result;
 }
 
@@ -123,7 +128,17 @@ class BuildImpl {
   BuildResult _firstBuild;
   BuildResult get firstBuild => _firstBuild;
 
+  FinalizedReader _finalizedReader;
+  FinalizedReader get finalizedReader => _finalizedReader;
+
   final AssetGraph _assetGraph;
+  // TODO(grouma) - do not expose the asset graph.
+  AssetGraph get assetGraph => _assetGraph;
+
+  final BuildScriptUpdates _buildScriptUpdates;
+  // TODO(grouma) - do not expose the build script updates.
+  BuildScriptUpdates get buildScriptUpdates => _buildScriptUpdates;
+
   final List<BuildPhase> _buildPhases;
   final bool _failOnSevere;
   final PackageGraph _packageGraph;
@@ -137,9 +152,12 @@ class BuildImpl {
   final BuildEnvironment _environment;
   final List<String> _buildDirs;
 
+  Future<Null> beforeExit() => _resourceManager.beforeExit();
+
   BuildImpl._(
       BuildDefinition buildDefinition, BuildOptions options, this._buildPhases)
-      : _packageGraph = buildDefinition.packageGraph,
+      : _buildScriptUpdates = buildDefinition.buildScriptUpdates,
+        _packageGraph = buildDefinition.packageGraph,
         _reader = options.enableLowResourcesMode
             ? buildDefinition.reader
             : new CachingAssetReader(buildDefinition.reader),
@@ -151,13 +169,40 @@ class BuildImpl {
         _failOnSevere = options.failOnSevere,
         _environment = buildDefinition.environment,
         _trackPerformance = options.trackPerformance,
-        _buildDirs = options.buildDirs;
+        _buildDirs = options.buildDirs {
+    var singleStepReader = new SingleStepReader(
+        buildDefinition.reader,
+        buildDefinition.assetGraph,
+        _buildPhases.length,
+        true,
+        _packageGraph.root.name,
+        null);
+    var optionalOutputTracker = new OptionalOutputTracker(
+        buildDefinition.assetGraph, options.buildDirs, _buildPhases);
+    _finalizedReader = new FinalizedReader(
+        singleStepReader, buildDefinition.assetGraph, optionalOutputTracker);
+  }
 
   Future<BuildResult> run(Map<AssetId, ChangeType> updates) =>
       new _SingleBuild(this).run(updates)..whenComplete(_resolvers.reset);
 
-  static Future<BuildImpl> create(BuildDefinition buildDefinition,
-      BuildOptions options, List<BuildPhase> buildPhases) async {
+  static Future<BuildImpl> create(
+      BuildOptions options,
+      BuildEnvironment environment,
+      List<BuilderApplication> builders,
+      Map<String, Map<String, dynamic>> builderConfigOverrides,
+      Map<String, BuildConfig> overrideBuildConfig,
+      {bool isReleaseBuild: false}) async {
+    var targetGraph = await TargetGraph.forPackageGraph(options.packageGraph,
+        overrideBuildConfig: overrideBuildConfig);
+    var buildPhases = await createBuildPhases(
+        targetGraph, builders, builderConfigOverrides, isReleaseBuild);
+    if (buildPhases.isEmpty) {
+      _logger.severe('Nothing can be built, yet a build was requested.');
+      return null;
+    }
+    var buildDefinition = await BuildDefinition.prepareWorkspace(
+        environment, options, buildPhases);
     var build = new BuildImpl._(buildDefinition, options, buildPhases);
 
     build._firstBuild = await build.run({});

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -72,7 +72,8 @@ class ServeHandler implements BuildState {
       }
       if (request.url.path.startsWith(_graphPath)) {
         var graphHandler = await _assetGraphHandler;
-        return graphHandler.handle(request.change(path: _graphPath), rootDir);
+        return await graphHandler.handle(
+            request.change(path: _graphPath), rootDir);
       }
       var assetHandler = await _assetHandler;
       return assetHandler.handle(request, rootDir);

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -67,13 +67,14 @@ a:file://fake/pkg/path
         expect(await results.hasNext, isFalse);
       });
 
-      test('returns null if no builders are specified', () async {
+      test('emits an error when no builders are specified', () async {
         var buildState = await startWatch(
           [],
           {'a|web/a.txt.copy': 'a'},
           writer,
         );
-        expect(buildState, isNull);
+        var result = await buildState.buildResults.first;
+        expect(result.status, BuildStatus.failure);
       });
 
       test('rebuilds on file updates outside hardcoded whitelist', () async {

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -38,7 +38,7 @@ void main() {
             reader, assetGraph, new OptionalOutputTracker(assetGraph, [], [])),
         packageGraph,
         assetGraph);
-    serveHandler = await createServeHandler(watchImpl);
+    serveHandler = createServeHandler(watchImpl);
     watchImpl.addFutureResult(
         new Future.value(new BuildResult(BuildStatus.success, [])));
   });
@@ -192,14 +192,13 @@ class MockWatchImpl implements WatchImpl {
   final PackageGraph packageGraph;
 
   @override
-  final Future<FinalizedReader> reader;
+  final FinalizedReader reader;
 
   void addFutureResult(Future<BuildResult> result) {
     _futureBuildResultsController.add(result);
   }
 
-  MockWatchImpl(FinalizedReader reader, this.packageGraph, this.assetGraph)
-      : this.reader = new Future.value(reader) {
+  MockWatchImpl(this.reader, this.packageGraph, this.assetGraph) {
     _futureBuildResultsController.stream.listen((futureBuildResult) {
       if (_currentBuild != null) {
         _currentBuild = _currentBuild.then((_) => futureBuildResult);
@@ -213,4 +212,7 @@ class MockWatchImpl implements WatchImpl {
       });
     });
   }
+
+  @override
+  Future<Null> get ready => new Future.value(null);
 }


### PR DESCRIPTION
More towards #1427

- Remove concept of `BuildDefinition`, `SingleStepReader` and `OptionalOutputTracker` from `watch_impl`
- Expose `AssetGraph`, `FinalizedReader` and `BuildScriptUpdates` from `build_impl`
  - Note work will be done to remove the concept of AssetGraph and BuildScriptUpdates from watch_impl
- Introduce new `ready` future on `watch_impl` which is completed when the `build_impl` is constructed and the corresponding `FinalizedReader` is created.

Follow up PRs will address the use of `TargetGraph` in `watch_impl`.