### PR TITLE
Update build_web_compilers readme

### DIFF
--- a/build_web_compilers/README.md
+++ b/build_web_compilers/README.md
@@ -63,7 +63,7 @@ targets:
           compiler: dart2js
           # List any dart2js specific args here, or omit it.
           dart2js_args:
-          - --checked
+          - -O2
 ```
 
 ## Manual Usage


### PR DESCRIPTION
Use `-O2` instead of `--checked` as an example dart2js arg.

Fixes https://github.com/dart-lang/build/issues/1890