### PR TITLE
Prevent terminals launching on Windows when using the daemon

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7
+
+- Run workers with mode `detachedWithStdio` if no terminal is connected. 
+
 ## 1.0.6
 
 - Improved the time tracking for kernel and analyzer actions by not reporting

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -122,13 +122,11 @@ final dartdevcDriverResource =
 /// Manages a shared set of persistent dartdevk workers.
 BazelWorkerDriver get _dartdevkDriver {
   _dartdevkWorkersAreDoneCompleter ??= Completer<Null>();
-  var packages = p.joinAll([sdkDir, '..', '..', '..', '.packages']);
   return __dartdevkDriver ??= BazelWorkerDriver(
       () => Process.start(
           p.join(sdkDir, 'bin', 'dart'),
           [
-            p.join(sdkDir, 'bin', 'snapshots', 'dartdevk.dart.snapshot'),
-            '--packages=$packages',
+            p.join(sdkDir, 'bin', 'snapshots', 'dartdevc.dart.snapshot'),
             '--kernel',
             '--persistent_worker'
           ],

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -298,7 +298,8 @@ class _Dart2JsWorker {
         _jobsSinceLastRestartCount = 0;
         __worker ??= await _spawnWorker();
         _spawningWorker = null;
-        unawaited(__worker.exitCode.then((_) {
+        // exitCode can be null: https://github.com/dart-lang/sdk/issues/35874
+        unawaited(__worker.exitCode?.then((_) {
           __worker = null;
           __workerStdoutLines = null;
           __workerStderrLines = null;
@@ -379,7 +380,10 @@ class _Dart2JsWorker {
     __worker = null;
     __workerStdoutLines = null;
     __workerStderrLines = null;
-    worker?.kill();
+    if (worker != null) {
+      worker.kill();
+      await worker.stdin.close();
+    }
     await worker?.exitCode;
   }
 }

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -122,7 +122,7 @@ final dartdevcDriverResource =
 /// Manages a shared set of persistent dartdevk workers.
 BazelWorkerDriver get _dartdevkDriver {
   _dartdevkWorkersAreDoneCompleter ??= Completer<Null>();
-  var packages = p.joinAll([sdkDir, '..', '..', '..', '.packageas']);
+  var packages = p.joinAll([sdkDir, '..', '..', '..', '.packages']);
   return __dartdevkDriver ??= BazelWorkerDriver(
       () => Process.start(
           p.join(sdkDir, 'bin', 'dart'),

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -17,7 +17,7 @@ import 'scratch_space.dart';
 
 final sdkDir = p.dirname(p.dirname(Platform.resolvedExecutable));
 
-// If no terminal is attached, prevent a new one from launcing.
+// If no terminal is attached, prevent a new one from launching.
 final _processMode = stdin.hasTerminal
     ? ProcessStartMode.normal
     : ProcessStartMode.detachedWithStdio;

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -177,12 +177,13 @@ final frontendDriverResource =
 /// Manages a shared set of persistent dart2js workers.
 Dart2JsBatchWorkerPool get _dart2jsWorkerPool {
   _dart2jsWorkersAreDoneCompleter ??= Completer<Null>();
+  var librariesSpec = p.joinAll([sdkDir, 'lib', 'libraries.json']);
   return __dart2jsWorkerPool ??= Dart2JsBatchWorkerPool(() => Process.start(
       p.join(sdkDir, 'bin', 'dart'),
       [
         p.join(sdkDir, 'bin', 'snapshots', 'dart2js.dart.snapshot'),
+        '--libraries-spec=$librariesSpec',
         '--batch',
-        '--library-root=$sdkDir'
       ],
       mode: _processMode,
       workingDirectory: scratchSpace.tempDir.path));

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: '>0.30.0 <0.36.0'
   async: '>=1.13.3 <3.0.0'
-  bazel_worker: ^0.1.18
+  bazel_worker: ^0.1.20
   build: '>=0.12.3 <2.0.0'
   build_config: '>=0.2.1 <0.4.0'
   glob: ^1.0.0

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 1.0.6
+version: 1.0.7
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.6
+
+- Prevent terminals being launched when running the daemon command on Windows.
+
 ## 1.2.5
 
 - Fix a bug with the build daemon where the output options were ignored.

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,10 +1,7 @@
 ## 1.2.6
 
-<<<<<<< HEAD
 - Prevent terminals being launched when running the daemon command on Windows.
-=======
 - Ensure the daemon command always exits.
->>>>>>> master
 
 ## 1.2.5
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.5
+version: 1.2.6
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
The daemon command is typically launched in a process with mode `detachedWithStdio`. Due to the behavior outlined in https://github.com/dart-lang/sdk/issues/35809 we need to launch nested programs with mode `detachedWithStdio` as well. Also we must run the snapshot directly, otherwise the `.bat` file will create a terminal. Ideally we simply run these snapshots as isolates, but that change can come at a further date. Given the check on `stdin.hasTerminal` this should only impact the `daemon` command and tests.

Towards https://github.com/dart-lang/webdev/issues/111