### PR TITLE
Support latest pkg:analyzer in 3 packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,9 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.1.0; PKGS: build, build_daemon, build_resolvers, build_runner, build_runner_core; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.1.0; PKGS: build, build_daemon, build_resolvers, build_runner, build_runner_core, build_vm_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.1.0"
-      env: PKGS="build build_daemon build_resolvers build_runner build_runner_core"
+      env: PKGS="build build_daemon build_resolvers build_runner build_runner_core build_vm_compilers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: build; TASKS: `pub run build_runner test`"
@@ -91,9 +91,9 @@ jobs:
       env: PKGS="scratch_space"
       script: ./tool/travis.sh command_2
     - stage: analyze_and_format
-      name: "SDK: 2.0.0; PKGS: build_config, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.0.0; PKGS: build_config, build_test, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.0.0"
-      env: PKGS="build_config build_test build_vm_compilers scratch_space"
+      env: PKGS="build_config build_test scratch_space"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: build_config; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs`"

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Update the kernel worker to pass input digests, along with
   `--reuse-compiler-result` and `--use-incremental-compiler`.
+- Increased the upper bound for `package:analyzer` to `<0.37.0`.
 
 ## 1.0.10
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.2.1-dev.3.0 <3.0.0"
 
 dependencies:
-  analyzer: '>0.30.0 <0.36.0'
+  analyzer: '>0.30.0 <0.37.0'
   async: '>=1.13.3 <3.0.0'
   bazel_worker: ^0.1.20
   build: '>=0.12.3 <2.0.0'
@@ -36,5 +36,12 @@ dev_dependencies:
     path: test/fixtures/b
 
 dependency_overrides:
+  build:
+    path: ../build
+  build_resolvers:
+    path: ../build_resolvers
   build_vm_compilers:
     path: ../build_vm_compilers
+
+  # TEMP - enable testing while waiting on source_gen and json_serializable
+  analyzer: 0.36.0

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.4-dev
 
 - Increase lower bound sdk constraint to 2.1.0.
+- Increased the upper bound for `package:analyzer` to `<0.37.0`.
 
 ## 1.0.3
 
@@ -39,7 +40,7 @@
 
 ## 0.2.2+6
 
-- Increased the upper bound for `package:analyzer` to '<0.34.0'.
+- Increased the upper bound for `package:analyzer` to `<0.34.0`.
 
 ## 0.2.2+5
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: ^0.35.0
+  analyzer: '>=0.35.0 <0.37.0'
   build: ">=1.1.0 <1.2.0"
   path: ^1.1.0
 
@@ -17,3 +17,11 @@ dev_dependencies:
   build_test: ^0.10.1
   build_runner: ^1.0.0
   build_vm_compilers: ^0.1.0
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_modules:
+    path: ../build_modules
+  build_vm_compilers:
+    path: ../build_vm_compilers

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   watcher: ^0.9.7
 
 dev_dependencies:
-  analyzer: ">=0.27.1 <0.36.0"
+  analyzer: ">=0.27.1 <0.37.0"
   build_runner: ^1.0.0
   build_vm_compilers: ^0.1.0
   collection: ^1.14.0

--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.2-dev
 
 - Increased the upper bound for `package:analyzer` to `<0.37.0`.
+- Require Dart SDK `>=2.1.0`.
 
 ## 0.1.1+5
 

--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2-dev
+
+- Increased the upper bound for `package:analyzer` to `<0.37.0`.
+
 ## 0.1.1+5
 
 - Increased the upper bound for `package:analyzer` to `<0.36.0`.
@@ -8,7 +12,7 @@
 
 ## 0.1.1+3
 
-- Increased the upper bound for `package:analyzer` to '<0.34.0'.
+- Increased the upper bound for `package:analyzer` to `<0.34.0`.
 
 ## 0.1.1+2
 

--- a/build_vm_compilers/mono_pkg.yaml
+++ b/build_vm_compilers/mono_pkg.yaml
@@ -8,6 +8,6 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.0.0
+        - 2.1.0
   - unit_test:
     - test

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.30.0 <0.37.0"

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_vm_compilers
-version: 0.1.1+5
+version: 0.1.2-dev
 description: Builder implementations wrapping Dart VM compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.30.0 <0.36.0"
+  analyzer: ">=0.30.0 <0.37.0"
   build: '>=0.12.0 <2.0.0'
   build_modules: '>=0.4.0 <2.0.0'
   path: ^1.6.0
@@ -20,3 +20,11 @@ dev_dependencies:
   test_descriptor: ^1.1.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_modules:
+    path: ../build_modules
+  build_resolvers:
+    path: ../build_resolvers


### PR DESCRIPTION
build_modules, build_resolvers, build_vm_compilers

Also updated dev_dep in build_test

The other packages won't pick up the latest analyzer on travis until
source_gen and json_serializable are updated

Fixes https://github.com/dart-lang/build/issues/2126