### PR TITLE
Allow running builds with fake `test` package

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.8
+
+- Allow running when the root package, or a path dependency, is named `test`.
+
 ## 1.2.7
 
 - Fix issue where daemon command would occasionally color a log.

--- a/build_runner/lib/src/entrypoint/test.dart
+++ b/build_runner/lib/src/entrypoint/test.dart
@@ -140,6 +140,7 @@ bool _packageTestSupportsSymlinks(PackageGraph packageGraph) {
   if (testPackage == null) return false;
   var pubspecPath = p.join(testPackage.path, 'pubspec.yaml');
   var pubspec = Pubspec.parse(File(pubspecPath).readAsStringSync());
+  if (pubspec.version == null) return false;
   return pubspec.version >= Version(1, 3, 0);
 }
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.2.7
+version: 1.2.8
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Fixes #2059

If there is a path or git dependency on some packge that _isn't_ the
official test package, but happens to be named `test`, it may not have a
version. That case should be detected later on when we look for
`build_test` which depends on the pub version of test (unless a
dependency override is used, in which case unexpected things may
happen).