### PR TITLE
update the sdk deps and package:test deps across packages

### DIFF
--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -2,12 +2,12 @@ name: _test
 description: A basic web app
 
 environment:
-  sdk: '>=2.0.0-dev.61 <2.0.0'
+  sdk: '>=2.0.0-dev.61 <3.0.0'
 
 dev_dependencies:
   analyzer: ">=0.30.0 <0.33.0"
   path: ^1.4.2
-  test: ^0.12.0
+  test: ^1.0.0
   provides_builder:
     path: pkgs/provides_builder/
 

--- a/_test_common/pubspec.yaml
+++ b/_test_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: Test infra for writing build tests. Is not published.
 
 environment:
-  sdk: '>=2.0.0-dev.54 <2.0.0'
+  sdk: '>=2.0.0-dev.54 <3.0.0'
 
 dependencies:
   build: any

--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,10 +1,8 @@
-# 0.3.1+4
+# 0.3.2-dev
 
+- Increased the upper bound for the sdk to `<3.0.0`.
 - Drop dependency on `build_barback`.
 - Use the latest `build`.
-
-# 0.3.1+3
-
 - Support `package:analyzer` `0.32.0`.
 
 # 0.3.1+2

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,10 +2,10 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/bazel_codegen
-version: 0.3.1+4
+version: 0.3.2-dev
 
 environment:
-  sdk: ">=2.0.0-dev.32 <2.0.0"
+  sdk: ">=2.0.0-dev.32 <3.0.0"
 
 dependencies:
   analyzer: '>=0.31.2-alpha.1 <0.33.0'
@@ -20,5 +20,5 @@ dependencies:
 
 dev_dependencies:
   build_test: ^0.10.0
-  test: ^0.12.15
+  test: ^1.0.0
   test_descriptor: ^1.0.0

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.7+2
+
+- Increased the upper bound for the sdk to `<3.0.0`.
+
 ## 0.12.7+1
 
 - `AssetId`s can no longer be constructed with paths that reach outside their

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build
-version: 0.12.7+1
+version: 0.12.7+2
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build
 
 environment:
-  sdk: '>=2.0.0-dev.9 <2.0.0'
+  sdk: '>=2.0.0-dev.9 <3.0.0'
 
 dependencies:
   analyzer: ">=0.27.1 <0.33.0"

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+1
+
+- Increased the upper bound for the sdk to `<3.0.0`.
+
 ## 0.3.1
 
 - Improve validation and errors when parsing `build.yaml`.

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_config
-version: 0.3.1
+version: 0.3.1+1
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config
 
 environment:
-  sdk: '>=2.0.0-dev.54 <2.0.0'
+  sdk: '>=2.0.0-dev.54 <3.0.0'
 
 dependencies:
   build: ^0.12.1
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   build_runner: ^0.8.0
   json_serializable: ^0.5.7
-  test: ^0.12.24
+  test: ^1.0.0

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated dart2js support so that it can do multiple builds concurrently and
   will restart workers periodically to mitigate the effects of
   dart-lang/sdk#33708.
+- Increased the upper bound for the sdk to `<3.0.0`.
 
 ### Breaking Changes
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: '>=2.0.0-dev.48 <2.0.0'
+  sdk: '>=2.0.0-dev.48 <3.0.0'
 
 dependencies:
   analyzer: ">0.30.0 < 0.33.0"

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,25 +1,29 @@
-# 0.2.1
+## 0.2.1+1
+
+- Increased the upper bound for the sdk to `<3.0.0`.
+
+## 0.2.1
 
 - Allow passing in custom `AnalysisOptions`.
 
-# 0.2.0+2
+## 0.2.0+2
 
 - Support `package:analyzer` `0.32.0`.
 
-# 0.2.0+1
+## 0.2.0+1
 
 - Switch to `firstWhere(orElse)` for compatibility with the SDK dev.45
 
-# 0.2.0
+## 0.2.0
 
 - Removed locking between uses of the Resolver and added a mandatory `reset`
   call to indicate that a complete build is finished.
 
-# 0.1.1
+## 0.1.1
 
 - Support the latest `analyzer` package.
 
