### PR TITLE
Include part files in build script update checks

### DIFF
--- a/build_runner_core/lib/src/changes/build_script_updates.dart
+++ b/build_runner_core/lib/src/changes/build_script_updates.dart
@@ -52,8 +52,13 @@ class BuildScriptUpdates {
     return BuildScriptUpdates._(supportsIncrementalRebuilds, allSources);
   }
 
-  static Iterable<Uri> get _urisForThisScript =>
-      currentMirrorSystem().libraries.keys;
+  static Set<Uri> get _urisForThisScript => currentMirrorSystem()
+      .libraries
+      .values
+      .expand((l) => l.declarations.values)
+      .map((d) => d.location?.sourceUri)
+      .where((u) => u != null)
+      .toSet();
 
   /// Checks if the current running program has been updated, based on
   /// [updatedIds].


### PR DESCRIPTION
Fixes #1912

Iterate over all declarations and pull out the source URIs for each.
This prevents the issue of only including the root of each library as an
asset used by the build script.

If a part file has no declarations it may be skipped, however an edit to
such a part file should have no impact on the build until an edit is
also made to another file to use the new declaration.