### PR TITLE
Add a bounded lru cache for files

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2-dev
+
+- Changed the default file caching logic to use an LRU cache.
+
 ## 0.2.1+2
 
 - Clarify wording for conflicting output directory options. No behavioral

--- a/build_runner_core/lib/src/asset/cache.dart
+++ b/build_runner_core/lib/src/asset/cache.dart
@@ -68,12 +68,8 @@ class CachingAssetReader implements AssetReader {
     return _pendingBytesContentCache.putIfAbsent(
         id,
         () => _delegate.readAsBytes(id).then((result) {
-              // Defensive tactic for unawaited futures which could potentially
-              // leak old data into the cache.
-              if (_pendingBytesContentCache.containsKey(id)) {
-                if (cache) _bytesContentCache[id] = result;
-                _pendingBytesContentCache.remove(id);
-              }
+              if (cache) _bytesContentCache[id] = result;
+              _pendingBytesContentCache.remove(id);
               return result;
             }));
   }
@@ -94,12 +90,8 @@ class CachingAssetReader implements AssetReader {
         encoding,
         () => readAsBytes(id, cache: false).then((bytes) {
               var decoded = encoding.decode(bytes);
-              // Defensive tactic for unawaited futures which could potentially
-              // leak old data into the cache.
-              if (_pendingStringContentCache.containsKey(id)) {
-                _stringContentCache[id] = decoded;
-                _pendingStringContentCache.remove(id);
-              }
+              _stringContentCache[id] = decoded;
+              _pendingStringContentCache.remove(id);
               return decoded;
             }));
   }

--- a/build_runner_core/lib/src/asset/cache.dart
+++ b/build_runner_core/lib/src/asset/cache.dart
@@ -4,10 +4,13 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:build/build.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
+
+import 'lru_cache.dart';
 
 /// An [AssetReader] that wraps another [AssetReader] and caches all results
 /// from it.
@@ -17,15 +20,34 @@ import 'package:glob/glob.dart';
 /// Does not implement [findAssets].
 class CachingAssetReader implements AssetReader {
   /// Cached results of [readAsBytes].
-  final _bytesContentCache = <AssetId, Future<List<int>>>{};
+  final _bytesContentCache =
+      new LruCache<AssetId, List<int>>(1024 * 1024, 1024 * 1024 * 512, (value) {
+    if (value is Uint8List) {
+      return value.lengthInBytes;
+    } else {
+      return value.length * 8;
+    }
+  });
+
+  /// Pending [readAsBytes] operations.
+  final _pendingBytesContentCache = <AssetId, Future<List<int>>>{};
 
   /// Cached results of [canRead].
+  ///
+  /// Don't bother using an LRU cache for this since it's just booleans.
   final _canReadCache = <AssetId, Future<bool>>{};
 
   /// Cached results of [readAsString], per [Encoding] type used.
   ///
   /// These are computed and stored lazily using [readAsBytes].
-  final _stringContentCache = <AssetId, Map<Encoding, Future<String>>>{};
+  final _stringContentCache = new LruCache<_AssetIdWithEncoding, String>(
+      1024 * 1024, 1024 * 1024 * 512, (value) => value.length);
+
+  /// Pending `readAsString` operations.
+  final _pendingStringContentCache = <AssetId, Map<Encoding, Future<String>>>{};
+
+  /// All [Encoding]s ever used.
+  final _encodingsUsed = new Set<Encoding>();
 
   /// The [AssetReader] to delegate all reads to.
   final AssetReader _delegate;
@@ -44,15 +66,43 @@ class CachingAssetReader implements AssetReader {
       throw new UnimplementedError('unimplemented!');
 
   @override
-  Future<List<int>> readAsBytes(AssetId id) =>
-      _bytesContentCache.putIfAbsent(id, () => _delegate.readAsBytes(id));
+  Future<List<int>> readAsBytes(AssetId id, {bool cache = true}) {
+    var cached = _bytesContentCache[id];
+    if (cached != null) return new Future.value(cached);
+
+    return _pendingBytesContentCache.putIfAbsent(
+        id,
+        () => _delegate.readAsBytes(id).then((result) {
+              // Defensive tactic for unawaited futures which could potentially
+              // leak old data into the cache.
+              if (_pendingBytesContentCache.containsKey(id)) {
+                if (cache) _bytesContentCache[id] = result;
+                _pendingBytesContentCache.remove(id);
+              }
+              return result;
+            }));
+  }
 
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding}) {
     encoding ??= utf8;
-    return _stringContentCache
-        .putIfAbsent(id, () => {})
-        .putIfAbsent(encoding, () => readAsBytes(id).then(encoding.decode));
+
+    var key = new _AssetIdWithEncoding(id, encoding);
+    var cached = _stringContentCache[key];
+    if (cached != null) return new Future.value(cached);
+
+    return _pendingStringContentCache.putIfAbsent(id, () => {}).putIfAbsent(
+        encoding,
+        () => readAsBytes(id, cache: false).then((bytes) {
+              var decoded = encoding.decode(bytes);
+              // Defensive tactic for unawaited futures which could potentially
+              // leak old data into the cache.
+              if (_pendingStringContentCache.containsKey(id)) {
+                _stringContentCache[key] = decoded;
+                _pendingStringContentCache.remove(id);
+              }
+              return decoded;
+            }));
   }
 
   /// Clears all [ids] from all caches.
