### PR TITLE
Report null assetId during deserialization

### DIFF
--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -62,6 +62,13 @@ class _AssetGraphDeserializer {
       if (node is BuilderOptionsAssetNode) continue;
 
       for (var output in node.outputs) {
+        if (output == null) {
+          log.severe('Found a null output from ${node.id} which is a '
+              '${node.runtimeType}. If you encounter this error please copy '
+              'the details from this message and add them to '
+              'https://github.com/dart-lang/build/issues/1804.');
+          throw AssetGraphCorruptedException();
+        }
         var inputsNode = graph.get(output) as NodeWithInputs;
         if (inputsNode == null) {
           log.severe('Failed to locate $output referenced from ${node.id} '


### PR DESCRIPTION
Towards #1804
Followup on #2181

In a reported case where we were able to inspect the serialized asset
graph the problem exhibited is that a `null` was tracked through
`outputs`, rather than an ID which points to a missing node. Catch that
case specifically as well because the error message can be more direct.