### PR TITLE
Use the latest build_config from build_runner

### DIFF
--- a/_test_common/pubspec.yaml
+++ b/_test_common/pubspec.yaml
@@ -1,4 +1,4 @@
-name: _test_common 
+name: _test_common
 version: 0.1.0
 description: Test infra for writing build tests. Is not published.
 author: Dart Team <misc@dartlang.org>
@@ -8,8 +8,17 @@ environment:
 
 dependencies:
   build: any
-  build_config: any 
-  build_runner:
-    path: ../build_runner 
+  build_config: any
+  build_runner: any
   build_test: any
   test_descriptor: ^1.0.0
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_config:
+    path: ../build_config
+  build_runner:
+    path: ../build_runner
+  build_test:
+    path: ../build_test

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.3.0-dev
+
+- Parsing of `build.yaml` files is now done with the `json_serializable` package
+  and is Dart 2 compatible.
+
+  - The error reporting will be a bit different, but generally should be better,
+    and will include the yaml spans of the problem sections.
+
+### Breaking Changes
+
+- The Constructors for most of the build config classes other than `BuildConfig`
+  itself now have to be ran inside a build config zone, which can be done using
+  the `runInBuildConfigZone` function. This gives the context about what package
+  is currently being parsed, as well as what the default dependencies should be
+  for targets.
+- Many constructor signatures have changed, for the most part removing the
+  `package` parameter (it is now read off the zone).
+
 ## 0.2.6+2
 
 - Restore error for missing default target.

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Breaking Changes
 
+There are no changes to the `build.yaml` format, the following changes only
+affect the imperative apis of this package.
+
 - The Constructors for most of the build config classes other than `BuildConfig`
   itself now have to be ran inside a build config zone, which can be done using
   the `runInBuildConfigZone` function. This gives the context about what package

--- a/build_config/lib/build_config.dart
+++ b/build_config/lib/build_config.dart
@@ -11,6 +11,7 @@ export 'src/builder_definition.dart'
         BuildTo,
         PostProcessBuilderDefinition,
         TargetBuilderConfigDefaults;
+export 'src/common.dart' show runInBuildConfigZone;
 export 'src/input_set.dart' show InputSet;
 export 'src/key_normalization.dart'
     show normalizeBuilderKeyUsage, normalizeTargetKeyUsage;

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -68,17 +68,19 @@ class BuildConfig {
   /// The default config if you have no `build.yaml` file.
   factory BuildConfig.useDefault(
       String packageName, Iterable<String> dependencies) {
-    final key = '$packageName:$packageName';
-    final target = new BuildTarget(
-      dependencies: dependencies
-          .map((dep) => normalizeTargetKeyUsage(dep, packageName))
-          .toList(),
-      sources: InputSet.anything,
-    );
-    return new BuildConfig(
-      packageName: packageName,
-      buildTargets: {key: target},
-    );
+    return runInBuildConfigZone(() {
+      final key = '$packageName:$packageName';
+      final target = new BuildTarget(
+        dependencies: dependencies
+            .map((dep) => normalizeTargetKeyUsage(dep, packageName))
+            .toList(),
+        sources: InputSet.anything,
+      );
+      return new BuildConfig(
+        packageName: packageName,
+        buildTargets: {key: target},
+      );
+    }, packageName, dependencies.toList());
   }
 
   /// Create a [BuildConfig] by parsing [configYaml].

--- a/build_config/lib/src/common.dart
+++ b/build_config/lib/src/common.dart
@@ -22,13 +22,21 @@ T runInBuildConfigZone<T>(
 
 String get currentPackage {
   var package = Zone.current[_packageZoneKey] as String;
-  assert(package != null);
+  if (package == null) {
+    throw new StateError(
+        'Must be running inside a build config zone, which can be done using '
+        'the `runInBuildConfigZone` function.');
+  }
   return package;
 }
 
 List<String> get currentPackageDefaultDependencies {
   var defaultDependencies =
       Zone.current[_defaultDependenciesZoneKey] as List<String>;
-  assert(defaultDependencies != null);
+  if (defaultDependencies == null) {
+    throw new StateError(
+        'Must be running inside a build config zone, which can be done using '
+        'the `runInBuildConfigZone` function.');
+  }
   return defaultDependencies;
 }

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -18,3 +18,7 @@ dev_dependencies:
   build_runner: ^0.8.0
   json_serializable: ^0.5.4
   test: ^0.12.24
+
+dependency_overrides:
+  build_runner:
+    path: ../build_runner

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.2.6+2
+version: 0.3.0-dev
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -42,3 +42,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_config:
+    path: ../build_config

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
   build: ">=0.12.4 <0.12.7"
-  build_config: ^0.2.6
+  build_config: ^0.3.0
   build_resolvers: ^0.2.0
   cli_util: ^0.1.2
   code_builder: ">2.3.0 <4.0.0"

--- a/build_runner/test/build_script_generate/builder_ordering_test.dart
+++ b/build_runner/test/build_script_generate/builder_ordering_test.dart
@@ -15,13 +15,13 @@ void main() {
         'a': {
           'builders': {
             'runs_second': {
-              'builder_factories': [],
+              'builder_factories': ['createBuilder'],
               'build_extensions': {},
               'target': '',
               'import': '',
             },
             'runs_first': {
-              'builder_factories': [],
+              'builder_factories': ['createBuilder'],
               'build_extensions': {},
               'target': '',
               'import': '',
@@ -41,14 +41,14 @@ void main() {
         'a': {
           'builders': {
             'runs_second': {
-              'builder_factories': [],
+              'builder_factories': ['createBuilder'],
               'build_extensions': {},
               'target': '',
               'import': '',
               'required_inputs': ['.first_output'],
             },
             'runs_first': {
-              'builder_factories': [],
+              'builder_factories': ['createBuilder'],
               'build_extensions': {
                 '.anything': ['.first_output']
               },
@@ -69,7 +69,7 @@ void main() {
         'a': {
           'builders': {
             'builder_a': {
-              'builder_factories': [],
+              'builder_factories': ['createBuilder'],
               'build_extensions': {},
               'target': '',
               'import': '',
@@ -77,7 +77,7 @@ void main() {
               'runs_before': ['|builder_b'],
             },
             'builder_b': {
-              'builder_factories': [],
+              'builder_factories': ['createBuilder'],
               'build_extensions': {
                 '.anything': ['.output_b']
               },


### PR DESCRIPTION
- Updated test_common to use dependency overrides
- Updated the pubspec/changelog for build_config
- Updated `BuildConfig.useDefault` factory constructor to auto-construct the zone
- Throw a better error if we detect that we are not running in a build config zone
- Fix all the tests 
- Export `runInBuildConfigZone`