### PR TITLE
Always log messages to stdout

### DIFF
--- a/_test/test/build_integration_test.dart
+++ b/_test/test/build_integration_test.dart
@@ -56,26 +56,6 @@ void main() {
     });
   });
 
-  group('--fail-on-severe', () {
-    setUp(() async {
-      // Perform an edit that should cause a failure.
-      await deleteFile('test/common/message.dart');
-    });
-
-    test('causes builds to return a non-zero exit code on errors', () async {
-      var result = await runBuild(trailingArgs: ['--fail-on-severe']);
-      expect(result.exitCode, isNot(0));
-      expect(result.stderr, contains('Failed'));
-    });
-
-    test('causes tests to return a non-zero exit code on errors', () async {
-      var result = await runTests(buildArgs: ['--fail-on-severe']);
-      expect(result.exitCode, isNot(0));
-      expect(result.stderr, contains('Failed'));
-      expect(result.stdout, contains('Skipping tests due to build failure'));
-    });
-  });
-
   group('regression tests', () {
     test('Failing optional outputs which are required during the next build',
         () async {
@@ -87,7 +67,7 @@ void main() {
           "import: 'package:_test/bad_file.dart';");
       final result = await runBuild(trailingArgs: ['--fail-on-severe']);
       expect(result.exitCode, isNot(0));
-      expect(result.stderr, contains('Failed'));
+      expect(result.stdout, contains('Failed'));
 
       // Remove the import to the bad file so it is no longer a requirement for
       // the overall build

--- a/_test/test/exception_handling_test.dart
+++ b/_test/test/exception_handling_test.dart
@@ -16,7 +16,7 @@ void main() {
             'error.');
     var result = await asyncResult;
     expect(
-        result.stderr, contains('Throwing on purpose cause you asked for it!'),
+        result.stdout, contains('Throwing on purpose cause you asked for it!'),
         reason: 'Exceptions from the isolate should be logged.');
     expect(result.exitCode, isNot(0),
         reason:

--- a/_test/test/serve_integration_test.dart
+++ b/_test/test/serve_integration_test.dart
@@ -50,7 +50,7 @@ void main() {
 
     test('ddc errors can be fixed', () async {
       var path = p.join('test', 'common', 'message.dart');
-      var error = nextStdErrLine('Error compiling dartdevc module:'
+      var error = nextStdOutLine('Error compiling dartdevc module:'
           '_test|test/common/message.ddc.js');
       var nextBuild = nextFailedBuild;
       await replaceAllInFile(path, "'Hello World!'", '1');

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -21,6 +21,10 @@
   exit code for the process.
 - Dropped `failOnSevere` arguments and `--fail-on-severe` flag. Severe logs are
   always considered failing.
+- Severe level logs now go to `stdout` along with other logs rather than
+  `stderr`. Uncaught exceptions from the `build_runner` system itself still go
+  to `stderr`.
+
 
 ## Other
 

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -60,11 +60,7 @@ void _stdIOLogListener(LogRecord record, {bool verbose}) {
     message.writeln('');
   }
 
-  if (record.level >= Level.SEVERE) {
-    stderr.write(message);
-  } else {
-    stdout.write(message);
-  }
+  stdout.write(message);
 }
 
 /// Filter out the Logger names known to come from `build_runner` and splits the

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -136,6 +136,9 @@ main(List<String> args) async {
           ]),
           d.dir('tool', [
             d.file('build.dart', '''
+import 'dart:async';
+
+import 'package:build/build.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:build_test/build_test.dart';
 import 'package:glob/glob.dart';
@@ -533,7 +536,7 @@ main() async {
       expect(result.exitCode, isNot(0),
           reason: 'build should fail due to conflicting outputs');
       expect(
-          result.stderr,
+          result.stdout,
           allOf(contains('Conflicting outputs'),
               contains('web/a.txt.copy.copy')));
     });

--- a/build_runner/test/generate/watch_integration_test.dart
+++ b/build_runner/test/generate/watch_integration_test.dart
@@ -12,7 +12,6 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:_test_common/common.dart';
 
 Process process;
-Stream<String> stdErrLines;
 Stream<String> stdOutLines;
 
 final String originalBuildContent = '''
@@ -54,11 +53,6 @@ main() {
           .transform(const LineSplitter())
           .asBroadcastStream();
 
-      stdErrLines = process.stderr
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())
-          .asBroadcastStream();
-
       await nextSuccessfulBuild;
       await d.dir('a', [
         d.dir('web', [d.file('a.txt.copy', 'a')])
@@ -72,7 +66,7 @@ main() {
           d.dir('tool', [d.file('build.dart', '$originalBuildContent\n')])
         ]).create();
 
-        await nextStdErrLine('Terminating builds due to build script update');
+        await nextStdOutLine('Terminating builds due to build script update');
         expect(await process.exitCode, equals(0));
       });
     });
@@ -106,5 +100,5 @@ main() {
 Future get nextSuccessfulBuild =>
     stdOutLines.firstWhere((line) => line.contains('Succeeded after'));
 
-Future nextStdErrLine(String message) =>
-    stdErrLines.firstWhere((line) => line.contains(message));
+Future nextStdOutLine(String message) =>
+    stdOutLines.firstWhere((line) => line.contains(message));

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -731,6 +731,7 @@ Future<BuildState> startWatch(List<BuilderApplication> builders,
     onLog(LogRecord record),
     Level logLevel = Level.OFF,
     String configKey}) {
+  onLog ??= (_) {};
   inputs.forEach((serializedId, contents) {
     writer.writeAsString(makeAssetId(serializedId), contents);
   });

--- a/build_runner/test/integration_tests/utils/build_descriptor.dart
+++ b/build_runner/test/integration_tests/utils/build_descriptor.dart
@@ -261,7 +261,7 @@ class BuildTool {
         _executable, _baseArgs.followedBy(['build']).followedBy(args).toList(),
         workingDirectory: p.join(d.sandbox, 'a'));
     await process.shouldExit(expectExitCode);
-    return process.stderr;
+    return process.stdout;
   }
 }
 


### PR DESCRIPTION
Closes #1594

- Update tests expecting the logs on stderr.
- Use a silent default `onLog` in `watch_test` to avoid extra output.
- Delete some no longer useful tests for `--fail-on-severe`.