### PR TITLE
Add simple live-reload implementation

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1-dev
+
+- Added `--live-reload` cli option and appropriate functionality
+
 ## 0.10.0-dev
 
 ### Breaking Changes

--- a/build_runner/README.md
+++ b/build_runner/README.md
@@ -100,6 +100,8 @@ Some commands also have additional options:
 
 - `--hostname`: The host to run the server on.
 
+- `--live-reload`: Enables automatic page reloading on rebuilds.
+
 Trailing args of the form `<directory>:<port>` are supported to customize what
 directories are served, and on what ports.
 

--- a/build_runner/README.md
+++ b/build_runner/README.md
@@ -99,7 +99,6 @@ Some commands also have additional options:
 ##### serve
 
 - `--hostname`: The host to run the server on.
-
 - `--live-reload`: Enables automatic page reloading on rebuilds.
 
 Trailing args of the form `<directory>:<port>` are supported to customize what

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -14,6 +14,7 @@ import 'package:path/path.dart' as p;
 const assumeTtyOption = 'assume-tty';
 const defineOption = 'define';
 const deleteFilesByDefaultOption = 'delete-conflicting-outputs';
+const liveReloadOption = 'live-reload';
 const logPerformanceOption = 'log-performance';
 const logRequestsOption = 'log-requests';
 const lowResourcesModeOption = 'low-resources-mode';
