### PR TITLE
Fix NoSuchMethodError when running from source after adding new deps

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,11 @@
+## 1.1.2
+
+- Fix a `NoSuchMethodError` that the user could get when adding new
+  dependencies.
+
 ## 1.1.1
 
-- Fix a bugs where adding new dependencies or removing dependencies could cause
+- Fix a bug where adding new dependencies or removing dependencies could cause
   subsequent build errors, requiring a `pub run build_runner clean` to fix.
 
 ## 1.1.0

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -227,6 +227,7 @@ class _Loader {
           if (_runningFromSnapshot) {
             throw BuildScriptChangedException();
           }
+          return null;
         }
         if (!isSameSdkVersion(cachedGraph.dartVersion, Platform.version)) {
           _logger.warning(
@@ -238,6 +239,7 @@ class _Loader {
           if (_runningFromSnapshot) {
             throw BuildScriptChangedException();
           }
+          return null;
         }
         return cachedGraph;
       } on AssetGraphVersionException catch (_) {

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 1.1.1
+version: 1.1.2
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/1913

When I added in the throw in snapshot mode for this situation, I forgot to leave the return in place so in non-snapshot mode we would return an invalid asset graph instead of null.