### PR TITLE
release build_modules 0.4.0

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -19,7 +19,8 @@ targets:
         strategy: fine
 ```
 
-  The supported platforms are currently `dart2js`, `dartdevc`, and `vm`.
+  The supported platforms are currently `dart2js`, `dartdevc`, `flutter`, and
+  `vm`.
 
 ### Breaking API Changes
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 0.4.0-dev
+version: 0.4.0
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -37,7 +37,3 @@ dev_dependencies:
 dependency_overrides:
   build_vm_compilers:
     path: ../build_vm_compilers
-  build_runner_core:
-    path: ../build_runner_core
-  build_runner:
-    path: ../build_runner


### PR DESCRIPTION
Note that for tests only, there is still a dependency override for build_vm_compilers.

My plan is to just comment that out before publishing.