### PR TITLE
Drop some unnecessary typedefs

### DIFF
--- a/_test_common/lib/in_memory_writer.dart
+++ b/_test_common/lib/in_memory_writer.dart
@@ -11,11 +11,9 @@ import 'package:watcher/watcher.dart';
 
 import 'package:build_runner_core/build_runner_core.dart';
 
-typedef void OnDelete(AssetId id);
-
 class InMemoryRunnerAssetWriter extends InMemoryAssetWriter
     implements RunnerAssetWriter {
-  OnDelete onDelete;
+  void Function(AssetId) onDelete;
 
   @override
   Future writeAsBytes(AssetId id, List<int> bytes) async {

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -125,8 +125,6 @@ WatchImpl _runWatch(
         directoryWatcherFactory, configKey, willCreateOutputDirs, buildDirs,
         isReleaseMode: isReleaseMode);
 
-typedef Future<BuildResult> _BuildAction(List<List<AssetChange>> changes);
-
 class WatchImpl implements BuildState {
   BuildImpl _build;
 

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -285,7 +285,8 @@ class WatchImpl implements BuildState {
         })
         .transform(debounceBuffer(_debounceDelay))
         .transform(takeUntil(terminate))
-        .transform(asyncMapBuffer(_recordCurrentBuild(doBuild)))
+        .transform(asyncMapBuffer((changes) => currentBuild = doBuild(changes)
+          ..whenComplete(() => currentBuild = null)))
         .listen((BuildResult result) {
           if (controller.isClosed) return;
           controller.add(result);
@@ -333,9 +334,6 @@ class WatchImpl implements BuildState {
 
     return controller.stream;
   }
-
-  _BuildAction _recordCurrentBuild(_BuildAction build) => (changes) =>
-      currentBuild = build(changes)..then((_) => currentBuild = null);
 
   bool _isBuildYaml(AssetId id) => id.path == 'build.yaml';
   bool _isConfiguredBuildYaml(AssetId id) =>

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -11,14 +11,13 @@ import 'package:logging/logging.dart';
 import 'asset_change.dart';
 import 'node_watcher.dart';
 
-typedef PackageNodeWatcher _NodeWatcherStrategy(PackageNode node);
 PackageNodeWatcher _default(PackageNode node) => PackageNodeWatcher(node);
 
 /// Allows watching an entire graph of packages to schedule rebuilds.
 class PackageGraphWatcher {
   // TODO: Consider pulling logging out and providing hooks instead.
   final Logger _logger;
-  final _NodeWatcherStrategy _strategy;
+  final PackageNodeWatcher Function(PackageNode) _strategy;
   final PackageGraph _graph;
 
   var _readyCompleter = Completer<Null>();

--- a/build_runner/lib/src/watcher/node_watcher.dart
+++ b/build_runner/lib/src/watcher/node_watcher.dart
@@ -10,12 +10,11 @@ import 'package:watcher/watcher.dart';
 
 import 'asset_change.dart';
 
-typedef Watcher _WatcherStrategy(String path);
 Watcher _default(String path) => Watcher(path);
 
 /// Allows watching significant files and directories in a given package.
 class PackageNodeWatcher {
-  final _WatcherStrategy _strategy;
+  final Watcher Function(String) _strategy;
   final PackageNode _node;
 
   /// The actual watcher instance.

--- a/build_runner_core/lib/src/asset/writer.dart
+++ b/build_runner_core/lib/src/asset/writer.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:build/build.dart';
 
+@deprecated
 typedef void OnDelete(AssetId id);
 
 abstract class RunnerAssetWriter implements AssetWriter {

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -209,7 +209,7 @@ Future<T> _resolveAssets<T>(
 /// It simulates what a user builder would do in order to resolve a primary
 /// input given a set of dependencies to also use. See `resolveSource`.
 class _ResolveSourceBuilder<T> implements Builder {
-  final FutureOr<T> Function(Resolver)  _action;
+  final FutureOr<T> Function(Resolver) _action;
   final Future _tearDown;
   final AssetId _resolverFor;
 

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -204,14 +204,12 @@ Future<T> _resolveAssets<T>(
   return resolveBuilder.onDone.future;
 }
 
-typedef FutureOr<T> _ResolverAction<T>(Resolver resolver);
-
 /// A [Builder] that is only used to retrieve a [Resolver] instance.
 ///
 /// It simulates what a user builder would do in order to resolve a primary
 /// input given a set of dependencies to also use. See `resolveSource`.
 class _ResolveSourceBuilder<T> implements Builder {
-  final _ResolverAction<T> _action;
+  final FutureOr<T> Function(Resolver)  _action;
   final Future _tearDown;
   final AssetId _resolverFor;
 


### PR DESCRIPTION
Closes #1086

Remove some typedefs that are not saving enough space or used often
enough to justify a unique name.

Keep typedefs that are giving a significantly shorter or more clear name
to a function type.

Deprecate the `OnDelete` typedef in `build_runner_core` since it is
public, even though it's not used anywhere removing it would technically
be a breaking change.