### PR TITLE
Use dartdevc --kernel

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+
+- Use `dartdevc --kernel` instead of `dartdevk`.
+
 ## 1.0.4
 
 - Update to `package:graphs` version `0.2.0`.

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -108,8 +108,8 @@ final dartdevcDriverResource =
 BazelWorkerDriver get _dartdevkDriver {
   _dartdevkWorkersAreDoneCompleter ??= Completer<Null>();
   return __dartdevkDriver ??= BazelWorkerDriver(
-      () => Process.start(p.join(sdkDir, 'bin', 'dartdevk$_scriptExtension'),
-          ['--persistent_worker'],
+      () => Process.start(p.join(sdkDir, 'bin', 'dartdevc$_scriptExtension'),
+          ['--kernel', '--persistent_worker'],
           workingDirectory: scratchSpace.tempDir.path),
       maxWorkers: _maxWorkersPerTask);
 }

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_modules
-version: 1.0.4
+version: 1.0.5
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   analyzer: '>0.30.0 <0.35.0'


### PR DESCRIPTION
The dartdevk binary may be removed. The `--kernel` flag has existed
since https://github.com/dart-lang/sdk/commit/d673847bd8c which should
be included in version 2.1.0