### PR TITLE
Refactor IOEnvironment

### DIFF
--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -54,7 +54,7 @@ Future<Null> main(List<String> args) async {
 
   StreamSubscription logListener;
   if (commandName != _generateCommand) {
-    logListener = Logger.root.onRecord.listen(stdIOLogListener);
+    logListener = Logger.root.onRecord.listen(stdIOLogListener());
   }
   var buildScript = await generateBuildScript();
   var scriptFile = new File(scriptLocation)..createSync(recursive: true);

--- a/build_runner/lib/src/entrypoint/clean.dart
+++ b/build_runner/lib/src/entrypoint/clean.dart
@@ -29,7 +29,7 @@ class CleanCommand extends Command<int> {
 
   @override
   Future<int> run() async {
-    var logSubscription = Logger.root.onRecord.listen(stdIOLogListener);
+    var logSubscription = Logger.root.onRecord.listen(stdIOLogListener());
 
     logger.warning('Deleting cache and generated source files.\n'
         'This shouldn\'t be necessary for most applications, unless you have '

--- a/build_runner/lib/src/environment/io_environment.dart
+++ b/build_runner/lib/src/environment/io_environment.dart
@@ -5,13 +5,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
 
 import '../asset/file_based.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
-import '../logging/std_io_logging.dart';
 import '../package_graph/package_graph.dart';
 import 'build_environment.dart';
 
@@ -24,21 +22,19 @@ class IOEnvironment implements BuildEnvironment {
   final RunnerAssetWriter writer;
 
   final bool _isInteractive;
-  final bool _assumeTty;
-  final bool _verbose;
 
-  IOEnvironment(PackageGraph packageGraph, bool assumeTty, {bool verbose})
+  IOEnvironment(PackageGraph packageGraph, bool assumeTty)
       : _isInteractive = assumeTty == true || _canPrompt(),
-        _assumeTty = assumeTty,
-        _verbose = verbose ?? false,
         reader = new FileBasedAssetReader(packageGraph),
         writer = new FileBasedAssetWriter(packageGraph);
 
   @override
   void onLog(LogRecord record) {
-    overrideAnsiOutput(_assumeTty == true || ansiOutputEnabled, () {
-      stdIOLogListener(record, verbose: _verbose);
-    });
+    if (record.level >= Level.SEVERE) {
+      stderr.writeln(record);
+    } else {
+      stdout.writeln(record);
+    }
   }
 
   @override

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -14,6 +14,7 @@ import 'package:shelf/shelf.dart';
 
 import '../asset/reader.dart';
 import '../asset/writer.dart';
+import '../logging/std_io_logging.dart';
 import '../package_graph/apply_builders.dart';
 import '../package_graph/package_graph.dart';
 import '../server/server.dart';
@@ -75,10 +76,10 @@ Future<BuildResult> build(List<BuilderApplication> builders,
   builderConfigOverrides ??= const {};
   packageGraph ??= new PackageGraph.forThisPackage();
   var environment = new OverrideableEnvironment(
-      new IOEnvironment(packageGraph, assumeTty, verbose: verbose),
+      new IOEnvironment(packageGraph, assumeTty),
       reader: reader,
       writer: writer,
-      onLog: onLog);
+      onLog: onLog ?? stdIOLogListener(assumeTty: assumeTty, verbose: verbose));
   var options = await BuildOptions.create(environment,
       configKey: configKey,
       deleteFilesByDefault: deleteFilesByDefault,

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -9,8 +9,12 @@ import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
 import 'package:stack_trace/stack_trace.dart';
 
-void stdIOLogListener(LogRecord record, {bool verbose}) {
-  verbose ??= false;
+Function(LogRecord) stdIOLogListener({bool assumeTty, bool verbose}) =>
+    (record) => overrideAnsiOutput(assumeTty == true || ansiOutputEnabled, () {
+          _stdIOLogListener(record, verbose: verbose ?? false);
+        });
+
+void _stdIOLogListener(LogRecord record, {bool verbose}) {
   AnsiCode color;
   if (record.level < Level.WARNING) {
     color = cyan;

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -9,6 +9,7 @@ import 'package:build_runner/src/environment/io_environment.dart';
 import 'package:build_runner/src/environment/overridable_environment.dart';
 import 'package:build_runner/src/generate/build_result.dart';
 import 'package:build_runner/src/generate/options.dart';
+import 'package:build_runner/src/logging/std_io_logging.dart';
 import 'package:build_runner/src/package_graph/apply_builders.dart';
 import 'package:build_runner/src/package_graph/package_graph.dart';
 import 'package:logging/logging.dart';
@@ -110,10 +111,10 @@ Future<BuildResult> testBuilders(
 
   builderConfigOverrides ??= const {};
   var environment = new OverrideableEnvironment(
-      new IOEnvironment(packageGraph, null, verbose: verbose),
+      new IOEnvironment(packageGraph, null),
       reader: reader,
       writer: writer,
-      onLog: onLog);
+      onLog: onLog ?? stdIOLogListener(verbose: verbose));
   var options = await BuildOptions.create(environment,
       deleteFilesByDefault: deleteFilesByDefault,
       failOnSevere: failOnSevere,


### PR DESCRIPTION
More towards #1427

- Remove `stdIOLogListener` from  `io_environment.dart` as this will be moved into `build_runner_core` and we don't want to depend on `package:io`.