### PR TITLE
update pubspecs to remove overrides

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -24,13 +24,3 @@ dev_dependencies:
   build_vm_compilers: ^0.1.0
   pedantic: ^1.0.0
   test: ^1.2.0
-
-dependency_overrides:
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core
-  build_modules:
-    path: ../build_modules
-  build_resolvers:
-    path: ../build_resolvers

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 1.0.5
-
-- Use `dartdevc --kernel` instead of `dartdevk`.
-
 ## 1.0.4
 
 - Update to `package:graphs` version `0.2.0`.
+- Use `dartdevc --kernel` instead of `dartdevk`.
 
 ## 1.0.3
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 1.0.5
+version: 1.0.4
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
@@ -33,13 +33,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  build:
-    path: ../build
-  build_resolvers:
-    path: ../build_resolvers
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -17,7 +17,3 @@ dev_dependencies:
   build_test: ^0.10.1
   build_runner: ^1.0.0
   build_vm_compilers: ^0.1.0
-
-dependency_overrides:
-  build:
-    path: ../build

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.3-dev
+## 1.1.3
 
 - Update to `package:graphs` version `0.2.0`.
 - Fix an issue where when running from source in watch mode the script would

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.1.3-dev
+version: 1.1.3
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -52,13 +52,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build:
-    path: ../build
-  build_resolvers:
-    path: ../build_resolvers
-  build_runner_core:
-    path: ../build_runner_core
-  build_modules:
-    path: ../build_modules

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Allow `build` version `1.1.x`.
 - Update the way combined input hashes are computed to not rely on ordering.
   - Digest implementations must now include the AssetId, not just the contents.
-- Require package:build version 1.1.1, which meets the new requirements for
+- Require package:build version 1.1.0, which meets the new requirements for
   digests.
 
 ## 1.1.2

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.1.1 <1.2.0"
+  build: ">=1.1.0 <1.2.0"
   build_config: ^0.3.1
   build_resolvers: ^0.2.0
   collection: ^1.14.0
@@ -38,9 +38,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build:
-    path: ../build
-  build_resolvers:
-    path: ../build_resolvers


### PR DESCRIPTION
All the packages are published now, so this should get a green presubmit.

I also tweaked a few other small things (changed build_modules version to 1.0.4 which wasn't published yet, and updated the minimum `build` version for build_runner_core)