### PR TITLE
Create a build runner abstraction

### DIFF
--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -7,7 +7,6 @@ import 'dart:collection';
 import 'dart:io';
 
 import 'package:build/build.dart';
-import 'package:build_config/build_config.dart';
 import 'package:build_resolvers/build_resolvers.dart';
 import 'package:build_runner/src/asset/finalized_reader.dart';
 import 'package:build_runner/src/changes/build_script_updates.dart';
@@ -23,8 +22,6 @@ import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../asset_graph/optional_output_tracker.dart';
 import '../environment/build_environment.dart';
-import '../environment/io_environment.dart';
-import '../environment/overridable_environment.dart';
 import '../logging/build_for_input_logger.dart';
 import '../logging/human_readable_duration.dart';
 import '../logging/logging.dart';
@@ -41,95 +38,17 @@ import 'heartbeat.dart';
 import 'options.dart';
 import 'performance_tracker.dart';
 import 'phase.dart';
-import 'terminator.dart';
 
 final _logger = new Logger('Build');
 
-Future<BuildResult> build(
-  List<BuilderApplication> builders, {
-  bool deleteFilesByDefault,
-  bool failOnSevere,
-  bool assumeTty,
-  String configKey,
-  PackageGraph packageGraph,
-  RunnerAssetReader reader,
-  RunnerAssetWriter writer,
-  Level logLevel,
-  onLog(LogRecord record),
-  Stream terminateEventStream,
-  bool skipBuildScriptCheck,
-  bool enableLowResourcesMode,
-  Map<String, BuildConfig> overrideBuildConfig,
-  Map<String, String> outputMap,
-  bool trackPerformance,
-  bool verbose,
-  Map<String, Map<String, dynamic>> builderConfigOverrides,
-  bool isReleaseBuild,
-  List<String> buildDirs,
-}) async {
-  builderConfigOverrides ??= const {};
-  packageGraph ??= new PackageGraph.forThisPackage();
-  var environment = new OverrideableEnvironment(
-      new IOEnvironment(packageGraph, assumeTty, verbose: verbose),
-      reader: reader,
-      writer: writer,
-      onLog: onLog);
-  var options = await BuildOptions.create(environment,
-      configKey: configKey,
-      deleteFilesByDefault: deleteFilesByDefault,
-      failOnSevere: failOnSevere,
-      packageGraph: packageGraph,
-      overrideBuildConfig: overrideBuildConfig,
-      logLevel: logLevel,
-      skipBuildScriptCheck: skipBuildScriptCheck,
-      enableLowResourcesMode: enableLowResourcesMode,
-      outputMap: outputMap,
-      trackPerformance: trackPerformance,
-      verbose: verbose,
-      buildDirs: buildDirs);
-  var terminator = new Terminator(terminateEventStream);
-
-  var result = await _singleBuild(
-      options, environment, builders, builderConfigOverrides,
-      isReleaseBuild: isReleaseBuild ?? false);
-
-  await terminator.cancel();
-  await options.logListener.cancel();
-  return result;
-}
-
-Future<BuildResult> _singleBuild(
-    BuildOptions options,
-    BuildEnvironment environment,
-    List<BuilderApplication> builders,
-    Map<String, Map<String, dynamic>> builderConfigOverrides,
-    {bool isReleaseBuild: false}) async {
-  var build = await BuildImpl.create(
-    options,
-    environment,
-    builders,
-    builderConfigOverrides,
-    isReleaseBuild: isReleaseBuild,
-  );
-  if (build == null) return new BuildResult(BuildStatus.failure, []);
-  var result = build.firstBuild;
-  await build.beforeExit();
-  return result;
-}
-
 class BuildImpl {
-  BuildResult _firstBuild;
-  BuildResult get firstBuild => _firstBuild;
-
   final FinalizedReader _finalizedReader;
   FinalizedReader get finalizedReader => _finalizedReader;
 
   final AssetGraph _assetGraph;
-  // TODO(grouma) - do not expose the asset graph.
   AssetGraph get assetGraph => _assetGraph;
 
   final BuildScriptUpdates _buildScriptUpdates;
-  // TODO(grouma) - do not expose the build script updates.
   BuildScriptUpdates get buildScriptUpdates => _buildScriptUpdates;
 
   final List<BuildPhase> _buildPhases;
@@ -194,7 +113,6 @@ class BuildImpl {
         singleStepReader, buildDefinition.assetGraph, optionalOutputTracker);
     var build =
         new BuildImpl._(buildDefinition, options, buildPhases, finalizedReader);
-    build._firstBuild = await build.run({});
     return build;
   }
 }

--- a/build_runner/lib/src/generate/build_runner.dart
+++ b/build_runner/lib/src/generate/build_runner.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:watcher/watcher.dart';
+
+import '../environment/build_environment.dart';
+import '../package_graph/apply_builders.dart';
+import 'build_impl.dart';
+import 'build_result.dart';
+import 'options.dart';
+
+class BuildRunner {
+  final BuildImpl _build;
+  BuildRunner._(this._build);
+
+  Future<Null> beforeExit() => _build.beforeExit();
+
+  Future<BuildResult> run(Map<AssetId, ChangeType> updates) =>
+      _build.run(updates);
+
+  static Future<BuildRunner> create(
+      BuildOptions options,
+      BuildEnvironment environment,
+      List<BuilderApplication> builders,
+      Map<String, Map<String, dynamic>> builderConfigOverrides,
+      {bool isReleaseBuild: false}) async {
+    var build = await BuildImpl.create(
+        options, environment, builders, builderConfigOverrides,
+        isReleaseBuild: isReleaseBuild);
+    return build == null ? null : new BuildRunner._(build);
+  }
+}

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -302,21 +302,19 @@ class WatchImpl implements BuildState {
           options, watcherEnvironment, builders, builderConfigOverrides,
           isReleaseBuild: isReleaseMode);
 
-      _reader = _build?.finalizedReader;
-      _readyCompleter.complete(null);
-
+      BuildResult firstBuild;
       if (_build == null) {
-        var result = new BuildResult(BuildStatus.failure, []);
-        controller.add(result);
-        firstBuildCompleter.complete(result);
-        return;
+        firstBuild = new BuildResult(BuildStatus.failure, []);
+      } else {
+        firstBuild = await _build.run({});
       }
 
+      _reader = _build?.finalizedReader;
+      _readyCompleter.complete(null);
       // It is possible this is already closed if the user kills the process
       // early, which results in an exception without this check.
-      if (!controller.isClosed) controller.add(_build.firstBuild);
-
-      firstBuildCompleter.complete(_build.firstBuild);
+      if (!controller.isClosed) controller.add(firstBuild);
+      firstBuildCompleter.complete(firstBuild);
     }();
 
     return controller.stream;


### PR DESCRIPTION
- Create new `BuildRunner` abstraction which will be exposed from `build_runner_core`
  - Note this abstraction is a simple wrapper around `BuildImpl` which exposes less details e.g. `AssetGraph`
- Change `BuildImpl` to not automatically do a first build
- Update `WatchImpl` to now manually initiate the first build
- Update `generate/build.dart` to now use `BuildRunner` instead of `BuildImpl`
- Update `test_phases` to now use `BuildRunner` API