### PR TITLE
Forward daemon output while connecting / starting

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Forward daemon output while starting up / connecting. 
+
 ## 0.2.3
 
 - Shutdown the daemon if no client connects within 30 seconds.

--- a/build_daemon/example/example.dart
+++ b/build_daemon/example/example.dart
@@ -25,10 +25,10 @@ void main(List<String> args) async {
   } catch (e) {
     if (e is VersionSkew) {
       print('Version skew. Please disconnect all other clients '
-          'before trying to start a new one: ${e.details}');
+          'before trying to start a new one.');
     } else if (e is OptionsSkew) {
       print('Options skew. Please disconnect all other clients '
-          'before trying to start a new one: ${e.details}');
+          'before trying to start a new one.');
     } else {
       print('Unexpected error: $e');
     }

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -84,18 +84,18 @@ class BuildDaemonClient {
         .transform(utf8.decoder)
         .transform(const LineSplitter())
         .asBroadcastStream();
-    var output = stream.where((line) => !_isActionMessage(line)).toList();
+    // Forward output from the daemon until an action message is provided.
+    // TODO(grouma) - we probably should use a logger here.
+    var sub = stream.where((line) => !_isActionMessage(line)).listen(print);
     var result = await stream.firstWhere(_isActionMessage, orElse: () => null);
-
     if (result == null) {
-      throw Exception(
-          'Unable to start build daemon: ${(await output).join('\n')}');
+      throw Exception('Unable to start build daemon.');
     } else if (result == versionSkew) {
-      throw VersionSkew('${await output}');
+      throw VersionSkew();
     } else if (result == optionsSkew) {
-      throw OptionsSkew('${await output}');
+      throw OptionsSkew();
     }
-
+    await sub.cancel();
     var port = _existingPort(workingDirectory);
     var client = BuildDaemonClient._();
     await client._connect(workingDirectory, port, serializersOverride);
@@ -110,11 +110,9 @@ class BuildDaemonClient {
 }
 
 class VersionSkew extends Error {
-  final String details;
-  VersionSkew(this.details);
+  VersionSkew();
 }
 
 class OptionsSkew extends Error {
-  final String details;
-  OptionsSkew(this.details);
+  OptionsSkew();
 }

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -109,10 +109,6 @@ class BuildDaemonClient {
   }
 }
 
-class VersionSkew extends Error {
-  VersionSkew();
-}
+class VersionSkew extends Error {}
 
-class OptionsSkew extends Error {
-  OptionsSkew();
-}
+class OptionsSkew extends Error {}

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 0.2.3
+version: 0.3.0
 description: A daemon for running Dart builds.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon


### PR DESCRIPTION
When running webdev with the daemon it looks like it is hanging while in actuality it is generating the build script. This change forwards these events which makes the experience much better. The initial logs don't have the proper tty settings so that will have to be addressed later. 