### PR TITLE
Run build_runner scripts from snapshot.

### DIFF
--- a/_test/test/build_script_invalidation_test.dart
+++ b/_test/test/build_script_invalidation_test.dart
@@ -96,9 +96,8 @@ void main() {
       expect(stdOutLines, emitsThrough(contains(line)));
     }
     await replaceAllInFile('build.yaml', '''
-      build_vm_compilers|entrypoint:''', '''
-      build_vm_compilers|entrypoint:
-        options:
-          compiler: dartdevc''');
-  }, onPlatform: {'windows': const Skip('flaky on windows')});
+targets:''', '''
+# Test Edit
+targets:''');
+  });
 }

--- a/_test/test/build_script_invalidation_test.dart
+++ b/_test/test/build_script_invalidation_test.dart
@@ -43,22 +43,24 @@ void main() {
       var filePath = p.join('pkgs', 'provides_builder', 'lib', 'builders.dart');
       await stopServer();
       await replaceAllInFile(filePath, RegExp(r'$'), '// do a build');
-      await startServer(
-        buildArgs: ['lib'],
-        extraExpects: [
-          () => nextStdOutLine(
-              'Invalidating asset graph due to build script update'),
-          () => nextStdOutLine('Creating build script snapshot'),
-          () => nextStdOutLine('Building new asset graph'),
-          () => nextStdOutLine('Succeeded after'),
-        ],
-      );
+      await startServer(buildArgs: [
+        'lib'
+      ], extraExpects: [
+        () => nextStdOutLine(
+            'Invalidating asset graph due to build script update'),
+        () => nextStdOutLine('Creating build script snapshot'),
+        () => nextStdOutLine('Building new asset graph'),
+        () => nextStdOutLine('Succeeded after'),
+      ]);
+      expect(await File(extraFilePath).exists(), isFalse,
+          reason: 'The cache dir should get deleted when the build '
+              'script changes.');
     });
 
     test('Invalid asset graph version causes a new full build', () async {
       await stopServer();
-      var assetGraph = assetGraphPathFor(
-          p.join('.dart_tool', 'build', 'entrypoint', 'build.dart.snapshot'));
+      var assetGraph = assetGraphPathFor(p.url
+          .join('.dart_tool', 'build', 'entrypoint', 'build.dart.snapshot'));
       // Prepend a 1 to the version number
       await replaceAllInFile(assetGraph, '"version":', '"version":1');
 
@@ -76,6 +78,9 @@ void main() {
         () => nextStdOutLine('Building new asset graph'),
         () => nextStdOutLine('Succeeded after'),
       ]);
+      expect(await File(extraFilePath).exists(), isFalse,
+          reason: 'The cache dir should get deleted when the asset graph '
+              'can\'t be parsed');
     });
   });
 }

--- a/_test/test/build_script_invalidation_test.dart
+++ b/_test/test/build_script_invalidation_test.dart
@@ -100,5 +100,5 @@ void main() {
       build_vm_compilers|entrypoint:
         options:
           compiler: dartdevc''');
-  });
+  }, onPlatform: {'windows': const Skip('flaky on windows')});
 }

