### PR TITLE
Allow configuring Dart sdk location in KernelBuilder

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.9
 
-- Allow configuring the dart SDK directory in the `KernelBuilder` builder.
+- Allow configuring the platform SDK directory in the `KernelBuilder` builder.
 
 ## 1.0.8
 

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.9
+
+- Allow configuring the dart SDK directory in the `KernelBuilder` builder.
+
 ## 1.0.8
 
 - Don't follow `dart.library.isolate` conditional imports for the DDC

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -43,19 +43,22 @@ class KernelBuilder implements Builder {
   /// The sdk kernel file for the current platform.
   final String sdkKernelPath;
 
-  /// The root directory of the Dart SDK.
+  /// The root directory of the platform's dart SDK.
   ///
   /// If not provided, defaults to the directory of
   /// [Platform.resolvedExecutable].
-  final String dartSdkDir;
+  ///
+  /// On flutter this is the path to the root of the flutter_patched_sdk
+  /// directory, which contains the platform kernel files.
+  final String platformSdk;
 
   KernelBuilder(
       {@required this.platform,
       @required this.summaryOnly,
       @required this.sdkKernelPath,
       @required this.outputExtension,
-      String dartSdkDir})
-      : dartSdkDir = dartSdkDir ?? sdkDir,
+      String platformSdk})
+      : platformSdk = platformSdk ?? sdkDir,
         buildExtensions = {
           moduleExtension(platform): [outputExtension]
         };
@@ -71,7 +74,7 @@ class KernelBuilder implements Builder {
           buildStep: buildStep,
           summaryOnly: summaryOnly,
           outputExtension: outputExtension,
-          dartSdkDir: dartSdkDir,
+          dartSdkDir: platformSdk,
           sdkKernelPath: sdkKernelPath);
     } on KernelException catch (e, s) {
       log.severe(

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -43,11 +43,18 @@ class KernelBuilder implements Builder {
   /// The sdk kernel file for the current platform.
   final String sdkKernelPath;
 
+  /// The root directory of the Dart SDK.
+  ///
+  /// If not provided, defaults to the directory of
+  /// [Platform.resolvedExecutable].
+  final String dartSdkDir;
+
   KernelBuilder(
       {@required this.platform,
       @required this.summaryOnly,
       @required this.sdkKernelPath,
-      @required this.outputExtension})
+      @required this.outputExtension,
+      this.dartSdkDir})
       : buildExtensions = {
           moduleExtension(platform): [outputExtension]
         };
@@ -63,6 +70,7 @@ class KernelBuilder implements Builder {
           buildStep: buildStep,
           summaryOnly: summaryOnly,
           outputExtension: outputExtension,
+          dartSdkDir: dartSdkDir ?? sdkDir,
           sdkKernelPath: sdkKernelPath);
     } on KernelException catch (e, s) {
       log.severe(
@@ -80,6 +88,7 @@ Future<void> _createKernel(
     @required BuildStep buildStep,
     @required bool summaryOnly,
     @required String outputExtension,
+    @required String dartSdkDir,
     @required String sdkKernelPath}) async {
   var request = WorkRequest();
   var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
@@ -109,7 +118,7 @@ Future<void> _createKernel(
 
     packagesFile = await createPackagesFile(allAssetIds);
 
-    _addRequestArguments(request, module, transitiveKernelDeps, sdkDir,
+    _addRequestArguments(request, module, transitiveKernelDeps, dartSdkDir,
         sdkKernelPath, outputFile, packagesFile, summaryOnly);
   }
 

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -54,8 +54,9 @@ class KernelBuilder implements Builder {
       @required this.summaryOnly,
       @required this.sdkKernelPath,
       @required this.outputExtension,
-      this.dartSdkDir})
-      : buildExtensions = {
+      String dartSdkDir})
+      : dartSdkDir = dartSdkDir ?? sdkDir,
+        buildExtensions = {
           moduleExtension(platform): [outputExtension]
         };
 
@@ -70,7 +71,7 @@ class KernelBuilder implements Builder {
           buildStep: buildStep,
           summaryOnly: summaryOnly,
           outputExtension: outputExtension,
-          dartSdkDir: dartSdkDir ?? sdkDir,
+          dartSdkDir: dartSdkDir,
           sdkKernelPath: sdkKernelPath);
     } on KernelException catch (e, s) {
       log.severe(

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 1.0.8
+version: 1.0.9
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules


### PR DESCRIPTION
Currently the KernelBuilder allows configuring the location of the platform dill file via `sdkKernelPath`, but always joins this path with location of the Dart SDK used to execute the builder. For flutter (and eventually flutter web), the platform dill is located in another directory. 

I think we could use relative paths in the `sdkKernelPath` to work around this for now, but it will be more resilient to allow configuring the SDK directory as well.