### PR TITLE
return empty sources for non-dart uris in BuildAssetUriResolver

### DIFF
--- a/bazel_codegen/CHANGELOG.md
+++ b/bazel_codegen/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.3.4
 
 - Fix the exceptions thrown when attempting to read invalid assets.
+- Return empty sources for unknown assets instead of null.
 
 # 0.3.3+1
 

--- a/bazel_codegen/lib/src/resolver/analysis_driver.dart
+++ b/bazel_codegen/lib/src/resolver/analysis_driver.dart
@@ -36,7 +36,7 @@ AnalysisDriver summaryAnalysisDriver(
   var summaryResolver =
       InSummaryUriResolver(PhysicalResourceProvider.INSTANCE, summaryData);
 
-  var resolvers = [buildAssetUriResolver, sdkResolver, summaryResolver];
+  var resolvers = [sdkResolver, summaryResolver, buildAssetUriResolver];
   var sourceFactory = SourceFactory(resolvers);
 
   var logger = PerformanceLog(null);

--- a/bazel_codegen/lib/src/summaries/analysis_context.dart
+++ b/bazel_codegen/lib/src/summaries/analysis_context.dart
@@ -30,9 +30,9 @@ AnalysisContext summaryAnalysisContext(
       InSummaryUriResolver(PhysicalResourceProvider.INSTANCE, summaryData);
 
   var resolvers = <UriResolver>[]
-    ..addAll(additionalResolvers)
     ..add(sdkResolver)
-    ..add(summaryResolver);
+    ..add(summaryResolver)
+    ..addAll(additionalResolvers);
   var sourceFactory = SourceFactory(resolvers);
 
   var context = AnalysisEngine.instance.createAnalysisContext()

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/bazel_codegen
-version: 0.3.4
+version: 0.3.4-dev
 
 environment:
   sdk: ">=2.0.0 <3.0.0"

--- a/bazel_codegen/pubspec.yaml
+++ b/bazel_codegen/pubspec.yaml
@@ -2,7 +2,7 @@ name: _bazel_codegen
 description: Bazel code generation runner
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/bazel_codegen
-version: 0.3.4-dev
+version: 0.3.4
 
 environment:
   sdk: ">=2.0.0 <3.0.0"

--- a/bazel_codegen/test/build_asset_uri_resolver_test.dart
+++ b/bazel_codegen/test/build_asset_uri_resolver_test.dart
@@ -23,7 +23,7 @@ main() {
   test('returns an empty source for unknown assets', () {
     var source = resolver.resolveAbsolute(Uri.parse('package:foo/bar.dart'));
     expect(source.exists(), isFalse);
-    expect(() => source.contents, throwsA(const TypeMatcher<StateError>()));
+    expect(() => source.contents, throwsStateError);
   });
 
   test('can resolve known sources', () async {

--- a/bazel_codegen/test/build_asset_uri_resolver_test.dart
+++ b/bazel_codegen/test/build_asset_uri_resolver_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2018, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:test/test.dart';
+
+import 'package:_bazel_codegen/src/summaries/build_asset_uri_resolver.dart';
+
+main() {
+  BuildAssetUriResolver resolver;
+
+  setUp(() {
+    resolver = BuildAssetUriResolver();
+  });
+
+  test('returns null for dart: uris', () {
+    expect(resolver.resolveAbsolute(Uri.parse('dart:async')), isNull);
+  });
+
+  test('returns an empty source for unknown assets', () {
+    var source = resolver.resolveAbsolute(Uri.parse('package:foo/bar.dart'));
+    expect(source.exists(), isFalse);
+    expect(() => source.contents, throwsA(const TypeMatcher<StateError>()));
+  });
+
+  test('can resolve known sources', () async {
+    final content = 'final hello = "world";';
+    await resolver.addAssets(
+        [AssetId('foo', 'lib/bar.dart')], (_) => Future.value(content));
+    var source = resolver.resolveAbsolute(Uri.parse('package:foo/bar.dart'));
+    expect(source.exists(), isTrue);
+    expect(source.contents.data, content);
+  });
+}

--- a/bazel_codegen/test/build_asset_uri_resolver_test.dart
+++ b/bazel_codegen/test/build_asset_uri_resolver_test.dart
@@ -3,8 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
 
 import 'package:build/build.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
This allows missing parts to appear in `LibraryElement#parts`.

cc @scheglov  