### PR TITLE
Move check for consistent module dir to assert

### DIFF
--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -268,11 +268,10 @@ bool _isEntrypoint(CompilationUnit dart) {
 
 Future<List<Module>> _computeModules(
     AssetReader reader, List<AssetId> assets, bool public) async {
-  var dir = _topLevelDir(assets.first.path);
-  if (!assets.every((src) => _topLevelDir(src.path) == dir)) {
-    throw new ArgumentError(
-        'All srcs must live in the same top level directory.');
-  }
+  assert(() {
+    var dir = _topLevelDir(assets.first.path);
+    return assets.every((src) => _topLevelDir(src.path) == dir);
+  }());
 
   // The set of entry points from `srcAssets` based on `mode`.
   var entryIds = new Set<AssetId>();


### PR DESCRIPTION
We're the only consumers of this API and the check is really meant to
ensure that there are no bugs in the usage. This can safely be skipped
during builds and will be checked within tests.