### PR TITLE
Add an option to use the analyis driver

### DIFF
--- a/bazel_codegen/lib/src/args/build_args.dart
+++ b/bazel_codegen/lib/src/args/build_args.dart
@@ -16,6 +16,7 @@ const _packagePathParam = 'package-path';
 const _packageMapParam = 'package-map';
 const _srcsParam = 'srcs-file';
 const _summariesParam = 'use-summaries';
+const _analysisDriverParam = 'use-analysis-driver';
 
 // All arguments other than `--help` and `--use-summaries` are required.
 final _argParser = ArgParser()
@@ -36,6 +37,10 @@ final _argParser = ArgParser()
       negatable: true,
       defaultsTo: true,
       help: 'Whether to use summaries for analysis')
+  ..addFlag(_analysisDriverParam,
+      negatable: true,
+      defaultsTo: false,
+      help: 'Whether to use the driver model for analysis')
   ..addOption(_packagePathParam,
       help: 'The path of the package we are processing relative to CWD')
   ..addOption(_packageMapParam,
@@ -66,24 +71,27 @@ class BuildArgs {
   final bool help;
   final bool isWorker;
   final bool useSummaries;
+  final bool useAnalysisDriver;
   final List<String> additionalArgs;
 
   BuildArgs._(
-      this.rootDirs,
-      this.packagePath,
-      this.outDir,
-      this.logPath,
-      this.buildExtensions,
-      this.packageMapPath,
-      this.srcsPath,
-      this.help,
-      this.logLevel,
-      {List<String> additionalArgs,
-      bool isWorker,
-      bool useSummaries})
-      : additionalArgs = additionalArgs ?? [],
+    this.rootDirs,
+    this.packagePath,
+    this.outDir,
+    this.logPath,
+    this.buildExtensions,
+    this.packageMapPath,
+    this.srcsPath,
+    this.help,
+    this.logLevel, {
+    List<String> additionalArgs,
+    bool isWorker,
+    bool useSummaries,
+    bool useAnalysisDriver,
+  })  : additionalArgs = additionalArgs ?? [],
         isWorker = isWorker ?? false,
-        useSummaries = useSummaries ?? true;
+        useSummaries = useSummaries ?? true,
+        useAnalysisDriver = useAnalysisDriver ?? false;
 
   factory BuildArgs.parse(List<String> args, {bool isWorker}) {
     // When not running as a worker, but that mode is supported, then we get
@@ -114,12 +122,23 @@ class BuildArgs {
     final srcsPath = _requiredArg(argResults, _srcsParam) as String;
     final help = argResults[_helpParam] as bool;
     final useSummaries = argResults[_summariesParam] as bool;
+    final useAnalysisDriver = argResults[_analysisDriverParam] as bool;
 
-    return BuildArgs._(rootDirs, packagePath, outDir, logPath, buildExtensions,
-        packageMapPath, srcsPath, help, logLevel,
-        additionalArgs: argResults.rest,
-        isWorker: isWorker,
-        useSummaries: useSummaries);
+    return BuildArgs._(
+      rootDirs,
+      packagePath,
+      outDir,
+      logPath,
+      buildExtensions,
+      packageMapPath,
+      srcsPath,
+      help,
+      logLevel,
+      additionalArgs: argResults.rest,
+      isWorker: isWorker,
+      useSummaries: useSummaries,
+      useAnalysisDriver: useAnalysisDriver,
+    );
   }
 
   void printUsage() {

--- a/bazel_codegen/lib/src/resolver/analysis_driver.dart
+++ b/bazel_codegen/lib/src/resolver/analysis_driver.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/src/dart/analysis/driver.dart';
+import 'package:analyzer/src/dart/analysis/file_state.dart';
+import 'package:analyzer/src/generated/engine.dart'
+    show AnalysisEngine, AnalysisOptionsImpl;
+import 'package:analyzer/src/generated/source.dart';
+import 'package:analyzer/src/summary/package_bundle_reader.dart'
+    show InSummaryUriResolver, SummaryDataStore;
+import 'package:analyzer/file_system/physical_file_system.dart'
+    show PhysicalResourceProvider;
+import 'package:analyzer/src/dart/analysis/byte_store.dart'
+    show MemoryByteStore;
+import 'package:analyzer/src/dart/analysis/performance_logger.dart'
+    show PerformanceLog;
+import 'package:analyzer/src/summary/summary_sdk.dart' show SummaryBasedDartSdk;
+
+import '../summaries/arg_parser.dart';
+import 'build_asset_uri_resolver.dart';
+
+/// Builds an [AnalysisDriver] backed by a summary SDK and package summary
+/// files.
+///
+/// Any code which is not covered by the summaries must be resolvable through
+/// [buildAssetUriResolver].
+AnalysisDriver summaryAnalysisDriver(
+    SummaryOptions options, BuildAssetUriResolver buildAssetUriResolver) {
+  AnalysisEngine.instance.processRequiredPlugins();
+  var sdk = SummaryBasedDartSdk(options.sdkSummary, true);
+  var sdkResolver = DartUriResolver(sdk);
+
+  var summaryData = SummaryDataStore(options.summaryPaths)
+    ..addBundle(null, sdk.bundle);
+  var summaryResolver =
+      InSummaryUriResolver(PhysicalResourceProvider.INSTANCE, summaryData);
+
+  var resolvers = [buildAssetUriResolver, sdkResolver, summaryResolver];
+  var sourceFactory = SourceFactory(resolvers);
+
+  var logger = PerformanceLog(null);
+  var scheduler = AnalysisDriverScheduler(logger);
+  var driver = AnalysisDriver(
+      scheduler,
+      logger,
+      buildAssetUriResolver.resourceProvider,
+      MemoryByteStore(),
+      FileContentOverlay(),
+      null,
+      sourceFactory,
+      AnalysisOptionsImpl(),
+      externalSummaries: summaryData);
+
+  scheduler.start();
+  return driver;
+}

--- a/bazel_codegen/lib/src/resolver/build_asset_uri_resolver.dart
+++ b/bazel_codegen/lib/src/resolver/build_asset_uri_resolver.dart
@@ -1,6 +1,7 @@
-// Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:analyzer/file_system/memory_file_system.dart';

--- a/bazel_codegen/lib/src/resolver/build_asset_uri_resolver.dart
+++ b/bazel_codegen/lib/src/resolver/build_asset_uri_resolver.dart
@@ -34,18 +34,18 @@ class BuildAssetUriResolver implements UriResolver {
     if (uri.isScheme('dart')) return null;
     final id = (uri.isScheme('package') || uri.isScheme('asset'))
         ? AssetId.resolve('$uri')
-        : AssetId(p.split(uri.path).elementAt(1),
-            p.joinAll(p.split(uri.path).skip(2)));
+        : AssetId(p.url.split(uri.path).elementAt(1),
+            p.url.joinAll(p.url.split(uri.path).skip(2)));
     if (!_cachedAssets.contains(id)) return null;
     return resourceProvider.getFile(assetPath(id)).createSource();
   }
 
   @override
-  Uri restoreAbsolute(Source source) => p.toUri(source.fullName);
+  Uri restoreAbsolute(Source source) => AssetId(
+          p.url.split(source.fullName).elementAt(1),
+          p.url.joinAll(p.url.split(source.fullName).skip(2)))
+      .uri;
 }
-
-Uri assetUri(AssetId assetId) =>
-    p.toUri(p.url.join('/${assetId.package}', assetId.path));
 
 String assetPath(AssetId assetId) =>
     p.url.join('/${assetId.package}', assetId.path);

--- a/bazel_codegen/lib/src/resolver/build_asset_uri_resolver.dart
+++ b/bazel_codegen/lib/src/resolver/build_asset_uri_resolver.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+
+import 'package:analyzer/file_system/memory_file_system.dart';
+import 'package:analyzer/src/generated/source.dart';
+import 'package:build/build.dart' show AssetId;
+import 'package:path/path.dart' as p;
+
+typedef Future<String> ReadAsset(AssetId assetId);
+
+/// A [UriResolver] which can read build assets by reading them as strings.
+///
+/// Will only read each asset once. This resolver does not handle cases where
+/// assets may change during a build process.
+class BuildAssetUriResolver implements UriResolver {
+  final _cachedAssets = Set<AssetId>();
+  final resourceProvider = MemoryResourceProvider();
+
+  /// Read all [assets] with the extension '.dart' using the [read] function up
+  /// front and cache them as a [Source].
+  Future<Null> addAssets(Iterable<AssetId> assets, ReadAsset read) async {
+    for (var asset in assets
+        .where((asset) => asset.path.endsWith('.dart'))
+        .where(_cachedAssets.add)) {
+      resourceProvider.newFile(assetPath(asset), await read(asset));
+    }
+  }
+
+  @override
+  Source resolveAbsolute(Uri uri, [Uri actualUri]) {
+    if (uri.isScheme('dart')) return null;
+    final id = (uri.isScheme('package') || uri.isScheme('asset'))
+        ? AssetId.resolve('$uri')
+        : AssetId(p.split(uri.path).elementAt(1),
+            p.joinAll(p.split(uri.path).skip(2)));
+    if (!_cachedAssets.contains(id)) return null;
+    return resourceProvider.getFile(assetPath(id)).createSource();
+  }
+
+  @override
+  Uri restoreAbsolute(Source source) => p.toUri(source.fullName);
+}
+
+Uri assetUri(AssetId assetId) =>
+    p.toUri(p.url.join('/${assetId.package}', assetId.path));
+
+String assetPath(AssetId assetId) =>
+    p.url.join('/${assetId.package}', assetId.path);

--- a/bazel_codegen/lib/src/resolver/resolvers.dart
+++ b/bazel_codegen/lib/src/resolver/resolvers.dart
@@ -73,8 +73,7 @@ class AnalysisResolver implements ReleasableResolver {
 
   @override
   Future<bool> isLibrary(AssetId assetId) async {
-    var uri = assetUri(assetId);
-    var source = _analysisDriver.sourceFactory.forUri2(uri);
+    var source = _analysisDriver.sourceFactory.forUri2(assetId.uri);
     return source != null &&
         (await _analysisDriver.getSourceKind(assetPath(assetId))) ==
             SourceKind.LIBRARY;
@@ -83,7 +82,7 @@ class AnalysisResolver implements ReleasableResolver {
   @override
   Future<LibraryElement> libraryFor(AssetId assetId) async {
     var path = assetPath(assetId);
-    var uri = assetUri(assetId);
+    var uri = assetId.uri;
     var source = _analysisDriver.sourceFactory.forUri2(uri);
     if (source == null) throw ArgumentError('missing source for $uri');
     var kind = await _analysisDriver.getSourceKind(path);

--- a/bazel_codegen/lib/src/resolver/resolvers.dart
+++ b/bazel_codegen/lib/src/resolver/resolvers.dart
@@ -1,0 +1,110 @@
+// Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/dart/analysis/driver.dart' show AnalysisDriver;
+import 'package:analyzer/src/generated/source.dart' show SourceKind;
+import 'package:build/build.dart';
+
+import '../assets/path_translation.dart';
+import '../summaries/arg_parser.dart';
+import 'analysis_driver.dart';
+import 'build_asset_uri_resolver.dart';
+
+/// A [Resolvers] which builds a single [AnalysisDriver] backed by summaries
+/// and shares it across [AnalysisResolver] instances.
+///
+/// For each call to [get] the [AssetId]s will be read and made available to the
+/// analysisDriver.
+class AnalysisDriverResolvers implements Resolvers {
+  final BuildAssetUriResolver _assetResolver;
+  final AnalysisDriver _driver;
+  final String _sourcesFile;
+  final String _packagePath;
+  final Map<String, String> _packageMap;
+  Future<Null> _priming;
+
+  factory AnalysisDriverResolvers(
+      SummaryOptions options, Map<String, String> packageMap) {
+    var assetResolver = BuildAssetUriResolver();
+    return AnalysisDriverResolvers._(
+        assetResolver,
+        summaryAnalysisDriver(options, assetResolver),
+        options.sourcesFile,
+        options.packagePath,
+        packageMap);
+  }
+
+  AnalysisDriverResolvers._(this._assetResolver, this._driver,
+      this._sourcesFile, this._packagePath, this._packageMap);
+
+  @override
+  Future<ReleasableResolver> get(BuildStep buildStep) async {
+    await (_priming ??= _primeWithSources(buildStep.readAsString));
+    var entryPoints = [buildStep.inputId];
+    await _assetResolver.addAssets(entryPoints, buildStep.readAsString);
+    return AnalysisResolver(_driver, entryPoints);
+  }
+
+  Future<Null> _primeWithSources(ReadAsset readAsset) async {
+    var sourceFiles = await File(_sourcesFile).readAsLines();
+    var assets = findAssetIds(sourceFiles, _packagePath, _packageMap);
+    await _assetResolver.addAssets(assets, readAsset);
+  }
+
+  @override
+  void reset() => _driver.dispose();
+}
+
+/// a [Resolver] backed by an [AnalysisDriver].
+class AnalysisResolver implements ReleasableResolver {
+  final AnalysisDriver _analysisDriver;
+  final List<AssetId> _assetIds;
+
+  AnalysisResolver(this._analysisDriver, this._assetIds);
+
+  @override
+  void release() {}
+
+  @override
+  Future<bool> isLibrary(AssetId assetId) async {
+    var uri = assetUri(assetId);
+    var source = _analysisDriver.sourceFactory.forUri2(uri);
+    return source != null &&
+        (await _analysisDriver.getSourceKind(assetPath(assetId))) ==
+            SourceKind.LIBRARY;
+  }
+
+  @override
+  Future<LibraryElement> libraryFor(AssetId assetId) async {
+    var path = assetPath(assetId);
+    var uri = assetUri(assetId);
+    var source = _analysisDriver.sourceFactory.forUri2(uri);
+    if (source == null) throw ArgumentError('missing source for $uri');
+    var kind = await _analysisDriver.getSourceKind(path);
+    if (kind != SourceKind.LIBRARY) return null;
+    return _analysisDriver.getLibraryByUri(assetId.uri.toString());
+  }
+
+  @override
+  Stream<LibraryElement> get libraries async* {
+    var allLibraries = Set<LibraryElement>();
+    var uncheckedLibraries = Queue<LibraryElement>()
+      ..addAll(await Future.wait(_assetIds.map(libraryFor)));
+    while (uncheckedLibraries.isNotEmpty) {
+      var library = uncheckedLibraries.removeFirst();
+      allLibraries.add(library);
+      yield library;
+      uncheckedLibraries.addAll(library.importedLibraries
+          .where((library) => !allLibraries.contains(library)));
+    }
+  }
+
+  @override
+  Future<LibraryElement> findLibraryByName(String name) => libraries
+      .firstWhere((library) => library.name == name, orElse: () => null);
+}

--- a/bazel_codegen/lib/src/resolver/resolvers.dart
+++ b/bazel_codegen/lib/src/resolver/resolvers.dart
@@ -1,6 +1,7 @@
-// Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:collection';
 import 'dart:io';

--- a/bazel_codegen/lib/src/run_phases.dart
+++ b/bazel_codegen/lib/src/run_phases.dart
@@ -18,6 +18,7 @@ import 'errors.dart';
 import 'logging.dart';
 import 'run_builders.dart';
 import 'summaries/summaries.dart';
+import 'resolver/resolvers.dart';
 import 'timing.dart';
 
 /// Runs builds as a worker.
@@ -141,7 +142,9 @@ Future<IOSinkLogHandle> _runBuilders(
   List<String> builderArgs;
   if (buildArgs.useSummaries) {
     var summaryOptions = SummaryOptions.fromArgs(buildArgs.additionalArgs);
-    resolvers = SummaryResolvers(summaryOptions, packageMap);
+    resolvers = buildArgs.useAnalysisDriver
+        ? AnalysisDriverResolvers(summaryOptions, packageMap)
+        : SummaryResolvers(summaryOptions, packageMap);
     builderArgs = summaryOptions.additionalArgs;
   } else {
     resolvers = AnalyzerResolvers();

--- a/bazel_codegen/lib/src/run_phases.dart
+++ b/bazel_codegen/lib/src/run_phases.dart
@@ -16,9 +16,9 @@ import 'assets/asset_reader.dart';
 import 'assets/asset_writer.dart';
 import 'errors.dart';
 import 'logging.dart';
+import 'resolver/resolvers.dart';
 import 'run_builders.dart';
 import 'summaries/summaries.dart';
-import 'resolver/resolvers.dart';
 import 'timing.dart';
 
 /// Runs builds as a worker.


### PR DESCRIPTION
Towards #1886

This is hidden behind a flag for now and should not be used, the
migration causes a number of breakinge changes in the behavior of the
`LibraryElement` instances that are returned by the resolver.

- Add a flag `--use-analysis-driver` defaulted to false.
- Add an implementation of the `Resolvers` class backed by an
  `AnalysisDriver`. There is a fair amount of duplication here but it
  will be removed when the migration is made as a hard flip.
- Switch a few argument lists to use trailing commas so future changes
  have single line diffs.