### PR TITLE
Use xor to compute combined input hashes instead of md5

### DIFF
--- a/_test_common/lib/common.dart
+++ b/_test_common/lib/common.dart
@@ -29,7 +29,8 @@ Digest computeDigest(AssetId id, String contents) {
     var package = id.package.substring(2);
     id = AssetId(package, '.dart_tool/build/generated/$package/${id.path}');
   }
-  return md5.convert(utf8.encode(contents).followedBy([id.hashCode]).toList());
+  return md5.convert(
+      utf8.encode(contents).followedBy(id.toString().codeUnits).toList());
 }
 
 class PlaceholderBuilder extends Builder {

--- a/_test_common/lib/common.dart
+++ b/_test_common/lib/common.dart
@@ -22,7 +22,15 @@ export 'package_graphs.dart';
 export 'sdk.dart';
 export 'test_phases.dart';
 
-Digest computeDigest(String contents) => md5.convert(utf8.encode(contents));
+Digest computeDigest(AssetId id, String contents) {
+  // Special handling for `$$` assets, these are generated under the .dart_tool
+  // dir and unfortunately that leaks into the digest computations.
+  if (id.package.startsWith(r'$$')) {
+    var package = id.package.substring(2);
+    id = AssetId(package, '.dart_tool/build/generated/$package/${id.path}');
+  }
+  return md5.convert(utf8.encode(contents).followedBy([id.hashCode]).toList());
+}
 
 class PlaceholderBuilder extends Builder {
   final String inputExtension;

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,13 +1,10 @@
-## 1.1.1
-
-- Include the AssetId hash code in the default digest implementation.
-  - Any custom implementations of the `AssetReader.digest` method should do the
-    same, and a comment has been added to that effect.
-
 ## 1.1.0
 
 - Add `Resolver.assetIdForElement` API. This allows finding the Dart source
   asset which contains the definition of an element found through the analyzer.
+- Include the AssetId hash code in the default digest implementation.
+  - Any custom implementations of the `AssetReader.digest` method should do the
+    same, and a comment has been added to that effect.
 
 ## 1.0.2
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.1
+
+- Include the AssetId hash code in the default digest implementation.
+  - Any custom implementations of the `AssetReader.digest` method should do the
+    same, and a comment has been added to that effect.
+
 ## 1.1.0
 
 - Add `Resolver.assetIdForElement` API. This allows finding the Dart source

--- a/build/lib/src/asset/reader.dart
+++ b/build/lib/src/asset/reader.dart
@@ -45,10 +45,10 @@ abstract class AssetReader {
   /// may differ based on the current build system being used.
   Future<Digest> digest(AssetId id) async {
     var digestSink = AccumulatorSink<Digest>();
-    var bytesSink = md5.startChunkedConversion(digestSink);
-    bytesSink.add(await readAsBytes(id));
-    bytesSink.add([id.hashCode]);
-    bytesSink.close();
+    md5.startChunkedConversion(digestSink)
+      ..add(await readAsBytes(id))
+      ..add(id.toString().codeUnits)
+      ..close();
     return digestSink.events.first;
   }
 }

--- a/build/lib/src/asset/reader.dart
+++ b/build/lib/src/asset/reader.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
+import 'package:convert/convert.dart';
 import 'package:glob/glob.dart';
 
 import 'id.dart';
@@ -36,11 +37,19 @@ abstract class AssetReader {
 
   /// Returns a [Digest] representing a hash of the contents of [id].
   ///
+  /// The digests should include the asset ID as well as the content of the
+  /// file, as some build systems may rely on the digests for two files being
+  /// different, even if their content is the same.
+  ///
   /// This should be treated as a transparent [Digest] and the implementation
   /// may differ based on the current build system being used.
   Future<Digest> digest(AssetId id) async {
-    var bytes = await readAsBytes(id);
-    return md5.convert(bytes);
+    var digestSink = AccumulatorSink<Digest>();
+    var bytesSink = md5.startChunkedConversion(digestSink);
+    bytesSink.add(await readAsBytes(id));
+    bytesSink.add([id.hashCode]);
+    bytesSink.close();
+    return digestSink.events.first;
   }
 }
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.1.1
+version: 1.1.0
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.1.0
+version: 1.1.1
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build
@@ -10,6 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.27.1 <0.35.0"
   async: ">=1.13.3 <3.0.0"
+  convert: ^2.0.0
   crypto: ">=0.9.2 <3.0.0"
   logging: ^0.11.2
   meta: ^1.1.0

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -35,6 +35,10 @@ dev_dependencies:
     path: test/fixtures/b
 
 dependency_overrides:
+  build:
+    path: ../build
+  build_resolvers:
+    path: ../build_resolvers
   build_runner:
     path: ../build_runner
   build_runner_core:

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   build_runner_core: ^1.1.0
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
-  convert: ^2.0.1
   crypto: ">=0.9.2 <3.0.0"
   dart_style: ^1.0.0
   glob: ^1.1.0
@@ -55,6 +54,10 @@ dev_dependencies:
     path: ../_test_common
 
 dependency_overrides:
+  build:
+    path: ../build
+  build_resolvers:
+    path: ../build_resolvers
   build_runner_core:
     path: ../build_runner_core
   build_modules:

--- a/build_runner/test/entrypoint/run_test.dart
+++ b/build_runner/test/entrypoint/run_test.dart
@@ -26,6 +26,7 @@ main() {
           'build',
           'build_config',
           'build_modules',
+          'build_resolvers',
           'build_runner',
           'build_runner_core',
           'build_test',

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -263,35 +263,39 @@ a:file://fake/pkg/path
             computeBuilderOptionsDigest(defaultBuilderOptions));
         expectedGraph.add(builderOptionsNode);
 
-        var bCopyNode = GeneratedAssetNode(makeAssetId('a|web/b.txt.copy'),
+        var bCopyId = makeAssetId('a|web/b.txt.copy');
+        var bTxtId = makeAssetId('a|web/b.txt');
+        var bCopyNode = GeneratedAssetNode(bCopyId,
             phaseNumber: 0,
             primaryInput: makeAssetId('a|web/b.txt'),
             state: NodeState.upToDate,
             wasOutput: true,
             isFailure: false,
             builderOptionsId: builderOptionsId,
-            lastKnownDigest: computeDigest('b2'),
+            lastKnownDigest: computeDigest(bCopyId, 'b2'),
             inputs: [makeAssetId('a|web/b.txt')],
             isHidden: false);
         builderOptionsNode.outputs.add(bCopyNode.id);
         expectedGraph.add(bCopyNode);
-        expectedGraph.add(
-            makeAssetNode('a|web/b.txt', [bCopyNode.id], computeDigest('b2')));
+        expectedGraph.add(makeAssetNode(
+            'a|web/b.txt', [bCopyNode.id], computeDigest(bTxtId, 'b2')));
 
-        var cCopyNode = GeneratedAssetNode(makeAssetId('a|web/c.txt.copy'),
+        var cCopyId = makeAssetId('a|web/c.txt.copy');
+        var cTxtId = makeAssetId('a|web/c.txt');
+        var cCopyNode = GeneratedAssetNode(cCopyId,
             phaseNumber: 0,
-            primaryInput: makeAssetId('a|web/c.txt'),
+            primaryInput: cTxtId,
             state: NodeState.upToDate,
             wasOutput: true,
             isFailure: false,
             builderOptionsId: builderOptionsId,
-            lastKnownDigest: computeDigest('c'),
+            lastKnownDigest: computeDigest(cCopyId, 'c'),
             inputs: [makeAssetId('a|web/c.txt')],
             isHidden: false);
         builderOptionsNode.outputs.add(cCopyNode.id);
         expectedGraph.add(cCopyNode);
-        expectedGraph.add(
-            makeAssetNode('a|web/c.txt', [cCopyNode.id], computeDigest('c')));
+        expectedGraph.add(makeAssetNode(
+            'a|web/c.txt', [cCopyNode.id], computeDigest(cTxtId, 'c')));
 
         // TODO: We dont have a shared way of computing the combined input
         // hashes today, but eventually we should test those here too.

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:build/build.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
@@ -31,7 +32,7 @@ void main() {
   });
 
   void _addAsset(String id, String content, {bool deleted = false}) {
-    var node = makeAssetNode(id, [], computeDigest('a'));
+    var node = makeAssetNode(id, [], computeDigest(AssetId.parse(id), 'a'));
     if (deleted) {
       node.deletedBy.add(node.id.addExtension('.post_anchor.1'));
     }

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -46,7 +46,7 @@ void main() {
   });
 
   void _addSource(String id, String content, {bool deleted = false}) {
-    var node = makeAssetNode(id, [], computeDigest('a'));
+    var node = makeAssetNode(id, [], computeDigest(AssetId.parse(id), 'a'));
     if (deleted) {
       node.deletedBy.add(node.id.addExtension('.post_anchor.1'));
     }
@@ -180,8 +180,11 @@ void main() {
           'packages/a/absent.dart.js'
         ])));
     expect(jsonDecode(await response.readAsString()), {
-      'index.html': '7e55db001d319a94b0b713529a756623',
-      'packages/a/some.dart.js': 'eea670f4ac941df71a3b5f268ebe3eac',
+      'index.html':
+          computeDigest(AssetId('a', 'web/index.html'), 'content1').toString(),
+      'packages/a/some.dart.js':
+          computeDigest(AssetId('a', 'lib/some.dart.js'), 'content2')
+              .toString(),
     });
   });
 
