### PR TITLE
Change the fine module strategy to output to meta modules

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.2-dev
+## 0.3.2
 
 - Module strategies are now respected for all packages instead of just the root
   package.

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.2-dev
+
+- Module strategies are now respected for all packages instead of just the root
+  package.
+- Can now mix and match fine and coarse strategies at will, even within package
+  cycles (although this may cause larger modules).
+- Removed analyzer dependency.
+
 ## 0.3.1+1
 
 - Support `package:json_annotation` v1.

--- a/build_modules/lib/builders.dart
+++ b/build_modules/lib/builders.dart
@@ -9,11 +9,11 @@ import 'package:build_modules/src/meta_module_clean_builder.dart';
 import 'package:build_modules/src/module_cleanup.dart';
 import 'package:build_modules/src/module_library_builder.dart';
 
-Builder moduleBuilder(BuilderOptions options) =>
-    ModuleBuilder.forOptions(options);
+Builder moduleBuilder(_) => ModuleBuilder();
 Builder unlinkedSummaryBuilder(_) => const UnlinkedSummaryBuilder();
 Builder linkedSummaryBuilder(_) => const LinkedSummaryBuilder();
-Builder metaModuleBuilder(_) => const MetaModuleBuilder();
+Builder metaModuleBuilder(BuilderOptions options) =>
+    MetaModuleBuilder.forOptions(options);
 Builder metaModuleCleanBuilder(BuilderOptions options) =>
     const MetaModuleCleanBuilder();
 Builder moduleLibraryBuilder(_) => const ModuleLibraryBuilder();

