### PR TITLE
Add build_config support for global options

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.1
 
 - Improve validation and errors when parsing `build.yaml`.
+- Add `BuildConfig.globalOptions` support.
 
 ## 0.3.0
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -56,6 +56,26 @@ configuration may have the following keys:
   mode with `dev_options` or `release_options`.
 - **dev_options**: Map, Optional: A free-form map which will be passed to the
   `Builder` as a `BuilderOptions` when it is constructed. Usage varies depending
+  on the particular builder. The values in this map override Builder defaults or
+  non mode-specific options per-key when the build is done in dev mode.
+- **release_options**: Map, Optional: A free-form map which will be passed to
+  the `Builder` as a `BuilderOptions` when it is constructed. Usage varies
+  depending on the particular builder. The values in this map override Builder
+  defaults or non mode-specific options when the build is done in release mode.
+
+## Configuring `Builder`s globally
+Target level builder options can be overridden globally across all packages with
+the `global_options` section. These options are applied _after_ all Builder
+defaults and target level configuration, and _before_ `--define` command line
+arguments.
+
+- **options**: Map, Optional: A free-form map which will be passed to the
+  `Builder` as a `BuilderOptions` when it is constructed. Usage varies depending
+  on the particular builder. Values in this map will override the default
+  provided by builder authors or at the target level. Values may also be
+  overridden based on the build mode with `dev_options` or `release_options`.
+- **dev_options**: Map, Optional: A free-form map which will be passed to the
+  `Builder` as a `BuilderOptions` when it is constructed. Usage varies depending
   on the particular builder. The values in this map override all other values
   per-key when the build is done in dev mode.
 - **release_options**: Map, Optional: A free-form map which will be passed to

