### PR TITLE
Dont prompt in daemon mode

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.2
+
+- Fix an error where daemon mode would claim support for prompts when it can't
+  actually support them and would hang instead.
+- Improve logging when the daemon fails to start up, previously no logs would
+  be shown.
+
 ## 1.3.1
 
 - Remove usage of set literals to fix errors on older sdks that don't support

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -151,7 +151,6 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
 
     var environment = OverrideableEnvironment(
         IOEnvironment(packageGraph,
-            assumeTty: true,
             outputSymlinksOnly: sharedOptions.outputSymlinksOnly),
         onLog: (record) {
       outputStreamController.add(ServerLog((b) => b.log = record.toString()));

--- a/build_runner/lib/src/entrypoint/daemon.dart
+++ b/build_runner/lib/src/entrypoint/daemon.dart
@@ -57,7 +57,7 @@ class DaemonCommand extends BuildRunnerCommand {
       BuildRunnerDaemonBuilder builder;
       // Ensure we capture any logs that happen during startup.
       var startupLogSub =
-          Logger.root.onRecord.listen((LogRecord l) => stdout.writeln('$l\n'));
+          Logger.root.onRecord.listen((record) => stdout.writeln('$record\n'));
       builder = await BuildRunnerDaemonBuilder.create(
         packageGraph,
         builderApplications,

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.3.1
+version: 1.3.2
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Also handle startup logs in daemon mode better, we didn't log anything before if it failed to start up.

Fixes https://github.com/dart-lang/webdev/issues/259