### PR TITLE
Add assetIdForElement

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+- Add `Resolver.assetIdForElement` API. This allows finding the Dart source
+  asset which contains the definition of an element found through the analyzer.
+
 ## 1.0.2
 
 - Increased the upper bound for `package:analyzer` to `<0.35.0`.

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -34,6 +34,16 @@ abstract class Resolver {
   /// asset id instead of a named identifier that has the possibility of not
   /// being unique.
   Future<LibraryElement> findLibraryByName(String libraryName);
+
+  /// Returns the [AssetId] of the Dart library or part declaring [element].
+  ///
+  /// If [element] is defined in the SDK or in a summary throws
+  /// `UnresolvableAssetException`, although a non-throwing return here does not
+  /// guarantee that the asset is readable.
+  ///
+  /// The returned asset is not necessarily the asset that should be imported to
+  /// use the element, it may be a part file instead of the library.
+  Future<AssetId> assetIdForElement(Element element);
 }
 
 /// A resolver that should be manually released at the end of a build step.

--- a/build/lib/src/asset/exceptions.dart
+++ b/build/lib/src/asset/exceptions.dart
@@ -46,3 +46,12 @@ class BuildStepCompletedException implements Exception {
   String toString() => 'BuildStepCompletedException: '
       'Attempt to use a BuildStep after is has completed';
 }
+
+class UnresolvableAssetException implements Exception {
+  final String description;
+
+  const UnresolvableAssetException(this.description);
+
+  @override
+  String toString() => 'Unresolvable Asset from $description.';
+}

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -194,4 +194,8 @@ class _DelayedResolver implements Resolver {
   @override
   Future<LibraryElement> findLibraryByName(String libraryName) async =>
       (await _delegate).findLibraryByName(libraryName);
+
+  @override
+  Future<AssetId> assetIdForElement(Element element) async =>
+      (await _delegate).assetIdForElement(element);
 }

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.0.2
+version: 1.1.0
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -17,9 +17,18 @@ dependencies:
   glob: ^1.1.0
 
 dev_dependencies:
-  build_resolvers: ^0.2.2+4
   build_runner: ^1.0.0
   build_test: ^0.10.0
   build_vm_compilers: ^0.1.0
   pedantic: ^1.0.0
   test: ^1.2.0
+
+dependency_overrides:
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core
+  build_modules:
+    path: ../build_modules
+  build_resolvers:
+    path: ../build_resolvers

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+- Update to `build` `1.1.0` and add `assetIdForElement`.
+
 ## 0.2.2+7
 
 - Updated _AssetUriResolver to prepare for a future release of the analyzer.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -66,6 +66,10 @@ class PerActionResolver implements ReleasableResolver {
 
   @override
   void release() => _delegate.release();
+
+  @override
+  Future<AssetId> assetIdForElement(Element element) =>
+      _delegate.assetIdForElement(element);
 }
 
 class AnalyzerResolver implements ReleasableResolver {
@@ -181,6 +185,16 @@ class AnalyzerResolver implements ReleasableResolver {
     // We don't know what libraries to expose without leaking libraries written
     // by later phases.
     throw UnimplementedError();
+  }
+
+  @override
+  Future<AssetId> assetIdForElement(Element element) async {
+    final uri = element.source.uri;
+    if (!uri.isScheme('package') && !uri.isScheme('asset')) {
+      throw UnresolvableAssetException(
+          '${element.name} in ${element.source.uri}');
+    }
+    return AssetId.resolve('${element.source.uri}');
   }
 }
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 0.2.2+7
+version: 0.2.3
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.27.1 <0.35.0"
-  build: ">=0.12.7 <1.1.0"
+  build: ">=1.1.0 <1.2.0"
   path: ^1.1.0
 
 dev_dependencies:
@@ -17,3 +17,7 @@ dev_dependencies:
   build_test: ^0.10.1
   build_runner: ^1.0.0
   build_vm_compilers: ^0.1.0
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -166,5 +166,26 @@ void main() {
         expect(libs.contains('b'), isTrue);
       }, resolvers: AnalyzerResolvers());
     });
+
+    test('assetIdForElement', () {
+      return resolveSources({
+        'a|lib/a.dart': '''
+              import 'b.dart';
+
+              main() {
+                SomeClass();
+              } ''',
+        'a|lib/b.dart': '''
+            class SomeClass {}
+              ''',
+      }, (resolver) async {
+        var entry = await resolver.libraryFor(AssetId('a', 'lib/a.dart'));
+        var classDefinition = entry.importedLibraries
+            .map((l) => l.getType('SomeClass'))
+            .singleWhere((c) => c != null);
+        expect(await resolver.assetIdForElement(classDefinition),
+            AssetId('a', 'lib/b.dart'));
+      }, resolvers: AnalyzerResolvers());
+    });
   });
 }

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -5,6 +5,7 @@
   delete itself when it shouldn't.
 - Add digest string to the asset graph visualization.
 - Added a filter box to the asset graph visualization.
+- Allow `build` version `1.1.x`.
 
 ## 1.1.2
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.0.0 <1.1.0"
+  build: ">=1.1.0 <1.0.0"
   build_config: ^0.3.1
   build_resolvers: ^0.2.0
   build_runner_core: ^1.1.0
@@ -59,3 +59,5 @@ dependency_overrides:
     path: ../build_runner_core
   build_modules:
     path: ../build_modules
+  build:
+    path: ../build

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.1.0 <1.0.0"
+  build: ">=1.0.0 <1.2.0"
   build_config: ^0.3.1
   build_resolvers: ^0.2.0
   build_runner_core: ^1.1.0
@@ -59,5 +59,3 @@ dependency_overrides:
     path: ../build_runner_core
   build_modules:
     path: ../build_modules
-  build:
-    path: ../build

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.3
 
 - Update to `package:graphs` version `0.2.0`.
+- Allow `build` version `1.1.x`.
 
 ## 1.1.2
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.1.0 <1.2.0"
+  build: ">=1.0.0 <1.2.0"
   build_config: ^0.3.1
   build_resolvers: ^0.2.0
   collection: ^1.14.0
@@ -38,7 +38,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build:
-    path: ../build

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.0.0 <1.1.0"
+  build: ">=1.1.0 <1.2.0"
   build_config: ^0.3.1
   build_resolvers: ^0.2.0
   collection: ^1.14.0
@@ -38,3 +38,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build:
+    path: ../build


### PR DESCRIPTION
This replaces some functionality that builders were implementing outside
of the resolver, which then depended on details of the resolver
implementation.

- Add `UnresolavableAssetException`. Eventually we should update
  `AssetId.resolve` to use this exception.
- Add `assetIdForElement` API and implementations in all places
  necessary.
- Bump `build` to version `1.1.0` and update dependencies accordingly.