--- a/_test/test/build_script_invalidation_test.dart
+++ b/_test/test/build_script_invalidation_test.dart
@@ -55,7 +55,7 @@ void main() {
       expect(await File(extraFilePath).exists(), isFalse,
           reason: 'The cache dir should get deleted when the build '
               'script changes.');
-    });
+    }, onPlatform: {'windows': const Skip('flaky on windows')});
 
     test('Invalid asset graph version causes a new full build', () async {
       await stopServer();

--- a/_test/test/common/utils.dart
+++ b/_test/test/common/utils.dart
@@ -14,6 +14,7 @@ Directory _toolDir = Directory(p.join('.dart_tool', 'build'));
 
 Process _process;
 Stream<String> _stdOutLines;
+Stream<String> get stdOutLines => _stdOutLines;
 
 final String _pubBinary = Platform.isWindows ? 'pub.bat' : 'pub';
 

--- a/_test/test/common/utils.dart
+++ b/_test/test/common/utils.dart
@@ -40,9 +40,15 @@ Future<Null> startServer(
         {bool ensureCleanBuild,
         List<Function> extraExpects,
         List<String> buildArgs}) =>
-    _startServer(_pubBinary,
-        ['run', 'build_runner', 'serve']..addAll(buildArgs ?? const []),
-        ensureCleanBuild: ensureCleanBuild, extraExpects: extraExpects);
+    _startServer(
+        'dart',
+        [
+          '--packages=.packages',
+          p.join('..', 'build_runner', 'bin', 'build_runner.dart'),
+          'serve'
+        ],
+        ensureCleanBuild: ensureCleanBuild,
+        extraExpects: extraExpects);
 
 Future<ProcessResult> _runBuild(String command, List<String> args,
     {bool ensureCleanBuild}) async {

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.0-dev
+
+### New Features
+
+- The build script will now be ran from snapshot, which speeds up initial builds
+  significantly.
+- The build script will automatically re-run itself when the build script is
+  changed, instead of requiring the user to re-run it manually.
+
 ## 1.0.0
 
 ### Breaking Changes

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ### New Features
 
-- The build script will now be ran from snapshot, which speeds up initial builds
-  significantly.
+- The build script will now be ran from snapshot, which improves startup times.
 - The build script will automatically re-run itself when the build script is
   changed, instead of requiring the user to re-run it manually.
 

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -60,17 +60,18 @@ Future<Null> main(List<String> args) async {
   if (commandName != _generateCommand) {
     logListener = Logger.root.onRecord.listen(stdIOLogListener());
   }
-  var buildScript = await generateBuildScript();
-  var scriptFile = File(scriptLocation)..createSync(recursive: true);
-  scriptFile.writeAsStringSync(buildScript);
-  if (commandName == _generateCommand) {
-    print(p.absolute(scriptLocation));
-    return;
-  }
 
   var shouldRerun = true;
   while (shouldRerun) {
     shouldRerun = false;
+
+    var buildScript = await generateBuildScript();
+    var scriptFile = File(scriptLocation)..createSync(recursive: true);
+    scriptFile.writeAsStringSync(buildScript);
+    if (commandName == _generateCommand) {
+      print(p.absolute(scriptLocation));
+      return;
+    }
 
     if (!await _createSnapshotIfMissing()) return;
 

--- a/build_runner/lib/src/entrypoint/run.dart
+++ b/build_runner/lib/src/entrypoint/run.dart
@@ -3,11 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:io/ansi.dart' as ansi;
 import 'package:io/io.dart' show ExitCode;
+import 'package:pedantic/pedantic.dart';
 
 import 'runner.dart';
 
@@ -18,19 +20,57 @@ import 'runner.dart';
 /// implies success.
 Future<int> run(List<String> args, List<BuilderApplication> builders) async {
   var runner = BuildCommandRunner(builders);
-  try {
-    var result = await runner.run(args);
-    return result ?? 0;
-  } on UsageException catch (e) {
-    print(ansi.red.wrap(e.message));
-    print('');
-    print(e.usage);
-    return ExitCode.usage.code;
-  } on ArgumentError catch (e) {
-    print(ansi.red.wrap(e.toString()));
-    return ExitCode.usage.code;
-  } on CannotBuildException {
-    // A message should have already been logged.
-    return ExitCode.config.code;
+  var resultCompleter = Completer<int>();
+
+  void safeComplete(int exitCode) {
+    if (resultCompleter.isCompleted) return;
+    resultCompleter.complete(exitCode);
+  }
+
+  unawaited(runZoned(() async {
+    try {
+      var result = await runner.run(args);
+      safeComplete(result ?? 0);
+    } on UsageException catch (e) {
+      print(ansi.red.wrap(e.message));
+      print('');
+      print(e.usage);
+      safeComplete(ExitCode.usage.code);
+    } on ArgumentError catch (e) {
+      print(ansi.red.wrap(e.toString()));
+      safeComplete(ExitCode.usage.code);
+    } on CannotBuildException {
+      // A message should have already been logged.
+      safeComplete(ExitCode.config.code);
+    }
+  }, onError: (Object e, StackTrace s) {
+    if (e is BuildScriptChangedException) {
+      _deleteAssetGraph();
+      _deleteSelf();
+      safeComplete(ExitCode.tempFail.code);
+    } else if (!resultCompleter.isCompleted) {
+      resultCompleter.completeError(e, s);
+    }
+  }));
+
+  return resultCompleter.future;
+}
+
+/// Deletes the asset graph for the current build script from disk.
+void _deleteAssetGraph() {
+  var graph = File(assetGraphPath);
+  if (graph.existsSync()) {
+    graph.deleteSync();
+  }
+}
+
+/// Deletes the current running script.
+///
+/// This should only happen if the current script is a snapshot, and it has
+/// been invalidated.
+void _deleteSelf() {
+  var self = File(Platform.script.toFilePath());
+  if (self.existsSync()) {
+    self.deleteSync();
   }
 }

--- a/build_runner/lib/src/entrypoint/run.dart
+++ b/build_runner/lib/src/entrypoint/run.dart
@@ -33,11 +33,11 @@ Future<int> run(List<String> args, List<BuilderApplication> builders) async {
   } on CannotBuildException {
     // A message should have already been logged.
     return ExitCode.config.code;
-  } on BuildScriptChangedException catch (e, s) {
+  } on BuildScriptChangedException {
     _deleteAssetGraph();
     _deleteSelf();
     return ExitCode.tempFail.code;
-  } on BuildConfigChangedException catch (e, s) {
+  } on BuildConfigChangedException {
     return ExitCode.tempFail.code;
   }
 }

--- a/build_runner/lib/src/entrypoint/run.dart
+++ b/build_runner/lib/src/entrypoint/run.dart
@@ -48,6 +48,8 @@ Future<int> run(List<String> args, List<BuilderApplication> builders) async {
       _deleteAssetGraph();
       _deleteSelf();
       safeComplete(ExitCode.tempFail.code);
+    } else if (e is BuildConfigChangedException) {
+      safeComplete(ExitCode.tempFail.code);
     } else if (!resultCompleter.isCompleted) {
       resultCompleter.completeError(e, s);
     }

--- a/build_runner/lib/src/entrypoint/watch.dart
+++ b/build_runner/lib/src/entrypoint/watch.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:build_runner_core/build_runner_core.dart';
 import 'package:io/io.dart';
 
 import '../generate/build.dart';
@@ -44,8 +45,26 @@ class WatchCommand extends BuildRunnerCommand {
     );
     if (handler == null) return ExitCode.config.code;
 
-    await handler.currentBuild;
-    await handler.buildResults.drain();
-    return ExitCode.success.code;
+    final completer = Completer<int>();
+    handleBuildResultsStream(handler.buildResults, completer);
+    return completer.future;
+  }
+
+  /// Listens to [buildResults], handling certain types of errors and completing
+  /// [completer] appropriately.
+  void handleBuildResultsStream(
+      Stream<BuildResult> buildResults, Completer<int> completer) async {
+    var subscription = buildResults.listen((result) {
+      if (completer.isCompleted) return;
+      if (result.status == BuildStatus.failure) {
+        if (result.failureType == FailureType.buildScriptChanged) {
+          completer.completeError(BuildScriptChangedException());
+        } else if (result.failureType == FailureType.buildConfigChanged) {
+          completer.completeError(BuildConfigChangedException());
+        }
+      }
+    });
+    await subscription.asFuture();
+    if (!completer.isCompleted) completer.complete(ExitCode.success.code);
   }
 }

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -243,7 +243,7 @@ class WatchImpl implements BuildState {
 
           /// Intentional unhandled async error here, which will be caught at the
           /// top level. We want to return a valid BuildResult.
-          unawaited(Future.error(BuildScriptChangedException()));
+          unawaited(Future.error(BuildConfigChangedException()));
           return BuildResult(BuildStatus.failure, []);
         }
       }
@@ -290,6 +290,10 @@ class WatchImpl implements BuildState {
               _isPackageBuildYamlOverride(id)) {
             // Kill future builds if the build.yaml files change.
             _terminateCompleter.complete();
+
+            /// Intentional unhandled async error here, which will be caught at
+            /// the top level.
+            unawaited(Future.error(BuildConfigChangedException()));
             _logger.severe(
                 'Terminating builds due to ${id.package}:${id.path} update.');
           }

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -87,7 +87,12 @@ class ServeHandler implements BuildState {
       throw ArgumentError.value(
           rootDir, 'rootDir', 'Only top level directories are supported');
     }
-    _state.currentBuild.then((_) => _warnForEmptyDirectory(rootDir));
+    _state.currentBuild.then((_) {
+      // If the first build fails with a handled exception, we might not have
+      // an asset graph and can't do this check.
+      if (_state.assetGraph == null) return;
+      _warnForEmptyDirectory(rootDir);
+    });
     var cascade = shelf.Cascade();
     if (buildUpdates != BuildUpdatesOption.none) {
       cascade = cascade.add(_webSocketHandler.createHandlerByRootDir(rootDir));

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.0.0
+version: 1.1.0-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -13,7 +13,7 @@ dependencies:
   build: ">=1.0.0 <1.1.0"
   build_config: ^0.3.1
   build_resolvers: ^0.2.0
-  build_runner_core: ^1.0.0
+  build_runner_core: ^1.1.0
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
   convert: ^2.0.1
@@ -53,3 +53,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_runner_core:
+    path: ../build_runner_core

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -393,7 +393,10 @@ a:file://different/fake/pkg/path
           test('to the root package', () async {
             await writer.writeAsString(
                 AssetId('a', 'build.yaml'), '# New build.yaml file');
-            expect(await results.hasNext, isFalse);
+            expect(await results.hasNext, isTrue);
+            var next = await results.next;
+            expect(next.status, BuildStatus.failure);
+            expect(next.failureType, FailureType.buildConfigChanged);
             expect(logs.length, 1);
             expect(logs.first.message,
                 contains('Terminating builds due to a:build.yaml update'));
@@ -403,7 +406,10 @@ a:file://different/fake/pkg/path
             await writer.writeAsString(
                 AssetId('b', 'build.yaml'), '# New build.yaml file');
 
-            expect(await results.hasNext, isFalse);
+            expect(await results.hasNext, isTrue);
+            var next = await results.next;
+            expect(next.status, BuildStatus.failure);
+            expect(next.failureType, FailureType.buildConfigChanged);
             expect(logs.length, 1);
             expect(logs.first.message,
                 contains('Terminating builds due to b:build.yaml update'));
@@ -412,7 +418,10 @@ a:file://different/fake/pkg/path
           test('<package>.build.yaml', () async {
             await writer.writeAsString(
                 AssetId('a', 'b.build.yaml'), '# New b.build.yaml file');
-            expect(await results.hasNext, isFalse);
+            expect(await results.hasNext, isTrue);
+            var next = await results.next;
+            expect(next.status, BuildStatus.failure);
+            expect(next.failureType, FailureType.buildConfigChanged);
             expect(logs.length, 1);
             expect(logs.first.message,
                 contains('Terminating builds due to a:b.build.yaml update'));
@@ -435,7 +444,10 @@ a:file://different/fake/pkg/path
             await writer.writeAsString(
                 AssetId('a', 'build.yaml'), '# Edited build.yaml file');
 
-            expect(await results.hasNext, isFalse);
+            expect(await results.hasNext, isTrue);
+            var next = await results.next;
+            expect(next.status, BuildStatus.failure);
+            expect(next.failureType, FailureType.buildConfigChanged);
             expect(logs.length, 1);
             expect(logs.first.message,
                 contains('Terminating builds due to a:build.yaml update'));
@@ -445,7 +457,10 @@ a:file://different/fake/pkg/path
             await writer.writeAsString(
                 AssetId('b', 'build.yaml'), '# Edited build.yaml file');
 
-            expect(await results.hasNext, isFalse);
+            expect(await results.hasNext, isTrue);
+            var next = await results.next;
+            expect(next.status, BuildStatus.failure);
+            expect(next.failureType, FailureType.buildConfigChanged);
             expect(logs.length, 1);
             expect(logs.first.message,
                 contains('Terminating builds due to b:build.yaml update'));
@@ -472,7 +487,10 @@ a:file://different/fake/pkg/path
             await writer.writeAsString(
                 AssetId('a', 'build.yaml'), '# Edited build.yaml file');
 
-            expect(await results.hasNext, isFalse);
+            expect(await results.hasNext, isTrue);
+            var next = await results.next;
+            expect(next.status, BuildStatus.failure);
+            expect(next.failureType, FailureType.buildConfigChanged);
             expect(logs.length, 1);
             expect(logs.first.message,
                 contains('Terminating builds due to a:build.yaml update'));
@@ -492,7 +510,10 @@ a:file://different/fake/pkg/path
             await writer.writeAsString(AssetId('a', 'build.cool.yaml'),
                 '# Edited build.cool.yaml file');
 
-            expect(await results.hasNext, isFalse);
+            expect(await results.hasNext, isTrue);
+            var next = await results.next;
+            expect(next.status, BuildStatus.failure);
+            expect(next.failureType, FailureType.buildConfigChanged);
             expect(logs.length, 1);
             expect(logs.first.message,
                 contains('Terminating builds due to a:build.cool.yaml update'));
@@ -741,24 +762,19 @@ Future<BuildState> startWatch(List<BuilderApplication> builders,
       rootPackage: packageGraph.root.name);
   final watcherFactory = (String path) => FakeWatcher(path);
 
-  return runZoned(
-      () => watch_impl.watch(builders,
-          configKey: configKey,
-          deleteFilesByDefault: true,
-          debounceDelay: _debounceDelay,
-          directoryWatcherFactory: watcherFactory,
-          overrideBuildConfig: overrideBuildConfig,
-          reader: reader,
-          writer: writer,
-          packageGraph: packageGraph,
-          terminateEventStream: _terminateWatchController.stream,
-          logLevel: logLevel,
-          onLog: onLog,
-          skipBuildScriptCheck: true), onError: (e) {
-    // Ignore these exceptions for testing, we watch the logs.
-    if (e is BuildConfigChangedException) return;
-    throw e;
-  });
+  return watch_impl.watch(builders,
+      configKey: configKey,
+      deleteFilesByDefault: true,
+      debounceDelay: _debounceDelay,
+      directoryWatcherFactory: watcherFactory,
+      overrideBuildConfig: overrideBuildConfig,
+      reader: reader,
+      writer: writer,
+      packageGraph: packageGraph,
+      terminateEventStream: _terminateWatchController.stream,
+      logLevel: logLevel,
+      onLog: onLog,
+      skipBuildScriptCheck: true);
 }
 
 /// Tells the program to stop watching files and terminate.

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -741,19 +741,24 @@ Future<BuildState> startWatch(List<BuilderApplication> builders,
       rootPackage: packageGraph.root.name);
   final watcherFactory = (String path) => FakeWatcher(path);
 
-  return watch_impl.watch(builders,
-      configKey: configKey,
-      deleteFilesByDefault: true,
-      debounceDelay: _debounceDelay,
-      directoryWatcherFactory: watcherFactory,
-      overrideBuildConfig: overrideBuildConfig,
-      reader: reader,
-      writer: writer,
-      packageGraph: packageGraph,
-      terminateEventStream: _terminateWatchController.stream,
-      logLevel: logLevel,
-      onLog: onLog,
-      skipBuildScriptCheck: true);
+  return runZoned(
+      () => watch_impl.watch(builders,
+          configKey: configKey,
+          deleteFilesByDefault: true,
+          debounceDelay: _debounceDelay,
+          directoryWatcherFactory: watcherFactory,
+          overrideBuildConfig: overrideBuildConfig,
+          reader: reader,
+          writer: writer,
+          packageGraph: packageGraph,
+          terminateEventStream: _terminateWatchController.stream,
+          logLevel: logLevel,
+          onLog: onLog,
+          skipBuildScriptCheck: true), onError: (e) {
+    // Ignore these exceptions for testing, we watch the logs.
+    if (e is BuildConfigChangedException) return;
+    throw e;
+  });
 }
 
 /// Tells the program to stop watching files and terminate.

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+
+- Support running the build script as a snapshot. When the original build script
+  changes and running as a snapshot, the build script will exit with an exit
+  code of 75.
+
 ## 1.0.2
 
 - Support the latest `package:json_annotation`.

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## 1.1.0
 
-- Support running the build script as a snapshot. When the original build script
-  changes and running as a snapshot, the build script will exit with an exit
-  code of 75.
+- Support running the build script as a snapshot.
+- Added new exceptions, `BuildScriptChangedException` and
+  `BuildConfigChangedException`. These should be handled by scripts as described
+  in the documentation.
+- Added new `FailureType`s of `buildScriptChanged` and `buildConfigChanged`.
 
 ## 1.0.2
 

--- a/build_runner_core/lib/build_runner_core.dart
+++ b/build_runner_core/lib/build_runner_core.dart
@@ -13,7 +13,8 @@ export 'src/environment/io_environment.dart';
 export 'src/environment/overridable_environment.dart';
 export 'src/generate/build_result.dart';
 export 'src/generate/build_runner.dart';
-export 'src/generate/exceptions.dart' show CannotBuildException;
+export 'src/generate/exceptions.dart'
+    show BuildScriptChangedException, CannotBuildException;
 export 'src/generate/finalized_assets_view.dart' show FinalizedAssetsView;
 export 'src/generate/options.dart'
     show defaultRootPackageWhitelist, LogSubscription, BuildOptions;

--- a/build_runner_core/lib/build_runner_core.dart
+++ b/build_runner_core/lib/build_runner_core.dart
@@ -14,7 +14,10 @@ export 'src/environment/overridable_environment.dart';
 export 'src/generate/build_result.dart';
 export 'src/generate/build_runner.dart';
 export 'src/generate/exceptions.dart'
-    show BuildScriptChangedException, CannotBuildException;
+    show
+        BuildConfigChangedException,
+        BuildScriptChangedException,
+        CannotBuildException;
 export 'src/generate/finalized_assets_view.dart' show FinalizedAssetsView;
 export 'src/generate/options.dart'
     show defaultRootPackageWhitelist, LogSubscription, BuildOptions;

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -93,8 +93,14 @@ class _Loader {
           _environment.reader, _options.packageGraph, assetGraph);
       if (!_options.skipBuildScriptCheck &&
           buildScriptUpdates.hasBeenUpdated(updates.keys.toSet())) {
-        _logger.warning('Invalidating asset graph due to build script update');
+        _logger.warning('Invalidating asset graph due to build script update!');
         var deletedSourceOutputs = await _cleanupOldOutputs(assetGraph);
+
+        if (!Platform.script.path.endsWith('.dart')) {
+          // We have to be regenerated if running from a snapshot.
+          throw BuildScriptChangedException();
+        }
+
         inputSources.removeAll(deletedSourceOutputs);
         assetGraph = null;
         buildScriptUpdates = null;
@@ -180,7 +186,7 @@ class _Loader {
   /// Deletes the generated output directory.
   ///
   /// Typically this should be done whenever an asset graph is thrown away.
-  Future<Null> _deleteGeneratedDir() async {
+  Future<void> _deleteGeneratedDir() async {
     var generatedDir = Directory(generatedOutputDirectory);
     if (await generatedDir.exists()) {
       await generatedDir.delete(recursive: true);

--- a/build_runner_core/lib/src/generate/build_result.dart
+++ b/build_runner_core/lib/src/generate/build_result.dart
@@ -54,10 +54,12 @@ enum BuildStatus {
 
 /// The type of failure
 class FailureType {
-  static const general = FailureType._(1);
-  static const cantCreate = FailureType._(73);
+  static final general = FailureType._(1);
+  static final cantCreate = FailureType._(73);
+  static final buildConfigChanged = FailureType._(75);
+  static final buildScriptChanged = FailureType._(75);
   final int exitCode;
-  const FailureType._(this.exitCode);
+  FailureType._(this.exitCode);
 }
 
 abstract class BuildState {

--- a/build_runner_core/lib/src/generate/exceptions.dart
+++ b/build_runner_core/lib/src/generate/exceptions.dart
@@ -2,7 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// Indicates that a build config file has changed, and the build needs to be
+/// re-ran.
+///
+/// An exit code of 75 should be set when handling this exception.
+class BuildConfigChangedException implements Exception {
+  const BuildConfigChangedException();
+}
+
 /// Indicates that the build script itself has changed, and needs to be re-ran.
+///
+/// If the build is running from a snapshot, the snapshot should also be
+/// deleted before exiting.
 ///
 /// An exit code of 75 should be set when handling this exception.
 class BuildScriptChangedException implements Exception {

--- a/build_runner_core/lib/src/generate/exceptions.dart
+++ b/build_runner_core/lib/src/generate/exceptions.dart
@@ -2,6 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// Indicates that the build script itself has changed, and needs to be re-ran.
+///
+/// An exit code of 75 should be set when handling this exception.
+class BuildScriptChangedException implements Exception {
+  const BuildScriptChangedException();
+}
+
 /// Indicates that the build cannot be attempted.
 ///
 /// Before throwing this exception a user actionable message should be logged.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 1.0.2
+version: 1.1.0
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
- Adds a new exception type (BuildScriptUpdated) which is thrown when (shocker) the build script is updated. When this exception is caught at the top level, we return an exit code 75.
- The wrapper script now generates build script snapshots and runs those in the isolate. When it sees the exit code 75 it will clean up the asset graph and old snapshot, and re-generate a new snapshot.

Closes https://github.com/dart-lang/build/issues/1496
Closes https://github.com/dart-lang/build/issues/1745
Closes https://github.com/dart-lang/build/issues/1201

cc @kevmoo as this will affect webdev as well, they would ideally do the same logic