### PR TITLE
Change Daemon Builder log message

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.2
+
+- Change the format of Build Daemon messages.
+
+
 ## 1.2.1
 
 - Update `package:build_runner_core` to version `2.0.1`.

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -57,7 +57,8 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
         .map<AssetChange>(
             (change) => AssetChange(AssetId.parse(change.path), change.type))
         .toList();
-    _logMessage(Level.INFO, 'About to build $targets...');
+    var targetNames = targets.map((t) => t.target);
+    _logMessage(Level.INFO, 'About to build $targetNames...');
     try {
       var mergedChanges = collectChanges([changes]);
       var result = await _builder.run(mergedChanges,

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -57,12 +57,12 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
         .map<AssetChange>(
             (change) => AssetChange(AssetId.parse(change.path), change.type))
         .toList();
-    var targetNames = targets.map((t) => t.target);
-    _logMessage(Level.INFO, 'About to build $targetNames...');
+    var targetNames = targets.map((t) => t.target).toSet();
+    _logMessage(Level.INFO, 'About to build ${targetNames.toList()}...');
     try {
       var mergedChanges = collectChanges([changes]);
-      var result = await _builder.run(mergedChanges,
-          buildDirs: targets.map((t) => t.target).toSet().toList());
+      var result =
+          await _builder.run(mergedChanges, buildDirs: targetNames.toList());
       var results = <daemon.BuildResult>[];
       for (var target in targets) {
         if (result.status == BuildStatus.success) {

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.1
+version: 1.2.2-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Now that the build target is a built value the `toString` value contains additional information which isn't relevant for users.