### PR TITLE
fix travis errors

### DIFF
--- a/build_config/mono_pkg.yaml
+++ b/build_config/mono_pkg.yaml
@@ -7,6 +7,8 @@ stages:
         - dartfmt: sdk
         - dartanalyzer: --fatal-infos --fatal-warnings .
   - unit_test:
+    # Run the script directly - running from snapshot has issues for packages
+    # that are depended on by build_runner itself.
     - command: dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs
 
 cache:

--- a/build_config/mono_pkg.yaml
+++ b/build_config/mono_pkg.yaml
@@ -7,7 +7,7 @@ stages:
         - dartfmt: sdk
         - dartanalyzer: --fatal-infos --fatal-warnings .
   - unit_test:
-    - command: pub run build_runner test --delete-conflicting-outputs
+    - command: dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs
 
 cache:
   directories:

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -7,7 +7,7 @@ stages:
         - dartfmt: sdk
         - dartanalyzer: --fatal-infos --fatal-warnings .
   - unit_test:
-    - command: pub run build_runner test --delete-conflicting-outputs -- -P presubmit
+    - command: dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs-- -P presubmit
 
 cache:
   directories:

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -7,6 +7,8 @@ stages:
         - dartfmt: sdk
         - dartanalyzer: --fatal-infos --fatal-warnings .
   - unit_test:
+    # Run the script directly - running from snapshot has issues for packages
+    # that are depended on by build_runner itself.
     - command: dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs-- -P presubmit
 
 cache:

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -67,14 +67,21 @@ a:file://fake/pkg/path
         expect(await results.hasNext, isFalse);
       });
 
-      test('emits an error when no builders are specified', () async {
+      test('emits an error message when no builders are specified', () async {
+        var logs = <LogRecord>[];
         var buildState = await startWatch(
           [],
           {'a|web/a.txt.copy': 'a'},
           writer,
+          onLog: logs.add,
+          logLevel: Level.SEVERE,
         );
         var result = await buildState.buildResults.first;
-        expect(result.status, BuildStatus.failure);
+        expect(result.status, BuildStatus.success);
+        expect(
+            logs,
+            contains(predicate((LogRecord record) => record.message.contains(
+                'Nothing can be built, yet a build was requested.'))));
       });
 
       test('rebuilds on file updates outside hardcoded whitelist', () async {


### PR DESCRIPTION
- bypass running from snapshot for build_config and build_modules since it doesn't play nicely for packages that have generated sources and are a dependency of build_runner_core.
- update the build_runner test to no longer expect a failure when the builders are empty