### PR TITLE
Use the same asset graph for .snapshot runs

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.3
+
+- Share an asset graph when building regardless of whether the build script was
+  started from a snapshot.
+
 ## 3.0.2
 
 - Only track valid and readable assets as inputs to globs. Fixes a crash when

--- a/build_runner_core/lib/src/util/constants.dart
+++ b/build_runner_core/lib/src/util/constants.dart
@@ -1,7 +1,9 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
+import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
@@ -63,8 +65,14 @@ void overrideGeneratedOutputDirectory(String path) {
 /// Relative path to the cache directory from the root package dir.
 const String cacheDir = '.dart_tool/build';
 
-/// Returns a hash for a given path.
-String _scriptHashFor(String path) => md5.convert(path.codeUnits).toString();
+/// Returns a hash for a given Dart script path.
+///
+/// Normalizes between snapshot and Dart source file paths so they give the same
+/// hash.
+String _scriptHashFor(String path) => md5
+    .convert(utf8.encode(
+        path.endsWith('.snapshot') ? path.substring(0, path.length - 9) : path))
+    .toString();
 
 /// The name of the pub binary on the current platform.
 final pubBinary = p.join(sdkBin, Platform.isWindows ? 'pub.bat' : 'pub');

--- a/build_runner_core/lib/src/util/constants.dart
+++ b/build_runner_core/lib/src/util/constants.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 3.0.2
+version: 3.0.3
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
Fixes #1940

When switching between invocations that do and do not use script
snapshots there is a bad UX around `--delete-conflicting-outputs` since
they won't share an asset graph. Normalize the paths so that both
invocations use the same graph.