### PR TITLE
Warn instead of create an output without assets

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+- Warn when there are no assets to write in a specified output directory.
+
 ## 2.0.2
 
 - Update `build_resolvers` to version `1.0.0`.

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -43,9 +43,7 @@ Future<bool> createMergedOutputDirectories(
   for (var output in outputMap.keys) {
     if (!await _createMergedOutputDir(output, outputMap[output], packageGraph,
         environment, reader, finalizedAssetsView, outputSymlinksOnly)) {
-      _logger.severe('Unable to create merged directory for $output.\n'
-          'Choose a different directory or delete the contents of that '
-          'directory.');
+      _logger.severe('Unable to create merged directory for $output.');
       return false;
     }
   }
@@ -65,19 +63,19 @@ Future<bool> _createMergedOutputDir(
   if (outputDirExists) {
     if (!await _cleanUpOutputDir(outputDir, environment)) return false;
   }
+  var builtAssets = finalizedOutputsView.allAssets(rootDir: root).toList();
+  if (root != null &&
+      !builtAssets
+          .where((id) => id.package == packageGraph.root.name)
+          .any((id) => p.isWithin(root, id.path))) {
+    _logger.severe('No assets exist in $root, skipping output');
+    return false;
+  }
 
   var outputAssets = <AssetId>[];
 
   var assetWriteResult = await logTimedAsync(
       _logger, 'Creating merged output dir `$outputPath`', () async {
-    var builtAssets = finalizedOutputsView.allAssets(rootDir: root).toList();
-    if (root != null &&
-        !builtAssets
-            .where((id) => id.package == packageGraph.root.name)
-            .any((id) => p.isWithin(root, id.path))) {
-      _logger.severe('No assets exist in $root, skipping output');
-      return false;
-    }
     if (!outputDirExists) {
       await outputDir.create(recursive: true);
     }
@@ -208,15 +206,18 @@ Future<bool> _cleanUpOutputDir(
       int choice;
       try {
         choice = await environment.prompt(
-            'Found existing output directory `$outputPath` but no manifest '
-            'file. Please choose one of the following options:',
+            'Found existing directory `$outputPath` but no manifest file.\n'
+            'Please choose one of the following options:',
             choices);
       } on NonInteractiveBuildException catch (_) {
-        choice = 0;
+        _logger.severe('Unable to create merged directory at $outputPath.\n'
+            'Choose a different directory or delete the contents of that '
+            'directory.');
+        return false;
       }
       switch (choice) {
         case 0:
-          _logger.warning('Skipped creation of the merged output directory.');
+          _logger.severe('Skipped creation of the merged output directory.');
           return false;
         case 1:
           try {

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -74,8 +74,8 @@ Future<bool> _createMergedOutputDir(
 
   var outputAssets = <AssetId>[];
 
-  var assetWriteResult = await logTimedAsync(
-      _logger, 'Creating merged output dir `$outputPath`', () async {
+  await logTimedAsync(_logger, 'Creating merged output dir `$outputPath`',
+      () async {
     if (!outputDirExists) {
       await outputDir.create(recursive: true);
     }
@@ -98,9 +98,7 @@ Future<bool> _createMergedOutputDir(
         }
       }
     }
-    return true;
   });
-  if (!assetWriteResult) return false;
 
   await logTimedAsync(_logger, 'Writing asset manifest', () async {
     var paths = outputAssets.map((id) => id.path).toList()..sort();

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 2.0.2
+version: 2.1.0-dev
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core

--- a/build_runner_core/test/environment/create_merged_dir_test.dart
+++ b/build_runner_core/test/environment/create_merged_dir_test.dart
@@ -119,6 +119,14 @@ main() {
       _expectFiles(webFiles, tmpDir);
     });
 
+    test('skips output directories with no assets', () async {
+      var success = await createMergedOutputDirectories({
+        tmpDir.path: 'no_assets_here',
+      }, packageGraph, environment, assetReader, finalizedAssetsView, false);
+      expect(success, isFalse);
+      expect(Directory(tmpDir.path).listSync(), isEmpty);
+    });
+
     test('does not output the input directory', () async {
       var success = await createMergedOutputDirectories({
         tmpDir.path: 'web',


### PR DESCRIPTION
Fixes #1297

Since we don't know which assets will exist (only those which may exist)
before the build, save this check until we are outputting the directory.
The build that already happen may be a waste - but it will get reused if
the command is corrected to specify an output from a root that does have
assets in it.