### PR TITLE
Remove `jsId` and `jsSourceMapId` from `Module`

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Remove the `merge` method from `Module` and replace with a static
   `Module.merge`. Module instances are now immutable.
+- Remove `jsId`, and `jsSourceMapId` from `Module`.
 
 ## 1.0.10
 

--- a/build_modules/lib/src/modules.dart
+++ b/build_modules/lib/src/modules.dart
@@ -56,14 +56,6 @@ class Module {
         isMissing: isMissing);
   }
 
-  /// The JS file for this module.
-  AssetId jsId(String jsModuleExtension) =>
-      primarySource.changeExtension(jsModuleExtension);
-
-  // The sourcemap for the JS file for this module.
-  AssetId jsSourceMapId(String jsSourceMapExtension) =>
-      primarySource.changeExtension(jsSourceMapExtension);
-
   /// The linked summary for this module.
   AssetId get linkedSummaryId =>
       primarySource.changeExtension(linkedSummaryExtension(platform));

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -75,7 +75,7 @@ Future _createDevCompilerModule(
     ..addAll(transitiveSummaryDeps);
   await buildStep.trackStage(
       'EnsureAssets', () => scratchSpace.ensureAssets(allAssetIds, buildStep));
-  var jsId = module.jsId(jsModuleExtension);
+  var jsId = module.primarySource.changeExtension(jsModuleExtension);
   var jsOutputFile = scratchSpace.fileFor(jsId);
   var sdkSummary = p.url
       .join(_sdkDir, 'lib/_internal/ddc_sdk.${useKernel ? 'dill' : 'sum'}');
@@ -125,7 +125,9 @@ Future _createDevCompilerModule(
     var summaryPath = useKernel
         ? p.url.relative(scratchSpace.fileFor(summaryId).path,
                 from: scratchSpace.tempDir.path) +
-            '=${ddcModuleName(depModule.jsId(jsModuleExtension))}'
+            '=' +
+            ddcModuleName(
+                depModule.primarySource.changeExtension(jsModuleExtension))
         : scratchSpace.fileFor(summaryId).path;
     request.arguments.addAll(['-s', summaryPath]);
   }
@@ -157,7 +159,7 @@ Future _createDevCompilerModule(
       '--packages',
       packagesFile.absolute.uri.toString(),
       '--module-name',
-      ddcModuleName(module.jsId(jsModuleExtension)),
+      ddcModuleName(module.primarySource.changeExtension(jsModuleExtension)),
     ]);
   }
 
@@ -195,7 +197,8 @@ Future _createDevCompilerModule(
     await scratchSpace.copyOutput(jsId, buildStep);
     if (debugMode) {
       await scratchSpace.copyOutput(
-          module.jsSourceMapId(jsSourceMapExtension), buildStep);
+          module.primarySource.changeExtension(jsSourceMapExtension),
+          buildStep);
     }
   }
 }


### PR DESCRIPTION
These aren't exposing any behavior specific to modules since they were
only a wrapper around `primarySource.changeExtension`. It also doesn't
make sense to have `js` as a concept on a general module since the
module may be for other platforms.

- Remove the methods.
- Remove usage of these methods from `build_web_compilers`.