### PR TITLE
add isSupported field to modules

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Breaking Changes
 
 - The `Module` constructor has an additional required parameter `isSupported`,
-  which indicates if a module is supported on the current platform.
+  which indicates if a module is supported on that module's platform.
 
 ## 0.4.0
 

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.0-dev
+
+### Breaking Changes
+
+- The `Module` constructor has an additional required parameter `isSupported`,
+  which indicates if a module is supported on the current platform.
+
 ## 0.4.0
 
 ### Improvements

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -50,7 +50,8 @@ Module _moduleForComponent(
     ..addAll(componentLibraries.expand((n) => n.depsForPlatform(platform)))
     ..removeAll(sources);
   var isSupported = componentLibraries
-      .every((l) => l.sdkDeps.every((d) => platform.supportsLibrary(d)));
+      .expand((l) => l.sdkDeps)
+      .every(platform.supportsLibrary);
   return Module(primaryId, sources, directDependencies, platform, isSupported);
 }
 
@@ -261,7 +262,7 @@ MetaModule _fineModulesForLibraries(
           library.parts.followedBy([library.id]),
           library.depsForPlatform(platform),
           platform,
-          library.sdkDeps.every((d) => platform.supportsLibrary(d))))
+          library.sdkDeps.every(platform.supportsLibrary)))
       .toList();
   _sortModules(modules);
   return MetaModule(modules);

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -34,10 +34,7 @@ String _topLevelDir(String path) {
   return parts.first;
 }
 
-/// Creates a module based strictly off of a strongly connected component of
-/// libraries nodes.
-///
-/// This creates more modules than we want, but we collapse them later on.
+/// Creates a module containing [componentLibraries].
 Module _moduleForComponent(
     List<ModuleLibrary> componentLibraries, DartPlatform platform) {
   // Name components based on first alphabetically sorted node, preferring
@@ -52,7 +49,9 @@ Module _moduleForComponent(
   var directDependencies = Set<AssetId>()
     ..addAll(componentLibraries.expand((n) => n.depsForPlatform(platform)))
     ..removeAll(sources);
-  return Module(primaryId, sources, directDependencies, platform);
+  var isSupported = componentLibraries
+      .every((l) => l.sdkDeps.every((d) => platform.supportsLibrary(d)));
+  return Module(primaryId, sources, directDependencies, platform, isSupported);
 }
 
 Map<AssetId, Module> _entryPointModules(
@@ -160,8 +159,8 @@ List<Module> _mergeModules(Iterable<Module> modules, Set<AssetId> entrypoints) {
       .toList();
 }
 
-Module _withConsistentPrimarySource(Module m) =>
-    Module(m.sources.reduce(_min), m.sources, m.directDependencies, m.platform);
+Module _withConsistentPrimarySource(Module m) => Module(m.sources.reduce(_min),
+    m.sources, m.directDependencies, m.platform, m.isSupported);
 
 T _min<T extends Comparable<T>>(T a, T b) => a.compareTo(b) < 0 ? a : b;
 
@@ -261,7 +260,8 @@ MetaModule _fineModulesForLibraries(
           library.id,
           library.parts.followedBy([library.id]),
           library.depsForPlatform(platform),
-          platform))
+          platform,
+          library.sdkDeps.every((d) => platform.supportsLibrary(d))))
       .toList();
   _sortModules(modules);
   return MetaModule(modules);

--- a/build_modules/lib/src/meta_module_clean_builder.dart
+++ b/build_modules/lib/src/meta_module_clean_builder.dart
@@ -53,7 +53,7 @@ class MetaModuleCleanBuilder implements Builder {
         (m) => m.primarySource,
         (m) => m.directDependencies.map((d) =>
             assetToModule[d] ??
-            Module(d, [d], [], _platform, isMissing: true)));
+            Module(d, [d], [], _platform, false, isMissing: true)));
     Module merge(List<Module> c) =>
         _mergeComponent(c, assetToPrimary, _platform);
     bool primarySourceInPackage(Module m) =>
