### PR TITLE
use a pool to limit the number of digests we ask for at a time

### DIFF
--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -715,22 +715,25 @@ class _SingleBuild {
     var builderOptionsNode = _assetGraph.get(builderOptionsId);
     _combine(builderOptionsNode.lastKnownDigest.bytes as Uint8List);
 
-    for (var id in ids) {
-      var node = _assetGraph.get(id);
-      if (node is GlobAssetNode) {
-        await _updateGlobNodeIfNecessary(node);
-      } else if (!await reader.canRead(id)) {
-        // We want to add something here, a missing/unreadable input should be
-        // different from no input at all.
-        //
-        // This needs to be unique per input so we use the md5 hash of the id.
-        _combine(md5.convert(id.toString().codeUnits).bytes as Uint8List);
-        continue;
-      } else {
-        node.lastKnownDigest ??= await reader.digest(id);
-      }
-      _combine(node.lastKnownDigest.bytes as Uint8List);
-    }
+    // Limit the total number of digests we are computing at a time. Otherwise
+    // this can overload the event queue.
+    var pool = Pool(8);
+    await Future.wait(ids.map((id) => pool.withResource(() async {
+          var node = _assetGraph.get(id);
+          if (node is GlobAssetNode) {
+            await _updateGlobNodeIfNecessary(node);
+          } else if (!await reader.canRead(id)) {
+            // We want to add something here, a missing/unreadable input should be
+            // different from no input at all.
+            //
+            // This needs to be unique per input so we use the md5 hash of the id.
+            _combine(md5.convert(id.toString().codeUnits).bytes as Uint8List);
+            return;
+          } else {
+            node.lastKnownDigest ??= await reader.digest(id);
+          }
+          _combine(node.lastKnownDigest.bytes as Uint8List);
+        })));
 
     return Digest(combinedBytes);
   }


### PR DESCRIPTION
The pool size of 8 is pretty arbitrary, but it does improve build times significantly (cuts api-affecting edits down by ~50% in some basic tests).

I tried using `Pool.forEach` but it was slower - probably because of all the throwaway streams it creates? I don't actually care about the values returned in this case.