@@ -355,13 +358,18 @@ void main() {
       test('emmits build results digests', () async {
         _addSource('a|web/index.html', 'content1');
         _addSource('a|lib/some.dart.js', 'content2');
+        var indexHash =
+            computeDigest(AssetId('a', 'web/index.html'), 'content1')
+                .toString();
         expect(
             clientChannel1.stream.map((s) => jsonDecode(s.toString())),
             emitsInOrder([
-              {'index.html': '7e55db001d319a94b0b713529a756623'},
+              {'index.html': indexHash},
               {
-                'index.html': '7e55db001d319a94b0b713529a756623',
-                'packages/a/some.dart.js': 'eea670f4ac941df71a3b5f268ebe3eac'
+                'index.html': indexHash,
+                'packages/a/some.dart.js':
+                    computeDigest(AssetId('a', 'lib/some.dart.js'), 'content2')
+                        .toString()
               },
               emitsDone
             ]));
@@ -380,12 +388,17 @@ void main() {
         _addSource('a|web1/index.html', 'content1');
         _addSource('a|web2/index.html', 'content2');
         _addSource('a|lib/some.dart.js', 'content3');
+        var someDartHash =
+            computeDigest(AssetId('a', 'lib/some.dart.js'), 'content3')
+                .toString();
         expect(
             clientChannel1.stream.map((s) => jsonDecode(s.toString())),
             emitsInOrder([
               {
-                'index.html': '7e55db001d319a94b0b713529a756623',
-                'packages/a/some.dart.js': 'c96310e55d9677b978eae0dada47642c'
+                'index.html':
+                    computeDigest(AssetId('a', 'web1/index.html'), 'content1')
+                        .toString(),
+                'packages/a/some.dart.js': someDartHash
               },
               emitsDone
             ]));
@@ -393,8 +406,10 @@ void main() {
             clientChannel2.stream.map((s) => jsonDecode(s.toString())),
             emitsInOrder([
               {
-                'index.html': 'eea670f4ac941df71a3b5f268ebe3eac',
-                'packages/a/some.dart.js': 'c96310e55d9677b978eae0dada47642c'
+                'index.html':
+                    computeDigest(AssetId('a', 'web2/index.html'), 'content2')
+                        .toString(),
+                'packages/a/some.dart.js': someDartHash
               },
               emitsDone
             ]));

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,14 +1,11 @@
-## 1.1.4-dev
-
-- Update the way combined input hashes are computed to not rely on ordering.
-  - Digest implementations must now include the AssetId, not just the contents.
-- Require package:build version 1.1.1, which meets the new requirements for
-  digests.
-
 ## 1.1.3
 
 - Update to `package:graphs` version `0.2.0`.
 - Allow `build` version `1.1.x`.
+- Update the way combined input hashes are computed to not rely on ordering.
+  - Digest implementations must now include the AssetId, not just the contents.
+- Require package:build version 1.1.1, which meets the new requirements for
+  digests.
 
 ## 1.1.2
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.4-dev
+
+- Update the way combined input hashes are computed to not rely on ordering.
+  - Digest implementations must now include the AssetId, not just the contents.
+- Require package:build version 1.1.1, which meets the new requirements for
+  digests.
+
 ## 1.1.3
 
 - Update to `package:graphs` version `0.2.0`.

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:collection';
 import 'dart:convert';
 
 import 'package:async/async.dart';
@@ -43,8 +42,8 @@ class SingleStepReader implements AssetReader {
   final FutureOr<GlobAssetNode> Function(
       Glob glob, String package, int phaseNum) _getGlobNode;
 
-  /// The assets read during this step in sorted order.
-  final assetsRead = SplayTreeSet<AssetId>();
+  /// The assets read during this step.
+  final assetsRead = Set<AssetId>();
 
   SingleStepReader(this._delegate, this._assetGraph, this._phaseNumber,
       this._primaryPackage, this._isReadableNode,

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:async/async.dart';
@@ -43,7 +44,7 @@ class SingleStepReader implements AssetReader {
       Glob glob, String package, int phaseNum) _getGlobNode;
 
   /// The assets read during this step.
-  final assetsRead = Set<AssetId>();
+  final assetsRead = HashSet<AssetId>();
 
   SingleStepReader(this._delegate, this._assetGraph, this._phaseNumber,
       this._primaryPackage, this._isReadableNode,

--- a/build_runner_core/lib/src/asset_graph/node.dart
+++ b/build_runner_core/lib/src/asset_graph/node.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:build/build.dart';
@@ -144,7 +145,7 @@ class GeneratedAssetNode extends AssetNode implements NodeWithInputs {
   /// This needs to be an ordered set because we compute combined input digests
   /// using this later on.
   @override
-  Set<AssetId> inputs;
+  HashSet<AssetId> inputs;
 
   /// A digest combining all digests of all previous inputs.
   ///
@@ -174,7 +175,7 @@ class GeneratedAssetNode extends AssetNode implements NodeWithInputs {
     @required this.isFailure,
     @required this.primaryInput,
     @required this.builderOptionsId,
-  })  : inputs = inputs != null ? Set.from(inputs) : Set(),
+  })  : inputs = inputs != null ? HashSet.from(inputs) : HashSet(),
         super(id, lastKnownDigest: lastKnownDigest);
 
   @override
@@ -267,7 +268,7 @@ class GlobAssetNode extends InternalAssetNode implements NodeWithInputs {
   /// This needs to be an ordered set because we compute combined input digests
   /// using this later on.
   @override
-  Set<AssetId> inputs;
+  HashSet<AssetId> inputs;
 
   @override
   bool get isReadable => false;
@@ -291,7 +292,7 @@ class GlobAssetNode extends InternalAssetNode implements NodeWithInputs {
 
 /// A node which has [inputs], a [NodeState], and a [phaseNumber].
 abstract class NodeWithInputs implements AssetNode {
-  Set<AssetId> inputs;
+  HashSet<AssetId> inputs;
 
   int get phaseNumber;
 

--- a/build_runner_core/lib/src/asset_graph/node.dart
+++ b/build_runner_core/lib/src/asset_graph/node.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:collection';
 import 'dart:convert';
 
 import 'package:build/build.dart';
@@ -145,7 +144,7 @@ class GeneratedAssetNode extends AssetNode implements NodeWithInputs {
   /// This needs to be an ordered set because we compute combined input digests
   /// using this later on.
   @override
-  SplayTreeSet<AssetId> inputs;
+  Set<AssetId> inputs;
 
   /// A digest combining all digests of all previous inputs.
   ///
@@ -175,9 +174,7 @@ class GeneratedAssetNode extends AssetNode implements NodeWithInputs {
     @required this.isFailure,
     @required this.primaryInput,
     @required this.builderOptionsId,
-  })  : inputs = inputs != null
-            ? SplayTreeSet.from(inputs)
-            : SplayTreeSet<AssetId>(),
+  })  : inputs = inputs != null ? Set.from(inputs) : Set(),
         super(id, lastKnownDigest: lastKnownDigest);
 
   @override
@@ -270,7 +267,7 @@ class GlobAssetNode extends InternalAssetNode implements NodeWithInputs {
   /// This needs to be an ordered set because we compute combined input digests
   /// using this later on.
   @override
-  SplayTreeSet<AssetId> inputs;
+  Set<AssetId> inputs;
 
   @override
   bool get isReadable => false;
@@ -294,7 +291,7 @@ class GlobAssetNode extends InternalAssetNode implements NodeWithInputs {
 
 /// A node which has [inputs], a [NodeState], and a [phaseNumber].
 abstract class NodeWithInputs implements AssetNode {
-  SplayTreeSet<AssetId> inputs;
+  Set<AssetId> inputs;
 
   int get phaseNumber;
 

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -55,7 +55,7 @@ class _AssetGraphDeserializer {
       for (var output in node.outputs) {
         var inputsNode = graph.get(output) as NodeWithInputs;
         assert(inputsNode != null, 'Asset Graph is missing $output');
-        inputsNode.inputs ??= SplayTreeSet<AssetId>();
+        inputsNode.inputs ??= Set<AssetId>();
         inputsNode.inputs.add(node.id);
       }
 

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -55,7 +55,7 @@ class _AssetGraphDeserializer {
       for (var output in node.outputs) {
         var inputsNode = graph.get(output) as NodeWithInputs;
         assert(inputsNode != null, 'Asset Graph is missing $output');
-        inputsNode.inputs ??= Set<AssetId>();
+        inputsNode.inputs ??= HashSet<AssetId>();
         inputsNode.inputs.add(node.id);
       }
 

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -677,7 +677,7 @@ class _SingleBuild {
           .where((n) => globNode.glob.matches(n.id.path))
           .toList();
       var potentialIds = SplayTreeSet.of(potentialNodes.map((n) => n.id));
-      globNode.inputs = potentialIds;
+      globNode.inputs = HashSet.from(potentialIds);
       for (var node in potentialNodes) {
         node.outputs.add(globNode.id);
       }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 1.1.4-dev
+version: 1.1.3
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 1.1.3
+version: 1.1.4-dev
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.0.0 <1.2.0"
+  build: ">=1.1.1 <1.2.0"
   build_config: ^0.3.1
   build_resolvers: ^0.2.0
   collection: ^1.14.0
@@ -38,3 +38,9 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_resolvers:
+    path: ../build_resolvers

--- a/build_runner_core/test/asset/file_based_test.dart
+++ b/build_runner_core/test/asset/file_based_test.dart
@@ -83,11 +83,21 @@ void main() {
       expect(helloDigest, isNot(equals(aDigest)));
     });
 
-    test('digests are identical for identical file contents', () async {
+    test('digests are identical for identical file contents and assets',
+        () async {
+      var helloDigest =
+          await reader.digest(makeAssetId('basic_pkg|lib/hello.txt'));
+      var aDigest = await reader.digest(makeAssetId('basic_pkg|lib/hello.txt'));
+      expect(helloDigest, equals(aDigest));
+    });
+
+    test(
+        'digests are different for identical file contents and different assets',
+        () async {
       var helloDigest =
           await reader.digest(makeAssetId('basic_pkg|lib/hello.txt'));
       var aDigest = await reader.digest(makeAssetId('basic_pkg|web/hello.txt'));
-      expect(helloDigest, equals(aDigest));
+      expect(helloDigest, isNot(equals(aDigest)));
     });
 
     test('can read from the SDK', () async {

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 @TestOn('vm')
+import 'package:build/build.dart';
 import 'package:build_runner_core/src/asset/finalized_reader.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
@@ -21,8 +22,10 @@ void main() {
       var graph = await AssetGraph.build(
           [], Set(), Set(), buildPackageGraph({rootPackage('foo'): []}), null);
 
-      notDeleted = makeAssetNode('a|web/a.txt', [], computeDigest('a'));
-      deleted = makeAssetNode('a|lib/b.txt', [], computeDigest('b'));
+      notDeleted = makeAssetNode(
+          'a|web/a.txt', [], computeDigest(AssetId('a', 'web/a.txt'), 'a'));
+      deleted = makeAssetNode(
+          'a|lib/b.txt', [], computeDigest(AssetId('a', 'lib/b.txt'), 'b'));
       deleted.deletedBy.add(deleted.id.addExtension('.post_anchor.1'));
 
       graph.add(notDeleted);

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:collection';
 import 'dart:convert';
 
 import 'package:build/build.dart';
@@ -87,7 +86,7 @@ void main() {
       test('serialize/deserialize', () {
         var globNode = GlobAssetNode(makeAssetId(), Glob('**/*.dart'), 0,
             NodeState.definitelyNeedsUpdate,
-            inputs: SplayTreeSet(), results: []);
+            inputs: Set(), results: []);
         graph.add(globNode);
         for (var n = 0; n < 5; n++) {
           var node = makeAssetNode();
@@ -351,7 +350,7 @@ void main() {
           primaryOutputNode.state = NodeState.upToDate;
           var globNode = GlobAssetNode(primaryInputId.addExtension('.glob'),
               Glob('lib/*.cool'), 0, NodeState.upToDate,
-              inputs: SplayTreeSet());
+              inputs: Set());
           primaryOutputNode.inputs.add(globNode.id);
           globNode.outputs.add(primaryOutputId);
           graph.add(globNode);

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:build/build.dart';
@@ -86,7 +87,7 @@ void main() {
       test('serialize/deserialize', () {
         var globNode = GlobAssetNode(makeAssetId(), Glob('**/*.dart'), 0,
             NodeState.definitelyNeedsUpdate,
-            inputs: Set(), results: []);
+            inputs: HashSet(), results: []);
         graph.add(globNode);
         for (var n = 0; n < 5; n++) {
           var node = makeAssetNode();
@@ -350,7 +351,7 @@ void main() {
           primaryOutputNode.state = NodeState.upToDate;
           var globNode = GlobAssetNode(primaryInputId.addExtension('.glob'),
               Glob('lib/*.cool'), 0, NodeState.upToDate,
-              inputs: Set());
+              inputs: HashSet());
           primaryOutputNode.inputs.add(globNode.id);
           globNode.outputs.add(primaryOutputId);
           graph.add(globNode);

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -776,8 +776,10 @@ void main() {
         [], Set(), Set(), buildPackageGraph({rootPackage('a'): []}), null);
 
     // Source nodes
-    var aSourceNode = makeAssetNode('a|web/a.txt', [], computeDigest('a'));
-    var bSourceNode = makeAssetNode('a|lib/b.txt', [], computeDigest('b'));
+    var aSourceNode = makeAssetNode(
+        'a|web/a.txt', [], computeDigest(AssetId('a', 'web/a.txt'), 'a'));
+    var bSourceNode = makeAssetNode(
+        'a|lib/b.txt', [], computeDigest(AssetId('a', 'lib/b.txt'), 'b'));
     expectedGraph.add(aSourceNode);
     expectedGraph.add(bSourceNode);
 
@@ -787,14 +789,15 @@ void main() {
         builderOptionsId, computeBuilderOptionsDigest(defaultBuilderOptions));
     expectedGraph.add(builderOptionsNode);
 
-    var aCopyNode = GeneratedAssetNode(makeAssetId('a|web/a.txt.copy'),
+    var aCopyId = makeAssetId('a|web/a.txt.copy');
+    var aCopyNode = GeneratedAssetNode(aCopyId,
         phaseNumber: 0,
         primaryInput: makeAssetId('a|web/a.txt'),
         state: NodeState.upToDate,
         wasOutput: true,
         isFailure: false,
         builderOptionsId: builderOptionsId,
-        lastKnownDigest: computeDigest('a'),
+        lastKnownDigest: computeDigest(aCopyId, 'a'),
         inputs: [makeAssetId('a|web/a.txt')],
         isHidden: false);
     builderOptionsNode.outputs.add(aCopyNode.id);
@@ -802,14 +805,15 @@ void main() {
     aSourceNode.outputs.add(aCopyNode.id);
     aSourceNode.primaryOutputs.add(aCopyNode.id);
 
-    var bCopyNode = GeneratedAssetNode(makeAssetId('a|lib/b.txt.copy'),
+    var bCopyId = makeAssetId('a|lib/b.txt.copy'); //;
+    var bCopyNode = GeneratedAssetNode(bCopyId,
         phaseNumber: 0,
         primaryInput: makeAssetId('a|lib/b.txt'),
         state: NodeState.upToDate,
         wasOutput: true,
         isFailure: false,
         builderOptionsId: builderOptionsId,
-        lastKnownDigest: computeDigest('b'),
+        lastKnownDigest: computeDigest(bCopyId, 'b'),
         inputs: [makeAssetId('a|lib/b.txt')],
         isHidden: false);
     builderOptionsNode.outputs.add(bCopyNode.id);
@@ -837,7 +841,7 @@ void main() {
         wasOutput: true,
         isFailure: false,
         builderOptionsId: postBuilderOptionsId,
-        lastKnownDigest: computeDigest('a'),
+        lastKnownDigest: computeDigest(makeAssetId(r'$$a|web/a.txt.post'), 'a'),
         inputs: [makeAssetId('a|web/a.txt'), aAnchorNode.id],
         isHidden: true);
     // Note we don't expect this node to get added to the builder options node
@@ -855,7 +859,7 @@ void main() {
         wasOutput: true,
         isFailure: false,
         builderOptionsId: postBuilderOptionsId,
-        lastKnownDigest: computeDigest('b'),
+        lastKnownDigest: computeDigest(makeAssetId(r'$$a|lib/b.txt.post'), 'b'),
         inputs: [makeAssetId('a|lib/b.txt'), bAnchorNode.id],
         isHidden: true);
     // Note we don't expect this node to get added to the builder options node


### PR DESCRIPTION
This should still be unique enough for our purposes (we don't use these digests in hash maps), and it allows us to use unordered sets which are more efficient, as well as being very fast on its own.

On angular gallery for edits to the material button example I saw incremental build time improvements of about 10%.

This will also allow us to add parallelism to the computeCombinedDigest function in a followup PR, without having to retain ordering.

There is one known potential bug this would introduce, which is if you were to swap the contents of two files the resulting combined digest would not change. In order to resolve that issue we include the `AssetId.hashCode` in the digest in the default `AssetReader.digest` implementation, and add a comment that custom implementations should include the asset id in their digest as well.