### PR TITLE
Prep to publish build_runner_core / build_daemon

### DIFF
--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -55,13 +55,7 @@ dev_dependencies:
     path: ../_test_common
 
 dependency_overrides:
-  build:
-    path: ../build
   build_daemon:
     path: ../build_daemon
-  build_resolvers:
-    path: ../build_resolvers
   build_runner_core:
     path: ../build_runner_core
-  build_modules:
-    path: ../build_modules

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 2.0.0-dev
+version: 2.0.0
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
- `package:build_daemon` is already in a state to be published
- Update `pacage:build_runner` pubspec in preparation for publish
- Remove unnecessary overrides in `package:build_runner`. Once `package:build_runner_core` and `package:build_daemon` are published those corresponding overrides will be removed as well.