### PR TITLE
Drop DirectoryWatcherFactory typedef

### DIFF
--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -10,11 +10,11 @@ import 'package:build_runner/src/generate/terminator.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
+import 'package:watcher/watcher.dart';
 
 import '../logging/std_io_logging.dart';
 import '../package_graph/build_config_overrides.dart';
 import '../server/server.dart';
-import 'directory_watcher_factory.dart';
 import 'watch_impl.dart' as watch_impl;
 
 /// Runs all of the BuilderApplications in [builders] once.
@@ -153,7 +153,7 @@ Future<ServeHandler> watch(List<BuilderApplication> builders,
         Level logLevel,
         onLog(LogRecord record),
         Duration debounceDelay,
-        DirectoryWatcherFactory directoryWatcherFactory,
+        DirectoryWatcher Function(String) directoryWatcherFactory,
         Stream terminateEventStream,
         bool enableLowResourcesMode,
         Map<String, String> outputMap,

--- a/build_runner/lib/src/generate/directory_watcher_factory.dart
+++ b/build_runner/lib/src/generate/directory_watcher_factory.dart
@@ -6,8 +6,6 @@ import 'dart:io';
 
 import 'package:watcher/watcher.dart';
 
-typedef DirectoryWatcher DirectoryWatcherFactory(String path);
-
 DirectoryWatcher defaultDirectoryWatcherFactory(String path) =>
     // TODO: Use `DirectoryWatcher` on windows. See the following issues:
     // - https://github.com/dart-lang/build/issues/1031

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -23,7 +23,6 @@ import 'package:watcher/watcher.dart';
 
 import '../logging/std_io_logging.dart';
 import '../server/server.dart';
-import 'directory_watcher_factory.dart';
 import 'terminator.dart';
 
 final _logger = Logger('Watch');
@@ -40,7 +39,7 @@ Future<ServeHandler> watch(
   Level logLevel,
   onLog(LogRecord record),
   Duration debounceDelay,
-  DirectoryWatcherFactory directoryWatcherFactory,
+  DirectoryWatcher Function(String) directoryWatcherFactory,
   Stream terminateEventStream,
   bool skipBuildScriptCheck,
   bool enableLowResourcesMode,
@@ -117,7 +116,7 @@ WatchImpl _runWatch(
         List<BuilderApplication> builders,
         Map<String, Map<String, dynamic>> builderConfigOverrides,
         Future until,
-        DirectoryWatcherFactory directoryWatcherFactory,
+        DirectoryWatcher Function(String) directoryWatcherFactory,
         String configKey,
         bool willCreateOutputDirs,
         {bool isReleaseMode = false}) =>
@@ -163,7 +162,7 @@ class WatchImpl implements BuildState {
   final Duration _debounceDelay;
 
   /// Injectable factory for creating directory watchers.
-  final DirectoryWatcherFactory _directoryWatcherFactory;
+  final DirectoryWatcher Function(String) _directoryWatcherFactory;
 
   /// Whether or not we will be creating any output directories.
   ///


### PR DESCRIPTION
Towards #1086

It doesn't hold it's weight - the Function type is not much longer, the
variable and argument names are already descriptive, and it's more clear
to see the definition inline than to have an indirection to see the
argument type.

The most important place to change this is `build.dart` where it is used
in a public API but the typedef itself is not public.