### PR TITLE
Log the output from summary steps

### DIFF
--- a/build_modules/lib/src/summary_builder.dart
+++ b/build_modules/lib/src/summary_builder.dart
@@ -97,6 +97,10 @@ Future _createUnlinkedSummary(Module module, BuildStep buildStep,
           buildStep.trackStage('Summarize', () => response, isExternal: true));
   if (response.exitCode == EXIT_CODE_ERROR) {
     throw AnalyzerSummaryException(module.unlinkedSummaryId, response.output);
+  } else {
+    if (response.output.isNotEmpty) {
+      log.fine(response.output);
+    }
   }
 
   // Copy the output back using the buildStep.
@@ -163,6 +167,10 @@ Future _createLinkedSummary(Module module, BuildStep buildStep,
   var summaryFile = scratchSpace.fileFor(module.linkedSummaryId);
   if (response.exitCode == EXIT_CODE_ERROR || !await summaryFile.exists()) {
     throw AnalyzerSummaryException(module.linkedSummaryId, response.output);
+  } else {
+    if (response.output.isNotEmpty) {
+      log.fine(response.output);
+    }
   }
 
   // Copy the output back using the buildStep.


### PR DESCRIPTION
Analyzer output can be seen when building with `--verbose`.