### PR TITLE
Explicit check for overwriting input extension

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.2
+
+- Add an explicit error when `buildExtensions` is configured to overwrite it's
+  input.
+
 ## 0.3.1+4
 
 - Support the latest `package:json_annotation`.

--- a/build_config/lib/src/builder_definition.dart
+++ b/build_config/lib/src/builder_definition.dart
@@ -139,6 +139,13 @@ class BuilderDefinition {
       throw ArgumentError.value(builderFactories, 'builderFactories',
           'Must have at least one value.');
     }
+    if (buildExtensions.entries.any((e) => e.value.contains(e.key))) {
+      throw ArgumentError.value(
+          buildExtensions,
+          'buildExtensions',
+          'May not overwrite an input, '
+          'the output extensions must not contain the input extension');
+    }
   }
 
   factory BuilderDefinition.fromJson(Map json) =>

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.3.1+4
+version: 0.3.2-dev
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config

--- a/build_config/test/errors_test.dart
+++ b/build_config/test/errors_test.dart
@@ -7,6 +7,8 @@ import 'package:test/test.dart';
 import 'package:build_config/build_config.dart';
 
 void main() {
+  Matcher throwsError(String content) => throwsA(TypeMatcher<ArgumentError>()
+      .having((e) => e.message, 'message', contains(content)));
   group('parse errors', () {
     test('for missing default target', () {
       var buildYaml = r'''
@@ -15,7 +17,21 @@ targets:
     sources: ["lib/**"]
 ''';
       expect(() => BuildConfig.parse('package_name', [], buildYaml),
-          throwsArgumentError);
+          throwsError('Must specify a target with the name'));
+    });
+
+    test('for bad build extensions', () {
+      var buildYaml = r'''
+builders:
+  some_builder:
+    build_extensions:
+      .dart:
+      - .dart
+    builder_factories: ["someFactory"]
+    import: package:package_name/builders.dart
+''';
+      expect(() => BuildConfig.parse('package_name', [], buildYaml),
+          throwsError('May not overwrite an input'));
     });
   });
 }


### PR DESCRIPTION
Fixes #1715

When attempting to replicate the behavior of a Transformer that modified
it's input a user may try to configure a Builder that has the same
output extension as the input. Look for this case explicitly and emit a
specific error.

This prevents an infinite loop attemptint to construct an AssetGraph.