### PR TITLE
add configurable exports test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
       env: PKGS="_test _test_common"
       script: ./tool/travis.sh dartanalyzer_0
     - stage: unit_test
-      name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome`, `pub run build_runner test -- -p vm test/config_specific_import_test.dart`]"
+      name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart`]"
       dart: dev
       env: PKGS="_test"
       script: ./tool/travis.sh command_0 command_1

--- a/_test/build.dart2js.yaml
+++ b/_test/build.dart2js.yaml
@@ -9,8 +9,8 @@ targets:
         generate_for:
           - web/main.dart
           - web/sub/main.dart
-          - test/config_specific_import_test.dart
-          - test/config_specific_import_test.dart.browser_test.dart
+          - test/configurable_uri_test.dart
+          - test/configurable_uri_test.dart.browser_test.dart
           - test/hello_world_test.dart
           - test/hello_world_test.dart.browser_test.dart
           - test/hello_world_deferred_test.dart
@@ -22,5 +22,5 @@ targets:
           - test/sub-dir/subdir_test.dart.browser_test.dart
       build_vm_compilers|entrypoint:
         generate_for:
-          - test/config_specific_import_test.dart.vm_test.dart
+          - test/configurable_uri_test.dart.vm_test.dart
           - test/help_test.dart.vm_test.dart

--- a/_test/build.yaml
+++ b/_test/build.yaml
@@ -5,8 +5,8 @@ targets:
         generate_for:
           - web/main.dart
           - web/sub/main.dart
-          - test/config_specific_import_test.dart
-          - test/config_specific_import_test.dart.browser_test.dart
+          - test/configurable_uri_test.dart
+          - test/configurable_uri_test.dart.browser_test.dart
           - test/hello_world_test.dart
           - test/hello_world_test.dart.browser_test.dart
           - test/hello_world_deferred_test.dart
@@ -18,5 +18,5 @@ targets:
           - test/sub-dir/subdir_test.dart.browser_test.dart
       build_vm_compilers|entrypoint:
         generate_for:
-          - test/config_specific_import_test.dart.vm_test.dart
+          - test/configurable_uri_test.dart.vm_test.dart
           - test/help_test.dart.vm_test.dart

--- a/_test/mono_pkg.yaml
+++ b/_test/mono_pkg.yaml
@@ -7,7 +7,7 @@ stages:
   - unit_test:
     - group:
       - command: pub run build_runner test -- -p chrome
-      - command: pub run build_runner test -- -p vm test/config_specific_import_test.dart
+      - command: pub run build_runner test -- -p vm test/configurable_uri_test.dart
   - e2e_test:
     - test: --total-shards 6 --shard-index 0
     - test: --total-shards 6 --shard-index 1

--- a/_test/test/common/message_export.dart
+++ b/_test/test/common/message_export.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'message.dart'
+    if (dart.library.io) 'message_io.dart'
+    if (dart.library.html) 'message_html.dart';

--- a/_test/test/configurable_uri_test.dart
+++ b/_test/test/configurable_uri_test.dart
@@ -4,19 +4,30 @@
 
 import 'package:test/test.dart';
 
-// ignore: uri_does_not_exist
 import 'common/message.dart'
-    // ignore: uri_does_not_exist
     if (dart.library.io) 'common/message_io.dart'
-    // ignore: uri_does_not_exist
     if (dart.library.html) 'common/message_html.dart';
 
+import 'common/message_export.dart' as exported;
+
 main() {
-  test('Message matches expected', () {
-    if (1.0 is int) {
+  group('browser', () {
+    test('imports', () {
       expect(message, contains('Javascript'));
-    } else {
+    });
+
+    test('exports', () {
+      expect(exported.message, contains('Javascript'));
+    });
+  }, testOn: 'browser');
+
+  group('vm', () {
+    test('imports', () {
       expect(message, contains('VM'));
-    }
-  });
+    });
+
+    test('exports', () {
+      expect(exported.message, contains('VM'));
+    });
+  }, testOn: 'vm');
 }

--- a/_test/test/test_integration_test.dart
+++ b/_test/test/test_integration_test.dart
@@ -43,12 +43,12 @@ void main() {
 
     test('create new test', () async {
       await createFile(p.join('test', 'other_test.dart'), basicTestContents);
-      await expectTestsPass(expectedNumRan: 6);
+      await expectTestsPass(expectedNumRan: 7);
     });
 
     test('delete test', () async {
       await deleteFile(p.join('test', 'sub-dir', 'subdir_test.dart'));
-      await expectTestsPass(expectedNumRan: 4);
+      await expectTestsPass(expectedNumRan: 5);
     });
   });
 }

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -27,8 +27,8 @@ for PKG in ${PKGS}; do
       ;;
     command_1) echo
       echo -e '\033[1mTASK: command_1\033[22m'
-      echo -e 'pub run build_runner test -- -p vm test/config_specific_import_test.dart'
-      pub run build_runner test -- -p vm test/config_specific_import_test.dart || EXIT_CODE=$?
+      echo -e 'pub run build_runner test -- -p vm test/configurable_uri_test.dart'
+      pub run build_runner test -- -p vm test/configurable_uri_test.dart || EXIT_CODE=$?
       ;;
     command_2) echo
       echo -e '\033[1mTASK: command_2\033[22m'


### PR DESCRIPTION
These work in kernel :tada: .

I was also able to remove all the `// ignore:` comments, and I refactored the test to rely on `testOn` instead of integer semantics. 