### PR TITLE
Fix error handling with missing directories when globbing

### DIFF
--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -178,11 +178,8 @@ class _Loader {
       _listGeneratedAssetIds().toSet();
 
   /// Returns all the internal sources, such as those under [entryPointDir].
-  Future<Set<AssetId>> _findInternalSources() {
-    return _environment.reader
-        .findAssets(new Glob('$entryPointDir/**'))
-        .toSet();
-  }
+  Future<Set<AssetId>> _findInternalSources() =>
+      _listIdsSafe(new Glob('$entryPointDir/**')).toSet();
 
   /// Attempts to read in an [AssetGraph] from disk, and returns `null` if it
   /// fails for any reason.

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -78,6 +78,7 @@ targets:
     sources:
       include:
         - lib/**
+        - does_not_exist/**
       exclude:
         - lib/excluded/**
 '''),


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/1534

The asset reader itself is now returning the stream from the glob api, just filtered a bit (but not handling the errors).

The `BuildDefinition` class which is the only thing that actually directly uses this api now swallows the errors explicitly. 

cc @chalin 