### PR TITLE
Use p.join more consistently for .dart_tool paths

### DIFF
--- a/build_runner_core/lib/src/util/constants.dart
+++ b/build_runner_core/lib/src/util/constants.dart
@@ -7,24 +7,26 @@ import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
 
 /// Relative path to the asset graph from the root package dir.
-final String assetGraphPath = assetGraphPathFor(Platform.script.scheme == 'file'
+final assetGraphPath = assetGraphPathFor(_scriptPath);
+
+final _scriptPath = Platform.script.scheme == 'file'
     ? Platform.script.toFilePath()
-    : Platform.script.path);
+    : Platform.script.path;
 
 /// Relative path to the asset graph for a build script at [path]
 String assetGraphPathFor(String path) =>
-    '$cacheDir/${_scriptHashFor(path)}/asset_graph.json';
+    p.join(cacheDir, _scriptHashFor(path), 'asset_graph.json');
 
 /// Directory containing automatically generated build entrypoints.
 ///
 /// Files in this directory must be read to do build script invalidation.
-const entryPointDir = '.dart_tool/build/entrypoint';
+final entryPointDir = p.join(cacheDir, 'entrypoint');
 
 /// The directory to which hidden assets will be written.
-const generatedOutputDirectory = '$cacheDir/generated';
+final generatedOutputDirectory = p.join(cacheDir, 'generated');
 
 /// Relative path to the cache directory from the root package dir.
-const String cacheDir = '.dart_tool/build';
+final cacheDir = p.join('.dart_tool', 'build');
 
 /// Returns a hash for a given path.
 String _scriptHashFor(String path) => md5.convert(path.codeUnits).toString();


### PR DESCRIPTION
Makes these `final` instead of `const` but more has better consistency
across OSes.