### PR TITLE
Log an actionable warning for missing config

### DIFF
--- a/_test_common/lib/test_phases.dart
+++ b/_test_common/lib/test_phases.dart
@@ -110,14 +110,14 @@ Future<BuildResult> testBuilders(
   builderConfigOverrides ??= const {};
   var environment = OverrideableEnvironment(IOEnvironment(packageGraph),
       reader: reader, writer: writer, onLog: onLog);
-  var options = await BuildOptions.create(environment,
+  var logSubscription =
+      LogSubscription(environment, verbose: verbose, logLevel: logLevel);
+  var options = await BuildOptions.create(logSubscription,
       deleteFilesByDefault: deleteFilesByDefault,
       packageGraph: packageGraph,
-      logLevel: logLevel,
       skipBuildScriptCheck: true,
       overrideBuildConfig: overrideBuildConfig,
       enableLowResourcesMode: enableLowResourcesMode,
-      verbose: verbose,
       buildDirs: buildDirs,
       logPerformanceDir: logPerformanceDir);
 

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -85,10 +85,10 @@ Future<BuildResult> build(List<BuilderApplication> builders,
       reader: reader,
       writer: writer,
       onLog: onLog ?? stdIOLogListener(assumeTty: assumeTty, verbose: verbose));
-  var logEnvironment =
-      LogEnvironment(environment, verbose: verbose, logLevel: logLevel);
+  var logSubscription =
+      LogSubscription(environment, verbose: verbose, logLevel: logLevel);
   var options = await BuildOptions.create(
-    logEnvironment,
+    logSubscription,
     deleteFilesByDefault: deleteFilesByDefault,
     packageGraph: packageGraph,
     skipBuildScriptCheck: skipBuildScriptCheck,

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -85,17 +85,17 @@ Future<BuildResult> build(List<BuilderApplication> builders,
       reader: reader,
       writer: writer,
       onLog: onLog ?? stdIOLogListener(assumeTty: assumeTty, verbose: verbose));
+  var logEnvironment =
+      LogEnvironment(environment, verbose: verbose, logLevel: logLevel);
   var options = await BuildOptions.create(
-    environment,
+    logEnvironment,
     deleteFilesByDefault: deleteFilesByDefault,
     packageGraph: packageGraph,
-    logLevel: logLevel,
     skipBuildScriptCheck: skipBuildScriptCheck,
     overrideBuildConfig:
         await findBuildConfigOverrides(packageGraph, configKey),
     enableLowResourcesMode: enableLowResourcesMode,
     trackPerformance: trackPerformance,
-    verbose: verbose,
     buildDirs: buildDirs,
     logPerformanceDir: logPerformanceDir,
     resolvers: resolvers,

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -64,19 +64,19 @@ Future<ServeHandler> watch(
       reader: reader,
       writer: writer,
       onLog: onLog ?? stdIOLogListener(assumeTty: assumeTty, verbose: verbose));
+  var logEnvironment =
+      LogEnvironment(environment, verbose: verbose, logLevel: logLevel);
   overrideBuildConfig ??=
       await findBuildConfigOverrides(packageGraph, configKey);
   var options = await BuildOptions.create(
-    environment,
+    logEnvironment,
     deleteFilesByDefault: deleteFilesByDefault,
     packageGraph: packageGraph,
     overrideBuildConfig: overrideBuildConfig,
-    logLevel: logLevel,
     debounceDelay: debounceDelay,
     skipBuildScriptCheck: skipBuildScriptCheck,
     enableLowResourcesMode: enableLowResourcesMode,
     trackPerformance: trackPerformance,
-    verbose: verbose,
     buildDirs: buildDirs,
     logPerformanceDir: logPerformanceDir,
     resolvers: resolvers,

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -64,12 +64,12 @@ Future<ServeHandler> watch(
       reader: reader,
       writer: writer,
       onLog: onLog ?? stdIOLogListener(assumeTty: assumeTty, verbose: verbose));
-  var logEnvironment =
-      LogEnvironment(environment, verbose: verbose, logLevel: logLevel);
+  var logSubscription =
+      LogSubscription(environment, verbose: verbose, logLevel: logLevel);
   overrideBuildConfig ??=
       await findBuildConfigOverrides(packageGraph, configKey);
   var options = await BuildOptions.create(
-    logEnvironment,
+    logSubscription,
     deleteFilesByDefault: deleteFilesByDefault,
     packageGraph: packageGraph,
     overrideBuildConfig: overrideBuildConfig,

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -69,6 +69,7 @@ String _loggerName(LogRecord record, bool verbose) {
   var knownNames = const [
     'ApplyBuilders',
     'Build',
+    'BuildConfigOverrides',
     'BuildDefinition',
     'BuildOptions',
     'BuildScriptUpdates',

--- a/build_runner/lib/src/package_graph/build_config_overrides.dart
+++ b/build_runner/lib/src/package_graph/build_config_overrides.dart
@@ -8,7 +8,10 @@ import 'dart:io';
 import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:glob/glob.dart';
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+
+final _log = Logger('BuildConfigOverrides');
 
 Future<Map<String, BuildConfig>> findBuildConfigOverrides(
     PackageGraph packageGraph, String configKey) async {
@@ -26,6 +29,10 @@ Future<Map<String, BuildConfig>> findBuildConfigOverrides(
   }
   if (configKey != null) {
     final file = File('build.$configKey.yaml');
+    if (!file.existsSync()) {
+      _log.warning('Cannot find build.$configKey.yaml for specified config.');
+      throw CannotBuildException();
+    }
     final yaml = file.readAsStringSync();
     final config = BuildConfig.parse(packageGraph.root.name,
         packageGraph.root.dependencies.map((n) => n.name), yaml);

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - The performance tracking apis have changed significantly, and performance
   tracking now uses the `timing` package.
-- The `BuildOptions` static factory now takes a `LogEnvironment` instead of a
+- The `BuildOptions` static factory now takes a `LogSubscription` instead of a
   `BuildEnvironment`. Logging should be start as early as possible to catch logs
   emitted during setup.
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - The performance tracking apis have changed significantly, and performance
   tracking now uses the `timing` package.
+- The `BuildOptions` static factory now takes a `LogEnvironment` instead of a
+  `BuildEnvironment`. Logging should be start as early as possible to catch logs
+  emitted during setup.
 
 ### New Features
 

--- a/build_runner_core/lib/build_runner_core.dart
+++ b/build_runner_core/lib/build_runner_core.dart
@@ -16,7 +16,7 @@ export 'src/generate/build_runner.dart';
 export 'src/generate/exceptions.dart' show CannotBuildException;
 export 'src/generate/finalized_assets_view.dart' show FinalizedAssetsView;
 export 'src/generate/options.dart'
-    show defaultRootPackageWhitelist, LogEnvironment, BuildOptions;
+    show defaultRootPackageWhitelist, LogSubscription, BuildOptions;
 export 'src/generate/performance_tracker.dart'
     show BuildPerformance, BuilderActionPerformance, BuildPhasePerformance;
 export 'src/logging/human_readable_duration.dart';

--- a/build_runner_core/lib/build_runner_core.dart
+++ b/build_runner_core/lib/build_runner_core.dart
@@ -15,7 +15,8 @@ export 'src/generate/build_result.dart';
 export 'src/generate/build_runner.dart';
 export 'src/generate/exceptions.dart' show CannotBuildException;
 export 'src/generate/finalized_assets_view.dart' show FinalizedAssetsView;
-export 'src/generate/options.dart';
+export 'src/generate/options.dart'
+    show defaultRootPackageWhitelist, LogEnvironment, BuildOptions;
 export 'src/generate/performance_tracker.dart'
     show BuildPerformance, BuilderActionPerformance, BuildPhasePerformance;
 export 'src/logging/human_readable_duration.dart';

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -32,8 +32,8 @@ const List<String> defaultRootPackageWhitelist = [
 
 final _logger = Logger('BuildOptions');
 
-class LogEnvironment {
-  factory LogEnvironment(BuildEnvironment environment,
+class LogSubscription {
+  factory LogSubscription(BuildEnvironment environment,
       {bool verbose, Level logLevel}) {
     // Set up logging
     verbose ??= false;
@@ -45,10 +45,10 @@ class LogEnvironment {
     Logger.root.level = logLevel;
 
     var logListener = Logger.root.onRecord.listen(environment.onLog);
-    return LogEnvironment._(verbose, logListener);
+    return LogSubscription._(verbose, logListener);
   }
 
-  LogEnvironment._(this.verbose, this.logListener);
+  LogSubscription._(this.verbose, this.logListener);
 
   final bool verbose;
   final StreamSubscription<LogRecord> logListener;
@@ -93,7 +93,7 @@ class BuildOptions {
   });
 
   static Future<BuildOptions> create(
-    LogEnvironment logEnvironment, {
+    LogSubscription logSubscription, {
     Duration debounceDelay,
     bool deleteFilesByDefault,
     bool enableLowResourcesMode,
@@ -139,11 +139,11 @@ class BuildOptions {
       debounceDelay: debounceDelay,
       deleteFilesByDefault: deleteFilesByDefault,
       enableLowResourcesMode: enableLowResourcesMode,
-      logListener: logEnvironment.logListener,
+      logListener: logSubscription.logListener,
       packageGraph: packageGraph,
       skipBuildScriptCheck: skipBuildScriptCheck,
       trackPerformance: trackPerformance,
-      verbose: logEnvironment.verbose,
+      verbose: logSubscription.verbose,
       buildDirs: buildDirs,
       targetGraph: targetGraph,
       logPerformanceDir: logPerformanceDir,

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -104,9 +104,9 @@ targets:
       var packageGraph = PackageGraph.forPath(pkgARoot);
       environment =
           OverrideableEnvironment(IOEnvironment(packageGraph), onLog: (_) {});
-      options = await BuildOptions.create(environment,
+      options = await BuildOptions.create(
+          LogSubscription(environment, logLevel: Level.OFF),
           packageGraph: packageGraph,
-          logLevel: Level.OFF,
           skipBuildScriptCheck: true);
     });
 
@@ -358,9 +358,9 @@ targets:
         await options.logListener.cancel();
         logs.clear();
         environment = OverrideableEnvironment(environment, onLog: logs.add);
-        options = await BuildOptions.create(environment,
+        options = await BuildOptions.create(
+            LogSubscription(environment, logLevel: Level.WARNING),
             packageGraph: options.packageGraph,
-            logLevel: Level.WARNING,
             skipBuildScriptCheck: true);
       });
 
@@ -557,7 +557,7 @@ targets:
       // https://github.com/dart-lang/build/issues/1042
       test('a missing sources/include does not cause an error', () async {
         var rootPkg = options.packageGraph.root.name;
-        options = await BuildOptions.create(environment,
+        options = await BuildOptions.create(LogSubscription(environment),
             packageGraph: options.packageGraph,
             overrideBuildConfig: {
               rootPkg: BuildConfig.fromMap(rootPkg, [], {
@@ -585,7 +585,7 @@ targets:
       test('a missing sources/include results in the default whitelist',
           () async {
         var rootPkg = options.packageGraph.root.name;
-        options = await BuildOptions.create(environment,
+        options = await BuildOptions.create(LogSubscription(environment),
             packageGraph: options.packageGraph,
             overrideBuildConfig: {
               rootPkg: BuildConfig.fromMap(rootPkg, [], {
@@ -613,7 +613,7 @@ targets:
 
       test('allows a target config with empty sources list', () async {
         var rootPkg = options.packageGraph.root.name;
-        options = await BuildOptions.create(environment,
+        options = await BuildOptions.create(LogSubscription(environment),
             packageGraph: options.packageGraph,
             overrideBuildConfig: {
               rootPkg: BuildConfig.fromMap(rootPkg, [], {

--- a/build_runner_core/tool/build.dart
+++ b/build_runner_core/tool/build.dart
@@ -7,8 +7,8 @@ import 'package:source_gen/builder.dart';
 main() async {
   var packageGraph = PackageGraph.forThisPackage();
   var environment = OverrideableEnvironment(IOEnvironment(packageGraph));
-  var options =
-      await BuildOptions.create(environment, packageGraph: packageGraph);
+  var options = await BuildOptions.create(LogSubscription(environment),
+      packageGraph: packageGraph);
 
   BuildResult result;
   var build = await BuildRunner.create(

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -20,3 +20,11 @@ dev_dependencies:
   test_descriptor: ^1.1.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core
+  build:
+    path: ../build


### PR DESCRIPTION
Fixes #1841

Since there is a new place where we might log messages which can occur
before the `BuildOptions` can be constructed, add a `LogEnvironment`
which can be set up earlier.

Log an actionable warning when we fail to read the `buid.key.yaml` file
and throw a `CannotBuildException` which will bail out of the build and
exit with `ExitCode.config`.