### PR TITLE
Drop support for building with analyzer summaries

### DIFF
--- a/_test/tool/build_kernel_ddc.dart
+++ b/_test/tool/build_kernel_ddc.dart
@@ -33,15 +33,13 @@ Future main(List<String> args) async {
     apply(
         'build_web_compilers|ddc',
         [
-          (_) => DevCompilerBuilder(useKernel: true),
+          (_) => DevCompilerBuilder(),
         ],
         toAllPackages(),
         isOptional: true,
         hideOutput: true),
-    apply(
-        'build_web_compilers|entrypoint',
-        [(_) => WebEntrypointBuilder(WebCompiler.DartDevc, useKernel: true)],
-        toRoot(),
+    apply('build_web_compilers|entrypoint',
+        [(_) => WebEntrypointBuilder(WebCompiler.DartDevc)], toRoot(),
         defaultGenerateFor: const InputSet(include: [
           'web/**.dart',
           'test/**.browser_test.dart',

--- a/_test/tool/build_kernel_ddc.dart
+++ b/_test/tool/build_kernel_ddc.dart
@@ -30,14 +30,9 @@ Future main(List<String> args) async {
         toAllPackages(),
         isOptional: true,
         hideOutput: true),
-    apply(
-        'build_web_compilers|ddc',
-        [
-          (_) => DevCompilerBuilder(),
-        ],
+    apply('build_web_compilers|ddc', [(_) => DevCompilerBuilder()],
         toAllPackages(),
-        isOptional: true,
-        hideOutput: true),
+        isOptional: true, hideOutput: true),
     apply('build_web_compilers|entrypoint',
         [(_) => WebEntrypointBuilder(WebCompiler.DartDevc)], toRoot(),
         defaultGenerateFor: const InputSet(include: [

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -4,6 +4,7 @@
   analyzer summaries.
 - Increased the upper bound for `package:analyzer` to `<0.37.0`.
 - Removed support for `build_root_app_summary` configuration option.
+- Remove support for building DDC with analyzer summaries.
 
 ## 1.2.0
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Update to run DDC in kernel mode, and consume kernel outlines instead of
   analyzer summaries.
 - Increased the upper bound for `package:analyzer` to `<0.37.0`.
+- Removed support for `build_root_app_summary` configuration option.
 
 ## 1.2.0
 

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -9,9 +9,9 @@ import 'package:build_web_compilers/build_web_compilers.dart';
 
 import 'package:path/path.dart' as p;
 
-Builder devCompilerBuilder(_) => DevCompilerBuilder(useKernel: true);
+Builder devCompilerBuilder(_) => DevCompilerBuilder();
 Builder webEntrypointBuilder(BuilderOptions options) =>
-    WebEntrypointBuilder.fromOptions(options, useKernel: true);
+    WebEntrypointBuilder.fromOptions(options);
 PostProcessBuilder dart2JsArchiveExtractor(BuilderOptions options) =>
     Dart2JsArchiveExtractor.fromOptions(options);
 PostProcessBuilder dartSourceCleanup(BuilderOptions options) =>

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -229,8 +229,7 @@ var _currentDirectory = (function () {
 ''';
 
 /// Sets up `window.$dartLoader` based on [modulePaths].
-String _dartLoaderSetup(
-        Map<String, String> modulePaths, String appDigests) =>
+String _dartLoaderSetup(Map<String, String> modulePaths, String appDigests) =>
     '''
 $_baseUrlScript
 let modulePaths = ${const JsonEncoder.withIndent(" ").convert(modulePaths)};

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -20,17 +20,12 @@ _p.Context get _context => _p.url;
 
 var _modulePartialExtension = _context.withoutExtension(jsModuleExtension);
 
-Future<Null> bootstrapDdc(BuildStep buildStep,
-    {bool useKernel, bool buildRootAppSummary}) async {
-  buildRootAppSummary ??= false;
-  useKernel ??= false;
+Future<Null> bootstrapDdc(BuildStep buildStep) async {
   var dartEntrypointId = buildStep.inputId;
   var moduleId =
       buildStep.inputId.changeExtension(moduleExtension(DartPlatform.dartdevc));
   var module = Module.fromJson(json
       .decode(await buildStep.readAsString(moduleId)) as Map<String, dynamic>);
-
-  if (buildRootAppSummary) await buildStep.canRead(module.linkedSummaryId);
 
   // First, ensure all transitive modules are built.
   var transitiveDeps = await _ensureTransitiveModules(module, buildStep);
@@ -50,16 +45,8 @@ Future<Null> bootstrapDdc(BuildStep buildStep,
   // which will allow us to not rely on the naming schemes that dartdevc uses
   // internally, but instead specify our own.
   var appModuleScope = toJSIdentifier(() {
-    if (useKernel) {
-      var basename = _context.basename(jsId.path);
-      return basename.substring(0, basename.length - jsModuleExtension.length);
-    } else {
-      Iterable<String> scope = _context.split(ddcModuleName(jsId));
-      if (scope.first == 'packages') {
-        scope = scope.skip(1);
-      }
-      return scope.skip(1).join('__');
-    }
+    var basename = _context.basename(jsId.path);
+    return basename.substring(0, basename.length - jsModuleExtension.length);
   }());
 
   // Map from module name to module path for custom modules.
@@ -92,8 +79,7 @@ Future<Null> bootstrapDdc(BuildStep buildStep,
         ..write(_dartLoaderSetup(
             modulePaths,
             _p.url.relative(appDigestsOutput.path,
-                from: _p.url.dirname(bootstrapId.path)),
-            useKernel))
+                from: _p.url.dirname(bootstrapId.path))))
         ..write(_requireJsConfig)
         ..write(_appBootstrap(bootstrapModuleName, appModuleName,
             appModuleScope, appModuleSource));
@@ -244,7 +230,7 @@ var _currentDirectory = (function () {
 
 /// Sets up `window.$dartLoader` based on [modulePaths].
 String _dartLoaderSetup(
-        Map<String, String> modulePaths, String appDigests, bool useKernel) =>
+        Map<String, String> modulePaths, String appDigests) =>
     '''
 $_baseUrlScript
 let modulePaths = ${const JsonEncoder.withIndent(" ").convert(modulePaths)};
@@ -291,11 +277,6 @@ for (let moduleName of Object.getOwnPropertyNames(modulePaths)) {
     customModulePaths[moduleName] = modulePath;
   }
   var src = window.location.origin + '/' + modulePath + '.js';
-  // dartdevc only strips the final extension when adding modules to source
-  // maps, so we need to do the same.
-  if (moduleName != 'dart_sdk') {
-    ${useKernel ? '' : "moduleName += '$_modulePartialExtension'"};
-  }
   if (window.\$dartLoader.moduleIdToUrl.has(moduleName)) {
     continue;
   }

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -20,7 +20,7 @@ _p.Context get _context => _p.url;
 
 var _modulePartialExtension = _context.withoutExtension(jsModuleExtension);
 
-Future<Null> bootstrapDdc(BuildStep buildStep) async {
+Future<void> bootstrapDdc(BuildStep buildStep) async {
   var dartEntrypointId = buildStep.inputId;
   var moduleId =
       buildStep.inputId.changeExtension(moduleExtension(DartPlatform.dartdevc));

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -86,15 +86,13 @@ Future<void> _createDevCompilerModule(Module module, BuildStep buildStep,
       ..path = sdkSummary
       ..digest = [0])
     ..inputs.addAll(await Future.wait(transitiveDeps.map((dep) async {
-      final kernelAsset =
-          module.primarySource.changeExtension(ddcKernelExtension);
+      final kernelAsset = dep.primarySource.changeExtension(ddcKernelExtension);
       return Input()
         ..path = scratchSpace.fileFor(kernelAsset).path
         ..digest = (await buildStep.digest(kernelAsset)).bytes;
     })))
     ..arguments.addAll(transitiveDeps.expand((dep) {
-      final kernelAsset =
-          module.primarySource.changeExtension(ddcKernelExtension);
+      final kernelAsset = dep.primarySource.changeExtension(ddcKernelExtension);
       var moduleName =
           ddcModuleName(dep.primarySource.changeExtension(jsModuleExtension));
       return ['-s', '${scratchSpace.fileFor(kernelAsset).path}=$moduleName'];

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -39,7 +39,7 @@ class DevCompilerBuilder implements Builder {
         json.decode(await buildStep.readAsString(buildStep.inputId))
             as Map<String, dynamic>);
 
-    Future<Null> handleError(e) async {
+    Future<void> handleError(e) async {
       await buildStep.writeAsString(
           module.primarySource.changeExtension(jsModuleErrorsExtension), '$e');
       log.severe('$e');
@@ -56,7 +56,7 @@ class DevCompilerBuilder implements Builder {
 }
 
 /// Compile [module] with the dev compiler.
-Future _createDevCompilerModule(Module module, BuildStep buildStep,
+Future<void> _createDevCompilerModule(Module module, BuildStep buildStep,
     {bool debugMode = true}) async {
   var transitiveDeps = await buildStep.trackStage('CollectTransitiveDeps',
       () => module.computeTransitiveDependencies(buildStep));

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -24,10 +24,6 @@ const jsSourceMapExtension = '.ddc.js.map';
 
 /// A builder which can output ddc modules!
 class DevCompilerBuilder implements Builder {
-  final bool useKernel;
-
-  DevCompilerBuilder({bool useKernel}) : useKernel = useKernel ?? false;
-
   @override
   final buildExtensions = {
     moduleExtension(DartPlatform.dartdevc): [
@@ -50,7 +46,7 @@ class DevCompilerBuilder implements Builder {
     }
 
     try {
-      await _createDevCompilerModule(module, buildStep, useKernel);
+      await _createDevCompilerModule(module, buildStep);
     } on DartDevcCompilationException catch (e) {
       await handleError(e);
     } on MissingModulesException catch (e) {
@@ -60,134 +56,68 @@ class DevCompilerBuilder implements Builder {
 }
 
 /// Compile [module] with the dev compiler.
-Future _createDevCompilerModule(
-    Module module, BuildStep buildStep, bool useKernel,
+Future _createDevCompilerModule(Module module, BuildStep buildStep,
     {bool debugMode = true}) async {
   var transitiveDeps = await buildStep.trackStage('CollectTransitiveDeps',
       () => module.computeTransitiveDependencies(buildStep));
-  var transitiveSummaryDeps = transitiveDeps.map((module) => useKernel
-      ? module.primarySource.changeExtension(ddcKernelExtension)
-      : module.linkedSummaryId);
+  var transitiveKernelDeps = transitiveDeps.map(
+      (module) => module.primarySource.changeExtension(ddcKernelExtension));
   var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
 
   var allAssetIds = Set<AssetId>()
     ..addAll(module.sources)
-    ..addAll(transitiveSummaryDeps);
+    ..addAll(transitiveKernelDeps);
   await buildStep.trackStage(
       'EnsureAssets', () => scratchSpace.ensureAssets(allAssetIds, buildStep));
   var jsId = module.primarySource.changeExtension(jsModuleExtension);
   var jsOutputFile = scratchSpace.fileFor(jsId);
-  var sdkSummary = p.url
-      .join(_sdkDir, 'lib/_internal/ddc_sdk.${useKernel ? 'dill' : 'sum'}');
-  var request = WorkRequest();
+  var sdkSummary = p.url.join(_sdkDir, 'lib/_internal/ddc_sdk.dill');
 
-  request.arguments.addAll([
-    '--dart-sdk-summary=$sdkSummary',
-    '--modules=amd',
-    '--no-summarize',
-    '-o',
-    jsOutputFile.path,
-  ]);
-  request.inputs.add(Input()
-    ..path = sdkSummary
-    ..digest = [0]);
-
-  if (!useKernel) {
-    // Add the default analysis_options.
-    await scratchSpace.ensureAssets([defaultAnalysisOptionsId], buildStep);
-    var libraryRoot = '/${p.split(p.dirname(jsId.path)).first}';
-    var summaryExtension =
-        linkedSummaryExtension(DartPlatform.dartdevc).substring(1);
-    request.arguments.addAll([
-      '--module-root=.',
-      '--library-root=$libraryRoot',
-      '--summary-extension=$summaryExtension',
+  var request = WorkRequest()
+    ..arguments.addAll([
+      '--dart-sdk-summary=$sdkSummary',
+      '--modules=amd',
       '--no-summarize',
-      defaultAnalysisOptionsArg(scratchSpace),
-    ]);
-  }
+      '-o',
+      jsOutputFile.path,
+      debugMode ? '--source-map' : '--no-source-map',
+    ])
+    ..inputs.add(Input()
+      ..path = sdkSummary
+      ..digest = [0])
+    ..inputs.addAll(await Future.wait(transitiveDeps.map((dep) async {
+      final kernelAsset =
+          module.primarySource.changeExtension(ddcKernelExtension);
+      return Input()
+        ..path = scratchSpace.fileFor(kernelAsset).path
+        ..digest = (await buildStep.digest(kernelAsset)).bytes;
+    })))
+    ..arguments.addAll(transitiveDeps.expand((dep) {
+      final kernelAsset =
+          module.primarySource.changeExtension(ddcKernelExtension);
+      var moduleName =
+          ddcModuleName(dep.primarySource.changeExtension(jsModuleExtension));
+      return ['-s', '${scratchSpace.fileFor(kernelAsset).path}=$moduleName'];
+    }));
 
-  if (debugMode) {
-    request.arguments.addAll([
-      '--source-map',
-    ]);
-    if (!useKernel) {
-      request.arguments.addAll([
-        '--source-map-comment',
-        '--inline-source-map',
-      ]);
-    }
-  } else {
-    request.arguments.add('--no-source-map');
-  }
-
-  // Add linked summaries as summary inputs.
-  //
-  // Also request the digests for each and add those to the inputs.
-  //
-  // This runs synchronously and the digest futures will be awaited later on.
-  var digestFutures = <Future>[];
-  for (var depModule in transitiveDeps) {
-    var summaryId = useKernel
-        ? depModule.primarySource.changeExtension(ddcKernelExtension)
-        : depModule.linkedSummaryId;
-    var summaryPath = scratchSpace.fileFor(summaryId).path;
-
-    if (useKernel) {
-      var input = Input()..path = summaryPath;
-      request.inputs.add(input);
-      digestFutures.add(buildStep.digest(summaryId).then((digest) {
-        input.digest = digest.bytes;
-      }));
-      var moduleName = ddcModuleName(
-          depModule.primarySource.changeExtension(jsModuleExtension));
-      summaryPath += '=$moduleName';
-    }
-
-    request.arguments.addAll(['-s', summaryPath]);
-  }
-
-  // Wait for all the digests to complete.
-  await Future.wait(digestFutures);
-
-  // Add URL mappings for all the package: files to tell DartDevc where to
-  // find them.
-  //
-  // For non-lib files we use "fake" absolute file uris, using `id.path`.
-  if (!useKernel) {
-    for (var id in module.sources) {
-      var uri = canonicalUriFor(id);
-      if (uri.startsWith('package:')) {
-        request.arguments
-            .add('--url-mapping=$uri,${scratchSpace.fileFor(id).path}');
-      } else {
-        var absoluteFileUri = Uri.file('/${id.path}');
-        request.arguments.add('--url-mapping=$absoluteFileUri,${id.path}');
-      }
-    }
-  }
-
-  File packagesFile;
-  if (useKernel) {
-    var allDeps = <AssetId>[]
-      ..addAll(module.sources)
-      ..addAll(transitiveSummaryDeps);
-    packagesFile = await createPackagesFile(allDeps);
-    request.arguments.addAll([
-      '--packages',
-      packagesFile.absolute.uri.toString(),
-      '--module-name',
-      ddcModuleName(module.primarySource.changeExtension(jsModuleExtension)),
-      '--multi-root-scheme',
-      multiRootScheme,
-      '--multi-root',
-      '.',
-      '--reuse-compiler-result',
-      '--use-incremental-compiler',
-      '--track-widget-creation',
-      '--inline-source-map',
-    ]);
-  }
+  var allDeps = <AssetId>[]
+    ..addAll(module.sources)
+    ..addAll(transitiveKernelDeps);
+  var packagesFile = await createPackagesFile(allDeps);
+  request.arguments.addAll([
+    '--packages',
+    packagesFile.absolute.uri.toString(),
+    '--module-name',
+    ddcModuleName(module.primarySource.changeExtension(jsModuleExtension)),
+    '--multi-root-scheme',
+    multiRootScheme,
+    '--multi-root',
+    '.',
+    '--reuse-compiler-result',
+    '--use-incremental-compiler',
+    '--track-widget-creation',
+    '--inline-source-map',
+  ]);
 
   // And finally add all the urls to compile, using the package: path for
   // files under lib and the full absolute path for other files.
@@ -196,21 +126,18 @@ Future _createDevCompilerModule(
     if (uri.startsWith('package:')) {
       return uri;
     }
-    return useKernel
-        ? '$multiRootScheme:///${id.path}'
-        : Uri.file('/${id.path}').toString();
+    return '$multiRootScheme:///${id.path}';
   }));
 
   WorkResponse response;
   try {
-    var driverResource =
-        useKernel ? dartdevkDriverResource : dartdevcDriverResource;
+    var driverResource = dartdevkDriverResource;
     var driver = await buildStep.fetchResource(driverResource);
     response = await driver.doWork(request,
         trackWork: (response) =>
             buildStep.trackStage('Compile', () => response, isExternal: true));
   } finally {
-    if (useKernel) await packagesFile.parent.delete(recursive: true);
+    await packagesFile.parent.delete(recursive: true);
   }
 
   // TODO(jakemac53): Fix the ddc worker mode so it always sends back a bad

--- a/build_web_compilers/lib/src/errors.dart
+++ b/build_web_compilers/lib/src/errors.dart
@@ -19,29 +19,10 @@ abstract class _WorkerException implements Exception {
   String toString() => '$message:$failedAsset\n\n$error';
 }
 
-/// An [Exception] that is thrown when the analyzer fails to create a summary.
-class AnalyzerSummaryException extends _WorkerException {
-  @override
-  final String message = 'Error creating summary for module';
-
-  AnalyzerSummaryException(AssetId summaryId, String error)
-      : super(summaryId, error);
-}
-
 /// An [Exception] that is thrown when dartdevc compilation fails.
 class DartDevcCompilationException extends _WorkerException {
   @override
   final String message = 'Error compiling dartdevc module';
 
   DartDevcCompilationException(AssetId jsId, String error) : super(jsId, error);
-}
-
-/// An [Exception] that is thrown when the common frontend fails to create a
-/// kernel summary.
-class KernelSummaryException extends _WorkerException {
-  @override
-  final String message = 'Error creating kernel summary for module';
-
-  KernelSummaryException(AssetId summaryId, String error)
-      : super(summaryId, error);
 }

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -28,12 +28,10 @@ enum WebCompiler {
 /// The top level keys supported for the `options` config for the
 /// [WebEntrypointBuilder].
 const _supportedOptions = [
-  _buildRootAppSummary,
   _compiler,
   _dart2jsArgs,
 ];
 
-const _buildRootAppSummary = 'build_root_app_summary';
 const _compiler = 'compiler';
 const _dart2jsArgs = 'dart2js_args';
 
@@ -49,23 +47,14 @@ const _deprecatedOptions = [
 class WebEntrypointBuilder implements Builder {
   final WebCompiler webCompiler;
   final List<String> dart2JsArgs;
-  final bool buildRootAppSummary;
-  final bool useKernel;
 
-  const WebEntrypointBuilder(this.webCompiler,
-      {this.dart2JsArgs = const [],
-      this.useKernel = false,
-      this.buildRootAppSummary = false});
+  const WebEntrypointBuilder(this.webCompiler, {this.dart2JsArgs = const []});
 
-  factory WebEntrypointBuilder.fromOptions(BuilderOptions options,
-      {bool useKernel}) {
-    useKernel ??= false;
+  factory WebEntrypointBuilder.fromOptions(BuilderOptions options) {
     validateOptions(
         options.config, _supportedOptions, 'build_web_compilers|entrypoint',
         deprecatedOptions: _deprecatedOptions);
     var compilerOption = options.config[_compiler] as String ?? 'dartdevc';
-    var buildRootAppSummary =
-        options.config[_buildRootAppSummary] as bool ?? false;
     WebCompiler compiler;
     switch (compilerOption) {
       case 'dartdevc':
@@ -87,9 +76,7 @@ class WebEntrypointBuilder implements Builder {
     }
 
     return WebEntrypointBuilder(compiler,
-        buildRootAppSummary: buildRootAppSummary,
-        dart2JsArgs: dart2JsArgs as List<String>,
-        useKernel: useKernel);
+        dart2JsArgs: dart2JsArgs as List<String>);
   }
 
   @override
@@ -110,8 +97,7 @@ class WebEntrypointBuilder implements Builder {
     if (!isAppEntrypoint) return;
     if (webCompiler == WebCompiler.DartDevc) {
       try {
-        await bootstrapDdc(buildStep,
-            useKernel: useKernel, buildRootAppSummary: buildRootAppSummary);
+        await bootstrapDdc(buildStep);
       } on MissingModulesException catch (e) {
         log.severe('$e');
       }

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -5,8 +5,9 @@
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
-import 'package:build_web_compilers/build_web_compilers.dart';
 import 'package:build_modules/build_modules.dart';
+import 'package:build_web_compilers/build_web_compilers.dart';
+import 'package:build_web_compilers/builders.dart';
 
 import 'util.dart';
 
@@ -35,8 +36,7 @@ main() {
     await testBuilderAndCollectAssets(MetaModuleBuilder(platform), assets);
     await testBuilderAndCollectAssets(MetaModuleCleanBuilder(platform), assets);
     await testBuilderAndCollectAssets(ModuleBuilder(platform), assets);
-    await testBuilderAndCollectAssets(UnlinkedSummaryBuilder(platform), assets);
-    await testBuilderAndCollectAssets(LinkedSummaryBuilder(platform), assets);
+    await testBuilderAndCollectAssets(ddcKernelBuilder(null), assets);
     await testBuilderAndCollectAssets(DevCompilerBuilder(), assets);
   });
 

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -54,8 +54,7 @@ main() {
         'a|web/index$jsSourceMapExtension':
             decodedMatches(contains('index.dart')),
       };
-      await testBuilder(DevCompilerBuilder(useKernel: true), assets,
-          outputs: expectedOutputs);
+      await testBuilder(DevCompilerBuilder(), assets, outputs: expectedOutputs);
     });
   });
 


### PR DESCRIPTION
- Remove the `useKernel` flag and all branches where it was false.
- Remove `build_root_app_summary` config.
- Rename some variables from "summary" to "kernel".