### PR TITLE
use sdk summaries for the resolver

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+- Use sdk summaries for the analysis context, which makes getting the initial
+  resolver faster.
+
 ## 0.2.1+1
 
 - Increased the upper bound for the sdk to `<3.0.0`.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -428,7 +428,8 @@ class AnalyzerResolvers implements Resolvers {
     _initAnalysisEngine();
     var resourceProvider = PhysicalResourceProvider.INSTANCE;
     var sdk = FolderBasedDartSdk(
-        resourceProvider, resourceProvider.getFolder(cli_util.getSdkPath()));
+        resourceProvider, resourceProvider.getFolder(cli_util.getSdkPath()))
+      ..useSummary = true;
     var uriResolver = DartUriResolver(sdk);
     return AnalyzerResolvers._(AnalyzerResolver(uriResolver, analysisOptions));
   }

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 0.2.2-dev
+version: 0.2.2
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers


### PR DESCRIPTION
Saves a bit over a second when fetching the first resolver (tested on build_modules package, reduces `resolverGet` from ~2.9s to ~1.4s)