### PR TITLE
Prepare to publish build_resolvers 0.2.1

### DIFF
--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -5,18 +5,14 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 
 environment:
-  sdk: '>=2.0.0-dev.32 <2.0.0'
+  sdk: ">=2.0.0-dev.32 <2.0.0"
 
 dependencies:
-  analyzer: '>=0.27.1 <0.33.0'
-  build: ^0.12.7
+  analyzer: ">=0.27.1 <0.33.0"
+  build: ">=0.12.7 <0.12.8"
   cli_util: ^0.1.0
   path: ^1.1.0
 
 dev_dependencies:
   test: ^0.12.0
   build_test: ^0.10.1
-
-dependency_overrides:
-  build:
-    path: ../build


### PR DESCRIPTION
Use a narrow constraint on package:build since we implement APIs most
packages won't.