### PR TITLE
release(build_test): prepare to release v0.10.2+5

### DIFF
--- a/build_test/lib/src/matchers.dart
+++ b/build_test/lib/src/matchers.dart
@@ -9,33 +9,20 @@ import 'package:test/test.dart';
 import 'package:build/build.dart';
 
 /// Matches instance of [AssetNotFoundException].
-final Matcher assetNotFoundException =
-    const TypeMatcher<AssetNotFoundException>();
+final assetNotFoundException = const TypeMatcher<AssetNotFoundException>();
 
 /// Matches instance of [InvalidInputException].
-final Matcher invalidInputException =
-    const TypeMatcher<InvalidInputException>();
+final invalidInputException = const TypeMatcher<InvalidInputException>();
 
 /// Matches instance of [InvalidOutputException].
-final Matcher invalidOutputException =
-    const TypeMatcher<InvalidOutputException>();
+final invalidOutputException = const TypeMatcher<InvalidOutputException>();
 
 /// Matches instance of [PackageNotFoundException].
-final Matcher packageNotFoundException =
-    const TypeMatcher<PackageNotFoundException>();
+final packageNotFoundException = const TypeMatcher<PackageNotFoundException>();
 
-/// Decodes the value using [encoding] and matches it agains [expected].
-Matcher decodedMatches(dynamic expected, {Encoding encoding}) =>
-    new _DecodedMatcher(expected, encoding: encoding);
-
-/// A matcher that decodes bytes and matches against the resulting string.
-class _DecodedMatcher extends CustomMatcher {
-  final Encoding _encoding;
-
-  _DecodedMatcher(matcher, {Encoding encoding})
-      : this._encoding = encoding ?? utf8,
-        super('Utf8 decoded bytes', 'utf8.decode', matcher);
-
-  @override
-  featureValueOf(bytes) => _encoding.decode(bytes as List<int>);
+/// Decodes the value using [encoding] and matches it against [expected].
+TypeMatcher<List<int>> decodedMatches(dynamic expected, {Encoding encoding}) {
+  encoding ??= utf8;
+  return new TypeMatcher<List<int>>().having(
+      (e) => encoding.decode(e), '${encoding.name} decoded bytes', expected);
 }

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.2+5-dev
+version: 0.10.2+5
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
@@ -21,7 +21,7 @@ dependencies:
   matcher: ^0.12.0
   package_resolver: ^1.0.2
   path: ^1.4.1
-  test: ^0.12.42
+  test: '>=0.12.42 <2.0.0'
   watcher: ^0.9.7
 
 dev_dependencies:


### PR DESCRIPTION
Support pkg:test v1
Expose all matches as Type<Matcher> so `.have` is accessible with them