### PR TITLE
Remove the fine logs for file watching

### DIFF
--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -72,7 +72,6 @@ class PackageGraphWatcher {
         return;
       }
       final nestedPackages = _nestedPaths(node);
-      _logger.fine('Setting up watcher at ${node.path}');
       final nodeWatcher = _strategy(node);
       allWatchers.add(nodeWatcher);
       subscriptions.add(nodeWatcher.watch().listen((event) {
@@ -80,8 +79,6 @@ class PackageGraphWatcher {
         if (nestedPackages.any((path) => event.id.path.startsWith(path))) {
           return;
         }
-        _logger.finest(
-            'Got ${event.type} event for "${event.id.uri} in ${node.path}');
         sink.add(event);
       }));
     });


### PR DESCRIPTION
These make the `--verbose` output harder to use and haven't proven to be
useful in any scenarios that have come up.