### PR TITLE
significantly reduce the memory consumed by createOutputDirs

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Clarify wording for conflicting output directory options. No behavioral
   differences.
+- Reduce the memory consumption required to create an output dir significantly.
 
 ## 0.2.1+1
 


### PR DESCRIPTION
Wrap the read and write calls up together when grabbing from the pool of available descriptors, previously we would end up doing all reads first and blocking the writes, which effectively caused us to hold all assets in memory.