### PR TITLE
Discussion: Canonicalize AssetIds before storing them

### DIFF
--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -505,6 +505,8 @@ class AssetGraph {
   // TODO remove once tests are updated
   void add(AssetNode node) => _add(node);
   Set<AssetId> remove(AssetId id) => _removeRecursive(id);
+
+  AssetId canonicalize(AssetId id) => get(id)?.id ?? id;
 }
 
 /// Computes a [Digest] for [buildPhases] which can be used to compare one set

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -742,7 +742,8 @@ class _SingleBuild {
   /// Adds new inputs to [node] based on [updatedInputs], and adds the
   /// appropriate edges.
   void _addNewInputs(GeneratedAssetNode node, Set<AssetId> updatedInputs) {
-    var newInputs = updatedInputs.difference(node.inputs);
+    var newInputs =
+        updatedInputs.difference(node.inputs).map(_assetGraph.canonicalize);
     node.inputs.addAll(newInputs);
     for (var input in newInputs) {
       var inputNode = _assetGraph.get(input);


### PR DESCRIPTION
If we get duplicate copies of Strings or AssetIds generated by Builders
and passed to the AssetReader we might inflate the size of the
AssetGraph.