### PR TITLE
Refactor override configs

### DIFF
--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -9,6 +9,7 @@ import 'package:build_runner/src/environment/io_environment.dart';
 import 'package:build_runner/src/environment/overridable_environment.dart';
 import 'package:build_runner/src/generate/options.dart';
 import 'package:build_runner/src/generate/terminator.dart';
+import 'package:build_runner/src/package_graph/build_config_overrides.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 
@@ -80,12 +81,13 @@ Future<BuildResult> build(List<BuilderApplication> builders,
       writer: writer,
       onLog: onLog);
   var options = await BuildOptions.create(environment,
-      configKey: configKey,
       deleteFilesByDefault: deleteFilesByDefault,
       failOnSevere: failOnSevere,
       packageGraph: packageGraph,
       logLevel: logLevel,
       skipBuildScriptCheck: skipBuildScriptCheck,
+      overrideBuildConfig:
+          await findBuildConfigOverrides(packageGraph, configKey),
       enableLowResourcesMode: enableLowResourcesMode,
       outputMap: outputMap,
       trackPerformance: trackPerformance,

--- a/build_runner/lib/src/generate/options.dart
+++ b/build_runner/lib/src/generate/options.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:build_config/build_config.dart';
-import 'package:build_runner/src/package_graph/build_config_overrides.dart';
 import 'package:build_runner/src/package_graph/target_graph.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
@@ -36,7 +35,6 @@ class BuildOptions {
   final PackageGraph packageGraph;
   final List<String> rootPackageFilesWhitelist;
 
-  final String configKey; // May be null.
   final bool deleteFilesByDefault;
   final bool enableLowResourcesMode;
   final bool failOnSevere;
@@ -53,7 +51,6 @@ class BuildOptions {
   bool skipBuildScriptCheck;
 
   BuildOptions._({
-    @required this.configKey,
     @required this.debounceDelay,
     @required this.deleteFilesByDefault,
     @required this.enableLowResourcesMode,
@@ -72,7 +69,6 @@ class BuildOptions {
 
   static Future<BuildOptions> create(
     BuildEnvironment environment, {
-    String configKey,
     Duration debounceDelay,
     bool deleteFilesByDefault,
     bool enableLowResourcesMode,
@@ -97,8 +93,6 @@ class BuildOptions {
 
     Logger.root.level = logLevel;
 
-    overrideBuildConfig ??=
-        await findBuildConfigOverrides(packageGraph, configKey);
     TargetGraph targetGraph;
     try {
       targetGraph = await TargetGraph.forPackageGraph(packageGraph,
@@ -137,7 +131,6 @@ class BuildOptions {
       }
     }
     return new BuildOptions._(
-        configKey: configKey,
         debounceDelay: debounceDelay,
         deleteFilesByDefault: deleteFilesByDefault,
         enableLowResourcesMode: enableLowResourcesMode,

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -70,7 +70,7 @@ Future<ServeHandler> watch(
       reader: reader,
       writer: writer,
       onLog: onLog);
-  overrideBuildConfig ??
+  overrideBuildConfig ??=
       await findBuildConfigOverrides(packageGraph, configKey);
   var options = await BuildOptions.create(environment,
       deleteFilesByDefault: deleteFilesByDefault,

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -10,6 +10,7 @@ import 'package:build_runner/src/asset/finalized_reader.dart';
 import 'package:build_runner/src/watcher/asset_change.dart';
 import 'package:build_runner/src/watcher/graph_watcher.dart';
 import 'package:build_runner/src/watcher/node_watcher.dart';
+import 'package:build_runner/src/package_graph/build_config_overrides.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
@@ -69,8 +70,9 @@ Future<ServeHandler> watch(
       reader: reader,
       writer: writer,
       onLog: onLog);
+  overrideBuildConfig ??
+      await findBuildConfigOverrides(packageGraph, configKey);
   var options = await BuildOptions.create(environment,
-      configKey: configKey,
       deleteFilesByDefault: deleteFilesByDefault,
       failOnSevere: failOnSevere,
       packageGraph: packageGraph,
@@ -86,7 +88,7 @@ Future<ServeHandler> watch(
   var terminator = new Terminator(terminateEventStream);
 
   var watch = _runWatch(options, environment, builders, builderConfigOverrides,
-      terminator.shouldTerminate, directoryWatcherFactory,
+      terminator.shouldTerminate, directoryWatcherFactory, configKey,
       isReleaseMode: isReleaseBuild ?? false);
 
   // ignore: unawaited_futures
@@ -113,6 +115,7 @@ WatchImpl _runWatch(
         Map<String, Map<String, dynamic>> builderConfigOverrides,
         Future until,
         DirectoryWatcherFactory directoryWatcherFactory,
+        String configKey,
         {bool isReleaseMode: false}) =>
     new WatchImpl(
         options,
@@ -121,6 +124,7 @@ WatchImpl _runWatch(
         builderConfigOverrides,
         until,
         directoryWatcherFactory,
+        configKey,
         options.rootPackageFilesWhitelist.map((g) => new Glob(g)),
         isReleaseMode: isReleaseMode);
 
@@ -187,10 +191,10 @@ class WatchImpl implements BuildState {
       Map<String, Map<String, dynamic>> builderConfigOverrides,
       Future until,
       this._directoryWatcherFactory,
+      this._configKey,
       this._rootPackageFilesWhitelist,
       {bool isReleaseMode: false})
-      : _configKey = options.configKey,
-        _debounceDelay = options.debounceDelay,
+      : _debounceDelay = options.debounceDelay,
         packageGraph = options.packageGraph {
     buildResults = _run(
             options, environment, builders, builderConfigOverrides, until,


### PR DESCRIPTION
More towards #1427

`findBuildConfigOverrides` has a dependency on `watcher`. Refactor it out of `options`.