### PR TITLE
allow configuring build script updates via environment

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.7
+- `overrideEnvironment` factory can be optionally provided to
+   the`BuildCommandRunner` to allow further `BuildEnvironment` customization
+
 ## 1.2.6
 
 - Prevent terminals being launched when running the daemon command on Windows.

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -128,12 +128,10 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
     _buildResults.add(daemon.BuildResults((b) => b..results.addAll(results)));
   }
 
-  static Future<BuildRunnerDaemonBuilder> create(
-    PackageGraph packageGraph,
-    List<BuilderApplication> builders,
-    SharedOptions sharedOptions, {
-    OverrideableEnvironment Function(BuildEnvironment) overrideEnvironment
-  }) async {
+  static Future<BuildRunnerDaemonBuilder> create(PackageGraph packageGraph,
+      List<BuilderApplication> builders, SharedOptions sharedOptions,
+      {OverrideableEnvironment Function(BuildEnvironment)
+          overrideEnvironment}) async {
     var expectedDeletes = Set<AssetId>();
     var outputStreamController = StreamController<ServerLog>();
 

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -132,12 +132,13 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
     PackageGraph packageGraph,
     List<BuilderApplication> builders,
     SharedOptions sharedOptions,
+    BuildEnvironment overrideEnvironment,
   ) async {
     var expectedDeletes = Set<AssetId>();
     var outputStreamController = StreamController<ServerLog>();
 
     var environment = OverrideableEnvironment(
-        IOEnvironment(packageGraph,
+        overrideEnvironment ?? IOEnvironment(packageGraph,
             assumeTty: true,
             // TODO(grouma) - This should likely moved to the build_impl command
             // so that different daemon clients can output to different

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -131,9 +131,9 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
   static Future<BuildRunnerDaemonBuilder> create(
     PackageGraph packageGraph,
     List<BuilderApplication> builders,
-    SharedOptions sharedOptions,
-    OverrideableEnvironment Function(BuildEnvironment) overrideEnvironment,
-  ) async {
+    SharedOptions sharedOptions, {
+    OverrideableEnvironment Function(BuildEnvironment) overrideEnvironment
+  }) async {
     var expectedDeletes = Set<AssetId>();
     var outputStreamController = StreamController<ServerLog>();
 

--- a/build_runner/lib/src/entrypoint/base_command.dart
+++ b/build_runner/lib/src/entrypoint/base_command.dart
@@ -17,6 +17,8 @@ abstract class BuildRunnerCommand extends Command<int> {
 
   PackageGraph get packageGraph => (runner as BuildCommandRunner).packageGraph;
 
+  BuildEnvironment get overrideEnvironment => (runner as BuildCommandRunner).overrideEnvironment;
+
   BuildRunnerCommand({bool symlinksDefault}) {
     _addBaseFlags(symlinksDefault ?? false);
   }

--- a/build_runner/lib/src/entrypoint/base_command.dart
+++ b/build_runner/lib/src/entrypoint/base_command.dart
@@ -17,7 +17,8 @@ abstract class BuildRunnerCommand extends Command<int> {
 
   PackageGraph get packageGraph => (runner as BuildCommandRunner).packageGraph;
 
-  OverrideableEnvironment Function(BuildEnvironment) get overrideEnvironment => (runner as BuildCommandRunner).overrideEnvironment;
+  OverrideableEnvironment Function(BuildEnvironment) get overrideEnvironment =>
+      (runner as BuildCommandRunner).overrideEnvironment;
 
   BuildRunnerCommand({bool symlinksDefault}) {
     _addBaseFlags(symlinksDefault ?? false);

--- a/build_runner/lib/src/entrypoint/base_command.dart
+++ b/build_runner/lib/src/entrypoint/base_command.dart
@@ -17,7 +17,7 @@ abstract class BuildRunnerCommand extends Command<int> {
 
   PackageGraph get packageGraph => (runner as BuildCommandRunner).packageGraph;
 
-  BuildEnvironment get overrideEnvironment => (runner as BuildCommandRunner).overrideEnvironment;
+  OverrideableEnvironment Function(BuildEnvironment) get overrideEnvironment => (runner as BuildCommandRunner).overrideEnvironment;
 
   BuildRunnerCommand({bool symlinksDefault}) {
     _addBaseFlags(symlinksDefault ?? false);

--- a/build_runner/lib/src/entrypoint/build.dart
+++ b/build_runner/lib/src/entrypoint/build.dart
@@ -40,6 +40,7 @@ class BuildCommand extends BuildRunnerCommand {
       skipBuildScriptCheck: options.skipBuildScriptCheck,
       buildDirs: options.buildDirs,
       logPerformanceDir: options.logPerformanceDir,
+      overrideEnvironment: overrideEnvironment,
     );
     if (result.status == BuildStatus.success) {
       return ExitCode.success.code;

--- a/build_runner/lib/src/entrypoint/daemon.dart
+++ b/build_runner/lib/src/entrypoint/daemon.dart
@@ -57,6 +57,7 @@ class DaemonCommand extends BuildRunnerCommand {
         packageGraph,
         builderApplications,
         options,
+        overrideEnvironment,
       );
       // Forward server logs to daemon command STDIO.
       var logSub =

--- a/build_runner/lib/src/entrypoint/daemon.dart
+++ b/build_runner/lib/src/entrypoint/daemon.dart
@@ -57,7 +57,7 @@ class DaemonCommand extends BuildRunnerCommand {
         packageGraph,
         builderApplications,
         options,
-        overrideEnvironment,
+        overrideEnvironment: overrideEnvironment,
       );
       // Forward server logs to daemon command STDIO.
       var logSub =

--- a/build_runner/lib/src/entrypoint/run.dart
+++ b/build_runner/lib/src/entrypoint/run.dart
@@ -17,7 +17,7 @@ import 'runner.dart';
 ///
 /// Returns the exit code that should be set when the calling process exits. `0`
 /// implies success.
-Future<int> run(List<String> args, List<BuilderApplication> builders, {BuildEnvironment overrideEnvironment}) async {
+Future<int> run(List<String> args, List<BuilderApplication> builders, {OverrideableEnvironment Function(BuildEnvironment) overrideEnvironment}) async {
   var runner = BuildCommandRunner(builders, overrideEnvironment: overrideEnvironment);
   try {
     var result = await runner.run(args);

--- a/build_runner/lib/src/entrypoint/run.dart
+++ b/build_runner/lib/src/entrypoint/run.dart
@@ -17,8 +17,11 @@ import 'runner.dart';
 ///
 /// Returns the exit code that should be set when the calling process exits. `0`
 /// implies success.
-Future<int> run(List<String> args, List<BuilderApplication> builders, {OverrideableEnvironment Function(BuildEnvironment) overrideEnvironment}) async {
-  var runner = BuildCommandRunner(builders, overrideEnvironment: overrideEnvironment);
+Future<int> run(List<String> args, List<BuilderApplication> builders,
+    {OverrideableEnvironment Function(BuildEnvironment)
+        overrideEnvironment}) async {
+  var runner =
+      BuildCommandRunner(builders, overrideEnvironment: overrideEnvironment);
   try {
     var result = await runner.run(args);
     return result ?? 0;

--- a/build_runner/lib/src/entrypoint/run.dart
+++ b/build_runner/lib/src/entrypoint/run.dart
@@ -17,8 +17,8 @@ import 'runner.dart';
 ///
 /// Returns the exit code that should be set when the calling process exits. `0`
 /// implies success.
-Future<int> run(List<String> args, List<BuilderApplication> builders) async {
-  var runner = BuildCommandRunner(builders);
+Future<int> run(List<String> args, List<BuilderApplication> builders, {BuildEnvironment overrideEnvironment}) async {
+  var runner = BuildCommandRunner(builders, overrideEnvironment: overrideEnvironment);
   try {
     var result = await runner.run(args);
     return result ?? 0;

--- a/build_runner/lib/src/entrypoint/runner.dart
+++ b/build_runner/lib/src/entrypoint/runner.dart
@@ -17,7 +17,7 @@ import 'watch.dart';
 /// Unified command runner for all build_runner commands.
 class BuildCommandRunner extends CommandRunner<int> {
   final List<BuilderApplication> builderApplications;
-  final BuildEnvironment overrideEnvironment;
+  final OverrideableEnvironment Function(BuildEnvironment) overrideEnvironment;
 
   final packageGraph = PackageGraph.forThisPackage();
 

--- a/build_runner/lib/src/entrypoint/runner.dart
+++ b/build_runner/lib/src/entrypoint/runner.dart
@@ -21,7 +21,8 @@ class BuildCommandRunner extends CommandRunner<int> {
 
   final packageGraph = PackageGraph.forThisPackage();
 
-  BuildCommandRunner(List<BuilderApplication> builderApplications, {this.overrideEnvironment})
+  BuildCommandRunner(List<BuilderApplication> builderApplications,
+      {this.overrideEnvironment})
       : builderApplications = List.unmodifiable(builderApplications),
         super('build_runner', 'Unified interface for running Dart builds.') {
     addCommand(DaemonCommand());

--- a/build_runner/lib/src/entrypoint/runner.dart
+++ b/build_runner/lib/src/entrypoint/runner.dart
@@ -17,10 +17,11 @@ import 'watch.dart';
 /// Unified command runner for all build_runner commands.
 class BuildCommandRunner extends CommandRunner<int> {
   final List<BuilderApplication> builderApplications;
+  final BuildEnvironment overrideEnvironment;
 
   final packageGraph = PackageGraph.forThisPackage();
 
-  BuildCommandRunner(List<BuilderApplication> builderApplications)
+  BuildCommandRunner(List<BuilderApplication> builderApplications, {this.overrideEnvironment})
       : builderApplications = List.unmodifiable(builderApplications),
         super('build_runner', 'Unified interface for running Dart builds.') {
     addCommand(DaemonCommand());

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -72,11 +72,12 @@ Future<BuildResult> build(List<BuilderApplication> builders,
     bool isReleaseBuild,
     Map<String, Map<String, dynamic>> builderConfigOverrides,
     List<String> buildDirs,
-    String logPerformanceDir}) async {
+    String logPerformanceDir,
+    BuildEnvironment overrideEnvironment}) async {
   builderConfigOverrides ??= const {};
   packageGraph ??= PackageGraph.forThisPackage();
   var environment = OverrideableEnvironment(
-      IOEnvironment(
+      overrideEnvironment ?? IOEnvironment(
         packageGraph,
         assumeTty: assumeTty,
         outputMap: outputMap,

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -73,11 +73,11 @@ Future<BuildResult> build(List<BuilderApplication> builders,
     Map<String, Map<String, dynamic>> builderConfigOverrides,
     List<String> buildDirs,
     String logPerformanceDir,
-    BuildEnvironment overrideEnvironment}) async {
+    OverrideableEnvironment Function(BuildEnvironment) overrideEnvironment}) async {
   builderConfigOverrides ??= const {};
   packageGraph ??= PackageGraph.forThisPackage();
   var environment = OverrideableEnvironment(
-      overrideEnvironment ?? IOEnvironment(
+      IOEnvironment(
         packageGraph,
         assumeTty: assumeTty,
         outputMap: outputMap,
@@ -86,6 +86,9 @@ Future<BuildResult> build(List<BuilderApplication> builders,
       reader: reader,
       writer: writer,
       onLog: onLog ?? stdIOLogListener(assumeTty: assumeTty, verbose: verbose));
+  if (overrideEnvironment != null) {
+    environment = OverrideableEnvironment(environment);
+  }
   var logSubscription =
       LogSubscription(environment, verbose: verbose, logLevel: logLevel);
   var options = await BuildOptions.create(

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -73,7 +73,8 @@ Future<BuildResult> build(List<BuilderApplication> builders,
     Map<String, Map<String, dynamic>> builderConfigOverrides,
     List<String> buildDirs,
     String logPerformanceDir,
-    OverrideableEnvironment Function(BuildEnvironment) overrideEnvironment}) async {
+    OverrideableEnvironment Function(BuildEnvironment)
+        overrideEnvironment}) async {
   builderConfigOverrides ??= const {};
   packageGraph ??= PackageGraph.forThisPackage();
   var environment = OverrideableEnvironment(

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.6
+version: 1.2.7
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.7
+version: 1.2.8
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+
+- `BuildScriptUpdates` is now provided by the `BuildEnvironment` via the    
+  `buildScriptUpdates` method.
+
 ## 2.1.0
 
 - Warn when there are no assets to write in a specified output directory.

--- a/build_runner_core/lib/src/environment/build_environment.dart
+++ b/build_runner_core/lib/src/environment/build_environment.dart
@@ -30,7 +30,8 @@ abstract class BuildEnvironment {
   /// Determines whether current build script needs to be updated.
   ///
   /// Defaults to [BuildScriptUpdates].
-  Future<BuildScriptUpdates> buildScriptUpdates(PackageGraph packageGraph, AssetGraph graph) {
+  Future<BuildScriptUpdates> buildScriptUpdates(
+      PackageGraph packageGraph, AssetGraph graph) {
     return BuildScriptUpdates.create(reader, packageGraph, graph);
   }
 

--- a/build_runner_core/lib/src/environment/build_environment.dart
+++ b/build_runner_core/lib/src/environment/build_environment.dart
@@ -9,8 +9,11 @@ import 'package:logging/logging.dart';
 
 import '../asset/reader.dart';
 import '../asset/writer.dart';
+import '../asset_graph/graph.dart';
+import '../changes/build_script_updates.dart';
 import '../generate/build_result.dart';
 import '../generate/finalized_assets_view.dart';
+import '../package_graph/package_graph.dart';
 
 /// Utilities to interact with the environment in which a build is running.
 ///
@@ -23,6 +26,13 @@ abstract class BuildEnvironment {
   RunnerAssetWriter get writer;
 
   void onLog(LogRecord record);
+
+  /// Determines whether current build script needs to be updated.
+  ///
+  /// Defaults to [BuildScriptUpdates].
+  Future<BuildScriptUpdates> buildScriptUpdates(PackageGraph packageGraph, AssetGraph graph) {
+    return BuildScriptUpdates.create(reader, packageGraph, graph);
+  }
 
   /// Prompt the user for input.
   ///

--- a/build_runner_core/lib/src/environment/io_environment.dart
+++ b/build_runner_core/lib/src/environment/io_environment.dart
@@ -11,6 +11,8 @@ import 'package:logging/logging.dart';
 import '../asset/file_based.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
+import '../asset_graph/graph.dart';
+import '../changes/build_script_updates.dart';
 import '../generate/build_result.dart';
 import '../generate/finalized_assets_view.dart';
 import '../package_graph/package_graph.dart';
@@ -85,6 +87,11 @@ class IOEnvironment implements BuildEnvironment {
       }
     }
     return buildResult;
+  }
+
+  @override
+  Future<BuildScriptUpdates> buildScriptUpdates(PackageGraph packageGraph, AssetGraph graph) {
+    return BuildScriptUpdates.create(reader, packageGraph, graph);
   }
 }
 

--- a/build_runner_core/lib/src/environment/io_environment.dart
+++ b/build_runner_core/lib/src/environment/io_environment.dart
@@ -11,8 +11,6 @@ import 'package:logging/logging.dart';
 import '../asset/file_based.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
-import '../asset_graph/graph.dart';
-import '../changes/build_script_updates.dart';
 import '../generate/build_result.dart';
 import '../generate/finalized_assets_view.dart';
 import '../package_graph/package_graph.dart';
@@ -22,7 +20,7 @@ import 'create_merged_dir.dart';
 final _logger = Logger('IOEnvironment');
 
 /// A [BuildEnvironment] writing to disk and stdout.
-class IOEnvironment implements BuildEnvironment {
+class IOEnvironment extends BuildEnvironment {
   @override
   final RunnerAssetReader reader;
 
@@ -78,20 +76,15 @@ class IOEnvironment implements BuildEnvironment {
 
   @override
   Future<BuildResult> finalizeBuild(BuildResult buildResult,
-      FinalizedAssetsView finalizedAssetsView, AssetReader reader) async {
+      FinalizedAssetsView finalizedAssetsView, AssetReader assetReader) async {
     if (_outputMap != null && buildResult.status == BuildStatus.success) {
       if (!await createMergedOutputDirectories(_outputMap, _packageGraph, this,
-          reader, finalizedAssetsView, _outputSymlinksOnly)) {
+          assetReader, finalizedAssetsView, _outputSymlinksOnly)) {
         return _convertToFailure(buildResult,
             failureType: FailureType.cantCreate);
       }
     }
     return buildResult;
-  }
-
-  @override
-  Future<BuildScriptUpdates> buildScriptUpdates(PackageGraph packageGraph, AssetGraph graph) {
-    return BuildScriptUpdates.create(reader, packageGraph, graph);
   }
 }
 

--- a/build_runner_core/lib/src/environment/overridable_environment.dart
+++ b/build_runner_core/lib/src/environment/overridable_environment.dart
@@ -44,11 +44,9 @@ class OverrideableEnvironment implements BuildEnvironment {
     Future<BuildResult> Function(BuildResult result,
             FinalizedAssetsView finalizedAssetsView, AssetReader reader)
         finalizeBuild,
-    Future<BuildScriptUpdates> Function(
-    AssetReader assetReader,
-    PackageGraph packageGraph,
-    AssetGraph graph,
-      ) buildScriptUpdates,
+    Future<BuildScriptUpdates> Function(AssetReader assetReader,
+            PackageGraph packageGraph, AssetGraph graph)
+        buildScriptUpdates,
   })  : _reader = reader,
         _writer = writer,
         _onLog = onLog,
@@ -81,7 +79,8 @@ class OverrideableEnvironment implements BuildEnvironment {
       _default.prompt(message, choices);
 
   @override
-  Future<BuildScriptUpdates> buildScriptUpdates(PackageGraph packageGraph, AssetGraph graph) {
+  Future<BuildScriptUpdates> buildScriptUpdates(
+      PackageGraph packageGraph, AssetGraph graph) {
     if (_buildScriptUpdates != null) {
       return _buildScriptUpdates(reader, packageGraph, graph);
     }

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -89,8 +89,8 @@ class _Loader {
           () => _updateAssetGraph(assetGraph, _buildPhases, inputSources,
               cacheDirSources, internalSources));
 
-      buildScriptUpdates = await BuildScriptUpdates.create(
-          _environment.reader, _options.packageGraph, assetGraph);
+      buildScriptUpdates = await _environment.buildScriptUpdates(
+          _options.packageGraph, assetGraph);
       if (!_options.skipBuildScriptCheck &&
           buildScriptUpdates.hasBeenUpdated(updates.keys.toSet())) {
         _logger.warning('Invalidating asset graph due to build script update!');
@@ -118,8 +118,8 @@ class _Loader {
           _logger.severe('Conflicting outputs', e, st);
           throw CannotBuildException();
         }
-        buildScriptUpdates = await BuildScriptUpdates.create(
-            _environment.reader, _options.packageGraph, assetGraph);
+        buildScriptUpdates = await _environment.buildScriptUpdates(
+            _options.packageGraph, assetGraph);
         conflictingOutputs = assetGraph.outputs
             .where((n) => n.package == _options.packageGraph.root.name)
             .where(inputSources.contains)

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 2.1.0-dev
+version: 2.1.1
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
Allows configuring how to do the build script checks via the environment, allowing flutter tools to skip them when running build scripts. 

---

More general topic of discussion: I've drifted towards using build_runner more directly because incorporating it into the flutter_tool doesn't have very high costs in terms of dependencies, and also because it exposes a ton of very useful functionality. In that case, I am not sure the best route to allow configuring this build_script check from build_runner, or whether it should be done at all.

For example, daemon_builder has a ton of useful functionality that I don't really want to duplicate. We would like to find a way to disable the script check in its environment though.

The second commit contains an example of piping an `overrideEnvironment` this through build_runner itself. This could be provided directly via the flutter tool or by generating a slightly different build script.