### PR TITLE
Refactor directory factory

### DIFF
--- a/build_runner/lib/src/environment/build_environment.dart
+++ b/build_runner/lib/src/environment/build_environment.dart
@@ -8,7 +8,6 @@ import 'package:logging/logging.dart';
 
 import '../asset/reader.dart';
 import '../asset/writer.dart';
-import '../generate/directory_watcher_factory.dart';
 
 /// Utilities to interact with the environment in which a build is running.
 ///
@@ -19,7 +18,6 @@ import '../generate/directory_watcher_factory.dart';
 abstract class BuildEnvironment {
   RunnerAssetReader get reader;
   RunnerAssetWriter get writer;
-  DirectoryWatcherFactory get directoryWatcherFactory;
 
   void onLog(LogRecord record);
 

--- a/build_runner/lib/src/environment/io_environment.dart
+++ b/build_runner/lib/src/environment/io_environment.dart
@@ -11,7 +11,6 @@ import 'package:logging/logging.dart';
 import '../asset/file_based.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
-import '../generate/directory_watcher_factory.dart';
 import '../logging/std_io_logging.dart';
 import '../package_graph/package_graph.dart';
 import 'build_environment.dart';
@@ -24,9 +23,6 @@ class IOEnvironment implements BuildEnvironment {
   @override
   final RunnerAssetWriter writer;
 
-  @override
-  final DirectoryWatcherFactory directoryWatcherFactory;
-
   final bool _isInteractive;
   final bool _assumeTty;
   final bool _verbose;
@@ -36,8 +32,7 @@ class IOEnvironment implements BuildEnvironment {
         _assumeTty = assumeTty,
         _verbose = verbose ?? false,
         reader = new FileBasedAssetReader(packageGraph),
-        writer = new FileBasedAssetWriter(packageGraph),
-        directoryWatcherFactory = defaultDirectoryWatcherFactory;
+        writer = new FileBasedAssetWriter(packageGraph);
 
   @override
   void onLog(LogRecord record) {

--- a/build_runner/lib/src/environment/overridable_environment.dart
+++ b/build_runner/lib/src/environment/overridable_environment.dart
@@ -8,7 +8,6 @@ import 'package:logging/logging.dart';
 
 import '../asset/reader.dart';
 import '../asset/writer.dart';
-import '../generate/directory_watcher_factory.dart';
 import 'build_environment.dart';
 
 /// A [BuildEnvironment] which can have individual features overridden.
@@ -17,7 +16,6 @@ class OverrideableEnvironment implements BuildEnvironment {
 
   final RunnerAssetReader _reader;
   final RunnerAssetWriter _writer;
-  final DirectoryWatcherFactory _directoryWatcherFactory;
 
   final void Function(LogRecord) _onLog;
 
@@ -25,11 +23,9 @@ class OverrideableEnvironment implements BuildEnvironment {
     this._default, {
     RunnerAssetReader reader,
     RunnerAssetWriter writer,
-    DirectoryWatcherFactory directoryWatcherFactory,
     void Function(LogRecord) onLog,
   })  : _reader = reader,
         _writer = writer,
-        _directoryWatcherFactory = directoryWatcherFactory,
         _onLog = onLog;
 
   @override

--- a/build_runner/lib/src/environment/overridable_environment.dart
+++ b/build_runner/lib/src/environment/overridable_environment.dart
@@ -39,10 +39,6 @@ class OverrideableEnvironment implements BuildEnvironment {
   RunnerAssetWriter get writer => _writer ?? _default.writer;
 
   @override
-  DirectoryWatcherFactory get directoryWatcherFactory =>
-      _directoryWatcherFactory ?? _default.directoryWatcherFactory;
-
-  @override
   void onLog(LogRecord record) {
     if (_onLog != null) {
       _onLog(record);

--- a/build_runner/test/common/test_environment.dart
+++ b/build_runner/test/common/test_environment.dart
@@ -9,7 +9,6 @@ import 'package:logging/logging.dart';
 import 'package:build_runner/src/asset/reader.dart';
 import 'package:build_runner/src/asset/writer.dart';
 import 'package:build_runner/src/environment/build_environment.dart';
-import 'package:build_runner/src/generate/directory_watcher_factory.dart';
 
 import 'common.dart';
 
@@ -26,9 +25,6 @@ class TestBuildEnvironment implements BuildEnvironment {
   final RunnerAssetReader reader;
   @override
   final RunnerAssetWriter writer;
-  @override
-  DirectoryWatcherFactory get directoryWatcherFactory =>
-      (path) => new FakeWatcher(path);
 
   /// If true, this will throw a [NonInteractiveBuildException] for all calls to
   /// [prompt].


### PR DESCRIPTION
More towards #1427

- Remove environment dependency on `directory_watcher_factory` as the environment classes will be moved to `build_runner_core`.