### PR TITLE
handle sdk updates with retry logic

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bug Fixes
 
 - Handle re-snapshotting the build script on SDK updates.
-- Add `Bootstrap` to the list of known loggers.
+- Suppress header for the `Bootstrap` logger.
 
 ## 1.1.0
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.1
+
+### Bug Fixes
+
+- Handle re-snapshotting the build script on SDK updates.
+- Add `Bootstrap` to the list of known loggers.
+
 ## 1.1.0
 
 ### New Features

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:build_runner_core/build_runner_core.dart';
+import 'package:io/io.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:stack_trace/stack_trace.dart';
+
+import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
+
+final _logger = Logger('Bootstrap');
+
+/// Generates the build script, snapshots it if needed, and runs it.
+///
+/// Will retry once on [IsolateSpawnException]s to handle SDK updates.
+///
+/// Returns the exit code from running the build script.
+///
+/// If an exit code of 75 is returned, this function should be re-ran.
+Future<int> generateAndRun(List<String> args, {Logger logger}) async {
+  logger ??= _logger;
+  ReceivePort exitPort;
+  ReceivePort errorPort;
+  ReceivePort messagePort;
+  StreamSubscription errorListener;
+  int scriptExitCode;
+
+  var tryCount = 0;
+  var succeeded = false;
+  while (tryCount < 2 && !succeeded) {
+    tryCount++;
+    exitPort?.close();
+    errorPort?.close();
+    messagePort?.close();
+    await errorListener?.cancel();
+
+    scriptExitCode = await _createSnapshotIfMissing(logger);
+    if (scriptExitCode != 0) return scriptExitCode;
+
+    exitPort = ReceivePort();
+    errorPort = ReceivePort();
+    messagePort = ReceivePort();
+    errorListener = errorPort.listen((e) {
+      stderr.writeln('\n\nYou have hit a bug in build_runner');
+      stderr.writeln('Please file an issue with reproduction steps at '
+          'https://github.com/dart-lang/build/issues\n\n');
+      final error = e[0];
+      final trace = e[1] as String;
+      stderr.writeln(error);
+      stderr.writeln(Trace.parse(trace).terse);
+      if (scriptExitCode == 0) scriptExitCode = 1;
+    });
+    try {
+      await Isolate.spawnUri(Uri.file(p.absolute(scriptSnapshotLocation)), args,
+          messagePort.sendPort,
+          onExit: exitPort.sendPort, onError: errorPort.sendPort);
+      succeeded = true;
+    } on IsolateSpawnException catch (e) {
+      if (tryCount > 1) {
+        logger.severe(
+            'Failed to spawn build script after retry. '
+            'This is likely due to a misconfigured builder definition. '
+            'See the generated script at $scriptLocation to find errors.',
+            e);
+        messagePort.sendPort.send(ExitCode.config.code);
+        exitPort.sendPort.send(null);
+      } else {
+        logger.warning(
+            'Error spawning build script isolate, this is likely due to a Dart '
+            'SDK update. Deleting snapshot and retrying...');
+      }
+      await File(scriptSnapshotLocation).delete();
+    }
+  }
+
+  StreamSubscription exitCodeListener;
+  exitCodeListener = messagePort.listen((isolateExitCode) {
+    if (isolateExitCode is int) {
+      scriptExitCode = isolateExitCode;
+    } else {
+      throw StateError(
+          'Bad response from isolate, expected an exit code but got '
+          '$isolateExitCode');
+    }
+    exitCodeListener.cancel();
+    exitCodeListener = null;
+  });
+  await exitPort.first;
+  await errorListener.cancel();
+  await exitCodeListener?.cancel();
+
+  return scriptExitCode;
+}
+
+/// Creates a script snapshot for the build script.
+///
+/// Returns zero for success or a number for failure which should be set to the
+/// exit code.
+Future<int> _createSnapshotIfMissing(Logger logger) async {
+  var snapshotFile = File(scriptSnapshotLocation);
+  if (!await snapshotFile.exists()) {
+    await logTimedAsync(logger, 'Creating build script snapshot...', () async {
+      await Process.run(Platform.executable,
+          ['--snapshot=$scriptSnapshotLocation', scriptLocation]);
+    });
+    if (!await snapshotFile.exists()) {
+      logger.severe('Failed to snapshot build script $scriptLocation');
+      return ExitCode.software.code;
+    }
+  }
+  return 0;
+}

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -40,6 +40,11 @@ Future<int> generateAndRun(List<String> args, {Logger logger}) async {
     messagePort?.close();
     await errorListener?.cancel();
 
+    var buildScript = await generateBuildScript();
+    File(scriptLocation)
+      ..createSync(recursive: true)
+      ..writeAsStringSync(buildScript);
+
     scriptExitCode = await _createSnapshotIfMissing(logger);
     if (scriptExitCode != 0) return scriptExitCode;
 

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -17,6 +17,7 @@ import '../package_graph/build_config_overrides.dart';
 import 'builder_ordering.dart';
 
 const scriptLocation = '$entryPointDir/build.dart';
+const scriptSnapshotLocation = '$scriptLocation.snapshot';
 
 Future<String> generateBuildScript() => logTimedAsync(
     Logger('Entrypoint'), 'Generating build script', _generateBuildScript);

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -68,6 +68,7 @@ void _stdIOLogListener(LogRecord record, {bool verbose}) {
 String _loggerName(LogRecord record, bool verbose) {
   var knownNames = const [
     'ApplyBuilders',
+    'Bootstrap',
     'Build',
     'BuildConfigOverrides',
     'BuildDefinition',

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.1.0
+version: 1.1.1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
- If we get an isolate spawn exception, we will always resnapshot and rerun once to handle sdk updates.
- Exposes a utility for generating and snapshotting the build script (under `src`, only intended for use by `webdev`).
- Adds `Bootstrap` logger to the list of known loggers to hide its name from output.

cc @kevmoo see the `generateAndRun` method in `lib/src/build_script_generate/bootstrap.dart`, which webdev can hopefully use. Let me know if it needs to change at all.