### PR TITLE
fix(runner_core): don't double-initialize builders

### DIFF
--- a/build_runner_core/lib/src/package_graph/apply_builders.dart
+++ b/build_runner_core/lib/src/package_graph/apply_builders.dart
@@ -258,8 +258,7 @@ Future<List<BuildPhase>> createBuildPhases(
             return targetGraph.allModules[key];
           })?.where((n) => n != null));
   final applyWith = _applyWith(builderApplications);
-
-  var expandedPhases = cycles
+  final expandedPhases = cycles
       .expand((cycle) => _createBuildPhasesWithinCycle(
           cycle,
           builderApplications,
@@ -267,15 +266,15 @@ Future<List<BuildPhase>> createBuildPhases(
           applyWith,
           isReleaseMode))
       .toList();
-  var inBuildPhases =
+
+  final inBuildPhases =
       expandedPhases.where((p) => p is InBuildPhase).cast<BuildPhase>();
 
-  var postBuildPhases = expandedPhases
+  final postBuildPhases = expandedPhases
       .where((p) => p is PostBuildPhase)
       .cast<PostBuildPhase>()
       .toList();
-
-  var collapsedPostBuildPhase = <PostBuildPhase>[];
+  final collapsedPostBuildPhase = <PostBuildPhase>[];
   if (postBuildPhases.isNotEmpty) {
     collapsedPostBuildPhase.add(postBuildPhases
         .fold<PostBuildPhase>(new PostBuildPhase([]), (previous, next) {

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -55,6 +55,30 @@ void main() {
       );
     });
 
+    test('Builder factories are only invoked once per application', () async {
+      var invokedCount = 0;
+      final packageGraph = buildPackageGraph({
+        rootPackage('a'): ['b'],
+        package('b'): []
+      });
+      await testBuilders([
+        apply(
+            '',
+            [
+              (_) {
+                invokedCount += 1;
+                return new TestBuilder();
+              }
+            ],
+            toAllPackages(),
+            isOptional: false,
+            hideOutput: true),
+      ], {}, packageGraph: packageGraph);
+
+      // Once per package, including the SDK.
+      expect(invokedCount, 3);
+    });
+
     test('throws an error if the builderFactory fails', () async {
       expect(
           () async => await testBuilders(


### PR DESCRIPTION
expandedPhases is an Iterable that is accessed twice with a call to
.where causing double iteartion – and double initialization of each
builder

This code goes through the same items, but only once.