### PR TITLE
Use a shared AnalyzerResolvers by default

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.10.2+5-dev
+## 0.10.3
 
 - Require test version ^0.12.42 and use `TypeMatcher`.
+- Improve performance of test methods which use a `Resolver` by keeping a cached
+  instance of `AnalyzerResolvers`.
 
 ## 0.10.2+4
 

--- a/build_test/lib/build_test.dart
+++ b/build_test/lib/build_test.dart
@@ -14,7 +14,8 @@ export 'src/matchers.dart';
 export 'src/multi_asset_reader.dart' show MultiAssetReader;
 export 'src/package_reader.dart' show PackageAssetReader;
 export 'src/record_logs.dart';
-export 'src/resolve_source.dart';
+export 'src/resolve_source.dart'
+    show useAssetReader, resolveSource, resolveSources, resolveAsset;
 export 'src/stub_reader.dart';
 export 'src/stub_writer.dart';
 export 'src/test_builder.dart';

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -13,6 +13,8 @@ import 'in_memory_writer.dart';
 import 'multi_asset_reader.dart';
 import 'package_reader.dart';
 
+final defaultResolvers = new AnalyzerResolvers();
+
 /// Marker constant that may be used in combination with [resolveSources].
 ///
 /// Use of this string means instead of using the contents of the string as the
@@ -197,7 +199,7 @@ Future<T> _resolveAssets<T>(
     inputAssets.keys,
     new MultiAssetReader([inMemory, assetReader]),
     new InMemoryAssetWriter(),
-    resolvers ?? new AnalyzerResolvers(),
+    resolvers ?? defaultResolvers,
   );
   return resolveBuilder.onDone.future;
 }

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -133,8 +133,7 @@ Future testBuilder(
   var writerSpy = new AssetWriterSpy(writer);
   var logger = new Logger('testBuilder');
   var logSubscription = logger.onRecord.listen(onLog);
-  await runBuilder(
-      builder, inputIds, reader, writerSpy, defaultResolvers,
+  await runBuilder(builder, inputIds, reader, writerSpy, defaultResolvers,
       logger: logger);
   await logSubscription.cancel();
   var actualOutputs = writerSpy.assetsWritten;

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -5,13 +5,13 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:build/build.dart';
-import 'package:build_resolvers/build_resolvers.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import 'assets.dart';
 import 'in_memory_reader.dart';
 import 'in_memory_writer.dart';
+import 'resolve_source.dart';
 
 AssetId _passThrough(AssetId id) => id;
 
@@ -134,7 +134,7 @@ Future testBuilder(
   var logger = new Logger('testBuilder');
   var logSubscription = logger.onRecord.listen(onLog);
   await runBuilder(
-      builder, inputIds, reader, writerSpy, new AnalyzerResolvers(),
+      builder, inputIds, reader, writerSpy, defaultResolvers,
       logger: logger);
   await logSubscription.cancel();
   var actualOutputs = writerSpy.assetsWritten;

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.2+5
+version: 0.10.3
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 


### PR DESCRIPTION
Closes #1418

This brings performance for tests back inline with what it was when this
code was using a `const BarbackResolvers()` instance.