### PR TITLE
Add reset API to Resolvers

### DIFF
--- a/bazel_codegen/lib/src/run_builders.dart
+++ b/bazel_codegen/lib/src/run_builders.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:analyzer/src/generated/engine.dart' show AnalysisEngine;
 import 'package:build/build.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
@@ -71,9 +70,7 @@ Future<Null> runBuilders(
     allWrittenAssets.addAll(writerSpy.assetsWritten);
   }
 
-  // Technically we don't always have to do this, but better safe than sorry.
-  timings.trackOperation(
-      'Clearing analysis engine cache', AnalysisEngine.instance.clearCaches);
+  timings.trackOperation('Resetting Resolvers', resolvers.reset);
 
   await timings.trackOperation('Checking outputs and writing defaults',
       () async {

--- a/bazel_codegen/lib/src/summaries/resolvers.dart
+++ b/bazel_codegen/lib/src/summaries/resolvers.dart
@@ -6,7 +6,8 @@ import 'dart:collection';
 import 'dart:io';
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/generated/engine.dart' show AnalysisContext;
+import 'package:analyzer/src/generated/engine.dart'
+    show AnalysisContext, AnalysisEngine;
 import 'package:analyzer/src/generated/source.dart' show SourceKind;
 import 'package:build/build.dart';
 
@@ -55,6 +56,9 @@ class SummaryResolvers implements Resolvers {
     var assets = findAssetIds(sourceFiles, _packagePath, _packageMap);
     await _assetResolver.addAssets(assets, readAsset);
   }
+
+  @override
+  void reset() => AnalysisEngine.instance.clearCaches();
 }
 
 /// a [Resolver] backed by an [AnalysisContext].

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -26,3 +26,5 @@ dev_dependencies:
 dependency_overrides:
   build:
     path: ../build
+  build_barback:
+    path: ../build_barback

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   analyzer: '>=0.31.2-alpha.1 <0.33.0'
   args: ^1.4.1
   bazel_worker: ^0.1.2
-  build: ">=0.11.1 <0.13.0"
+  build: ">=0.12.7 <0.12.8"
   build_barback: ">=0.4.0 <0.6.0"
   glob: ^1.1.0
   logging: ^0.11.3
@@ -22,3 +22,7 @@ dev_dependencies:
   build_test: ^0.10.0
   test: ^0.12.15
   test_descriptor: ^1.0.0
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.7
+
+- Added `Resolvers.reset` method.
+
 ## 0.12.6
 
 - Added `List<String> get pathSegments` to `AssetId`.

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -44,7 +44,17 @@ abstract class ReleasableResolver implements Resolver {
 
 /// A factory that returns a resolver for a given [BuildStep].
 abstract class Resolvers {
+  const Resolvers();
+
   Future<ReleasableResolver> get(BuildStep buildStep);
+
+  /// Reset the state of any caches within [Resolver] instances produced by
+  /// this [Resolvers].
+  ///
+  /// In between calls to [reset] no Assets should change, so every call to
+  /// [BuildStep.readAsString] for a given AssetId should return identical
+  /// contents. Any time an Asset's contents may change [reset] must be called.
+  void reset() {}
 }
 
 /// Thrown when attempting to read a non-Dart library in a [Resolver].

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.12.6
+version: 0.12.7
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build

--- a/build_barback/lib/src/analyzer/resolver.dart
+++ b/build_barback/lib/src/analyzer/resolver.dart
@@ -44,7 +44,7 @@ final code_transformers.Resolvers codeTransformerResolvers =
         // Same as bazel_codegen/src/summaries/analysis_context.dart
         options: new AnalysisOptionsImpl()..strongMode = true);
 
-class BarbackResolvers implements Resolvers {
+class BarbackResolvers extends Resolvers {
   const BarbackResolvers();
 
   @override

--- a/build_barback/pubspec.yaml
+++ b/build_barback/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.27.1 <0.33.0"
   barback: ^0.15.0
-  build: ^0.12.0
+  build: ^0.12.7
   code_transformers: ">=0.5.1 <0.6.0"
   glob: ^1.1.0
   graphs: ^0.1.0
@@ -20,3 +20,7 @@ dev_dependencies:
   build_test: ^0.10.0
   test: ^0.12.0
   transformer_test: ^0.2.1
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_barback/test/analyzer/resolver_test.dart
+++ b/build_barback/test/analyzer/resolver_test.dart
@@ -25,6 +25,9 @@ class ResolversSpy implements BarbackResolvers {
         false);
     return new BarbackResolver(lastResolved);
   }
+
+  @override
+  void reset() {}
 }
 
 // Ported from

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -426,6 +426,7 @@ class AnalyzerResolvers implements Resolvers {
           (r) => new PerActionResolver(r, [buildStep.inputId]));
 
   /// Must be called between each build.
+  @override
   void reset() => _resolver.reset();
 }
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -9,10 +9,14 @@ environment:
 
 dependencies:
   analyzer: '>=0.27.1 <0.33.0'
-  build: ^0.12.0
+  build: ^0.12.7
   cli_util: ^0.1.0
   path: ^1.1.0
 
 dev_dependencies:
   test: ^0.12.0
   build_test: ^0.10.1
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
-  build: ">=0.12.4 <0.12.7"
+  build: ">=0.12.7 <0.12.8"
   build_config: ^0.3.1
   build_resolvers: ^0.2.0
   # We re-export many types from this package, so we maintain a tight
@@ -51,3 +51,5 @@ dependency_overrides:
     path: ../build_runner_core
   build_config:
     path: ../build_config
+  build:
+    path: ../build

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -57,7 +57,7 @@ class BuildImpl {
   final List<BuildPhase> _buildPhases;
   final PackageGraph _packageGraph;
   final AssetReader _reader;
-  final _resolvers = new AnalyzerResolvers();
+  final Resolvers _resolvers = new AnalyzerResolvers();
   final ResourceManager _resourceManager;
   final RunnerAssetWriter _writer;
   final Map<String, String> _outputMap;

--- a/build_runner_core/lib/src/performance_tracking/performance_tracking_resolvers.dart
+++ b/build_runner_core/lib/src/performance_tracking/performance_tracking_resolvers.dart
@@ -18,4 +18,7 @@ class PerformanceTrackingResolvers implements Resolvers {
   Future<ReleasableResolver> get(BuildStep buildStep) =>
       _tracker.track(() => _delegate.get(buildStep), 'ResolverGet')
           as Future<ReleasableResolver>;
+
+  @override
+  void reset() => _delegate.reset();
 }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
-  build: ">=0.12.4 <0.12.7"
+  build: ">=0.12.7 <0.12.8"
   build_config: ^0.3.1
   build_resolvers: ^0.2.0
   collection: ^1.14.0
@@ -39,3 +39,5 @@ dev_dependencies:
 dependency_overrides:
   build_config:
     path: ../build_config
+  build:
+    path: ../build


### PR DESCRIPTION
Towards #1584

We were already counting on the build system resetting information from
the AnalysisContext and we were doing so in different ways.
`build_runner` was using an explicit type for it's resolvers and
resetting through that interface, `bazel_codegen` was making assumptions
about the use of the Analyzer and resetting global state.

This makes the resetting explicit and adds an interface for it to
`Resolvers` so that the build systems can make fewer assumptions about
the particulars.