### PR TITLE
Forward filesystem changes to daemon builder

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Options are no longer dynamic and are provided upon connecting.
 - Report OptionsSkew.
 - Prefix build daemon directory with username.
+- Forward filesystem changes to daemon builder.
 
 ## 0.0.1
 

--- a/build_daemon/lib/daemon_builder.dart
+++ b/build_daemon/lib/daemon_builder.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:watcher/src/watch_event.dart';
+
 import 'data/build_status.dart';
 import 'data/server_log.dart';
 
@@ -12,7 +14,8 @@ class DaemonBuilder {
 
   Stream<ServerLog> get logs => Stream.empty();
 
-  Future<void> build(Set<String> targets, Set<String> logToPaths) async {}
+  Future<void> build(Set<String> targets, Set<String> logToPaths,
+      Iterable<WatchEvent> changes) async {}
 
   Future<void> stop() async {}
 }

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -55,7 +55,8 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
   Stream<ServerLog> get logs => _outputStreamController.stream;
 
   @override
-  Future<void> build(Set<String> targets, Set<String> logToPaths) async {
+  Future<void> build(Set<String> targets, Set<String> logToPaths,
+      Iterable<WatchEvent> fileChanges) async {
     _logMessage(Level.INFO, 'About to build $targets...');
     try {
       var mergedChanges = collectChanges([_changesFromLastBuild]);


### PR DESCRIPTION
This should give builders more flexibility in terms of reporting/ignoring changes