### PR TITLE
Simplify daemon client logging

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+- Replace the client log stream with an optional logHandler. This simplifies the
+  logging logic and prevents the need for the client to print to stdio. 
+
 ## 0.3.0
 
 - Forward daemon output while starting up / connecting. 

--- a/build_daemon/example/example.dart
+++ b/build_daemon/example/example.dart
@@ -48,7 +48,6 @@ void main(List<String> args) async {
     print('Registered test target...');
   }
   client.buildResults.listen((status) => print('BUILD STATUS: $status'));
-  client.serverLogs.listen((serverLog) => print(serverLog.log));
   client.startBuild();
   await client.finished;
 }

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -19,9 +19,7 @@ import 'data/server_log.dart';
 
 int _existingPort(String workingDirectory) {
   var portFile = File(portFilePath(workingDirectory));
-  if (!portFile.existsSync()) {
-    throw FileSystemException('Unable to read port file.');
-  }
+  if (!portFile.existsSync()) throw MissingPortFileException();
   return int.parse(portFile.readAsStringSync());
 }
 
@@ -122,6 +120,8 @@ class BuildDaemonClient {
         _existingPort(workingDirectory), daemonSerializers, logHandler);
   }
 }
+
+class MissingPortFileException extends Error {}
 
 class OptionsSkew extends Error {}
 

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -19,7 +19,7 @@ import 'data/server_log.dart';
 
 int _existingPort(String workingDirectory) {
   var portFile = File(portFilePath(workingDirectory));
-  if (!portFile.existsSync()) throw MissingPortFileException();
+  if (!portFile.existsSync()) throw MissingPortFile();
   return int.parse(portFile.readAsStringSync());
 }
 
@@ -121,8 +121,8 @@ class BuildDaemonClient {
   }
 }
 
-class MissingPortFileException extends Error {}
+class MissingPortFile implements Exception {}
 
-class OptionsSkew extends Error {}
+class OptionsSkew implements Exception {}
 
-class VersionSkew extends Error {}
+class VersionSkew implements Exception {}

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -19,7 +19,9 @@ import 'data/server_log.dart';
 
 int _existingPort(String workingDirectory) {
   var portFile = File(portFilePath(workingDirectory));
-  if (!portFile.existsSync()) throw Exception('Unable to read port file.');
+  if (!portFile.existsSync()) {
+    throw FileSystemException('Unable to read port file.');
+  }
   return int.parse(portFile.readAsStringSync());
 }
 

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -17,22 +17,80 @@ import 'data/build_target_request.dart';
 import 'data/serializers.dart';
 import 'data/server_log.dart';
 
