### PR TITLE
Initial Build Daemon Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,13 +86,23 @@ jobs:
       env: PKG="build_config"
       dart: dev
     - stage: analyze_and_format
+      name: "SDK: dev - DIR: build_daemon - TASKS: [dartfmt -n --set-exit-if-changed ., dartanalyzer --fatal-infos --fatal-warnings .]"
+      script: ./tool/travis.sh dartfmt dartanalyzer
+      env: PKG="build_daemon"
+      dart: dev
+    - stage: unit_test
+      name: "SDK: dev - DIR: build_daemon - TASKS: pub run test"
+      script: ./tool/travis.sh test_06
+      env: PKG="build_daemon"
+      dart: dev
+    - stage: analyze_and_format
       name: "SDK: dev - DIR: build_modules - TASKS: [dartfmt -n --set-exit-if-changed ., dartanalyzer --fatal-infos --fatal-warnings .]"
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="build_modules"
       dart: dev
     - stage: unit_test
       name: "SDK: dev - DIR: build_modules - TASKS: dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs-- -P presubmit"
-      script: ./tool/travis.sh command_4
+      script: ./tool/travis.sh command_5
       env: PKG="build_modules"
       dart: dev
     - stage: analyze_and_format

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,7 +24,7 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
+    #- avoid_returning_null
     - avoid_shadowing_type_parameters
     - avoid_types_as_parameter_names
     - avoid_unused_constructor_parameters

--- a/build_daemon/bin/build_daemon.dart
+++ b/build_daemon/bin/build_daemon.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:build_daemon/constants.dart';
+import 'package:build_daemon/src/daemon.dart';
+import 'package:build_daemon/daemon_builder.dart';
+import 'package:watcher/watcher.dart';
+
+/// Entrypoint for the Dart Build Daemon.
+Future main(List<String> args) async {
+  var workingDirectory = args[0];
+
+  var daemon = Daemon(workingDirectory);
+
+  if (!daemon.tryGetLock()) {
+    if (runningVersion(workingDirectory) == currentVersion) {
+      print('Daemon is already running.');
+      print(readyToConnectLog);
+    } else {
+      print(versionSkew);
+    }
+  } else {
+    print('Starting daemon...');
+    // TODO(grouma) - Create a real builder for package:build
+    var builder = DaemonBuilder();
+    var watcher = Watcher(workingDirectory);
+    await daemon.start(builder, watcher.events);
+    print(readyToConnectLog);
+    await daemon.onDone;
+  }
+}

--- a/build_daemon/bin/build_daemon.dart
+++ b/build_daemon/bin/build_daemon.dart
@@ -7,7 +7,7 @@ import 'package:watcher/watcher.dart';
 
 /// Entrypoint for the Dart Build Daemon.
 Future main(List<String> args) async {
-  var workingDirectory = args[0];
+  var workingDirectory = args.first;
 
   var daemon = Daemon(workingDirectory);
 

--- a/build_daemon/example/example.dart
+++ b/build_daemon/example/example.dart
@@ -23,7 +23,7 @@ void main(List<String> args) async {
     client.registerBuildTarget('/some/test/path', []);
     print('Registered test target...');
   }
-  client.buildResultsStream.listen((status) => print('BUILD STATUS: $status'));
+  client.buildResults.listen((status) => print('BUILD STATUS: $status'));
   client.startBuild();
   await client.finished;
 }

--- a/build_daemon/example/example.dart
+++ b/build_daemon/example/example.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:build_daemon/client.dart';
+
+void main(List<String> args) async {
+  BuildDaemonClient client;
+  var workingDirectory = Directory.current.path;
+  try {
+    client = await BuildDaemonClient.connect(workingDirectory);
+  } on VersionSkew {
+    print('Version skew. Please disconnect all other clients '
+        'before trying to start a new one.');
+    exit(1);
+  }
+  if (client == null) throw Exception('Error connecting');
+  print('Connected to Dart Build Daemon');
+  if (Random().nextBool()) {
+    client.registerBuildTarget('/some/client/path', [r'.*_test\.dart$']);
+    client.addBuildOptions(['--define=DART_CHECKS=none']);
+    print('Registered example client target...');
+  } else {
+    client.registerBuildTarget('/some/test/path', []);
+    print('Registered test target...');
+  }
+  client.buildResultsStream.listen((status) => print('BUILD STATUS: $status'));
+  client.startBuild();
+  await client.finished;
+}

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:web_socket_channel/io.dart';
+
+import 'constants.dart';
+import 'data/build_options_request.dart';
+import 'data/build_request.dart';
+import 'data/build_status.dart';
+import 'data/build_target_request.dart';
+import 'data/log_to_paths_request.dart';
+import 'data/serializers.dart';
+import 'data/server_log.dart';
+
+class BuildDaemonClient {
+  IOWebSocketChannel _channel;
+
+  final _buildResultsStreamController =
+      StreamController<BuildResults>.broadcast();
+
+  final _serverLogStreamController = StreamController<ServerLog>.broadcast();
+
+  BuildDaemonClient._();
+
+  Stream<BuildResults> get buildResultsStream =>
+      _buildResultsStreamController.stream;
+  Future<void> get finished async {
+    if (_channel != null) await _channel.sink.done;
+  }
+
+  Stream<ServerLog> get serverLogs => _serverLogStreamController.stream;
+
+  /// Adds a list of build options to be used for all builds.
+  ///
+  /// When this client disconnects these options will no longer be used by the
+  /// build daemon.
+  void addBuildOptions(Iterable<String> options) {
+    var request = BuildOptionsRequest((b) => b..options.replace(options));
+    _channel.sink.add(jsonEncode(serializers.serialize(request)));
+  }
+
+  /// Adds paths to write usage logs to.
+  ///
+  /// When the client disconnects these files will no longer be logged to.
+  void logToPaths(Iterable<String> paths) {
+    var request = LogToPathsRequest((b) => b..paths.replace(paths));
+    _channel.sink.add(jsonEncode(serializers.serialize(request)));
+  }
+
+  /// Registers a build target to be built upon any file change.
+  ///
+  /// Changes that match the patterns in [blackListPattern] will be ignored.
+  ///
+  /// Note that you should provide the "fully qualified" target name. For
+  /// example one should provide //some-target:test_run instead of
+  /// //some-target:test.
+  void registerBuildTarget(String target, Iterable<String> blackListPattern) {
+    var request = BuildTargetRequest((b) => b
+      ..target = target
+      ..blackListPattern.replace(blackListPattern));
+    _channel.sink.add(jsonEncode(serializers.serialize(request)));
+  }
+
+  /// Builds all registered targets.
+  void startBuild() {
+    var request = BuildRequest();
+    _channel.sink.add(jsonEncode(serializers.serialize(request)));
+  }
+
+  Future<void> _connect(String workingDirectory, int port) async {
+    _channel = IOWebSocketChannel.connect('ws://localhost:$port');
+    _channel.stream.listen(_handleServerMessage)
+      // TODO(grouma) - Implement proper error handling.
+      ..onError(print);
+  }
+
+  void _handleServerMessage(dynamic data) {
+    var message = serializers.deserialize(jsonDecode(data as String));
+    if (message is ServerLog) {
+      _serverLogStreamController.add(message);
+    } else if (message is BuildResults) {
+      _buildResultsStreamController.add(message);
+    } else {
+      // In practice we should never reach this state due to the
+      // deserialize call.
+      throw StateError(
+          'Unexpected message from the Dart Build Daemon\n $message');
+    }
+  }
+
+  static Future<BuildDaemonClient> connect(String workingDirectory,
+      {String daemonCommand = ''}) async {
+    Process process;
+    if (daemonCommand.isEmpty) {
+      process = await Process.start(
+          'pub', ['run', 'build_daemon', workingDirectory],
+          mode: ProcessStartMode.detachedWithStdio);
+    } else {
+      process = await Process.start(daemonCommand, [workingDirectory],
+          mode: ProcessStartMode.detachedWithStdio);
+    }
+    // Print errors coming from the Dart Build Daemon to help with debugging.
+    process.stderr.transform(utf8.decoder).listen(print);
+    var result = await process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .firstWhere((line) => line == versionSkew || line == readyToConnectLog);
+
+    if (result == versionSkew) {
+      throw VersionSkew();
+    }
+
+    var port = _existingPort(workingDirectory);
+    if (port == null) return null;
+    var client = BuildDaemonClient._();
+    await client._connect(workingDirectory, port);
+    return client;
+  }
+
+  static int _existingPort(String workingDirectory) {
+    var portFile = File('${daemonWorkspace(workingDirectory)}'
+        '/.dart_build_daemon_port');
+    if (!portFile.existsSync()) return null;
+    return int.parse(portFile.readAsStringSync());
+  }
+}
+
+class VersionSkew extends Error {}

