### PR TITLE
Add a tag to the header line for cached errors

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2+1
+
+- Tag errors from cached actions when they are printed.
+
 ## 0.2.2
 
 - Changed the default file caching logic to use an LRU cache.

--- a/build_runner_core/lib/src/logging/failure_reporter.dart
+++ b/build_runner_core/lib/src/logging/failure_reporter.dart
@@ -83,7 +83,7 @@ class FailureReporter {
     return Future.wait(errorFiles.map((errorFile) async {
       if (await errorFile.exists()) {
         final errorReports = jsonDecode(await errorFile.readAsString());
-        final actionDescription = (errorReports as List).first as String;
+        final actionDescription = '${(errorReports as List).first} (cached)';
         final logger = new Logger(actionDescription);
         for (final List error in errorReports.skip(1)) {
           final stackTraceString = error[2] as String;

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 0.2.2
+version: 0.2.2+1
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -84,3 +84,13 @@ targets:
         # Example that excludes intellij's swap files
         - **/*___jb_tmp___
 ```
+
+## Why are some logs "(cached)"?
+
+`build_runner` will only run actions that have changes in their inputs. When an
+action fails, and a subsequent build has exactly the same inputs for that action
+it will not be rerun - the previous error messages, however, will get reprinted
+to avoid confusion if a build fails with no printed errors. To force the action
+to run again make an edit to any file that is an input to that action, or throw
+away all cached values with `pub run build_runner clean` before starting the
+next build.


### PR DESCRIPTION
Closes #1673

Attempting to debug build actions which aren't actually running is
really confusing today - the builder will never throw and breakpoints
will not be hit, but we'll print logs as if it did. Making the header
line look different and adding an FAQ will hopefully clear this up.