### PR TITLE
Cleanup Future<Null> to Future<void>

### DIFF
--- a/_test/test/common/utils.dart
+++ b/_test/test/common/utils.dart
@@ -36,7 +36,7 @@ Future<ProcessResult> runCommand(List<String> args) =>
 /// This expects the first build to complete successfully, but you can add extra
 /// expects that happen before that using [extraExpects]. All of these will be
 /// invoked and awaited before awaiting the next successful build.
-Future<Null> startServer(
+Future<void> startServer(
         {bool ensureCleanBuild,
         List<Function> extraExpects,
         List<String> buildArgs}) =>
@@ -65,7 +65,7 @@ Future<ProcessResult> _runBuild(String command, List<String> args,
   return result;
 }
 
-Future<Null> _startServer(String command, List<String> buildArgs,
+Future<void> _startServer(String command, List<String> buildArgs,
     {bool ensureCleanBuild, List<Function> extraExpects}) async {
   ensureCleanBuild ??= false;
   extraExpects ??= [];
@@ -96,7 +96,7 @@ Future<Null> _startServer(String command, List<String> buildArgs,
 /// Kills the current build script.
 ///
 /// To clean up the `.dart_tool` directory as well, set [cleanUp] to `true`.
-Future<Null> stopServer({bool cleanUp}) async {
+Future<void> stopServer({bool cleanUp}) async {
   cleanUp ??= false;
   if (_process != null) {
     expect(_process.kill(), true);
@@ -130,25 +130,25 @@ void ensureCleanGitClient() {
   addTearDown(_resetGitClient);
 }
 
-Future<Null> _resetGitClient() async {
+Future<void> _resetGitClient() async {
   if (_gitIsClean()) return;
 
   // Reset our state after each test, assuming we didn't abandon tests due
   // to a non-pristine git environment.
   Process.runSync('git', ['checkout', 'HEAD', '--', '.']);
 
-  Future<Null> nextBuild;
+  Future<void> nextBuild;
   if (_process != null) nextBuild = nextSuccessfulBuild;
   // Delete the untracked files.
   await Process.run('git', ['clean', '-df', '.']);
   if (nextBuild != null) await nextBuild;
 }
 
-Future<Null> get nextSuccessfulBuild async {
+Future<void> get nextSuccessfulBuild async {
   await _stdOutLines.firstWhere((line) => line.contains('Succeeded after'));
 }
 
-Future<Null> get nextFailedBuild async {
+Future<void> get nextFailedBuild async {
   await _stdOutLines.firstWhere((line) => line.contains('Failed after'));
 }
 
@@ -183,14 +183,14 @@ Future<ProcessResult> _runTests(String executable, List<String> scriptArgs,
   }
 }
 
-Future<Null> expectTestsFail() async {
+Future<void> expectTestsFail() async {
   var result = await runTests();
   printOnFailure('${result.stderr}');
   expect(result.stdout, contains('Some tests failed'));
   expect(result.exitCode, isNot(0));
 }
 
-Future<Null> expectTestsPass(
+Future<void> expectTestsPass(
     {int expectedNumRan, bool usePrecompiled, List<String> args}) async {
   var result = await runTests(usePrecompiled: usePrecompiled, buildArgs: args);
   printOnFailure('${result.stderr}');
@@ -201,14 +201,14 @@ Future<Null> expectTestsPass(
   }
 }
 
-Future<Null> createFile(String path, String contents) async {
+Future<void> createFile(String path, String contents) async {
   var file = File(path);
   expect(await file.exists(), isFalse);
   await file.create(recursive: true);
   await file.writeAsString(contents);
 }
 
-Future<Null> deleteFile(String path) async {
+Future<void> deleteFile(String path) async {
   var file = File(path);
   expect(await file.exists(), isTrue);
   await file.delete();
@@ -220,7 +220,7 @@ Future<String> readGeneratedFileAsString(String path) async {
   return file.readAsString();
 }
 
-Future<Null> replaceAllInFile(String path, Pattern from, String replace) async {
+Future<void> replaceAllInFile(String path, Pattern from, String replace) async {
   var file = File(path);
   expect(await file.exists(), isTrue);
   var content = await file.readAsString();

--- a/_test/test/dart2js_integration_test.dart
+++ b/_test/test/dart2js_integration_test.dart
@@ -27,7 +27,7 @@ void main() {
         '--config=dart2js',
         '--output=$_outputDir',
       ]);
-      await expectWasCompiledWithDart2Js(minified: false);
+      await _expectWasCompiledWithDart2JS(minified: false);
     }, onPlatform: {'windows': const Skip('flaky on windows')});
 
     test('via --define flag', () async {
@@ -38,7 +38,7 @@ void main() {
         'build_web_compilers|entrypoint=dart2js_args=["--minify","--checked"]',
         '--output=$_outputDir',
       ]);
-      await expectWasCompiledWithDart2Js(minified: true);
+      await _expectWasCompiledWithDart2JS(minified: true);
     }, onPlatform: {'windows': const Skip('flaky on windows')});
 
     test('via --release mode', () async {
@@ -46,7 +46,7 @@ void main() {
         '--release',
         '--output=$_outputDir',
       ]);
-      await expectWasCompiledWithDart2Js(minified: true);
+      await _expectWasCompiledWithDart2JS(minified: true);
     }, onPlatform: {'windows': const Skip('flaky on windows')});
 
     test('--define overrides --config', () async {
@@ -59,12 +59,12 @@ void main() {
         'build_web_compilers|entrypoint=dart2js_args=["--minify","--checked"]',
         '--output=$_outputDir',
       ]);
-      await expectWasCompiledWithDart2Js(minified: true);
+      await _expectWasCompiledWithDart2JS(minified: true);
     }, onPlatform: {'windows': const Skip('flaky on windows')});
   });
 }
 
-Future<Null> expectWasCompiledWithDart2Js({bool minified = false}) async {
+Future<void> _expectWasCompiledWithDart2JS({bool minified = false}) async {
   var jsFile = File(
       '$_outputDir/test/hello_world_deferred_test.dart.browser_test.dart.js');
   expect(await jsFile.exists(), isTrue);

--- a/_test/test/help_test.dart
+++ b/_test/test/help_test.dart
@@ -12,31 +12,31 @@ import 'common/utils.dart';
 
 void main() {
   test('pub run build_runner help', () async {
-    await testHelpCommand(() => runCommand(['help']));
+    await _testHelpCommand(() => runCommand(['help']));
   });
 
   test('pub run build_runner --help', () async {
-    await testHelpCommand(() => runCommand(['--help']));
+    await _testHelpCommand(() => runCommand(['--help']));
   });
 
   test('pub run build_runner build --help', () async {
-    await testHelpCommand(() => runCommand(['build', '--help']));
+    await _testHelpCommand(() => runCommand(['build', '--help']));
   });
 
   test('pub run build_runner serve --help', () async {
-    await testHelpCommand(() => runCommand(['serve', '--help']));
+    await _testHelpCommand(() => runCommand(['serve', '--help']));
   });
 
   test('pub run build_runner test --help', () async {
-    await testHelpCommand(() => runCommand(['test', '--help']));
+    await _testHelpCommand(() => runCommand(['test', '--help']));
   });
 
   test('pub run build_runner watch --help', () async {
-    await testHelpCommand(() => runCommand(['watch', '--help']));
+    await _testHelpCommand(() => runCommand(['watch', '--help']));
   });
 }
 
-Future<Null> testHelpCommand(Future<ProcessResult> runCommand()) async {
+Future<void> _testHelpCommand(Future<ProcessResult> runCommand()) async {
   var asyncResult = runCommand();
   expect(asyncResult, completes,
       reason: 'should not cause the auto build script to hang');

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -26,7 +26,7 @@ import 'expected_outputs.dart';
 /// automatically disposed of (its up to the caller to dispose of it later). If
 /// one is not provided then one will be created and disposed at the end of
 /// this function call.
-Future<Null> runBuilder(Builder builder, Iterable<AssetId> inputs,
+Future<void> runBuilder(Builder builder, Iterable<AssetId> inputs,
     AssetReader reader, AssetWriter writer, Resolvers resolvers,
     {Logger logger,
     ResourceManager resourceManager,
@@ -36,7 +36,7 @@ Future<Null> runBuilder(Builder builder, Iterable<AssetId> inputs,
   resourceManager ??= ResourceManager();
   logger ??= Logger('runBuilder');
   //TODO(nbosch) check overlapping outputs?
-  Future<Null> buildForInput(AssetId input) async {
+  Future<void> buildForInput(AssetId input) async {
     var outputs = expectedOutputs(builder, input);
     if (outputs.isEmpty) return;
     var buildStep = BuildStepImpl(input, outputs, reader, writer,

--- a/build/lib/src/generate/run_post_process_builder.dart
+++ b/build/lib/src/generate/run_post_process_builder.dart
@@ -20,7 +20,7 @@ import '../builder/post_process_builder.dart';
 /// If an asset should not be written this function should throw.
 /// [deleteAsset] should remove the asset from the build system, it will not be
 /// deleted on disk since the `writer` has no mechanism for delete.
-Future<Null> runPostProcessBuilder(PostProcessBuilder builder, AssetId inputId,
+Future<void> runPostProcessBuilder(PostProcessBuilder builder, AssetId inputId,
     AssetReader reader, AssetWriter writer, Logger logger,
     {@required void Function(AssetId) addAsset,
     @required void Function(AssetId) deleteAsset}) async {

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -23,19 +23,19 @@ final _processMode = stdin.hasTerminal
     : ProcessStartMode.detachedWithStdio;
 
 /// Completes once the dartdevk workers have been shut down.
-Future<Null> get dartdevkWorkersAreDone =>
-    _dartdevkWorkersAreDoneCompleter?.future ?? Future.value(null);
-Completer<Null> _dartdevkWorkersAreDoneCompleter;
+Future<void> get dartdevkWorkersAreDone =>
+    _dartdevkWorkersAreDoneCompleter?.future ?? Future.value();
+Completer<void> _dartdevkWorkersAreDoneCompleter;
 
 /// Completes once the dart2js workers have been shut down.
-Future<Null> get dart2jsWorkersAreDone =>
-    _dart2jsWorkersAreDoneCompleter?.future ?? Future.value(null);
-Completer<Null> _dart2jsWorkersAreDoneCompleter;
+Future<void> get dart2jsWorkersAreDone =>
+    _dart2jsWorkersAreDoneCompleter?.future ?? Future.value();
+Completer<void> _dart2jsWorkersAreDoneCompleter;
 
 /// Completes once the common frontend workers have been shut down.
-Future<Null> get frontendWorkersAreDone =>
-    _frontendWorkersAreDoneCompleter?.future ?? Future.value(null);
-Completer<Null> _frontendWorkersAreDoneCompleter;
+Future<void> get frontendWorkersAreDone =>
+    _frontendWorkersAreDoneCompleter?.future ?? Future.value();
+Completer<void> _frontendWorkersAreDoneCompleter;
 
 final int _defaultMaxWorkers = min((Platform.numberOfProcessors / 2).ceil(), 4);
 
@@ -56,7 +56,7 @@ final int _maxWorkersPerTask = () {
 
 /// Manages a shared set of persistent dartdevk workers.
 BazelWorkerDriver get _dartdevkDriver {
-  _dartdevkWorkersAreDoneCompleter ??= Completer<Null>();
+  _dartdevkWorkersAreDoneCompleter ??= Completer<void>();
   return __dartdevkDriver ??= BazelWorkerDriver(
       () => Process.start(
           p.join(sdkDir, 'bin', 'dart'),
@@ -83,7 +83,7 @@ final dartdevkDriverResource =
 
 /// Manages a shared set of persistent common frontend workers.
 BazelWorkerDriver get _frontendDriver {
-  _frontendWorkersAreDoneCompleter ??= Completer<Null>();
+  _frontendWorkersAreDoneCompleter ??= Completer<void>();
   return __frontendDriver ??= BazelWorkerDriver(
       () => Process.start(
           p.join(sdkDir, 'bin', 'dart'),
@@ -109,7 +109,7 @@ final frontendDriverResource =
 
 /// Manages a shared set of persistent dart2js workers.
 Dart2JsBatchWorkerPool get _dart2jsWorkerPool {
-  _dart2jsWorkersAreDoneCompleter ??= Completer<Null>();
+  _dart2jsWorkersAreDoneCompleter ??= Completer<void>();
   var librariesSpec = p.joinAll([sdkDir, 'lib', 'libraries.json']);
   return __dart2jsWorkerPool ??= Dart2JsBatchWorkerPool(() => Process.start(
       p.join(sdkDir, 'bin', 'dart'),
@@ -185,7 +185,7 @@ class Dart2JsBatchWorkerPool {
     }();
   }
 
-  Future<Null> terminateWorkers() async {
+  Future<void> terminateWorkers() async {
     var allWorkers = _allWorkers.toList();
     _allWorkers.clear();
     _availableWorkers.clear();

--- a/build_modules/test/util.dart
+++ b/build_modules/test/util.dart
@@ -8,7 +8,7 @@ import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 
 /// Forwards to [testBuilder], and adds all output assets to [assets].
-Future<Null> testBuilderAndCollectAssets(
+Future<void> testBuilderAndCollectAssets(
     Builder builder, Map<String, dynamic> assets) async {
   var writer = InMemoryAssetWriter();
   await testBuilder(builder, assets, writer: writer);

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -17,7 +17,7 @@ import 'package:build_runner/src/build_script_generate/bootstrap.dart';
 import 'package:build_runner/src/entrypoint/runner.dart';
 import 'package:build_runner/src/logging/std_io_logging.dart';
 
-Future<Null> main(List<String> args) async {
+Future<void> main(List<String> args) async {
   // Use the actual command runner to parse the args and immediately print the
   // usage information if there is no command provided or the help command was
   // explicitly invoked.

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -129,8 +129,8 @@ class WatchImpl implements BuildState {
 
   AssetGraph get assetGraph => _build?.assetGraph;
 
-  final _readyCompleter = Completer<Null>();
-  Future<Null> get ready => _readyCompleter.future;
+  final _readyCompleter = Completer<void>();
+  Future<void> get ready => _readyCompleter.future;
 
   final String _configKey; // may be null
 
@@ -321,7 +321,7 @@ class WatchImpl implements BuildState {
       }
 
       _reader = _build?.finalizedReader;
-      _readyCompleter.complete(null);
+      _readyCompleter.complete();
       // It is possible this is already closed if the user kills the process
       // early, which results in an exception without this check.
       if (!controller.isClosed) controller.add(firstBuild);

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -21,8 +21,8 @@ class PackageGraphWatcher {
   final PackageNodeWatcher Function(PackageNode) _strategy;
   final PackageGraph _graph;
 
-  final _readyCompleter = Completer<Null>();
-  Future<Null> get ready => _readyCompleter.future;
+  final _readyCompleter = Completer<void>();
+  Future<void> get ready => _readyCompleter.future;
 
   bool _isWatching = false;
 

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -341,7 +341,7 @@ main(List<String> args) async {
 ''';
 
       /// Expects the build output based on [expectedContent].
-      Future<Null> expectBuildOutput(String expectedContent) async {
+      Future<void> expectBuildOutput(String expectedContent) async {
         await d.dir('a', [
           d.dir('web', [
             d.file('a.txt', 'a'),

--- a/build_runner/test/integration_tests/optional_outputs_test.dart
+++ b/build_runner/test/integration_tests/optional_outputs_test.dart
@@ -77,7 +77,7 @@ main() {
 
   group('build', () {
     /// Expects the build output based on [expectCopy].
-    Future<Null> expectBuildOutput(
+    Future<void> expectBuildOutput(
         {@required bool expectCopy, @required String content}) async {
       await d.dir('a', [
         d.dir('build', [

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -477,5 +477,5 @@ class MockWatchImpl implements WatchImpl {
   }
 
   @override
-  Future<Null> get ready => Future.value(null);
+  Future<void> get ready => Future.value();
 }

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -150,7 +150,7 @@ class AssetGraph {
 
   /// Uses [digestReader] to compute the [Digest] for [nodes] and set the
   /// `lastKnownDigest` field.
-  Future<Null> _setLastKnownDigests(
+  Future<void> _setLastKnownDigests(
       Iterable<AssetNode> nodes, AssetReader digestReader) async {
     await Future.wait(nodes.map((node) async {
       node.lastKnownDigest = await digestReader.digest(node.id);

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -439,7 +439,7 @@ class _Loader {
 
   /// Handles cleanup of pre-existing outputs for initial builds (where there is
   /// no cached graph).
-  Future<Null> _initialBuildCleanup(
+  Future<void> _initialBuildCleanup(
       Set<AssetId> conflictingAssets, RunnerAssetWriter writer) async {
     if (conflictingAssets.isEmpty) return;
 

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -72,7 +72,7 @@ class BuildImpl {
   final BuildEnvironment _environment;
   final String _logPerformanceDir;
 
-  Future<Null> beforeExit() => _resourceManager.beforeExit();
+  Future<void> beforeExit() => _resourceManager.beforeExit();
 
   BuildImpl._(BuildDefinition buildDefinition, BuildOptions options,
       this._buildPhases, this._finalizedReader)
@@ -149,7 +149,7 @@ class _SingleBuild {
   final List<Pool> _buildPhasePool;
   final BuildEnvironment _environment;
   final _lazyPhases = <String, Future<Iterable<AssetId>>>{};
-  final _lazyGlobs = <AssetId, Future<Null>>{};
+  final _lazyGlobs = <AssetId, Future<void>>{};
   final PackageGraph _packageGraph;
   final BuildPerformanceTracker _performanceTracker;
   final AssetReader _reader;
@@ -234,7 +234,7 @@ class _SingleBuild {
     return result;
   }
 
-  Future<Null> _updateAssetGraph(Map<AssetId, ChangeType> updates) async {
+  Future<void> _updateAssetGraph(Map<AssetId, ChangeType> updates) async {
     await logTimedAsync(_logger, 'Updating asset graph', () async {
       var invalidated = await _assetGraph.updateAndInvalidate(
           _buildPhases, updates, _packageGraph.root.name, _delete, _reader);
@@ -764,7 +764,7 @@ class _SingleBuild {
   /// - Setting the `lastKnownDigest` on each output based on the new contents.
   /// - Setting the `previousInputsDigest` on each output based on the inputs.
   /// - Storing the error message with the [_failureReporter].
-  Future<Null> _setOutputsState(
+  Future<void> _setOutputsState(
       Iterable<AssetId> outputs,
       SingleStepReader reader,
       AssetWriterSpy writer,

--- a/build_runner_core/lib/src/generate/build_runner.dart
+++ b/build_runner_core/lib/src/generate/build_runner.dart
@@ -18,7 +18,7 @@ class BuildRunner {
   final BuildImpl _build;
   BuildRunner._(this._build);
 
-  Future<Null> beforeExit() => _build.beforeExit();
+  Future<void> beforeExit() => _build.beforeExit();
 
   Future<BuildResult> run(Map<AssetId, ChangeType> updates,
           {Set<BuildDirectory> buildDirs}) =>

--- a/build_runner_core/test/environment/io_environment_test.dart
+++ b/build_runner_core/test/environment/io_environment_test.dart
@@ -24,21 +24,21 @@ void main() {
   tearDown(() => stdoutLines.cancel());
 
   test('Can give the user interactive prompts', () async {
-    await expectEmits(stdoutLines, contains('Select an option!'));
-    await expectEmits(stdoutLines, contains('1 - a'));
-    await expectEmits(stdoutLines, contains('2 - b'));
-    await expectEmits(stdoutLines, contains('3 - c'));
+    await _expectEmits(stdoutLines, contains('Select an option!'));
+    await _expectEmits(stdoutLines, contains('1 - a'));
+    await _expectEmits(stdoutLines, contains('2 - b'));
+    await _expectEmits(stdoutLines, contains('3 - c'));
 
     process.stdin.writeln('4');
     expect(await stdoutLines.next, contains('Unrecognized option 4'));
 
     process.stdin.writeln('3');
-    await expectEmits(stdoutLines, contains('2'));
+    await _expectEmits(stdoutLines, contains('2'));
     await process.exitCode;
   });
 }
 
-Future<Null> expectEmits(StreamQueue<String> stream, Matcher line) async {
+Future<void> _expectEmits(StreamQueue<String> stream, Matcher line) async {
   while (true) {
     if (line.matches(await stream.next, null)) {
       return;

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -39,7 +39,7 @@ main() {
     BuildEnvironment environment;
     String pkgARoot;
 
-    Future<Null> createFile(String path, dynamic contents) async {
+    Future<void> createFile(String path, dynamic contents) async {
       var file = File(p.join(pkgARoot, path));
       expect(await file.exists(), isFalse);
       await file.create(recursive: true);
@@ -51,13 +51,13 @@ main() {
       addTearDown(() async => await file.exists() ? await file.delete() : null);
     }
 
-    Future<Null> deleteFile(String path) async {
+    Future<void> deleteFile(String path) async {
       var file = File(p.join(pkgARoot, path));
       expect(await file.exists(), isTrue);
       await file.delete();
     }
 
-    Future<Null> modifyFile(String path, String contents) async {
+    Future<void> modifyFile(String path, String contents) async {
       var file = File(p.join(pkgARoot, path));
       expect(await file.exists(), isTrue);
       await file.writeAsString(contents);

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -17,7 +17,7 @@ import 'package:scratch_space/scratch_space.dart';
 import 'platforms.dart';
 import 'web_entrypoint_builder.dart';
 
-Future<Null> bootstrapDart2Js(
+Future<void> bootstrapDart2Js(
     BuildStep buildStep, List<String> dart2JsArgs) async {
   var dartEntrypointId = buildStep.inputId;
   var moduleId =
@@ -111,7 +111,7 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
   }
 }
 
-Future<Null> _copyIfExists(
+Future<void> _copyIfExists(
     AssetId id, ScratchSpace scratchSpace, AssetWriter writer) async {
   var file = scratchSpace.fileFor(id);
   if (await file.exists()) {


### PR DESCRIPTION
`Future<void>` is the recommended way to express what we want, clean up
the cases that were introduced before it was possible to write it this
way.

Some of these are technically breaking but are known to have no negative
impact on the build systems that use those code paths.

The interfaces implemented by users - Builder and Resource - are left as
is since it could be breaking to change them.

Also make some local test utilities private.