### PR TITLE
Fix issue: dartdevc expects dependency on default import of condition…

### DIFF
--- a/build_modules/lib/src/module_library.dart
+++ b/build_modules/lib/src/module_library.dart
@@ -174,9 +174,10 @@ class ModuleLibrary {
       });
 
   List<AssetId> depsForPlatform(DartPlatform platform) {
-    return _deps.followedBy(conditionalDeps.map((conditions) {
+    return _deps.followedBy(conditionalDeps.map((conditions) sync* {
       var selectedImport = conditions[r'$default'];
       assert(selectedImport != null);
+      yield(selectedImport);
       for (var condition in conditions.keys) {
         if (condition == r'$default') continue;
         if (!condition.startsWith('dart.library.')) {
@@ -186,12 +187,11 @@ class ModuleLibrary {
         }
         var library = condition.substring('dart.library.'.length);
         if (platform.supportsLibrary(library)) {
-          selectedImport = conditions[condition];
-          break;
+          yield conditions[condition];
+          return;
         }
       }
-      return selectedImport;
-    })).toList();
+    }).expand((assetId) => assetId)).toList();
   }
 }
 


### PR DESCRIPTION
Hi everyone,

I believe that dartdevc expects also dependency on default import of conditional import directive:

```dart
import 'package:my_models/interface.dart'
if (dart.library.html) 'package:my_models_html/models.dart'
if (dart.library.io) 'package:my_models_io/models.dart';
```

dartdevc will need both dependencies:
'package:my_models/interface.dart'
'package:my_models_html/models.dart'

Signed-off-by: Nikolay Samokhin <nickclmb@gmail.com>