### PR TITLE
Don't assume primary input is an actual input

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1+5
+
+- Fixed an issue where builders that didn't read their primary input would get
+  invalidated on fresh builds when they shouldn't.
+
 ## 0.3.1+4
 
 - Removed the constraint on reading files that output to cache from files that

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -56,7 +56,8 @@ class AssetGraph {
         placeholders: placeholders);
     // Pre-emptively compute digests for the nodes we know have outputs.
     await graph._setLastKnownDigests(
-        sourceNodes.where((node) => node.outputs.isNotEmpty), digestReader);
+        sourceNodes.where((node) => node.primaryOutputs.isNotEmpty),
+        digestReader);
     // Always compute digests for all internal nodes.
     var internalNodes = graph._addInternalSources(internalSources);
     await graph._setLastKnownDigests(internalNodes, digestReader);
@@ -263,7 +264,9 @@ class AssetGraph {
     await _setLastKnownDigests(
         newAndModifiedNodes.where((node) =>
             node.isValidInput &&
-            (node.outputs.isNotEmpty || node.lastKnownDigest != null)),
+            (node.outputs.isNotEmpty ||
+                node.primaryOutputs.isNotEmpty ||
+                node.lastKnownDigest != null)),
         digestReader);
 
     // Collects the set of all transitive ids to be removed from the graph,
@@ -419,7 +422,6 @@ class AssetGraph {
       var outputs = expectedOutputs(phase.builder, input);
       phaseOutputs.addAll(outputs);
       node.primaryOutputs.addAll(outputs);
-      node.outputs.addAll(outputs);
       var deleted = _addGeneratedOutputs(
           outputs, phaseNum, builderOptionsNode, buildPhases, rootPackage,
           primaryInput: input, isHidden: phase.hideOutput);

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -306,10 +306,8 @@ class AssetGraph {
       if (node == null) return;
       if (!invalidatedIds.add(id)) return;
 
-      if (node is NodeWithInputs) {
-        if (node.state == NodeState.upToDate) {
-          node.state = NodeState.mayNeedUpdate;
-        }
+      if (node is NodeWithInputs && node.state == NodeState.upToDate) {
+        node.state = NodeState.mayNeedUpdate;
       }
 
       // Update all outputs of this asset as well.

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -178,9 +178,6 @@ class AssetGraph {
       if (inputsNode != null) {
         inputsNode.inputs.remove(id);
       }
-      if (inputsNode.state == NodeState.upToDate) {
-        inputsNode.state = NodeState.mayNeedUpdate;
-      }
     }
     if (node is NodeWithInputs) {
       for (var input in node.inputs) {

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -796,10 +796,6 @@ class _SingleBuild {
     var removedInputs = node.inputs.difference(updatedInputs);
     node.inputs.removeAll(removedInputs);
     for (var input in removedInputs) {
-      // TODO: special type of dependency here? This means the primary input
-      // was never actually read.
-      if (input == node.primaryInput) continue;
-
       var inputNode = _assetGraph.get(input);
       assert(inputNode != null, 'Asset Graph is missing $input');
       inputNode.outputs.remove(node.id);

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 0.3.1+4
+version: 0.3.1+5
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -209,7 +209,7 @@ void main() {
             ]..addAll(placeholders)));
         var node = graph.get(primaryInputId);
         expect(node.primaryOutputs, [primaryOutputId]);
-        expect(node.outputs, [primaryOutputId]);
+        expect(node.outputs, []);
         expect(node.lastKnownDigest, isNotNull,
             reason: 'Nodes with outputs should get an eager digest.');
 
@@ -268,8 +268,10 @@ void main() {
           var deletes = <AssetId>[];
           expect(graph.contains(primaryOutputId), isTrue);
           // pretend a build happened
-          (graph.get(primaryOutputId) as GeneratedAssetNode).state =
-              NodeState.upToDate;
+          (graph.get(primaryOutputId) as GeneratedAssetNode)
+            ..state = NodeState.upToDate
+            ..inputs.add(primaryInputId);
+          graph.get(primaryInputId).outputs.add(primaryOutputId);
           await graph.updateAndInvalidate(buildPhases, changes, 'foo',
               (id) async => deletes.add(id), digestReader);
           expect(graph.contains(primaryInputId), isTrue);

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -172,20 +172,19 @@ targets:
       });
 
       test('for changed sources', () async {
+        var aTxt = AssetId('a', 'lib/a.txt');
+        var aTxtCopy = AssetId('a', 'lib/a.txt.copy');
         await createFile(p.join('lib', 'a.txt'), 'a');
         var buildPhases = [InBuildPhase(TestBuilder(), 'a', hideOutput: true)];
 
-        var originalAssetGraph = await AssetGraph.build(
-            buildPhases,
-            [makeAssetId('a|lib/a.txt')].toSet(),
-            Set(),
-            aPackageGraph,
-            environment.reader);
+        var originalAssetGraph = await AssetGraph.build(buildPhases,
+            [aTxt].toSet(), Set(), aPackageGraph, environment.reader);
 
         // pretend a build happened
-        (originalAssetGraph.get(makeAssetId('a|lib/a.txt.copy'))
-                as GeneratedAssetNode)
-            .state = NodeState.upToDate;
+        (originalAssetGraph.get(aTxtCopy) as GeneratedAssetNode)
+          ..state = NodeState.upToDate
+          ..inputs.add(aTxt);
+        originalAssetGraph.get(aTxt).outputs.add(aTxtCopy);
         await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         await modifyFile(p.join('lib', 'a.txt'), 'b');

--- a/build_runner_core/test/generate/build_error_test.dart
+++ b/build_runner_core/test/generate/build_error_test.dart
@@ -166,6 +166,7 @@ class _LoggingBuilder implements Builder {
   @override
   Future<Null> build(BuildStep buildStep) async {
     log.log(level, buildStep.inputId.toString());
+    await buildStep.canRead(buildStep.inputId);
     await buildStep.writeAsString(buildStep.inputId.addExtension('.empty'), '');
   }
 


### PR DESCRIPTION
- `outputs` is no longer always a superset of `primaryOutputs` - it only contains nodes that actually read the file.
- `inputs` is now allowed to not contain the primary input

Fixes https://github.com/dart-lang/build/issues/1792