### PR TITLE
meta module parse conditional imports

### DIFF
--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -96,7 +96,8 @@ class _AssetNode {
 
       if (directive is ImportDirective && directive.configurations.isNotEmpty) {
         conditionalDirectiveConfigurations = directive.configurations;
-      } else if (directive is ExportDirective && directive.configurations.isNotEmpty) {
+      } else if (directive is ExportDirective &&
+          directive.configurations.isNotEmpty) {
         conditionalDirectiveConfigurations = directive.configurations;
       }
 

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -92,20 +92,20 @@ class _AssetNode {
         continue;
       }
 
-      List<Configuration> conditionalImportConfigurations;
+      List<Configuration> conditionalDirectiveConfigurations;
 
       if (directive is ImportDirective && directive.configurations.isNotEmpty) {
-        conditionalImportConfigurations = directive.configurations;
+        conditionalDirectiveConfigurations = directive.configurations;
       } else if (directive is ExportDirective && directive.configurations.isNotEmpty) {
-        conditionalImportConfigurations = directive.configurations;
+        conditionalDirectiveConfigurations = directive.configurations;
       }
 
       final allDeps = <AssetId>[linkedId];
-      if (conditionalImportConfigurations != null) {
-        allDeps.addAll(conditionalImportConfigurations
-            .map((c) => Uri.parse(c.uri.value))
+      if (conditionalDirectiveConfigurations != null) {
+        allDeps.addAll(conditionalDirectiveConfigurations
+            .map((c) => Uri.parse(c.uri.stringValue))
             .where((u) => u.scheme != 'dart')
-            .map((u) => new AssetId.resolve(u.toString())));
+            .map((u) => new AssetId.resolve(u.toString(), from: id)));
       }
 
       for (var dep in allDeps) {

--- a/build_modules/test/meta_module_test.dart
+++ b/build_modules/test/meta_module_test.dart
@@ -354,4 +354,40 @@ void main() {
     var meta = await MetaModule.forAssets(reader, assets);
     expect(meta.modules, unorderedMatches(expectedModules));
   });
+
+  test('conditional import directive added to module dependencies', () async {
+    var assets = makeAssets({
+      'myapp|web/a.dart': '''
+        import 'b.dart'
+        if (expression1) 'b1.dart'
+        if (expression2) 'b2.dart'
+        if (expression3) 'b3.dart';
+      ''',
+      'myapp|web/b.dart': '',
+      'myapp|web/b1.dart': '''
+      ''',
+      'myapp|web/b2.dart': '''
+      ''',
+      'myapp|web/b3.dart': '''
+      ''',
+    });
+
+    var a = new AssetId('myapp', 'web/a.dart');
+    var b = new AssetId('myapp', 'web/b.dart');
+    var b1 = new AssetId('myapp', 'web/b1.dart');
+    var b2 = new AssetId('myapp', 'web/b2.dart');
+    var b3 = new AssetId('myapp', 'web/b3.dart');
+
+    var expectedModules = [
+      matchesModule(new Module(a, [a], [b, b1, b2, b3])),
+      matchesModule(new Module(b, [b], [])),
+      matchesModule(new Module(b1, [b1], [])),
+      matchesModule(new Module(b2, [b2], [])),
+      matchesModule(new Module(b3, [b3], [])),
+    ];
+
+    var meta = await MetaModule.forAssets(reader, assets);
+
+    expect(meta.modules, unorderedMatches(expectedModules));
+  });
 }


### PR DESCRIPTION
Signed-off-by: Nikolay Samokhin <nickclmb@gmail.com>
Hi everyone,

At the moment if you have conditional imports in dart file, meta module will not have them in module dependencies:
```dart
import 'package:RAL/html_i.dart'
if (dart.library.html) 'dart:html'
if (dart.library.io) 'package:RAL/io/html_io.dart';
```
As a result the module will have dependency only on RAL/html_i.dart, missing RAL/io/html_io.dart
This pull request fixes that.
