### PR TITLE
Main injection hook

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Add a marker to inject code before the application main method is called.
+
 ## 1.1.0
 
 - Output a `.digests` file which contains transitive digests for an entrypoint.

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -425,11 +425,11 @@ requirejs.onResourceLoad = function (context, map, depArray) {
 };
 ''';
 
-/// Marker comment used by build_runner to identify the entrypoint file,
+/// Marker comment used by tools to identify the entrypoint file,
 /// to inject custom code.
 final _entrypointExtensionMarker = '/* ENTRYPOINT_EXTENTION_MARKER */';
 
-/// Marker comment used by build_runner to identify the main function
+/// Marker comment used by tools to identify the main function
 /// to inject custom code.
 final _mainExtensionMarker = '/* MAIN_EXTENSION_MARKER */';
 

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -150,7 +150,7 @@ String _appBootstrap(String bootstrapModuleName, String moduleName,
 define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_sdk) {
   dart_sdk.dart.setStartAsyncSynchronously(true);
   dart_sdk._isolate_helper.startRootIsolate(() => {}, []);
-$_initializeTools
+  $_initializeTools
   $_mainExtensionMarker
   app.$moduleScope.main();
   var bootstrap = {

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -151,6 +151,7 @@ define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_s
   dart_sdk.dart.setStartAsyncSynchronously(true);
   dart_sdk._isolate_helper.startRootIsolate(() => {}, []);
 $_initializeTools
+  $_mainExtensionMarker
   app.$moduleScope.main();
   var bootstrap = {
       hot\$onChildUpdate: function(childName, child) {
@@ -424,11 +425,13 @@ requirejs.onResourceLoad = function (context, map, depArray) {
 };
 ''';
 
-/// Marker comment used by build_runner (or any other thinks) to identify
-/// entrypoint file, to inject custom code there.
-///
-/// Should be first line in a file, so server don't need to parse whole body
+/// Marker comment used by build_runner to identify the entrypoint file,
+/// to inject custom code.
 final _entrypointExtensionMarker = '/* ENTRYPOINT_EXTENTION_MARKER */';
+
+/// Marker comment used by build_runner to identify the main function
+/// to inject custom code.
+final _mainExtensionMarker = '/* MAIN_EXTENSION_MARKER */';
 
 final _baseUrlScript = '''
 var baseUrl = (function () {

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 1.1.0
+version: 1.2.0
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
- Add a new marker to inject code before the application's main method is called
- Update the comments to be a little more clear

We need a hook right before the main is called so that we have a guarantee that DDC is set up. We also will be able to pause the application before it actually begins executing.