### PR TITLE
Make Module instances immutable

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0
+
+- Remove the `merge` method from `Module` and replace with a static
+  `Module.merge`. Module instances are now immutable.
+
 ## 1.0.10
 
 - Fix a performance issue in the kernel_builder, especially for larger projects.

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -204,7 +204,7 @@ class MetaModule {
   @JsonKey(name: 'm', nullable: false)
   final List<Module> modules;
 
-  MetaModule(this.modules);
+  MetaModule(List<Module> modules) : modules = List.unmodifiable(modules);
 
   /// Generated factory constructor.
   factory MetaModule.fromJson(Map<String, dynamic> json) =>

--- a/build_modules/lib/src/modules.dart
+++ b/build_modules/lib/src/modules.dart
@@ -28,7 +28,8 @@ part 'modules.g.dart';
 class Module {
   /// Merge the sources and dependencies from [modules] into a single module.
   ///
-  /// The resulting modules will have the same [primarySource],  [isMissing],
+  /// The resulting modules will have a [primarySource] which is the earliest
+  /// value from [sources] if it were sorted. It will have the same [isMissing],
   /// [isSupported] and [platform] as the first entry. The [sources] and
   /// [directDependencies] will be merged, and dependencies will be filtered so
   /// that no source is a dependency.
@@ -38,10 +39,11 @@ class Module {
     final allSources = Set.of(modules.expand((m) => m.sources));
     final allDependencies = Set.of(modules.expand((m) => m.directDependencies))
       ..removeAll(allSources);
-    final first = modules.first;
-    return Module(first.primarySource, allSources, allDependencies,
-        first.platform, first.isSupported,
-        isMissing: first.isMissing);
+    final primarySource =
+        allSources.reduce((a, b) => a.compareTo(b) < 0 ? a : b);
+    return Module(primarySource, allSources, allDependencies,
+        modules.first.platform, modules.first.isSupported,
+        isMissing: modules.first.isMissing);
   }
 
   /// The JS file for this module.

--- a/build_modules/lib/src/modules.g.dart
+++ b/build_modules/lib/src/modules.g.dart
@@ -20,10 +20,8 @@ Module _$ModuleFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$ModuleToJson(Module instance) => <String, dynamic>{
       'p': const _AssetIdConverter().toJson(instance.primarySource),
-      's': instance.sources.map(const _AssetIdConverter().toJson).toList(),
-      'd': instance.directDependencies
-          .map(const _AssetIdConverter().toJson)
-          .toList(),
+      's': _toJsonAssetIds(instance.sources),
+      'd': _toJsonAssetIds(instance.directDependencies),
       'm': instance.isMissing,
       'is': instance.isSupported,
       'pf': const _DartPlatformConverter().toJson(instance.platform)

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -34,3 +34,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  build_vm_compilers:
+    path: ../build_vm_compilers

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 1.0.10
+version: 2.0.0-dev
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
@@ -13,6 +13,7 @@ dependencies:
   bazel_worker: ^0.1.20
   build: '>=0.12.3 <2.0.0'
   build_config: '>=0.2.1 <0.4.0'
+  collection: ^1.0.0
   glob: ^1.0.0
   graphs: ^0.2.0
   json_annotation: '>=1.2.0 <3.0.0'


### PR DESCRIPTION
This makes it safer to share instances across a build. We were already
treating them as immutable once they were read from a serialized asset.

- Wrap the collections in `UnmodifiableSetView` for safety. Maintain the
  behavior of copying them.
- Remove the `merge` instance method in favor a static method merging an
  `List<Module>`.
- Update the code calling `merge` to track lists of modules and merge
  them all at the last moment.