### PR TITLE
Filter out non-lib assets in deps

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1+1
+
+- Bug Fix: Don't include any non-lib assets from dependencies in the build, even
+  if they are a source in a target.
+
 ## 0.3.1
 
 - Migrated glob tracking to a specialized node type to fix dart-lang/build#1702.

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -399,12 +399,14 @@ class _Loader {
   Stream<AssetId> _mergeAll(Iterable<Stream<AssetId>> streams) =>
       streams.first.transform(mergeAll(streams.skip(1)));
 
-  Stream<AssetId> _listAssetIds(TargetNode targetNode) =>
-      targetNode.sourceIncludes.isEmpty
-          ? Stream<AssetId>.empty()
-          : _mergeAll(targetNode.sourceIncludes.map((glob) =>
-              _listIdsSafe(glob, package: targetNode.package.name)
-                  .where((id) => !targetNode.excludesSource(id))));
+  Stream<AssetId> _listAssetIds(TargetNode targetNode) => targetNode
+          .sourceIncludes.isEmpty
+      ? Stream<AssetId>.empty()
+      : _mergeAll(targetNode.sourceIncludes.map((glob) =>
+          _listIdsSafe(glob, package: targetNode.package.name)
+              .where((id) =>
+                  targetNode.package.isRoot || id.pathSegments.first == 'lib')
+              .where((id) => !targetNode.excludesSource(id))));
 
   Stream<AssetId> _listGeneratedAssetIds() {
     var glob = Glob('$generatedOutputDirectory/**');

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 0.3.1
+version: 0.3.1+1
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
Fixes #1740

We use a default glob of `lib/**` where there is no explicit target, but
honor exact globs when there is a target. We can only allow non-lib
sources in targets for the root package, so they are now filtered out
for deps.

Add a second package to the test setup for the `BuildDefinition` and add
a regression test for this case.