### PR TITLE
misc(test): add SDK constraint to _test/pkgs/provides_builder

### DIFF
--- a/_test/pkgs/provides_builder/pubspec.yaml
+++ b/_test/pkgs/provides_builder/pubspec.yaml
@@ -1,4 +1,8 @@
 name: provides_builder
+
+environment:
+  sdk: ">=2.0.0-dev.62 <3.0.0"
+
 dependencies:
   build:
     path: ../../../build


### PR DESCRIPTION
Otherwise, it's treated as <2.0.0