### PR TITLE
fix: use postMessage during bootstrap iff the current context is Window

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.3
+
+- Only call `window.postMessage` during initialization if the current context
+  is a `Window`.
+
 ## 0.4.2+2
 
 - Add magic comment marker for build_runner to know where to inject

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -267,7 +267,7 @@ $_baseUrlScript
         return dart.getSourceMap(module);
       });
   }
-  if (window.postMessage) {
+  if (typeof Window === 'function') {
     window.postMessage({ type: "DDC_STATE_CHANGE", state: "start" }, "*");
   }
 ''';

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -267,7 +267,7 @@ $_baseUrlScript
         return dart.getSourceMap(module);
       });
   }
-  if (typeof Window === 'function') {
+  if (self.document) { // only true for windows and not workers
     window.postMessage({ type: "DDC_STATE_CHANGE", state: "start" }, "*");
   }
 ''';

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -267,7 +267,7 @@ $_baseUrlScript
         return dart.getSourceMap(module);
       });
   }
-  if (self.document) { // only true for windows and not workers
+  if (typeof document != 'undefined') {
     window.postMessage({ type: "DDC_STATE_CHANGE", state: "start" }, "*");
   }
 ''';

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.4.2+2
+version: 0.4.3-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/1059

Improves on logic from https://github.com/dart-lang/build/pull/1116

Just checking for `postMessage` is not sufficient.
DedicatedWorkerGlobalScope also has `postMessage`, but with only one
parameter instead of two. This causes a runtime failure when loading
a WebWorking with DDC + build_web_compilers

Use a type test instead