### PR TITLE
Add error details and fallback for null node bug

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.4
+
+- Add additional error details and a fallback for
+  https://github.com/dart-lang/build/issues/1804
+
 ## 3.0.3
 
 - Share an asset graph when building regardless of whether the build script was

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -63,7 +63,13 @@ class _AssetGraphDeserializer {
 
       for (var output in node.outputs) {
         var inputsNode = graph.get(output) as NodeWithInputs;
-        assert(inputsNode != null, 'Asset Graph is missing $output');
+        if (inputsNode == null) {
+          log.severe('Failed to locate $output referenced from ${node.id} '
+              'which is a ${node.runtimeType}. If you encounter this error '
+              'please copy the details from this message and add them to '
+              'https://github.com/dart-lang/build/issues/1804.');
+          throw AssetGraphCorruptedException();
+        }
         inputsNode.inputs ??= HashSet<AssetId>();
         inputsNode.inputs.add(node.id);
       }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 3.0.3
+version: 3.0.4
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
Towards #1804 

We don't know how the asset graph can get into a state where we fail to
find a referenced output during deserialization. When this happens we
can't trust the graph, so consider it corrupted and build it again. This
is not a great UX but will unblock users who hit this without requiring
them to perform a clean themselves.