### PR TITLE
Prepare to republish build_runner_core

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+3
+
+- Bug Fix: Don't output a `packages` symlink within the `packages` directory.
+
 ## 0.3.1+2
 
 - Restore `new` keyword for a working release on Dart 1 VM.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 0.3.2-dev
+version: 0.3.1+3
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
Fixes #1751

A bug fix was missed when publishing the backwards compatible 0.3.1+2