### PR TITLE
Use untranslated AssetIds to find top level dirs

### DIFF
--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -75,10 +75,9 @@ Future<bool> _createMergedOutputDir(
       await outputDir.create(recursive: true);
     }
 
-    outputAssets.addAll(await Future.wait(finalizedOutputsView
-        .allAssets(rootDir: root)
-        .map((id) => _writeAsset(
-            id, outputDir, root, packageGraph, reader, symlinkOnly))));
+    var builtAssets = finalizedOutputsView.allAssets(rootDir: root).toList();
+    outputAssets.addAll(await Future.wait(builtAssets.map((id) =>
+        _writeAsset(id, outputDir, root, packageGraph, reader, symlinkOnly))));
 
     var packagesFileContent = packageGraph.allPackages.keys
         .map((p) => '$p:packages/$p/')
@@ -88,7 +87,7 @@ Future<bool> _createMergedOutputDir(
     outputAssets.add(packagesAsset);
 
     if (root == null) {
-      for (var dir in _findRootDirs(outputAssets, outputPath)) {
+      for (var dir in _findRootDirs(builtAssets, outputPath)) {
         var link = Link(p.join(outputDir.path, dir, 'packages'));
         if (!link.existsSync()) {
           link.createSync(p.join('..', 'packages'), recursive: true);

--- a/build_runner_core/test/environment/create_merged_dir_test.dart
+++ b/build_runner_core/test/environment/create_merged_dir_test.dart
@@ -149,6 +149,13 @@ main() {
       _expectFiles(webFiles, tmpDir);
     });
 
+    test('does not nest packages symlinks with no root', () async {
+      var success = await createMergedOutputDirectories({tmpDir.path: null},
+          packageGraph, environment, assetReader, finalizedAssetsView, false);
+      expect(success, isTrue);
+      _expectNoFiles(Set<String>.of(['packages/packages/a/a.txt']), tmpDir);
+    });
+
     test('only outputs files contained in the provided root', () async {
       var success = await createMergedOutputDirectories(
           {tmpDir.path: 'web', anotherTmpDir.path: 'foo'},


### PR DESCRIPTION
Fixes #1723

When we find output paths for assets `lib/` is translated to
`packages/name` and looks like an extra top-level directory which then
causes a nested symlink. Add a regression test and find the directory
names using untranslated asset paths.