### PR TITLE
Update all SDK constraints to >=2.0.0

### DIFF
--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -1,8 +1,8 @@
 name: _test
-description: A basic web app
+publish_to: none
 
 environment:
-  sdk: '>=2.0.0-dev.61 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dev_dependencies:
   analyzer: ">=0.30.0 <0.33.0"

--- a/_test_common/pubspec.yaml
+++ b/_test_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: Test infra for writing build tests. Is not published.
 
 environment:
-  sdk: '>=2.0.0-dev.54 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   build: any

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -5,10 +5,10 @@ homepage: https://github.com/dart-lang/build/tree/master/bazel_codegen
 version: 0.3.2
 
 environment:
-  sdk: ">=2.0.0-dev.32 <3.0.0"
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.31.2-alpha.1 <0.33.0'
+  analyzer: ">=0.31.2-alpha.1 <0.33.0"
   args: ^1.4.1
   bazel_worker: ^0.1.2
   build: ">=0.12.7 <0.12.8"

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build
 
 environment:
-  sdk: '>=2.0.0-dev.9 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.27.1 <0.33.0"

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: '>=2.0.0-dev.48 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   analyzer: ">0.30.0 < 0.33.0"

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 
 environment:
-  sdk: '>=2.0.0-dev.61 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   args: ">=1.4.0 <2.0.0"

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
-  sdk: '>=2.0.0-dev.32 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   async: ">=1.2.0 <3.0.0"

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
 
 environment:
-  sdk: '>=2.0.0-dev.65 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.30.0 <0.33.0"

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -5,10 +5,10 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space
 
 environment:
-  sdk: '>=2.0.0-dev.9 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  build: '>=0.10.0 <0.13.0'
+  build: ">=0.10.0 <0.13.0"
   crypto: ">=2.0.3 <3.0.0"
   path: ^1.1.0
   pool: ^1.0.0


### PR DESCRIPTION
Next time any packag is published it will be safe to omit `new`.

- Update all constraints, including in unpublished packages.
- Add `publish_to: none` for `_test`.
- Update quoting to be consistent double quotes in `pubspec.yaml`.