### PR TITLE
Resolve path issues under Windows

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+- Resolve client path issues with running on Windows.
+
 ## 0.2.1
 
 - Resolve issues with running on Windows.

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -103,8 +103,7 @@ class BuildDaemonClient {
   }
 
   static int _existingPort(String workingDirectory) {
-    var portFile = File('${daemonWorkspace(workingDirectory)}'
-        '/.dart_build_daemon_port');
+    var portFile = File(portFilePath(workingDirectory));
     if (!portFile.existsSync()) throw Exception('Unable to read port file.');
     return int.parse(portFile.readAsStringSync());
   }

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 0.2.1
+version: 0.2.2
 description: A daemon for running Dart builds.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -3,7 +3,6 @@
 - Change the format of Build Daemon messages.
 - Fix path issues with Daemon command under Windows.
 
-
 ## 1.2.1
 
 - Update `package:build_runner_core` to version `2.0.1`.

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.2.2
 
 - Change the format of Build Daemon messages.
+- Fix path issues with Daemon command under Windows.
 
 
 ## 1.2.1

--- a/build_runner/lib/src/daemon/constants.dart
+++ b/build_runner/lib/src/daemon/constants.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build_daemon/constants.dart';
+import 'package:path/path.dart' as p;
 
 String assetServerPortFilePath(String workingDirectory) =>
-    '${daemonWorkspace(workingDirectory)}/.asset_server_port';
+    p.join(daemonWorkspace(workingDirectory), '.asset_server_port');


### PR DESCRIPTION
Haven't had to deal with Windows in quite some time. I've learned my lesson and will use `package:path` from now on.