--- a/build_config/lib/build_config.dart
+++ b/build_config/lib/build_config.dart
@@ -3,7 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'src/build_config.dart' show BuildConfig;
-export 'src/build_target.dart' show BuildTarget, TargetBuilderConfig;
+export 'src/build_target.dart'
+    show BuildTarget, TargetBuilderConfig, GlobalBuilderConfig;
 export 'src/builder_definition.dart'
     show
         BuilderDefinition,

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -108,7 +108,7 @@ class BuildConfig {
   BuildConfig({
     String packageName,
     @required Map<String, BuildTarget> buildTargets,
-    @required Map<String, GlobalBuilderConfig> globalOptions,
+    Map<String, GlobalBuilderConfig> globalOptions,
     Map<String, BuilderDefinition> builderDefinitions,
     Map<String, PostProcessBuilderDefinition> postProcessBuilderDefinitions =
         const {},

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -64,6 +64,9 @@ class BuildConfig {
   @JsonKey(name: 'targets', fromJson: _buildTargetsFromJson)
   final Map<String, BuildTarget> buildTargets;
 
+  @JsonKey(name: 'global_options')
+  final Map<String, GlobalBuilderConfig> globalOptions;
+
   /// The default config if you have no `build.yaml` file.
   factory BuildConfig.useDefault(
       String packageName, Iterable<String> dependencies) {
@@ -78,6 +81,7 @@ class BuildConfig {
       return new BuildConfig(
         packageName: packageName,
         buildTargets: {key: target},
+        globalOptions: {},
       );
     }, packageName, dependencies.toList());
   }
@@ -104,6 +108,7 @@ class BuildConfig {
   BuildConfig({
     String packageName,
     @required Map<String, BuildTarget> buildTargets,
+    @required Map<String, GlobalBuilderConfig> globalOptions,
     Map<String, BuilderDefinition> builderDefinitions,
     Map<String, PostProcessBuilderDefinition> postProcessBuilderDefinitions =
         const {},
@@ -113,6 +118,9 @@ class BuildConfig {
                 dependencies: currentPackageDefaultDependencies,
               )
             },
+        this.globalOptions = (globalOptions ?? const {}).map((key, config) =>
+            new MapEntry(
+                normalizeBuilderKeyUsage(key, currentPackage), config)),
         this.builderDefinitions = _normalizeBuilderDefinitions(
             builderDefinitions ?? const {}, packageName ?? currentPackage),
         this.postProcessBuilderDefinitions = _normalizeBuilderDefinitions(

--- a/build_config/lib/src/build_config.g.dart
+++ b/build_config/lib/src/build_config.g.dart
@@ -8,11 +8,23 @@ part of 'build_config.dart';
 
 BuildConfig _$BuildConfigFromJson(Map json) {
   return $checkedNew('BuildConfig', json, () {
-    $checkKeys(json,
-        allowedKeys: const ['builders', 'post_process_builders', 'targets']);
+    $checkKeys(json, allowedKeys: const [
+      'builders',
+      'post_process_builders',
+      'targets',
+      'global_options'
+    ]);
     var val = new BuildConfig(
         buildTargets: $checkedConvert(json, 'targets',
             (v) => v == null ? null : _buildTargetsFromJson(v as Map)),
+        globalOptions: $checkedConvert(
+            json,
+            'global_options',
+            (v) => (v as Map)?.map((k, e) => new MapEntry(
+                k as String,
+                e == null
+                    ? null
+                    : new GlobalBuilderConfig.fromJson(e as Map)))),
         builderDefinitions: $checkedConvert(
             json,
             'builders',
@@ -29,6 +41,7 @@ BuildConfig _$BuildConfigFromJson(Map json) {
     return val;
   }, fieldKeyMap: const {
     'buildTargets': 'targets',
+    'globalOptions': 'global_options',
     'builderDefinitions': 'builders',
     'postProcessBuilderDefinitions': 'post_process_builders'
   });

--- a/build_config/lib/src/build_target.dart
+++ b/build_config/lib/src/build_target.dart
@@ -119,3 +119,43 @@ class TargetBuilderConfig {
         'releaseOptions': releaseOptions.config,
       }.toString();
 }
+
+/// The configuration for a Builder applied globally.
+@JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)
+class GlobalBuilderConfig {
+  /// The options to pass to the `BuilderFactory` when constructing this
+  /// builder.
+  ///
+  /// The `options` key in the configuration.
+  ///
+  /// Individual keys may be overridden by either [devOptions] or
+  /// [releaseOptions].
+  @JsonKey(fromJson: builderOptionsFromJson)
+  final BuilderOptions options;
+
+  /// Overrides for [options] in dev mode.
+  @JsonKey(name: 'dev_options', fromJson: builderOptionsFromJson)
+  final BuilderOptions devOptions;
+
+  /// Overrides for [options] in release mode.
+  @JsonKey(name: 'release_options', fromJson: builderOptionsFromJson)
+  final BuilderOptions releaseOptions;
+
+  GlobalBuilderConfig({
+    BuilderOptions options,
+    BuilderOptions devOptions,
+    BuilderOptions releaseOptions,
+  })  : options = options ?? BuilderOptions.empty,
+        devOptions = devOptions ?? BuilderOptions.empty,
+        releaseOptions = releaseOptions ?? BuilderOptions.empty;
+
+  factory GlobalBuilderConfig.fromJson(Map json) =>
+      _$GlobalBuilderConfigFromJson(json);
+
+  @override
+  String toString() => {
+        'options': options.config,
+        'devOptions': devOptions.config,
+        'releaseOptions': releaseOptions.config,
+      }.toString();
+}

--- a/build_config/lib/src/build_target.g.dart
+++ b/build_config/lib/src/build_target.g.dart
@@ -59,3 +59,21 @@ TargetBuilderConfig _$TargetBuilderConfigFromJson(Map json) {
     'releaseOptions': 'release_options'
   });
 }
+
+GlobalBuilderConfig _$GlobalBuilderConfigFromJson(Map json) {
+  return $checkedNew('GlobalBuilderConfig', json, () {
+    $checkKeys(json,
+        allowedKeys: const ['options', 'dev_options', 'release_options']);
+    var val = new GlobalBuilderConfig(
+        options: $checkedConvert(json, 'options',
+            (v) => v == null ? null : builderOptionsFromJson(v as Map)),
+        devOptions: $checkedConvert(json, 'dev_options',
+            (v) => v == null ? null : builderOptionsFromJson(v as Map)),
+        releaseOptions: $checkedConvert(json, 'release_options',
+            (v) => v == null ? null : builderOptionsFromJson(v as Map)));
+    return val;
+  }, fieldKeyMap: const {
+    'devOptions': 'dev_options',
+    'releaseOptions': 'release_options'
+  });
+}

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -77,6 +77,13 @@ void main() {
         ),
       ),
     });
+    expectGlobalOptions(buildConfig.globalOptions, {
+      'example|h': new GlobalBuilderConfig(
+          options: const BuilderOptions(const {'foo': 'global'})),
+      'b|b': new GlobalBuilderConfig(
+          devOptions: const BuilderOptions(const {'foo': 'global_dev'}),
+          releaseOptions: const BuilderOptions(const {'foo': 'global_release'}))
+    });
   });
 
   test('build.yaml can omit a targets section', () {
@@ -127,6 +134,15 @@ void main() {
 }
 
 var buildYaml = r'''
+global_options:
+  "|h":
+    options:
+      foo: global
+  b|b:
+    dev_options:
+      foo: global_dev
+    release_options:
+      foo: global_release
 targets:
   a:
     builders:
@@ -211,6 +227,14 @@ void expectPostProcessBuilderDefinitions(
   }
 }
 
+void expectGlobalOptions(Map<String, GlobalBuilderConfig> actual,
+    Map<String, GlobalBuilderConfig> expected) {
+  expect(actual.keys, unorderedEquals(expected.keys));
+  for (var p in actual.keys) {
+    expect(actual[p], new _GlobalBuilderConfigMatcher(expected[p]));
+  }
+}
+
 class _BuilderDefinitionMatcher extends Matcher {
   final BuilderDefinition _expected;
   _BuilderDefinitionMatcher(this._expected);
@@ -250,6 +274,23 @@ class _PostProcessBuilderDefinitionMatcher extends Matcher {
       item.import == _expected.import &&
       item.key == _expected.key &&
       item.package == _expected.package;
+
+  @override
+  Description describe(Description description) =>
+      description.addDescriptionOf(_expected);
+}
+
+class _GlobalBuilderConfigMatcher extends Matcher {
+  final GlobalBuilderConfig _expected;
+  _GlobalBuilderConfigMatcher(this._expected);
+
+  @override
+  bool matches(item, _) =>
+      item is GlobalBuilderConfig &&
+      equals(_expected.options.config).matches(item.options.config, _) &&
+      equals(_expected.devOptions.config).matches(item.devOptions.config, _) &&
+      equals(_expected.releaseOptions.config)
+          .matches(item.releaseOptions.config, _);
 
   @override
   Description describe(Description description) =>

--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -13,6 +13,7 @@ key | value | default
 targets | Map<String, [BuildTarget](#buildtarget)> | a single target with the same name as the package
 builders | Map<String, [BuilderDefinition](#builderdefinition)> | empty
 post_process_builders | Map<String, [PostProcessBuilderDefinition](#postprocessbuilderdefinition)> | empty
+global_options | Map<String, [GlobalBuilderOptions](#globalBuilderOptions)> | empty
 
 ## BuildTarget
 
@@ -71,6 +72,13 @@ release_options | [BuilderOptions](#builderoptions) | none
 key | value | default
 --- | --- | ---
 generate_for | [InputSet](#inputset) | `**`
+options | [BuilderOptions](#builderoptions) | none
+dev_options | [BuilderOptions](#builderoptions) | none
+release_options | [BuilderOptions](#builderoptions) | none
+
+## GlobalBuilderOptions
+key | value | default
+--- | --- | ---
 options | [BuilderOptions](#builderoptions) | none
 dev_options | [BuilderOptions](#builderoptions) | none
 release_options | [BuilderOptions](#builderoptions) | none


### PR DESCRIPTION
Towards #1370

Not including `enabled` for now since it's not clear we'll want it.

- Add `GlobalBuilderOptions` class since it is slightly different than
  existing similar classes. Add parsing
- Document in `README.md` and `build_yaml_format.md`
- Include parsing and result checking in the parse test.