### PR TITLE
Drop override for build_modules

### DIFF
--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -53,7 +53,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build_modules:
-    path: ../build_modules


### PR DESCRIPTION
This was only necessary for a green travis to submit a change which
fixed `build_modules` - no that it's published the pub solved version
should be fine.