@@ -144,8 +144,10 @@ Module _mergeComponent(List<Module> connectedComponent,
       SplayTreeSet<Module>((a, b) => a.primarySource.compareTo(b.primarySource))
         ..addAll(connectedComponent);
   var primarySource = components.first.primarySource;
+  var isSupported = true;
   for (var module in connectedComponent) {
     sources.addAll(module.sources);
+    isSupported = isSupported && module.isSupported;
     for (var dep in module.directDependencies) {
       var primaryDep = assetToPrimary[dep];
       if (primaryDep == null) continue;
@@ -158,7 +160,8 @@ Module _mergeComponent(List<Module> connectedComponent,
     }
   }
   // Update map so that sources now point to the merged module.
-  var mergedModule = Module(primarySource, sources, deps, platform);
+  var mergedModule =
+      Module(primarySource, sources, deps, platform, isSupported);
   for (var source in mergedModule.sources) {
     assetToPrimary[source] = mergedModule.primarySource;
   }

--- a/build_modules/lib/src/modules.dart
+++ b/build_modules/lib/src/modules.dart
@@ -96,6 +96,13 @@ class Module {
   @JsonKey(name: 'm', nullable: true, defaultValue: false)
   final bool isMissing;
 
+  /// Whether or not this module is supported for [platform].
+  ///
+  /// Compilers can use this to either silently skip compilation of this module
+  /// or throw early errors or warnings.
+  ///
+  /// Modules are allowed to exist even if they aren't supported, which can help
+  /// with discovering root causes of incompatibility.
   @JsonKey(name: 'is', nullable: false)
   final bool isSupported;
 

--- a/build_modules/lib/src/modules.dart
+++ b/build_modules/lib/src/modules.dart
@@ -98,6 +98,9 @@ class Module {
 
   /// Whether or not this module is supported for [platform].
   ///
+  /// Note that this only indicates support for the [sources] within this
+  /// module, and not its transitive (or direct) dependencies.
+  ///
   /// Compilers can use this to either silently skip compilation of this module
   /// or throw early errors or warnings.
   ///

--- a/build_modules/lib/src/modules.dart
+++ b/build_modules/lib/src/modules.dart
@@ -96,6 +96,9 @@ class Module {
   @JsonKey(name: 'm', nullable: true, defaultValue: false)
   final bool isMissing;
 
+  @JsonKey(name: 'is', nullable: false)
+  final bool isSupported;
+
   @JsonKey(
       name: 'pf',
       nullable: false,
@@ -104,7 +107,7 @@ class Module {
   final DartPlatform platform;
 
   Module(this.primarySource, Iterable<AssetId> sources,
-      Iterable<AssetId> directDependencies, this.platform,
+      Iterable<AssetId> directDependencies, this.platform, this.isSupported,
       {bool isMissing})
       : this.sources = sources.toSet(),
         this.directDependencies = directDependencies.toSet(),

--- a/build_modules/lib/src/modules.g.dart
+++ b/build_modules/lib/src/modules.g.dart
@@ -12,6 +12,7 @@ Module _$ModuleFromJson(Map<String, dynamic> json) {
       _assetIdsFromJson(json['s'] as List),
       _assetIdsFromJson(json['d'] as List),
       _platformFromJson(json['pf'] as String),
+      json['is'] as bool,
       isMissing: json['m'] as bool ?? false);
 }
 
@@ -19,6 +20,7 @@ Map<String, dynamic> _$ModuleToJson(Module instance) => <String, dynamic>{
       'p': _assetIdToJson(instance.primarySource),
       's': _assetIdsToJson(instance.sources),
       'd': _assetIdsToJson(instance.directDependencies),
+      'is': instance.isSupported,
       'm': instance.isMissing,
       'pf': _platformToJson(instance.platform)
     };

--- a/build_modules/lib/src/modules.g.dart
+++ b/build_modules/lib/src/modules.g.dart
@@ -20,7 +20,7 @@ Map<String, dynamic> _$ModuleToJson(Module instance) => <String, dynamic>{
       'p': _assetIdToJson(instance.primarySource),
       's': _assetIdsToJson(instance.sources),
       'd': _assetIdsToJson(instance.directDependencies),
-      'is': instance.isSupported,
       'm': instance.isMissing,
+      'is': instance.isSupported,
       'pf': _platformToJson(instance.platform)
     };

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -33,3 +33,6 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  build_vm_compilers: ^0.1.0

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 0.4.0
+version: 0.5.0-dev
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_modules/test/meta_module_builder_test.dart
+++ b/build_modules/test/meta_module_builder_test.dart
@@ -84,5 +84,24 @@ main() {
             encodedMatchesMetaModule(metaA),
       });
     });
+
+    test('does not look at dependencies', () async {
+      var assetA = AssetId('a', 'lib/a.dart');
+      var assetB = AssetId('a', 'lib/b.dart');
+      var moduleA = Module(
+          assetA, [assetA], <AssetId>[assetB], DartPlatform.dart2js, true);
+      var moduleB =
+          Module(assetB, [assetB], <AssetId>[], DartPlatform.dart2js, false);
+      var metaA = MetaModule([moduleA, moduleB]);
+      await testBuilder(MetaModuleBuilder(DartPlatform.dart2js), {
+        'a|lib/a.module.library':
+            ModuleLibrary.fromSource(assetA, "import 'b.dart';").serialize(),
+        'a|lib/b.module.library':
+            ModuleLibrary.fromSource(assetB, "import 'dart:io';").serialize(),
+      }, outputs: {
+        'a|lib/${metaModuleExtension(DartPlatform.dart2js)}':
+            encodedMatchesMetaModule(metaA),
+      });
+    });
   });
 }

