### PR TITLE
Fail fast when there is an empty include glob

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Add an explicit error when `buildExtensions` is configured to overwrite it's
   input.
+- Add an explicit error when an `InputSet` has an empty or null value in a glob
+  list.
 
 ## 0.3.1+4
 

--- a/build_config/lib/src/input_set.dart
+++ b/build_config/lib/src/input_set.dart
@@ -33,7 +33,18 @@ class InputSet {
       throw ArgumentError.value(json, 'sources',
           'Expected a Map or a List but got a ${json.runtimeType}');
     }
-    return _$InputSetFromJson(json as Map);
+    final parsed = _$InputSetFromJson(json as Map);
+    if (parsed.include != null &&
+        parsed.include.any((s) => s == null || s.isEmpty)) {
+      throw ArgumentError.value(
+          parsed.include, 'include', 'Include globs must not be empty');
+    }
+    if (parsed.exclude != null &&
+        parsed.exclude.any((s) => s == null || s.isEmpty)) {
+      throw ArgumentError.value(
+          parsed.exclude, 'exclude', 'Exclude globs must not be empty');
+    }
+    return parsed;
   }
 
   @override

--- a/build_config/test/errors_test.dart
+++ b/build_config/test/errors_test.dart
@@ -33,5 +33,18 @@ builders:
       expect(() => BuildConfig.parse('package_name', [], buildYaml),
           throwsError('May not overwrite an input'));
     });
+
+    test('for empty include globs', () {
+      var buildYaml = r'''
+targets:
+  $default:
+    builders:
+      some_package|some_builder:
+        generate_for:
+        -
+''';
+      expect(() => BuildConfig.parse('package_name', [], buildYaml),
+          throwsError('Include globs must not be empty'));
+    });
   });
 }


### PR DESCRIPTION
Fixes #1878

Put some validation for the `include` and `exclude` lists after parsing
an `InputSet` from json. This validation cannot be done for instances
created using the default constructor in code since it's a const
constructor, but having it done for json solves the majority of the
problem.