### PR TITLE
Use output options in the build daemon

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.4
+## 1.2.5
 
 - Fix a bug with the build daemon where the output options were ignored.
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.4
+
+- Fix a bug with the build daemon where the output options were ignored.
+
 ## 1.2.3
 
 - Fix a bug where changing between `--live-reload` and `--hot-reload` might not

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -136,8 +136,15 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
     var expectedDeletes = Set<AssetId>();
     var outputStreamController = StreamController<ServerLog>();
 
-    var environment =
-        OverrideableEnvironment(IOEnvironment(packageGraph), onLog: (record) {
+    var environment = OverrideableEnvironment(
+        IOEnvironment(packageGraph,
+            assumeTty: true,
+            // TODO(grouma) - This should likely moved to the build_impl command
+            // so that different daemon clients can output to different
+            // directories.
+            outputMap: sharedOptions.outputMap,
+            outputSymlinksOnly: sharedOptions.outputSymlinksOnly),
+        onLog: (record) {
       // Print here as well so that severe errors can be caught by the
       // daemon client.
       print(record);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.4
+version: 1.2.5
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.3
+version: 1.2.4
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
In the future this should be a part of the `BuildTarget` that is sent to the Build Daemon. This would prevent options skew for options that are actually compatible.