### PR TITLE
Fix new analyzer warnings/lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -80,7 +80,6 @@ linter:
     - prefer_typing_uninitialized_variables
     - recursive_getters
     - slash_for_doc_comments
-    - super_goes_last
     - test_types_in_equals
     - throw_in_finally
     - type_init_formals

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -64,6 +64,7 @@ linter:
     - package_names
     - package_prefixed_library_names
     - prefer_adjacent_string_concatenation
+    # TODO: reenable this once we want to pin the SDK to >=2.2.0
     # - prefer_collection_literals
     - prefer_conditional_assignment
     #- prefer_const_constructors

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -64,7 +64,7 @@ linter:
     - package_names
     - package_prefixed_library_names
     - prefer_adjacent_string_concatenation
-    - prefer_collection_literals
+    # - prefer_collection_literals
     - prefer_conditional_assignment
     #- prefer_const_constructors
     - prefer_contains

--- a/build/lib/src/asset/reader.dart
+++ b/build/lib/src/asset/reader.dart
@@ -27,7 +27,7 @@ abstract class AssetReader {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws a `AssetNotFoundException` if `id.path` is not found.
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8});
+  Future<String> readAsString(AssetId id, {Encoding encoding});
 
   /// Indicates whether asset at [id] is readable.
   Future<bool> canRead(AssetId id);

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -37,3 +37,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -19,3 +19,7 @@ dev_dependencies:
   build_test: ^0.10.0
   build_vm_compilers: ^0.1.0
   test: ^1.0.0
+
+dependency_overrides:
+  build:
+    path: ../build


### PR DESCRIPTION
- removed prefer_collection_literals, this now triggers for Sets, and even empty Sets which you can't use a collection literal for
- removed super_goes_last, this is now deprecated
- removed the default `utf8` encoding from `AssetReader.readAsString` (it is now a warning if you don't copy the defaults for all named args when overriding a method). This was only present on the AssetReader abstract class for documentation purposes.
- add some dependency overrides to make sure things pick up the latest build