### PR TITLE
MetaModule: use parseDirectives instead of parseCompilationUnit

### DIFF
--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -262,8 +262,8 @@ Future<List<Module>> _computeModules(
   for (var asset in assets) {
     var content = await reader.readAsString(asset);
     // Skip errors here, dartdevc gives nicer messages.
-    var parsed = parseCompilationUnit(content,
-        name: asset.path, parseFunctionBodies: false, suppressErrors: true);
+    var parsed = parseDirectives(content,
+        name: asset.path, suppressErrors: true);
     parsedAssetsById[asset] = parsed;
 
     // Skip any files which contain a `dart:_` import.

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -262,8 +262,8 @@ Future<List<Module>> _computeModules(
   for (var asset in assets) {
     var content = await reader.readAsString(asset);
     // Skip errors here, dartdevc gives nicer messages.
-    var parsed = parseDirectives(content,
-        name: asset.path, suppressErrors: true);
+    var parsed =
+        parseDirectives(content, name: asset.path, suppressErrors: true);
     parsedAssetsById[asset] = parsed;
 
     // Skip any files which contain a `dart:_` import.

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -262,8 +262,10 @@ Future<List<Module>> _computeModules(
   for (var asset in assets) {
     var content = await reader.readAsString(asset);
     // Skip errors here, dartdevc gives nicer messages.
-    var parsed =
-        parseDirectives(content, name: asset.path, suppressErrors: true);
+    var parsed = public
+        ? parseDirectives(content, name: asset.path, suppressErrors: true)
+        : parseCompilationUnit(content,
+            name: asset.path, suppressErrors: true, parseFunctionBodies: false);
     parsedAssetsById[asset] = parsed;
 
     // Skip any files which contain a `dart:_` import.


### PR DESCRIPTION
The MetaModule builder collects dependencies of each asset, and it only needs import/export directives from dart file. So using the analyzer's parseCompilationUnit is overkill, and parseDirectives should be enough. 

As a result - less time for parsing, and less memory for analyzer cache.

Signed-off-by: Nikolay Samokhin <nickclmb@gmail.com>