### PR TITLE
build_test: support the latest pkg:html

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.7-dev
+
+- Support the latest version of `package:html`.
+
 ## 0.10.6
 
 - Allow build_resolvers version `1.0.0`.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.6
+version: 0.10.7-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
@@ -14,7 +14,7 @@ dependencies:
   build_resolvers: ">=0.2.0 <2.0.0"
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0
-  html: ">=0.9.0 <=0.14.0"
+  html: ">=0.9.0 <0.15.0"
   logging: ^0.11.2
   matcher: ^0.12.0
   package_resolver: ^1.0.2


### PR DESCRIPTION
Turns out 0.14.0 was already supported (weird) - this allows future 0.14
releases, too