### PR TITLE
Serve output digests through build daemon

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.3
+
+- `daemon` command now serves output asset digests under `/$outputDigests`. 
+
 ## 1.2.2
 
 - Change the format of Build Daemon messages.

--- a/build_runner/lib/src/daemon/asset_server.dart
+++ b/build_runner/lib/src/daemon/asset_server.dart
@@ -3,13 +3,40 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:build/build.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
 
+import '../server/path_to_asset_id.dart';
 import '../server/server.dart';
 import 'daemon_builder.dart';
+
+Future<Response> Function(Request) _outputDigestHandler(
+        BuildRunnerDaemonBuilder builder, String rootPackage) =>
+    (Request request) async {
+      if (request.url.path.endsWith(r'$outputDigests')) {
+        var digests = <AssetId, String>{};
+        for (var output in builder.outputs) {
+          try {
+            digests[output] = '${await builder.reader.digest(output)}';
+          } on AssetNotFoundException {
+            // Ignore assets which can't be found.
+          }
+        }
+        var result = <String, String>{};
+        for (var assetId in digests.keys) {
+          var path = assetIdToPath(assetId, rootPackage);
+          if (path != null) {
+            result[path] = digests[assetId];
+          }
+        }
+        return Response.ok(jsonEncode(result));
+      }
+      return Response.notFound('Not found');
+    };
 
 class AssetServer {
   HttpServer _server;
@@ -25,10 +52,13 @@ class AssetServer {
     String rootPackage,
   ) async {
     var server = await HttpServer.bind(InternetAddress.anyIPv6, 0);
-    var cascade = Cascade().add((_) async {
-      await builder.building;
-      return Response.notFound('');
-    }).add(AssetHandler(builder.reader, rootPackage).handle);
+    var cascade = Cascade()
+        .add((_) async {
+          await builder.building;
+          return Response.notFound('');
+        })
+        .add(_outputDigestHandler(builder, rootPackage))
+        .add(AssetHandler(builder.reader, rootPackage).handle);
     shelf_io.serveRequests(server, cascade.handler);
     return AssetServer._(server);
   }

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -42,18 +42,20 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
     this._changes,
   );
 
-  @override
-  Stream<daemon.BuildResults> get builds => _buildResults.stream;
-
-  Stream<WatchEvent> get changes => _changes;
-
   /// Waits for a running build to complete before returning.
   ///
   /// If there is no running build, it will return immediately.
   Future<void> get building => _buildingCompleter?.future;
 
   @override
+  Stream<daemon.BuildResults> get builds => _buildResults.stream;
+
+  Stream<WatchEvent> get changes => _changes;
+
+  @override
   Stream<ServerLog> get logs => _outputStreamController.stream;
+
+  Iterable<AssetId> get outputs => _builder.assetGraph.outputs;
 
   FinalizedReader get reader => _builder.finalizedReader;
 


### PR DESCRIPTION
Create a handler for `/$outputDigests` which returns the digests for all outputs. These digests will be consumed by the hot reload client to determine which modules should be reloaded.

Discussion:
The complete output digests contain significantly more data than necessary. We can do something similar to https://github.com/dart-lang/build/blob/master/build_runner/lib/src/server/server.dart#L165 which returns digests for just requested assets. I'm not sure if this is strictly necessary but it's an optimization we can do later.