### PR TITLE
Update to new builder key format in tests

### DIFF
--- a/build_runner/test/build_script_generate/builder_ordering_test.dart
+++ b/build_runner/test/build_script_generate/builder_ordering_test.dart
@@ -25,7 +25,7 @@ void main() {
               'build_extensions': {},
               'target': '',
               'import': '',
-              'runs_before': ['|runs_second'],
+              'runs_before': [':runs_second'],
             },
           }
         }
@@ -33,7 +33,7 @@ void main() {
       final orderedBuilders = findBuilderOrder(
           buildConfigs.values.expand((v) => v.builderDefinitions.values));
       final orderedKeys = orderedBuilders.map((b) => b.key);
-      expect(orderedKeys, ['a|runs_first', 'a|runs_second']);
+      expect(orderedKeys, ['a:runs_first', 'a:runs_second']);
     });
 
     test('orders builders with `required_inputs`', () async {
@@ -61,7 +61,7 @@ void main() {
       final orderedBuilders = findBuilderOrder(
           buildConfigs.values.expand((v) => v.builderDefinitions.values));
       final orderedKeys = orderedBuilders.map((b) => b.key);
-      expect(orderedKeys, ['a|runs_first', 'a|runs_second']);
+      expect(orderedKeys, ['a:runs_first', 'a:runs_second']);
     });
 
     test('disallows cycles', () async {
@@ -74,7 +74,7 @@ void main() {
               'target': '',
               'import': '',
               'required_inputs': ['.output_b'],
-              'runs_before': ['|builder_b'],
+              'runs_before': [':builder_b'],
             },
             'builder_b': {
               'builder_factories': ['createBuilder'],

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -321,7 +321,7 @@ import 'package:build_test/build_test.dart';
 main(List<String> args) async {
   var buildApplications = [
     apply(
-        'root|copy',
+        'root:copy',
         [
           (options) {
             var copyFromId = options.config['copy_from'];
@@ -375,7 +375,7 @@ main(List<String> args) async {
 targets:
   $default:
     builders:
-      root|copy:
+      root:copy:
         options:
           copy_from: a|web/b.txt
 '''),
@@ -394,7 +394,7 @@ targets:
         await expectBuildOutput('b');
 
         // Run another build but add the --define.
-        await runBuild(extraArgs: ['--define=root|copy=copy_from=a|web/c.txt']);
+        await runBuild(extraArgs: ['--define=root:copy=copy_from=a|web/c.txt']);
         await expectBuildOutput('c');
       });
     });
@@ -409,7 +409,7 @@ import 'package:build_test/build_test.dart';
 
 main(List<String> args) async {
   var buildApplications = [
-    apply('root|copy', [(_) => new TestBuilder()], toRoot(),
+    apply('root:copy', [(_) => new TestBuilder()], toRoot(),
         hideOutput: false, isOptional: false),
   ];
   await run(args, buildApplications);
@@ -440,7 +440,7 @@ main(List<String> args) async {
 targets:
   $default:
     builders:
-      bad|builder:
+      bad:builder:
 '''),
         d.dir('tool', [d.file('build.dart', buildContent)]),
         d.dir('web', [
@@ -468,7 +468,7 @@ targets:
         ]),
         d.file('build.yaml', r'''
 global_options:
-  bad|builder:
+  bad:builder:
 '''),
         d.dir('tool', [d.file('build.dart', buildContent)]),
         d.dir('web', [
@@ -502,7 +502,7 @@ global_options:
 
       await pubGet('a');
 
-      var result = await runBuild(extraArgs: ['--define=bad|key=foo=bar']);
+      var result = await runBuild(extraArgs: ['--define=bad:key=foo=bar']);
 
       expect(result, contains('not a known Builder'));
     });

--- a/build_runner_core/test/generate/build_configuration_test.dart
+++ b/build_runner_core/test/generate/build_configuration_test.dart
@@ -22,7 +22,7 @@ void main() {
         'targets': {
           'a': {
             'builders': {
-              'a|optioned_builder': {
+              'a:optioned_builder': {
                 'options': {'inputExtension': '.matches'}
               }
             }
@@ -32,7 +32,7 @@ void main() {
     });
     await testBuilders(
         [
-          apply('a|optioned_builder', [copyBuilder], toRoot(),
+          apply('a:optioned_builder', [copyBuilder], toRoot(),
               hideOutput: false),
         ],
         {
@@ -54,7 +54,7 @@ void main() {
       package('b'): [],
     });
     await testBuilders([
-      apply('a|optioned_builder', [copyBuilder], toAllPackages(),
+      apply('a:optioned_builder', [copyBuilder], toAllPackages(),
           hideOutput: true),
     ], {
       'a|lib/a.txt': 'a',

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -24,9 +24,9 @@ void main() {
   final copyABuilderApplication = applyToRoot(testBuilder);
   final requiresPostProcessBuilderApplication = apply(
       'test_builder', [(_) => testBuilder], toRoot(),
-      appliesBuilders: ['a|post_copy_builder'], hideOutput: false);
+      appliesBuilders: ['a:post_copy_builder'], hideOutput: false);
   final postCopyABuilderApplication = applyPostProcess(
-      'a|post_copy_builder',
+      'a:post_copy_builder',
       (options) => CopyingPostProcessBuilder(
           outputExtension: options.config['extension'] as String ?? '.post'));
   final globBuilder = GlobbingBuilder(Glob('**.txt'));
@@ -183,7 +183,7 @@ void main() {
               toRoot(),
               isOptional: true),
           apply(
-              'a|only_on_1',
+              'a:only_on_1',
               [
                 (_) => TestBuilder(
                     buildExtensions: appendExtension('.copy', from: '.1'))
@@ -233,14 +233,14 @@ void main() {
         var builders = [
           copyABuilderApplication,
           apply(
-              'a|clone_txt',
+              'a:clone_txt',
               [(_) => TestBuilder(buildExtensions: appendExtension('.clone'))],
               toRoot(),
               isOptional: true,
               hideOutput: false,
-              appliesBuilders: ['a|post_copy_builder']),
+              appliesBuilders: ['a:post_copy_builder']),
           apply(
-              'a|copy_web_clones',
+              'a:copy_web_clones',
               [
                 (_) => TestBuilder(
                     buildExtensions: appendExtension('.copy', numCopies: 2))
@@ -255,13 +255,13 @@ void main() {
               'a': {
                 'sources': ['**'],
                 'builders': {
-                  'a|clone_txt': {
+                  'a:clone_txt': {
                     'generate_for': ['**/*.txt']
                   },
-                  'a|copy_web_clones': {
+                  'a:copy_web_clones': {
                     'generate_for': ['web/*.txt.clone']
                   },
-                  'a|post_copy_builder': {
+                  'a:post_copy_builder': {
                     'options': {'extension': '.custom.post'},
                     'generate_for': ['web/*.txt']
                   }
@@ -470,7 +470,7 @@ void main() {
         await testBuilders(
             [
               apply('', [(_) => TestBuilder()], toPackage('b'),
-                  hideOutput: true, appliesBuilders: ['a|post_copy_builder']),
+                  hideOutput: true, appliesBuilders: ['a:post_copy_builder']),
               postCopyABuilderApplication,
             ],
             {'b|lib/b.txt': 'b'},

--- a/build_runner_core/test/package_graph/apply_builders_test.dart
+++ b/build_runner_core/test/package_graph/apply_builders_test.dart
@@ -24,14 +24,14 @@ void main() {
       });
       var targetGraph = await TargetGraph.forPackageGraph(packageGraph);
       var builderApplications = [
-        apply('b|cool_builder', [(options) => CoolBuilder(options)],
+        apply('b:cool_builder', [(options) => CoolBuilder(options)],
             toAllPackages())
       ];
       var phases = await createBuildPhases(
           targetGraph,
           builderApplications,
           {
-            'b|cool_builder': {'option_a': 'a', 'option_c': 'c'},
+            'b:cool_builder': {'option_a': 'a', 'option_c': 'c'},
           },
           false);
       for (final phase in phases.cast<InBuildPhase>()) {
@@ -55,7 +55,7 @@ void main() {
               'a:a': BuildTarget(dependencies: Set.of(['b:b']))
             },
             globalOptions: {
-              'b|cool_builder': GlobalBuilderConfig(
+              'b:cool_builder': GlobalBuilderConfig(
                 options: const BuilderOptions(
                     {'option_a': 'global a', 'option_b': 'global b'}),
                 releaseOptions:
@@ -67,14 +67,14 @@ void main() {
         var targetGraph = await TargetGraph.forPackageGraph(packageGraph,
             overrideBuildConfig: overrides);
         var builderApplications = [
-          apply('b|cool_builder', [(options) => CoolBuilder(options)],
+          apply('b:cool_builder', [(options) => CoolBuilder(options)],
               toAllPackages())
         ];
         var phases = await createBuildPhases(
             targetGraph,
             builderApplications,
             {
-              'b|cool_builder': {'option_c': '--define c'},
+              'b:cool_builder': {'option_c': '--define c'},
             },
             true);
         for (final phase in phases.cast<InBuildPhase>()) {
@@ -94,7 +94,7 @@ void main() {
       });
       var targetGraph = await TargetGraph.forPackageGraph(packageGraph);
       var builderApplications = [
-        apply('b|cool_builder', [(options) => CoolBuilder(options)],
+        apply('b:cool_builder', [(options) => CoolBuilder(options)],
             toDependentsOf('b')),
       ];
       var phases =
@@ -110,10 +110,10 @@ void main() {
       });
       var targetGraph = await TargetGraph.forPackageGraph(packageGraph);
       var builderApplications = [
-        apply('b|cool_builder', [(options) => CoolBuilder(options)],
+        apply('b:cool_builder', [(options) => CoolBuilder(options)],
             toDependentsOf('b'),
-            appliesBuilders: ['b|not_by_default']),
-        apply('b|not_by_default', [(_) => TestBuilder()], toNoneByDefault()),
+            appliesBuilders: ['b:not_by_default']),
+        apply('b:not_by_default', [(_) => TestBuilder()], toNoneByDefault()),
       ];
       var phases =
           await createBuildPhases(targetGraph, builderApplications, {}, false);
@@ -132,7 +132,7 @@ void main() {
       });
       var targetGraph = await TargetGraph.forPackageGraph(packageGraph);
       var builderApplications = [
-        apply('c|cool_builder', [(options) => CoolBuilder(options)],
+        apply('c:cool_builder', [(options) => CoolBuilder(options)],
             toDependentsOf('c'),
             hideOutput: false),
       ];
@@ -154,10 +154,10 @@ void main() {
       });
       var targetGraph = await TargetGraph.forPackageGraph(packageGraph);
       var builderApplications = [
-        apply('c|cool_builder', [(options) => CoolBuilder(options)],
+        apply('c:cool_builder', [(options) => CoolBuilder(options)],
             toDependentsOf('c'),
-            appliesBuilders: ['c|not_by_default']),
-        apply('c|not_by_default', [(_) => TestBuilder()], toNoneByDefault(),
+            appliesBuilders: ['c:not_by_default']),
+        apply('c:not_by_default', [(_) => TestBuilder()], toNoneByDefault(),
             hideOutput: false),
       ];
       var phases =
@@ -186,7 +186,7 @@ void main() {
         var targetGraph = await TargetGraph.forPackageGraph(packageGraph,
             overrideBuildConfig: overrides);
         var builderApplications = [
-          apply('b|cool_builder', [(options) => CoolBuilder(options)],
+          apply('b:cool_builder', [(options) => CoolBuilder(options)],
               toAllPackages()),
         ];
         expect(


### PR DESCRIPTION
After the update to `build_config` version `0.3.2` the keys that we see
in the code no longer match what they were before. When we have
expectations against builders keys they need to use `:` as the
separator.

Manual calls to `apply` also need to use the new format since this is
what gets generated in the build script.

Also update the uses which mimic `build.yaml` files even though it isn't
strictly required.