### PR TITLE
misc(build_config): update json_serializable to latest and regenerate

### DIFF
--- a/build_config/lib/src/build_target.g.dart
+++ b/build_config/lib/src/build_target.g.dart
@@ -8,13 +8,8 @@ part of 'build_target.dart';
 
 BuildTarget _$BuildTargetFromJson(Map json) {
   return $checkedNew('BuildTarget', json, () {
-    $checkKeys(json, allowedKeys: const [
-      'builders',
-      'dependencies',
-      'sources',
-      'key',
-      'package'
-    ]);
+    $checkKeys(json,
+        allowedKeys: const ['builders', 'dependencies', 'sources']);
     var val = BuildTarget(
         sources: $checkedConvert(
             json, 'sources', (v) => v == null ? null : InputSet.fromJson(v)),

--- a/build_config/lib/src/builder_definition.g.dart
+++ b/build_config/lib/src/builder_definition.g.dart
@@ -9,8 +9,6 @@ part of 'builder_definition.dart';
 BuilderDefinition _$BuilderDefinitionFromJson(Map json) {
   return $checkedNew('BuilderDefinition', json, () {
     $checkKeys(json, allowedKeys: const [
-      'package',
-      'key',
       'builder_factories',
       'import',
       'build_extensions',
@@ -106,8 +104,6 @@ const _$BuildToEnumMap = <BuildTo, dynamic>{
 PostProcessBuilderDefinition _$PostProcessBuilderDefinitionFromJson(Map json) {
   return $checkedNew('PostProcessBuilderDefinition', json, () {
     $checkKeys(json, allowedKeys: const [
-      'package',
-      'key',
       'builder_factory',
       'import',
       'input_extensions',

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
   yaml: ^2.1.11
 
 dev_dependencies:
-  build_runner: ^0.9.0
+  build_runner: ^0.10.0
   build_test: ^0.10.0
   build_vm_compilers: ^0.1.0
-  json_serializable: ^1.0.0
+  json_serializable: ^1.2.1
   test: ^1.0.0


### PR DESCRIPTION
Removes fields that should not be allowed - due to bug fix in v1.2.1
Also bump dependency on build_runner