### PR TITLE
Better explain build_to cache vs source

### DIFF
--- a/docs/builder_author_faq.md
+++ b/docs/builder_author_faq.md
@@ -3,13 +3,13 @@
 Outputs to `source` will generally be published with the package on pub. **This
 can be risky.** If the generated code depends on _any_ details from the current
 pub solve - that is it reads information from dependencies - then a consumer of
-the package which got different versions of dependencies in their pub solve
+the package which has different versions of dependencies in their pub solve
 **may be broken**. If the generated code imports any libraries, including from
 the package providing the builder, it must only use the API surface area which
 is guaranteed to not break without a major version bump.
 
-Outputs to `cache` will never be published with the package and if they are
-required to compile or run then the build system must be used by every consumer
+Outputs to `cache` will never be published with the package, and if they are
+required to compile or run, then the build system must be used by every consumer
 of the code. **This is always safe**, but may place limitations on the end user.
 Any outputs which are used _during_ a build to produce other outputs, but don't
 need to be compiled or seen by the user, should also be built to `cache`.

--- a/docs/builder_author_faq.md
+++ b/docs/builder_author_faq.md
@@ -1,21 +1,18 @@
 ## When should a Builder build to `cache` vs `source`?
 
-Use `build_to: source` when:
-- The generated code should be `pub publish`ed with the package and used by
-  downstream packages without running a build themselves.
-- The generated code _does not_ depend on details outside of the containing
-  package that might change with a different version of its dependencies. Any
-  details from the _generating_ package, or any other dependency used by the
-  generated code must not change without a major version bump.
+Outputs to `source` will generally be published with the package on pub. **This
+can be risky.** If the generated code depends on _any_ details from the current
+pub solve - that is it reads information from dependencies - then a consumer of
+the package which got different versions of dependencies in their pub solve may
+be broken. If the generated code imports any libraries, including from the
+package providing the builder, it must only use the API surface area which is
+guaranteed to not break without a major version bump.
 
-Use `build_to: cache` when:
-- The builder targets use cases for "application" packages that are unlikely to
-  be published rather than packages which will be published and become
-  dependencies.
-- The generated code uses details from outside of the package with the generated
-  code, including from the _generating_ package which may change without a major
-  version bump.
-- The builder generates lots of files that the user might not expect to see.
+Outputs to `cache` will never be published with the package and if they are
+required to compile or run then the build system must be used by every consumer
+of the code. **This is always safe**, but may place limitations on the end user.
+Any outputs which are used _during_ a build to produce other outputs, but don't
+need to be compiled or seen by the user, should also be built to `cache`.
 
 ## How can I have temporary outputs only used during the Build?
 

--- a/docs/builder_author_faq.md
+++ b/docs/builder_author_faq.md
@@ -3,10 +3,10 @@
 Outputs to `source` will generally be published with the package on pub. **This
 can be risky.** If the generated code depends on _any_ details from the current
 pub solve - that is it reads information from dependencies - then a consumer of
-the package which got different versions of dependencies in their pub solve may
-be broken. If the generated code imports any libraries, including from the
-package providing the builder, it must only use the API surface area which is
-guaranteed to not break without a major version bump.
+the package which got different versions of dependencies in their pub solve
+**may be broken**. If the generated code imports any libraries, including from
+the package providing the builder, it must only use the API surface area which
+is guaranteed to not break without a major version bump.
 
 Outputs to `cache` will never be published with the package and if they are
 required to compile or run then the build system must be used by every consumer

--- a/docs/builder_author_faq.md
+++ b/docs/builder_author_faq.md
@@ -1,21 +1,21 @@
 ## When should a Builder build to `cache` vs `source`?
 
 Use `build_to: source` when:
+- The generated code should be `pub publish`ed with the package and used by
+  downstream packages without running a build themselves.
 - The generated code _does not_ depend on details outside of the containing
   package that might change with a different version of its dependencies. Any
   details from the _generating_ package, or any other dependency used by the
   generated code must not change without a major version bump.
-- The generated code should be `pub publish`ed with the package and used by
-  downstream packages without running a build themselves.
 
 Use `build_to: cache` when:
+- The builder targets use cases for "application" packages that are unlikely to
+  be published rather than packages which will be published and become
+  dependencies.
 - The generated code uses details from outside of the package with the generated
   code, including from the _generating_ package which may change without a major
   version bump.
 - The builder generates lots of files that the user might not expect to see.
-- The builder targets use cases for "application" packages that are unlikely to
-  be published rather than packages which will be published and become
-  dependencies.
 
 ## How can I have temporary outputs only used during the Build?
 


### PR DESCRIPTION
- re-order the `build_to: source` and `build_to: cache` recommendations to emphasize the choice between building for packages vs building for applications