### PR TITLE
update the graph serialization test to ensure glob results are preserved

### DIFF
--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -92,6 +92,7 @@ void main() {
         for (var n = 0; n < 5; n++) {
           var node = makeAssetNode();
           globNode.inputs.add(node.id);
+          globNode.results.add(node.id);
           node.outputs.add(globNode.id);
           graph.add(node);
           var phaseNum = n;


### PR DESCRIPTION
this already passes but I noticed it was missing from the test