### PR TITLE
Ignore `uri_does_not_exist` in analyzer/DDC

### DIFF
--- a/_test/test/config_specific_import_test.dart
+++ b/_test/test/config_specific_import_test.dart
@@ -4,11 +4,8 @@
 
 import 'package:test/test.dart';
 
-// ignore: uri_does_not_exist
 import 'common/message.dart'
-    // ignore: uri_does_not_exist
     if (dart.library.io) 'common/message_io.dart'
-    // ignore: uri_does_not_exist
     if (dart.library.html) 'common/message_html.dart';
 
 main() {

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+- Ignore `uri_does_not_exist` errors in DDC. Missing imports are checked while
+  crawling for modules.
+
 ## 1.0.4
 
 - Update to `package:graphs` version `0.2.0`.

--- a/build_modules/lib/src/analysis_options.default.yaml
+++ b/build_modules/lib/src/analysis_options.default.yaml
@@ -1,2 +1,3 @@
 analyzer:
-  strong-mode: true
+  errors:
+    uri_does_not_exist: ignore

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 1.0.4
+version: 1.1.0
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules


### PR DESCRIPTION
- Drop `strong-mode` option - it is the default.
- Add ignore for `uri_does_not_exist`.

Since imports are crawled while finding modules we have separate error
reporting already for missing imports. We don't need DDC to find these
for us.