### PR TITLE
allow analyzer version 0.36.x on build_web_compilers 1.x

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+- Allow analyzer version 0.36.x.
+
 ## 1.2.0
 
 - Add a marker to inject code before the application main method is called.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 1.2.0
+version: 1.2.1
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.30.0 <0.36.0"
+  analyzer: ">=0.30.0 <0.37.0"
   archive: ">=1.0.13 <3.0.0"
   bazel_worker: ^0.1.18
   build: '>=0.12.8 <2.0.0'


### PR DESCRIPTION
Fixes the issue where users are picking up the alpha instead of stable