### PR TITLE
Prepare for breaking change to UriResolver.

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.3.4
 
 - Fix the exceptions thrown when attempting to read invalid assets.
+- Updated BuildAssetUriResolver classes to prepare for a future release of the
+  analyzer.
 
 # 0.3.3+1
 

--- a/bazel_codegen/lib/src/resolver/build_asset_uri_resolver.dart
+++ b/bazel_codegen/lib/src/resolver/build_asset_uri_resolver.dart
@@ -29,6 +29,9 @@ class BuildAssetUriResolver implements UriResolver {
   }
 
   @override
+  void clearCache() {}
+
+  @override
   Source resolveAbsolute(Uri uri, [Uri actualUri]) {
     final cachedId = _lookupAsset(uri);
     if (cachedId == null) return null;

--- a/bazel_codegen/lib/src/resolver/build_asset_uri_resolver.dart
+++ b/bazel_codegen/lib/src/resolver/build_asset_uri_resolver.dart
@@ -14,7 +14,7 @@ typedef Future<String> ReadAsset(AssetId assetId);
 ///
 /// Will only read each asset once. This resolver does not handle cases where
 /// assets may change during a build process.
-class BuildAssetUriResolver implements UriResolver {
+class BuildAssetUriResolver extends UriResolver {
   final _cachedAssets = Set<AssetId>();
   final resourceProvider = MemoryResourceProvider();
 
@@ -27,9 +27,6 @@ class BuildAssetUriResolver implements UriResolver {
       resourceProvider.newFile(assetPath(asset), await read(asset));
     }
   }
-
-  @override
-  void clearCache() {}
 
   @override
   Source resolveAbsolute(Uri uri, [Uri actualUri]) {

--- a/bazel_codegen/lib/src/summaries/build_asset_uri_resolver.dart
+++ b/bazel_codegen/lib/src/summaries/build_asset_uri_resolver.dart
@@ -29,6 +29,9 @@ class BuildAssetUriResolver implements UriResolver {
   }
 
   @override
+  void clearCache() {}
+  
+  @override
   Source resolveAbsolute(Uri uri, [Uri actualUri]) => _knownAssets[uri];
 
   @override

--- a/bazel_codegen/lib/src/summaries/build_asset_uri_resolver.dart
+++ b/bazel_codegen/lib/src/summaries/build_asset_uri_resolver.dart
@@ -14,7 +14,7 @@ typedef Future<String> ReadAsset(AssetId assetId);
 ///
 /// Will only read each asset once. This resolver does not handle cases where
 /// assets may change during a build process.
-class BuildAssetUriResolver implements UriResolver {
+class BuildAssetUriResolver extends UriResolver {
   final _knownAssets = <Uri, Source>{};
 
   /// Read all [assets] with the extension '.dart' using the [read] function up
@@ -27,9 +27,6 @@ class BuildAssetUriResolver implements UriResolver {
       }
     }
   }
-
-  @override
-  void clearCache() {}
   
   @override
   Source resolveAbsolute(Uri uri, [Uri actualUri]) => _knownAssets[uri];

--- a/bazel_codegen/lib/src/summaries/build_asset_uri_resolver.dart
+++ b/bazel_codegen/lib/src/summaries/build_asset_uri_resolver.dart
@@ -27,7 +27,7 @@ class BuildAssetUriResolver extends UriResolver {
       }
     }
   }
-  
+
   @override
   Source resolveAbsolute(Uri uri, [Uri actualUri]) => _knownAssets[uri];
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2+7
+
+- Updated _AssetUriResolver to prepare for a future release of the analyzer.
+
 ## 0.2.2+6
 
 - Increased the upper bound for `package:analyzer` to '<0.34.0'.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -288,6 +288,9 @@ class _AssetUriResolver implements UriResolver {
   _AssetUriResolver(this._resolver);
 
   @override
+  void clearCache() {}
+
+  @override
   Source resolveAbsolute(Uri uri, [Uri actualUri]) {
     assert(uri.scheme != 'dart');
     AssetId assetId;

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -283,12 +283,9 @@ class AssetBasedSource extends Source {
 }
 
 /// Implementation of Analyzer's UriResolver for Barback based assets.
-class _AssetUriResolver implements UriResolver {
+class _AssetUriResolver extends UriResolver {
   final AnalyzerResolver _resolver;
   _AssetUriResolver(this._resolver);
-
-  @override
-  void clearCache() {}
 
   @override
   Source resolveAbsolute(Uri uri, [Uri actualUri]) {

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 0.2.2+6
+version: 0.2.2+7-dev
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers


### PR DESCRIPTION
Analyzer version 0.34.0 contains a breaking change to UriResolver: the
addition of a `clearCache` method - see
https://dart-review.googlesource.com/c/sdk/+/85726/1/pkg/analyzer/lib/src/generated/source.dart.

Even though we are not ready to upgrade to analyzer 0.34.0 yet, we can
prepare for the change by adding implementations of the method.  It's
not necessary for the implementations to do anything, since our
UriResolver implementations don't cache any URI resolution.