### PR TITLE
Improve ddc/analyzer/kernel time tracking

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.6
+
+- Improved the time tracking for kernel and analyzer actions by not reporting
+  time spent waiting for a worker to be available.
+
 ## 1.0.5
 
 - Increased the upper bound for `package:analyzer` to `<0.36.0`.

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -116,7 +116,9 @@ Future<void> _createKernel(
   // We need to make sure and clean up the temp dir, even if we fail to compile.
   try {
     var analyzer = await buildStep.fetchResource(frontendDriverResource);
-    var response = await analyzer.doWork(request);
+    var response = await analyzer.doWork(request,
+        trackWork: (response) => buildStep
+            .trackStage('Kernel Generate', () => response, isExternal: true));
     if (response.exitCode != EXIT_CODE_OK || !await outputFile.exists()) {
       throw KernelException(
           outputId, '${request.arguments.join(' ')}\n${response.output}');

--- a/build_modules/lib/src/summary_builder.dart
+++ b/build_modules/lib/src/summary_builder.dart
@@ -93,7 +93,9 @@ Future _createUnlinkedSummary(Module module, BuildStep buildStep,
   request.arguments.addAll(_analyzerSourceArgsForModule(module, scratchSpace));
 
   var analyzer = await buildStep.fetchResource(analyzerDriverResource);
-  var response = await analyzer.doWork(request);
+  var response = await analyzer.doWork(request,
+      trackWork: (response) =>
+          buildStep.trackStage('Summarize', () => response, isExternal: true));
   if (response.exitCode == EXIT_CODE_ERROR) {
     throw AnalyzerSummaryException(module.unlinkedSummaryId, response.output);
   }

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 1.0.5
+version: 1.0.6
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: '>0.30.0 <0.36.0'
   async: '>=1.13.3 <3.0.0'
-  bazel_worker: ^0.1.4
+  bazel_worker: ^0.1.18
   build: '>=0.12.3 <2.0.0'
   build_config: '>=0.2.1 <0.4.0'
   glob: ^1.0.0

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.2
+
+- Improved the time tracking for ddc actions by not reporting time spent waiting
+  for a worker to be available.
+
 ## 1.0.1
 
 - Increased the upper bound for `package:analyzer` to `<0.36.0`.

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -176,8 +176,9 @@ Future _createDevCompilerModule(
     var driverResource =
         useKernel ? dartdevkDriverResource : dartdevcDriverResource;
     var driver = await buildStep.fetchResource(driverResource);
-    response = await buildStep
-        .trackStage('Compile', () => driver.doWork(request), isExternal: true);
+    response = await driver.doWork(request,
+        trackWork: (response) =>
+            buildStep.trackStage('Compile', () => response, isExternal: true));
   } finally {
     if (useKernel) await packagesFile.parent.delete(recursive: true);
   }

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 1.0.1
+version: 1.0.2
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.30.0 <0.36.0"
   archive: ">=1.0.13 <3.0.0"
-  bazel_worker: ^0.1.4
+  bazel_worker: ^0.1.18
   build: '>=0.12.8 <2.0.0'
   build_config: '>=0.2.6 <0.4.0'
   build_modules: '>=0.4.0 <2.0.0'


### PR DESCRIPTION
This makes sure we don't track the time spent waiting for a worker as part of the compile