### PR TITLE
Add back dep on build_resolvers

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   glob: ^1.1.0
 
 dev_dependencies:
+  build_resolvers: ^0.2.3
   build_runner: ^1.0.0
   build_test: ^0.10.0
   build_vm_compilers: ^0.1.0


### PR DESCRIPTION
This was erroneously removed, there is an import to `build_resolvers` in
a test.