--- a/build_daemon/lib/constants.dart
+++ b/build_daemon/lib/constants.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+const readyToConnectLog = 'READY TO CONNECT';
+
+const versionSkew = 'DIFFERENT RUNNING VERSION';
+
+// TODO(grouma) - use pubspec version when this is open sourced.
+const currentVersion = '1.0.0';
+
+String daemonWorkspace(String workingDirectory) =>
+    '${Directory.systemTemp.path}/dart_build_daemon/'
+    '${workingDirectory.replaceAll("/", "_")}';
+
+/// Used to ensure that only one instance of this daemon is running at a time.
+String lockFilePath(String workingDirectory) =>
+    '${daemonWorkspace(workingDirectory)}/.dart_build_lock';
+
+/// Used to signal to clients on what port the running daemon is listening.
+String portFilePath(String workingDirectory) =>
+    '${daemonWorkspace(workingDirectory)}/.dart_build_daemon_port';
+
+/// Used to signal to clients the current version of the build daemon.
+String versionFilePath(String workingDirectory) =>
+    '${daemonWorkspace(workingDirectory)}/.dart_build_daemon_version';

--- a/build_daemon/lib/daemon_builder.dart
+++ b/build_daemon/lib/daemon_builder.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+import 'data/build_status.dart';
+import 'data/server_log.dart';
+
+class DaemonBuilder {
+  Stream<BuildResults> get builds => Stream.empty();
+
+  Stream<ServerLog> get logs => Stream.empty();
+
+  Future<void> build(
+      Set<String> targets, Set<String> options, Set<String> logToPaths) async {}
+
+  Future<void> stop() async {}
+}

--- a/build_daemon/lib/data/build_options_request.dart
+++ b/build_daemon/lib/data/build_options_request.dart
@@ -1,0 +1,18 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'build_options_request.g.dart';
+
+abstract class BuildOptionsRequest
+    implements Built<BuildOptionsRequest, BuildOptionsRequestBuilder> {
+  static Serializer<BuildOptionsRequest> get serializer =>
+      _$buildOptionsRequestSerializer;
+
+  factory BuildOptionsRequest([updates(BuildOptionsRequestBuilder b)]) =
+      _$BuildOptionsRequest;
+
+  BuildOptionsRequest._();
+
+  BuiltList<String> get options;
+}

