### PR TITLE
Daemon asset serving

### DIFF
--- a/build_runner/lib/src/daemon/asset_server.dart
+++ b/build_runner/lib/src/daemon/asset_server.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:build_runner/src/server/server.dart';
 import 'package:build_runner_core/build_runner_core.dart';
-import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 
 class AssetServer {
@@ -22,15 +21,7 @@ class AssetServer {
   static Future<AssetServer> run(
       FinalizedReader reader, String rootPackage) async {
     var server = await HttpServer.bind(InternetAddress.anyIPv6, 0);
-    shelf_io.serveRequests(server, _handler(reader, rootPackage));
+    shelf_io.serveRequests(server, AssetHandler(reader, rootPackage).handle);
     return AssetServer._(server);
-  }
-
-  static Handler _handler(FinalizedReader reader, String rootPackage) {
-    var cascade = Cascade().add((request) {
-      return AssetHandler(reader, rootPackage).handle(request);
-    });
-    var pipeline = Pipeline();
-    return pipeline.addHandler(cascade.handler);
   }
 }

--- a/build_runner/lib/src/daemon/asset_server.dart
+++ b/build_runner/lib/src/daemon/asset_server.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:build_runner/src/server/server.dart';
+import 'package:build_runner_core/build_runner_core.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+
+class AssetServer {
+  HttpServer _server;
+
+  AssetServer._(this._server);
+
+  int get port => _server.port;
+
+  Future<void> stop() => _server.close(force: true);
+
+  static Future<AssetServer> run(
+      FinalizedReader reader, String rootPackage) async {
+    var server = await HttpServer.bind(InternetAddress.anyIPv6, 0);
+    shelf_io.serveRequests(server, _handler(reader, rootPackage));
+    return AssetServer._(server);
+  }
+
+  static Handler _handler(FinalizedReader reader, String rootPackage) {
+    var cascade = Cascade().add((request) {
+      return AssetHandler(reader, rootPackage).handle(request);
+    });
+    var pipeline = Pipeline();
+    return pipeline.addHandler(cascade.handler);
+  }
+}

--- a/build_runner/lib/src/daemon/asset_server.dart
+++ b/build_runner/lib/src/daemon/asset_server.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:io';
 

--- a/build_runner/lib/src/daemon/constants.dart
+++ b/build_runner/lib/src/daemon/constants.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:build_daemon/constants.dart';
 
 String assetServerPortFilePath(String workingDirectory) =>

--- a/build_runner/lib/src/daemon/constants.dart
+++ b/build_runner/lib/src/daemon/constants.dart
@@ -1,0 +1,4 @@
+import 'package:build_daemon/constants.dart';
+
+String assetServerPortFilePath(String workingDirectory) =>
+    '${daemonWorkspace(workingDirectory)}/.asset_server_port';

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -51,6 +51,8 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
 
   Stream<WatchEvent> get changes => _changes;
 
+  FinalizedReader get reader => _builder.finalizedReader;
+
   @override
   Stream<ServerLog> get logs => _outputStreamController.stream;
 

--- a/build_runner/lib/src/entrypoint/daemon.dart
+++ b/build_runner/lib/src/entrypoint/daemon.dart
@@ -7,8 +7,10 @@ import 'dart:io';
 
 import 'package:build_daemon/constants.dart';
 import 'package:build_daemon/src/daemon.dart';
+import 'package:build_runner/src/daemon/constants.dart';
 import 'package:io/ansi.dart';
 
+import '../daemon/asset_server.dart';
 import '../daemon/daemon_builder.dart';
 import 'base_command.dart';
 
@@ -56,9 +58,13 @@ class DaemonCommand extends BuildRunnerCommand {
           builderApplications,
           options,
         );
+        var server =
+            await AssetServer.run(builder.reader, packageGraph.root.name);
+        File(assetServerPortFilePath(workingDirectory))
+            .writeAsStringSync('${server.port}');
         await daemon.start(requestedOptions, builder, builder.changes);
         stdout.writeln(readyToConnectLog);
-        await daemon.onDone;
+        await daemon.onDone.then((_) => server.stop());
       });
     }
     return 0;

