### PR TITLE
Allow using `:` as separator for builders

### DIFF
--- a/_test/test/build_integration_test.dart
+++ b/_test/test/build_integration_test.dart
@@ -37,13 +37,11 @@ void main() {
       var content = 'cool';
       await runBuild(trailingArgs: [
         '--define',
-        'provides_builder|some_post_process_builder=default_content=$content'
+        'provides_builder:some_post_process_builder=default_content=$content'
       ]);
       var generated =
           await readGeneratedFileAsString('_test/lib/hello.txt.post');
       expect(generated, equals(content));
-    }, onPlatform: {
-      'windows': const Skip('https://github.com/dart-lang/build/issues/1127')
     });
 
     test('rebuilds if the input file changes and not otherwise', () async {

--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -12,29 +12,29 @@ import 'dart:isolate' as _i9;
 import 'package:build_runner/build_runner.dart' as _i10;
 
 final _builders = <_i1.BuilderApplication>[
-  _i1.apply('provides_builder|some_not_applied_builder', [_i2.notApplied],
+  _i1.apply('provides_builder:some_not_applied_builder', [_i2.notApplied],
       _i1.toNoneByDefault(),
       hideOutput: true),
-  _i1.apply('provides_builder|throwing_builder', [_i2.throwingBuilder],
+  _i1.apply('provides_builder:throwing_builder', [_i2.throwingBuilder],
       _i1.toDependentsOf('provides_builder'),
       hideOutput: true),
-  _i1.apply('provides_builder|some_builder', [_i2.someBuilder],
+  _i1.apply('provides_builder:some_builder', [_i2.someBuilder],
       _i1.toDependentsOf('provides_builder'),
       hideOutput: true,
-      appliesBuilders: ['provides_builder|some_post_process_builder']),
+      appliesBuilders: ['provides_builder:some_post_process_builder']),
   _i1.apply(
-      'build_test|test_bootstrap',
+      'build_test:test_bootstrap',
       [_i3.debugIndexBuilder, _i3.debugTestBuilder, _i3.testBootstrapBuilder],
       _i1.toRoot(),
       hideOutput: true,
       defaultGenerateFor: const _i4.InputSet(include: ['test/**'])),
-  _i1.apply('build_modules|module_library', [_i5.moduleLibraryBuilder],
+  _i1.apply('build_modules:module_library', [_i5.moduleLibraryBuilder],
       _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true,
-      appliesBuilders: ['build_modules|module_cleanup']),
+      appliesBuilders: ['build_modules:module_cleanup']),
   _i1.apply(
-      'build_web_compilers|ddc_modules',
+      'build_web_compilers:ddc_modules',
       [
         _i6.ddcMetaModuleBuilder,
         _i6.ddcMetaModuleCleanBuilder,
@@ -43,9 +43,9 @@ final _builders = <_i1.BuilderApplication>[
       _i1.toNoneByDefault(),
       isOptional: true,
       hideOutput: true,
-      appliesBuilders: ['build_modules|module_cleanup']),
+      appliesBuilders: ['build_modules:module_cleanup']),
   _i1.apply(
-      'build_web_compilers|dart2js_modules',
+      'build_web_compilers:dart2js_modules',
       [
         _i6.dart2jsMetaModuleBuilder,
         _i6.dart2jsMetaModuleCleanBuilder,
@@ -54,20 +54,20 @@ final _builders = <_i1.BuilderApplication>[
       _i1.toNoneByDefault(),
       isOptional: true,
       hideOutput: true,
-      appliesBuilders: ['build_modules|module_cleanup']),
-  _i1.apply('build_web_compilers|ddc_kernel', [_i6.ddcKernelBuilder],
+      appliesBuilders: ['build_modules:module_cleanup']),
+  _i1.apply('build_web_compilers:ddc_kernel', [_i6.ddcKernelBuilder],
       _i1.toNoneByDefault(),
       isOptional: true, hideOutput: true),
-  _i1.apply('build_web_compilers|ddc', [_i6.ddcBuilder], _i1.toAllPackages(),
+  _i1.apply('build_web_compilers:ddc', [_i6.ddcBuilder], _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true,
       appliesBuilders: [
-        'build_web_compilers|ddc_modules',
-        'build_web_compilers|ddc_kernel',
-        'build_web_compilers|dart2js_modules',
-        'build_web_compilers|dart_source_cleanup'
+        'build_web_compilers:ddc_modules',
+        'build_web_compilers:ddc_kernel',
+        'build_web_compilers:dart2js_modules',
+        'build_web_compilers:dart_source_cleanup'
       ]),
-  _i1.apply('build_web_compilers|entrypoint', [_i6.webEntrypointBuilder],
+  _i1.apply('build_web_compilers:entrypoint', [_i6.webEntrypointBuilder],
       _i1.toRoot(),
       hideOutput: true,
       defaultGenerateFor: const _i4.InputSet(include: [
@@ -83,20 +83,20 @@ final _builders = <_i1.BuilderApplication>[
         'dart2js_args': ['--minify']
       }),
       defaultReleaseOptions: _i7.BuilderOptions({'compiler': 'dart2js'}),
-      appliesBuilders: ['build_web_compilers|dart2js_archive_extractor']),
+      appliesBuilders: ['build_web_compilers:dart2js_archive_extractor']),
   _i1.apply(
-      'build_vm_compilers|modules',
+      'build_vm_compilers:modules',
       [_i8.metaModuleBuilder, _i8.metaModuleCleanBuilder, _i8.moduleBuilder],
       _i1.toNoneByDefault(),
       isOptional: true,
       hideOutput: true,
-      appliesBuilders: ['build_modules|module_cleanup']),
+      appliesBuilders: ['build_modules:module_cleanup']),
   _i1.apply(
-      'build_vm_compilers|vm', [_i8.vmKernelModuleBuilder], _i1.toAllPackages(),
+      'build_vm_compilers:vm', [_i8.vmKernelModuleBuilder], _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true,
-      appliesBuilders: ['build_vm_compilers|modules']),
-  _i1.apply('build_vm_compilers|entrypoint', [_i8.vmKernelEntrypointBuilder],
+      appliesBuilders: ['build_vm_compilers:modules']),
+  _i1.apply('build_vm_compilers:entrypoint', [_i8.vmKernelEntrypointBuilder],
       _i1.toRoot(),
       hideOutput: true,
       defaultGenerateFor: const _i4.InputSet(include: [
@@ -107,15 +107,15 @@ final _builders = <_i1.BuilderApplication>[
         'benchmark/**'
       ])),
   _i1.applyPostProcess(
-      'provides_builder|some_post_process_builder', _i2.somePostProcessBuilder,
+      'provides_builder:some_post_process_builder', _i2.somePostProcessBuilder,
       defaultGenerateFor: const _i4.InputSet()),
-  _i1.applyPostProcess('build_modules|module_cleanup', _i5.moduleCleanup,
+  _i1.applyPostProcess('build_modules:module_cleanup', _i5.moduleCleanup,
       defaultGenerateFor: const _i4.InputSet()),
   _i1.applyPostProcess(
-      'build_web_compilers|dart_source_cleanup', _i6.dartSourceCleanup,
+      'build_web_compilers:dart_source_cleanup', _i6.dartSourceCleanup,
       defaultReleaseOptions: _i7.BuilderOptions({'enabled': true}),
       defaultGenerateFor: const _i4.InputSet()),
-  _i1.applyPostProcess('build_web_compilers|dart2js_archive_extractor',
+  _i1.applyPostProcess('build_web_compilers:dart2js_archive_extractor',
       _i6.dart2jsArchiveExtractor,
       defaultReleaseOptions: _i7.BuilderOptions({'filter_outputs': true}),
       defaultGenerateFor: const _i4.InputSet())

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add an explicit error when an `InputSet` has an empty or null value in a glob
   list.
 - Increase lower bound sdk constraint to 2.0.0.
+- Normalize builder keys with the legacy `|` separator to use `:` instead.
 
 ## 0.3.1+4
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -38,7 +38,7 @@ Each target may also contain the following keys:
 ## Configuring `Builder`s applied to your package
 Each target can specify a `builders` key which configures the builders which are
 applied to that target. The value is a Map from builder to configuration for
-that builder. The key is in the format `'$packageName|$builderName'`. The
+that builder. The key is in the format `'$packageName:$builderName'`. The
 configuration may have the following keys:
 
 - **enabled**: Boolean, Optional: Whether to apply the builder to this target.
@@ -90,7 +90,7 @@ then you can define `Builder`s and have those applied to packages with a
 dependency on yours.
 
 The key for a Builder will be normalized so that consumers of the builder can
-refer to it in `'$definingPackageName|$builderName'` format. If the builder name
+refer to it in `'$definingPackageName:$builderName'` format. If the builder name
 matches the package name it can also be referred to with just the package name.
 
 Exposed `Builder`s are configured in the `builders` section of the `build.yaml`.
@@ -198,7 +198,7 @@ builders:
     builder_factories: ["myBuilder"]
     build_extensions: {".dart": [".tar.gz"]}
     auto_apply: dependents
-    apply_builders: ["|archive_extract_builder"]
+    apply_builders: [":archive_extract_builder"]
 post_process_builders:
   # The post process builder config, extracts `.tar.gz` files.
   extract_archive_builder:

--- a/build_config/lib/src/builder_definition.dart
+++ b/build_config/lib/src/builder_definition.dart
@@ -38,7 +38,7 @@ class BuilderDefinition {
   /// The package which provides this Builder.
   String get package => packageExpando[this];
 
-  /// A unique key for this Builder in `'$package|$builder'` format.
+  /// A unique key for this Builder in `'$package:$builder'` format.
   String get key => builderKeyExpando[this];
 
   /// The names of the top-level methods in [import] from args -> Builder.
@@ -79,12 +79,12 @@ class BuilderDefinition {
   @JsonKey(name: 'required_inputs')
   final List<String> requiredInputs;
 
-  /// Builder keys in `$package|$builder` format which should only be run after
+  /// Builder keys in `$package:$builder` format which should only be run after
   /// this Builder.
   @JsonKey(name: 'runs_before')
   final List<String> runsBefore;
 
-  /// Builder keys in `$package|$builder` format which should be run on any
+  /// Builder keys in `$package:$builder` format which should be run on any
   /// target which also runs this Builder.
   @JsonKey(name: 'applies_builders')
   final List<String> appliesBuilders;
@@ -172,7 +172,7 @@ class PostProcessBuilderDefinition {
   /// The package which provides this Builder.
   String get package => packageExpando[this];
 
-  /// A unique key for this Builder in `'$package|$builder'` format.
+  /// A unique key for this Builder in `'$package:$builder'` format.
   String get key => builderKeyExpando[this];
 
   /// The name of the top-level method in [import] from

--- a/build_config/lib/src/key_normalization.dart
+++ b/build_config/lib/src/key_normalization.dart
@@ -8,21 +8,33 @@ const _defaultTargetNamePlaceholder = r'$default';
 ///
 /// Example normalizations:
 ///
-///   - "some_builder" => "$packageName|some_builder"
-///   - "|some_builder" => "$packageName|some_builder"
-///   - "some_package|some_builder" => "some_package|some_builder"
+///   - "some_builder" => "$packageName:some_builder"
+///   - ":some_builder" => "$packageName:some_builder"
+///   - "some_package:some_builder" => "some_package:some_builder"
+///
+/// If the legacy separator `|` is used it will be transformed to `:`
 String normalizeBuilderKeyDefinition(String builderKey, String packageName) =>
-    _normalizeDefinition(builderKey, packageName, '|');
+    _normalizeDefinition(
+        builderKey.contains('|')
+            ? builderKey.replaceFirst('|', ':')
+            : builderKey,
+        packageName);
 
 /// Returns the normalized [builderKey] usage when used from [packageName].
 ///
 /// Example normalizations:
 ///
-///   - "some_package" => "some_package|some_package"
-///   - "|some_builder" => "$packageName|some_builder"
-///   - "some_package|some_builder" => "some_package|some_builder"
+///   - "some_package" => "some_package:some_package"
+///   - ":some_builder" => "$packageName:some_builder"
+///   - "some_package:some_builder" => "some_package:some_builder"
+///
+/// If the legacy separator `|` is used it will be transformed to `:`
 String normalizeBuilderKeyUsage(String builderKey, String packageName) =>
-    _normalizeUsage(builderKey, packageName, '|');
+    _normalizeUsage(
+        builderKey.contains('|')
+            ? builderKey.replaceFirst('|', ':')
+            : builderKey,
+        packageName);
 
 /// Returns the normalized [targetKey] definition when used from [packageName].
 ///
@@ -35,7 +47,7 @@ String normalizeBuilderKeyUsage(String builderKey, String packageName) =>
 String normalizeTargetKeyDefinition(String targetKey, String packageName) =>
     targetKey == _defaultTargetNamePlaceholder
         ? '$packageName:$packageName'
-        : _normalizeDefinition(targetKey, packageName, ':');
+        : _normalizeDefinition(targetKey, packageName);
 
 /// Returns the normalized [targetKey] usage when used from [packageName].
 ///
@@ -54,7 +66,7 @@ String normalizeTargetKeyUsage(String targetKey, String packageName) {
     case '$_defaultTargetNamePlaceholder:$_defaultTargetNamePlaceholder':
       return '$packageName:$packageName';
     default:
-      return _normalizeUsage(targetKey, packageName, ':');
+      return _normalizeUsage(targetKey, packageName);
   }
 }
 
@@ -67,9 +79,9 @@ String normalizeTargetKeyUsage(String targetKey, String packageName) {
 ///
 /// For example: If I depend on `angular` from `my_package` it is treated as a
 /// dependency on the globally unique `angular:angular`.
-String _normalizeUsage(String name, String packageName, String separator) {
-  if (name.startsWith(separator)) return '$packageName$name';
-  if (!name.contains(separator)) return '$name$separator$name';
+String _normalizeUsage(String name, String packageName) {
+  if (name.startsWith(':')) return '$packageName$name';
+  if (!name.contains(':')) return '$name:$name';
   return name;
 }
 
@@ -80,8 +92,8 @@ String _normalizeUsage(String name, String packageName, String separator) {
 ///
 /// For example: If I expose a builder `my_builder` within `my_package` it is
 /// turned into the globally unique `my_package|my_builder`.
-String _normalizeDefinition(String name, String packageName, String separator) {
-  if (name.startsWith(separator)) return '$packageName$name';
-  if (!name.contains(separator)) return '$packageName$separator$name';
+String _normalizeDefinition(String name, String packageName) {
+  if (name.startsWith(':')) return '$packageName$name';
+  if (!name.contains(':')) return '$packageName:$name';
   return name;
 }

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -17,12 +17,12 @@ void main() {
         'example',
         key: 'example:a',
         builders: {
-          'b|b': TargetBuilderConfig(
+          'b:b': TargetBuilderConfig(
               isEnabled: true, generateFor: InputSet(include: ['lib/a.dart'])),
-          'c|c': TargetBuilderConfig(isEnabled: false),
-          'example|h': TargetBuilderConfig(
+          'c:c': TargetBuilderConfig(isEnabled: false),
+          'example:h': TargetBuilderConfig(
               isEnabled: true, options: BuilderOptions({'foo': 'bar'})),
-          'example|p': TargetBuilderConfig(
+          'example:p': TargetBuilderConfig(
               isEnabled: true, options: BuilderOptions({'baz': 'zap'})),
         },
         // Expecting $default => example:example
@@ -38,9 +38,9 @@ void main() {
       )
     });
     expectBuilderDefinitions(buildConfig.builderDefinitions, {
-      'example|h': createBuilderDefinition(
+      'example:h': createBuilderDefinition(
         'example',
-        key: 'example|h',
+        key: 'example:h',
         builderFactories: ['createBuilder'],
         autoApply: AutoApply.dependents,
         isOptional: true,
@@ -53,8 +53,8 @@ void main() {
           ]
         },
         requiredInputs: ['.dart'],
-        runsBefore: ['foo_builder|foo_builder'].toSet(),
-        appliesBuilders: ['foo_builder|foo_builder'].toSet(),
+        runsBefore: ['foo_builder:foo_builder'].toSet(),
+        appliesBuilders: ['foo_builder:foo_builder'].toSet(),
         defaults: TargetBuilderConfigDefaults(
           generateFor: const InputSet(include: ['lib/**']),
           options: const BuilderOptions({'foo': 'bar'}),
@@ -64,9 +64,9 @@ void main() {
     });
     expectPostProcessBuilderDefinitions(
         buildConfig.postProcessBuilderDefinitions, {
-      'example|p': createPostProcessBuilderDefinition(
+      'example:p': createPostProcessBuilderDefinition(
         'example',
-        key: 'example|p',
+        key: 'example:p',
         builderFactory: 'createPostProcessBuilder',
         import: 'package:example/p.dart',
         defaults: TargetBuilderConfigDefaults(
@@ -77,9 +77,9 @@ void main() {
       ),
     });
     expectGlobalOptions(buildConfig.globalOptions, {
-      'example|h':
+      'example:h':
           GlobalBuilderConfig(options: const BuilderOptions({'foo': 'global'})),
-      'b|b': GlobalBuilderConfig(
+      'b:b': GlobalBuilderConfig(
           devOptions: const BuilderOptions({'foo': 'global_dev'}),
           releaseOptions: const BuilderOptions({'foo': 'global_release'}))
     });
@@ -96,9 +96,9 @@ void main() {
       ),
     });
     expectBuilderDefinitions(buildConfig.builderDefinitions, {
-      'example|a': createBuilderDefinition(
+      'example:a': createBuilderDefinition(
         'example',
-        key: 'example|a',
+        key: 'example:a',
         builderFactories: ['createBuilder'],
         autoApply: AutoApply.none,
         isOptional: false,
@@ -134,10 +134,10 @@ void main() {
 
 var buildYaml = r'''
 global_options:
-  "|h":
+  ":h":
     options:
       foo: global
-  b|b:
+  b:b:
     dev_options:
       foo: global_dev
     release_options:
@@ -145,16 +145,16 @@ global_options:
 targets:
   a:
     builders:
-      "|h":
+      ":h":
         options:
           foo: bar
-      "|p":
+      ":p":
         options:
           baz: zap
-      b|b:
+      b:b:
         generate_for:
           - lib/a.dart
-      c|c:
+      c:c:
         enabled: false
     dependencies:
       - $default

--- a/build_config/test/errors_test.dart
+++ b/build_config/test/errors_test.dart
@@ -39,7 +39,7 @@ builders:
 targets:
   $default:
     builders:
-      some_package|some_builder:
+      some_package:some_builder:
         generate_for:
         -
 ''';


### PR DESCRIPTION
Closes #1127 

Update the `normalizeBuilderKey` methods so that they first translate a
`|` into `:` and then continue normally from there.

Both `build.yaml` parsing, and `--define` argument parsing, use this
normalization so they will continue to accept existing keys.