--- a/build_daemon/lib/data/build_options_request.g.dart
+++ b/build_daemon/lib/data/build_options_request.g.dart
@@ -1,0 +1,152 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'build_options_request.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<BuildOptionsRequest> _$buildOptionsRequestSerializer =
+    new _$BuildOptionsRequestSerializer();
+
+class _$BuildOptionsRequestSerializer
+    implements StructuredSerializer<BuildOptionsRequest> {
+  @override
+  final Iterable<Type> types = const [
+    BuildOptionsRequest,
+    _$BuildOptionsRequest
+  ];
+  @override
+  final String wireName = 'BuildOptionsRequest';
+
+  @override
+  Iterable serialize(Serializers serializers, BuildOptionsRequest object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'options',
+      serializers.serialize(object.options,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  BuildOptionsRequest deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new BuildOptionsRequestBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      switch (key) {
+        case 'options':
+          result.options.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(String)]))
+              as BuiltList);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BuildOptionsRequest extends BuildOptionsRequest {
+  @override
+  final BuiltList<String> options;
+
+  factory _$BuildOptionsRequest([void updates(BuildOptionsRequestBuilder b)]) =>
+      (new BuildOptionsRequestBuilder()..update(updates)).build();
+
+  _$BuildOptionsRequest._({this.options}) : super._() {
+    if (options == null) {
+      throw new BuiltValueNullFieldError('BuildOptionsRequest', 'options');
+    }
+  }
+
+  @override
+  BuildOptionsRequest rebuild(void updates(BuildOptionsRequestBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BuildOptionsRequestBuilder toBuilder() =>
+      new BuildOptionsRequestBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BuildOptionsRequest && options == other.options;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, options.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('BuildOptionsRequest')
+          ..add('options', options))
+        .toString();
+  }
+}
+
+class BuildOptionsRequestBuilder
+    implements Builder<BuildOptionsRequest, BuildOptionsRequestBuilder> {
+  _$BuildOptionsRequest _$v;
+
+  ListBuilder<String> _options;
+  ListBuilder<String> get options =>
+      _$this._options ??= new ListBuilder<String>();
+  set options(ListBuilder<String> options) => _$this._options = options;
+
+  BuildOptionsRequestBuilder();
+
+  BuildOptionsRequestBuilder get _$this {
+    if (_$v != null) {
+      _options = _$v.options?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BuildOptionsRequest other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$BuildOptionsRequest;
+  }
+
+  @override
+  void update(void updates(BuildOptionsRequestBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$BuildOptionsRequest build() {
+    _$BuildOptionsRequest _$result;
+    try {
+      _$result = _$v ?? new _$BuildOptionsRequest._(options: options.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'options';
+        options.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'BuildOptionsRequest', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/build_daemon/lib/data/build_request.dart
+++ b/build_daemon/lib/data/build_request.dart
@@ -1,0 +1,13 @@
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'build_request.g.dart';
+
+abstract class BuildRequest
+    implements Built<BuildRequest, BuildRequestBuilder> {
+  static Serializer<BuildRequest> get serializer => _$buildRequestSerializer;
+
+  factory BuildRequest([updates(BuildRequestBuilder b)]) = _$BuildRequest;
+
+  BuildRequest._();
+}

--- a/build_daemon/lib/data/build_request.g.dart
+++ b/build_daemon/lib/data/build_request.g.dart
@@ -1,0 +1,88 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'build_request.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<BuildRequest> _$buildRequestSerializer =
+    new _$BuildRequestSerializer();
+
+class _$BuildRequestSerializer implements StructuredSerializer<BuildRequest> {
+  @override
+  final Iterable<Type> types = const [BuildRequest, _$BuildRequest];
+  @override
+  final String wireName = 'BuildRequest';
+
+  @override
+  Iterable serialize(Serializers serializers, BuildRequest object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return <Object>[];
+  }
+
+  @override
+  BuildRequest deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return new BuildRequestBuilder().build();
+  }
+}
+
+class _$BuildRequest extends BuildRequest {
+  factory _$BuildRequest([void updates(BuildRequestBuilder b)]) =>
+      (new BuildRequestBuilder()..update(updates)).build();
+
+  _$BuildRequest._() : super._();
+
+  @override
+  BuildRequest rebuild(void updates(BuildRequestBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BuildRequestBuilder toBuilder() => new BuildRequestBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BuildRequest;
+  }
+
+  @override
+  int get hashCode {
+    return 52408894;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper('BuildRequest').toString();
+  }
+}
+
+class BuildRequestBuilder
+    implements Builder<BuildRequest, BuildRequestBuilder> {
+  _$BuildRequest _$v;
+
+  BuildRequestBuilder();
+
+  @override
+  void replace(BuildRequest other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$BuildRequest;
+  }
+
+  @override
+  void update(void updates(BuildRequestBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$BuildRequest build() {
+    final _$result = _$v ?? new _$BuildRequest._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/build_daemon/lib/data/build_status.dart
+++ b/build_daemon/lib/data/build_status.dart
@@ -1,0 +1,45 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'build_status.g.dart';
+
+class BuildStatus extends EnumClass {
+  static const BuildStatus started = _$started;
+  static const BuildStatus succeeded = _$succeeded;
+  static const BuildStatus failed = _$failed;
+
+  static Serializer<BuildStatus> get serializer => _$buildStatusSerializer;
+
+  const BuildStatus._(String name) : super(name);
+  static BuildStatus valueOf(String name) => _$valueOf(name);
+  static BuiltSet<BuildStatus> get values => _$values;
+}
+
+abstract class BuildResult implements Built<BuildResult, BuildResultBuilder> {
+  static Serializer<BuildResult> get serializer => _$buildResultSerializer;
+
+  factory BuildResult([updates(BuildResultBuilder b)]) = _$BuildResult;
+
+  BuildResult._();
+
+  BuildStatus get status;
+  String get target;
+  @nullable
+  String get buildId;
+  @nullable
+  String get error;
+  @nullable
+  bool get isCached;
+}
+
+abstract class BuildResults
+    implements Built<BuildResults, BuildResultsBuilder> {
+  static Serializer<BuildResults> get serializer => _$buildResultsSerializer;
+
+  factory BuildResults([updates(BuildResultsBuilder b)]) = _$BuildResults;
+
+  BuildResults._();
+
+  BuiltList<BuildResult> get results;
+}

--- a/build_daemon/lib/data/build_status.g.dart
+++ b/build_daemon/lib/data/build_status.g.dart
@@ -1,0 +1,397 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'build_status.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+const BuildStatus _$started = const BuildStatus._('started');
+const BuildStatus _$succeeded = const BuildStatus._('succeeded');
+const BuildStatus _$failed = const BuildStatus._('failed');
+
+BuildStatus _$valueOf(String name) {
+  switch (name) {
+    case 'started':
+      return _$started;
+    case 'succeeded':
+      return _$succeeded;
+    case 'failed':
+      return _$failed;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<BuildStatus> _$values =
+    new BuiltSet<BuildStatus>(const <BuildStatus>[
+  _$started,
+  _$succeeded,
+  _$failed,
+]);
+
+Serializer<BuildStatus> _$buildStatusSerializer = new _$BuildStatusSerializer();
+Serializer<BuildResult> _$buildResultSerializer = new _$BuildResultSerializer();
+Serializer<BuildResults> _$buildResultsSerializer =
+    new _$BuildResultsSerializer();
+
+class _$BuildStatusSerializer implements PrimitiveSerializer<BuildStatus> {
+  @override
+  final Iterable<Type> types = const <Type>[BuildStatus];
+  @override
+  final String wireName = 'BuildStatus';
+
+  @override
+  Object serialize(Serializers serializers, BuildStatus object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
+
+  @override
+  BuildStatus deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      BuildStatus.valueOf(serialized as String);
+}
+
+class _$BuildResultSerializer implements StructuredSerializer<BuildResult> {
+  @override
+  final Iterable<Type> types = const [BuildResult, _$BuildResult];
+  @override
+  final String wireName = 'BuildResult';
+
+  @override
+  Iterable serialize(Serializers serializers, BuildResult object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'status',
+      serializers.serialize(object.status,
+          specifiedType: const FullType(BuildStatus)),
+      'target',
+      serializers.serialize(object.target,
+          specifiedType: const FullType(String)),
+    ];
+    if (object.buildId != null) {
+      result
+        ..add('buildId')
+        ..add(serializers.serialize(object.buildId,
+            specifiedType: const FullType(String)));
+    }
+    if (object.error != null) {
+      result
+        ..add('error')
+        ..add(serializers.serialize(object.error,
+            specifiedType: const FullType(String)));
+    }
+    if (object.isCached != null) {
+      result
+        ..add('isCached')
+        ..add(serializers.serialize(object.isCached,
+            specifiedType: const FullType(bool)));
+    }
+
+    return result;
+  }
+
+  @override
+  BuildResult deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new BuildResultBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      switch (key) {
+        case 'status':
+          result.status = serializers.deserialize(value,
+              specifiedType: const FullType(BuildStatus)) as BuildStatus;
+          break;
+        case 'target':
+          result.target = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'buildId':
+          result.buildId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'error':
+          result.error = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+        case 'isCached':
+          result.isCached = serializers.deserialize(value,
+              specifiedType: const FullType(bool)) as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BuildResultsSerializer implements StructuredSerializer<BuildResults> {
+  @override
+  final Iterable<Type> types = const [BuildResults, _$BuildResults];
+  @override
+  final String wireName = 'BuildResults';
+
+  @override
+  Iterable serialize(Serializers serializers, BuildResults object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'results',
+      serializers.serialize(object.results,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(BuildResult)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  BuildResults deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new BuildResultsBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      switch (key) {
+        case 'results':
+          result.results.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(BuildResult)]))
+              as BuiltList);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BuildResult extends BuildResult {
+  @override
+  final BuildStatus status;
+  @override
+  final String target;
+  @override
+  final String buildId;
+  @override
+  final String error;
+  @override
+  final bool isCached;
+
+  factory _$BuildResult([void updates(BuildResultBuilder b)]) =>
+      (new BuildResultBuilder()..update(updates)).build();
+
+  _$BuildResult._(
+      {this.status, this.target, this.buildId, this.error, this.isCached})
+      : super._() {
+    if (status == null) {
+      throw new BuiltValueNullFieldError('BuildResult', 'status');
+    }
+    if (target == null) {
+      throw new BuiltValueNullFieldError('BuildResult', 'target');
+    }
+  }
+
+  @override
+  BuildResult rebuild(void updates(BuildResultBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BuildResultBuilder toBuilder() => new BuildResultBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BuildResult &&
+        status == other.status &&
+        target == other.target &&
+        buildId == other.buildId &&
+        error == other.error &&
+        isCached == other.isCached;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(
+        $jc(
+            $jc($jc($jc(0, status.hashCode), target.hashCode),
+                buildId.hashCode),
+            error.hashCode),
+        isCached.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('BuildResult')
+          ..add('status', status)
+          ..add('target', target)
+          ..add('buildId', buildId)
+          ..add('error', error)
+          ..add('isCached', isCached))
+        .toString();
+  }
+}
+
+class BuildResultBuilder implements Builder<BuildResult, BuildResultBuilder> {
+  _$BuildResult _$v;
+
+  BuildStatus _status;
+  BuildStatus get status => _$this._status;
+  set status(BuildStatus status) => _$this._status = status;
+
+  String _target;
+  String get target => _$this._target;
+  set target(String target) => _$this._target = target;
+
+  String _buildId;
+  String get buildId => _$this._buildId;
+  set buildId(String buildId) => _$this._buildId = buildId;
+
+  String _error;
+  String get error => _$this._error;
+  set error(String error) => _$this._error = error;
+
+  bool _isCached;
+  bool get isCached => _$this._isCached;
+  set isCached(bool isCached) => _$this._isCached = isCached;
+
+  BuildResultBuilder();
+
+  BuildResultBuilder get _$this {
+    if (_$v != null) {
+      _status = _$v.status;
+      _target = _$v.target;
+      _buildId = _$v.buildId;
+      _error = _$v.error;
+      _isCached = _$v.isCached;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BuildResult other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$BuildResult;
+  }
+
+  @override
+  void update(void updates(BuildResultBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$BuildResult build() {
+    final _$result = _$v ??
+        new _$BuildResult._(
+            status: status,
+            target: target,
+            buildId: buildId,
+            error: error,
+            isCached: isCached);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$BuildResults extends BuildResults {
+  @override
+  final BuiltList<BuildResult> results;
+
+  factory _$BuildResults([void updates(BuildResultsBuilder b)]) =>
+      (new BuildResultsBuilder()..update(updates)).build();
+
+  _$BuildResults._({this.results}) : super._() {
+    if (results == null) {
+      throw new BuiltValueNullFieldError('BuildResults', 'results');
+    }
+  }
+
+  @override
+  BuildResults rebuild(void updates(BuildResultsBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BuildResultsBuilder toBuilder() => new BuildResultsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BuildResults && results == other.results;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, results.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('BuildResults')
+          ..add('results', results))
+        .toString();
+  }
+}
+
+class BuildResultsBuilder
+    implements Builder<BuildResults, BuildResultsBuilder> {
+  _$BuildResults _$v;
+
+  ListBuilder<BuildResult> _results;
+  ListBuilder<BuildResult> get results =>
+      _$this._results ??= new ListBuilder<BuildResult>();
+  set results(ListBuilder<BuildResult> results) => _$this._results = results;
+
+  BuildResultsBuilder();
+
+  BuildResultsBuilder get _$this {
+    if (_$v != null) {
+      _results = _$v.results?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BuildResults other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$BuildResults;
+  }
+
+  @override
+  void update(void updates(BuildResultsBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$BuildResults build() {
+    _$BuildResults _$result;
+    try {
+      _$result = _$v ?? new _$BuildResults._(results: results.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'results';
+        results.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'BuildResults', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/build_daemon/lib/data/build_target_request.dart
+++ b/build_daemon/lib/data/build_target_request.dart
@@ -1,0 +1,19 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'build_target_request.g.dart';
+
+abstract class BuildTargetRequest
+    implements Built<BuildTargetRequest, BuildTargetRequestBuilder> {
+  static Serializer<BuildTargetRequest> get serializer =>
+      _$buildTargetRequestSerializer;
+
+  factory BuildTargetRequest([updates(BuildTargetRequestBuilder b)]) =
+      _$BuildTargetRequest;
+
+  BuildTargetRequest._();
+
+  BuiltList<String> get blackListPattern;
+  String get target;
+}

--- a/build_daemon/lib/data/build_target_request.g.dart
+++ b/build_daemon/lib/data/build_target_request.g.dart
@@ -1,0 +1,173 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'build_target_request.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<BuildTargetRequest> _$buildTargetRequestSerializer =
+    new _$BuildTargetRequestSerializer();
+
+class _$BuildTargetRequestSerializer
+    implements StructuredSerializer<BuildTargetRequest> {
+  @override
+  final Iterable<Type> types = const [BuildTargetRequest, _$BuildTargetRequest];
+  @override
+  final String wireName = 'BuildTargetRequest';
+
+  @override
+  Iterable serialize(Serializers serializers, BuildTargetRequest object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'blackListPattern',
+      serializers.serialize(object.blackListPattern,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(String)])),
+      'target',
+      serializers.serialize(object.target,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  BuildTargetRequest deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new BuildTargetRequestBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      switch (key) {
+        case 'blackListPattern':
+          result.blackListPattern.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(String)]))
+              as BuiltList);
+          break;
+        case 'target':
+          result.target = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BuildTargetRequest extends BuildTargetRequest {
+  @override
+  final BuiltList<String> blackListPattern;
+  @override
+  final String target;
+
+  factory _$BuildTargetRequest([void updates(BuildTargetRequestBuilder b)]) =>
+      (new BuildTargetRequestBuilder()..update(updates)).build();
+
+  _$BuildTargetRequest._({this.blackListPattern, this.target}) : super._() {
+    if (blackListPattern == null) {
+      throw new BuiltValueNullFieldError(
+          'BuildTargetRequest', 'blackListPattern');
+    }
+    if (target == null) {
+      throw new BuiltValueNullFieldError('BuildTargetRequest', 'target');
+    }
+  }
+
+  @override
+  BuildTargetRequest rebuild(void updates(BuildTargetRequestBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BuildTargetRequestBuilder toBuilder() =>
+      new BuildTargetRequestBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BuildTargetRequest &&
+        blackListPattern == other.blackListPattern &&
+        target == other.target;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc($jc(0, blackListPattern.hashCode), target.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('BuildTargetRequest')
+          ..add('blackListPattern', blackListPattern)
+          ..add('target', target))
+        .toString();
+  }
+}
+
+class BuildTargetRequestBuilder
+    implements Builder<BuildTargetRequest, BuildTargetRequestBuilder> {
+  _$BuildTargetRequest _$v;
+
+  ListBuilder<String> _blackListPattern;
+  ListBuilder<String> get blackListPattern =>
+      _$this._blackListPattern ??= new ListBuilder<String>();
+  set blackListPattern(ListBuilder<String> blackListPattern) =>
+      _$this._blackListPattern = blackListPattern;
+
+  String _target;
+  String get target => _$this._target;
+  set target(String target) => _$this._target = target;
+
+  BuildTargetRequestBuilder();
+
+  BuildTargetRequestBuilder get _$this {
+    if (_$v != null) {
+      _blackListPattern = _$v.blackListPattern?.toBuilder();
+      _target = _$v.target;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BuildTargetRequest other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$BuildTargetRequest;
+  }
+
+  @override
+  void update(void updates(BuildTargetRequestBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$BuildTargetRequest build() {
+    _$BuildTargetRequest _$result;
+    try {
+      _$result = _$v ??
+          new _$BuildTargetRequest._(
+              blackListPattern: blackListPattern.build(), target: target);
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'blackListPattern';
+        blackListPattern.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'BuildTargetRequest', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/build_daemon/lib/data/log_to_paths_request.dart
+++ b/build_daemon/lib/data/log_to_paths_request.dart
@@ -1,0 +1,18 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'log_to_paths_request.g.dart';
+
+abstract class LogToPathsRequest
+    implements Built<LogToPathsRequest, LogToPathsRequestBuilder> {
+  static Serializer<LogToPathsRequest> get serializer =>
+      _$logToPathsRequestSerializer;
+
+  factory LogToPathsRequest([updates(LogToPathsRequestBuilder b)]) =
+      _$LogToPathsRequest;
+
+  LogToPathsRequest._();
+
+  BuiltList<String> get paths;
+}

--- a/build_daemon/lib/data/log_to_paths_request.g.dart
+++ b/build_daemon/lib/data/log_to_paths_request.g.dart
@@ -1,0 +1,148 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'log_to_paths_request.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<LogToPathsRequest> _$logToPathsRequestSerializer =
+    new _$LogToPathsRequestSerializer();
+
+class _$LogToPathsRequestSerializer
+    implements StructuredSerializer<LogToPathsRequest> {
+  @override
+  final Iterable<Type> types = const [LogToPathsRequest, _$LogToPathsRequest];
+  @override
+  final String wireName = 'LogToPathsRequest';
+
+  @override
+  Iterable serialize(Serializers serializers, LogToPathsRequest object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'paths',
+      serializers.serialize(object.paths,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  LogToPathsRequest deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new LogToPathsRequestBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      switch (key) {
+        case 'paths':
+          result.paths.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(String)]))
+              as BuiltList);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$LogToPathsRequest extends LogToPathsRequest {
+  @override
+  final BuiltList<String> paths;
+
+  factory _$LogToPathsRequest([void updates(LogToPathsRequestBuilder b)]) =>
+      (new LogToPathsRequestBuilder()..update(updates)).build();
+
+  _$LogToPathsRequest._({this.paths}) : super._() {
+    if (paths == null) {
+      throw new BuiltValueNullFieldError('LogToPathsRequest', 'paths');
+    }
+  }
+
+  @override
+  LogToPathsRequest rebuild(void updates(LogToPathsRequestBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  LogToPathsRequestBuilder toBuilder() =>
+      new LogToPathsRequestBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is LogToPathsRequest && paths == other.paths;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, paths.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('LogToPathsRequest')
+          ..add('paths', paths))
+        .toString();
+  }
+}
+
+class LogToPathsRequestBuilder
+    implements Builder<LogToPathsRequest, LogToPathsRequestBuilder> {
+  _$LogToPathsRequest _$v;
+
+  ListBuilder<String> _paths;
+  ListBuilder<String> get paths => _$this._paths ??= new ListBuilder<String>();
+  set paths(ListBuilder<String> paths) => _$this._paths = paths;
+
+  LogToPathsRequestBuilder();
+
+  LogToPathsRequestBuilder get _$this {
+    if (_$v != null) {
+      _paths = _$v.paths?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(LogToPathsRequest other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$LogToPathsRequest;
+  }
+
+  @override
+  void update(void updates(LogToPathsRequestBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$LogToPathsRequest build() {
+    _$LogToPathsRequest _$result;
+    try {
+      _$result = _$v ?? new _$LogToPathsRequest._(paths: paths.build());
+    } catch (_) {
+      String _$failedField;
+      try {
+        _$failedField = 'paths';
+        paths.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            'LogToPathsRequest', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/build_daemon/lib/data/serializers.dart
+++ b/build_daemon/lib/data/serializers.dart
@@ -1,0 +1,23 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'build_options_request.dart';
+import 'build_request.dart';
+import 'build_status.dart';
+import 'build_target_request.dart';
+import 'log_to_paths_request.dart';
+import 'server_log.dart';
+
+part 'serializers.g.dart';
+
+/// Serializers for all the types used in Dart Build Daemon communication.
+@SerializersFor([
+  BuildRequest,
+  BuildStatus,
+  BuildResult,
+  BuildResults,
+  BuildTargetRequest,
+  BuildOptionsRequest,
+  LogToPathsRequest,
+  ServerLog,
+])
+final Serializers serializers = _$serializers;

--- a/build_daemon/lib/data/serializers.g.dart
+++ b/build_daemon/lib/data/serializers.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'serializers.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializers _$serializers = (new Serializers().toBuilder()
+      ..add(BuildOptionsRequest.serializer)
+      ..add(BuildRequest.serializer)
+      ..add(BuildResult.serializer)
+      ..add(BuildResults.serializer)
+      ..add(BuildStatus.serializer)
+      ..add(BuildTargetRequest.serializer)
+      ..add(LogToPathsRequest.serializer)
+      ..add(ServerLog.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(BuildResult)]),
+          () => new ListBuilder<BuildResult>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => new ListBuilder<String>()))
+    .build();
+
+// ignore_for_file: always_put_control_body_on_new_line,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/build_daemon/lib/data/server_log.dart
+++ b/build_daemon/lib/data/server_log.dart
@@ -1,0 +1,13 @@
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'server_log.g.dart';
+
+abstract class ServerLog implements Built<ServerLog, ServerLogBuilder> {
+  static Serializer<ServerLog> get serializer => _$serverLogSerializer;
+
+  factory ServerLog([updates(ServerLogBuilder b)]) = _$ServerLog;
+
+  ServerLog._();
+  String get log;
+}

--- a/build_daemon/lib/data/server_log.g.dart
+++ b/build_daemon/lib/data/server_log.g.dart
@@ -1,0 +1,126 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'server_log.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<ServerLog> _$serverLogSerializer = new _$ServerLogSerializer();
+
+class _$ServerLogSerializer implements StructuredSerializer<ServerLog> {
+  @override
+  final Iterable<Type> types = const [ServerLog, _$ServerLog];
+  @override
+  final String wireName = 'ServerLog';
+
+  @override
+  Iterable serialize(Serializers serializers, ServerLog object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object>[
+      'log',
+      serializers.serialize(object.log, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ServerLog deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new ServerLogBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final dynamic value = iterator.current;
+      switch (key) {
+        case 'log':
+          result.log = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ServerLog extends ServerLog {
+  @override
+  final String log;
+
+  factory _$ServerLog([void updates(ServerLogBuilder b)]) =>
+      (new ServerLogBuilder()..update(updates)).build();
+
+  _$ServerLog._({this.log}) : super._() {
+    if (log == null) {
+      throw new BuiltValueNullFieldError('ServerLog', 'log');
+    }
+  }
+
+  @override
+  ServerLog rebuild(void updates(ServerLogBuilder b)) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ServerLogBuilder toBuilder() => new ServerLogBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ServerLog && log == other.log;
+  }
+
+  @override
+  int get hashCode {
+    return $jf($jc(0, log.hashCode));
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper('ServerLog')..add('log', log))
+        .toString();
+  }
+}
+
+class ServerLogBuilder implements Builder<ServerLog, ServerLogBuilder> {
+  _$ServerLog _$v;
+
+  String _log;
+  String get log => _$this._log;
+  set log(String log) => _$this._log = log;
+
+  ServerLogBuilder();
+
+  ServerLogBuilder get _$this {
+    if (_$v != null) {
+      _log = _$v.log;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ServerLog other) {
+    if (other == null) {
+      throw new ArgumentError.notNull('other');
+    }
+    _$v = other as _$ServerLog;
+  }
+
+  @override
+  void update(void updates(ServerLogBuilder b)) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _$ServerLog build() {
+    final _$result = _$v ?? new _$ServerLog._(log: log);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: always_put_control_body_on_new_line,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,lines_longer_than_80_chars,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new

--- a/build_daemon/lib/src/daemon.dart
+++ b/build_daemon/lib/src/daemon.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:pedantic/pedantic.dart';
+import 'package:watcher/watcher.dart';
+
+import '../constants.dart';
+import '../daemon_builder.dart';
+import 'server.dart';
+
+/// Returns the current version of the running build daemon. Null if one isn't
+/// running.
+String runningVersion(String workingDirectory) {
+  var versionFile = File(versionFilePath(workingDirectory));
+  if (!versionFile.existsSync()) return null;
+  return versionFile.readAsStringSync();
+}
+
+class Daemon {
+  final String _workingDirectory;
+
+  final _doneCompleter = Completer();
+
+  Server _server;
+  StreamSubscription _sub;
+
+  Daemon(this._workingDirectory);
+
+  Future<void> get onDone => _doneCompleter.future;
+
+  Future<void> start(DaemonBuilder builder, Stream<WatchEvent> changes) async {
+    if (_server != null) return;
+    _handleGracefulExit();
+
+    _createVersionFile();
+
+    _server = Server(builder, changes);
+    var port = await _server.listen();
+    _createPortFile(port);
+
+    unawaited(_server.onDone.then((_) async {
+      await _cleanUp();
+    }));
+  }
+
+  bool tryGetLock() {
+    try {
+      _createDaemonWorkspace();
+      File(lockFilePath(_workingDirectory))
+          .openSync(mode: FileMode.write)
+          .lockSync();
+      return true;
+    } on FileSystemException {
+      return false;
+    }
+  }
+
+  Future<void> _cleanUp() async {
+    await _server?.stop();
+    await _sub?.cancel();
+    var workspace = Directory(daemonWorkspace(_workingDirectory));
+    if (workspace.existsSync()) {
+      workspace.deleteSync(recursive: true);
+    }
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+
+  void _createDaemonWorkspace() {
+    try {
+      Directory(daemonWorkspace(_workingDirectory)).createSync(recursive: true);
+    } catch (e) {
+      throw Exception('Unable to create daemon workspace: $e');
+    }
+  }
+
+  void _createPortFile(int port) =>
+      File(portFilePath(_workingDirectory)).writeAsStringSync('$port');
+
+  void _createVersionFile() => File(versionFilePath(_workingDirectory))
+      .writeAsStringSync(currentVersion);
+
+  void _handleGracefulExit() {
+    var cancelCount = 0;
+    _sub = ProcessSignal.sigint.watch().listen((signal) async {
+      if (signal == ProcessSignal.sigint) {
+        cancelCount++;
+        await _cleanUp();
+        if (cancelCount > 1) exit(1);
+      }
+    });
+  }
+}

--- a/build_daemon/lib/src/managers/build_target_manager.dart
+++ b/build_daemon/lib/src/managers/build_target_manager.dart
@@ -1,0 +1,82 @@
+import 'package:watcher/watcher.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../../data/build_target_request.dart';
+
+bool _isBlacklistedPath(String filePath, Set<RegExp> blackListedPatterns) {
+  // Ignore the first three directories when filtering as these often
+  // relate to team directories which can contain black listed patterns.
+  var splitPath = filePath.split('/');
+  // TODO(grouma) - We'll want to refactor this so that the WatchEvent stream
+  // provided by the google3 build daemon does this automatically.
+  var path = splitPath.length > 3
+      ? '/${splitPath.sublist(3).join('/')}'
+      : splitPath.join('/');
+  if (blackListedPatterns.any((pattern) => path.contains(pattern))) {
+    return true;
+  }
+  return false;
+}
+
+class BuildTarget {
+  // The target to build.
+  final String target;
+
+  // Set of channels interested in this target.
+  final listeners = Set<WebSocketChannel>();
+
+  final Set<RegExp> _patterns;
+
+  BuildTarget(
+      this.target, Set<String> blackListPatterns, WebSocketChannel listener)
+      : _patterns = blackListPatterns.map((p) => RegExp(p)).toSet() {
+    listeners.add(listener);
+  }
+
+  bool operator ==(o) =>
+      o is BuildTarget &&
+      o.target == target &&
+      o._patterns
+          .map((p) => p.pattern)
+          .toSet()
+          .difference(_patterns.map((p) => p.pattern).toSet())
+          .isEmpty;
+
+  bool shouldBuild(List<WatchEvent> changes) =>
+      changes.any((change) => !_isBlacklistedPath(change.path, _patterns));
+}
+
+/// Manages the set of build targets, and corersponding listeners, tracked by
+/// the Dart Build Daemon.
+class BuildTargetManager {
+  final _buildTargets = Set<BuildTarget>();
+
+  bool get isEmpty => _buildTargets.isEmpty;
+
+  Set<BuildTarget> get targets => _buildTargets;
+
+  void addBuildTarget(BuildTargetRequest request, WebSocketChannel channel) {
+    var buildTarget =
+        BuildTarget(request.target, request.blackListPattern.toSet(), channel);
+    var existingTarget =
+        _buildTargets.firstWhere((b) => b == buildTarget, orElse: () => null);
+    if (existingTarget != null) {
+      existingTarget.listeners.add(channel);
+    } else {
+      _buildTargets.add(buildTarget);
+    }
+  }
+
+  void removeChannel(WebSocketChannel channel) {
+    var toRemove = [];
+    // Find the set of Build Targets that no longer have any listeners.
+    for (var buildTarget in _buildTargets) {
+      buildTarget.listeners.remove(channel);
+      if (buildTarget.listeners.isEmpty) toRemove.add(buildTarget);
+    }
+    _buildTargets.removeAll(toRemove);
+  }
+
+  Set<BuildTarget> targetsForChanges(List<WatchEvent> changes) =>
+      _buildTargets.where((target) => target.shouldBuild(changes)).toSet();
+}

--- a/build_daemon/lib/src/managers/build_target_manager.dart
+++ b/build_daemon/lib/src/managers/build_target_manager.dart
@@ -33,10 +33,14 @@ class BuildTarget {
     listeners.add(listener);
   }
 
-  bool operator ==(o) =>
-      o is BuildTarget &&
-      o.target == target &&
-      o._patterns
+  @override
+  int get hashCode => super.hashCode;
+
+  @override
+  bool operator ==(other) =>
+      other is BuildTarget &&
+      other.target == target &&
+      other._patterns
           .map((p) => p.pattern)
           .toSet()
           .difference(_patterns.map((p) => p.pattern).toSet())

--- a/build_daemon/lib/src/managers/build_target_manager.dart
+++ b/build_daemon/lib/src/managers/build_target_manager.dart
@@ -19,7 +19,7 @@ bool _isBlacklistedPath(String filePath, Set<RegExp> blackListedPatterns) {
 }
 
 class BuildTarget {
-  // The target to build.
+  // The build system identifier for the target.
   final String target;
 
   // Set of channels interested in this target.
@@ -72,7 +72,7 @@ class BuildTargetManager {
   }
 
   void removeChannel(WebSocketChannel channel) {
-    var toRemove = [];
+    var toRemove = <BuildTarget>[];
     // Find the set of Build Targets that no longer have any listeners.
     for (var buildTarget in _buildTargets) {
       buildTarget.listeners.remove(channel);

--- a/build_daemon/lib/src/managers/channel_options_manager.dart
+++ b/build_daemon/lib/src/managers/channel_options_manager.dart
@@ -2,7 +2,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// Manages options that are tied to particular web socket channels.
 class ChannelOptionsManager {
-  final _optionToChannels = Map<String, Set<WebSocketChannel>>();
+  final _optionToChannels = <String, Set<WebSocketChannel>>{};
 
   Set<String> get options => _optionToChannels.keys.toSet();
 

--- a/build_daemon/lib/src/managers/channel_options_manager.dart
+++ b/build_daemon/lib/src/managers/channel_options_manager.dart
@@ -1,0 +1,28 @@
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Manages options that are tied to particular web socket channels.
+class ChannelOptionsManager {
+  final _optionToChannels = Map<String, Set<WebSocketChannel>>();
+
+  Set<String> get options => _optionToChannels.keys.toSet();
+
+  void addOption(String option, WebSocketChannel channel) {
+    if (!_optionToChannels.containsKey(option)) {
+      _optionToChannels[option] = Set<WebSocketChannel>();
+    }
+    _optionToChannels[option].add(channel);
+  }
+
+  /// Removes a channel; any options that were only tied to that channel are
+  /// also removed.
+  void removeChannel(WebSocketChannel channel) {
+    var toRemove = [];
+    // Find the set of options that no longer have any listeners.
+    for (var option in _optionToChannels.keys) {
+      var listeners = _optionToChannels[option];
+      listeners.remove(channel);
+      if (listeners.isEmpty) toRemove.add(option);
+    }
+    toRemove.forEach(_optionToChannels.remove);
+  }
+}

--- a/build_daemon/lib/src/server.dart
+++ b/build_daemon/lib/src/server.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pool/pool.dart';
+import 'package:shelf/shelf_io.dart';
+import 'package:shelf_web_socket/shelf_web_socket.dart';
+import 'package:stream_transform/stream_transform.dart' hide concat;
+import 'package:watcher/watcher.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../daemon_builder.dart';
+import '../data/build_options_request.dart';
+import '../data/build_request.dart';
+import '../data/build_target_request.dart';
+import '../data/log_to_paths_request.dart';
+import '../data/serializers.dart';
+import 'managers/build_target_manager.dart';
+import 'managers/channel_options_manager.dart';
+
+class Server {
+  final _isDoneCompleter = Completer();
+  final _buildTargetManager = BuildTargetManager();
+  final _buildOptionsManager = ChannelOptionsManager();
+  final _logPathsManager = ChannelOptionsManager();
+  final _pool = Pool(1);
+
+  HttpServer _server;
+  DaemonBuilder _builder;
+  final _channels = Set<WebSocketChannel>();
+  // Channels that are interested in the current build.
+  var _interestedChannels = Set<WebSocketChannel>();
+
+  final _subs = <StreamSubscription>[];
+
+  Server(this._builder, Stream<WatchEvent> changes) {
+    _forwardData();
+    _handleChanges(changes);
+  }
+
+  Future<void> get onDone => _isDoneCompleter.future;
+
+  Future<int> listen() async {
+    var handler = webSocketHandler((WebSocketChannel channel) async {
+      _channels.add(channel);
+
+      channel.stream.listen((message) async {
+        dynamic request;
+        try {
+          request = serializers.deserialize(jsonDecode(message as String));
+        } catch (_) {
+          print('Unable to parse message: $message');
+          return;
+        }
+        if (request is BuildTargetRequest) {
+          _buildTargetManager.addBuildTarget(request, channel);
+        } else if (request is BuildOptionsRequest) {
+          for (var option in request.options) {
+            _buildOptionsManager.addOption(option, channel);
+          }
+        } else if (request is LogToPathsRequest) {
+          for (var path in request.paths) {
+            _logPathsManager.addOption(path, channel);
+          }
+        } else if (request is BuildRequest) {
+          await _build(_buildTargetManager.targets);
+        }
+      }, onDone: () {
+        _channels.remove(channel);
+        _removeChannel(channel);
+      });
+    });
+    _server = await serve(handler, 'localhost', 0);
+    return _server.port;
+  }
+
+  Future<void> stop() async {
+    await _server?.close(force: true);
+    await _builder?.stop();
+    for (var sub in _subs) {
+      await sub.cancel();
+    }
+    if (!_isDoneCompleter.isCompleted) _isDoneCompleter.complete();
+  }
+
+  Future<void> _build(Set<BuildTarget> buildTargets) => _pool.withResource(() {
+        _interestedChannels = Set<WebSocketChannel>();
+        var paths = Set<String>();
+        for (var buildTarget in buildTargets) {
+          paths.add(buildTarget.target);
+          _interestedChannels.addAll(buildTarget.listeners.toList());
+        }
+        return _builder.build(
+            paths, _buildOptionsManager.options, _logPathsManager.options);
+      });
+
+  void _forwardData() {
+    _subs.add(_builder.logs.listen((log) {
+      var message = jsonEncode(serializers.serialize(log));
+      for (var channel in _interestedChannels) {
+        channel.sink.add(message);
+      }
+    }));
+    _subs.add(_builder.builds.listen((status) {
+      var message = jsonEncode(serializers.serialize(status));
+      for (var channel in _interestedChannels) {
+        channel.sink.add(message);
+      }
+    }));
+  }
+
+  void _handleChanges(Stream<WatchEvent> changes) {
+    _subs.add(changes.transform(asyncMapBuffer((changes) async {
+      if (changes.isEmpty) return;
+      if (_buildTargetManager.targets.isEmpty) return;
+      var buildTargets = _buildTargetManager.targetsForChanges(changes);
+      if (buildTargets.isEmpty) return;
+      await _build(buildTargets);
+    })).listen((_) {}));
+  }
+
+  void _removeChannel(WebSocketChannel channel) async {
+    _buildTargetManager.removeChannel(channel);
+    _buildOptionsManager.removeChannel(channel);
+    if (_buildTargetManager.isEmpty) {
+      await stop();
+    }
+  }
+}

--- a/build_daemon/mono_pkg.yaml
+++ b/build_daemon/mono_pkg.yaml
@@ -1,0 +1,10 @@
+dart:
+  - dev
+
+stages:
+  - analyze_and_format:
+    - group:
+      - dartfmt: sdk
+      - dartanalyzer: --fatal-infos --fatal-warnings .
+  - unit_test:
+    - command: pub run test

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,0 +1,23 @@
+name: build_daemon 
+version: 0.0.1
+description: A daemon for running Dart builds. 
+author: Dart Team <misc@dartlang.org>
+homepage: https://github.com/dart-lang/build/tree/master/build_daemon
+
+environment:
+  sdk: ">=2.1.0 <3.0.0"
+
+dependencies:
+  built_collection: ^4.1.0
+  built_value: ^6.2.0
+  pedantic: ^1.0.0
+  watcher: ^0.9.7
+
+
+dev_dependencies:
+  build_runner: ^1.0.0
+  built_value_generator: ^6.2.0
+  mockito: ^4.0.0
+  test: ^1.3.3
+  test_descriptor: ^1.1.1
+  uuid: ^1.0.3

--- a/build_daemon/test/daemon_test.dart
+++ b/build_daemon/test/daemon_test.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:build_daemon/constants.dart';
+// Keep the daemon_builder import so the fake daemon script below
+// can resolve it.
+// ignore: unused_import
+import 'package:build_daemon/daemon_builder.dart';
+import 'package:build_daemon/src/daemon.dart';
+import 'package:package_resolver/package_resolver.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+import 'package:uuid/uuid.dart';
+
+void main() {
+  var testDaemons = <Process>[];
+  var testWorkspaces = <String>[];
+  var uuid = Uuid();
+
+  group('Daemon', () {
+    setUp(() {
+      testDaemons.clear();
+      testWorkspaces.clear();
+    });
+
+    tearDown(() async {
+      for (var testDaemon in testDaemons) {
+        testDaemon.kill(ProcessSignal.sigkill);
+      }
+      for (var testWorkspace in testWorkspaces) {
+        var workspace = Directory(daemonWorkspace(testWorkspace));
+        if (workspace.existsSync()) {
+          workspace.deleteSync(recursive: true);
+        }
+      }
+    });
+
+    test('can run if no other daemon is running', () async {
+      String workspace = uuid.v1();
+      var daemon = await _runDaemon(workspace);
+      testDaemons.add(daemon);
+      expect(await getOutput(daemon), 'RUNNING');
+    });
+
+    test('can not run if another daemon is running in the same workspace',
+        () async {
+      String workspace = uuid.v1();
+      testWorkspaces.add(workspace);
+      var daemonOne = await _runDaemon(workspace);
+      expect(await getOutput(daemonOne), 'RUNNING');
+      var daemonTwo = await _runDaemon(workspace);
+      testDaemons.addAll([daemonOne, daemonTwo]);
+      expect(await getOutput(daemonTwo), 'ALREADY RUNNING');
+    });
+
+    test('can run if another daemon is running in a different workspace',
+        () async {
+      String workspace1 = uuid.v1();
+      String workspace2 = uuid.v1();
+      testWorkspaces.addAll([workspace1, workspace2]);
+      var daemonOne = await _runDaemon(workspace1);
+      expect(await getOutput(daemonOne), 'RUNNING');
+      var daemonTwo = await _runDaemon(workspace2);
+      testDaemons.addAll([daemonOne, daemonTwo]);
+      expect(await getOutput(daemonTwo), 'RUNNING');
+    });
+
+    test('logs the version when running', () async {
+      String workspace = uuid.v1();
+      testWorkspaces.add(workspace);
+      var daemon = await _runDaemon(workspace);
+      testDaemons.add(daemon);
+      expect(await getOutput(daemon), 'RUNNING');
+      expect(runningVersion(workspace), currentVersion);
+    });
+
+    test('does not set the current version if not running', () async {
+      String workspace = uuid.v1();
+      testWorkspaces.add(workspace);
+      expect(runningVersion(workspace), null);
+    });
+
+    test('cleans up after itself', () async {
+      String workspace = uuid.v1();
+      testWorkspaces.add(workspace);
+      var daemon = await _runDaemon(workspace);
+      // Wait for the daemon to be running before checking the workspace exits.
+      expect(await getOutput(daemon), 'RUNNING');
+      expect(Directory(daemonWorkspace(workspace)).existsSync(), isTrue);
+      // Daemon expects sigint twice before quitting.
+      daemon.kill(ProcessSignal.sigint);
+      daemon.kill(ProcessSignal.sigint);
+      await daemon.exitCode;
+      expect(Directory(daemonWorkspace(workspace)).existsSync(), isFalse);
+    });
+  });
+}
+
+Future<String> getOutput(Process daemon) async {
+  return await daemon.stdout
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .firstWhere((line) => line == 'RUNNING' || line == 'ALREADY RUNNING');
+}
+
+Future<Process> _runDaemon(String workspace) async {
+  await d.file('test.dart', '''
+    import 'package:build_daemon/src/daemon.dart';
+    import 'package:build_daemon/daemon_builder.dart';
+
+    main() async {
+      var daemon = Daemon('$workspace');
+      if (daemon.tryGetLock()) {
+        await daemon.start(DaemonBuilder(), Stream.empty());
+        print('RUNNING');
+      } else {
+        print('ALREADY RUNNING');
+      }
+    }
+      ''').create();
+
+  var packageArg = await PackageResolver.current.processArgument;
+
+  var process = await Process.start(
+      Platform.resolvedExecutable, [packageArg, 'test.dart'],
+      workingDirectory: d.sandbox);
+
+  return process;
+}

--- a/build_daemon/test/managers/build_target_manager_test.dart
+++ b/build_daemon/test/managers/build_target_manager_test.dart
@@ -1,0 +1,121 @@
+import 'package:build_daemon/data/build_target_request.dart';
+import 'package:build_daemon/src/managers/build_target_manager.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'package:watcher/watcher.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  test('can add build targets', () {
+    var manager = BuildTargetManager();
+    var channel = DummyChannel();
+    var request = BuildTargetRequest((b) => b
+      ..target = 'foo'
+      ..blackListPattern = ListBuilder());
+    expect(manager.targets.isEmpty, isTrue);
+    manager.addBuildTarget(request, channel);
+    expect(
+        manager.targets.map((target) => target.target).toList().contains('foo'),
+        isTrue);
+  });
+
+  test('when a channel is removed the corresponding target is removed', () {
+    var manager = BuildTargetManager();
+    var channelA = DummyChannel();
+    var channelB = DummyChannel();
+    var requestA = BuildTargetRequest((b) => b
+      ..target = 'foo'
+      ..blackListPattern = ListBuilder());
+    manager.addBuildTarget(requestA, channelA);
+    expect(
+        manager.targets.map((target) => target.target).toList().contains('foo'),
+        isTrue);
+    var requestB = BuildTargetRequest((b) => b
+      ..target = 'bar'
+      ..blackListPattern = ListBuilder());
+    manager.addBuildTarget(requestB, channelB);
+    expect(manager.targets.isNotEmpty, isTrue);
+    manager.removeChannel(channelA);
+    expect(
+        manager.targets.map((target) => target.target).toList().contains('foo'),
+        isFalse);
+    expect(
+        manager.targets.map((target) => target.target).toList().contains('bar'),
+        isTrue);
+  });
+
+  test(
+      'when multiple channels are listening to a target, '
+      'it is only removed when both channels are removed', () {
+    var manager = BuildTargetManager();
+    var channelA = DummyChannel();
+    var channelB = DummyChannel();
+    var request = BuildTargetRequest((b) => b
+      ..target = 'foo'
+      ..blackListPattern = ListBuilder());
+    manager.addBuildTarget(request, channelA);
+    manager.addBuildTarget(request, channelB);
+    expect(
+        manager.targets.map((target) => target.target).toList().contains('foo'),
+        isTrue);
+    manager.removeChannel(channelB);
+    expect(
+        manager.targets.map((target) => target.target).toList().contains('foo'),
+        isTrue);
+    manager.removeChannel(channelA);
+    expect(manager.targets.isEmpty, isTrue);
+  });
+
+  test(
+      'a build target will be reused if the target and the blackListPattern '
+      'is the same', () {
+    var manager = BuildTargetManager();
+    var channelA = DummyChannel();
+    var channelB = DummyChannel();
+    var requestA = BuildTargetRequest((b) => b
+      ..target = 'foo'
+      ..blackListPattern = ListBuilder(['bar']));
+    var requestB = BuildTargetRequest((b) => b
+      ..target = 'foo'
+      ..blackListPattern = ListBuilder(['bar']));
+    manager.addBuildTarget(requestA, channelA);
+    manager.addBuildTarget(requestB, channelB);
+    expect(manager.targets.length, 1);
+  });
+
+  test('different blackListPatterns result in different build targets', () {
+    var manager = BuildTargetManager();
+    var channelA = DummyChannel();
+    var channelB = DummyChannel();
+    var requestA = BuildTargetRequest((b) => b
+      ..target = 'foo'
+      ..blackListPattern = ListBuilder());
+    var requestB = BuildTargetRequest((b) => b
+      ..target = 'foo'
+      ..blackListPattern = ListBuilder(['bar']));
+    manager.addBuildTarget(requestA, channelA);
+    manager.addBuildTarget(requestB, channelB);
+    expect(manager.targets.length, 2);
+  });
+
+  test(
+      'correctly uses the blackListPattern to filter build targets for changes',
+      () {
+    var manager = BuildTargetManager();
+    var channel = DummyChannel();
+    var request = BuildTargetRequest((b) => b
+      ..target = 'foo'
+      ..blackListPattern = ListBuilder([r'.*_test\.dart$']));
+    manager.addBuildTarget(request, channel);
+    var targets = manager.targetsForChanges(
+        [WatchEvent(ChangeType.ADD, 'foo/bar/blah/some_file.dart')]);
+    expect(targets.map((target) => target.target).toList().contains('foo'),
+        isTrue);
+    targets = manager.targetsForChanges(
+        [WatchEvent(ChangeType.ADD, 'foo/bar/blah/some_test.dart')]);
+    expect(targets.isEmpty, isTrue);
+  });
+}
+
+class DummyChannel extends Mock implements WebSocketChannel {}

--- a/build_daemon/test/managers/channel_options_manager_test.dart
+++ b/build_daemon/test/managers/channel_options_manager_test.dart
@@ -1,0 +1,44 @@
+import 'package:build_daemon/src/managers/channel_options_manager.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  test('can add options', () {
+    var manager = ChannelOptionsManager();
+    var channel = DummyChannel();
+    expect(manager.options.isEmpty, isTrue);
+    manager.addOption('--foo', channel);
+    expect(manager.options.contains('--foo'), isTrue);
+  });
+
+  test('when a channel is removed the corresponding option is removed', () {
+    var manager = ChannelOptionsManager();
+    var channelA = DummyChannel();
+    var channelB = DummyChannel();
+    manager.addOption('--foo', channelA);
+    expect(manager.options.contains('--foo'), isTrue);
+    manager.addOption('--bar', channelB);
+    expect(manager.options.isNotEmpty, isTrue);
+    manager.removeChannel(channelA);
+    expect(manager.options.contains('--foo'), isFalse);
+    expect(manager.options.contains('--bar'), isTrue);
+  });
+
+  test(
+      'when multiple channels request and option, '
+      'it is only removed when both channels are removed', () {
+    var manager = ChannelOptionsManager();
+    var channelA = DummyChannel();
+    var channelB = DummyChannel();
+    manager.addOption('--foo', channelA);
+    manager.addOption('--foo', channelB);
+    expect(manager.options.contains('--foo'), isTrue);
+    manager.removeChannel(channelB);
+    expect(manager.options.contains('--foo'), isTrue);
+    manager.removeChannel(channelA);
+    expect(manager.options.isEmpty, isTrue);
+  });
+}
+
+class DummyChannel extends Mock implements WebSocketChannel {}

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -39,8 +39,8 @@ while (( "$#" )); do
     echo -e 'dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs'
     dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs || EXIT_CODE=$?
     ;;
-  command_4) echo
-    echo -e '\033[1mTASK: command_4\033[22m'
+  command_5) echo
+    echo -e '\033[1mTASK: command_5\033[22m'
     echo -e 'dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs-- -P presubmit'
     dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs-- -P presubmit || EXIT_CODE=$?
     ;;


### PR DESCRIPTION
Initial export of Build Daemon logic.

Notable changes from the internal version:
- Merged a number of disjoint libraries into a single package
- Updated the client to take an optional command path
  - Internally this command path will be the prebuilt daemon vm binary
- Updated the daemon binary and example to work externally
- Cleaned up a number of lints

Additional changes:
- Updated mono repo settings to include build daemon
- Removed `avoid_returning_null` lint

Remaining work:
Provide a working implementation of `DaemonBuilder` which makes use of `build_runner_core`.