### PR TITLE
add overrideGeneratedOutputDirectory and lockGeneratedOutputDirectory

### DIFF
--- a/_test_common/lib/test_phases.dart
+++ b/_test_common/lib/test_phases.dart
@@ -92,6 +92,7 @@ Future<BuildResult> testBuilders(
   bool verbose = false,
   List<String> buildDirs,
   String logPerformanceDir,
+  String expectedGeneratedDir,
 }) async {
   packageGraph ??= buildPackageGraph({rootPackage('a'): []});
   writer ??= InMemoryRunnerAssetWriter();
@@ -137,7 +138,8 @@ Future<BuildResult> testBuilders(
         outputs: outputs,
         writer: writer,
         status: status,
-        rootPackage: packageGraph.root.name);
+        rootPackage: packageGraph.root.name,
+        expectedGeneratedDir: expectedGeneratedDir);
   }
   return result;
 }
@@ -148,7 +150,9 @@ void checkBuild(BuildResult result,
     {Map<String, dynamic> outputs,
     InMemoryAssetWriter writer,
     BuildStatus status = BuildStatus.success,
-    String rootPackage}) {
+    String rootPackage,
+    String expectedGeneratedDir}) {
+  expectedGeneratedDir ??= 'generated';
   expect(result.status, status, reason: '$result');
 
   final unhiddenOutputs = <String, dynamic>{};
@@ -163,13 +167,14 @@ void checkBuild(BuildResult result,
     }
   }
 
-  AssetId mapHidden(AssetId id) => unhiddenAssets.contains(id)
-      ? AssetId(
-          rootPackage, '.dart_tool/build/generated/${id.package}/${id.path}')
-      : id;
+  AssetId mapHidden(AssetId id, String expectedGeneratedDir) =>
+      unhiddenAssets.contains(id)
+          ? AssetId(rootPackage,
+              '.dart_tool/build/$expectedGeneratedDir/${id.package}/${id.path}')
+          : id;
 
   if (status == BuildStatus.success) {
     checkOutputs(unhiddenOutputs, result.outputs, writer,
-        mapAssetIds: mapHidden);
+        mapAssetIds: (id) => mapHidden(id, expectedGeneratedDir));
   }
 }

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - The `build` method now requires a list of `buildDirs`.
 - Remove `buildDirs` from `BuildOptions`.
+- Added the `overrideGeneratedDirectory` method which overrides the directory
+  for generated outputs.
+  - Must be invoked before creating a `BuildRunner` instance.
 
 ## 1.1.3
 

