### PR TITLE
release new build_runner that depends on the latest build_runner_core

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.2
+
+- Changed the default file caching logic to use an LRU cache.
+
 ## 0.9.1+1
 
 - Increased the upper bound for the sdk to `<3.0.0`.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.9.1+1
+version: 0.9.2
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -15,7 +15,7 @@ dependencies:
   build_resolvers: ^0.2.0
   # We re-export many types from this package, so we maintain a tight
   # constraint on it.
-  build_runner_core: ">=0.2.1 <0.2.2"
+  build_runner_core: ">=0.2.2 <0.2.3"
   cli_util: ^0.1.2
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0


### PR DESCRIPTION
forgot we have a tight constraint here...