### PR TITLE
Allow PackageAssetReader without package as cwd

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.10.4
 
-- Allow using `PackageAssetReader` when the current working directory is root
-  package's directory. Instead assume the root package uses a pub layout.
+- Allow using `PackageAssetReader` when the current working directory is not the
+  root package directory as long as it uses a pub layout.
 
 ## 0.10.3+4
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.4
+
+- Allow using `PackageAssetReader` when the current working directory is root
+  package's directory. Instead assume the root package uses a pub layout.
+
 ## 0.10.3+4
 
 - Increased the upper bound for `package:analyzer` to `<0.35.0`.

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -78,8 +78,9 @@ class PackageAssetReader extends AssetReader
       return File.fromUri(_packageResolver.resolveUri(id.uri));
     }
     if (id.package == _rootPackage) {
-      // TODO this assumes the cwd is the root package
-      return File(p.canonicalize(p.join(p.current, id.path)));
+      // TODO this assumes the root package uses a pub layout
+      return File(p.canonicalize(
+          p.join(_packageResolver.packagePath(_rootPackage), id.path)));
     }
     throw UnsupportedError('Unabled to resolve $id');
   }
@@ -103,11 +104,12 @@ class PackageAssetReader extends AssetReader
         .map((f) =>
             p.join('lib', p.relative(f.path, from: p.fromUri(packageLibDir))));
     if (package == _rootPackage) {
-      // TODO this assumes the cwd is the root package
-      packageFiles = packageFiles.transform(merge(Directory.current
+      // TODO this assumes the root package uses a pub layout
+      final rootPackagePath = _packageResolver.packagePath(_rootPackage);
+      packageFiles = packageFiles.transform(merge(Directory(rootPackagePath)
           .list(recursive: true)
           .where((e) => e is File)
-          .map((f) => p.relative(f.path, from: Directory.current.path))
+          .map((f) => p.relative(f.path, from: rootPackagePath))
           .where((p) => !(p.startsWith('packages/') || p.startsWith('lib/')))));
     }
     return packageFiles.where(glob.matches).map((p) => AssetId(package, p));

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.3+4
+version: 0.10.4
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 

--- a/build_test/test/package_reader_test.dart
+++ b/build_test/test/package_reader_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:glob/glob.dart';
@@ -22,10 +20,6 @@ void main() {
       reader = await PackageAssetReader.currentIsolate(
         rootPackage: 'build_test',
       );
-      final oldDirectory = Directory.current;
-      addTearDown(() {
-        Directory.current = oldDirectory;
-      });
     });
 
     test('should be able to read `build_test.dart`', () async {
@@ -34,13 +28,7 @@ void main() {
     });
 
     test('should be able to read this file (in test/)', () async {
-      expect(await reader.readAsString(thisFile), isNotEmpty);
-    });
-
-    test('should be able to read this file (in test/) from different cwd',
-        () async {
-      Directory.current = Directory.current.parent;
-      expect(await reader.readAsString(thisFile), isNotEmpty);
+      expect(await reader.canRead(thisFile), isTrue);
     });
 
     test('should not be able to read a missing file', () async {

--- a/build_test/test/package_reader_test.dart
+++ b/build_test/test/package_reader_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:glob/glob.dart';
@@ -20,6 +22,10 @@ void main() {
       reader = await PackageAssetReader.currentIsolate(
         rootPackage: 'build_test',
       );
+      final oldDirectory = Directory.current;
+      addTearDown(() {
+        Directory.current = oldDirectory;
+      });
     });
 
     test('should be able to read `build_test.dart`', () async {
@@ -28,7 +34,13 @@ void main() {
     });
 
     test('should be able to read this file (in test/)', () async {
-      expect(await reader.canRead(thisFile), isTrue);
+      expect(await reader.readAsString(thisFile), isNotEmpty);
+    });
+
+    test('should be able to read this file (in test/) from different cwd',
+        () async {
+      Directory.current = Directory.current.parent;
+      expect(await reader.readAsString(thisFile), isNotEmpty);
     });
 
     test('should not be able to read a missing file', () async {


### PR DESCRIPTION
We can't rely on a pub layout for all packages because when running
tests under a `build_runner` generated output directory we omit the
`lib/` directory for non-root packages. It should be a safe assumption,
however, that the root package uses a pub layout whether we're running
from the actual package, a `build_runner` output, or a bazel test
environment.