@@ -60,7 +110,32 @@ class CachingAssetReader implements AssetReader {
     for (var id in ids) {
       _bytesContentCache.remove(id);
       _canReadCache.remove(id);
-      _stringContentCache.remove(id);
+      for (var encoding in _encodingsUsed) {
+        _stringContentCache.remove(new _AssetIdWithEncoding(id, encoding));
+      }
+
+      _pendingBytesContentCache.remove(id);
+      _pendingStringContentCache.remove(id);
     }
   }
+}
+
+/// Combines an [AssetId] and an [Encoding] for use as a hash key.
+class _AssetIdWithEncoding {
+  final AssetId id;
+  final Encoding encoding;
+
+  _AssetIdWithEncoding(this.id, this.encoding);
+
+  @override
+  bool operator ==(other) =>
+      other is _AssetIdWithEncoding &&
+      other.id == id &&
+      other.encoding.name == encoding.name;
+
+  @override
+  int get hashCode => id.hashCode ^ encoding.name.hashCode;
+
+  @override
+  String toString() => '$id:$encoding';
 }

--- a/build_runner_core/lib/src/asset/lru_cache.dart
+++ b/build_runner_core/lib/src/asset/lru_cache.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A basic LRU Cache.
+class LruCache<K, V> {
+  _Link<K, V> _head;
+  _Link<K, V> _tail;
+
+  final int Function(V) _computeWeight;
+
+  int _currentWeightTotal = 0;
+  final int _individualWeightMax;
+  final int _totalWeightMax;
+
+  final _entries = <K, _Link<K, V>>{};
+
+  LruCache(
+      this._individualWeightMax, this._totalWeightMax, this._computeWeight);
+
+  V operator [](K key) {
+    var entry = _entries[key];
+    if (entry == null) return null;
+
+    _promote(entry);
+    return entry.value;
+  }
+
+  void operator []=(K key, V value) {
+    var entry = new _Link(key, value, _computeWeight(value));
+    // Don't cache at all if above the individual weight max.
+    if (entry.weight > _individualWeightMax) {
+      return;
+    }
+
+    _entries[key] = entry;
+    _currentWeightTotal += entry.weight;
+    _promote(entry);
+
+    while (_currentWeightTotal > _totalWeightMax) {
+      assert(_tail != null);
+      remove(_tail.key);
+    }
+  }
+
+  /// Removes the value at [key] from the cache, and returns the value if it
+  /// existed.
+  V remove(K key) {
+    var entry = _entries[key];
+    if (entry == null) return null;
+
+    _currentWeightTotal -= entry.weight;
+    _entries.remove(key);
+
+    if (entry == _tail) {
+      _tail = entry.next;
+      _tail?.previous = null;
+    }
+    if (entry == _head) {
+      _head = entry.previous;
+      _head?.next = null;
+    }
+
+    return entry.value;
+  }
+
+  /// Moves [link] to the [_head] of the list.
+  void _promote(_Link<K, V> link) {
+    if (link == _head) return;
+
+    if (link == _tail) {
+      _tail = link.next;
+    }
+
+    if (link.previous != null) {
+      link.previous.next = link.next;
+    }
+    if (link.next != null) {
+      link.next.previous = link.previous;
+    }
+
+    _head?.next = link;
+    link.previous = _head;
+    _head = link;
+    _tail ??= link;
+    link.next = null;
+  }
+}
+
+/// A [MapEntry] which is also a part of a doubly linked list.
+class _Link<K, V> implements MapEntry<K, V> {
+  _Link<K, V> next;
+  _Link<K, V> previous;
+
+  final int weight;
+
+  @override
+  final K key;
+
+  @override
+  final V value;
+
+  _Link(this.key, this.value, this.weight);
+}

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 0.2.1+2
+version: 0.2.2-dev
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core

