### PR TITLE
Add more missing integration test imports

### DIFF
--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -241,6 +241,9 @@ main() async {
           ]),
           d.dir('tool', [
             d.file('build.dart', '''
+import 'dart:async';
+
+import 'package:build/build.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:build_test/build_test.dart';
 import 'package:glob/glob.dart';


### PR DESCRIPTION
Dart 1 treated these missing types as `dynamic`, but Dart 2 doesn't do
that and we get an invalid override.