### PR TITLE
Don't allow dart:isolate on DDC

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.8
+
+- Don't follow `dart.library.isolate` conditional imports for the DDC
+  platform.
+
 ## 1.0.7+2
 
 - Update `dart2js` snapshot arguments for upcoming SDK.

--- a/build_modules/lib/src/platform.dart
+++ b/build_modules/lib/src/platform.dart
@@ -18,7 +18,6 @@ class DartPlatform {
     'html',
     'html_common',
     'indexed_db',
-    'isolate',
     'js',
     'js_util',
     'math',

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 1.0.7+2
+version: 1.0.8
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -53,3 +53,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_modules:
+    path: ../build_modules


### PR DESCRIPTION
We're pulling in the `dart.library.isolate` import choices and sending
them to DDC to compile, but then it's following the default import and
not finding a file. Since we ignore the `uri_does_not_exist` error the
actual error reported confusingly refers to a `part-of` directive that
does not actually exist in the file.