### PR TITLE
Catch asset graph deserialize failure during clean

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.10.3-dev
 
 - Improve performance tracking and visualization using the `timing` package.
+- Handle bad asset graph in the `clean` command.
 
 ## 0.10.2
 

--- a/build_runner/lib/src/entrypoint/clean.dart
+++ b/build_runner/lib/src/entrypoint/clean.dart
@@ -39,7 +39,7 @@ class CleanCommand extends Command<int> {
       var assetGraphFile = File(assetGraphPath);
       if (!assetGraphFile.existsSync()) {
         logger.warning('No asset graph found. '
-            'Skipping cleanup of generated file in source directories.');
+            'Skipping cleanup of generated files in source directories.');
         return;
       }
       AssetGraph assetGraph;
@@ -47,7 +47,7 @@ class CleanCommand extends Command<int> {
         assetGraph = AssetGraph.deserialize(await assetGraphFile.readAsBytes());
       } catch (_) {
         logger.warning('Failed to deserialize AssetGraph. '
-            'Skipping cleanup of generated file in source directories.');
+            'Skipping cleanup of generated files in source directories.');
         return;
       }
       var packageGraph = PackageGraph.forThisPackage();


### PR DESCRIPTION
See #1838

If we fail to deserialize an asset graph during a build the next logical
step for the user is to try the `clean` command, which will also fail
and not fix the issue.