### PR TITLE
Fix exponential blowup in the kernel builder impl

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.10
+
+- Fix a performance issue in the kernel_builder, especially for larger projects.
+
 ## 1.0.9
 
 - Allow configuring the platform SDK directory in the `KernelBuilder` builder.

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -159,8 +159,7 @@ Future<void> _addModuleDeps(
   //
   // For each of those we have to ensure that all parents of that module are
   // provided via source as well.
-  void Function(AssetId) updateParents;
-  updateParents = (AssetId nodeId) {
+  void updateParents(AssetId nodeId) {
     var node = nodes[nodeId];
     for (var parent in node.parents) {
       var parentNode = nodes[parent];
@@ -169,7 +168,7 @@ Future<void> _addModuleDeps(
         parentNode.parents.forEach(updateParents);
       }
     }
-  };
+  }
 
   // Builds the module graph, the `sourceOnly` property of nodes gets
   // incrementally updated so we need to wait until we are done to actually

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 1.0.9
+version: 1.0.10
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules


### PR DESCRIPTION
Specifically the problem this logic is solving is that any dependency which is provided as sources instead of kernel is essentially a "poison pill" node - all parents of those modules must also be provided as sources and not dill files.

The previous implementation worked around this in a weird way, checking all transitive deps (of each transtive dep) for package cycles. This was both inefficient and relied upon knowledge of the module structure and how it deals with package cycles which wasn't ideal.

The new logic handles this while collecting the transitive deps initially - it tracks module parents and any time it finds a module that has to be provided via source it marks all transitive parents as also being provided by source. It also bails early if the parent is already marked, preventing exponential behavior during marking.