### PR TITLE
Use correct exceptions in bazel AssetReader

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.4
+
+- Fix the exceptions thrown when attempting to read invalid assets.
+
 # 0.3.3+1
 
 - Increased the upper bound for `package:analyzer` to '<0.34.0'.

--- a/bazel_codegen/lib/src/assets/asset_reader.dart
+++ b/bazel_codegen/lib/src/assets/asset_reader.dart
@@ -8,7 +8,6 @@ import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' as p;
 
-import '../errors.dart';
 import 'asset_filter.dart';
 import 'file_system.dart';
 

--- a/bazel_codegen/lib/src/assets/asset_reader.dart
+++ b/bazel_codegen/lib/src/assets/asset_reader.dart
@@ -57,9 +57,8 @@ class BazelAssetReader extends AssetReader {
 
   String _filePathForId(AssetId id) {
     final packagePath = _packageMap[id.package];
-    if (!_assetFilter.isValid(id) || packagePath == null) {
-      throw CodegenError('Attempted to read invalid input $id.');
-    }
+    if (packagePath == null) throw PackageNotFoundException(id.package);
+    if (!_assetFilter.isValid(id)) throw AssetNotFoundException(id);
     return p.join(packagePath, id.path);
   }
 

--- a/bazel_codegen/lib/src/assets/asset_reader.dart
+++ b/bazel_codegen/lib/src/assets/asset_reader.dart
@@ -38,8 +38,9 @@ class BazelAssetReader extends AssetReader {
         _assetFilter = assetFilter;
 
   BazelAssetReader.forTest(
-      this._rootPackage, this._packageMap, this._fileSystem)
-      : _assetFilter = const _AllowAllAssets();
+      this._rootPackage, this._packageMap, this._fileSystem,
+      {AssetFilter assetFilter})
+      : _assetFilter = assetFilter ?? const _AllowAllAssets();
 
   @override
   Future<List<int>> readAsBytes(AssetId id) async {

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/bazel_codegen
-version: 0.3.3+1
+version: 0.3.4-dev
 
 environment:
   sdk: ">=2.0.0 <3.0.0"


### PR DESCRIPTION
Fixes #1880

The doc comment on the `AssetReader` interface cals out these
exceptions.