### PR TITLE
build_runner: add type annotation to `_builders` field in build script

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -8,7 +8,7 @@ import 'package:build/build.dart' as _i7;
 import 'dart:convert' as _i8;
 import 'dart:isolate' as _i9;
 
-final _builders = [
+final _builders = <_i1.BuilderApplication>[
   _i1.apply('provides_builder|some_not_applied_builder', [_i2.notApplied],
       _i1.toNoneByDefault(),
       hideOutput: true),

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -27,8 +27,15 @@ Future<String> generateBuildScript([String configKey]) => logTimedAsync(
 
 Future<String> _generateBuildScript(String configKey) async {
   final builders = await _findBuilderApplications(configKey);
-  final library = new Library((b) => b.body.addAll(
-      [literalList(builders).assignFinal('_builders').statement, _main()]));
+  final library = new Library((b) => b.body.addAll([
+        literalList(
+                builders,
+                refer('BuilderApplication',
+                    'package:build_runner/build_runner.dart'))
+            .assignFinal('_builders')
+            .statement,
+        _main()
+      ]));
   final emitter = new DartEmitter(new Allocator.simplePrefixing());
   return new DartFormatter().format('${library.accept(emitter)}');
 }


### PR DESCRIPTION
Fixes Dart 2 error when this List is empty and the type cannot be
inferred