### PR TITLE
Prepare to publish bazel_codegen

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3.2-dev
+# 0.3.2
 
 - Increased the upper bound for the sdk to `<3.0.0`.
 - Drop dependency on `build_barback`.

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/bazel_codegen
-version: 0.3.2-dev
+version: 0.3.2
 
 environment:
   sdk: ">=2.0.0-dev.32 <3.0.0"


### PR DESCRIPTION
Compatible with the non-dev Dart 2 SDK