### PR TITLE
Fix daemon client issues on Windows

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Fix client issues with Windows.
+
 ## 0.2.2
 
 - Resolve client path issues with running on Windows.

--- a/build_daemon/lib/constants.dart
+++ b/build_daemon/lib/constants.dart
@@ -8,9 +8,10 @@ import 'package:path/path.dart' as p;
 const readyToConnectLog = 'READY TO CONNECT';
 const versionSkew = 'DIFFERENT RUNNING VERSION';
 const optionsSkew = 'DIFFERENT OPTIONS';
+const errorLog = 'ERROR';
 
 // TODO(grouma) - use pubspec version when this is open sourced.
-const currentVersion = '4.0.0';
+const currentVersion = '5.0.0';
 
 var _username = Platform.environment['USER'] ?? '';
 String daemonWorkspace(String workingDirectory) {
@@ -26,6 +27,12 @@ String daemonWorkspace(String workingDirectory) {
 /// Used to ensure that only one instance of this daemon is running at a time.
 String lockFilePath(String workingDirectory) =>
     p.join(daemonWorkspace(workingDirectory), '.dart_build_lock');
+
+/// Used to communicate between daemon and client.
+///
+/// Unfortunate work around for https://github.com/dart-lang/sdk/issues/35809.
+String communicationFilePath(String workingDirectory) => p.join(
+    daemonWorkspace(workingDirectory), '.dart_build_daemon_communication');
 
 /// Used to signal to clients on what port the running daemon is listening.
 String portFilePath(String workingDirectory) =>

--- a/build_daemon/lib/src/daemon.dart
+++ b/build_daemon/lib/src/daemon.dart
@@ -14,24 +14,6 @@ import '../daemon_builder.dart';
 import '../data/build_target.dart';
 import 'server.dart';
 
-/// Returns the current version of the running build daemon.
-///
-/// Null if one isn't running.
-String runningVersion(String workingDirectory) {
-  var versionFile = File(versionFilePath(workingDirectory));
-  if (!versionFile.existsSync()) return null;
-  return versionFile.readAsStringSync();
-}
-
-/// Returns the current options of the running build daemon.
-///
-/// Null if one isn't running.
-Set<String> currentOptions(String workingDirectory) {
-  var optionsFile = File(optionsFilePath(workingDirectory));
-  if (!optionsFile.existsSync()) return Set();
-  return optionsFile.readAsLinesSync().toSet();
-}
-
 class Daemon {
   final String _workingDirectory;
 

--- a/build_daemon/lib/utilities.dart
+++ b/build_daemon/lib/utilities.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'constants.dart';
+
+/// Returns the current options of the running build daemon.
+///
+/// Null if one isn't running.
+Set<String> currentOptions(String workingDirectory) {
+  var optionsFile = File(optionsFilePath(workingDirectory));
+  if (!optionsFile.existsSync()) return Set();
+  return optionsFile.readAsLinesSync().toSet();
+}
+
+/// Notifies the initiating client that there was an error
+/// starting the daemon.
+void notifyError(String workingDirectory, String error) =>
+    File(communicationFilePath(workingDirectory))
+        .writeAsStringSync('$errorLog\n$error');
+
+/// Notifies the initiating client that the daemon is ready
+/// for connections.
+void notifyReady(String workingDirectory) =>
+    File(communicationFilePath(workingDirectory))
+        .writeAsStringSync(readyToConnectLog);
+
+/// Returns the current version of the running build daemon.
+///
+/// Null if one isn't running.
+String runningVersion(String workingDirectory) {
+  var versionFile = File(versionFilePath(workingDirectory));
+  if (!versionFile.existsSync()) return null;
+  return versionFile.readAsStringSync();
+}
+
+/// Creates a file for communication between client and daemon.
+///
+/// Unfortunate work around for https://github.com/dart-lang/sdk/issues/35809.
+File createCommunicationFile(String workingDirectory) =>
+    File(communicationFilePath(workingDirectory))..createSync(recursive: true);
+
+/// Returns true if the options are valid with the current running daemon.
+bool validateOptions(String workingDirectory, Set<String> requestedOptions) {
+  var runningOptions = currentOptions(workingDirectory);
+  if (!(runningOptions.length == requestedOptions.length &&
+      runningOptions.containsAll(requestedOptions))) {
+    var output = '$optionsSkew\n';
+    output += 'Running Options: $runningOptions\n';
+    output += 'Requested Options: $requestedOptions';
+    File(communicationFilePath(workingDirectory)).writeAsStringSync(output);
+    return false;
+  }
+  return true;
+}
+
+/// Returns true if the current running daemon version matches.
+bool validateVersion(String workingDirectory) {
+  var version = runningVersion(workingDirectory);
+  var output = '';
+  var comFile = File(communicationFilePath(workingDirectory));
+  if (version != currentVersion) {
+    output += '$versionSkew\n';
+    output += 'Running Version: $version\n';
+    output += 'Current Version: $currentVersion\n';
+    comFile.writeAsStringSync(output);
+    return false;
+  }
+  return true;
+}

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 0.2.2
+version: 0.3.0
 description: A daemon for running Dart builds.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon

--- a/build_daemon/test/daemon_test.dart
+++ b/build_daemon/test/daemon_test.dart
@@ -10,7 +10,7 @@ import 'package:build_daemon/constants.dart';
 // can resolve it.
 // ignore: unused_import
 import 'package:build_daemon/daemon_builder.dart';
-import 'package:build_daemon/src/daemon.dart';
+import 'package:build_daemon/utilities.dart';
 import 'package:package_resolver/package_resolver.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- Depend on the latest `package:build_daemon`.
+
 ## 1.2.3
 
 - Fix a bug where changing between `--live-reload` and `--hot-reload` might not

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.3
+version: 1.3.0
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -12,7 +12,7 @@ dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ">=1.0.0 <1.2.0"
   build_config: ^0.3.1
-  build_daemon: ^0.2.0
+  build_daemon: ^0.3.0
   build_resolvers: ^0.2.0
   build_runner_core: ^2.0.1
   code_builder: ">2.3.0 <4.0.0"
@@ -53,3 +53,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_daemon:
+    path: ../build_daemon


### PR DESCRIPTION
Workaround for https://github.com/dart-lang/sdk/issues/35809

- Route communication through a shared file instead of STDIO
- Provide shared utilities for this communication
- Update `package:build_runner` to depend on the latest `package:build_daemon` and make use of new shared utilities