### PR TITLE
Build Daemon asset server waits while a build in progress

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.2.2
 
 - Change the format of Build Daemon messages.
+- Build Daemon asset server now properly waits for build results.
+- Build Daemon now properly signals the start of a build.
 
 
 ## 1.2.1

--- a/build_runner/lib/src/daemon/asset_server.dart
+++ b/build_runner/lib/src/daemon/asset_server.dart
@@ -5,10 +5,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:build_runner/src/daemon/daemon_builder.dart';
-import 'package:build_runner/src/server/server.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
+
+import '../server/server.dart';
+import 'daemon_builder.dart';
 
 class AssetServer {
   HttpServer _server;

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -33,7 +33,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
   final StreamController<ServerLog> _outputStreamController;
   final Stream<WatchEvent> _changes;
 
-  var _buildingCompleter = Completer();
+  Completer _buildingCompleter;
 
   BuildRunnerDaemonBuilder._(
     this._builder,
@@ -47,7 +47,10 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
 
   Stream<WatchEvent> get changes => _changes;
 
-  Future<void> get building => _buildingCompleter.future;
+  /// Waits for a running build to complete before returning.
+  ///
+  /// If there is no running build, it will return immediately.
+  Future<void> get building => _buildingCompleter?.future;
 
   @override
   Stream<ServerLog> get logs => _outputStreamController.stream;
@@ -115,7 +118,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
   }
 
   void _signalStart(Iterable<String> targets) {
-    if (_buildingCompleter.isCompleted) _buildingCompleter = Completer();
+    _buildingCompleter = Completer();
     var results = <daemon.BuildResult>[];
     for (var target in targets) {
       results.add(daemon.DefaultBuildResult((b) => b

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -33,7 +33,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
   final StreamController<ServerLog> _outputStreamController;
   final Stream<WatchEvent> _changes;
 
-  Completer _buildingCompleter;
+  Completer<Null> _buildingCompleter;
 
   BuildRunnerDaemonBuilder._(
     this._builder,

--- a/build_runner/lib/src/entrypoint/daemon.dart
+++ b/build_runner/lib/src/entrypoint/daemon.dart
@@ -58,8 +58,7 @@ class DaemonCommand extends BuildRunnerCommand {
           builderApplications,
           options,
         );
-        var server =
-            await AssetServer.run(builder.reader, packageGraph.root.name);
+        var server = await AssetServer.run(builder, packageGraph.root.name);
         File(assetServerPortFilePath(workingDirectory))
             .writeAsStringSync('${server.port}');
         await daemon.start(requestedOptions, builder, builder.changes);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.2-dev
+version: 1.2.2
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -95,6 +95,15 @@ main() {
       expect(File(assetServerPortFilePath(workspace())).existsSync(), isTrue);
     });
 
+    test('notifies upon build start', () async {
+      await _startDaemon();
+      var client = await _startClient();
+      client.registerBuildTarget(webTarget);
+      client.startBuild();
+      var buildResults = await client.buildResults.first;
+      expect(buildResults.results.first.status, BuildStatus.started);
+    });
+
     test('can complete builds', () async {
       await _startDaemon();
       var client = await _startClient();

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -117,7 +117,8 @@ main() {
 
       // Both clients should be notified.
       await clientA.buildResults.first;
-      var buildResultsB = await clientB.buildResults.first;
+      var buildResultsB = await clientB.buildResults
+          .firstWhere((b) => b.results.first.status != BuildStatus.started);
 
       expect(buildResultsB.results.first.status, BuildStatus.succeeded);
       expect(buildResultsB.results.length, equals(2));

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -100,7 +100,8 @@ main() {
       var client = await _startClient();
       client.registerBuildTarget(webTarget);
       client.startBuild();
-      var buildResults = await client.buildResults.first;
+      var buildResults = await client.buildResults
+          .firstWhere((b) => b.results.first.status != BuildStatus.started);
       expect(buildResults.results.first.status, BuildStatus.succeeded);
     });
 


### PR DESCRIPTION
- Properly signal the start of a build
- Update asset server to wait while a build is in progress
- Prepare for release

Towards https://github.com/dart-lang/build/issues/1999

Note: When I get around to building out integration tests this behavior will be tested.