### PR TITLE
Update build_vm_compilers to support package:build v1.x

### DIFF
--- a/_test_common/lib/builders.dart
+++ b/_test_common/lib/builders.dart
@@ -45,5 +45,5 @@ class DelegatingBuilder implements Builder {
   Map<String, List<String>> get buildExtensions => delegate.buildExtensions;
 
   @override
-  FutureOr<void> build(BuildStep buildStep) => delegate.build(buildStep);
+  Future build(BuildStep buildStep) async => delegate.build(buildStep);
 }

--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+1
+
+Support `package:build` version `1.x.x`.
+
 ## 0.1.1
 
 Support the latest build_modules.

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_vm_compilers
-version: 0.1.1
+version: 0.1.1+1
 description: Builder implementations wrapping Dart VM compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.30.0 <0.33.0"
-  build: ^0.12.0
+  build: '>=0.12.0 <2.0.0'
   build_modules: ^0.4.0
   path: ^1.6.0
   pool: ^1.3.0
@@ -20,11 +20,3 @@ dev_dependencies:
   test_descriptor: ^1.1.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core
-  build:
-    path: ../build


### PR DESCRIPTION
I also modified the common test helper so the delegating builder can support earlier versions of package:build