### PR TITLE
publish build_runner_core 0.2.2

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.2-dev
+## 0.2.2
 
 - Changed the default file caching logic to use an LRU cache.
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 0.2.2-dev
+version: 0.2.2
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
I wanted to get this released before submitting https://github.com/dart-lang/build/pull/1647 (breaking change)