### PR TITLE
track digests in scratch_space to speed up ensureAssets

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.3-dev
+
+- Update to the latest `package:scratch_space` and don't manually clear it out
+  between builds. This provides significant speed improvements for large
+  projects.
+
 ## 0.2.2+6
 
 - Support the latest `package:build_config`.

--- a/build_modules/lib/src/scratch_space.dart
+++ b/build_modules/lib/src/scratch_space.dart
@@ -26,10 +26,6 @@ final scratchSpaceResource = new Resource<ScratchSpace>(() {
     scratchSpace.exists = true;
   }
   return scratchSpace;
-}, dispose: (_) async {
-  await for (var entity in scratchSpace.tempDir.list()) {
-    await entity.delete(recursive: true);
-  }
 }, beforeExit: () async {
   // The workers are running inside the scratch space, so wait for them to
   // shut down before deleting it.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 0.2.2+6
+version: 0.2.3-dev
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
@@ -19,7 +19,7 @@ dependencies:
   json_annotation: ^0.2.2
   logging: ^0.11.2
   path: ^1.4.2
-  scratch_space: ^0.0.1
+  scratch_space: ^0.0.3
 
 dev_dependencies:
   build_runner: ^0.8.4
@@ -31,3 +31,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  scratch_space:
+    path: ../scratch_space

--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.3
+
+- Use digests to improve `ensureAssets` performance.
+  - Scratch spaces can now be used across builds without cleaning them up, and
+    will check digests and update assets as needed.
+
 ## 0.0.2+1
 
 - Fix a bug where failing to read an asset in serve mode could get the build
@@ -19,7 +25,7 @@
 
 - Fix a deadlock issue around the file descriptor pool, only take control of a
   resource right before actually touching disk instead of also encapsulating
-  the `readAsBytes` call from the wrapped `AssetReader`.  
+  the `readAsBytes` call from the wrapped `AssetReader`.
 
 ## 0.0.1
 

--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -105,7 +105,8 @@ class ScratchSpace {
                   await file.writeAsBytes(await reader.readAsBytes(id));
                 }));
       } finally {
-        _pendingWrites..remove(id);
+        // ignore: unawaited_futures
+        _pendingWrites.remove(id);
       }
     }).toList();
 

--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -66,6 +66,7 @@ class ScratchSpace {
           'Tried to delete a ScratchSpace which was already deleted');
     }
     exists = false;
+    _digests.clear();
     return tempDir.delete(recursive: true);
   }
 

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scratch_space
-version: 0.0.2+1
+version: 0.0.3
 description: A tool to manage running external executables within package:build
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space
@@ -9,10 +9,10 @@ environment:
 
 dependencies:
   build: '>=0.10.0 <0.13.0'
+  crypto: ">=2.0.3 <3.0.0"
   path: ^1.1.0
   pool: ^1.0.0
 
 dev_dependencies:
   build_test: ^0.10.0
-  crypto: ^2.0.3
   test: ^0.12.0

--- a/scratch_space/test/scratch_space_test.dart
+++ b/scratch_space/test/scratch_space_test.dart
@@ -162,5 +162,5 @@ class RecursiveScratchSpaceAssetReader implements AssetReader {
   readAsString(_, {encoding}) => throw new UnimplementedError();
 
   @override
-  Future<Digest> digest(AssetId id) => throw new UnimplementedError();
+  Future<Digest> digest(AssetId id) async => new Digest(await readAsBytes(id));
 }


### PR DESCRIPTION
This allows us to not have to clear the scratch space between builds, and also eliminates a lot of `file.existsSync()` calls.

Will publish scratch_space after this PR, then send a PR to publish build_modules.