### PR TITLE
Handle asset graph decode failures

### DIFF
--- a/_test/test/build_script_invalidation_test.dart
+++ b/_test/test/build_script_invalidation_test.dart
@@ -74,7 +74,7 @@ void main() {
         'lib'
       ], extraExpects: [
         () => nextStdOutLine(
-            'Throwing away cached asset graph due to version mismatch.'),
+            'Throwing away cached asset graph due to version mismatch'),
         () => nextStdOutLine('Building new asset graph'),
         () => nextStdOutLine('Succeeded after'),
       ]);

--- a/_test_common/lib/matchers.dart
+++ b/_test_common/lib/matchers.dart
@@ -7,8 +7,8 @@ import 'package:build_runner_core/src/asset_graph/exceptions.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
 
-final Matcher assetGraphVersionException =
-    TypeMatcher<AssetGraphVersionException>();
+final Matcher throwsCorruptedException =
+    throwsA(TypeMatcher<AssetGraphCorruptedException>());
 final Matcher duplicateAssetNodeException =
     TypeMatcher<DuplicateAssetNodeException>();
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -53,3 +53,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_runner_core:
+    path: ../build_runner_core

--- a/build_runner_core/lib/src/asset_graph/exceptions.dart
+++ b/build_runner_core/lib/src/asset_graph/exceptions.dart
@@ -23,13 +23,4 @@ class DuplicateAssetNodeException implements Exception {
   }
 }
 
-class AssetGraphVersionException implements Exception {
-  final int versionSeen;
-  final int currentVersion;
-
-  AssetGraphVersionException(this.versionSeen, this.currentVersion);
-
-  @override
-  String toString() => 'AssetGraphVersionException: saw version $versionSeen '
-      'but the current version is $currentVersion.';
-}
+class AssetGraphCorruptedException implements Exception {}

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -16,16 +16,25 @@ class _AssetGraphDeserializer {
   final _idToAssetId = HashMap<int, AssetId>();
   final Map _serializedGraph;
 
-  _AssetGraphDeserializer(List<int> bytes)
-      : _serializedGraph = json.decode(utf8.decode(bytes)) as Map;
+  _AssetGraphDeserializer._(this._serializedGraph);
+
+  factory _AssetGraphDeserializer(List<int> bytes) {
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(utf8.decode(bytes));
+    } on FormatException {
+      throw AssetGraphCorruptedException();
+    }
+    if (decoded is! Map) throw AssetGraphCorruptedException();
+    final serializedGraph = decoded as Map;
+    if (serializedGraph['version'] != _version) {
+      throw AssetGraphCorruptedException();
+    }
+    return _AssetGraphDeserializer._(serializedGraph);
+  }
 
   /// Perform the deserialization, should only be called once.
   AssetGraph deserialize() {
-    if (_serializedGraph['version'] != _version) {
-      throw AssetGraphVersionException(
-          _serializedGraph['version'] as int, _version);
-    }
-
     var graph = AssetGraph._(
         _deserializeDigest(_serializedGraph['buildActionsDigest'] as String),
         _serializedGraph['dart_version'] as String);

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -242,11 +242,10 @@ class _Loader {
           return null;
         }
         return cachedGraph;
-      } on AssetGraphVersionException catch (_) {
-        // Start fresh if the cached asset_graph version doesn't match up with
-        // the current version. We don't currently support old graph versions.
-        _logger.warning(
-            'Throwing away cached asset graph due to version mismatch.');
+      } on AssetGraphCorruptedException catch (_) {
+        // Start fresh if the cached asset_graph cannot be deserialized
+        _logger.warning('Throwing away cached asset graph due to '
+            'version mismatch or corrupted asset graph.');
         await Future.wait([
           _deleteGeneratedDir(),
           FailureReporter.cleanErrorCache(),

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -157,7 +157,7 @@ void main() {
       });
 
       test('Throws an AssetGraphCorruptedException on invalid json', () {
-        var bytes = graph.serialize()..removeLast();
+        var bytes = List.of(graph.serialize())..removeLast();
         expect(() => AssetGraph.deserialize(bytes), throwsCorruptedException);
       });
     });

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -157,8 +157,7 @@ void main() {
       });
 
       test('Throws an AssetGraphCorruptedException on invalid json', () {
-        var bytes = graph.serialize();
-        bytes.removeLast();
+        var bytes = graph.serialize()..removeLast();
         expect(() => AssetGraph.deserialize(bytes), throwsCorruptedException);
       });
     });

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -147,13 +147,19 @@ void main() {
         expect(graph, equalsAssetGraph(decoded));
       });
 
-      test('Throws an AssetGraphVersionError if versions dont match up', () {
+      test('Throws an AssetGraphCorruptedException if versions dont match up',
+          () {
         var bytes = graph.serialize();
         var serialized = json.decode(utf8.decode(bytes));
         serialized['version'] = -1;
         var encoded = utf8.encode(json.encode(serialized));
-        expect(() => AssetGraph.deserialize(encoded),
-            throwsA(assetGraphVersionException));
+        expect(() => AssetGraph.deserialize(encoded), throwsCorruptedException);
+      });
+
+      test('Throws an AssetGraphCorruptedException on invalid json', () {
+        var bytes = graph.serialize();
+        bytes.removeLast();
+        expect(() => AssetGraph.deserialize(bytes), throwsCorruptedException);
       });
     });
 

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -20,3 +20,7 @@ dev_dependencies:
   test_descriptor: ^1.1.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_runner_core:
+    path: ../build_runner_core


### PR DESCRIPTION
Fixes #2026

- Rename AssetGraphVersionException to AssetGraphCorruptedException and
  make the error message more general. Remove the fields from the
  exception that were never read.
- Catch `FormatException` for decoding failures, and throw as a corrupted
  exception.
- Throw a corrupted exception is the decoded graph is not a `Map`.
- Add a test for a graph with invalid json.