### PR TITLE
Style tweaks for output cleanup

### DIFF
--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -544,7 +544,7 @@ class _SingleBuild {
     await FailureReporter.clean(phaseNum, input);
     await _cleanUpStaleOutputs(anchorNode.outputs);
     anchorNode.outputs
-      ..forEach(_assetGraph.remove)
+      ..toList().forEach(_assetGraph.remove)
       ..clear();
     inputNode.deletedBy.remove(anchorNode.id);
 


### PR DESCRIPTION
- Group all of the "cleanup" for a post process phase into a block with
  a single comment.
- Use iterable chaining for deleting generated outputs.
- Update the doc to make it clear that only generated outputs should be
  cleaned up.