### PR TITLE
Enable unnecessary_overrides lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -93,6 +93,7 @@ linter:
     - unnecessary_parenthesis
     - unnecessary_statements
     - unnecessary_this
+    - unnecessary_overrides
     - unrelated_type_equality_checks
     - use_rethrow_when_possible
     - valid_regexps

--- a/build_runner_core/lib/src/generate/performance_tracker.dart
+++ b/build_runner_core/lib/src/generate/performance_tracker.dart
@@ -82,9 +82,6 @@ class BuilderActionPerformance extends TimeSlice {
 class BuilderActionStagePerformance extends TimeSliceGroup {
   final String label;
 
-  @override
-  List<TimeSlice> get slices => super.slices;
-
   BuilderActionStagePerformance(this.label, List<TimeSlice> slices)
       : super(slices);
 


### PR DESCRIPTION
This way the focus is on what's different in a subclass.