### PR TITLE
Add null_closures lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -48,6 +48,7 @@ linter:
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names
+    - null_closures
     - omit_local_variable_types
     - only_throw_errors
     - overridden_fields


### PR DESCRIPTION
Helps avoid easy mistakes like `orElse: null` instead of
`orElse: () => null`