### PR TITLE
Fix new analyzer hints, which revealed a subtle bug

### DIFF
--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -257,7 +257,8 @@ class _Loader {
           deletedSources.add(id);
           return _environment.writer.delete(id);
         }
-      }).where((v) => v is Future));
+        return null;
+      }).whereType<Future>());
 
       await _deleteGeneratedDir();
     });

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -297,17 +297,17 @@ class _SingleBuild {
     for (var phaseNum = 0; phaseNum < _buildPhases.length; phaseNum++) {
       var phase = _buildPhases[phaseNum];
       if (phase.isOptional) continue;
-      await _performanceTracker.trackBuildPhase(phase, () async {
+      outputs.addAll(await _performanceTracker.trackBuildPhase(phase, () async {
         if (phase is InBuildPhase) {
           var primaryInputs =
               await _matchingPrimaryInputs(phase.package, phaseNum);
-          outputs.addAll(await _runBuilder(phaseNum, phase, primaryInputs));
+          return _runBuilder(phaseNum, phase, primaryInputs);
         } else if (phase is PostBuildPhase) {
-          outputs.addAll(await _runPostProcessPhase(phaseNum, phase));
+          return _runPostProcessPhase(phaseNum, phase);
         } else {
           throw StateError('Unrecognized BuildPhase type $phase');
         }
-      });
+      }));
     }
     await Future.forEach(
         _lazyPhases.values,


### PR DESCRIPTION
It looks like the inference for return values of closures is better now and that caused a couple hints.

One was technically a bug although the way in which it was used it didn't actually matter :).