### PR TITLE
Fix sourcemaps and stack trace issues while using different baseHref

### DIFF
--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -335,7 +335,7 @@ var baseUrl = (function () {
   if (typeof document !== 'undefined') {
     var el = document.getElementsByTagName('base');
     if (el && el[0] && el[0].getAttribute("href") && el[0].getAttribute("href").startsWith("/")){
-      return el[0].href;
+      return el[0].getAttribute("href");
     }
   }
   // Attempt to detect --precompiled mode for tests, and set the base url


### PR DESCRIPTION
At the moment source maps are not working properly when `<base>` tag is used.

See this issue for example :
https://github.com/dart-lang/build/issues/1780

```js
window.\$dartLoader.rootDirectories.push(window.location.origin + baseUrl);
```

This method requires `baseUrl` to be a relative path and not an absolute URL.

`stack_trace_mapper.dart` relies on correctness of `$dartLoader.rootDirectories` to generate stack trace.

Because of adding incorrect URLs to `$dartLoader.rootDirectories` sourcemaps are not working, 

Merging above PR will fix this issue, no further action is needed.
