### PR TITLE
Remove an unnecessary sorted set

### DIFF
--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -681,8 +681,7 @@ class _SingleBuild {
           .packageNodes(globNode.id.package)
           .where((n) => globNode.glob.matches(n.id.path))
           .toList();
-      var potentialIds = SplayTreeSet.of(potentialNodes.map((n) => n.id));
-      globNode.inputs = HashSet.from(potentialIds);
+      globNode.inputs = HashSet.of(potentialNodes.map((n) => n.id));
       for (var node in potentialNodes) {
         node.outputs.add(globNode.id);
       }


### PR DESCRIPTION
Since we don't do anything with `potentialIds` other than read it into a
`HashSet` we aren't gaining anything from the extra work of sorting it
in a `SplayTreeSet`.