### PR TITLE
Throw an UnsupportedError on unresolvable URIs

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.5
+
+- Improve error messages for unresolvable URIs in the PackageAssetReader.
+
 ## 0.10.4
 
 - Allow using `PackageAssetReader` when the current working directory is not the

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -75,12 +75,15 @@ class PackageAssetReader extends AssetReader
   File _resolve(AssetId id) {
     final uri = id.uri;
     if (uri.isScheme('package')) {
-      return File.fromUri(_packageResolver.resolveUri(id.uri));
+      final uri = _packageResolver.resolveUri(id.uri);
+      if (uri != null) {
+        return File.fromUri(uri);
+      }
     }
     if (id.package == _rootPackage) {
       return File(p.canonicalize(p.join(_rootPackagePath, id.path)));
     }
-    throw UnsupportedError('Unabled to resolve $id');
+    throw UnsupportedError('Unable to resolve $id');
   }
 
   String get _rootPackagePath {

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.4
+version: 0.10.5
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 


### PR DESCRIPTION
Fall through to the throw statement if _packageResolver can not resolve a URI.

Also, fix a typo in the error message.