### PR TITLE
remove overrides after publishing

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -24,11 +24,3 @@ dev_dependencies:
   build_vm_compilers: ^0.1.0
   pedantic: ^1.0.0
   test: ^1.2.0
-
-dependency_overrides:
-  build_modules:
-    path: ../build_modules
-  build_resolvers:
-    path: ../build_resolvers
-  build_vm_compilers:
-    path: ../build_vm_compilers

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -33,18 +33,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  analyzer: 0.35.0
-  build:
-    path: ../build
-  build_daemon:
-    path: ../build_daemon
-  build_resolvers:
-    path: ../build_resolvers
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core
-  build_vm_compilers:
-    path:  ../build_vm_compilers

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -33,3 +33,6 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  analyzer: ^0.35.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -17,17 +17,3 @@ dev_dependencies:
   build_test: ^0.10.1
   build_runner: ^1.0.0
   build_vm_compilers: ^0.1.0
-
-dependency_overrides:
-  build:
-    path: ../build
-  build_runner_core:
-    path:  ../build_runner_core
-  build_modules:
-    path: ../build_modules
-  build_runner:
-    path: ../build_runner
-  build_test:
-    path: ../build_test
-  build_vm_compilers:
-    path: ../build_vm_compilers

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.4
+
+- Update `build_resolvers` to version `1.0.0`.
+
 ## 1.2.3
 
 - Fix a bug where changing between `--live-reload` and `--hot-reload` might not

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -53,7 +53,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build_runner_core:
-    path: ../build_runner_core

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.3
+version: 1.2.4
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -13,7 +13,7 @@ dependencies:
   build: ">=1.0.0 <1.2.0"
   build_config: ^0.3.1
   build_daemon: ^0.2.0
-  build_resolvers: ^0.2.0
+  build_resolvers: "^1.0.0"
   build_runner_core: ^2.0.1
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
@@ -53,3 +53,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_runner_core:
+    path: ../build_runner_core

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+- Update `build_resolvers` to version `1.0.0`.
+
 ## 2.0.1
 
 - Fix an issue where the `finalizedReader` was not `reset` prior to build.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -40,4 +40,4 @@ dev_dependencies:
     path: ../_test_common
 
 dependency_overrides:
-  analyzer: 0.35.0
+  analyzer: ^0.35.0

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 2.0.1
+version: 2.0.2
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
@@ -11,7 +11,7 @@ dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ">=1.1.0 <1.2.0"
   build_config: ^0.3.1
-  build_resolvers: ^0.2.0
+  build_resolvers: ^1.0.0
   collection: ^1.14.0
   convert: ^2.0.1
   crypto: ">=0.9.2 <3.0.0"
@@ -38,3 +38,6 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  analyzer: 0.35.0

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -29,13 +29,3 @@ dev_dependencies:
   build_runner: ^1.0.0
   build_vm_compilers: ^0.1.0
   collection: ^1.14.0
-
-dependency_overrides:
-  build:
-    path: ../build
-  build_modules:
-    path: ../build_modules
-  build_resolvers:
-    path: ../build_resolvers
-  build_vm_compilers:
-    path: ../build_vm_compilers

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -20,17 +20,3 @@ dev_dependencies:
   test_descriptor: ^1.1.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build:
-    path: ../build
-  build_daemon:
-    path: ../build_daemon
-  build_modules:
-    path: ../build_modules
-  build_resolvers:
-    path: ../build_resolvers
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core


### PR DESCRIPTION
Everything should be good now, the only override left is an analyzer override for a couple packages due to source_gen and json_serializable dev dependencies.