-# 0.1.0
+## 0.1.0
 
 - Initial release as a migration from `code_transformers` with a near-identical
   implementation.

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_resolvers
-version: 0.2.1
+version: 0.2.1+1
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 
 environment:
-  sdk: ">=2.0.0-dev.32 <2.0.0"
+  sdk: ">=2.0.0-dev.32 <3.0.0"
 
 dependencies:
   analyzer: ">=0.27.1 <0.33.0"
@@ -14,5 +14,5 @@ dependencies:
   path: ^1.1.0
 
 dev_dependencies:
-  test: ^0.12.0
+  test: ^1.0.0
   build_test: ^0.10.1

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1+1
+
+- Increased the upper bound for the sdk to `<3.0.0`.
+
 ## 0.9.1
 
 - The hash dir for the asset graph under `.dart_tool/build` is now based on a

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.9.1
+version: 0.9.1+1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -40,7 +40,7 @@ dependencies:
 dev_dependencies:
   build_test: ^0.10.0
   package_resolver: ^1.0.2
-  test: ^0.12.42
+  test: ^1.0.0
   test_descriptor: ^1.0.0
   test_process: ^1.0.0
   _test_common:

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.2.1+2-dev
+## 0.2.1+2
 
 - Clarify wording for conflicting output directory options. No behavioral
   differences.
 - Reduce the memory consumption required to create an output dir significantly.
+- Increased the upper bound for the sdk to `<3.0.0`.
 
 ## 0.2.1+1
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_runner_core
-version: 0.2.1+2-dev
+version: 0.2.1+2
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 
 environment:
-  sdk: '>=2.0.0-dev.54 <2.0.0'
+  sdk: '>=2.0.0-dev.54 <3.0.0'
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
@@ -30,7 +30,7 @@ dev_dependencies:
   build_test: ^0.10.0
   package_resolver: ^1.0.2
   json_serializable: ^0.5.6
-  test: ^0.12.42
+  test: ^1.0.0
   test_descriptor: ^1.0.0
   test_process: ^1.0.0
   _test_common:

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.3+1
+
+- Increased the upper bound for the sdk to `<3.0.0`.
+
 ## 0.10.3
 
 - Require test version ^0.12.42 and use `TypeMatcher`.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.3
+version: 0.10.3+1
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
-  sdk: '>=2.0.0-dev.32 <2.0.0'
+  sdk: '>=2.0.0-dev.32 <3.0.0'
 
 dependencies:
   async: ">=1.2.0 <3.0.0"

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
 
 environment:
-  sdk: '>=2.0.0-dev.65 <2.0.0'
+  sdk: '>=2.0.0-dev.65 <3.0.0'
 
 dependencies:
   build: ^0.12.0

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Improvements to reduce the memory usage of the dart2js builder, so that
   transitive dependency information can be garbage collected before the dart2js
   compile is completed.
+- Increased the upper bound for the sdk to `<3.0.0`.
 
 ## 0.4.0+5
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: '>=2.0.0-dev.50 <2.0.0'
+  sdk: '>=2.0.0-dev.50 <3.0.0'
 
 dependencies:
   analyzer: ">=0.30.0 <0.33.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 
 environment:
-  sdk: '>=2.0.0-dev <2.0.0'
+  sdk: '>=2.0.0-dev <3.0.0'
 
 dependencies:
   build: ^0.12.1

--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3+1
+
+- Increased the upper bound for the sdk to `<3.0.0`.
+
 ## 0.0.3
 
 - Use digests to improve `ensureAssets` performance.

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,11 +1,11 @@
 name: scratch_space
-version: 0.0.3
+version: 0.0.3+1
 description: A tool to manage running external executables within package:build
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space
 
 environment:
-  sdk: '>=2.0.0-dev.9 <2.0.0'
+  sdk: '>=2.0.0-dev.9 <3.0.0'
 
 dependencies:
   build: '>=0.10.0 <0.13.0'
@@ -15,4 +15,4 @@ dependencies:
 
 dev_dependencies:
   build_test: ^0.10.0
-  test: ^0.12.0
+  test: ^1.0.0


### PR DESCRIPTION
I will go ahead and publish all of these that don't have a `-dev` in the version after this, then send out an update to publish the remaining packages and drop the `-dev`.