### PR TITLE
Log print messages at warning

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.7+4
+
+- `print` calls inside a Builder will now log at warning instead of info.
+
 ## 0.12.7+3
 
 - Throw when attempting to use a `BuildStep` after it has been completed.

--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -13,8 +13,8 @@ Logger get log => Zone.current[logKey] as Logger ?? _default;
 
 /// Runs [fn] in an error handling [Zone].
 ///
-/// Any calls to [print] will be logged with `log.info`, and any errors will be
-/// logged with `log.severe`.
+/// Any calls to [print] will be logged with `log.warning`, and any errors will
+/// be logged with `log.severe`.
 ///
 /// Completes with the first error or result of `fn`, whichever comes first.
 Future<T> scopeLogAsync<T>(Future<T> fn(), Logger log) {
@@ -22,7 +22,7 @@ Future<T> scopeLogAsync<T>(Future<T> fn(), Logger log) {
   runZoned(fn,
       zoneSpecification:
           new ZoneSpecification(print: (self, parent, zone, message) {
-        log.info(message);
+        log.warning(message);
       }),
       zoneValues: {logKey: log},
       onError: (Object e, StackTrace s) {

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 0.12.7+3
+version: 0.12.7+4
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build


### PR DESCRIPTION
This comes up repeatedly that Builder authors are confused when they add
print calls and can't see the messages because info lines get
overwritten without `--verbose`, and `--verbose` adds a bunch of extra
noise that drowns out the wanted messages.

Since we expect Builder authors to rely on `log.info` for long term
logging they want to keep at info and `print` to be used only for short
term stuff it should be safe to up the level to warning.