### PR TITLE
Improve error message when build script is invalid

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.2
+
+- Improve error message when the generated build script cannot be parsed or
+  compiled and exit with code `78` to indicate that there is a problem with
+  configuration in the project or a dependency's `build.yaml`.
+
 ## 1.1.1
 
 ### Bug Fixes

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.1.1
+version: 1.1.2
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner

--- a/build_runner/test/build_script_generate/build_script_generate_test.dart
+++ b/build_runner/test/build_script_generate/build_script_generate_test.dart
@@ -29,9 +29,8 @@ void main() {
         d.file('build.yaml', '''
 builders:
   fake:
-    import: '../../../tool/builder.dart'
-    builder_factories:
-      - myFactory
+    import: "../../../tool/builder.dart"
+    builder_factories: ["myFactory"]
     build_extensions: {"foo": ["bar"]}
 '''),
       ]).create();
@@ -46,9 +45,8 @@ builders:
         d.file('build.yaml', '''
 builders:
   fake:
-    import: 'tool/builder.dart'
-    builder_factories:
-      - myFactory
+    import: "tool/builder.dart"
+    builder_factories: ["myFactory"]
     build_extensions: {"foo": ["bar"]}
 '''),
       ]).create();
@@ -69,6 +67,20 @@ builders:
           ])
         ])
       ]).validate();
+    });
+
+    test('warns for builder config that leaves unparseable Dart', () async {
+      await d.dir('a', [
+        d.file('build.yaml', '''
+builders:
+  fake:
+    import: "tool/builder.dart"
+    builder_factories: ["not an identifier"]
+    build_extensions: {"foo": ["bar"]}
+''')
+      ]).create();
+      var result = await runPub('a', 'run', args: ['build_runner', 'build']);
+      expect(result.stdout, contains('could not be parsed'));
     });
   });
 }

--- a/build_runner/test/integration_tests/wrong_builder_factory_test.dart
+++ b/build_runner/test/integration_tests/wrong_builder_factory_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['integration'])
+
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+import 'package:io/io.dart' show ExitCode;
+
+import 'utils/build_descriptor.dart';
+
+// test-package-start #########################################################
+final correctKey = TestBuilder(buildExtensions: {
+  '.txt': ['.txt.copy', '.txt.extra']
+});
+// test-package-end ###########################################################
+
+main() {
+  final builders = [
+    builder('wrongKey', correctKey),
+  ];
+
+  BuildTool buildTool;
+
+  setUpAll(() async {
+    buildTool = await package([await packageWithBuilders(builders)]);
+  });
+
+  group('build', () {
+    test('warns when builder definition produces invalid build script',
+        () async {
+      var result = await buildTool.build(expectExitCode: ExitCode.config.code);
+      expect(
+          result, emitsThrough(contains('misconfigured builder definition')));
+      expect(result, emitsThrough(contains('Getter not found: \'wrongKey\'')));
+    });
+  });
+}


### PR DESCRIPTION
See #1900

Add explicit error handling in the places where we can identify either
syntactically or semantically invalid code.

If the script fails to parse when attempting to format the output
pointing to the error isn't very useful, since at that point the script
is all on one line - for this case indicate that the script cannot be
parsed.

If the script fails to snapshot we can print the stderr from the dart
process which should include details of the problem.

In both cases we assume that the problem stems from bad config and so we
exit with code 78.

Also fix some bugs with the test utilities for integration tests using
`pub run build_runner` instead of running with a simulated manual build
script:

- Add missing dependencies for the pubspecs in `packageWithBuilders`.
- Create the directories for dependencies when creating with `package`.
- In pubspecs write both `dependencies` and `dependency_overrides` since
  overrides are not taken into account for the non-root package.