### PR TITLE
Use unawaited from package:pedantic

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -17,8 +17,9 @@ dependencies:
   glob: ^1.1.0
 
 dev_dependencies:
-  build_vm_compilers: ^0.1.0
   build_resolvers: ^0.2.1
   build_runner: ^0.9.0
   build_test: ^0.10.0
+  build_vm_compilers: ^0.1.0
+  pedantic: ^1.0.0
   test: ^1.2.0

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:build_resolvers/build_resolvers.dart';
 import 'package:build_test/build_test.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import 'package:build/build.dart';
@@ -150,13 +151,11 @@ void main() {
     });
 
     test('Completes only after writes finish', () async {
-      // ignore: unawaited_futures
-      buildStep.writeAsString(outputId, outputContent);
+      unawaited(buildStep.writeAsString(outputId, outputContent));
       var isComplete = false;
-      // ignore: unawaited_futures
-      buildStep.complete().then((_) {
+      unawaited(buildStep.complete().then((_) {
         isComplete = true;
-      });
+      }));
       await Future(() {});
       expect(isComplete, false,
           reason: 'File has not written, should not be complete');
@@ -167,13 +166,11 @@ void main() {
 
     test('Completes only after async writes finish', () async {
       var outputCompleter = Completer<String>();
-      // ignore: unawaited_futures
-      buildStep.writeAsString(outputId, outputCompleter.future);
+      unawaited(buildStep.writeAsString(outputId, outputCompleter.future));
       var isComplete = false;
-      // ignore: unawaited_futures
-      buildStep.complete().then((_) {
+      unawaited(buildStep.complete().then((_) {
         isComplete = true;
-      });
+      }));
       await Future(() {});
       expect(isComplete, false,
           reason: 'File has not resolved, should not be complete');

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -12,6 +12,7 @@ import 'package:bazel_worker/driver.dart';
 import 'package:build/build.dart';
 import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:path/path.dart' as p;
+import 'package:pedantic/pedantic.dart';
 
 import 'scratch_space.dart';
 
@@ -213,10 +214,9 @@ class Dart2JsBatchWorkerPool {
           await Future.delayed(Duration(seconds: 1));
           worker = nextWorker();
         }
-        // ignore: unawaited_futures
-        worker
+        unawaited(worker
             .doJob(_workQueue.removeFirst())
-            .whenComplete(() => _availableWorkers.add(worker));
+            .whenComplete(() => _availableWorkers.add(worker)));
       }
       _queueIsActive = false;
     }();
@@ -268,14 +268,13 @@ class _Dart2JsWorker {
         _jobsSinceLastRestartCount = 0;
         __worker ??= await _spawnWorker();
         _spawningWorker = null;
-        // ignore: unawaited_futures
-        __worker.exitCode.then((_) {
+        unawaited(__worker.exitCode.then((_) {
           __worker = null;
           __workerStdoutLines = null;
           __workerStderrLines = null;
           _currentJobResult
               ?.completeError('Dart2js exited with an unknown error');
-        });
+        }));
       }
       return __worker;
     }();

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   logging: ^0.11.2
   meta: ^1.1.0
   path: ^1.4.2
+  pedantic: ^1.0.0
   scratch_space: ^0.0.3
 
 dev_dependencies:

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -6,17 +6,18 @@ import 'dart:convert';
 
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
-import 'package:build_runner_core/build_runner_core.dart';
-import 'package:build_runner_core/src/package_graph/target_graph.dart';
-import 'package:build_runner_core/src/asset_graph/graph.dart';
-import 'package:build_runner_core/src/asset_graph/node.dart';
-import 'package:build_runner_core/src/generate/build_impl.dart';
+import 'package:build_runner/src/package_graph/build_config_overrides.dart';
 import 'package:build_runner/src/watcher/asset_change.dart';
 import 'package:build_runner/src/watcher/graph_watcher.dart';
 import 'package:build_runner/src/watcher/node_watcher.dart';
-import 'package:build_runner/src/package_graph/build_config_overrides.dart';
+import 'package:build_runner_core/build_runner_core.dart';
+import 'package:build_runner_core/src/asset_graph/graph.dart';
+import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/generate/build_impl.dart';
+import 'package:build_runner_core/src/package_graph/target_graph.dart';
 import 'package:crypto/crypto.dart';
 import 'package:logging/logging.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:watcher/watcher.dart';
 
@@ -94,11 +95,10 @@ Future<ServeHandler> watch(
       outputMap?.isNotEmpty == true,
       isReleaseMode: isReleaseBuild ?? false);
 
-  // ignore: unawaited_futures
-  watch.buildResults.drain().then((_) async {
+  unawaited(watch.buildResults.drain().then((_) async {
     await terminator.cancel();
     await options.logListener.cancel();
-  });
+  }));
 
   return createServeHandler(watch);
 }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   meta: ^1.1.0
   mime: ^0.9.3
   path: ^1.1.0
+  pedantic: ^1.0.0
   pool: ^1.0.0
   pub_semver: ^1.4.0
   pubspec_parse: ^0.1.0

--- a/build_runner/test/watcher/graph_watcher_test.dart
+++ b/build_runner/test/watcher/graph_watcher_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:build/build.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 
@@ -83,8 +84,7 @@ void main() {
 
       final watcher = PackageGraphWatcher(graph, watch: noBWatcher);
 
-      // ignore: unawaited_futures
-      watcher.watch().drain();
+      unawaited(watcher.watch().drain());
 
       for (final node in nodes.values) {
         node.markReady();
@@ -107,12 +107,10 @@ void main() {
         return nodes[node.name];
       });
       // We have to listen in order for `ready` to complete.
-      // ignore: unawaited_futures
-      watcher.watch().drain();
+      unawaited(watcher.watch().drain());
 
       var done = false;
-      // ignore: unawaited_futures
-      watcher.ready.then((_) => done = true);
+      unawaited(watcher.ready.then((_) => done = true));
       await Future.value();
 
       for (final node in nodes.values) {

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -12,6 +12,7 @@ import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+import 'package:pedantic/pedantic.dart';
 import 'package:pool/pool.dart';
 // TODO(grouma) - remove dependency on ChangeType API to remove the following
 // import.
@@ -693,8 +694,7 @@ class _SingleBuild {
         ..lastKnownDigest =
             md5.convert(utf8.encode(globNode.results.join(' ')));
 
-      // ignore: unawaited_futures
-      _lazyGlobs.remove(globNode.id);
+      unawaited(_lazyGlobs.remove(globNode.id));
     });
   }
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   logging: ^0.11.2
   meta: ^1.1.0
   path: ^1.1.0
+  pedantic: ^1.0.0
   pool: ^1.0.0
   stream_transform: ^0.0.13
   watcher: ^0.9.7

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -8,6 +8,7 @@ import 'dart:math' as math;
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
 import 'package:glob/glob.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import 'package:build_runner_core/build_runner_core.dart';
@@ -354,12 +355,10 @@ void main() {
 
         // After the first builder runs, delete the asset from the reader and
         // allow the 2nd builder to run.
-        //
-        // ignore: unawaited_futures
-        firstBuilder.buildsCompleted.first.then((_) {
+        unawaited(firstBuilder.buildsCompleted.first.then((_) {
           reader.assets.remove(aTxtId);
           ready.complete();
-        });
+        }));
 
         await testBuilders(
             builders,

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:build/build.dart';
 import 'package:build_resolvers/build_resolvers.dart';
 import 'package:package_resolver/package_resolver.dart';
+import 'package:pedantic/pedantic.dart';
 
 import 'in_memory_reader.dart';
 import 'in_memory_writer.dart';
@@ -193,14 +194,13 @@ Future<T> _resolveAssets<T>(
     rootPackage: rootPackage,
   );
   // We don't care about the results of this build.
-  // ignore: unawaited_futures
-  runBuilder(
+  unawaited(runBuilder(
     resolveBuilder,
     inputAssets.keys,
     MultiAssetReader([inMemory, assetReader]),
     InMemoryAssetWriter(),
     resolvers ?? defaultResolvers,
-  );
+  ));
   return resolveBuilder.onDone.future;
 }
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   build_config: ">=0.2.0 <0.4.0"
   build_resolvers: ^0.2.0
   collection: ^1.14.0
-  stream_transform: ^0.0.11
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0
   html: ">=0.9.0 <=0.14.0"
@@ -21,6 +20,8 @@ dependencies:
   matcher: ^0.12.0
   package_resolver: ^1.0.2
   path: ^1.4.1
+  pedantic: ^1.0.0
+  stream_transform: ^0.0.11
   test: '>=0.12.42 <2.0.0'
   watcher: ^0.9.7
 

--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:build/build.dart';
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
+import 'package:pedantic/pedantic.dart';
 import 'package:pool/pool.dart';
 
 import 'util.dart';
@@ -105,8 +106,7 @@ class ScratchSpace {
                   await file.writeAsBytes(await reader.readAsBytes(id));
                 }));
       } finally {
-        // ignore: unawaited_futures
-        _pendingWrites.remove(id);
+        unawaited(_pendingWrites.remove(id));
       }
     }).toList();
 

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   build: ">=0.10.0 <0.13.0"
   crypto: ">=2.0.3 <3.0.0"
   path: ^1.1.0
+  pedantic: ^1.0.0
   pool: ^1.0.0
 
 dev_dependencies:

--- a/scratch_space/test/scratch_space_test.dart
+++ b/scratch_space/test/scratch_space_test.dart
@@ -10,6 +10,7 @@ import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
+import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import 'package:scratch_space/scratch_space.dart';
@@ -93,15 +94,13 @@ void main() {
     });
 
     test('Can\'t use a ScratchSpace after deleting it', () async {
-      // ignore: unawaited_futures
-      scratchSpace.delete();
+      unawaited(scratchSpace.delete());
       expect(() => scratchSpace.ensureAssets(allAssets.keys, assetReader),
           throwsStateError);
     });
 
     test('Can\'t delete a ScratchSpace twice', () async {
-      // ignore: unawaited_futures
-      scratchSpace.delete();
+      unawaited(scratchSpace.delete());
       expect(scratchSpace.delete, throwsStateError);
     });
 


### PR DESCRIPTION
Models the new best practices for ignoring unawaited futures lints. This
is largely to avoid encouraging use of `/ignore`, but also has benefits
like encolosing the full unawaited expression in parens which is more
clear than a comment on the line above.