### PR TITLE
update build_modules to 1.x, and widen constraints to allow it

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0-dev
+## 1.0.0-dev
 
 ### Breaking Changes
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 0.5.0-dev
+version: 1.0.0-dev
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
@@ -8,10 +8,10 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  analyzer: ">0.30.0 < 0.33.0"
-  async: ">=1.13.3 <3.0.0"
+  analyzer: '>0.30.0 < 0.33.0'
+  async: '>=1.13.3 <3.0.0'
   bazel_worker: ^0.1.4
-  build: ^0.12.3
+  build: '>=0.12.3 <2.0.0'
   build_config: '>=0.2.1 <0.4.0'
   glob: ^1.0.0
   graphs: ^0.1.0

--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+2
+
+Support `package:build_modules` version `1.x.x`.
+
 ## 0.1.1+1
 
 Support `package:build` version `1.x.x`.

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_vm_compilers
-version: 0.1.1+1
+version: 0.1.1+2
 description: Builder implementations wrapping Dart VM compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.30.0 <0.33.0"
   build: '>=0.12.0 <2.0.0'
-  build_modules: ^0.4.0
+  build_modules: '>=0.4.0 <2.0.0'
   path: ^1.6.0
   pool: ^1.3.0
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.4+1
+
+- Support `package:build_modules` version `1.x.x`.
+
 ## 0.4.4
 
 - Track performance of different builder stages.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 0.4.4
+version: 0.4.4+1
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
@@ -12,8 +12,8 @@ dependencies:
   archive: ">=1.0.13 <3.0.0"
   bazel_worker: ^0.1.4
   build: '>=0.12.8 <2.0.0'
-  build_config: ">=0.2.6 <0.4.0"
-  build_modules: ^0.4.0
+  build_config: '>=0.2.6 <0.4.0'
+  build_modules: '>=0.4.0 <2.0.0'
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0
   js: ^0.6.1


### PR DESCRIPTION
Widened build_web_compilers and build_vm_compilers constraints to allow the new version and prepped versions to publish (will follow up with a pr to publish build_modules once these are published and I can remove the override).

Ran the tests for each of these packages with the latest build_modules version (path override) and things are happy.