--- a/build_modules/test/meta_module_builder_test.dart
+++ b/build_modules/test/meta_module_builder_test.dart
@@ -16,7 +16,8 @@ import 'matchers.dart';
 main() {
   test('can serialize meta modules', () async {
     var assetA = AssetId('a', 'lib/a.dart');
-    var moduleA = Module(assetA, [assetA], <AssetId>[], DartPlatform.dart2js);
+    var moduleA =
+        Module(assetA, [assetA], <AssetId>[], DartPlatform.dart2js, true);
     var metaA = MetaModule([moduleA]);
     await testBuilder(MetaModuleBuilder(DartPlatform.dart2js), {
       'a|lib/a.module.library':

--- a/build_modules/test/meta_module_builder_test.dart
+++ b/build_modules/test/meta_module_builder_test.dart
@@ -27,4 +27,62 @@ main() {
           encodedMatchesMetaModule(metaA),
     });
   });
+
+  group('isSupported', () {
+    test('is false for libraries that import dart:io on web', () async {
+      var assetA = AssetId('a', 'lib/a.dart');
+      var assetB = AssetId('a', 'lib/b.dart');
+      var moduleA =
+          Module(assetA, [assetA], <AssetId>[], DartPlatform.dart2js, true);
+      var moduleB =
+          Module(assetB, [assetB], <AssetId>[], DartPlatform.dart2js, false);
+      var metaA = MetaModule([moduleA, moduleB]);
+      await testBuilder(MetaModuleBuilder(DartPlatform.dart2js), {
+        'a|lib/a.module.library':
+            ModuleLibrary.fromSource(assetA, '').serialize(),
+        'a|lib/b.module.library':
+            ModuleLibrary.fromSource(assetB, "import 'dart:io';").serialize(),
+      }, outputs: {
+        'a|lib/${metaModuleExtension(DartPlatform.dart2js)}':
+            encodedMatchesMetaModule(metaA),
+      });
+    });
+
+    test('is false for connected components that import dart:io on web',
+        () async {
+      var assetA = AssetId('a', 'lib/a.dart');
+      var assetB = AssetId('a', 'lib/b.dart');
+      var moduleA = Module(
+          assetA, [assetA, assetB], <AssetId>[], DartPlatform.dart2js, false);
+      var metaA = MetaModule([moduleA]);
+      await testBuilder(MetaModuleBuilder(DartPlatform.dart2js), {
+        'a|lib/a.module.library':
+            ModuleLibrary.fromSource(assetA, "import 'b.dart';").serialize(),
+        'a|lib/b.module.library': ModuleLibrary.fromSource(
+                assetB, "import 'dart:io';import 'a.dart';")
+            .serialize(),
+      }, outputs: {
+        'a|lib/${metaModuleExtension(DartPlatform.dart2js)}':
+            encodedMatchesMetaModule(metaA),
+      });
+    });
+
+    test('is false for coarse modules that import dart:io on web', () async {
+      var assetA = AssetId('a', 'lib/a.dart');
+      var assetB = AssetId('a', 'lib/src/b.dart');
+      var moduleA = Module(
+          assetA, [assetA, assetB], <AssetId>[], DartPlatform.dart2js, false);
+      var metaA = MetaModule([moduleA]);
+      await testBuilder(MetaModuleBuilder(DartPlatform.dart2js), {
+        'a|lib/a.module.library':
+            ModuleLibrary.fromSource(assetA, "import 'src/b.dart';")
+                .serialize(),
+        'a|lib/src/b.module.library':
+            ModuleLibrary.fromSource(assetB, "import 'dart:io';").serialize(),
+      }, outputs: {
+        'a|lib/${metaModuleExtension(DartPlatform.dart2js)}':
+            encodedMatchesMetaModule(metaA),
+      });
+    });
+  });
 }

--- a/build_modules/test/meta_module_clean_builder_test.dart
+++ b/build_modules/test/meta_module_clean_builder_test.dart
@@ -22,8 +22,8 @@ main() {
   final platform = DartPlatform.dart2js;
 
   test('unconnected components stay disjoint', () async {
-    var moduleA = Module(assetA, [assetA], [], platform);
-    var moduleB = Module(assetB, [assetB], [], platform);
+    var moduleA = Module(assetA, [assetA], [], platform, true);
+    var moduleB = Module(assetB, [assetB], [], platform, true);
 
     var metaA = MetaModule([moduleA]);
     var metaB = MetaModule([moduleB]);
@@ -42,13 +42,13 @@ main() {
   });
 
   test('can handle cycles', () async {
-    var moduleA = Module(assetA, [assetA], [assetB], platform);
-    var moduleB = Module(assetB, [assetB], [assetA], platform);
+    var moduleA = Module(assetA, [assetA], [assetB], platform, true);
+    var moduleB = Module(assetB, [assetB], [assetA], platform, true);
 
     var metaA = MetaModule([moduleA]);
     var metaB = MetaModule([moduleB]);
     var clean = MetaModule([
-      Module(assetA, [assetA, assetB], [], platform)
+      Module(assetA, [assetA, assetB], [], platform, true)
     ]);
 
     await testBuilder(MetaModuleCleanBuilder(platform), {
@@ -66,7 +66,7 @@ main() {
 
   test('Warns about missing .meta_module.raw files from dependencies',
       () async {
-    var moduleA = Module(assetA, [assetA], [assetB], platform);
+    var moduleA = Module(assetA, [assetA], [assetB], platform, true);
     var metaA = MetaModule([moduleA]);
     var logs = <LogRecord>[];
     await testBuilder(MetaModuleCleanBuilder(platform), {

--- a/build_modules/test/meta_module_test.dart
+++ b/build_modules/test/meta_module_test.dart
@@ -76,9 +76,9 @@ void main() {
     var d = AssetId('myapp', 'lib/src/d.dart');
 
     var expectedModules = [
-      matchesModule(Module(a, [a], [b, c], defaultPlatform)),
-      matchesModule(Module(b, [b], [c], defaultPlatform)),
-      matchesModule(Module(c, [c, d], [], defaultPlatform)),
+      matchesModule(Module(a, [a], [b, c], defaultPlatform, true)),
+      matchesModule(Module(b, [b], [c], defaultPlatform, true)),
+      matchesModule(Module(c, [c, d], [], defaultPlatform, true)),
     ];
 
     var meta = await metaModuleFromSources(reader, assets);
@@ -104,7 +104,7 @@ void main() {
     var c = AssetId('myapp', 'lib/src/c.dart');
 
     var expectedModules = [
-      matchesModule(Module(a, [a, b, c], [], defaultPlatform))
+      matchesModule(Module(a, [a, b, c], [], defaultPlatform, true))
     ];
 
     var meta = await metaModuleFromSources(reader, assets);
@@ -148,9 +148,9 @@ void main() {
     var f = AssetId('myapp', 'lib/src/f.dart');
 
     var expectedModules = [
-      matchesModule(Module(a, [a, c], [g, e], defaultPlatform)),
-      matchesModule(Module(b, [b, d], [c, e, g], defaultPlatform)),
-      matchesModule(Module(e, [e, g, f], [], defaultPlatform)),
+      matchesModule(Module(a, [a, c], [g, e], defaultPlatform, true)),
+      matchesModule(Module(b, [b, d], [c, e, g], defaultPlatform, true)),
+      matchesModule(Module(e, [e, g, f], [], defaultPlatform, true)),
     ];
 
     var meta = await metaModuleFromSources(reader, assets);
@@ -168,7 +168,7 @@ void main() {
     var b = AssetId('b', 'lib/b.dart');
 
     var expectedModules = [
-      matchesModule(Module(a, [a], [b], defaultPlatform)),
+      matchesModule(Module(a, [a], [b], defaultPlatform, true)),
     ];
 
     var meta = await metaModuleFromSources(reader, assets);
@@ -196,8 +196,8 @@ void main() {
     var d = AssetId('myapp', 'lib/src/d.dart');
 
     var expectedModules = [
-      matchesModule(Module(a, [a, c, d], [b], defaultPlatform)),
-      matchesModule(Module(b, [b], [], defaultPlatform)),
+      matchesModule(Module(a, [a, c, d], [b], defaultPlatform, true)),
+      matchesModule(Module(b, [b], [], defaultPlatform, true)),
     ];
 
     var meta = await metaModuleFromSources(reader, assets);
@@ -237,12 +237,12 @@ void main() {
     var f = AssetId('myapp', 'lib/src/f.dart');
 
     var expectedModules = [
-      matchesModule(Module(a, [a], [d, e, f], defaultPlatform)),
-      matchesModule(Module(b, [b], [d, e], defaultPlatform)),
-      matchesModule(Module(c, [c], [d, f], defaultPlatform)),
-      matchesModule(Module(d, [d], [], defaultPlatform)),
-      matchesModule(Module(e, [e], [d], defaultPlatform)),
-      matchesModule(Module(f, [f], [d], defaultPlatform)),
+      matchesModule(Module(a, [a], [d, e, f], defaultPlatform, true)),
+      matchesModule(Module(b, [b], [d, e], defaultPlatform, true)),
+      matchesModule(Module(c, [c], [d, f], defaultPlatform, true)),
+      matchesModule(Module(d, [d], [], defaultPlatform, true)),
+      matchesModule(Module(e, [e], [d], defaultPlatform, true)),
+      matchesModule(Module(f, [f], [d], defaultPlatform, true)),
     ];
 
     var meta = await metaModuleFromSources(reader, assets);
@@ -270,7 +270,7 @@ void main() {
     var sap = AssetId('myapp', 'lib/src/a.part.dart');
 
     var expectedModules = [
-      matchesModule(Module(a, [a, ap, sap], [], defaultPlatform)),
+      matchesModule(Module(a, [a, ap, sap], [], defaultPlatform, true)),
     ];
 
     var meta = await metaModuleFromSources(reader, assets);
@@ -298,9 +298,9 @@ void main() {
     var c = AssetId('myapp', 'lib/src/c.dart');
 
     var expectedModules = [
-      matchesModule(Module(a, [a], [], defaultPlatform)),
-      matchesModule(Module(b, [b, c], [], defaultPlatform)),
-      matchesModule(Module(sa, [sa], [c], defaultPlatform)),
+      matchesModule(Module(a, [a], [], defaultPlatform, true)),
+      matchesModule(Module(b, [b, c], [], defaultPlatform, true)),
+      matchesModule(Module(sa, [sa], [c], defaultPlatform, true)),
     ];
 
     var meta = await metaModuleFromSources(reader, assets);
@@ -332,9 +332,9 @@ void main() {
     var d = AssetId('myapp', 'web/d.dart');
 
     var expectedModules = [
-      matchesModule(Module(a, [a], [b, c], defaultPlatform)),
-      matchesModule(Module(b, [b], [c], defaultPlatform)),
-      matchesModule(Module(c, [c, d], [], defaultPlatform)),
+      matchesModule(Module(a, [a], [b, c], defaultPlatform, true)),
+      matchesModule(Module(b, [b], [c], defaultPlatform, true)),
+      matchesModule(Module(c, [c, d], [], defaultPlatform, true)),
     ];
 
     var meta = await metaModuleFromSources(reader, assets);
@@ -373,9 +373,9 @@ void main() {
     var e = AssetId('myapp', 'web/e.dart');
 
     var expectedModules = [
-      matchesModule(Module(a, [a, b], [c], defaultPlatform)),
-      matchesModule(Module(c, [c, d], [], defaultPlatform)),
-      matchesModule(Module(e, [e], [d], defaultPlatform)),
+      matchesModule(Module(a, [a, b], [c], defaultPlatform, true)),
+      matchesModule(Module(c, [c, d], [], defaultPlatform, true)),
+      matchesModule(Module(e, [e], [d], defaultPlatform, true)),
     ];
 
     var meta = await metaModuleFromSources(reader, assets);
@@ -409,36 +409,41 @@ void main() {
 
     var expectedModulesForPlatform = {
       DartPlatform.dart2js: [
+        matchesModule(Module(
+            primaryId, [primaryId], [htmlId], DartPlatform.dart2js, true)),
+        matchesModule(Module(htmlId, [htmlId], [], DartPlatform.dart2js, true)),
+        matchesModule(Module(ioId, [ioId], [], DartPlatform.dart2js, true)),
         matchesModule(
-            Module(primaryId, [primaryId], [htmlId], DartPlatform.dart2js)),
-        matchesModule(Module(htmlId, [htmlId], [], DartPlatform.dart2js)),
-        matchesModule(Module(ioId, [ioId], [], DartPlatform.dart2js)),
-        matchesModule(Module(defaultId, [defaultId], [], DartPlatform.dart2js)),
-        matchesModule(Module(uiId, [uiId], [], DartPlatform.dart2js)),
+            Module(defaultId, [defaultId], [], DartPlatform.dart2js, true)),
+        matchesModule(Module(uiId, [uiId], [], DartPlatform.dart2js, true)),
       ],
       DartPlatform.dartdevc: [
+        matchesModule(Module(
+            primaryId, [primaryId], [htmlId], DartPlatform.dartdevc, true)),
         matchesModule(
-            Module(primaryId, [primaryId], [htmlId], DartPlatform.dartdevc)),
-        matchesModule(Module(htmlId, [htmlId], [], DartPlatform.dartdevc)),
-        matchesModule(Module(ioId, [ioId], [], DartPlatform.dartdevc)),
+            Module(htmlId, [htmlId], [], DartPlatform.dartdevc, true)),
+        matchesModule(Module(ioId, [ioId], [], DartPlatform.dartdevc, true)),
         matchesModule(
-            Module(defaultId, [defaultId], [], DartPlatform.dartdevc)),
-        matchesModule(Module(uiId, [uiId], [], DartPlatform.dartdevc)),
+            Module(defaultId, [defaultId], [], DartPlatform.dartdevc, true)),
+        matchesModule(Module(uiId, [uiId], [], DartPlatform.dartdevc, true)),
       ],
       DartPlatform.flutter: [
         matchesModule(
-            Module(primaryId, [primaryId], [uiId], DartPlatform.flutter)),
-        matchesModule(Module(htmlId, [htmlId], [], DartPlatform.flutter)),
-        matchesModule(Module(ioId, [ioId], [], DartPlatform.flutter)),
-        matchesModule(Module(defaultId, [defaultId], [], DartPlatform.flutter)),
-        matchesModule(Module(uiId, [uiId], [], DartPlatform.flutter)),
+            Module(primaryId, [primaryId], [uiId], DartPlatform.flutter, true)),
+        matchesModule(Module(htmlId, [htmlId], [], DartPlatform.flutter, true)),
+        matchesModule(Module(ioId, [ioId], [], DartPlatform.flutter, true)),
+        matchesModule(
+            Module(defaultId, [defaultId], [], DartPlatform.flutter, true)),
+        matchesModule(Module(uiId, [uiId], [], DartPlatform.flutter, true)),
       ],
       DartPlatform.vm: [
-        matchesModule(Module(primaryId, [primaryId], [ioId], DartPlatform.vm)),
-        matchesModule(Module(htmlId, [htmlId], [], DartPlatform.vm)),
-        matchesModule(Module(ioId, [ioId], [], DartPlatform.vm)),
-        matchesModule(Module(defaultId, [defaultId], [], DartPlatform.vm)),
-        matchesModule(Module(uiId, [uiId], [], DartPlatform.vm)),
+        matchesModule(
+            Module(primaryId, [primaryId], [ioId], DartPlatform.vm, true)),
+        matchesModule(Module(htmlId, [htmlId], [], DartPlatform.vm, true)),
+        matchesModule(Module(ioId, [ioId], [], DartPlatform.vm, true)),
+        matchesModule(
+            Module(defaultId, [defaultId], [], DartPlatform.vm, true)),
+        matchesModule(Module(uiId, [uiId], [], DartPlatform.vm, true)),
       ]
     };
 

--- a/build_modules/test/module_builder_test.dart
+++ b/build_modules/test/module_builder_test.dart
@@ -22,9 +22,10 @@ main() {
     var assetC = AssetId('a', 'lib/c.dart');
     var assetD = AssetId('a', 'lib/d.dart');
     var assetE = AssetId('a', 'lib/e.dart');
-    var moduleA = Module(assetA, [assetA], <AssetId>[], platform);
-    var moduleB = Module(assetB, [assetB, assetC], <AssetId>[], platform);
-    var moduleD = Module(assetD, [assetD, assetE], <AssetId>[], platform);
+    var moduleA = Module(assetA, [assetA], <AssetId>[], platform, true);
+    var moduleB = Module(assetB, [assetB, assetC], <AssetId>[], platform, true);
+    var moduleD =
+        Module(assetD, [assetD, assetE], <AssetId>[], platform, false);
     var metaModule = MetaModule([moduleA, moduleB, moduleD]);
     await testBuilder(ModuleBuilder(platform), {
       'a|lib/a.dart': '',

--- a/build_modules/test/modules_test.dart
+++ b/build_modules/test/modules_test.dart
@@ -20,13 +20,13 @@ void main() {
     final directDepId = AssetId('a', 'lib/src/dep.dart');
     final transitiveDepId = AssetId('b', 'lib/b.dart');
     final deepTransitiveDepId = AssetId('b', 'lib/src/dep.dart');
-    final rootModule = Module(rootId, [rootId], [directDepId], platform);
+    final rootModule = Module(rootId, [rootId], [directDepId], platform, true);
     final directDepModule =
-        Module(directDepId, [directDepId], [transitiveDepId], platform);
-    final transitiveDepModule = Module(
-        transitiveDepId, [transitiveDepId], [deepTransitiveDepId], platform);
+        Module(directDepId, [directDepId], [transitiveDepId], platform, true);
+    final transitiveDepModule = Module(transitiveDepId, [transitiveDepId],
+        [deepTransitiveDepId], platform, true);
     final deepTransitiveDepModule =
-        Module(deepTransitiveDepId, [deepTransitiveDepId], [], platform);
+        Module(deepTransitiveDepId, [deepTransitiveDepId], [], platform, true);
     InMemoryAssetReader reader;
 
     setUp(() {


### PR DESCRIPTION
Towards https://github.com/dart-lang/build/issues/1810

Use the `sdkDeps` and `platform.supportsLibrary` fields to check for module support, and encode that in the module.