### PR TITLE
Use the coarse module by default, even on root

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Change the default module strategy for the root package to `coarse`.
+
 ## 0.3.0
 
 ### Improvements

--- a/build_modules/lib/src/common.dart
+++ b/build_modules/lib/src/common.dart
@@ -35,7 +35,7 @@ enum ModuleStrategy { fine, coarse }
 
 ModuleStrategy moduleStrategy(BuilderOptions options) {
   if (options.isRoot) {
-    var config = options.config['strategy'] as String ?? 'fine';
+    var config = options.config['strategy'] as String ?? 'coarse';
     switch (config) {
       case 'coarse':
         return ModuleStrategy.coarse;

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 0.3.0
+version: 0.3.1
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules


### PR DESCRIPTION
The coarse strategy has the advantage of not using a resolver, and in
many cases it seems to be the saner default.