### PR TITLE
Publish build_runner_core 1.0.0

### DIFF
--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -13,9 +13,7 @@ dependencies:
   build: ">=0.12.8 <0.12.9"
   build_config: ^0.3.1
   build_resolvers: ^0.2.0
-  # We re-export many types from this package, so we maintain a tight
-  # constraint on it.
-  build_runner_core: ">=0.4.0 <0.4.1"
+  build_runner_core: ^1.0.0
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
   convert: ^2.0.1

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.0-dev
+## 1.0.0
 
 ### Breaking Changes
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 0.4.0-dev
+version: 1.0.0
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
@@ -38,7 +38,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build:
-    path: ../build


### PR DESCRIPTION
No more planned changes here - and we need to depend on this from the next build_runner release.

There will actually be a pre-1.x version of build_runner which depends on this, but that should be fine. 