### PR TITLE
Implement checkOutputs as a Matcher

### DIFF
--- a/_test_common/lib/test_phases.dart
+++ b/_test_common/lib/test_phases.dart
@@ -167,14 +167,13 @@ void checkBuild(BuildResult result,
     }
   }
 
-  AssetId mapHidden(AssetId id, String expectedGeneratedDir) =>
-      unhiddenAssets.contains(id)
-          ? AssetId(rootPackage,
-              '.dart_tool/build/$expectedGeneratedDir/${id.package}/${id.path}')
-          : id;
-
   if (status == BuildStatus.success) {
-    checkOutputs(unhiddenOutputs, result.outputs, writer,
-        mapAssetIds: (id) => mapHidden(id, expectedGeneratedDir));
+    final actualOutputs = Map.fromIterable(
+        result.outputs.map((id) => unhiddenAssets.contains(id)
+            ? AssetId(rootPackage,
+                '.dart_tool/build/$expectedGeneratedDir/${id.package}/${id.path}')
+            : id),
+        value: (id) => writer.assets[id]);
+    expect(actualOutputs, hasOutputs(unhiddenOutputs));
   }
 }


### PR DESCRIPTION
Closes #376

Add a method to create a Matcher against a map of output contents.
Deprecate `checkOutputs`.

This shifts the burden of handling the `mapAssetIds` concept to a more
localized place where it is needed. The implementation is also more
idiomatic by reusing existing matcher concepts like Map equality.