### PR TITLE
Change all build methods to Future<void>

### DIFF
--- a/_test/pkgs/provides_builder/lib/builders.dart
+++ b/_test/pkgs/provides_builder/lib/builders.dart
@@ -41,7 +41,7 @@ class _SomePostProcessBuilder extends PostProcessBuilder {
       : defaultContent = options.config['default_content'] as String;
 
   @override
-  Future<Null> build(PostProcessBuildStep buildStep) async {
+  Future<void> build(PostProcessBuildStep buildStep) async {
     var content = defaultContent ?? await buildStep.readInputAsString();
     await buildStep.writeAsString(
         buildStep.inputId.changeExtension('.txt.post'), content);
@@ -55,7 +55,7 @@ class _ThrowingBuilder extends Builder {
   };
 
   @override
-  Future<Null> build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     throw UnsupportedError(await buildStep.readAsString(buildStep.inputId));
   }
 }

--- a/_test_common/lib/builders.dart
+++ b/_test_common/lib/builders.dart
@@ -15,7 +15,7 @@ class CopyingPostProcessBuilder implements PostProcessBuilder {
   CopyingPostProcessBuilder({this.outputExtension = '.copy'});
 
   @override
-  Future<Null> build(PostProcessBuildStep buildStep) async {
+  Future<void> build(PostProcessBuildStep buildStep) async {
     await buildStep.writeAsString(
         buildStep.inputId.addExtension(outputExtension),
         await buildStep.readInputAsString());
@@ -29,7 +29,7 @@ class DeletePostProcessBuilder implements PostProcessBuilder {
   DeletePostProcessBuilder();
 
   @override
-  Future<Null> build(PostProcessBuildStep buildStep) async {
+  Future<void> build(PostProcessBuildStep buildStep) async {
     buildStep.deletePrimaryInput();
   }
 }

--- a/build/test/common/builders.dart
+++ b/build/test/common/builders.dart
@@ -16,7 +16,7 @@ class CopyingPostProcessBuilder implements PostProcessBuilder {
   CopyingPostProcessBuilder({this.outputExtension = '.copy'});
 
   @override
-  Future<Null> build(PostProcessBuildStep buildStep) async {
+  Future<void> build(PostProcessBuildStep buildStep) async {
     await buildStep.writeAsString(
         buildStep.inputId.addExtension(outputExtension),
         await buildStep.readInputAsString());
@@ -32,7 +32,7 @@ class DeletePostProcessBuilder implements PostProcessBuilder {
   DeletePostProcessBuilder();
 
   @override
-  Future<Null> build(PostProcessBuildStep buildStep) async {
+  Future<void> build(PostProcessBuildStep buildStep) async {
     buildStep.deletePrimaryInput();
   }
 }

--- a/build_runner/test/server/serve_integration_test.dart
+++ b/build_runner/test/server/serve_integration_test.dart
@@ -183,7 +183,7 @@ class UppercaseBuilder implements Builder {
   const UppercaseBuilder();
 
   @override
-  Future<Null> build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     final content = await buildStep.readAsString(buildStep.inputId);
     await buildStep.writeAsString(
       buildStep.inputId.changeExtension('.g.txt'),

--- a/build_runner_core/test/generate/build_error_test.dart
+++ b/build_runner_core/test/generate/build_error_test.dart
@@ -164,7 +164,7 @@ class _LoggingBuilder implements Builder {
   _LoggingBuilder(this.level);
 
   @override
-  Future<Null> build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     log.log(level, buildStep.inputId.toString());
     await buildStep.canRead(buildStep.inputId);
     await buildStep.writeAsString(buildStep.inputId.addExtension('.empty'), '');

--- a/build_runner_core/test/generate/resolution_test.dart
+++ b/build_runner_core/test/generate/resolution_test.dart
@@ -37,7 +37,7 @@ void main() {
 
 class ListClassesAndHierarchyBuilder implements Builder {
   @override
-  Future<Null> build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     // Ignore part files.
     if (!await buildStep.resolver.isLibrary(buildStep.inputId)) {
       return;

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -218,7 +218,7 @@ class _ResolveSourceBuilder<T> implements Builder {
   _ResolveSourceBuilder(this._action, this._resolverFor, this._tearDown);
 
   @override
-  Future<Null> build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     if (_resolverFor != buildStep.inputId) return;
     var result = await _action(buildStep.resolver);
     onDone.complete(result);

--- a/build_test/lib/src/test_bootstrap_builder.dart
+++ b/build_test/lib/src/test_bootstrap_builder.dart
@@ -25,7 +25,7 @@ class TestBootstrapBuilder extends Builder {
   TestBootstrapBuilder();
 
   @override
-  Future<Null> build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     var id = buildStep.inputId;
     var contents = await buildStep.readAsString(id);
     var assetPath = id.pathSegments.first == 'lib'

--- a/build_test/test/test_builder_test.dart
+++ b/build_test/test/test_builder_test.dart
@@ -87,7 +87,7 @@ class _ConcatBuilder implements Builder {
   }
 
   @override
-  Future<Null> build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     final results = StringBuffer();
     await for (final asset in buildStep.findAssets(Glob('data/*.txt'))) {
       results.writeln(await buildStep.readAsString(asset));

--- a/build_vm_compilers/lib/src/vm_entrypoint_builder.dart
+++ b/build_vm_compilers/lib/src/vm_entrypoint_builder.dart
@@ -30,7 +30,7 @@ class VmEntrypointBuilder implements Builder {
   };
 
   @override
-  Future<Null> build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     await _buildPool.withResource(() async {
       var dartEntrypointId = buildStep.inputId;
       var isAppEntrypoint = await _isAppEntryPoint(dartEntrypointId, buildStep);

--- a/build_web_compilers/lib/src/archive_extractor.dart
+++ b/build_web_compilers/lib/src/archive_extractor.dart
@@ -25,7 +25,7 @@ class Dart2JsArchiveExtractor implements PostProcessBuilder {
   final inputExtensions = const [jsEntrypointArchiveExtension];
 
   @override
-  Future<Null> build(PostProcessBuildStep buildStep) async {
+  Future<void> build(PostProcessBuildStep buildStep) async {
     var bytes = await buildStep.readInputAsBytes();
     var archive = TarDecoder().decodeBytes(bytes);
     for (var file in archive.files) {

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -91,7 +91,7 @@ class WebEntrypointBuilder implements Builder {
   };
 
   @override
-  Future<Null> build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     var dartEntrypointId = buildStep.inputId;
     var isAppEntrypoint = await _isAppEntryPoint(dartEntrypointId, buildStep);
     if (!isAppEntrypoint) return;


### PR DESCRIPTION
The `Builder` interface was already compatible with `Future<void>`.
Clean up all builder implementations in this repo away from the older
`Future<Null>`.