### PR TITLE
update archive dependency to support version 2.x

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+3
+
+- Expand support for `package:archive` to include version `2.x.x`.
+
 ## 0.4.0+2
 
 - Fix a dart2 error.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.4.0+2
+version: 0.4.0+3
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.30.0 <0.33.0"
-  archive: ^1.0.13
+  archive: ">=1.0.13 <3.0.0"
   bazel_worker: ^0.1.4
   build: ^0.12.4
   build_config: ^0.2.6


### PR DESCRIPTION
There were no breaking changes as far as I can tell - so this shouldn't have been a breaking release. The ship seems to have sailed though...

Fixes https://github.com/dart-lang/build/issues/1501.