### PR TITLE
Make sure unused builder is still instantiable

### DIFF
--- a/_test/pkgs/provides_builder/lib/builders.dart
+++ b/_test/pkgs/provides_builder/lib/builders.dart
@@ -62,7 +62,7 @@ class _ThrowingBuilder extends Builder {
 
 Builder someBuilder(BuilderOptions options) =>
     _SomeBuilder.fromOptions(options);
-Builder notApplied(_) => null;
+Builder notApplied(BuilderOptions options) => _SomeBuilder.fromOptions(options);
 PostProcessBuilder somePostProcessBuilder(BuilderOptions options) =>
     _SomePostProcessBuilder.fromOptions(options);
 Builder throwingBuilder(_) => _ThrowingBuilder();


### PR DESCRIPTION
While working toward #590 it became clear that even if a builder is not
applied in a given build, we still need to be able to construct it.

This case is not yet enforced, and it is very unlikely to have come up
outside of this test.