### PR TITLE
Don't try to list files with empty sources

### DIFF
--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -397,11 +397,12 @@ class _Loader {
   Stream<AssetId> _mergeAll(Iterable<Stream<AssetId>> streams) =>
       streams.first.transform(mergeAll(streams.skip(1)));
 
-  Stream<AssetId> _listAssetIds(TargetNode targetNode) {
-    return _mergeAll(targetNode.sourceIncludes.map((glob) =>
-        _listIdsSafe(glob, package: targetNode.package.name)
-            .where((id) => !targetNode.excludesSource(id))));
-  }
+  Stream<AssetId> _listAssetIds(TargetNode targetNode) =>
+      targetNode.sourceIncludes.isEmpty
+          ? new Stream<AssetId>.empty()
+          : _mergeAll(targetNode.sourceIncludes.map((glob) =>
+              _listIdsSafe(glob, package: targetNode.package.name)
+                  .where((id) => !targetNode.excludesSource(id))));
 
   Stream<AssetId> _listGeneratedAssetIds() {
     var glob = new Glob('$generatedOutputDirectory/**');

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -87,7 +87,9 @@ targets:
       ).create();
       pkgARoot = p.join(d.sandbox, 'pkg_a');
       var packageGraph = new PackageGraph.forPath(pkgARoot);
-      environment = new IOEnvironment(packageGraph, null);
+      environment = new OverrideableEnvironment(
+          new IOEnvironment(packageGraph, null),
+          onLog: (_) {});
       options = await BuildOptions.create(environment,
           packageGraph: packageGraph,
           logLevel: Level.OFF,
@@ -609,6 +611,24 @@ targets:
             options.targetGraph.allModules['$rootPkg:$rootPkg'].sourceIncludes
                 .map((glob) => glob.pattern),
             defaultRootPackageWhitelist);
+      });
+
+      test('allows a target config with empty sources list', () async {
+        var rootPkg = options.packageGraph.root.name;
+        options = await BuildOptions.create(environment,
+            packageGraph: options.packageGraph,
+            overrideBuildConfig: {
+              rootPkg: new BuildConfig.fromMap(rootPkg, [], {
+                'targets': {
+                  'another': {},
+                  '\$default': {
+                    'sources': {'include': []}
+                  }
+                }
+              })
+            });
+        expect(BuildDefinition.prepareWorkspace(environment, options, []),
+            completes);
       });
     });
   });


### PR DESCRIPTION
Fixes #1574

This bug was never present in a published build_runner so no changelog
is necessary.

- Bail out with an empty stream when `sourceIncludes` is empty.
- Add a regression test.
- Silence logging by default in this test.