### PR TITLE
Log a more actionable message for output conflicts

### DIFF
--- a/build_runner/lib/src/generate/exceptions.dart
+++ b/build_runner/lib/src/generate/exceptions.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:build/build.dart';
 import 'package:build_runner/src/generate/phase.dart';
 
 import 'phase.dart';

--- a/build_runner/lib/src/generate/exceptions.dart
+++ b/build_runner/lib/src/generate/exceptions.dart
@@ -11,19 +11,6 @@ abstract class FatalBuildException implements Exception {
   const FatalBuildException();
 }
 
-class UnexpectedExistingOutputsException extends FatalBuildException {
-  final Set<AssetId> conflictingOutputs;
-
-  const UnexpectedExistingOutputsException(this.conflictingOutputs);
-
-  @override
-  String toString() => 'UnexpectedExistingOutputsException: Either you opted '
-      'not to delete existing files, or you are not running in interactive '
-      'mode and did not specify `deleteFilesByDefault` as `true`.\n\n'
-      'Found ${conflictingOutputs.length} outputs already on disk:\n\n'
-      '${conflictingOutputs.join('\n')}\n';
-}
-
 class InvalidBuildPhaseException extends FatalBuildException {
   final String _reason;
 

--- a/build_runner/test/generate/build_error_test.dart
+++ b/build_runner/test/generate/build_error_test.dart
@@ -27,7 +27,7 @@ void main() {
         packageGraph: buildPackageGraph({rootPackage('a'): []}),
         deleteFilesByDefault: false,
       ),
-      throwsA(const isInstanceOf<UnexpectedExistingOutputsException>()),
+      throwsA(const isInstanceOf<CannotBuildException>()),
     );
   });
 

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -501,8 +501,8 @@ main() async {
           reason: 'build should fail due to conflicting outputs');
       expect(
           result.stderr,
-          allOf(contains('Found 1 outputs already on disk'),
-              contains('a|web/a.txt.copy.copy')));
+          allOf(contains('Conflicting outputs'),
+              contains('web/a.txt.copy.copy')));
     });
 
     test('Missing build_test dependency reports the right error', () async {


### PR DESCRIPTION
Closes #1434

Instead of a stack trace and an apparent bug in the build system this
gives a different and more actionable message for each of the cases
where we will be unable to build over conflicting sources.