### PR TITLE
Drop exception and stack trace from BuildResult

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -14,6 +14,7 @@
   `BuildPhasePerformance.builderKeys`.
 - `BuilderActionPerformance.builder` has been replaced with
   `BuilderActionPerformance.builderKey`.
+- `BuildResult` no longer has an `exception` or `stackTrace` field.
 
 ## Other
 

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -81,8 +81,6 @@ void main() {
   group('build failures', () {
     setUp(() async {
       _addSource('a|web/index.html', '');
-      var fakeException = 'Really bad error omg!';
-      var fakeStackTrace = 'My cool stack trace!';
       assetGraph.add(new GeneratedAssetNode(
         makeAssetId('a|web/main.ddc.js'),
         builderOptionsId: null,
@@ -93,10 +91,8 @@ void main() {
         isFailure: true,
         primaryInput: null,
       ));
-      watchImpl.addFutureResult(new Future.value(new BuildResult(
-          BuildStatus.failure, [],
-          exception: fakeException,
-          stackTrace: new StackTrace.fromString(fakeStackTrace))));
+      watchImpl.addFutureResult(
+          new Future.value(new BuildResult(BuildStatus.failure, [])));
     });
 
     test('serves successful assets', () async {

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -14,6 +14,7 @@
   `BuildPhasePerformance.builderKeys`.
 - `BuilderActionPerformance.builder` has been replaced with
   `BuilderActionPerformance.builderKey`.
+- `BuildResult` no longer has an `exception` or `stackTrace` field.
 
 ### Internal changes
 

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -154,10 +154,22 @@ class _Loader {
     final root = _options.packageGraph.root.name;
     for (final action in _buildPhases) {
       if (!action.hideOutput) {
-        // Only `BuilderBuildAction`s can be not hidden.
-        if (action is InBuildPhase &&
-            action.package != _options.packageGraph.root.name) {
-          throw new InvalidBuildPhaseException.nonRootPackage(action, root);
+        // Only `InBuildPhase`s can be not hidden.
+        if (action is InBuildPhase && action.package != root) {
+          // This should happen only with a manual build script since the build
+          // script generation filters these out.
+          _logger.severe('A build phase (${action.builderLabel}) is attempting '
+              'to operate on package "${action.package}", but the build script '
+              'is located in package "$root". It\'s not valid to attempt to '
+              'generate files for another package unless the BuilderApplication'
+              'specified "hideOutput".'
+              '\n\n'
+              'Did you mean to write:\n'
+              '  new BuilderApplication(..., toRoot())\n'
+              'or\n'
+              '  new BuilderApplication(..., hideOutput: true)\n'
+              '... instead?');
+          throw new CannotBuildException();
         }
       }
     }

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:build/build.dart';
 import 'package:build_resolvers/build_resolvers.dart';
@@ -204,31 +203,23 @@ class _SingleBuild {
     if (_outputMap != null && result.status == BuildStatus.success) {
       if (!await createMergedOutputDirectories(_outputMap, _assetGraph,
           _packageGraph, _reader, _environment, optionalOutputTracker)) {
-        result = _convertToFailure(
-            result, 'Failed to create merged output directories.',
-            failureType: FailureType.cantCreate);
+        result = _convertToFailure(result, failureType: FailureType.cantCreate);
       }
     }
     if (result.status == BuildStatus.success) {
       _logger.info('Succeeded after ${humanReadable(watch.elapsed)} with '
           '${result.outputs.length} outputs ($actionsCompletedCount actions)\n');
     } else {
-      if (result.exception is FatalBuildException) {
-        // TODO(???) Really bad idea. Should not set exit codes in libraries!
-        exitCode = 1;
-      }
-      _logger.severe('Failed after ${humanReadable(watch.elapsed)}',
-          result.exception, result.stackTrace);
+      _logger.severe('Failed after ${humanReadable(watch.elapsed)}');
     }
     return result;
   }
 
-  BuildResult _convertToFailure(BuildResult previous, String errorMessge,
+  BuildResult _convertToFailure(BuildResult previous,
           {FailureType failureType}) =>
       new BuildResult(
         BuildStatus.failure,
         previous.outputs,
-        exception: errorMessge,
         performance: previous.performance,
         failureType: failureType,
       );
@@ -288,8 +279,7 @@ class _SingleBuild {
       if (!done.isCompleted) done.complete(result);
     }, onError: (e, StackTrace st) {
       if (!done.isCompleted) {
-        done.complete(new BuildResult(BuildStatus.failure, [],
-            exception: e, stackTrace: st));
+        done.complete(new BuildResult(BuildStatus.failure, []));
       }
     });
     return done.future;

--- a/build_runner_core/lib/src/generate/build_result.dart
+++ b/build_runner_core/lib/src/generate/build_result.dart
@@ -25,8 +25,7 @@ class BuildResult {
   final BuildPerformance performance;
 
   BuildResult(this.status, List<AssetId> outputs,
-      {this.performance,
-      FailureType failureType})
+      {this.performance, FailureType failureType})
       : outputs = new List.unmodifiable(outputs),
         this.failureType = failureType == null && status == BuildStatus.failure
             ? FailureType.general

--- a/build_runner_core/lib/src/generate/build_result.dart
+++ b/build_runner_core/lib/src/generate/build_result.dart
@@ -17,12 +17,6 @@ class BuildResult {
   /// The type of failure.
   final FailureType failureType;
 
-  /// The error that was thrown during this build if it failed.
-  final Object exception;
-
-  /// The [StackTrace] for [exception] if non-null.
-  final StackTrace stackTrace;
-
   /// All outputs created/updated during this build.
   final List<AssetId> outputs;
 
@@ -31,9 +25,7 @@ class BuildResult {
   final BuildPerformance performance;
 
   BuildResult(this.status, List<AssetId> outputs,
-      {this.exception,
-      this.stackTrace,
-      this.performance,
+      {this.performance,
       FailureType failureType})
       : outputs = new List.unmodifiable(outputs),
         this.failureType = failureType == null && status == BuildStatus.failure
@@ -50,9 +42,6 @@ Build Succeeded!
       return '''
 
 Build Failed :(
-Exception: $exception
-Stack Trace:
-$stackTrace
 ''';
     }
   }

--- a/build_runner_core/lib/src/generate/exceptions.dart
+++ b/build_runner_core/lib/src/generate/exceptions.dart
@@ -2,31 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'phase.dart';
-
-abstract class FatalBuildException implements Exception {
-  const FatalBuildException();
-}
-
-class InvalidBuildPhaseException extends FatalBuildException {
-  final String _reason;
-
-  InvalidBuildPhaseException.nonRootPackage(InBuildPhase phase, String root)
-      : _reason = 'A build phase ($phase) is attempting to operate on '
-            'package "${phase.package}", but the build script is '
-            'located in package "$root". It\'s not valid to attempt to '
-            'generate files for another package unless the BuilderApplication'
-            'specified "hideOutput".'
-            '\n\n'
-            'Did you mean to write:\n'
-            '  new BuilderApplication(..., toRoot())\n'
-            'or\n'
-            '  new BuilderApplication(..., hideOutput: true)\n'
-            '... instead?';
-  @override
-  String toString() => 'InvalidBuildPhaseException: $_reason';
-}
-
 /// Indicates that the build cannot be attempted.
 ///
 /// Before throwing this exception a user actionable message should be logged.


### PR DESCRIPTION
Closes #1209

- Migrate the one remaining use case for throwing a
  `FatalBuildException` to handle the logging itself and remove special
  handling for this exceptio type in the build result.
- Remove all uses of the `exception` field. Most uses were already
  irrelevant because exceptions should already be logged.