--- a/build_runner_core/test/asset/cache_test.dart
+++ b/build_runner_core/test/asset/cache_test.dart
@@ -73,13 +73,13 @@ void main() {
       expect(delegate.assetsRead, [fooTxt]);
     });
 
-    test('caches bytes from readAsString calls', () async {
+    test('should not cache bytes during readAsString calls', () async {
       expect(await reader.readAsString(fooTxt), fooContent);
       expect(delegate.assetsRead, [fooTxt]);
       delegate.assetsRead.clear();
 
       expect(await reader.readAsBytes(fooTxt), fooutf8Bytes);
-      expect(delegate.assetsRead, []);
+      expect(delegate.assetsRead, [fooTxt]);
     });
   });
 

--- a/build_runner_core/test/asset/lru_cache_test.dart
+++ b/build_runner_core/test/asset/lru_cache_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:build_runner_core/src/asset/lru_cache.dart';
+
+main() {
+  LruCache<String, int> cache;
+  final maxIndividualWeight = 10;
+  final maxTotalWeight = 100;
+
+  setUp(() {
+    cache = new LruCache(maxIndividualWeight, maxTotalWeight, (v) => v);
+  });
+
+  test('can cache values', () {
+    cache['a'] = 1;
+    cache['b'] = 2;
+    expect(cache['a'], 1);
+    expect(cache['b'], 2);
+  });
+
+  test('can remove entries by key', () {
+    cache['a'] = 1;
+    cache['b'] = 2;
+    cache.remove('b');
+    expect(cache['a'], 1);
+    expect(cache['b'], null);
+  });
+
+  test('doesnt cache values over the max individual weight', () {
+    cache['a'] = maxIndividualWeight;
+    expect(cache['a'], maxIndividualWeight);
+
+    cache['b'] = maxIndividualWeight + 1;
+    expect(cache['b'], null);
+  });
+
+  test('removes least recently used items when full', () {
+    // Populate the cache until full.
+    var total = 0;
+    var n = 0;
+    while (total + maxIndividualWeight <= maxTotalWeight) {
+      total += maxIndividualWeight;
+      cache['$n'] = maxIndividualWeight;
+      n++;
+    }
+    // Read all the items in order, the first is now the least recently used.
+    for (var i = 0; i < n; i++) {
+      expect(cache['$i'], maxIndividualWeight);
+    }
+
+    // Add another item, the first item should now be removed.
+    cache['${n++}'] = maxIndividualWeight;
+    expect(cache['0'], null);
+
+    // Read the 2nd/3rd item, and add 2 new items. The 4rd/5th should now be
+    // removed.
+    expect(cache['1'], maxIndividualWeight);
+    expect(cache['2'], maxIndividualWeight);
+    cache['${n++}'] = maxIndividualWeight;
+    cache['${n++}'] = maxIndividualWeight;
+    expect(cache['1'], maxIndividualWeight);
+    expect(cache['2'], maxIndividualWeight);
+    expect(cache['3'], null);
+    expect(cache['4'], null);
+  });
+}


### PR DESCRIPTION
For now I have set the following defaults, which we can make configurable in the future:

- ~512MB per cache (one for bytes and one for strings)
- 1MB max per file, anything larger than that is never cached

I also fixed an issue where we actually were using the Encoding as a key before but it doesn't implement `hashCode` or `==` so it could have exploded in size since we had separate caches per encoding _instance_. It now uses the name of the Encoding, which should be pretty reasonable.

Note that sizes are based on the file size on disk and not necessarily how much memory is actually consumed by the vm representation of the objects.

Closes https://github.com/dart-lang/build/issues/1461