### PR TITLE
Directly inline a map literal instead of using json encode/decode

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -5,8 +5,7 @@ import 'package:build_config/build_config.dart' as _i4;
 import 'package:build_modules/builders.dart' as _i5;
 import 'package:build_web_compilers/builders.dart' as _i6;
 import 'package:build/build.dart' as _i7;
-import 'dart:convert' as _i8;
-import 'dart:isolate' as _i9;
+import 'dart:isolate' as _i8;
 
 final _builders = <_i1.BuilderApplication>[
   _i1.apply('provides_builder|some_not_applied_builder', [_i2.notApplied],
@@ -55,10 +54,10 @@ final _builders = <_i1.BuilderApplication>[
         'test/**.node_test.dart',
         'test/**.vm_test.dart'
       ]),
-      defaultOptions: new _i7.BuilderOptions(
-          _i8.jsonDecode('{"dart2js_args":["--minify"]}')),
-      defaultReleaseOptions:
-          new _i7.BuilderOptions(_i8.jsonDecode('{"compiler":"dart2js"}')),
+      defaultOptions: new _i7.BuilderOptions({
+        'dart2js_args': ['--minify']
+      }),
+      defaultReleaseOptions: new _i7.BuilderOptions({'compiler': 'dart2js'}),
       appliesBuilders: ['build_web_compilers|dart2js_archive_extractor']),
   _i1.applyPostProcess(
       'provides_builder|some_post_process_builder', _i2.somePostProcessBuilder,
@@ -67,16 +66,14 @@ final _builders = <_i1.BuilderApplication>[
       defaultGenerateFor: const _i4.InputSet()),
   _i1.applyPostProcess(
       'build_web_compilers|dart_source_cleanup', _i6.dartSourceCleanup,
-      defaultReleaseOptions:
-          new _i7.BuilderOptions(_i8.jsonDecode('{"enabled":true}')),
+      defaultReleaseOptions: new _i7.BuilderOptions({'enabled': true}),
       defaultGenerateFor: const _i4.InputSet()),
   _i1.applyPostProcess('build_web_compilers|dart2js_archive_extractor',
       _i6.dart2JsArchiveExtractor,
-      defaultReleaseOptions:
-          new _i7.BuilderOptions(_i8.jsonDecode('{"filter_outputs":true}')),
+      defaultReleaseOptions: new _i7.BuilderOptions({'filter_outputs': true}),
       defaultGenerateFor: const _i4.InputSet())
 ];
-main(List<String> args, [_i9.SendPort sendPort]) async {
+main(List<String> args, [_i8.SendPort sendPort]) async {
   var result = await _i1.run(args, _builders);
   sendPort?.send(result);
 }

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -9,6 +9,8 @@
   dependency.
 - Sources that are not a part of a `target` will no longer appear in the asset
   graph, so they will not be readable or globbable.
+- Updated the generated build script to not rely on json encode/decode for the
+  builder options object. Instead it now directly inlines a map literal.
 
 ## 0.8.9
 

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -220,7 +220,5 @@ Expression _findToExpression(BuilderDefinition definition) {
 
 /// An expression creating a [BuilderOptions] from a json string.
 Expression _constructBuilderOptions(BuilderOptions options) =>
-    refer('BuilderOptions', 'package:build/build.dart').newInstance([
-      refer('jsonDecode', 'dart:convert')
-          .call([literalString(jsonEncode(options.config))])
-    ]);
+    refer('BuilderOptions', 'package:build/build.dart')
+        .newInstance([literalMap(options.config)]);

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';


### PR DESCRIPTION
This is for the default builder options that we generate in the build script. 

The previous logic was relying on implicit casts, the new logic relies on inference instead.