### PR TITLE
Honor `global_options` from `build.yaml`

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -6,6 +6,7 @@
   information to `<dir>` after each build.
 - The `BuildPerformance` class is now serializable, it has a `fromJson`
   constructor and a `toJson` instance method.
+- Added support for `global_options` in `build.yaml` of the root package.
 
 ### Breaking changes
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
   build: ">=0.12.4 <0.12.7"
-  build_config: ^0.3.0
+  build_config: ^0.3.1
   build_resolvers: ^0.2.0
   # We re-export many types from this package, so we maintain a tight
   # constraint on it.
@@ -49,3 +49,5 @@ dev_dependencies:
 dependency_overrides:
   build_runner_core:
     path: ../build_runner_core
+  build_config:
+    path: ../build_config

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -409,7 +409,7 @@ main(List<String> args) async {
       return '${result.stdout}';
     }
 
-    test('warns on invalid builder key --define', () async {
+    test('warns on invalid builder key in target options', () async {
       await d.dir('a', [
         await pubspec('a', currentIsolateDependencies: [
           'build',
@@ -428,14 +428,39 @@ targets:
         d.dir('tool', [d.file('build.dart', buildContent)]),
         d.dir('web', [
           d.file('a.txt', 'a'),
-          d.file('b.txt', 'b'),
-          d.file('c.txt', 'c'),
         ]),
       ]).create();
 
       await pubGet('a');
 
-      var result = await runBuild(extraArgs: ['--define=bad|key=foo=bar']);
+      var result = await runBuild();
+
+      expect(result, contains('not a known Builder'));
+    });
+
+    test('warns on invalid builder key in global options', () async {
+      await d.dir('a', [
+        await pubspec('a', currentIsolateDependencies: [
+          'build',
+          'build_config',
+          'build_resolvers',
+          'build_runner',
+          'build_runner_core',
+          'build_test',
+        ]),
+        d.file('build.yaml', r'''
+global_options:
+  bad|builder:
+'''),
+        d.dir('tool', [d.file('build.dart', buildContent)]),
+        d.dir('web', [
+          d.file('a.txt', 'a'),
+        ]),
+      ]).create();
+
+      await pubGet('a');
+
+      var result = await runBuild();
 
       expect(result, contains('not a known Builder'));
     });
@@ -453,8 +478,6 @@ targets:
         d.dir('tool', [d.file('build.dart', buildContent)]),
         d.dir('web', [
           d.file('a.txt', 'a'),
-          d.file('b.txt', 'b'),
-          d.file('c.txt', 'c'),
         ]),
       ]).create();
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -6,6 +6,7 @@
   constructor and a `toJson` instance method.
 - Added `BuildOptions.logPerformanceDir`, performance logs will be continuously
   written to that directory if provided.
+- Added support for `global_options` in `build.yaml` of the root package.
 
 ### Breaking changes
 

--- a/build_runner_core/lib/src/validation/config_validation.dart
+++ b/build_runner_core/lib/src/validation/config_validation.dart
@@ -28,4 +28,10 @@ void validateBuilderConfig(
       }
     }
   }
+  for (final key in rootPackageConfig.globalOptions.keys) {
+    if (!builderKeys.contains(key)) {
+      logger.warning('Configuring `$key` in global options but this is not a '
+          'known Builder');
+    }
+  }
 }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ">=0.12.4 <0.12.7"
-  build_config: ^0.3.0
+  build_config: ^0.3.1
   build_resolvers: ^0.2.0
   collection: ^1.14.0
   convert: ^2.0.1
@@ -35,3 +35,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_config:
+    path: ../build_config


### PR DESCRIPTION
Closes #1370

- Add merging of the `global_options` before the overrides.
- Add a test using global options.
- Add a test for the error message when specifying an invalid key in the
  global options.