--- a/build_runner/lib/src/entrypoint/daemon.dart
+++ b/build_runner/lib/src/entrypoint/daemon.dart
@@ -64,7 +64,7 @@ class DaemonCommand extends BuildRunnerCommand {
             .writeAsStringSync('${server.port}');
         await daemon.start(requestedOptions, builder, builder.changes);
         stdout.writeln(readyToConnectLog);
-        await daemon.onDone.then((_) => server.stop());
+        await daemon.onDone.whenComplete(server.stop);
       });
     }
     return 0;

--- a/build_runner/lib/src/server/path_to_asset_id.dart
+++ b/build_runner/lib/src/server/path_to_asset_id.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 AssetId pathToAssetId(
     String rootPackage, String rootDir, List<String> pathSegments) {
   var packagesIndex = pathSegments.indexOf('packages');
+  rootDir ??= '';
   return packagesIndex >= 0
       ? AssetId(pathSegments[packagesIndex + 1],
           p.join('lib', p.joinAll(pathSegments.sublist(packagesIndex + 2))))

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -111,7 +111,7 @@ class ServeHandler implements BuildState {
             request.change(path: _graphPath), rootDir);
       }
       var assetHandler = await _assetHandler;
-      return assetHandler.handle(request, rootDir);
+      return assetHandler.handle(request, rootDir: rootDir);
     });
     var pipeline = shelf.Pipeline();
     if (logRequests) {
@@ -294,7 +294,7 @@ class AssetHandler {
 
   AssetHandler(this._reader, this._rootPackage);
 
-  Future<shelf.Response> handle(shelf.Request request, String rootDir) =>
+  Future<shelf.Response> handle(shelf.Request request, {String rootDir}) =>
       (request.url.path.endsWith('/') || request.url.path.isEmpty)
           ? _handle(
               request.headers,

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -1,0 +1,124 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+@Timeout(Duration(minutes: 2))
+@Tags(['integration'])
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:_test_common/common.dart';
+import 'package:build_daemon/client.dart';
+import 'package:build_daemon/constants.dart';
+import 'package:build_daemon/data/build_status.dart';
+import 'package:build_runner/src/daemon/constants.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+main() {
+  Process daemonProcess;
+  Stream<String> stdoutLines;
+
+  String workspace() => p.join(d.sandbox, 'a');
+
+  setUpAll(() async {
+    await d.dir('a', [
+      await pubspec(
+        'a',
+        currentIsolateDependencies: [
+          'build',
+          'build_config',
+          'build_daemon',
+          'build_modules',
+          'build_resolvers',
+          'build_runner',
+          'build_runner_core',
+          'build_test',
+          'test',
+        ],
+        versionDependencies: {
+          'build_web_compilers': 'any',
+        },
+      ),
+      d.dir('test', [
+        d.file('hello_test.dart', '''
+import 'package:test/test.dart';
+main() {
+  test('hello', () {});
+}'''),
+      ]),
+      d.dir('web', [
+        d.file('main.dart', '''
+main() {
+  print('hello world');
+}'''),
+      ]),
+    ]).create();
+
+    await pubGet('a', offline: false);
+  });
+
+  tearDown(() async {
+    stdoutLines = null;
+    daemonProcess?.kill(ProcessSignal.sigkill);
+    await runPub('a', 'run', args: ['build_runner', 'clean']);
+  });
+
+  Future<BuildDaemonClient> _startClient() =>
+      BuildDaemonClient.connect(workspace(), [
+        pubBinary.toString(),
+        'run',
+        'build_runner',
+        'daemon',
+      ]);
+
+  Future<void> _startDaemon() async {
+    daemonProcess =
+        await startPub('a', 'run', args: ['build_runner', 'daemon']);
+    stdoutLines = daemonProcess.stdout
+        .transform(Utf8Decoder())
+        .transform(LineSplitter())
+        .asBroadcastStream();
+    expect(await stdoutLines.contains(readyToConnectLog), isTrue);
+  }
+
+  group('Build Daemon', () {
+    test('successfully starts', () async {
+      await _startDaemon();
+    });
+
+    test('writes the asset server port', () async {
+      await _startDaemon();
+      expect(File(assetServerPortFilePath(workspace())).existsSync(), isTrue);
+    });
+
+    test('can complete builds', () async {
+      await _startDaemon();
+      var client = await _startClient();
+      client.registerBuildTarget('web', []);
+      client.startBuild();
+      var buildResults = await client.buildResults.first;
+      expect(buildResults.results.first.status, BuildStatus.succeeded);
+    });
+
+    test('allows multiple clients to connect and build', () async {
+      await _startDaemon();
+
+      var clientA = await _startClient();
+      clientA.registerBuildTarget('web', []);
+
+      var clientB = await _startClient();
+      clientB.registerBuildTarget('test', []);
+
+      clientB.startBuild();
+
+      // Both clients should be notified.
+      await clientA.buildResults.first;
+      var buildResultsB = await clientB.buildResults.first;
+
+      expect(buildResultsB.results.first.status, BuildStatus.succeeded);
+      expect(buildResultsB.results.length, equals(2));
+    });
+  });
+}

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 @Timeout(Duration(minutes: 2))
 @Tags(['integration'])
 import 'dart:async';

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -41,7 +41,8 @@ void main() {
   test('can not read deleted nodes', () async {
     _addAsset('a|web/index.html', 'content', deleted: true);
     var response = await handler.handle(
-        Request('GET', Uri.parse('http://server.com/index.html')), 'web');
+        Request('GET', Uri.parse('http://server.com/index.html')),
+        rootDir: 'web');
     expect(response.statusCode, 404);
     expect(await response.readAsString(), 'Not Found');
   });
@@ -49,7 +50,8 @@ void main() {
   test('can read from the root package', () async {
     _addAsset('a|web/index.html', 'content');
     var response = await handler.handle(
-        Request('GET', Uri.parse('http://server.com/index.html')), 'web');
+        Request('GET', Uri.parse('http://server.com/index.html')),
+        rootDir: 'web');
     expect(await response.readAsString(), 'content');
   });
 
@@ -57,7 +59,7 @@ void main() {
     _addAsset('b|lib/b.dart', 'content');
     var response = await handler.handle(
         Request('GET', Uri.parse('http://server.com/packages/b/b.dart')),
-        'web');
+        rootDir: 'web');
     expect(await response.readAsString(), 'content');
   });
 
