### PR TITLE
fix ddk builder to pass module names

### DIFF
--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -35,7 +35,7 @@ Future<Null> bootstrapDdc(BuildStep buildStep,
   // First, ensure all transitive modules are built.
   var transitiveDeps = await _ensureTransitiveModules(module, buildStep);
   var jsId = module.jsId(jsModuleExtension);
-  var appModuleName = _ddcModuleName(jsId);
+  var appModuleName = ddcModuleName(jsId);
 
   // The name of the entrypoint dart library within the entrypoint JS module.
   //
@@ -52,7 +52,7 @@ Future<Null> bootstrapDdc(BuildStep buildStep,
       var basename = _context.basename(jsId.path);
       return basename.substring(0, basename.length - jsModuleExtension.length);
     } else {
-      Iterable<String> scope = _context.split(_ddcModuleName(jsId));
+      Iterable<String> scope = _context.split(ddcModuleName(jsId));
       if (scope.first == 'packages') {
         scope = scope.skip(1);
       }
@@ -69,7 +69,7 @@ Future<Null> bootstrapDdc(BuildStep buildStep,
     // Strip out the top level dir from the path for any module, and set it to
     // `packages/` for lib modules. We set baseUrl to `/` to simplify things,
     // and we only allow you to serve top level directories.
-    var moduleName = _ddcModuleName(jsId);
+    var moduleName = ddcModuleName(jsId);
     modulePaths[moduleName] = _context.withoutExtension(
         jsId.path.startsWith('lib')
             ? '$moduleName$jsModuleExtension'
@@ -122,15 +122,6 @@ Future<List<Module>> _ensureTransitiveModules(
         'log file.');
   }));
   return transitiveDeps;
-}
-
-/// The module name according to ddc for [jsId] which represents the real js
-/// module file.
-String _ddcModuleName(AssetId jsId) {
-  var jsPath = jsId.path.startsWith('lib/')
-      ? jsId.path.replaceFirst('lib/', 'packages/${jsId.package}/')
-      : jsId.path;
-  return jsPath.substring(0, jsPath.length - jsModuleExtension.length);
 }
 
 /// Code that actually imports the [moduleName] module, and calls the

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -118,11 +118,15 @@ Future _createDevCompilerModule(
   }
 
   // Add all the linked summaries as summary inputs.
-  for (var id in transitiveSummaryDeps) {
+  for (var depModule in transitiveDeps) {
+    var summaryId = useKernel
+        ? depModule.primarySource.changeExtension(ddcKernelExtension)
+        : depModule.linkedSummaryId;
     var summaryPath = useKernel
-        ? p.url.relative(scratchSpace.fileFor(id).path,
-            from: scratchSpace.tempDir.path)
-        : scratchSpace.fileFor(id).path;
+        ? p.url.relative(scratchSpace.fileFor(summaryId).path,
+                from: scratchSpace.tempDir.path) +
+            '=${ddcModuleName(depModule.jsId(jsModuleExtension))}'
+        : scratchSpace.fileFor(summaryId).path;
     request.arguments.addAll(['-s', summaryPath]);
   }
 
@@ -152,6 +156,8 @@ Future _createDevCompilerModule(
     request.arguments.addAll([
       '--packages',
       packagesFile.absolute.uri.toString(),
+      '--module-name',
+      ddcModuleName(module.jsId(jsModuleExtension)),
     ]);
   }
 
@@ -191,4 +197,13 @@ Future _createDevCompilerModule(
           module.jsSourceMapId(jsSourceMapExtension), buildStep);
     }
   }
+}
+
+/// The module name according to ddc for [jsId] which represents the real js
+/// module file.
+String ddcModuleName(AssetId jsId) {
+  var jsPath = jsId.path.startsWith('lib/')
+      ? jsId.path.replaceFirst('lib/', 'packages/${jsId.package}/')
+      : jsId.path;
+  return jsPath.substring(0, jsPath.length - jsModuleExtension.length);
 }


### PR DESCRIPTION
cc @vsmenon

This gets ddk working externally, although you still need a custom build script to enable it.

There is an example in this repo at  https://github.com/dart-lang/build/blob/master/_test/tool/build_kernel_ddc.dart (this can be served with `dart tool/build_kernel_ddc.dart serve web`).

However - it looks like we need to wait for a new dev sdk with some of the other fixes in order for complicated examples to work.