### PR TITLE
release build_config 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,6 +141,10 @@ jobs:
       env: PKG="scratch_space"
       dart: dev
 
+matrix:
+  allow_failures:
+    - env: PKG="build_config"
+
 stages:
   - analyze_and_format
   - unit_test

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-dev
+## 0.3.0
 
 - Parsing of `build.yaml` files is now done with the `json_serializable` package
   and is Dart 2 compatible.

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.3.0-dev
+version: 0.3.0
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config
@@ -19,9 +19,3 @@ dev_dependencies:
   build_runner: ^0.8.0
   json_serializable: ^0.5.6
   test: ^0.12.24
-
-dependency_overrides:
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core


### PR DESCRIPTION
Note that travis is going to fail for the unit tests in this package because it won't be able to get build_runner/build_runner_core dependencies without the overrides. I have ran the tests locally with the overrides in place though.

I will merge/publish this, then send out a PR to publish build_runner_core, and then build_runner after that, at which point master will go green again.

Fixes https://github.com/dart-lang/build/issues/1514