### PR TITLE
Add back missing build/mono_pkg.yaml

### DIFF
--- a/build/mono_pkg.yaml
+++ b/build/mono_pkg.yaml
@@ -1,0 +1,14 @@
+dart:
+  - dev
+
+stages:
+  - analyze_and_format:
+    - group:
+      - dartfmt: sdk
+      - dartanalyzer: --fatal-infos --fatal-warnings .
+  - unit_test:
+    - command: pub run build_runner test
+
+cache:
+  directories:
+  - .dart_tool/build


### PR DESCRIPTION
Not sure how this was skipped in https://github.com/dart-lang/build/pull/1795