### PR TITLE
Prepare to publish build_web_compilers and build_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,9 +116,9 @@ jobs:
       env: PKGS="build_vm_compilers"
       script: ./tool/travis.sh test_06
     - stage: analyze_and_format
-      name: "SDK: 2.2.1-dev.3.0; PKGS: build_modules, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.2.1-dev.3.0; PKG: build_modules; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.2.1-dev.3.0"
-      env: PKGS="build_modules build_web_compilers"
+      env: PKGS="build_modules"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs-- -P presubmit`"
@@ -154,6 +154,11 @@ jobs:
       name: "SDK: 2.2.0; PKG: build_test; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.2.0"
       env: PKGS="build_test"
+      script: ./tool/travis.sh dartanalyzer_1
+    - stage: analyze_and_format
+      name: "SDK: 2.2.1-dev.4.0; PKG: build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.2.1-dev.4.0"
+      env: PKGS="build_web_compilers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: build_web_compilers; TASKS: [`pub run test -x presubmit-only`, `pub run test -t presubmit-only --run-skipped`]"

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.0.0-dev
+version: 2.0.0
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -8,15 +8,15 @@ environment:
   sdk: ">=2.2.1-dev.3.0 <3.0.0"
 
 dependencies:
-  analyzer: '>0.30.0 <0.37.0'
-  async: '>=1.13.3 <3.0.0'
+  analyzer: ">0.30.0 <0.37.0"
+  async: ^2.0.0
   bazel_worker: ^0.1.20
-  build: '>=0.12.3 <2.0.0'
-  build_config: '>=0.2.1 <0.4.0'
+  build: ">=0.12.3 <2.0.0"
+  build_config: ^0.3.0
   collection: ^1.0.0
   glob: ^1.0.0
   graphs: ^0.2.0
-  json_annotation: '>=1.2.0 <3.0.0'
+  json_annotation: ">=1.2.0 <3.0.0"
   logging: ^0.11.2
   meta: ^1.1.0
   path: ^1.4.2

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-dev
+## 2.0.0-alpha.0
 
 - Update to run DDC in kernel mode, and consume kernel outlines instead of
   analyzer summaries.

--- a/build_web_compilers/mono_pkg.yaml
+++ b/build_web_compilers/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.2.1-dev.3.0
+        - 2.2.1-dev.4.0
   - unit_test:
     - group:
       - test: -x presubmit-only

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 
 dependencies:
   analyzer: ">=0.30.0 <0.37.0"
-  archive: ">=1.0.13 <3.0.0"
+  archive: ^2.0.0
   bazel_worker: ^0.1.18
-  build: '>=0.12.8 <2.0.0'
-  build_config: '>=0.2.6 <0.4.0'
+  build: ">=0.12.8 <2.0.0"
+  build_config: ^0.3.0
   build_modules: ^2.0.0
-  crypto: ">=0.9.2 <3.0.0"
+  crypto: ^2.0.0
   glob: ^1.1.0
   js: ^0.6.1
   logging: ^0.11.2

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: ">=2.2.1-dev.3.0 <3.0.0"
+  sdk: ">=2.2.1-dev.4.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.30.0 <0.37.0"

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.0.0-dev
+version: 2.0.0-alpha.0
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
Update pubspec versions and changelogs.

Publish build_web_compilers as an alpha since we still need an
SDK with the latest fixes.

Simplify unnecessarily broad package constraints. Switch to a `^`
constraint where:

- We were using a quoted range.
- The bottom of the range does not support the 2.x Dart SDK.
- The minimum version supporting Dart 2 is the same `^` constraint as
  the current upper bound.

Also change to use consistent double quotes.