### PR TITLE
Use the platform name for SDK dill digest

### DIFF
--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -78,6 +78,7 @@ class KernelBuilder implements Builder {
           buildStep: buildStep,
           summaryOnly: summaryOnly,
           outputExtension: outputExtension,
+          platform: platform,
           dartSdkDir: platformSdk,
           sdkKernelPath: sdkKernelPath);
     } on MissingModulesException catch (e) {
@@ -98,6 +99,7 @@ Future<void> _createKernel(
     @required BuildStep buildStep,
     @required bool summaryOnly,
     @required String outputExtension,
+    @required DartPlatform platform,
     @required String dartSdkDir,
     @required String sdkKernelPath}) async {
   var request = WorkRequest();
@@ -122,7 +124,7 @@ Future<void> _createKernel(
 
     packagesFile = await createPackagesFile(allAssetIds);
 
-    await _addRequestArguments(request, module, kernelDeps, sdkDir,
+    await _addRequestArguments(request, module, kernelDeps, platform, sdkDir,
         sdkKernelPath, outputFile, packagesFile, summaryOnly, buildStep);
   });
 
@@ -241,6 +243,7 @@ Future<void> _addRequestArguments(
     WorkRequest request,
     Module module,
     Iterable<AssetId> transitiveKernelDeps,
+    DartPlatform platform,
     String sdkDir,
     String sdkKernelPath,
     File outputFile,

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -9,10 +9,11 @@ import 'dart:io';
 
 import 'package:bazel_worker/bazel_worker.dart';
 import 'package:build/build.dart';
+import 'package:crypto/crypto.dart';
+import 'package:graphs/graphs.dart' show crawlAsync;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:scratch_space/scratch_space.dart';
-import 'package:graphs/graphs.dart' show crawlAsync;
 
 import 'common.dart';
 import 'errors.dart';
@@ -265,7 +266,7 @@ Future<void> _addRequestArguments(
   request.inputs.add(Input()
     ..path = '${Uri.file(p.join(sdkDir, sdkKernelPath))}'
     // Sdk updates fully invalidate the build anyways.
-    ..digest = [0]);
+    ..digest = md5.convert(utf8.encode(platform.name)).bytes);
 
   // Add all kernel outlines as summary inputs, with digests.
   var inputs = await Future.wait(transitiveKernelDeps.map((id) async {

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.0.0
+version: 2.0.1-dev
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules


### PR DESCRIPTION
Prevents a potential bug where we fail to invalidate stored state in the
incremental compiler. This isn't an issue today since the 'vm' platform
is never able to use the incremental compiler due to passing
`--input-linked` arguments.

In the long term we'll want to consider using separate workers, or
setting up the kernel worker to be able to avoid a full invalidation
when hopping between platforms.