@@ -65,28 +67,31 @@ void main() {
     _addAsset('b|lib/b.dart', 'content');
     var response = await handler.handle(
         Request('GET', Uri.parse('http://server.com/packages/b/b.dart')),
-        'web');
+        rootDir: 'web');
     expect(await response.readAsString(), 'content');
   });
 
   test('defaults to index.html if path is empty', () async {
     _addAsset('a|web/index.html', 'content');
     var response = await handler.handle(
-        Request('GET', Uri.parse('http://server.com/')), 'web');
+        Request('GET', Uri.parse('http://server.com/')),
+        rootDir: 'web');
     expect(await response.readAsString(), 'content');
   });
 
   test('defaults to index.html if URI ends with slash', () async {
     _addAsset('a|web/sub/index.html', 'content');
     var response = await handler.handle(
-        Request('GET', Uri.parse('http://server.com/sub/')), 'web');
+        Request('GET', Uri.parse('http://server.com/sub/')),
+        rootDir: 'web');
     expect(await response.readAsString(), 'content');
   });
 
   test('does not default to index.html if URI does not end in slash', () async {
     _addAsset('a|web/sub/index.html', 'content');
     var response = await handler.handle(
-        Request('GET', Uri.parse('http://server.com/sub')), 'web');
+        Request('GET', Uri.parse('http://server.com/sub')),
+        rootDir: 'web');
     expect(response.statusCode, 404);
   });
 
@@ -102,7 +107,8 @@ void main() {
       primaryInput: null,
     ));
     var response = await handler.handle(
-        Request('GET', Uri.parse('http://server.com/main.ddc.js')), 'web');
+        Request('GET', Uri.parse('http://server.com/main.ddc.js')),
+        rootDir: 'web');
     expect(response.statusCode, HttpStatus.internalServerError);
   });
 }


### PR DESCRIPTION
- Make the `rootDir` optional for the `AssetHandler`
- Create a basic `AssetServer` which uses the `AssetHandler`
- Spin up an asset server from within the build daemon
- Log the port for which this asset server is listening (webdev will know where to look)
- Add a handful of integration tests