### PR TITLE
change default dart2js args to the new -O2

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -86,10 +86,10 @@ final _builders = <_i1.BuilderApplication>[
         'test/**.node_test.dart',
         'test/**.vm_test.dart'
       ]),
-      defaultOptions: new _i7.BuilderOptions({
-        'dart2js_args': ['--minify']
+      defaultReleaseOptions: new _i7.BuilderOptions({
+        'dart2js_args': ['-O2'],
+        'compiler': 'dart2js'
       }),
-      defaultReleaseOptions: new _i7.BuilderOptions({'compiler': 'dart2js'}),
       appliesBuilders: ['build_web_compilers|dart2js_archive_extractor']),
   _i1.apply(
       'build_vm_compilers|vm', [_i8.vmKernelModuleBuilder], _i1.toAllPackages(),

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.4-dev
+
+- Change the default dart2js arguments in release mode from `--minify` to `-O2`.
+  This is a new argument, which applies all "safe" optimizations.
+
 ## 0.4.3
 
 - Only call `window.postMessage` during initialization if the current context

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -47,11 +47,10 @@ builders:
         exclude:
           - test/**.node_test.dart
           - test/**.vm_test.dart
-      options:
-        dart2js_args:
-          - --minify
       release_options:
         compiler: dart2js
+        dart2js_args:
+          - -O2
     applies_builders:
       - build_web_compilers|dart2js_archive_extractor
 post_process_builders:

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.4.3
+version: 0.4.4-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
This arg is intended to contain all "safe" optimizations, which today includes `--minify` and `--lax-runtime-type-to-string`.