### PR TITLE
Only consider valid inputs for glob nodes

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.2
+
+- Only track valid and readable assets as inputs to globs. Fixes a crash when
+  attempting to check outputs from an invalid asset.
+
 ## 3.0.1
 
 - Remove usage of set literals to fix errors on older sdks that don't support

--- a/build_runner_core/lib/src/asset_graph/node.dart
+++ b/build_runner_core/lib/src/asset_graph/node.dart
@@ -262,11 +262,11 @@ class PostProcessAnchorNode extends AssetNode with _SyntheticAssetNode {
 class GlobAssetNode extends InternalAssetNode implements NodeWithInputs {
   final Glob glob;
 
-  /// All the potential inputs matching this glob. Whether they appear in
-  /// [results] is dependent on if they were actually created or not.
+  /// All the potential inputs matching this glob.
   ///
-  /// This needs to be an ordered set because we compute combined input digests
-  /// using this later on.
+  /// This field differs from [results] in that [GeneratedAssetNode] which may
+  /// have been readable but were not output are included here and not in
+  /// [results].
   @override
   HashSet<AssetId> inputs;
 

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -694,12 +694,16 @@ class _SingleBuild {
           .where((n) => globNode.glob.matches(n.id.path))
           .toList();
 
+      await Future.wait(potentialNodes
+          .whereType<GeneratedAssetNode>()
+          .map(_ensureAssetIsBuilt)
+          .map(toFuture));
+
       var actualMatches = <AssetId>[];
       for (var node in potentialNodes) {
         node.outputs.add(globNode.id);
-        if (node is GeneratedAssetNode) {
-          await _ensureAssetIsBuilt(node);
-          if (!node.wasOutput || node.isFailure) continue;
+        if (node is GeneratedAssetNode && (!node.wasOutput || node.isFailure)) {
+          continue;
         }
         actualMatches.add(node.id);
       }

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -687,22 +687,26 @@ class _SingleBuild {
     return _lazyGlobs.putIfAbsent(globNode.id, () async {
       var potentialNodes = _assetGraph
           .packageNodes(globNode.id.package)
+          .where((n) => n.isReadable && n.isValidInput)
+          .where((n) =>
+              n is! GeneratedAssetNode ||
+              (n as GeneratedAssetNode).phaseNumber < globNode.phaseNumber)
           .where((n) => globNode.glob.matches(n.id.path))
           .toList();
-      globNode.inputs = HashSet.of(potentialNodes.map((n) => n.id));
-      for (var node in potentialNodes) {
-        node.outputs.add(globNode.id);
-      }
 
       var actualMatches = <AssetId>[];
       for (var node in potentialNodes) {
-        if (await _isReadableNode(
-            node, globNode.phaseNumber, globNode.id.package)) {
-          actualMatches.add(node.id);
+        node.outputs.add(globNode.id);
+        if (node is GeneratedAssetNode) {
+          await _ensureAssetIsBuilt(node);
+          if (!node.wasOutput || node.isFailure) continue;
         }
+        actualMatches.add(node.id);
       }
+
       globNode
         ..results = actualMatches
+        ..inputs = HashSet.of(potentialNodes.map((n) => n.id))
         ..state = NodeState.upToDate
         ..lastKnownDigest =
             md5.convert(utf8.encode(globNode.results.join(' ')));

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 3.0.1
+version: 3.0.2
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1311,9 +1311,8 @@ void main() {
             appliesBuilders: ['a|copy_builder']),
         applyPostProcess('a|copy_builder', (_) => CopyingPostProcessBuilder())
       ];
-      var writer = InMemoryRunnerAssetWriter();
       // A build does not crash in `_cleanUpStaleOutputs`
-      await testBuilders(builders, {'a|lib/a.txt': 'a'}, writer: writer);
+      await testBuilders(builders, {'a|lib/a.txt': 'a'});
     });
   });
 }

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1296,6 +1296,25 @@ void main() {
         expect(node.isFailure, isTrue);
       }
     });
+
+    test('a glob should not be an output of an anchor node', () async {
+      // https://github.com/dart-lang/build/issues/2017
+      var builders = [
+        apply(
+            'test_builder',
+            [
+              (_) => TestBuilder(build: (buildStep, _) {
+                    buildStep.findAssets(Glob('**'));
+                  })
+            ],
+            toRoot(),
+            appliesBuilders: ['a|copy_builder']),
+        applyPostProcess('a|copy_builder', (_) => CopyingPostProcessBuilder())
+      ];
+      var writer = InMemoryRunnerAssetWriter();
+      // A build does not crash in `_cleanUpStaleOutputs`
+      await testBuilders(builders, {'a|lib/a.txt': 'a'}, writer: writer);
+    });
   });
 }
 


### PR DESCRIPTION
Fixes #2017

Prevents the AssetGraph from getting in a state where `outputs` track
impossible dependencies - a glob can never return results for synthetic
assets, for outputs from later phases, or for post process anchor nodes.

- Update the doc comment for [inputs] to make it clear that it's only
  non-output generated nodes which may be excluded from [results].
- Move the `isReadable` and `isValidInput` checks earlier in the process
  rather than waiting for `_isReadableNode`.
- Explicitly check for non-output generated assets instead of re-using
  `_isReadableNode`.
- Add a regression test with a build that would fail before this change.