--- a/build_modules/lib/src/common.dart
+++ b/build_modules/lib/src/common.dart
@@ -34,19 +34,19 @@ Future<File> createPackagesFile(Iterable<AssetId> allAssets) async {
 enum ModuleStrategy { fine, coarse }
 
 ModuleStrategy moduleStrategy(BuilderOptions options) {
-  if (options.isRoot) {
-    var config = options.config['strategy'] as String ?? 'coarse';
-    switch (config) {
-      case 'coarse':
-        return ModuleStrategy.coarse;
-      case 'fine':
-        return ModuleStrategy.fine;
-      default:
-        throw 'Unexpected ModuleBuilder strategy: $config';
-    }
-  } else {
-    return ModuleStrategy.coarse;
+  // if (options.isRoot) {
+  var config = options.config['strategy'] as String ?? 'coarse';
+  switch (config) {
+    case 'coarse':
+      return ModuleStrategy.coarse;
+    case 'fine':
+      return ModuleStrategy.fine;
+    default:
+      throw 'Unexpected ModuleBuilder strategy: $config';
   }
+  // } else {
+  //   return ModuleStrategy.coarse;
+  // }
 }
 
 /// Validates that [config] only has the top level keys [supportedOptions].

--- a/build_modules/lib/src/common.dart
+++ b/build_modules/lib/src/common.dart
@@ -41,7 +41,7 @@ ModuleStrategy moduleStrategy(BuilderOptions options) {
     case 'fine':
       return ModuleStrategy.fine;
     default:
-      throw 'Unexpected ModuleBuilder strategy: $config';
+      throw ArgumentError('Unexpected ModuleBuilder strategy: $config');
   }
 }
 

--- a/build_modules/lib/src/common.dart
+++ b/build_modules/lib/src/common.dart
@@ -34,7 +34,6 @@ Future<File> createPackagesFile(Iterable<AssetId> allAssets) async {
 enum ModuleStrategy { fine, coarse }
 
 ModuleStrategy moduleStrategy(BuilderOptions options) {
-  // if (options.isRoot) {
   var config = options.config['strategy'] as String ?? 'coarse';
   switch (config) {
     case 'coarse':
@@ -44,9 +43,6 @@ ModuleStrategy moduleStrategy(BuilderOptions options) {
     default:
       throw 'Unexpected ModuleBuilder strategy: $config';
   }
-  // } else {
-  //   return ModuleStrategy.coarse;
-  // }
 }
 
 /// Validates that [config] only has the top level keys [supportedOptions].

--- a/build_modules/lib/src/errors.dart
+++ b/build_modules/lib/src/errors.dart
@@ -51,11 +51,8 @@ class MissingModulesException implements Exception {
 
   MissingModulesException._(this.message);
 
-  static Future<MissingModulesException> create(
-      Module module,
-      Set<AssetId> missingSources,
-      List<Module> transitiveModules,
-      AssetReader reader) async {
+  static Future<MissingModulesException> create(Set<AssetId> missingSources,
+      Iterable<Module> transitiveModules, AssetReader reader) async {
     var buffer = StringBuffer('''
 Unable to find modules for some sources, this is usually the result of either a
 bad import, a missing dependency in a package (or possibly a dev_dependency

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -239,8 +239,7 @@ MetaModule _coarseModulesForLibraries(
     librariesByDirectory[dir][library.id] = library;
   }
   final modules = librariesByDirectory.values.expand(_computeModules).toList();
-  // Deterministically output the modules.
-  modules.sort((a, b) => a.primarySource.compareTo(b.primarySource));
+  _sortModules(modules);
   return MetaModule(modules);
 }
 
@@ -250,7 +249,11 @@ MetaModule _fineModulesForLibraries(
       .map((library) => Module(
           library.id, library.parts.followedBy([library.id]), library.deps))
       .toList();
-  // Deterministically output the modules.
-  modules.sort((a, b) => a.primarySource.compareTo(b.primarySource));
+  _sortModules(modules);
   return MetaModule(modules);
+}
+
+/// Sorts [modules] in place so we get deterministic output.
+void _sortModules(List<Module> modules) {
+  modules.sort((a, b) => a.primarySource.compareTo(b.primarySource));
 }

--- a/build_modules/lib/src/meta_module_builder.dart
+++ b/build_modules/lib/src/meta_module_builder.dart
@@ -20,13 +20,13 @@ const metaModuleExtension = '.meta_module.raw';
 /// This file contains information about the full computed
 /// module structure for the package.
 class MetaModuleBuilder implements Builder {
-  final bool _isCoarse;
-  const MetaModuleBuilder({bool isCoarse}) : _isCoarse = isCoarse ?? true;
+  final ModuleStrategy strategy;
 
-  factory MetaModuleBuilder.forOptions(BuilderOptions options) {
-    return MetaModuleBuilder(
-        isCoarse: moduleStrategy(options) == ModuleStrategy.coarse);
-  }
+  const MetaModuleBuilder({ModuleStrategy strategy})
+      : this.strategy = strategy ?? ModuleStrategy.coarse;
+
+  MetaModuleBuilder.forOptions(BuilderOptions options)
+      : this.strategy = moduleStrategy(options);
 
   @override
   final buildExtensions = const {
@@ -35,11 +35,10 @@ class MetaModuleBuilder implements Builder {
 
   @override
   Future build(BuildStep buildStep) async {
-    if (!_isCoarse) return;
-
     var libraryAssets =
         await buildStep.findAssets(Glob('**$moduleLibraryExtension')).toList();
-    var metaModule = await MetaModule.forLibraries(buildStep, libraryAssets);
+    var metaModule =
+        await MetaModule.forLibraries(buildStep, libraryAssets, strategy);
     var id = AssetId(buildStep.inputId.package, 'lib/$metaModuleExtension');
     await buildStep.writeAsString(id, json.encode(metaModule.toJson()));
   }

--- a/build_modules/lib/src/meta_module_clean_builder.dart
+++ b/build_modules/lib/src/meta_module_clean_builder.dart
@@ -102,6 +102,12 @@ Future<Set<Module>> _transitiveModules(
         continue;
       }
       seenMetas.add(depMetaAsset);
+      if (!await buildStep.canRead(depMetaAsset)) {
+        log.warning('Unable to read module information for '
+            'package:${depMetaAsset.package}, make sure you have a dependency '
+            'in it in your pubspec.');
+        continue;
+      }
       var depMeta = MetaModule.fromJson(
           json.decode(await buildStep.readAsString(depMetaAsset))
               as Map<String, dynamic>);

--- a/build_modules/lib/src/meta_module_clean_builder.dart
+++ b/build_modules/lib/src/meta_module_clean_builder.dart
@@ -105,7 +105,7 @@ Future<Set<Module>> _transitiveModules(
       if (!await buildStep.canRead(depMetaAsset)) {
         log.warning('Unable to read module information for '
             'package:${depMetaAsset.package}, make sure you have a dependency '
-            'in it in your pubspec.');
+            'on it in your pubspec.');
         continue;
       }
       var depMeta = MetaModule.fromJson(

--- a/build_modules/lib/src/meta_module_clean_builder.dart
+++ b/build_modules/lib/src/meta_module_clean_builder.dart
@@ -45,9 +45,8 @@ class MetaModuleCleanBuilder implements Builder {
     var connectedComponents = stronglyConnectedComponents<AssetId, Module>(
         modules,
         (m) => m.primarySource,
-        (m) => m.directDependencies
-            .map((d) => assetToModule[d])
-            .where((d) => d != null));
+        (m) => m.directDependencies.map(
+            (d) => assetToModule[d] ?? Module(d, [d], [], isMissing: true)));
     Module merge(List<Module> c) => _mergeComponent(c, assetToPrimary);
     bool primarySourceInPackage(Module m) =>
         m.primarySource.package == buildStep.inputId.package;

--- a/build_modules/lib/src/module_builder.dart
+++ b/build_modules/lib/src/module_builder.dart
@@ -48,14 +48,13 @@ class ModuleBuilder implements Builder {
 
   @override
   Future build(BuildStep buildStep) async {
-    Module outputModule;
     var cleanMetaModules = await buildStep.fetchResource(_cleanMetaModules);
     var metaModule =
         await cleanMetaModules.find(buildStep.inputId.package, buildStep);
-    outputModule = metaModule.modules
-        .firstWhere((m) => m.sources.contains(buildStep.inputId));
+    final outputModule = metaModule.modules.firstWhere(
+        (m) => m.primarySource == buildStep.inputId,
+        orElse: () => null);
     if (outputModule == null) return;
-    if (outputModule.primarySource != buildStep.inputId) return;
     await buildStep.writeAsString(
         buildStep.inputId.changeExtension(moduleExtension),
         json.encode(outputModule.toJson()));

--- a/build_modules/lib/src/module_builder.dart
+++ b/build_modules/lib/src/module_builder.dart
@@ -8,7 +8,6 @@ import 'dart:convert';
 import 'package:async/async.dart';
 import 'package:build/build.dart';
 
-import 'common.dart';
 import 'meta_module.dart';
 import 'meta_module_clean_builder.dart';
 import 'modules.dart';
@@ -37,60 +36,10 @@ class _CleanMetaModuleCache {
   }
 }
 
-/// Updates dependencies from the provided [Module] so that they point to the
-/// primary resource of the dependencies corresponding [Module].
-///
-/// Note that this will process the clean meta modules for the module
-/// dependencies if necessary.
-Future<Module> _cleanModuleDeps(
-    BuildStep buildStep, Module module, _CleanMetaModuleCache cache) async {
-  var cleanedDeps = Set<AssetId>();
-  var depAssetToModules = <AssetId, Module>{};
-  for (var dep in module.directDependencies) {
-    // Since we are not using the course strategy we can safely add
-    // all dependencies in the same package as they will have a
-    // corresponding module file.
-    if (dep.package == module.primarySource.package) {
-      cleanedDeps.add(dep);
-      continue;
-      // It is possible that this dep came from another fine grained
-      // module. Look for the corresponding module file.
-    } else if (await buildStep.canRead(dep.changeExtension(moduleExtension))) {
-      cleanedDeps.add(dep);
-      continue;
-    }
-    var metaModule = await cache.find(dep.package, buildStep);
-    if (metaModule == null) {
-      // The dep is also fine but it's individual modules will come in a later
-      // phase. Need to recompute them.
-      if (!depAssetToModules.containsKey(dep)) {
-        var depLibrary = await buildStep.resolver.libraryFor(dep);
-        var depModule = Module.forLibrary(depLibrary);
-        for (var source in depModule.sources) {
-          depAssetToModules[source] = depModule;
-        }
-      }
-      cleanedDeps.add(depAssetToModules[dep].primarySource);
-    } else {
-      // The dep has a course strategy
-      cleanedDeps.add(metaModule.modules
-          .firstWhere((m) => m.sources.contains(dep))
-          .primarySource);
-    }
-  }
-  return Module(module.primarySource, module.sources, cleanedDeps);
-}
-
 /// Creates `.module` files for any `.dart` file that is the primary dart
 /// source of a [Module].
 class ModuleBuilder implements Builder {
-  final bool _isCoarse;
-  const ModuleBuilder({bool isCoarse}) : _isCoarse = isCoarse ?? true;
-
-  factory ModuleBuilder.forOptions(BuilderOptions options) {
-    return ModuleBuilder(
-        isCoarse: moduleStrategy(options) == ModuleStrategy.coarse);
-  }
+  const ModuleBuilder();
 
   @override
   final buildExtensions = const {
@@ -101,25 +50,10 @@ class ModuleBuilder implements Builder {
   Future build(BuildStep buildStep) async {
     Module outputModule;
     var cleanMetaModules = await buildStep.fetchResource(_cleanMetaModules);
-    var cleanMetaAsset =
-        AssetId(buildStep.inputId.package, 'lib/$metaModuleCleanExtension');
-    // If we can't read the clean meta module it is likely that this package
-    // is in a module cycle so fall back to the fine strategy.
-    if (_isCoarse && await buildStep.canRead(cleanMetaAsset)) {
-      var metaModule =
-          await cleanMetaModules.find(buildStep.inputId.package, buildStep);
-      outputModule = metaModule.modules
-          .firstWhere((m) => m.sources.contains(buildStep.inputId));
-    } else {
-      if (!await buildStep.resolver.isLibrary(buildStep.inputId)) return;
-
-      var library = await buildStep.inputLibrary;
-      if (!isPrimary(library)) return;
-
-      var module = Module.forLibrary(library);
-      outputModule =
-          await _cleanModuleDeps(buildStep, module, cleanMetaModules);
-    }
+    var metaModule =
+        await cleanMetaModules.find(buildStep.inputId.package, buildStep);
+    outputModule = metaModule.modules
+        .firstWhere((m) => m.sources.contains(buildStep.inputId));
     if (outputModule == null) return;
     if (outputModule.primarySource != buildStep.inputId) return;
     await buildStep.writeAsString(

--- a/build_modules/lib/src/modules.dart
+++ b/build_modules/lib/src/modules.dart
@@ -87,6 +87,11 @@ class Module {
       fromJson: _assetIdsFromJson)
   final Set<AssetId> directDependencies;
 
+  /// Missing modules are created if a module depends on another non-existent
+  /// module.
+  ///
+  /// We want to report these errors lazily to allow for builds to succeed if it
+  /// won't actually impact any apps negatively.
   @JsonKey(name: 'm', nullable: true, defaultValue: false)
   final bool isMissing;
 

--- a/build_modules/lib/src/modules.g.dart
+++ b/build_modules/lib/src/modules.g.dart
@@ -10,11 +10,13 @@ Module _$ModuleFromJson(Map<String, dynamic> json) {
   return Module(
       _assetIdFromJson(json['p'] as List),
       _assetIdsFromJson(json['s'] as List),
-      _assetIdsFromJson(json['d'] as List));
+      _assetIdsFromJson(json['d'] as List),
+      isMissing: json['m'] as bool ?? false);
 }
 
 Map<String, dynamic> _$ModuleToJson(Module instance) => <String, dynamic>{
       'p': _assetIdToJson(instance.primarySource),
       's': _assetIdsToJson(instance.sources),
-      'd': _assetIdsToJson(instance.directDependencies)
+      'd': _assetIdsToJson(instance.directDependencies),
+      'm': instance.isMissing
     };

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 0.3.2-dev
+version: 0.3.2
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
+  analyzer: ">0.30.0 < 0.33.0"
   async: ">=1.13.3 <3.0.0"
   bazel_worker: ^0.1.4
   build: ^0.12.3

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  analyzer: ">0.30.0 < 0.33.0"
   async: ">=1.13.3 <3.0.0"
   bazel_worker: ^0.1.4
   build: ^0.12.3
@@ -23,7 +22,7 @@ dependencies:
   scratch_space: ^0.0.3
 
 dev_dependencies:
-  build_runner: ^0.9.0
+  build_runner: ^0.10.0
   build_test: ^0.10.0
   build_vm_compilers: ^0.1.0
   json_serializable: ^1.0.0

--- a/build_modules/test/meta_module_clean_builder_test.dart
+++ b/build_modules/test/meta_module_clean_builder_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:build/build.dart';
 import 'package:build_modules/src/meta_module_clean_builder.dart';
 import 'package:build_test/build_test.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 import 'package:build_modules/build_modules.dart';
@@ -14,9 +15,10 @@ import 'package:build_modules/src/meta_module.dart';
 import 'matchers.dart';
 
 main() {
+  final assetA = AssetId('a', 'lib/a.dart');
+  final assetB = AssetId('b', 'lib/b.dart');
+
   test('unconnected components stay disjoint', () async {
-    var assetA = AssetId('a', 'lib/a.dart');
-    var assetB = AssetId('b', 'lib/b.dart');
     var moduleA = Module(assetA, [assetA], []);
     var moduleB = Module(assetB, [assetB], []);
 
@@ -35,8 +37,6 @@ main() {
   });
 
   test('can handle cycles', () async {
-    var assetA = AssetId('a', 'lib/a.dart');
-    var assetB = AssetId('b', 'lib/b.dart');
     var moduleA = Module(assetA, [assetA], [assetB]);
     var moduleB = Module(assetB, [assetB], [assetA]);
 
@@ -56,5 +56,26 @@ main() {
       'b|lib/$metaModuleCleanExtension':
           encodedMatchesMetaModule(MetaModule([])),
     });
+  });
+
+  test('Warns about missing .meta_module.raw files from dependencies',
+      () async {
+    var moduleA = Module(assetA, [assetA], [assetB]);
+    var metaA = MetaModule([moduleA]);
+    var logs = <LogRecord>[];
+    await testBuilder(MetaModuleCleanBuilder(), {
+      'a|lib/$metaModuleExtension': json.encode(metaA),
+      'a|lib/a.dart': 'import "package:b/b.dart"',
+    }, outputs: {
+      'a|lib/$metaModuleCleanExtension': encodedMatchesMetaModule(metaA),
+    }, onLog: (r) {
+      if (r.level >= Level.WARNING) logs.add(r);
+    });
+    expect(
+        logs,
+        orderedEquals([
+          predicate((LogRecord r) => r.message
+              .startsWith('Unable to read module information for package:b'))
+        ]));
   });
 }

--- a/build_modules/test/meta_module_clean_builder_test.dart
+++ b/build_modules/test/meta_module_clean_builder_test.dart
@@ -53,22 +53,8 @@ main() {
       'b|lib/b.dart': 'import "package:a/a.dart"',
     }, outputs: {
       'a|lib/$metaModuleCleanExtension': encodedMatchesMetaModule(clean),
-      'b|lib/$metaModuleCleanExtension': encodedMatchesMetaModule(clean),
+      'b|lib/$metaModuleCleanExtension':
+          encodedMatchesMetaModule(MetaModule([])),
     });
-  });
-
-  test('does not output a clean module if the dep\'s meta module is not found',
-      () async {
-    var assetA = AssetId('a', 'lib/a.dart');
-    var assetB = AssetId('b', 'lib/b.dart');
-    var moduleA = Module(assetA, [assetA], [assetB]);
-
-    var metaA = MetaModule([moduleA]);
-
-    await testBuilder(MetaModuleCleanBuilder(), {
-      'a|lib/$metaModuleExtension': json.encode(metaA),
-      'a|lib/a.dart': 'import "package:b/b.dart"',
-      'b|lib/b.dart': 'import "package:a/a.dart"',
-    }, outputs: {});
   });
 }

--- a/build_modules/test/meta_module_test.dart
+++ b/build_modules/test/meta_module_test.dart
@@ -9,6 +9,7 @@ import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
 import 'package:build_modules/build_modules.dart';
+import 'package:build_modules/src/common.dart';
 import 'package:build_modules/src/meta_module.dart';
 import 'package:build_modules/src/module_library.dart';
 import 'package:build_modules/src/modules.dart';
@@ -42,7 +43,8 @@ void main() {
         reader,
         libraries
             .map((l) => l.id.changeExtension(moduleLibraryExtension))
-            .toList());
+            .toList(),
+        ModuleStrategy.coarse);
   }
 
   test('no strongly connected components, one shared lib', () async {

--- a/build_modules/test/module_builder_test.dart
+++ b/build_modules/test/module_builder_test.dart
@@ -9,14 +9,12 @@ import 'package:test/test.dart';
 
 import 'package:build_modules/build_modules.dart';
 import 'package:build_modules/src/meta_module.dart';
-import 'package:build_modules/src/meta_module_clean_builder.dart';
 import 'package:build_modules/src/modules.dart';
 
 import 'matchers.dart';
 
 main() {
-  test('can serialize fine modules and only output for primary sources',
-      () async {
+  test('can serialize modules and only output for primary sources', () async {
     var assetA = AssetId('a', 'lib/a.dart');
     var assetB = AssetId('a', 'lib/b.dart');
     var assetC = AssetId('a', 'lib/c.dart');
@@ -25,45 +23,18 @@ main() {
     var moduleA = Module(assetA, [assetA], <AssetId>[]);
     var moduleB = Module(assetB, [assetB, assetC], <AssetId>[]);
     var moduleD = Module(assetD, [assetD, assetE], <AssetId>[]);
+    var metaModule = MetaModule([moduleA, moduleB, moduleD]);
     await testBuilder(ModuleBuilder(), {
       'a|lib/a.dart': '',
-      'a|lib/b.dart': 'part "c.dart";',
-      'a|lib/c.dart': 'part of "b.dart";',
-      'a|lib/d.dart': 'import "e.dart";',
-      'a|lib/e.dart': 'import "d.dart";',
+      'a|lib/b.dart': '',
+      'a|lib/c.dart': '',
+      'a|lib/d.dart': '',
+      'a|lib/e.dart': '',
+      'a|lib/.meta_module.clean': jsonEncode(metaModule.toJson()),
     }, outputs: {
       'a|lib/a.module': encodedMatchesModule(moduleA),
       'a|lib/b.module': encodedMatchesModule(moduleB),
       'a|lib/d.module': encodedMatchesModule(moduleD),
-    });
-  });
-  test('can serialize course modules and only output for primary sources',
-      () async {
-    var assetA = AssetId('a', 'lib/a.dart');
-    var moduleA = Module(assetA, [assetA], <AssetId>[]);
-    var meta = MetaModule([moduleA]);
-    await testBuilder(ModuleBuilder(), {
-      'a|lib/$metaModuleCleanExtension': json.encode(meta),
-      'a|lib/a.dart': '',
-    }, outputs: {
-      'a|lib/a.module': encodedMatchesModule(moduleA),
-    });
-  });
-
-  test('defaults to the fine strategy if the clean meta module is not found',
-      () async {
-    var assetA = AssetId('a', 'lib/a.dart');
-    var assetB = AssetId('a', 'lib/b.dart');
-    var assetC = AssetId('a', 'lib/c.dart');
-    var moduleA = Module(assetA, [assetA], <AssetId>[]);
-    var moduleB = Module(assetB, [assetB, assetC], <AssetId>[]);
-    await testBuilder(ModuleBuilder(), {
-      'a|lib/a.dart': '',
-      'a|lib/b.dart': 'part "c.dart";',
-      'a|lib/c.dart': 'part of "b.dart";',
-    }, outputs: {
-      'a|lib/a.module': encodedMatchesModule(moduleA),
-      'a|lib/b.module': encodedMatchesModule(moduleB),
     });
   });
 }

--- a/build_modules/test/modules_test.dart
+++ b/build_modules/test/modules_test.dart
@@ -3,9 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:io';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -13,162 +12,37 @@ import 'package:build_modules/src/errors.dart';
 import 'package:build_modules/src/modules.dart';
 import 'package:build_modules/src/module_builder.dart';
 
+String serializeModule(Module module) => jsonEncode(module.toJson());
+
 void main() {
-  LibraryElement libCycle;
-  LibraryElement libSecondaryInCycle;
-  LibraryElement libNoCycle;
-  LibraryElement libCycleWithB;
-  LibraryElement libCycleWithA;
-  LibraryElement libDepOnNonSdk;
-  LibraryElement libAImportsBNoCycle;
-  LibraryElement libBImportsANoCycle;
-  LibraryElement libBSecondImportsANoCycle;
-  final assetCycle = makeAssetId('a|lib/a_cycle.dart');
-  final assetSecondaryInCycle = makeAssetId('a|lib/a_secondary_in_cycle.dart');
-  final assetPartInCycle = makeAssetId('a|lib/a_part_in_cycle.dart');
-  final assetNoCycle = makeAssetId('a|lib/a_no_cycle.dart');
-  final assetCycleWithB = makeAssetId('a|lib/a_cycle_with_b.dart');
-  final assetCycleWithA = makeAssetId('b|lib/b_cycle_with_a.dart');
-  final assetDepOnNonSdk = makeAssetId('a|lib/a_dep_on_non_sdk.dart');
-  final assetNonSdk = makeAssetId('a|lib/a_non_sdk.dart');
-  final assetAImportsBNoCycle = makeAssetId('a|lib/a_imports_b_no_cycle.dart');
-  final assetAPartLibraryName = makeAssetId('a|lib/a_part_library_name.dart');
-  final assetBImportsANoCycle = makeAssetId('b|lib/b_imports_a_no_cycle.dart');
-  final assetBSecondImportsANoCycle =
-      makeAssetId('b|lib/b_second_import_to_a_no_cycle.dart');
-
-  setUpAll(() async {
-    await resolveAsset(assetCycle, (resolver) async {
-      libCycle = await resolver.libraryFor(assetCycle);
-      libSecondaryInCycle = await resolver.libraryFor(assetSecondaryInCycle);
-    });
-    await resolveAsset(assetNoCycle, (resolver) async {
-      libNoCycle = await resolver.libraryFor(assetNoCycle);
-    });
-    await resolveAsset(assetCycleWithB, (resolver) async {
-      libCycleWithB = await resolver.libraryFor(assetCycleWithB);
-      libCycleWithA = await resolver.libraryFor(assetCycleWithA);
-    });
-    await resolveAsset(assetDepOnNonSdk, (resolver) async {
-      libDepOnNonSdk = await resolver.libraryFor(assetDepOnNonSdk);
-    });
-    await resolveAsset(assetAImportsBNoCycle, (resolver) async {
-      libAImportsBNoCycle = await resolver.libraryFor(assetAImportsBNoCycle);
-    });
-    await resolveAsset(assetBImportsANoCycle, (resolver) async {
-      libBImportsANoCycle = await resolver.libraryFor(assetBImportsANoCycle);
-    });
-    await resolveAsset(assetBSecondImportsANoCycle, (resolver) async {
-      libBSecondImportsANoCycle =
-          await resolver.libraryFor(assetBSecondImportsANoCycle);
-    });
-  });
-
-  group('defineModule.sources', () {
-    test('Finds the assets in a cycle', () {
-      var sources = Module.forLibrary(libCycle).sources;
-      expect(
-          sources,
-          unorderedEquals(
-              [assetCycle, assetSecondaryInCycle, assetPartInCycle]));
-    });
-
-    test('Finds a single asset with no cycle', () {
-      var sources = Module.forLibrary(libNoCycle).sources;
-      expect(sources, unorderedEquals([assetNoCycle]));
-    });
-
-    test('Finds the assets in a cycle across packages', () {
-      var sources = Module.forLibrary(libCycleWithB).sources;
-      expect(sources, unorderedEquals([assetCycleWithA, assetCycleWithB]));
-    });
-  });
-
-  group('defineModule.directDependencies', () {
-    test('Chooses primary from cycle for dependency', () {
-      var dependencies = Module.forLibrary(libCycle).directDependencies;
-      expect(dependencies, unorderedEquals([assetCycleWithB]));
-    });
-
-    test('Includes libraries that have names starting with "dart."', () {
-      // https://github.com/dart-lang/sdk/issues/31045
-      // `library.isInSdk` is broken - we shouldn't use it
-      var dependencies = Module.forLibrary(libDepOnNonSdk).directDependencies;
-      expect(dependencies, unorderedEquals([assetNonSdk]));
-    });
-  });
-
-  group('isPrimary', () {
-    group('within package', () {
-      test('Marks library with no cycle as primary', () {
-        expect(isPrimary(libNoCycle), true);
-      });
-
-      test('Marks library with lowest alpha sort as primary', () {
-        expect(isPrimary(libCycle), true);
-      });
-
-      test('Does not mark library with higher alpha sort as primary', () {
-        expect(isPrimary(libSecondaryInCycle), false);
-      });
-    });
-    group('across packages', () {
-      test('Marks library with lowest alpha sort as primary', () {
-        expect(isPrimary(libCycleWithB), true);
-      });
-      test('Does not mark library with later alpha sort as primary', () {
-        expect(isPrimary(libCycleWithA), false);
-      });
-    });
-  });
-
   group('computeTransitiveDeps', () {
-    Module rootModule;
-    Module immediateDep;
-    Module immediateDep2;
-    Module transitiveDep;
+    final rootId = AssetId('a', 'lib/a.dart');
+    final directDepId = AssetId('a', 'lib/src/dep.dart');
+    final transitiveDepId = AssetId('b', 'lib/b.dart');
+    final deepTransitiveDepId = AssetId('b', 'lib/src/dep.dart');
+    final rootModule = Module(rootId, [rootId], [directDepId]);
+    final directDepModule =
+        Module(directDepId, [directDepId], [transitiveDepId]);
+    final transitiveDepModule =
+        Module(transitiveDepId, [transitiveDepId], [deepTransitiveDepId]);
+    final deepTransitiveDepModule =
+        Module(deepTransitiveDepId, [deepTransitiveDepId], []);
     InMemoryAssetReader reader;
 
     setUp(() {
-      rootModule = Module.forLibrary(libAImportsBNoCycle);
-      immediateDep = Module.forLibrary(libBImportsANoCycle);
-      immediateDep2 = Module.forLibrary(libBSecondImportsANoCycle);
-      transitiveDep = Module.forLibrary(libNoCycle);
       reader = InMemoryAssetReader();
       reader.cacheStringAsset(
-          assetAImportsBNoCycle,
-          File('test/fixtures/a/${assetAImportsBNoCycle.path}')
-              .readAsStringSync());
+          rootId.changeExtension(moduleExtension), serializeModule(rootModule));
+      reader.cacheStringAsset(directDepId.changeExtension(moduleExtension),
+          serializeModule(directDepModule));
+      reader.cacheStringAsset(transitiveDepId.changeExtension(moduleExtension),
+          serializeModule(transitiveDepModule));
       reader.cacheStringAsset(
-          assetAPartLibraryName,
-          File('test/fixtures/a/${assetAPartLibraryName.path}')
-              .readAsStringSync());
-      reader.cacheStringAsset(
-          assetBImportsANoCycle,
-          File('test/fixtures/b/${assetBImportsANoCycle.path}')
-              .readAsStringSync());
-      reader.cacheStringAsset(
-          assetBSecondImportsANoCycle,
-          File('test/fixtures/b/${assetBSecondImportsANoCycle.path}')
-              .readAsStringSync());
-      reader.cacheStringAsset(assetCycle,
-          File('test/fixtures/a/${assetCycle.path}').readAsStringSync());
-      reader.cacheStringAsset(
-          assetSecondaryInCycle,
-          File('test/fixtures/a/${assetSecondaryInCycle.path}')
-              .readAsStringSync());
+          deepTransitiveDepId.changeExtension(moduleExtension),
+          serializeModule(deepTransitiveDepModule));
     });
 
     test('finds transitive deps', () async {
-      reader.cacheStringAsset(
-          assetBImportsANoCycle.changeExtension(moduleExtension),
-          json.encode(immediateDep.toJson()));
-      reader.cacheStringAsset(
-          assetBSecondImportsANoCycle.changeExtension(moduleExtension),
-          json.encode(immediateDep2.toJson()));
-      reader.cacheStringAsset(assetNoCycle.changeExtension(moduleExtension),
-          json.encode(transitiveDep.toJson()));
-
       var transitiveDeps =
           (await rootModule.computeTransitiveDependencies(reader))
               .map((m) => m.primarySource)
@@ -176,19 +50,22 @@ void main() {
       expect(
           transitiveDeps,
           unorderedEquals([
-            immediateDep.primarySource,
-            immediateDep2.primarySource,
-            transitiveDep.primarySource
+            directDepModule.primarySource,
+            transitiveDepModule.primarySource,
+            deepTransitiveDepModule.primarySource,
           ]));
-      expect(transitiveDeps.indexOf(transitiveDep.primarySource),
-          lessThan(transitiveDeps.indexOf(immediateDep.primarySource)));
-      expect(transitiveDeps.indexOf(transitiveDep.primarySource),
-          lessThan(transitiveDeps.indexOf(immediateDep2.primarySource)));
+      expect(transitiveDeps.indexOf(transitiveDepModule.primarySource),
+          lessThan(transitiveDeps.indexOf(directDepModule.primarySource)));
+      expect(transitiveDeps.indexOf(deepTransitiveDepModule.primarySource),
+          lessThan(transitiveDeps.indexOf(transitiveDepModule.primarySource)));
     });
 
     test('missing modules report nice errors', () {
-      reader.cacheStringAsset(assetCycle.changeExtension(moduleExtension),
-          json.encode(immediateDep.toJson()));
+      reader.assets
+          .remove(deepTransitiveDepId.changeExtension(moduleExtension));
+      reader.cacheStringAsset(transitiveDepId, '''
+import 'src/dep.dart';
+''');
       expect(
           () => rootModule.computeTransitiveDependencies(reader),
           allOf(throwsA(TypeMatcher<MissingModulesException>()), throwsA(
@@ -203,8 +80,7 @@ generated file).
 
 Please check the following imports:
 
-`import 'package:b/b_second_import_to_a_no_cycle.dart';` from a|lib/a_imports_b_no_cycle.dart at 5:1
-`import 'package:b/b_imports_a_no_cycle.dart';` from a|lib/a_imports_b_no_cycle.dart at 4:1
+`import 'src/dep.dart';` from b|lib/b.dart at 1:1
 ''');
               },
             ),

--- a/build_modules/test/summary_builder_test.dart
+++ b/build_modules/test/summary_builder_test.dart
@@ -80,6 +80,7 @@ main() {
       assets = {
         'build_modules|lib/src/analysis_options.default.yaml': '',
         'a|web/index.dart': 'import "package:a/a.dart";',
+        'a|lib/a.dart': 'import "package:b/b.dart";',
       };
 
       // Set up all the other required inputs for this test.

--- a/build_modules/test/summary_builder_test.dart
+++ b/build_modules/test/summary_builder_test.dart
@@ -83,6 +83,9 @@ main() {
       };
 
       // Set up all the other required inputs for this test.
+      await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
+      await testBuilderAndCollectAssets(MetaModuleBuilder(), assets);
+      await testBuilderAndCollectAssets(MetaModuleCleanBuilder(), assets);
       await testBuilderAndCollectAssets(ModuleBuilder(), assets);
       await testBuilderAndCollectAssets(UnlinkedSummaryBuilder(), assets);
     });


### PR DESCRIPTION
All strategies now create meta_module files, and the analyzer dependency is now removed from build_modules :tada:.

- Module strategies are now respected for all packages instead of just the root package
- Deleted a lot of fallback code to discover when a package is using the fine strategy
- Can now mix and match fine and coarse strategies at will, even within package cycles (although this may cause larger modules)
- Added an explicit notion of "missing" modules - these are warned about when they are discovered but won't fail until some other builder tries to compute transitive dependencies.
- Unblocks config specific imports work (we are always doing our own crawling now instead of relying on analyzers computation of library cycles).

Fixes https://github.com/dart-lang/build/issues/1752