### PR TITLE
Ensure reader is reset prior to build

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.2.1
-
-- Update `package:build_runner_core` to version `2.0.1`.
-
 ## 1.2.0
 
 - Support building through `package:build_daemon`.

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,7 +1,11 @@
+## 1.2.1
+
+- Update `package:build_runner_core` to version `2.0.1`.
+
 ## 1.2.0
 
 - Support building through `package:build_daemon`.
-- Update `package:build_runner_core` to verions `2.0.0`.
+- Update `package:build_runner_core` to version `2.0.0`.
 
 ## 1.1.3
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+- Update `package:build_runner_core` to version `2.0.1`.
+
 ## 1.2.0
 
 - Support building through `package:build_daemon`.

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -208,7 +208,6 @@ class WatchImpl implements BuildState {
 
     Future<BuildResult> doBuild(List<List<AssetChange>> changes) async {
       assert(_build != null);
-      _build.finalizedReader.reset(_buildDirs);
       _logger.info('${'-' * 72}\n');
       _logger.info('Starting Build\n');
       var mergedChanges = collectChanges(changes);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.1
+version: 1.2.0
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -14,7 +14,7 @@ dependencies:
   build_config: ^0.3.1
   build_daemon: ^0.2.0
   build_resolvers: ^0.2.0
-  build_runner_core: ^2.0.1
+  build_runner_core: ^2.0.0
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
   crypto: ">=0.9.2 <3.0.0"

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.0
+version: 1.2.1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -14,7 +14,7 @@ dependencies:
   build_config: ^0.3.1
   build_daemon: ^0.2.0
   build_resolvers: ^0.2.0
-  build_runner_core: ^2.0.0
+  build_runner_core: ^2.0.1
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
   crypto: ">=0.9.2 <3.0.0"
@@ -53,3 +53,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_runner_core:
+    path: ../build_runner_core

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.0
+version: 1.2.1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -14,7 +14,7 @@ dependencies:
   build_config: ^0.3.1
   build_daemon: ^0.2.0
   build_resolvers: ^0.2.0
-  build_runner_core: ^2.0.0
+  build_runner_core: ^2.0.1
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
   crypto: ">=0.9.2 <3.0.0"

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Fix an issue where the `finalizedReader` was not `reset` prior to build.
+
 ## 2.0.0
 
 - The `build` method now requires a list of `buildDirs`.

--- a/build_runner_core/lib/src/asset/finalized_reader.dart
+++ b/build_runner_core/lib/src/asset/finalized_reader.dart
@@ -38,8 +38,7 @@ class FinalizedReader implements AssetReader {
     if (!node.isReadable) return UnreadableReason.assetType;
     if (node is GeneratedAssetNode) {
       if (node.isFailure) return UnreadableReason.failed;
-      if (!(node.wasOutput &&
-          (_optionalOutputTracker?.isRequired(node.id) ?? true))) {
+      if (!(node.wasOutput && (_optionalOutputTracker.isRequired(node.id)))) {
         return UnreadableReason.notOutput;
       }
     }

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -89,6 +89,7 @@ class BuildImpl {
   Future<BuildResult> run(Map<AssetId, ChangeType> updates,
       {List<String> buildDirs}) {
     buildDirs ??= [];
+    finalizedReader.reset(buildDirs);
     return _SingleBuild(this, buildDirs).run(updates)
       ..whenComplete(_resolvers.reset);
   }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 2.0.0
+version: 2.0.1
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
- Update version of `package:build_runner_core` to contain the reader fix
  - Will publish once this is in
- Update `package:build_runner` to depend on the latest `package:build_runner_core`.
- Fix a typo in the changelog