### PR TITLE
Simplify logging newline handling

### DIFF
--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -25,17 +25,9 @@ StringBuffer colorLog(LogRecord record, {bool verbose}) {
   }
   final level = color.wrap('[${record.level}]');
   final eraseLine = ansiOutputEnabled && !verbose ? '\x1b[2K\r' : '';
-  var headerMessage = record.message;
-  var blankLineCount = 0;
-  if (headerMessage.startsWith('\n')) {
-    blankLineCount =
-        headerMessage.split('\n').takeWhile((line) => line.isEmpty).length;
-    headerMessage = headerMessage.substring(blankLineCount);
-  }
-  var header = '$eraseLine$level ${_loggerName(record, verbose)}$headerMessage';
-  var lines = blankLineCount > 0
-      ? (List<Object>.generate(blankLineCount, (_) => '')..add(header))
-      : <Object>[header];
+  var lines = <Object>[
+    '$eraseLine$level ${_loggerName(record, verbose)}${record.message}'
+  ];
 
   if (record.error != null) {
     lines.add(record.error);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.6
+version: 1.2.7-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
The extra check for a leading newline was added as a hack to get a
specific behavior around enforcing certain messages to not get cleared
when starting a new build in watch mode. We've since added a line of
dashes and are using trailing newlines to avoid erasing these messages,
so the extra logic is no longer necessary.