@@ -130,11 +131,13 @@ class SharedOptions {
 /// Options specific to the `serve` command.
 class ServeOptions extends SharedOptions {
   final String hostName;
+  final bool liveReload;
   final bool logRequests;
   final List<ServeTarget> serveTargets;
 
   ServeOptions._({
     @required this.hostName,
+    @required this.liveReload,
     @required this.logRequests,
     @required this.serveTargets,
     @required bool assumeTty,
@@ -200,6 +203,7 @@ class ServeOptions extends SharedOptions {
 
     return new ServeOptions._(
       hostName: argResults[hostnameOption] as String,
+      liveReload: argResults[liveReloadOption] as bool,
       logRequests: argResults[logRequestsOption] as bool,
       serveTargets: serveTargets,
       assumeTty: argResults[assumeTtyOption] as bool,

--- a/build_runner/lib/src/entrypoint/serve.dart
+++ b/build_runner/lib/src/entrypoint/serve.dart
@@ -25,7 +25,11 @@ class ServeCommand extends WatchCommand {
       ..addFlag(logRequestsOption,
           defaultsTo: false,
           negatable: false,
-          help: 'Enables logging for each request to the server.');
+          help: 'Enables logging for each request to the server.')
+      ..addFlag(liveReloadOption,
+          defaultsTo: false,
+          negatable: false,
+          help: 'Enables automatic page reloading on rebuilds.');
   }
 
   @override

--- a/build_runner/lib/src/entrypoint/serve.dart
+++ b/build_runner/lib/src/entrypoint/serve.dart
@@ -97,7 +97,7 @@ Future<HttpServer> _startServer(
     ServeOptions options, ServeTarget target, ServeHandler handler) async {
   var server = await _bindServer(options, target);
   serveRequests(
-      server, handler.handlerFor(target.dir, logRequests: options.logRequests));
+      server, handler.handlerFor(target.dir, logRequests: options.logRequests, liveReload: options.liveReload));
   return server;
 }
 

--- a/build_runner/lib/src/entrypoint/serve.dart
+++ b/build_runner/lib/src/entrypoint/serve.dart
@@ -97,7 +97,9 @@ Future<HttpServer> _startServer(
     ServeOptions options, ServeTarget target, ServeHandler handler) async {
   var server = await _bindServer(options, target);
   serveRequests(
-      server, handler.handlerFor(target.dir, logRequests: options.logRequests, liveReload: options.liveReload));
+      server,
+      handler.handlerFor(target.dir,
+          logRequests: options.logRequests, liveReload: options.liveReload));
   return server;
 }
 

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -133,8 +133,9 @@ class BuildUpdatesWebSocketHandler {
   BuildUpdatesWebSocketHandler([this._handlerFactory = webSocketHandler]) {
     var untypedTearOff = (webSocket, protocol) =>
         _handleConnection(webSocket as WebSocketChannel, protocol as String);
-    _internalHandler = _handlerFactory(
-        untypedTearOff, protocols: [_buildUpdatesProtocol]) as shelf.Handler;
+    _internalHandler =
+        _handlerFactory(untypedTearOff, protocols: [_buildUpdatesProtocol])
+            as shelf.Handler;
   }
 
   shelf.Handler get handler => _internalHandler;

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -61,7 +61,8 @@ class ServeHandler implements BuildState {
   @override
   Stream<BuildResult> get buildResults => _state.buildResults;
 
-  shelf.Handler handlerFor(String rootDir, {bool logRequests, bool liveReload}) {
+  shelf.Handler handlerFor(String rootDir,
+      {bool logRequests, bool liveReload}) {
     liveReload ??= false;
     logRequests ??= false;
     if (p.url.split(rootDir).length != 1) {

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -23,7 +23,7 @@ const _performancePath = r'$perf';
 final _graphPath = r'$graph';
 final _buildUpdatesProtocol = r'$livereload';
 final _buildUpdatesMessage = 'update';
-final _entrypointExtensionMarker = '/* ENTRYPOINT_EXTENTION_MARKER */';
+final entrypointExtensionMarker = '/* ENTRYPOINT_EXTENTION_MARKER */';
 
 final _logger = new Logger('Serve');
 
@@ -127,15 +127,15 @@ class ServeHandler implements BuildState {
 /// build updates
 class BuildUpdatesWebSocketHandler {
   final activeConnections = <WebSocketChannel>[];
-  final Function _handlerFactory;
+  final shelf.Handler Function(Function, {Iterable<String> protocols})
+      _handlerFactory;
   shelf.Handler _internalHandler;
 
   BuildUpdatesWebSocketHandler([this._handlerFactory = webSocketHandler]) {
     var untypedTearOff = (webSocket, protocol) =>
         _handleConnection(webSocket as WebSocketChannel, protocol as String);
     _internalHandler =
-        _handlerFactory(untypedTearOff, protocols: [_buildUpdatesProtocol])
-            as shelf.Handler;
+        _handlerFactory(untypedTearOff, protocols: [_buildUpdatesProtocol]);
   }
 
   shelf.Handler get handler => _internalHandler;
@@ -161,7 +161,7 @@ shelf.Handler _injectBuildUpdatesClientCode(shelf.Handler innerHandler) {
     var response = await innerHandler(request);
     // TODO: Find a way how to check and/or modify body without reading it whole
     var body = await response.readAsString();
-    if (body.startsWith(_entrypointExtensionMarker)) {
+    if (body.startsWith(entrypointExtensionMarker)) {
       body += _buildUpdatesInjectedJS;
     }
     return response.change(body: body);

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -132,6 +132,9 @@ class BuildUpdatesWebSocketHandler {
   shelf.Handler _internalHandler;
 
   BuildUpdatesWebSocketHandler([this._handlerFactory = webSocketHandler]) {
+    // Because of dart-lang/shelf_web_socket#11, webSocketHandler doesn't work
+    // with strongly typed functions. As a workaround diskard type information
+    // wrapping it with lambda for now
     var untypedTearOff = (webSocket, protocol) =>
         _handleConnection(webSocket as WebSocketChannel, protocol as String);
     _internalHandler =
@@ -174,6 +177,7 @@ shelf.Handler _injectBuildUpdatesClientCode(shelf.Handler innerHandler) {
 ///
 /// Now only live-reload functional - just reload page on update message
 final _buildUpdatesInjectedJS = '''\n
+// Injected by build_runner for live reload support
 (function() {
   var ws = new WebSocket('ws://' + location.host, ['$_buildUpdatesProtocol']);
   ws.onmessage = function(event) {

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 0.10.0-dev
+version: 0.10.1-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -34,9 +34,11 @@ dependencies:
   pub_semver: ^1.4.0
   pubspec_parse: ^0.1.0
   shelf: ">=0.6.5 <0.8.0"
+  shelf_web_socket: ^0.2.2+3
   stack_trace: ^1.9.0
   stream_transform: ^0.0.9
   watcher: ^0.9.7
+  web_socket_channel: ^1.0.9
   yaml: ^2.1.0
 
 dev_dependencies:

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -166,31 +166,29 @@ void main() {
   });
 
   group('build updates', () {
-    final _entrypointExtensionMarker = '/* ENTRYPOINT_EXTENTION_MARKER */';
-
     test('injects client code if enabled', () async {
-      _addSource('a|web/some.js', _entrypointExtensionMarker);
+      _addSource('a|web/some.js', entrypointExtensionMarker + '\nalert(1)');
       var response = await serveHandler.handlerFor('web', liveReload: true)(
           new Request('GET', Uri.parse('http://server.com/some.js')));
       expect(await response.readAsString(), contains('\$livereload'));
     });
 
     test('doesn\'t inject client code if disabled', () async {
-      _addSource('a|web/some.js', _entrypointExtensionMarker);
+      _addSource('a|web/some.js', entrypointExtensionMarker + '\nalert(1)');
       var response = await serveHandler.handlerFor('web', liveReload: false)(
           new Request('GET', Uri.parse('http://server.com/some.js')));
       expect(await response.readAsString(), isNot(contains('\$livereload')));
     });
 
     test('doesn\'t inject client code in non-js files', () async {
-      _addSource('a|web/some.html', _entrypointExtensionMarker);
+      _addSource('a|web/some.html', entrypointExtensionMarker + '\n<br>some');
       var response = await serveHandler.handlerFor('web', liveReload: true)(
           new Request('GET', Uri.parse('http://server.com/some.html')));
       expect(await response.readAsString(), isNot(contains('\$livereload')));
     });
 
     test('doesn\'t inject client code in non-marked files', () async {
-      _addSource('a|web/some.js', 'content');
+      _addSource('a|web/some.js', 'alert(1)');
       var response = await serveHandler.handlerFor('web', liveReload: true)(
           new Request('GET', Uri.parse('http://server.com/some.js')));
       expect(await response.readAsString(), isNot(contains('\$livereload')));
@@ -224,92 +222,77 @@ void main() {
       expect(await response.readAsString(), 'content');
     });
 
-    test('emmits a message to all listners', () async {
-      Function exposedOnConnect;
-      var mockHandlerFactory = (Function onConnect, {protocols}) {
-        exposedOnConnect = onConnect;
-      };
-      var buildUpdatesWebSocketHandler =
-          BuildUpdatesWebSocketHandler(mockHandlerFactory);
+    group('WebSocket handler', () {
+      BuildUpdatesWebSocketHandler buildUpdatesWebSocketHandler;
+      Function createMockConection;
 
-      var streamControllerFirst1 = StreamController<List<int>>();
-      var streamControllerFirst2 = StreamController<List<int>>();
-      var serverChannelFirst = WebSocketChannel(
-          StreamChannel(
-              streamControllerFirst1.stream, streamControllerFirst2.sink),
-          serverSide: true);
-      var clientChannelFirst = WebSocketChannel(
-          StreamChannel(
-              streamControllerFirst2.stream, streamControllerFirst1.sink),
-          serverSide: false);
+      // client to server stream controlllers
+      StreamController<List<int>> c2sController1;
+      StreamController<List<int>> c2sController2;
+      // server to client stream controlllers
+      StreamController<List<int>> s2cController1;
+      StreamController<List<int>> s2cController2;
 
-      var streamControllerSecond1 = StreamController<List<int>>();
-      var streamControllerSecond2 = StreamController<List<int>>();
-      var serverChannelSecond = WebSocketChannel(
-          StreamChannel(
-              streamControllerSecond1.stream, streamControllerSecond2.sink),
-          serverSide: true);
-      var clientChannelSecond = WebSocketChannel(
-          StreamChannel(
-              streamControllerSecond2.stream, streamControllerSecond1.sink),
-          serverSide: false);
+      WebSocketChannel clientChannel1;
+      WebSocketChannel clientChannel2;
+      WebSocketChannel serverChannel1;
+      WebSocketChannel serverChannel2;
 
-      var deferredExpect1 = clientChannelFirst.stream.single
-          .then((value) => expect(value, 'update'));
-      var deferredExpect2 = clientChannelSecond.stream.single
-          .then((value) => expect(value, 'update'));
-      exposedOnConnect(serverChannelFirst, '');
-      exposedOnConnect(serverChannelSecond, '');
-      buildUpdatesWebSocketHandler.emitUpdateMessage(null);
-      await clientChannelFirst.sink.close();
-      await clientChannelSecond.sink.close();
-      await deferredExpect1;
-      await deferredExpect2;
-    });
+      setUp(() {
+        var mockHandlerFactory = (Function onConnect, {protocols}) {
+          createMockConection =
+              (WebSocketChannel serverChannel) => onConnect(serverChannel, '');
+        };
+        buildUpdatesWebSocketHandler =
+            BuildUpdatesWebSocketHandler(mockHandlerFactory);
 
-    test('deletes listners on disconect', () async {
-      Function exposedOnConnect;
-      var mockHandlerFactory = (Function onConnect, {protocols}) {
-        exposedOnConnect = onConnect;
-      };
-      var buildUpdatesWebSocketHandler =
-          BuildUpdatesWebSocketHandler(mockHandlerFactory);
+        c2sController1 = StreamController<List<int>>();
+        s2cController1 = StreamController<List<int>>();
+        serverChannel1 = WebSocketChannel(
+            StreamChannel(c2sController1.stream, s2cController1.sink),
+            serverSide: true);
+        clientChannel1 = WebSocketChannel(
+            StreamChannel(s2cController1.stream, c2sController1.sink),
+            serverSide: false);
 
-      var streamControllerFirst1 = StreamController<List<int>>();
-      var streamControllerFirst2 = StreamController<List<int>>();
-      var serverChannelFirst = WebSocketChannel(
-          StreamChannel(
-              streamControllerFirst1.stream, streamControllerFirst2.sink),
-          serverSide: true);
-      var clientChannelFirst = WebSocketChannel(
-          StreamChannel(
-              streamControllerFirst2.stream, streamControllerFirst1.sink),
-          serverSide: false);
+        c2sController2 = StreamController<List<int>>();
+        s2cController2 = StreamController<List<int>>();
+        serverChannel2 = WebSocketChannel(
+            StreamChannel(c2sController2.stream, s2cController2.sink),
+            serverSide: true);
+        clientChannel2 = WebSocketChannel(
+            StreamChannel(s2cController2.stream, c2sController2.sink),
+            serverSide: false);
+      });
 
-      var streamControllerSecond1 = StreamController<List<int>>();
-      var streamControllerSecond2 = StreamController<List<int>>();
-      var serverChannelSecond = WebSocketChannel(
-          StreamChannel(
-              streamControllerSecond1.stream, streamControllerSecond2.sink),
-          serverSide: true);
-      var clientChannelSecond = WebSocketChannel(
-          StreamChannel(
-              streamControllerSecond2.stream, streamControllerSecond1.sink),
-          serverSide: false);
+      tearDown(() {
+        c2sController1.close();
+        s2cController1.close();
+        c2sController2.close();
+        s2cController2.close();
+      });
 
-      var deferredExpect1 = clientChannelFirst.stream
-          .toList()
-          .then((value) => expect(value, ['update', 'update']));
-      var deferredExpect2 = clientChannelSecond.stream.single
-          .then((value) => expect(value, 'update'));
-      exposedOnConnect(serverChannelFirst, '');
-      exposedOnConnect(serverChannelSecond, '');
-      buildUpdatesWebSocketHandler.emitUpdateMessage(null);
-      await clientChannelSecond.sink.close();
-      buildUpdatesWebSocketHandler.emitUpdateMessage(null);
-      await clientChannelFirst.sink.close();
-      await deferredExpect1;
-      await deferredExpect2;
+      test('emmits a message to all listners', () async {
+        expect(clientChannel1.stream, emitsInOrder(['update', emitsDone]));
+        expect(clientChannel2.stream, emitsInOrder(['update', emitsDone]));
+        createMockConection(serverChannel1);
+        createMockConection(serverChannel2);
+        buildUpdatesWebSocketHandler.emitUpdateMessage(null);
+        await clientChannel1.sink.close();
+        await clientChannel2.sink.close();
+      });
+
+      test('deletes listners on disconect', () async {
+        expect(clientChannel1.stream,
+            emitsInOrder(['update', 'update', emitsDone]));
+        expect(clientChannel2.stream, emitsInOrder(['update', emitsDone]));
+        createMockConection(serverChannel1);
+        createMockConection(serverChannel2);
+        buildUpdatesWebSocketHandler.emitUpdateMessage(null);
+        await clientChannel2.sink.close();
+        buildUpdatesWebSocketHandler.emitUpdateMessage(null);
+        await clientChannel1.sink.close();
+      });
     });
   });
 }

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2
+
+- Add magic comment marker for build_runner to know where to inject 
+  live-reloading client code.
+
 ## 0.4.1
 
 - Support the latest build_modules, with updated dart2js support so that it can

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -82,6 +82,7 @@ Future<Null> bootstrapDdc(BuildStep buildStep,
   var bootstrapContent = new StringBuffer('(function() {\n');
   bootstrapContent.write(_dartLoaderSetup(modulePaths));
   bootstrapContent.write(_requireJsConfig);
+  bootstrapContent.write(_hotReloadConfig);
 
   bootstrapContent.write(_appBootstrap(
       appModuleName, appModuleScope, ignoreCastFailures, enableSyncAsync));
@@ -319,6 +320,36 @@ require.config({
     waitSeconds: 0,
     paths: customModulePaths
 });
+''';
+
+/// Hot-reload config
+///
+/// Listen WebSocket for updates in build results
+///
+/// Now only ilve-reload functional - just reload page on update message
+final _hotReloadConfig = '''
+(function() {
+  var wsUrl; 
+  if (baseUrl.startsWith('http')) {
+    wsUrl = baseUrl.replace('http', 'ws');
+  } else {
+    // TODO: when it may make sense? WebWorkers? Tests?
+    wsUrl = 'ws://' + location.host + baseUrl;
+  }
+  wsUrl += '\$hotreload';
+  try {
+    var ws = new WebSocket(wsUrl);
+    ws.onmessage = function(event) {
+      console.log(event);
+      if(event.data === 'update'){
+        location.reload();
+      }
+    };
+  } catch (e) {
+    // Live reload might be turned off. Just ignore it for now
+    // TODO: Find a way to pass serve option here, to not inject this code at all, if live/hot reload is turned off
+  }
+}());
 ''';
 
 final _baseUrlScript = '''

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -79,10 +79,9 @@ Future<Null> bootstrapDdc(BuildStep buildStep,
             : _context.joinAll(_context.split(jsId.path).skip(1)));
   }
 
-  var bootstrapContent = new StringBuffer('(function() {\n');
+  var bootstrapContent = new StringBuffer('$_entrypointExtensionMarker\n(function() {\n');
   bootstrapContent.write(_dartLoaderSetup(modulePaths));
   bootstrapContent.write(_requireJsConfig);
-  bootstrapContent.write(_hotReloadConfig);
 
   bootstrapContent.write(_appBootstrap(
       appModuleName, appModuleScope, ignoreCastFailures, enableSyncAsync));
@@ -322,35 +321,11 @@ require.config({
 });
 ''';
 
-/// Hot-reload config
+/// Marker comment used by build_runner (or any other thinks) to identify
+/// entrypoint file, to inject custom code there.
 ///
-/// Listen WebSocket for updates in build results
-///
-/// Now only ilve-reload functional - just reload page on update message
-final _hotReloadConfig = '''
-(function() {
-  var wsUrl; 
-  if (baseUrl.startsWith('http')) {
-    wsUrl = baseUrl.replace('http', 'ws');
-  } else {
-    // TODO: when it may make sense? WebWorkers? Tests?
-    wsUrl = 'ws://' + location.host + baseUrl;
-  }
-  wsUrl += '\$livereload';
-  try {
-    var ws = new WebSocket(wsUrl);
-    ws.onmessage = function(event) {
-      console.log(event);
-      if(event.data === 'update'){
-        location.reload();
-      }
-    };
-  } catch (e) {
-    // Live reload might be turned off. Just ignore it for now
-    // TODO: Find a way to pass serve option here, to not inject this code at all, if live/hot reload is turned off
-  }
-}());
-''';
+/// Should be first line in a file, so server don't need to parse whole body
+final _entrypointExtensionMarker = '/* ENTRYPOINT_EXTENTION_MARKER */';
 
 final _baseUrlScript = '''
 var baseUrl = (function () {

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -336,7 +336,7 @@ final _hotReloadConfig = '''
     // TODO: when it may make sense? WebWorkers? Tests?
     wsUrl = 'ws://' + location.host + baseUrl;
   }
-  wsUrl += '\$hotreload';
+  wsUrl += '\$livereload';
   try {
     var ws = new WebSocket(wsUrl);
     ws.onmessage = function(event) {

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -79,7 +79,8 @@ Future<Null> bootstrapDdc(BuildStep buildStep,
             : _context.joinAll(_context.split(jsId.path).skip(1)));
   }
 
-  var bootstrapContent = new StringBuffer('$_entrypointExtensionMarker\n(function() {\n');
+  var bootstrapContent =
+      new StringBuffer('$_entrypointExtensionMarker\n(function() {\n');
   bootstrapContent.write(_dartLoaderSetup(modulePaths));
   bootstrapContent.write(_requireJsConfig);
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.4.1
+version: 0.4.2-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
Add live-reload option that turns on simple WebSocket broadcaster of rebuild finished events.
Inject simple JS snippet to bootstrap that listen for update message from WebSocket and reloads the whole page.