--- a/build_runner_core/lib/src/asset/build_cache.dart
+++ b/build_runner_core/lib/src/asset/build_cache.dart
@@ -96,7 +96,8 @@ AssetId _cacheLocation(AssetId id, AssetGraph assetGraph, String rootPackage) {
   }
   final assetNode = assetGraph.get(id);
   if (assetNode is GeneratedAssetNode && assetNode.isHidden) {
-    return AssetId(rootPackage, '$cacheDir/generated/${id.package}/${id.path}');
+    return AssetId(
+        rootPackage, '$generatedOutputDirectory/${id.package}/${id.path}');
   }
   return id;
 }

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -99,6 +99,10 @@ class BuildImpl {
       List<BuilderApplication> builders,
       Map<String, Map<String, dynamic>> builderConfigOverrides,
       {bool isReleaseBuild = false}) async {
+    // Don't allow any changes to the generated asset directory after this
+    // point.
+    lockGeneratedOutputDirectory();
+
     var buildPhases = await createBuildPhases(
         options.targetGraph, builders, builderConfigOverrides, isReleaseBuild);
     if (buildPhases.isEmpty) {

--- a/build_runner_core/lib/src/generate/build_runner.dart
+++ b/build_runner_core/lib/src/generate/build_runner.dart
@@ -9,6 +9,7 @@ import 'package:watcher/watcher.dart';
 
 import '../environment/build_environment.dart';
 import '../package_graph/apply_builders.dart';
+import '../util/constants.dart';
 import 'build_impl.dart';
 import 'build_result.dart';
 import 'options.dart';
@@ -24,12 +25,17 @@ class BuildRunner {
       _build.run(updates, buildDirs: buildDirs);
 
   static Future<BuildRunner> create(
-          BuildOptions options,
-          BuildEnvironment environment,
-          List<BuilderApplication> builders,
-          Map<String, Map<String, dynamic>> builderConfigOverrides,
-          {bool isReleaseBuild = false}) async =>
-      BuildRunner._(await BuildImpl.create(
-          options, environment, builders, builderConfigOverrides,
-          isReleaseBuild: isReleaseBuild));
+      BuildOptions options,
+      BuildEnvironment environment,
+      List<BuilderApplication> builders,
+      Map<String, Map<String, dynamic>> builderConfigOverrides,
+      {bool isReleaseBuild = false}) async {
+    // Don't allow any changes to the generated asset directory after this
+    // point.
+    lockGeneratedOutputDirectory();
+
+    return BuildRunner._(await BuildImpl.create(
+        options, environment, builders, builderConfigOverrides,
+        isReleaseBuild: isReleaseBuild));
+  }
 }

--- a/build_runner_core/lib/src/generate/build_runner.dart
+++ b/build_runner_core/lib/src/generate/build_runner.dart
@@ -9,7 +9,6 @@ import 'package:watcher/watcher.dart';
 
 import '../environment/build_environment.dart';
 import '../package_graph/apply_builders.dart';
-import '../util/constants.dart';
 import 'build_impl.dart';
 import 'build_result.dart';
 import 'options.dart';
@@ -30,10 +29,6 @@ class BuildRunner {
       List<BuilderApplication> builders,
       Map<String, Map<String, dynamic>> builderConfigOverrides,
       {bool isReleaseBuild = false}) async {
-    // Don't allow any changes to the generated asset directory after this
-    // point.
-    lockGeneratedOutputDirectory();
-
     return BuildRunner._(await BuildImpl.create(
         options, environment, builders, builderConfigOverrides,
         isReleaseBuild: isReleaseBuild));

--- a/build_runner_core/lib/src/util/constants.dart
+++ b/build_runner_core/lib/src/util/constants.dart
@@ -26,10 +26,48 @@ final String _scriptPath = Platform.script.scheme == 'file'
 /// Directory containing automatically generated build entrypoints.
 ///
 /// Files in this directory must be read to do build script invalidation.
-const entryPointDir = '.dart_tool/build/entrypoint';
+const entryPointDir = '$cacheDir/entrypoint';
 
 /// The directory to which hidden assets will be written.
-const generatedOutputDirectory = '$cacheDir/generated';
+///
+/// Can not be accessed prior to being locked with
+/// [lockGeneratedOutputDirectory].
+String get generatedOutputDirectory {
+  if (!_generatedOutputDirectoryIsLocked) {
+    throw StateError('Attempted to access the generated directory name before '
+        'it was locked.');
+  }
+  return '$cacheDir/$_generatedOutputDirectory';
+}
+
+/// Locks the generated directory name for the duration of this process.
+///
+/// This should be invoked before any builds start.
+void lockGeneratedOutputDirectory() => _generatedOutputDirectoryIsLocked = true;
+
+/// The default generated dir name. Can be modified with
+/// [overrideGeneratedOutputDirectory].
+String _generatedOutputDirectory = 'generated';
+
+/// Whether or not the [generatedOutputDirectory] is locked. This must be `true`
+/// before you can access [generatedOutputDirectory];
+bool _generatedOutputDirectoryIsLocked = false;
+
+/// Overrides the generated directory name.
+///
+/// This is interpreted as a relative path under the [cacheDir].
+void overrideGeneratedOutputDirectory(String path) {
+  if (_generatedOutputDirectory != 'generated') {
+    throw StateError('You can only override the generated dir once.');
+  } else if (_generatedOutputDirectoryIsLocked) {
+    throw StateError(
+        'Attempted to override the generated dir after it was locked.');
+  } else if (!p.isRelative(path)) {
+    throw StateError('Only relative paths are accepted for the generated dir '
+        'but got `$path`.');
+  }
+  _generatedOutputDirectory = path;
+}
 
 /// Relative path to the cache directory from the root package dir.
 const String cacheDir = '.dart_tool/build';

--- a/build_runner_core/lib/src/util/constants.dart
+++ b/build_runner_core/lib/src/util/constants.dart
@@ -29,9 +29,6 @@ final String _scriptPath = Platform.script.scheme == 'file'
 const entryPointDir = '$cacheDir/entrypoint';
 
 /// The directory to which hidden assets will be written.
-///
-/// Can not be accessed prior to being locked with
-/// [lockGeneratedOutputDirectory].
 String get generatedOutputDirectory => '$cacheDir/$_generatedOutputDirectory';
 
 /// Locks the generated directory name for the duration of this process.

--- a/build_runner_core/lib/src/util/constants.dart
+++ b/build_runner_core/lib/src/util/constants.dart
@@ -32,13 +32,7 @@ const entryPointDir = '$cacheDir/entrypoint';
 ///
 /// Can not be accessed prior to being locked with
 /// [lockGeneratedOutputDirectory].
-String get generatedOutputDirectory {
-  if (!_generatedOutputDirectoryIsLocked) {
-    throw StateError('Attempted to access the generated directory name before '
-        'it was locked.');
-  }
-  return '$cacheDir/$_generatedOutputDirectory';
-}
+String get generatedOutputDirectory => '$cacheDir/$_generatedOutputDirectory';
 
 /// Locks the generated directory name for the duration of this process.
 ///

--- a/build_runner_core/test/generate/custom_generated_dir_test.dart
+++ b/build_runner_core/test/generate/custom_generated_dir_test.dart
@@ -1,21 +1,12 @@
 // Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import 'dart:async';
-import 'dart:convert';
-import 'dart:math' as math;
 
 import 'package:build/build.dart';
-import 'package:build_config/build_config.dart';
-import 'package:glob/glob.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import 'package:build_runner_core/build_runner_core.dart';
-import 'package:build_runner_core/src/asset_graph/graph.dart';
-import 'package:build_runner_core/src/asset_graph/node.dart';
 
-import 'package:_test_common/build_configs.dart';
 import 'package:_test_common/common.dart';
 import 'package:_test_common/package_graphs.dart';
 

--- a/build_runner_core/test/generate/custom_generated_dir_test.dart
+++ b/build_runner_core/test/generate/custom_generated_dir_test.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:build/build.dart';
+import 'package:build_config/build_config.dart';
+import 'package:glob/glob.dart';
+import 'package:pedantic/pedantic.dart';
+import 'package:test/test.dart';
+
+import 'package:build_runner_core/build_runner_core.dart';
+import 'package:build_runner_core/src/asset_graph/graph.dart';
+import 'package:build_runner_core/src/asset_graph/node.dart';
+
+import 'package:_test_common/build_configs.dart';
+import 'package:_test_common/common.dart';
+import 'package:_test_common/package_graphs.dart';
+
+main() {
+  final customGeneratedDir = 'my-custom-dir';
+  overrideGeneratedOutputDirectory(customGeneratedDir);
+
+  PackageGraph packageGraph;
+
+  setUp(() {
+    packageGraph = buildPackageGraph({
+      rootPackage('a', path: 'a/'): [],
+    });
+  });
+
+  test('can output files to a custom generated dir', () async {
+    var writer = InMemoryRunnerAssetWriter();
+    await testBuilders(
+        [
+          applyToRoot(
+              TestBuilder(
+                  buildExtensions: appendExtension('.copy', from: '.txt')),
+              hideOutput: true),
+        ],
+        {'a|lib/a.txt': 'a'},
+        packageGraph: packageGraph,
+        outputs: {
+          r'$$a|lib/a.txt.copy': 'a',
+        },
+        expectedGeneratedDir: customGeneratedDir,
+        writer: writer);
+    expect(
+        writer.assets[AssetId(
+            'a', '.dart_tool/build/$customGeneratedDir/a/lib/a.txt.copy')],
+        isNotNull);
+  });
+}


### PR DESCRIPTION
Will add tests/etc, for now just floating this as a potential resolution to https://github.com/dart-lang/build/issues/1972.

This is extremely defensive, so it should be quite safe without causing much churn elsewhere in the code.