### PR TITLE
fix dart2js args cast error in dart 2

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+2
+
+- Fix a dart2 error.
+
 ## 0.4.0+1
 
 - Support `package:analyzer` `0.32.0`.

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -78,7 +78,7 @@ class WebEntrypointBuilder implements Builder {
     }
 
     var dart2JsArgs =
-        options.config[_dart2jsArgs].cast<String>() ?? const <String>[];
+        options.config[_dart2jsArgs]?.cast<String>() ?? const <String>[];
     if (dart2JsArgs is! List<String>) {
       throw new ArgumentError.value(dart2JsArgs, _dart2jsArgs,
           'Expected a list of strings, but got a ${dart2JsArgs.runtimeType}:');

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -77,7 +77,8 @@ class WebEntrypointBuilder implements Builder {
             'Only `dartdevc` and `dart2js` are supported.');
     }
 
-    var dart2JsArgs = options.config[_dart2jsArgs] ?? const <String>[];
+    var dart2JsArgs =
+        options.config[_dart2jsArgs].cast<String>() ?? const <String>[];
     if (dart2JsArgs is! List<String>) {
       throw new ArgumentError.value(dart2JsArgs, _dart2jsArgs,
           'Expected a list of strings, but got a ${dart2JsArgs.runtimeType}:');

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.4.0+1
+version: 0.4.0+2
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
After this the _test package can now build/serve web apps with --preview-dart-2!

Fixes https://github.com/dart-lang/build/issues/1487