+int _existingPort(String workingDirectory) {
+  var portFile = File(portFilePath(workingDirectory));
+  if (!portFile.existsSync()) throw Exception('Unable to read port file.');
+  return int.parse(portFile.readAsStringSync());
+}
+
+Future<void> _handleDaemonStartup(
+    Process process, DaemonLogHandler logHandler) async {
+  process.stderr
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .listen((line) {
+    logHandler(ServerLog((b) => b..log = line));
+  });
+  var stream = process.stdout
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .asBroadcastStream();
+
+  // The daemon may log critical information prior to it successfully
+  // starting. Capture this data and forward to the logHandler.
+  var sub = stream.where((line) => !_isActionMessage(line)).listen((line) {
+    logHandler(ServerLog((b) => b..log = line));
+  });
+
+  var daemonAction =
+      await stream.firstWhere(_isActionMessage, orElse: () => null);
+
+  if (daemonAction == null) {
+    throw Exception('Unable to start build daemon.');
+  } else if (daemonAction == versionSkew) {
+    throw VersionSkew();
+  } else if (daemonAction == optionsSkew) {
+    throw OptionsSkew();
+  }
+  await sub.cancel();
+}
+
+bool _isActionMessage(String line) =>
+    line == versionSkew || line == readyToConnectLog || line == optionsSkew;
+
+typedef void DaemonLogHandler(ServerLog serverLog);
+
 class BuildDaemonClient {
-  IOWebSocketChannel _channel;
-  Serializers _serializers;
-
   final _buildResults = StreamController<BuildResults>.broadcast();
+  final Serializers _serializers;
 
-  final _serverLogStreamController = StreamController<ServerLog>.broadcast();
+  IOWebSocketChannel _channel;
 
-  BuildDaemonClient._();
-
-  Stream<BuildResults> get buildResults => _buildResults.stream;
-  Future<void> get finished async {
-    if (_channel != null) await _channel.sink.done;
+  BuildDaemonClient._(
+    int port,
+    this._serializers,
+    DaemonLogHandler logHandler,
+  ) {
+    _channel = IOWebSocketChannel.connect('ws://localhost:$port');
+    _channel.stream.listen((data) {
+      var message = _serializers.deserialize(jsonDecode(data as String));
+      if (message is ServerLog) {
+        logHandler(message);
+      } else if (message is BuildResults) {
+        _buildResults.add(message);
+      } else {
+        // In practice we should never reach this state due to the
+        // deserialize call.
+        throw StateError(
+            'Unexpected message from the Dart Build Daemon\n $message');
+      }
+    })
+      // TODO(grouma) - Implement proper error handling.
+      ..onError(print);
   }
 
-  Stream<ServerLog> get serverLogs => _serverLogStreamController.stream;
+  Stream<BuildResults> get buildResults => _buildResults.stream;
+  Future<void> get finished async => await _channel.sink.done;
 
   /// Registers a build target to be built upon any file change.
   void registerBuildTarget(BuildTarget target) => _channel.sink.add(jsonEncode(
@@ -44,71 +102,24 @@ class BuildDaemonClient {
     _channel.sink.add(jsonEncode(_serializers.serialize(request)));
   }
 
-  Future<void> _connect(String workingDirectory, int port,
-      Serializers serializersOverride) async {
-    _channel = IOWebSocketChannel.connect('ws://localhost:$port');
-    _channel.stream.listen(_handleServerMessage)
-      // TODO(grouma) - Implement proper error handling.
-      ..onError(print);
-    _serializers = serializersOverride ?? serializers;
-  }
-
-  void _handleServerMessage(dynamic data) {
-    var message = _serializers.deserialize(jsonDecode(data as String));
-    if (message is ServerLog) {
-      _serverLogStreamController.add(message);
-    } else if (message is BuildResults) {
-      _buildResults.add(message);
-    } else {
-      // In practice we should never reach this state due to the
-      // deserialize call.
-      throw StateError(
-          'Unexpected message from the Dart Build Daemon\n $message');
-    }
-  }
-
-  static bool _isActionMessage(String line) =>
-      line == versionSkew || line == readyToConnectLog || line == optionsSkew;
-
   static Future<BuildDaemonClient> connect(
       String workingDirectory, List<String> daemonCommand,
-      {Serializers serializersOverride}) async {
+      {Serializers serializersOverride, DaemonLogHandler logHandler}) async {
+    logHandler ??= (_) {};
+    var daemonSerializers = serializersOverride ?? serializers;
+
     var process = await Process.start(
         daemonCommand.first, daemonCommand.sublist(1),
         mode: ProcessStartMode.detachedWithStdio,
         workingDirectory: workingDirectory);
 
-    // Print errors coming from the Dart Build Daemon to help with debugging.
-    process.stderr.transform(utf8.decoder).listen(print);
-    var stream = process.stdout
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .asBroadcastStream();
-    // Forward output from the daemon until an action message is provided.
-    // TODO(grouma) - we probably should use a logger here.
-    var sub = stream.where((line) => !_isActionMessage(line)).listen(print);
-    var result = await stream.firstWhere(_isActionMessage, orElse: () => null);
-    if (result == null) {
-      throw Exception('Unable to start build daemon.');
-    } else if (result == versionSkew) {
-      throw VersionSkew();
-    } else if (result == optionsSkew) {
-      throw OptionsSkew();
-    }
-    await sub.cancel();
-    var port = _existingPort(workingDirectory);
-    var client = BuildDaemonClient._();
-    await client._connect(workingDirectory, port, serializersOverride);
-    return client;
-  }
+    await _handleDaemonStartup(process, logHandler);
 
-  static int _existingPort(String workingDirectory) {
-    var portFile = File(portFilePath(workingDirectory));
-    if (!portFile.existsSync()) throw Exception('Unable to read port file.');
-    return int.parse(portFile.readAsStringSync());
+    return BuildDaemonClient._(
+        _existingPort(workingDirectory), daemonSerializers, logHandler);
   }
 }
 
-class VersionSkew extends Error {}
-
 class OptionsSkew extends Error {}
+
+class VersionSkew extends Error {}

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 0.3.0
+version: 0.4.0
 description: A daemon for running Dart builds.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.6
+
+- No longer assumeTty when logging through the daemon command.
+- Update `build_daemon` to version `0.4.0`. 
+
 ## 1.2.5
 
 - Fix a bug with the build daemon where the output options were ignored.

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,11 +1,8 @@
 ## 1.2.6
 
-<<<<<<< HEAD
 - No longer assumeTty when logging through the daemon command.
 - Update `build_daemon` to version `0.4.0`. 
-=======
 - Ensure the daemon command always exits.
->>>>>>> master
 
 ## 1.2.5
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.5
+version: 1.2.6
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -12,7 +12,7 @@ dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ">=1.0.0 <1.2.0"
   build_config: ^0.3.1
-  build_daemon: ^0.2.0
+  build_daemon: ^0.4.0
   build_resolvers: "^1.0.0"
   build_runner_core: ^2.0.1
   code_builder: ">2.3.0 <4.0.0"
@@ -53,3 +53,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_daemon:
+    path: ../build_daemon


### PR DESCRIPTION
Issue: Critical information is logged to the STDIO prior to the daemon client being fully initialized. We want to provide an easy way for clients to listen for this information and display it to the user.

Changes:
- Remove the `ServerLog` stream from the `BuildDaemonClient`.
- Add an optional `daemonLogHandler` to be passed in during `BuildDaemonClient.connect`.
- Simplify the `BuildDaemonClient.connect` method into a handful of appropriately named helper methods. 
- No longer assumeTty within the daemon command, simply log messages to the STDIO. Note that webdev will handle pretty printing and related logic.
- Rev `package:build_daemon` and `package:build_runner`.