### PR TITLE
try using Platform.executable instead of Platform.resolvedExecutable

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4-dev
+
+- Use `Platform.resolvedExecutable` with `Platform.executable`.
+
 ## 1.0.3
 
 - Increased the upper bound for `package:analyzer` to `<0.35.0`.

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -15,7 +15,7 @@ import 'package:pedantic/pedantic.dart';
 
 import 'scratch_space.dart';
 
-final sdkDir = p.dirname(p.dirname(Platform.resolvedExecutable));
+final sdkDir = p.dirname(p.dirname(Platform.executable));
 
 /// Completes once the analyzer workers have been shut down.
 Future<Null> get analyzerWorkersAreDone =>

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -15,7 +15,7 @@ import 'package:pedantic/pedantic.dart';
 
 import 'scratch_space.dart';
 
-final sdkDir = p.dirname(p.dirname(Platform.executable));
+final sdkDir = p.dirname(p.dirname(p.absolute(Platform.executable)));
 
 /// Completes once the analyzer workers have been shut down.
 Future<Null> get analyzerWorkersAreDone =>

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 1.0.3
+version: 1.0.4-dev
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.2+8-dev
 
-- Use `Platform.resolvedExecutable` with `Platform.executable`.
+- Use `Platform.resolvedExecutable` with `Platform.executable`
 
 ## 0.2.2+7
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2+8-dev
+
+- Use `Platform.resolvedExecutable` with `Platform.executable`.
+
 ## 0.2.2+7
 
 - Updated _AssetUriResolver to prepare for a future release of the analyzer.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -429,8 +429,8 @@ class AnalyzerResolvers implements Resolvers {
     var resourceProvider = PhysicalResourceProvider.INSTANCE;
     var sdk = FolderBasedDartSdk(
         resourceProvider,
-        resourceProvider.getFolder(native_path
-            .dirname(native_path.dirname(Platform.executable))))
+        resourceProvider.getFolder(
+            native_path.dirname(native_path.dirname(Platform.executable))))
       ..useSummary = true;
     var uriResolver = DartUriResolver(sdk);
     return AnalyzerResolvers._(AnalyzerResolver(uriResolver, analysisOptions));

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -429,8 +429,8 @@ class AnalyzerResolvers implements Resolvers {
     var resourceProvider = PhysicalResourceProvider.INSTANCE;
     var sdk = FolderBasedDartSdk(
         resourceProvider,
-        resourceProvider.getFolder(
-            native_path.dirname(native_path.dirname(Platform.executable))))
+        resourceProvider.getFolder(native_path.dirname(
+            native_path.dirname(native_path.absolute(Platform.executable)))))
       ..useSummary = true;
     var uriResolver = DartUriResolver(sdk);
     return AnalyzerResolvers._(AnalyzerResolver(uriResolver, analysisOptions));

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -430,7 +430,7 @@ class AnalyzerResolvers implements Resolvers {
     var sdk = FolderBasedDartSdk(
         resourceProvider,
         resourceProvider.getFolder(native_path
-            .dirname(native_path.dirname(Platform.resolvedExecutable))))
+            .dirname(native_path.dirname(Platform.executable))))
       ..useSummary = true;
     var uriResolver = DartUriResolver(sdk);
     return AnalyzerResolvers._(AnalyzerResolver(uriResolver, analysisOptions));

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 0.2.2+7
+version: 0.2.2+8-dev
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3-dev
+
+- Use `Platform.resolvedExecutable` with `Platform.executable`.
+
 ## 1.1.2
 
 - Fix a `NoSuchMethodError` that the user could get when adding new

--- a/build_runner_core/lib/src/util/constants.dart
+++ b/build_runner_core/lib/src/util/constants.dart
@@ -44,7 +44,7 @@ final pubBinary = p.join(sdkBin, Platform.isWindows ? 'pub.bat' : 'pub');
 final sdkBin = p.join(sdkPath, 'bin');
 
 /// The path to the sdk on the current platform.
-final sdkPath = p.dirname(p.dirname(Platform.resolvedExecutable));
+final sdkPath = p.dirname(p.dirname(Platform.executable));
 
 /// The maximum number of concurrent actions to run per build phase.
 const buildPhasePoolSize = 16;

--- a/build_runner_core/lib/src/util/constants.dart
+++ b/build_runner_core/lib/src/util/constants.dart
@@ -44,7 +44,7 @@ final pubBinary = p.join(sdkBin, Platform.isWindows ? 'pub.bat' : 'pub');
 final sdkBin = p.join(sdkPath, 'bin');
 
 /// The path to the sdk on the current platform.
-final sdkPath = p.dirname(p.dirname(Platform.executable));
+final sdkPath = p.dirname(p.dirname(p.absolute(Platform.executable)));
 
 /// The maximum number of concurrent actions to run per build phase.
 const buildPhasePoolSize = 16;

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 1.1.2
+version: 1.1.3-dev
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core

--- a/build_runner_core/test/environment/io_environment_test.dart
+++ b/build_runner_core/test/environment/io_environment_test.dart
@@ -15,7 +15,7 @@ void main() {
   StreamQueue<String> stdoutLines;
 
   setUpAll(() async {
-    process = await Process.start(Platform.resolvedExecutable,
+    process = await Process.start(Platform.executable,
         [p.join('test', 'environment', 'simple_prompt.dart')]);
     stdoutLines = StreamQueue(
         process.stdout.transform(Utf8Decoder()).transform(LineSplitter()));

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-dev
+
+- Use `Platform.resolvedExecutable` with `Platform.executable`.
+
 ## 1.0.0
 
 - Removed the `enable_sync_async` and `ignore_cast_failures` options for the

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -16,7 +16,7 @@ import '../builders.dart';
 import 'common.dart';
 import 'errors.dart';
 
-final _sdkDir = p.dirname(p.dirname(Platform.executable));
+final _sdkDir = p.dirname(p.dirname(p.absolute(Platform.executable)));
 
 const jsModuleErrorsExtension = '.ddc.js.errors';
 const jsModuleExtension = '.ddc.js';

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -16,7 +16,7 @@ import '../builders.dart';
 import 'common.dart';
 import 'errors.dart';
 
-final _sdkDir = p.dirname(p.dirname(Platform.resolvedExecutable));
+final _sdkDir = p.dirname(p.dirname(Platform.executable));
 
 const jsModuleErrorsExtension = '.ddc.js.errors';
 const jsModuleExtension = '.ddc.js';

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 1.0.0
+version: 1.0.0-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
Will update with changelog/pubspec updates if travis is happy - internally we need to use Platform.executable so hopefully this can let us eliminate the custom patches.