### PR TITLE
Include builderLabels in duplicate asset exception

### DIFF
--- a/build_runner/lib/src/asset_graph/exceptions.dart
+++ b/build_runner/lib/src/asset_graph/exceptions.dart
@@ -2,17 +2,25 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'node.dart';
+import 'package:build/build.dart';
 
 class DuplicateAssetNodeException implements Exception {
-  final AssetNode assetNode;
+  final String rootPackage;
+  final AssetId assetId;
+  final String initialBuilderLabel;
+  final String newBuilderLabel;
 
-  DuplicateAssetNodeException(this.assetNode);
-
+  DuplicateAssetNodeException(this.rootPackage, this.assetId,
+      this.initialBuilderLabel, this.newBuilderLabel);
   @override
-  String toString() => 'DuplicateAssetNodeError: $assetNode\n'
-      'This probably means you have multiple actions that are trying to output '
-      'the same file.';
+  String toString() {
+    final friendlyAsset =
+        assetId.package == rootPackage ? assetId.path : assetId.uri;
+    return 'Both $initialBuilderLabel and $newBuilderLabel may output '
+        '$friendlyAsset. Potential outputs must be unique across all builders. '
+        'See https://github.com/dart-lang/build/blob/master/docs/faq.md'
+        '#why-do-builders-need-unique-outputs';
+  }
 }
 
 class AssetGraphVersionException implements Exception {

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -104,8 +104,8 @@ class _Loader {
         try {
           assetGraph = await AssetGraph.build(_buildPhases, inputSources,
               internalSources, _options.packageGraph, _environment.reader);
-        } on DuplicateAssetNodeException catch (e) {
-          _logger.severe('$e');
+        } on DuplicateAssetNodeException catch (e, st) {
+          _logger.severe('Conflicting outputs', e, st);
           throw new CannotBuildException();
         }
         buildScriptUpdates = await BuildScriptUpdates.create(

--- a/build_runner/lib/src/generate/build_definition.dart
+++ b/build_runner/lib/src/generate/build_definition.dart
@@ -101,8 +101,13 @@ class _Loader {
       Set<AssetId> conflictingOutputs;
 
       await logTimedAsync(_logger, 'Building new asset graph', () async {
-        assetGraph = await AssetGraph.build(_buildPhases, inputSources,
-            internalSources, _options.packageGraph, _environment.reader);
+        try {
+          assetGraph = await AssetGraph.build(_buildPhases, inputSources,
+              internalSources, _options.packageGraph, _environment.reader);
+        } on DuplicateAssetNodeException catch (e) {
+          _logger.severe('$e');
+          throw new CannotBuildException();
+        }
         buildScriptUpdates = await BuildScriptUpdates.create(
             _environment.reader, _options.packageGraph, assetGraph);
         conflictingOutputs = assetGraph.outputs

--- a/build_runner/lib/src/generate/build_impl.dart
+++ b/build_runner/lib/src/generate/build_impl.dart
@@ -267,7 +267,6 @@ class _SingleBuild {
 
       if (!done.isCompleted) done.complete(result);
     }, onError: (e, StackTrace st) {
-      log.severe('$e');
       if (!done.isCompleted) {
         done.complete(new BuildResult(BuildStatus.failure, [],
             exception: e, stackTrace: st));

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,15 @@
+## Why do Builders need unique outputs?
+
+`build_runner` relies on determining a static build graph before starting a
+build - it needs to know every file that may be written and which Builder would
+write it. If multiple builders are configured to (possibly) output the same file
+you can:
+
+- Add a `generate_for` configuration for one or both Builders so they do not
+  both operate on the same primary input.
+- Disable one of the Builders if it is unneeded.
+- Contact the author of the Builder and ask that a more unique output extension
+  is chosen.
+- Contact the author of the Builder and ask that a more unique input extension
+  is chose, for example only generating for files that end in `_something.dart`
+  rather than all files that end in `.dart`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 `build_runner` relies on determining a static build graph before starting a
 build - it needs to know every file that may be written and which Builder would
-write it. If multiple builders are configured to (possibly) output the same file
+write it. If multiple Builders are configured to (possibly) output the same file
 you can:
 
 - Add a `generate_for` configuration for one or both Builders so they do not


### PR DESCRIPTION
Closes #1273
Start towards #1431

- Pass through the `BuildPhase`s and `rootPackage` so that the builder
  labels and a friendlier string for the AssetId can be used.
- Catch and log the duplicate asset exception when it occurs while
  loading the build definition. Throw a `CannotBuildException` to cancel
  the overall build without printing a stack trace.
- Add an FAQ section for this problem.
- Catch all exceptions from updating the asset graph when they occur
  during the build.