### PR TITLE
Fix some issues around adding/removing dependencies and snapshots

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1
+
+- Fix a bugs where adding new dependencies or removing dependencies could cause
+  subsequent build errors, requiring a `pub run build_runner clean` to fix.
+
 ## 1.1.0
 
 - Support running the build script as a snapshot.

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -96,7 +96,7 @@ class _Loader {
         _logger.warning('Invalidating asset graph due to build script update!');
         var deletedSourceOutputs = await _cleanupOldOutputs(assetGraph);
 
-        if (!Platform.script.path.endsWith('.dart')) {
+        if (_runningFromSnapshot()) {
           // We have to be regenerated if running from a snapshot.
           throw BuildScriptChangedException();
         }
@@ -224,7 +224,9 @@ class _Loader {
             _cleanupOldOutputs(cachedGraph),
             FailureReporter.cleanErrorCache(),
           ]);
-          return null;
+          if (_runningFromSnapshot()) {
+            throw BuildScriptChangedException();
+          }
         }
         if (!isSameSdkVersion(cachedGraph.dartVersion, Platform.version)) {
           _logger.warning(
@@ -233,7 +235,9 @@ class _Loader {
             _cleanupOldOutputs(cachedGraph),
             FailureReporter.cleanErrorCache(),
           ]);
-          return null;
+          if (_runningFromSnapshot()) {
+            throw BuildScriptChangedException();
+          }
         }
         return cachedGraph;
       } on AssetGraphVersionException catch (_) {
@@ -489,3 +493,5 @@ class _Loader {
     }
   }
 }
+
+bool _runningFromSnapshot() => !Platform.script.path.endsWith('.dart');

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -39,7 +39,6 @@ import '../util/build_dirs.dart';
 import '../util/constants.dart';
 import 'build_definition.dart';
 import 'build_result.dart';
-import 'exceptions.dart';
 import 'finalized_assets_view.dart';
 import 'heartbeat.dart';
 import 'options.dart';

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -102,7 +102,6 @@ class BuildImpl {
         options.targetGraph, builders, builderConfigOverrides, isReleaseBuild);
     if (buildPhases.isEmpty) {
       _logger.severe('Nothing can be built, yet a build was requested.');
-      throw CannotBuildException();
     }
     var buildDefinition = await BuildDefinition.prepareWorkspace(
         environment, options, buildPhases);

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 1.1.0
+version: 1.1.1
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -377,8 +377,10 @@ targets:
             hideOutput: true));
         logs.clear();
 
-        var buildDefinition = await BuildDefinition.prepareWorkspace(
-            environment, options, buildPhases);
+        await expectLater(
+            () => BuildDefinition.prepareWorkspace(
+                environment, options, buildPhases),
+            throwsA(const TypeMatcher<BuildScriptChangedException>()));
         expect(
             logs.any(
               (log) =>
@@ -386,13 +388,10 @@ targets:
                   log.message.contains('build phases have changed'),
             ),
             isTrue);
-
-        var newAssetGraph = buildDefinition.assetGraph;
-        expect(originalAssetGraph.buildPhasesDigest,
-            isNot(newAssetGraph.buildPhasesDigest));
+        expect(File(assetGraphPath).existsSync(), isFalse);
       });
 
-      test('invalidates the graph a phase has different build extension',
+      test('invalidates the graph if a phase has different build extension',
           () async {
         var buildPhases = [InBuildPhase(TestBuilder(), 'a', hideOutput: true)];
 
@@ -408,8 +407,10 @@ targets:
         ];
         logs.clear();
 
-        var buildDefinition = await BuildDefinition.prepareWorkspace(
-            environment, options, buildPhases);
+        await expectLater(
+            () => BuildDefinition.prepareWorkspace(
+                environment, options, buildPhases),
+            throwsA(const TypeMatcher<BuildScriptChangedException>()));
         expect(
             logs.any(
               (log) =>
@@ -417,10 +418,7 @@ targets:
                   log.message.contains('build phases have changed'),
             ),
             isTrue);
-
-        var newAssetGraph = buildDefinition.assetGraph;
-        expect(originalAssetGraph.buildPhasesDigest,
-            isNot(newAssetGraph.buildPhasesDigest));
+        expect(File(assetGraphPath).existsSync(), isFalse);
       });
 
       test('invalidates the graph if the dart sdk version changes', () async {
@@ -437,8 +435,11 @@ targets:
 
         logs.clear();
 
-        await BuildDefinition.prepareWorkspace(
-            environment, options, buildPhases);
+        await expectLater(
+            () => BuildDefinition.prepareWorkspace(
+                environment, options, buildPhases),
+            throwsA(const TypeMatcher<BuildScriptChangedException>()));
+
         expect(
             logs.any(
               (log) =>
@@ -446,6 +447,7 @@ targets:
                   log.message.contains('due to Dart SDK update.'),
             ),
             isTrue);
+        expect(File(assetGraphPath).existsSync(), isFalse);
       });
 
       test('does not invalidate if a different Builder has the same extensions',
@@ -540,8 +542,10 @@ targets:
             targetSources: const InputSet(include: ['.copy']),
             hideOutput: true));
 
-        await BuildDefinition.prepareWorkspace(
-            environment, options, buildPhases);
+        await expectLater(
+            () => BuildDefinition.prepareWorkspace(
+                environment, options, buildPhases),
+            throwsA(const TypeMatcher<BuildScriptChangedException>()));
         expect(writerSpy.assetsDeleted, contains(aTxtCopy));
       });
     });

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -450,16 +450,13 @@ void main() {
         rootPackage('a', path: 'a/'): ['b'],
         package('b', path: 'a/b'): []
       });
-      expect(
-          () => testBuilders(
-              [
-                apply('', [(_) => TestBuilder()], toPackage('b'),
-                    hideOutput: false)
-              ],
-              {'b|lib/b.txt': 'b'},
-              packageGraph: packageGraph,
-              outputs: {}),
-          throwsA(TypeMatcher<CannotBuildException>()));
+      await testBuilders(
+          [
+            apply('', [(_) => TestBuilder()], toPackage('b'), hideOutput: false)
+          ],
+          {'b|lib/b.txt': 'b'},
+          packageGraph: packageGraph,
+          outputs: {});
     });
 
     group('with `hideOutput: true`', () {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/1906

- Allow the build to continue even if it won't do anything - which allows it to serialize the asset graph to disk.
- Always restart and re-snapshot when the build phases or sdk are updated, if running from snapshot.