### PR TITLE
Add all commands that may log to knownNames

### DIFF
--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -80,7 +80,12 @@ String _loggerName(LogRecord record, bool verbose) {
     'Serve',
     'Watch',
     'build_runner',
+    // commands
+    'build',
     'clean',
+    'serve',
+    'test',
+    'watch',
   ];
   var maybeSplit = record.level >= Level.WARNING ? '\n' : '';
   return verbose || !knownNames.contains(record.loggerName)


### PR DESCRIPTION
The `BuildRunnerCommand` creates a logger based on command names, add
them all to known names to silence their headers.