### PR TITLE
Refactor PackageGraphWatcher

### DIFF
--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -41,7 +41,8 @@ class PackageGraphWatcher {
   Stream<AssetChange> watch() {
     assert(!_isWatching);
     _isWatching = true;
-    return logTimedSync(_logger, 'Setting up file watchers', _watch);
+    return LazyStream(
+        () => logTimedSync(_logger, 'Setting up file watchers', _watch));
   }
 
   Stream<AssetChange> _watch() {

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -47,8 +47,7 @@ class PackageGraphWatcher {
 
   Stream<AssetChange> _watch() {
     final allWatchers = _graph.allPackages.values
-        .where((node) => !(node.dependencyType == DependencyType.hosted ||
-            node.dependencyType == DependencyType.github))
+        .where((node) => node.dependencyType == DependencyType.path)
         .map(_strategy)
         .toList();
     final filteredEvents = allWatchers

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:async/async.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:logging/logging.dart';
 
@@ -20,10 +21,10 @@ class PackageGraphWatcher {
   final PackageNodeWatcher Function(PackageNode) _strategy;
   final PackageGraph _graph;
 
-  var _readyCompleter = Completer<Null>();
+  final _readyCompleter = Completer<Null>();
   Future<Null> get ready => _readyCompleter.future;
 
-  StreamController<AssetChange> controller;
+  bool _isWatching = false;
 
   /// Creates a new watcher for a [PackageGraph].
   ///
@@ -38,49 +39,20 @@ class PackageGraphWatcher {
 
   /// Returns a stream of records for assets that changed in the package graph.
   Stream<AssetChange> watch() {
-    if (controller != null) return controller.stream;
-    List<StreamSubscription> subscriptions;
-    controller = StreamController<AssetChange>(
-      sync: true,
-      onListen: () {
-        subscriptions = logTimedSync(
-          _logger,
-          'Setting up file watchers',
-          () => _watch(controller),
-        );
-      },
-      onCancel: () {
-        for (final subscription in subscriptions) {
-          subscription.cancel();
-        }
-        _readyCompleter = Completer<Null>();
-        var done = controller.close();
-        controller = null;
-        return done;
-      },
-    );
-    return controller.stream;
+    assert(!_isWatching);
+    _isWatching = true;
+    return logTimedSync(_logger, 'Setting up file watchers', _watch);
   }
 
-  List<StreamSubscription> _watch(StreamSink<AssetChange> sink) {
-    final subscriptions = <StreamSubscription>[];
-    var allWatchers = <PackageNodeWatcher>[];
-    _graph.allPackages.forEach((name, node) {
-      if (node.dependencyType == DependencyType.hosted ||
-          node.dependencyType == DependencyType.github) {
-        return;
-      }
-      final nestedPackages = _nestedPaths(node);
-      final nodeWatcher = _strategy(node);
-      allWatchers.add(nodeWatcher);
-      subscriptions.add(nodeWatcher.watch().listen((event) {
-        // TODO: Consider a faster filtering strategy.
-        if (nestedPackages.any((path) => event.id.path.startsWith(path))) {
-          return;
-        }
-        sink.add(event);
-      }));
-    });
+  Stream<AssetChange> _watch() {
+    final allWatchers = _graph.allPackages.values
+        .where((node) => !(node.dependencyType == DependencyType.hosted ||
+            node.dependencyType == DependencyType.github))
+        .map(_strategy)
+        .toList();
+    final filteredEvents = allWatchers
+        .map((w) => w.watch().where(_nestedPathFilter(w.node)))
+        .toList();
     // Asynchronously complete the `_readyCompleter` once all the watchers
     // are done.
     () async {
@@ -88,7 +60,12 @@ class PackageGraphWatcher {
           allWatchers.map((nodeWatcher) => nodeWatcher.watcher.ready));
       _readyCompleter.complete();
     }();
-    return subscriptions;
+    return StreamGroup.merge(filteredEvents);
+  }
+
+  bool Function(AssetChange) _nestedPathFilter(PackageNode rootNode) {
+    final ignorePaths = _nestedPaths(rootNode);
+    return (change) => !ignorePaths.any(change.id.path.startsWith);
   }
 
   // Returns a set of all package paths that are "nested" within a node.

--- a/build_runner/lib/src/watcher/node_watcher.dart
+++ b/build_runner/lib/src/watcher/node_watcher.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:build_runner_core/build_runner_core.dart';
-import 'package:path/path.dart' as p;
 import 'package:watcher/watcher.dart';
 
 import 'asset_change.dart';
@@ -15,7 +14,7 @@ Watcher _default(String path) => Watcher(path);
 /// Allows watching significant files and directories in a given package.
 class PackageNodeWatcher {
   final Watcher Function(String) _strategy;
-  final PackageNode _node;
+  final PackageNode node;
 
   /// The actual watcher instance.
   Watcher _watcher;
@@ -27,27 +26,15 @@ class PackageNodeWatcher {
   /// reasonable default based on the current platform and the type of path
   /// (i.e. a file versus directory).
   PackageNodeWatcher(
-    this._node, {
+    this.node, {
     Watcher watch(String path),
   }) : _strategy = watch ?? _default;
 
   /// Returns a stream of records for assets that change recursively.
-  ///
-  /// If [relative] is omitted, the entire package is watched:
-  /// ```dart
-  /// // a/lib/**
-  /// packageA.watch('lib');
-  ///
-  /// // a/**
-  /// packageA.watch()
-  /// ```
-  Stream<AssetChange> watch([String relative]) {
+  Stream<AssetChange> watch() {
     assert(_watcher == null);
-
-    final path = _node.path;
-    final absolute = relative != null ? p.join(path, relative) : path;
-    _watcher = _strategy(absolute);
+    _watcher = _strategy(node.path);
     final events = _watcher.events;
-    return events.map((e) => AssetChange.fromEvent(_node, e));
+    return events.map((e) => AssetChange.fromEvent(node, e));
   }
 }

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -386,7 +386,7 @@ a:file://different/fake/pkg/path
       group('build.yaml', () {
         final packageGraph = buildPackageGraph({
           rootPackage('a', path: path.absolute('a')): ['b'],
-          package('b', path: path.absolute('b')): []
+          package('b', path: path.absolute('b'), type: DependencyType.path): []
         });
         List<LogRecord> logs;
         StreamQueue<BuildResult> results;

--- a/build_runner/test/watcher/graph_watcher_test.dart
+++ b/build_runner/test/watcher/graph_watcher_test.dart
@@ -21,7 +21,7 @@ void main() {
     test('should aggregate changes from all nodes', () {
       final graph = buildPackageGraph({
         rootPackage('a', path: '/g/a'): ['b'],
-        package('b', path: '/g/b'): []
+        package('b', path: '/g/b', type: DependencyType.path): []
       });
       final nodes = {
         'a': FakeNodeWatcher(graph['a']),
@@ -46,7 +46,7 @@ void main() {
     test('should avoid duplicate changes with nested packages', () async {
       final graph = buildPackageGraph({
         rootPackage('a', path: '/g/a'): ['b'],
-        package('b', path: '/g/a/b'): []
+        package('b', path: '/g/a/b', type: DependencyType.path): []
       });
       final nodes = {
         'a': FakeNodeWatcher(graph['a'])..markReady(),
@@ -96,7 +96,7 @@ void main() {
     test('ready waits for all node watchers to be ready', () async {
       final graph = buildPackageGraph({
         rootPackage('a', path: '/g/a'): ['b'],
-        package('b', path: '/g/b'): []
+        package('b', path: '/g/b', type: DependencyType.path): []
       });
       final nodes = {
         'a': FakeNodeWatcher(graph['a']),

--- a/build_runner/test/watcher/graph_watcher_test.dart
+++ b/build_runner/test/watcher/graph_watcher_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:async/async.dart';
 import 'package:build/build.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';

--- a/build_runner/test/watcher/node_watcher_test.dart
+++ b/build_runner/test/watcher/node_watcher_test.dart
@@ -47,7 +47,7 @@ void main() {
       initFiles(node);
 
       expect(
-        nodeWatcher.watch('lib'),
+        nodeWatcher.watch(),
         emitsInAnyOrder([
           AssetChange(
             AssetId('a', 'lib/1.dart'),
@@ -76,7 +76,7 @@ void main() {
       initFiles(node);
 
       expect(
-        nodeWatcher.watch('lib'),
+        nodeWatcher.watch(),
         emitsInAnyOrder([
           AssetChange(
             AssetId('a', 'lib/1.dart'),


### PR DESCRIPTION
Use `StreamGroup.merge` to combine all the individual node watchers
instead of dropping down to StreamController directly. This saves us
from needing to handle things like cancel forwarding.

- Make the `node` field public on `PackageNodeWatcher` so we can more
  easily `.map()` over the instances and set up the filtering.
- Add a `_nestedPathFilter` helper method to get a closure over the
  nested paths without needing a separate variable higher up.
- Fix the test for nested path filtering. The old test did not exercise
  the filtering code path since it did not send the change through the
  "outer" watcher like what would happen in a real file system.
- Enforce that a single call is made to `watch()` explicitly.
- Remove the `relative` concept from the node watcher since it was
  unused outside of tests.