### PR TITLE
fix: don't log severe when an asset URI cannot be resolved

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2+3
+
+- Don't log a severe message when a URI cannot be resolved. Just return `null`.
+
 ## 0.2.2+2
 
 - Use sdk summaries for the analysis context, which makes getting the initial

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -297,7 +297,6 @@ class _AssetUriResolver implements UriResolver {
     } else {
       assetId = _resolve(null, uri.toString());
       if (assetId == null) {
-        log.severe('Unable to resolve asset ID for "$uri"');
         return null;
       }
     }

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 0.2.2+2
+version: 0.2.2+3
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers


### PR DESCRIPTION
Follow-up to https://github.com/dart-lang/json_serializable/issues/236