### PR TITLE
Move the clean command to runner binary

### DIFF
--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -15,8 +15,8 @@ import 'package:build_runner/src/build_script_generate/bootstrap.dart';
 import 'package:build_runner/src/entrypoint/runner.dart';
 import 'package:build_runner/src/logging/std_io_logging.dart';
 
-import 'src/commands/generate_build_script.dart';
 import 'src/commands/clean.dart';
+import 'src/commands/generate_build_script.dart';
 
 Future<Null> main(List<String> args) async {
   // Use the actual command runner to parse the args and immediately print the

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -10,19 +10,22 @@ import 'package:args/command_runner.dart';
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
-import 'package:path/path.dart' as p;
 
-import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
 import 'package:build_runner/src/build_script_generate/bootstrap.dart';
 import 'package:build_runner/src/entrypoint/runner.dart';
 import 'package:build_runner/src/logging/std_io_logging.dart';
+
+import 'src/commands/generate_build_script.dart';
+import 'src/commands/clean.dart';
 
 Future<Null> main(List<String> args) async {
   // Use the actual command runner to parse the args and immediately print the
   // usage information if there is no command provided or the help command was
   // explicitly invoked.
-  var commandRunner = BuildCommandRunner([])
-    ..addCommand(_GenerateBuildScript());
+  var commandRunner = BuildCommandRunner([]);
+  var localCommands = [CleanCommand(), GenerateBuildScript()];
+  var localCommandNames = localCommands.map((c) => c.name).toSet();
+  localCommands.forEach(commandRunner.addCommand);
 
   ArgResults parsedArgs;
   try {
@@ -51,37 +54,11 @@ Future<Null> main(List<String> args) async {
     return;
   }
 
-  StreamSubscription logListener;
-  if (commandName == _generateCommand) {
+  final logListener = Logger.root.onRecord.listen(stdIOLogListener());
+  if (localCommandNames.contains(commandName)) {
     exitCode = await commandRunner.runCommand(parsedArgs);
-    return;
+  } else {
+    while ((exitCode = await generateAndRun(args)) == ExitCode.tempFail.code) {}
   }
-  logListener = Logger.root.onRecord.listen(stdIOLogListener());
-
-  while ((exitCode = await generateAndRun(args)) == ExitCode.tempFail.code) {}
   await logListener?.cancel();
-}
-
-const _generateCommand = 'generate-build-script';
-
-class _GenerateBuildScript extends Command<int> {
-  @override
-  final description = 'Generate a script to run builds and print the file path '
-      'with no other logging. Useful for wrapping builds with other tools.';
-
-  @override
-  final name = _generateCommand;
-
-  @override
-  bool get hidden => true;
-
-  @override
-  Future<int> run() async {
-    var buildScript = await generateBuildScript();
-    File(scriptLocation)
-      ..createSync(recursive: true)
-      ..writeAsStringSync(buildScript);
-    print(p.absolute(scriptLocation));
-    return 0;
-  }
 }

--- a/build_runner/bin/src/commands/clean.dart
+++ b/build_runner/bin/src/commands/clean.dart
@@ -3,15 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:build_runner_core/build_runner_core.dart';
-import 'package:build_runner_core/src/asset_graph/graph.dart';
-import 'package:build_runner_core/src/asset_graph/node.dart';
 import 'package:logging/logging.dart';
 
 import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
+import 'package:build_runner/src/entrypoint/clean.dart' show cleanFor;
 
 class CleanCommand extends Command<int> {
   @override
@@ -25,58 +23,7 @@ class CleanCommand extends Command<int> {
 
   @override
   Future<int> run() async {
-    logger.warning('Deleting cache and generated source files.\n'
-        'This shouldn\'t be necessary for most applications, unless you have '
-        'made intentional edits to generated files (i.e. for testing). '
-        'Consider filing a bug at '
-        'https://github.com/dart-lang/build/issues/new if you are using this '
-        'to work around an apparent (and reproducible) bug.');
-
-    await logTimedAsync(logger, 'Cleaning up source outputs', () async {
-      var assetGraphFile = File(assetGraphPathFor(scriptLocation));
-      if (!assetGraphFile.existsSync()) {
-        logger.warning('No asset graph found. '
-            'Skipping cleanup of generated files in source directories.');
-        return;
-      }
-      AssetGraph assetGraph;
-      try {
-        assetGraph = AssetGraph.deserialize(await assetGraphFile.readAsBytes());
-      } catch (_) {
-        logger.warning('Failed to deserialize AssetGraph. '
-            'Skipping cleanup of generated files in source directories.');
-        return;
-      }
-      var packageGraph = PackageGraph.forThisPackage();
-      await _cleanUpSourceOutputs(assetGraph, packageGraph);
-    });
-
-    await logTimedAsync(
-        logger, 'Cleaning up cache directory', _cleanUpGeneratedDirectory);
-
+    await cleanFor(assetGraphPathFor(scriptLocation), logger);
     return 0;
-  }
-}
-
-Future<void> _cleanUpSourceOutputs(
-    AssetGraph assetGraph, PackageGraph packageGraph) async {
-  var writer = FileBasedAssetWriter(packageGraph);
-  for (var id in assetGraph.outputs) {
-    if (id.package != packageGraph.root.name) continue;
-    var node = assetGraph.get(id) as GeneratedAssetNode;
-    if (node.wasOutput) {
-      // Note that this does a file.exists check in the root package and
-      // only tries to delete the file if it exists. This way we only
-      // actually delete to_source outputs, without reading in the build
-      // actions.
-      await writer.delete(id);
-    }
-  }
-}
-
-Future<void> _cleanUpGeneratedDirectory() async {
-  var generatedDir = Directory(cacheDir);
-  if (await generatedDir.exists()) {
-    await generatedDir.delete(recursive: true);
   }
 }

--- a/build_runner/bin/src/commands/generate_build_script.dart
+++ b/build_runner/bin/src/commands/generate_build_script.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
+
+class GenerateBuildScript extends Command<int> {
+  @override
+  String get description =>
+      'Generate a script to run builds and print the file path '
+      'with no other logging. Useful for wrapping builds with other tools.';
+
+  @override
+  String get name => 'generate-build-script';
+
+  @override
+  bool get hidden => true;
+
+  @override
+  Future<int> run() async {
+    Logger.root.clearListeners();
+    var buildScript = await generateBuildScript();
+    File(scriptLocation)
+      ..createSync(recursive: true)
+      ..writeAsStringSync(buildScript);
+    print(p.absolute(scriptLocation));
+    return 0;
+  }
+}

--- a/build_runner/lib/src/entrypoint/clean.dart
+++ b/build_runner/lib/src/entrypoint/clean.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:build_runner_core/build_runner_core.dart';
+import 'package:build_runner_core/src/asset_graph/graph.dart';
+import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:logging/logging.dart';
+
+import '../logging/std_io_logging.dart';
+
+class CleanCommand extends Command<int> {
+  @override
+  String get name => 'clean';
+
+  @override
+  String get description =>
+      'Cleans up output from previous builds. Does not clean up --output '
+      'directories.';
+
+  Logger get logger => Logger(name);
+
+  @override
+  Future<int> run() async {
+    var logSubscription = Logger.root.onRecord.listen(stdIOLogListener());
+
+    logger.warning('Deleting cache and generated source files.\n'
+        'This shouldn\'t be necessary for most applications, unless you have '
+        'made intentional edits to generated files (i.e. for testing). '
+        'Consider filing a bug at '
+        'https://github.com/dart-lang/build/issues/new if you are using this '
+        'to work around an apparent (and reproducible) bug.');
+
+    await logTimedAsync(logger, 'Cleaning up source outputs', () async {
+      var assetGraphFile = File(assetGraphPath);
+      if (!assetGraphFile.existsSync()) {
+        logger.warning('No asset graph found. '
+            'Skipping cleanup of generated files in source directories.');
+        return;
+      }
+      AssetGraph assetGraph;
+      try {
+        assetGraph = AssetGraph.deserialize(await assetGraphFile.readAsBytes());
+      } catch (_) {
+        logger.warning('Failed to deserialize AssetGraph. '
+            'Skipping cleanup of generated files in source directories.');
+        return;
+      }
+      var packageGraph = PackageGraph.forThisPackage();
+      await cleanUpSourceOutputs(assetGraph, packageGraph);
+    });
+
+    await logTimedAsync(
+        logger, 'Cleaning up cache directory', cleanUpGeneratedDirectory);
+
+    await logSubscription.cancel();
+
+    return 0;
+  }
+}
+
+Future<void> cleanUpSourceOutputs(
+    AssetGraph assetGraph, PackageGraph packageGraph) async {
+  var writer = FileBasedAssetWriter(packageGraph);
+  for (var id in assetGraph.outputs) {
+    if (id.package != packageGraph.root.name) continue;
+    var node = assetGraph.get(id) as GeneratedAssetNode;
+    if (node.wasOutput) {
+      // Note that this does a file.exists check in the root package and
+      // only tries to delete the file if it exists. This way we only
+      // actually delete to_source outputs, without reading in the build
+      // actions.
+      await writer.delete(id);
+    }
+  }
+}
+
+Future<void> cleanUpGeneratedDirectory() async {
+  var generatedDir = Directory(cacheDir);
+  if (await generatedDir.exists()) {
+    await generatedDir.delete(recursive: true);
+  }
+}

--- a/build_runner/lib/src/entrypoint/clean.dart
+++ b/build_runner/lib/src/entrypoint/clean.dart
@@ -27,43 +27,44 @@ class CleanCommand extends Command<int> {
   @override
   Future<int> run() async {
     var logSubscription = Logger.root.onRecord.listen(stdIOLogListener());
-
-    logger.warning('Deleting cache and generated source files.\n'
-        'This shouldn\'t be necessary for most applications, unless you have '
-        'made intentional edits to generated files (i.e. for testing). '
-        'Consider filing a bug at '
-        'https://github.com/dart-lang/build/issues/new if you are using this '
-        'to work around an apparent (and reproducible) bug.');
-
-    await logTimedAsync(logger, 'Cleaning up source outputs', () async {
-      var assetGraphFile = File(assetGraphPath);
-      if (!assetGraphFile.existsSync()) {
-        logger.warning('No asset graph found. '
-            'Skipping cleanup of generated files in source directories.');
-        return;
-      }
-      AssetGraph assetGraph;
-      try {
-        assetGraph = AssetGraph.deserialize(await assetGraphFile.readAsBytes());
-      } catch (_) {
-        logger.warning('Failed to deserialize AssetGraph. '
-            'Skipping cleanup of generated files in source directories.');
-        return;
-      }
-      var packageGraph = PackageGraph.forThisPackage();
-      await cleanUpSourceOutputs(assetGraph, packageGraph);
-    });
-
-    await logTimedAsync(
-        logger, 'Cleaning up cache directory', cleanUpGeneratedDirectory);
-
+    await cleanFor(assetGraphPath, logger);
     await logSubscription.cancel();
-
     return 0;
   }
 }
 
-Future<void> cleanUpSourceOutputs(
+Future<void> cleanFor(String assetGraphPath, Logger logger) async {
+  logger.warning('Deleting cache and generated source files.\n'
+      'This shouldn\'t be necessary for most applications, unless you have '
+      'made intentional edits to generated files (i.e. for testing). '
+      'Consider filing a bug at '
+      'https://github.com/dart-lang/build/issues/new if you are using this '
+      'to work around an apparent (and reproducible) bug.');
+
+  await logTimedAsync(logger, 'Cleaning up source outputs', () async {
+    var assetGraphFile = File(assetGraphPath);
+    if (!assetGraphFile.existsSync()) {
+      logger.warning('No asset graph found. '
+          'Skipping cleanup of generated files in source directories.');
+      return;
+    }
+    AssetGraph assetGraph;
+    try {
+      assetGraph = AssetGraph.deserialize(await assetGraphFile.readAsBytes());
+    } catch (_) {
+      logger.warning('Failed to deserialize AssetGraph. '
+          'Skipping cleanup of generated files in source directories.');
+      return;
+    }
+    var packageGraph = PackageGraph.forThisPackage();
+    await _cleanUpSourceOutputs(assetGraph, packageGraph);
+  });
+
+  await logTimedAsync(
+      logger, 'Cleaning up cache directory', _cleanUpGeneratedDirectory);
+}
+
+Future<void> _cleanUpSourceOutputs(
     AssetGraph assetGraph, PackageGraph packageGraph) async {
   var writer = FileBasedAssetWriter(packageGraph);
   for (var id in assetGraph.outputs) {
@@ -79,7 +80,7 @@ Future<void> cleanUpSourceOutputs(
   }
 }
 
-Future<void> cleanUpGeneratedDirectory() async {
+Future<void> _cleanUpGeneratedDirectory() async {
   var generatedDir = Directory(cacheDir);
   if (await generatedDir.exists()) {
     await generatedDir.delete(recursive: true);

--- a/build_runner/lib/src/entrypoint/run.dart
+++ b/build_runner/lib/src/entrypoint/run.dart
@@ -10,6 +10,7 @@ import 'package:build_runner_core/build_runner_core.dart';
 import 'package:io/ansi.dart' as ansi;
 import 'package:io/io.dart' show ExitCode;
 
+import 'clean.dart';
 import 'runner.dart';
 
 /// A common entry point to parse command line arguments and build or serve with
@@ -18,7 +19,7 @@ import 'runner.dart';
 /// Returns the exit code that should be set when the calling process exits. `0`
 /// implies success.
 Future<int> run(List<String> args, List<BuilderApplication> builders) async {
-  var runner = BuildCommandRunner(builders);
+  var runner = BuildCommandRunner(builders)..addCommand(CleanCommand());
   try {
     var result = await runner.run(args);
     return result ?? 0;

--- a/build_runner/lib/src/entrypoint/runner.dart
+++ b/build_runner/lib/src/entrypoint/runner.dart
@@ -8,7 +8,6 @@ import 'package:args/command_runner.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 
 import 'build.dart';
-import 'clean.dart';
 import 'daemon.dart';
 import 'doctor.dart';
 import 'serve.dart';
@@ -25,7 +24,6 @@ class BuildCommandRunner extends CommandRunner<int> {
       : builderApplications = List.unmodifiable(builderApplications),
         super('build_runner', 'Unified interface for running Dart builds.') {
     addCommand(BuildCommand());
-    addCommand(CleanCommand());
     addCommand(DaemonCommand());
     addCommand(DoctorCommand());
     addCommand(ServeCommand());


### PR DESCRIPTION
Since the clean process does not need instantiated Builders it can run
in the outer binary rather than from the generated script. This should
make it faster.

- Move the non build script commands to a `bin/src/commands` directory.
- Make a list of "local" commands.
- Start logging before running local commands, explicitly disable
  logging in the one command which must not have any other stdout.