### PR TITLE
Move ModuleLibrary parsing to a separate builder

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -28,6 +28,7 @@ final _builders = <_i1.BuilderApplication>[
   _i1.apply(
       'build_modules|modules',
       [
+        _i5.moduleLibraryBuilder,
         _i5.metaModuleBuilder,
         _i5.metaModuleCleanBuilder,
         _i5.moduleBuilder,

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Removed the `kernelSummaryExtension`, and renamed the `KernelSummaryBuilder`
   to `KernelBuilder`. The new builder can be used to create summaries or full
   kernel files, and requires users to give it a custom sdk.
+- Changed `metaModuleCleanBuilder` to read `.dart.library` files which are
+  produced by the `moduleLibrayBuilder`. Clients using the automatically
+  generated build script will get this automatically. Clients which have
+  manually written build scripts will need to add it.
 
 ## 0.2.3
 

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Removed the `kernelSummaryExtension`, and renamed the `KernelSummaryBuilder`
   to `KernelBuilder`. The new builder can be used to create summaries or full
   kernel files, and requires users to give it a custom sdk.
-- Changed `metaModuleCleanBuilder` to read `.dart.library` files which are
+- Changed `metaModuleCleanBuilder` to read `.module.library` files which are
   produced by the `moduleLibrayBuilder`. Clients using the automatically
   generated build script will get this automatically. Clients which have
   manually written build scripts will need to add it.

--- a/build_modules/build.yaml
+++ b/build_modules/build.yaml
@@ -2,6 +2,7 @@ builders:
   modules:
     import: "package:build_modules/builders.dart"
     builder_factories:
+      - moduleLibraryBuilder
       - metaModuleBuilder
       - metaModuleCleanBuilder
       - moduleBuilder
@@ -12,6 +13,7 @@ builders:
         - .meta_module.raw
         - .meta_module.clean
       .dart:
+        - .dart.library
         - .module
         - .linked.sum
         - .unlinked.sum

--- a/build_modules/build.yaml
+++ b/build_modules/build.yaml
@@ -13,7 +13,7 @@ builders:
         - .meta_module.raw
         - .meta_module.clean
       .dart:
-        - .dart.library
+        - .module.library
         - .module
         - .linked.sum
         - .unlinked.sum

--- a/build_modules/lib/build_modules.dart
+++ b/build_modules/lib/build_modules.dart
@@ -9,6 +9,7 @@ export 'src/meta_module_builder.dart'
 export 'src/meta_module_clean_builder.dart'
     show MetaModuleCleanBuilder, metaModuleCleanExtension;
 export 'src/module_builder.dart' show ModuleBuilder, moduleExtension;
+export 'src/module_library_builder.dart' show ModuleLibraryBuilder;
 export 'src/modules.dart';
 export 'src/scratch_space.dart' show scratchSpace, scratchSpaceResource;
 export 'src/summary_builder.dart'

--- a/build_modules/lib/build_modules.dart
+++ b/build_modules/lib/build_modules.dart
@@ -9,7 +9,8 @@ export 'src/meta_module_builder.dart'
 export 'src/meta_module_clean_builder.dart'
     show MetaModuleCleanBuilder, metaModuleCleanExtension;
 export 'src/module_builder.dart' show ModuleBuilder, moduleExtension;
-export 'src/module_library_builder.dart' show ModuleLibraryBuilder;
+export 'src/module_library_builder.dart'
+    show ModuleLibraryBuilder, moduleLibraryExtension;
 export 'src/modules.dart';
 export 'src/scratch_space.dart' show scratchSpace, scratchSpaceResource;
 export 'src/summary_builder.dart'

--- a/build_modules/lib/builders.dart
+++ b/build_modules/lib/builders.dart
@@ -7,6 +7,7 @@ import 'package:build_modules/build_modules.dart';
 import 'package:build_modules/src/meta_module_builder.dart';
 import 'package:build_modules/src/meta_module_clean_builder.dart';
 import 'package:build_modules/src/module_cleanup.dart';
+import 'package:build_modules/src/module_library_builder.dart';
 
 Builder moduleBuilder(BuilderOptions options) =>
     new ModuleBuilder.forOptions(options);
@@ -15,5 +16,6 @@ Builder linkedSummaryBuilder(_) => const LinkedSummaryBuilder();
 Builder metaModuleBuilder(_) => const MetaModuleBuilder();
 Builder metaModuleCleanBuilder(BuilderOptions options) =>
     const MetaModuleCleanBuilder();
+Builder moduleLibraryBuilder(_) => const ModuleLibraryBuilder();
 
 PostProcessBuilder moduleCleanup(_) => const ModuleCleanup();

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -213,8 +213,9 @@ class MetaModule extends Object with _$MetaModuleSerializerMixin {
       AssetReader reader, List<AssetId> libraryAssets) async {
     var librariesByDirectory = <String, Map<AssetId, ModuleLibrary>>{};
     for (var libraryAsset in libraryAssets) {
-      final library =
-          ModuleLibrary.parse(await reader.readAsString(libraryAsset));
+      final library = ModuleLibrary.parse(
+          libraryAsset.changeExtension('').changeExtension('.dart'),
+          await reader.readAsString(libraryAsset));
       final dir = _topLevelDir(libraryAsset.path);
       if (!librariesByDirectory.containsKey(dir)) {
         librariesByDirectory[dir] = <AssetId, ModuleLibrary>{};

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -209,18 +209,17 @@ class MetaModule extends Object with _$MetaModuleSerializerMixin {
   factory MetaModule.fromJson(Map<String, dynamic> json) =>
       _$MetaModuleFromJson(json);
 
-  static Future<MetaModule> forAssets(
-      AssetReader reader, List<AssetId> assets) async {
+  static Future<MetaModule> forLibraries(
+      AssetReader reader, List<AssetId> libraryAssets) async {
     var librariesByDirectory = <String, Map<AssetId, ModuleLibrary>>{};
-    for (var asset in assets) {
+    for (var libraryAsset in libraryAssets) {
       final library =
-          ModuleLibrary.fromSource(asset, await reader.readAsString(asset));
-      if (!library.isImportable) continue;
-      final dir = _topLevelDir(asset.path);
+          ModuleLibrary.parse(await reader.readAsString(libraryAsset));
+      final dir = _topLevelDir(libraryAsset.path);
       if (!librariesByDirectory.containsKey(dir)) {
         librariesByDirectory[dir] = <AssetId, ModuleLibrary>{};
       }
-      librariesByDirectory[dir][asset] = library;
+      librariesByDirectory[dir][library.id] = library;
     }
     final modules =
         librariesByDirectory.values.expand(_computeModules).toList();

--- a/build_modules/lib/src/meta_module_builder.dart
+++ b/build_modules/lib/src/meta_module_builder.dart
@@ -36,8 +36,9 @@ class MetaModuleBuilder implements Builder {
   Future build(BuildStep buildStep) async {
     if (!_isCoarse) return;
 
-    var assets = await buildStep.findAssets(new Glob('**.dart')).toList();
-    var metaModule = await MetaModule.forAssets(buildStep, assets);
+    var libraryAssets =
+        await buildStep.findAssets(new Glob('**.dart.library')).toList();
+    var metaModule = await MetaModule.forLibraries(buildStep, libraryAssets);
     var id = new AssetId(buildStep.inputId.package, 'lib/$metaModuleExtension');
     await buildStep.writeAsString(id, json.encode(metaModule.toJson()));
   }

--- a/build_modules/lib/src/meta_module_builder.dart
+++ b/build_modules/lib/src/meta_module_builder.dart
@@ -10,6 +10,7 @@ import 'package:glob/glob.dart';
 
 import 'common.dart';
 import 'meta_module.dart';
+import 'module_library_builder.dart';
 
 /// The extension for serialized meta module assets.
 const metaModuleExtension = '.meta_module.raw';
@@ -36,8 +37,9 @@ class MetaModuleBuilder implements Builder {
   Future build(BuildStep buildStep) async {
     if (!_isCoarse) return;
 
-    var libraryAssets =
-        await buildStep.findAssets(new Glob('**.dart.library')).toList();
+    var libraryAssets = await buildStep
+        .findAssets(new Glob('**$moduleLibraryExtension'))
+        .toList();
     var metaModule = await MetaModule.forLibraries(buildStep, libraryAssets);
     var id = new AssetId(buildStep.inputId.package, 'lib/$metaModuleExtension');
     await buildStep.writeAsString(id, json.encode(metaModule.toJson()));

--- a/build_modules/lib/src/module_cleanup.dart
+++ b/build_modules/lib/src/module_cleanup.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 
 import 'package:build/build.dart';
 
+import 'module_library_builder.dart';
+
 class ModuleCleanup implements PostProcessBuilder {
   const ModuleCleanup();
 
@@ -17,7 +19,7 @@ class ModuleCleanup implements PostProcessBuilder {
 
   @override
   final inputExtensions = const [
-    '.dart.library',
+    moduleLibraryExtension,
     '.meta_module.raw',
     '.meta_module.clean',
     '.module',

--- a/build_modules/lib/src/module_cleanup.dart
+++ b/build_modules/lib/src/module_cleanup.dart
@@ -17,6 +17,7 @@ class ModuleCleanup implements PostProcessBuilder {
 
   @override
   final inputExtensions = const [
+    '.dart.library',
     '.meta_module.raw',
     '.meta_module.clean',
     '.module',

--- a/build_modules/lib/src/module_library.dart
+++ b/build_modules/lib/src/module_library.dart
@@ -105,6 +105,33 @@ class ModuleLibrary {
         (isLibDir && !id.path.startsWith('lib/src/')) || _hasMainMethod(parsed);
     return new ModuleLibrary._fromCompilationUnit(id, isEntryPoint, parsed);
   }
+
+  /// Parses the output of [toString] back into a [ModuleLibrary].
+  ///
+  /// Importable libraries can be round tripped to a String. Non-importable
+  /// libraries should not be printed or parsed.
+  static ModuleLibrary parse(String encoded) {
+    final lines = encoded.split('\n');
+    final id = new AssetId.parse(lines.first);
+    final isEntryPoint = lines[1] == 'true';
+    final separator = lines.indexOf('');
+    final deps =
+        lines.sublist(2, separator).map((l) => new AssetId.parse(l)).toSet();
+    final parts = lines
+        .sublist(separator + 1)
+        .where((l) => l.isNotEmpty)
+        .map((l) => new AssetId.parse(l))
+        .toSet();
+    return new ModuleLibrary._(id,
+        isEntryPoint: isEntryPoint, deps: deps, parts: parts);
+  }
+
+  @override
+  String toString() => '$id\n'
+      '${isEntryPoint ? 'true' : 'false'}\n'
+      '${deps.join('\n')}\n'
+      '\n'
+      '${parts.join('\n')}\n';
 }
 
 bool _isPart(CompilationUnit dart) =>

--- a/build_modules/lib/src/module_library.dart
+++ b/build_modules/lib/src/module_library.dart
@@ -110,13 +110,12 @@ class ModuleLibrary {
   ///
   /// Importable libraries can be round tripped to a String. Non-importable
   /// libraries should not be printed or parsed.
-  static ModuleLibrary parse(String encoded) {
+  static ModuleLibrary parse(AssetId id, String encoded) {
     final lines = encoded.split('\n');
-    final id = new AssetId.parse(lines.first);
-    final isEntryPoint = lines[1] == 'true';
+    final isEntryPoint = lines.first == 'true';
     final separator = lines.indexOf('');
     final deps =
-        lines.sublist(2, separator).map((l) => new AssetId.parse(l)).toSet();
+        lines.sublist(1, separator).map((l) => new AssetId.parse(l)).toSet();
     final parts = lines
         .sublist(separator + 1)
         .where((l) => l.isNotEmpty)
@@ -127,8 +126,7 @@ class ModuleLibrary {
   }
 
   @override
-  String toString() => '$id\n'
-      '${isEntryPoint ? 'true' : 'false'}\n'
+  String toString() => '${isEntryPoint ? 'true' : 'false'}\n'
       '${deps.join('\n')}\n'
       '\n'
       '${parts.join('\n')}\n';

--- a/build_modules/lib/src/module_library_builder.dart
+++ b/build_modules/lib/src/module_library_builder.dart
@@ -8,21 +8,23 @@ import 'package:build/build.dart';
 
 import 'module_library.dart';
 
-/// Creates `.library` assets listing the dependencies and parts for aDart
-/// library, as well as whether it is an entrypoint.
+const moduleLibraryExtension = '.module.library';
+
+/// Creates `.module.library` assets listing the dependencies and parts for a
+/// Dart library, as well as whether it is an entrypoint.
 ///
 ///
 /// The output format is determined by [ModuleLibrary.toString] and can be
 /// restored by [ModuleLibrary.parse].
 ///
-/// Non-importable Dart source files will not get a `.library` asset output. See
-/// [ModuleLibrary.isImportable].
+/// Non-importable Dart source files will not get a `.module.library` asset
+/// output. See [ModuleLibrary.isImportable].
 class ModuleLibraryBuilder implements Builder {
   const ModuleLibraryBuilder();
 
   @override
   final buildExtensions = const {
-    '.dart': const ['.dart.library']
+    '.dart': const [moduleLibraryExtension]
   };
 
   @override
@@ -31,6 +33,6 @@ class ModuleLibraryBuilder implements Builder {
         buildStep.inputId, await buildStep.readAsString(buildStep.inputId));
     if (!library.isImportable) return;
     await buildStep.writeAsString(
-        buildStep.inputId.addExtension('.library'), '$library');
+        buildStep.inputId.changeExtension(moduleLibraryExtension), '$library');
   }
 }

--- a/build_modules/lib/src/module_library_builder.dart
+++ b/build_modules/lib/src/module_library_builder.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+
+import 'module_library.dart';
+
+/// Creates `.library` assets listing the dependencies and parts for aDart
+/// library, as well as whether it is an entrypoint.
+///
+///
+/// The output format is determined by [ModuleLibrary.toString] and can be
+/// restored by [ModuleLibrary.parse].
+///
+/// Non-importable Dart source files will not get a `.library` asset output. See
+/// [ModuleLibrary.isImportable].
+class ModuleLibraryBuilder implements Builder {
+  const ModuleLibraryBuilder();
+
+  @override
+  final buildExtensions = const {
+    '.dart': const ['.dart.library']
+  };
+
+  @override
+  Future build(BuildStep buildStep) async {
+    final library = ModuleLibrary.fromSource(
+        buildStep.inputId, await buildStep.readAsString(buildStep.inputId));
+    if (!library.isImportable) return;
+    await buildStep.writeAsString(
+        buildStep.inputId.addExtension('.library'), '$library');
+  }
+}

--- a/build_modules/test/meta_module_builder_test.dart
+++ b/build_modules/test/meta_module_builder_test.dart
@@ -17,7 +17,9 @@ main() {
     var moduleA = new Module(assetA, [assetA], <AssetId>[]);
     var metaA = new MetaModule([moduleA]);
     await testBuilder(new MetaModuleBuilder(), {
-      'a|lib/a.dart': '',
+      'a|lib/a.dart.library': 'a|lib/a.dart\n'
+          'true\n'
+          '\n',
     }, outputs: {
       'a|lib/$metaModuleExtension': encodedMatchesMetaModule(metaA),
     });

--- a/build_modules/test/meta_module_builder_test.dart
+++ b/build_modules/test/meta_module_builder_test.dart
@@ -17,9 +17,7 @@ main() {
     var moduleA = new Module(assetA, [assetA], <AssetId>[]);
     var metaA = new MetaModule([moduleA]);
     await testBuilder(new MetaModuleBuilder(), {
-      'a|lib/a.module.library': 'a|lib/a.dart\n'
-          'true\n'
-          '\n',
+      'a|lib/a.module.library': 'true\n\n',
     }, outputs: {
       'a|lib/$metaModuleExtension': encodedMatchesMetaModule(metaA),
     });

--- a/build_modules/test/meta_module_builder_test.dart
+++ b/build_modules/test/meta_module_builder_test.dart
@@ -17,7 +17,7 @@ main() {
     var moduleA = new Module(assetA, [assetA], <AssetId>[]);
     var metaA = new MetaModule([moduleA]);
     await testBuilder(new MetaModuleBuilder(), {
-      'a|lib/a.dart.library': 'a|lib/a.dart\n'
+      'a|lib/a.module.library': 'a|lib/a.dart\n'
           'true\n'
           '\n',
     }, outputs: {

--- a/build_modules/test/meta_module_test.dart
+++ b/build_modules/test/meta_module_test.dart
@@ -34,8 +34,7 @@ void main() {
             ModuleLibrary.fromSource(s, await reader.readAsString(s)))))
         .where((l) => l.isImportable);
     for (final library in libraries) {
-        reader.cacheStringAsset(
-            library.id.addExtension('.library'), '$library');
+      reader.cacheStringAsset(library.id.addExtension('.library'), '$library');
     }
     return MetaModule.forLibraries(
         reader, libraries.map((l) => l.id.addExtension('.library')).toList());

--- a/build_modules/test/meta_module_test.dart
+++ b/build_modules/test/meta_module_test.dart
@@ -8,6 +8,7 @@ import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
+import 'package:build_modules/build_modules.dart';
 import 'package:build_modules/src/meta_module.dart';
 import 'package:build_modules/src/module_library.dart';
 import 'package:build_modules/src/modules.dart';
@@ -34,10 +35,14 @@ void main() {
             ModuleLibrary.fromSource(s, await reader.readAsString(s)))))
         .where((l) => l.isImportable);
     for (final library in libraries) {
-      reader.cacheStringAsset(library.id.addExtension('.library'), '$library');
+      reader.cacheStringAsset(
+          library.id.changeExtension(moduleLibraryExtension), '$library');
     }
     return MetaModule.forLibraries(
-        reader, libraries.map((l) => l.id.addExtension('.library')).toList());
+        reader,
+        libraries
+            .map((l) => l.id.changeExtension(moduleLibraryExtension))
+            .toList());
   }
 
   test('no strongly connected components, one shared lib', () async {

--- a/build_modules/test/summary_builder_test.dart
+++ b/build_modules/test/summary_builder_test.dart
@@ -8,6 +8,7 @@ import 'package:test/test.dart';
 
 import 'package:build_modules/build_modules.dart';
 import 'package:build_modules/src/meta_module_clean_builder.dart';
+import 'package:build_modules/src/module_library_builder.dart';
 
 import 'matchers.dart';
 import 'util.dart';
@@ -33,6 +34,7 @@ main() {
       };
 
       // Set up all the other required inputs for this test.
+      await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
       await testBuilderAndCollectAssets(new MetaModuleBuilder(), assets);
       await testBuilderAndCollectAssets(new MetaModuleCleanBuilder(), assets);
       await testBuilderAndCollectAssets(new ModuleBuilder(), assets);

--- a/build_modules/test/summary_builder_test.dart
+++ b/build_modules/test/summary_builder_test.dart
@@ -2,13 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:build_modules/build_modules.dart';
 import 'package:build_test/build_test.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
-
-import 'package:build_modules/build_modules.dart';
-import 'package:build_modules/src/meta_module_clean_builder.dart';
-import 'package:build_modules/src/module_library_builder.dart';
 
 import 'matchers.dart';
 import 'util.dart';

--- a/build_web_compilers/test/dart2js_bootstrap_test.dart
+++ b/build_web_compilers/test/dart2js_bootstrap_test.dart
@@ -29,6 +29,7 @@ main() {
     };
 
     // Set up all the other required inputs for this test.
+    await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
     await testBuilderAndCollectAssets(new MetaModuleBuilder(), assets);
     await testBuilderAndCollectAssets(new MetaModuleCleanBuilder(), assets);
     await testBuilderAndCollectAssets(new ModuleBuilder(), assets);

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -30,6 +30,7 @@ main() {
     };
 
     // Set up all the other required inputs for this test.
+    await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
     await testBuilderAndCollectAssets(new MetaModuleBuilder(), assets);
     await testBuilderAndCollectAssets(new MetaModuleCleanBuilder(), assets);
     await testBuilderAndCollectAssets(new ModuleBuilder(), assets);

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -32,6 +32,7 @@ main() {
       };
 
       // Set up all the other required inputs for this test.
+      await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
       await testBuilderAndCollectAssets(new MetaModuleBuilder(), assets);
       await testBuilderAndCollectAssets(new MetaModuleCleanBuilder(), assets);
       await testBuilderAndCollectAssets(new ModuleBuilder(), assets);
@@ -63,6 +64,7 @@ main() {
         };
 
         // Set up all the other required inputs for this test.
+        await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
         await testBuilderAndCollectAssets(new MetaModuleBuilder(), assets);
         await testBuilderAndCollectAssets(new MetaModuleCleanBuilder(), assets);
         await testBuilderAndCollectAssets(new ModuleBuilder(), assets);


### PR DESCRIPTION
Closes #1644

- Add capability to write and parse a String for a `ModuleLibrary`.
- Add a Builder to produce these files. This is a thin wrapper around
  the functionality in `ModuleLibrary`.
- Change `MetaModuleBuilder` to use the library assets instead of the
  source assets.
- Update tests to reflect new behavior.
- Add cleanup of the `.dart.library` files since they are not useful
  outside of the build.