### PR TITLE
Add use-incremental-compiler option to the ddc builder

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.0.0-alpha.2
+
+- Add the `use-incremental-compiler` option for the `build_web_compilers:ddc`
+  builder. This is enabled by default but can be disabled if running into build
+  issues by setting it to `false` globally:
+
+```yaml
+global_options:
+  build_web_compilers:ddc:
+    options:
+      use-incremental-compiler: false
+```
+
 ## 2.0.0-alpha.1
 
 - Combine the `ddc_kernel` and `ddc` workers under a single name (`ddc`).

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -45,7 +45,10 @@ PostProcessBuilder dartSourceCleanup(BuilderOptions options) =>
         ? const FileDeletingBuilder(['.dart', '.js.map'])
         : const FileDeletingBuilder(['.dart', '.js.map'], isEnabled: false);
 
-const _useIncrementalCompilerOption = 'use-incremental-compiler';
+/// Reads the [_useIncrementalCompilerOption] from [options].
+///
+/// Note that [options] must be consistent across the entire build, and if it is
+/// not then an [ArgumentError] will be thrown.
 bool _readUseIncrementalCompilerOption(BuilderOptions options) {
   if (_previousDdcConfig != null) {
     if (!const MapEquality().equals(_previousDdcConfig, options.config)) {
@@ -65,3 +68,4 @@ bool _readUseIncrementalCompilerOption(BuilderOptions options) {
 }
 
 Map<String, dynamic> _previousDdcConfig;
+const _useIncrementalCompilerOption = 'use-incremental-compiler';

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -4,6 +4,7 @@
 
 import 'package:build/build.dart';
 import 'package:build_modules/build_modules.dart';
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 
 import 'build_web_compilers.dart';
@@ -46,7 +47,21 @@ PostProcessBuilder dartSourceCleanup(BuilderOptions options) =>
 
 const _useIncrementalCompilerOption = 'use-incremental-compiler';
 bool _readUseIncrementalCompilerOption(BuilderOptions options) {
+  if (_previousDdcConfig != null) {
+    if (!const MapEquality().equals(_previousDdcConfig, options.config)) {
+      throw ArgumentError(
+          'The build_web_compilers:ddc builder must have the same '
+          'configuration in all packages. Saw $_previousDdcConfig and '
+          '${options.config} which are not equal.\n\n '
+          'Please use the `global_options` section in '
+          '`build.yaml` or the `--define` flag to set global options.');
+    }
+  } else {
+    _previousDdcConfig = options.config;
+  }
   validateOptions(options.config, [_useIncrementalCompilerOption],
       'build_web_compilers:ddc');
   return options.config[_useIncrementalCompilerOption] as bool ?? true;
 }
+
+Map<String, dynamic> _previousDdcConfig;

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -7,6 +7,7 @@ import 'package:build_modules/build_modules.dart';
 import 'package:path/path.dart' as p;
 
 import 'build_web_compilers.dart';
+import 'src/common.dart';
 import 'src/platforms.dart';
 
 // Shared entrypoint builder
@@ -18,13 +19,15 @@ Builder ddcMetaModuleBuilder(BuilderOptions options) =>
     MetaModuleBuilder.forOptions(ddcPlatform, options);
 Builder ddcMetaModuleCleanBuilder(_) => MetaModuleCleanBuilder(ddcPlatform);
 Builder ddcModuleBuilder([_]) => ModuleBuilder(ddcPlatform);
-Builder ddcBuilder([_]) => DevCompilerBuilder();
+Builder ddcBuilder(BuilderOptions options) => DevCompilerBuilder(
+    useIncrementalCompiler: _readUseIncrementalCompilerOption(options));
 const ddcKernelExtension = '.ddc.dill';
-Builder ddcKernelBuilder([_]) => KernelBuilder(
+Builder ddcKernelBuilder(BuilderOptions options) => KernelBuilder(
     summaryOnly: true,
     sdkKernelPath: p.url.join('lib', '_internal', 'ddc_sdk.dill'),
     outputExtension: ddcKernelExtension,
-    platform: ddcPlatform);
+    platform: ddcPlatform,
+    useIncrementalCompiler: _readUseIncrementalCompilerOption(options));
 
 // Dart2js related builders
 Builder dart2jsMetaModuleBuilder(BuilderOptions options) =>
@@ -40,3 +43,10 @@ PostProcessBuilder dartSourceCleanup(BuilderOptions options) =>
     (options.config['enabled'] as bool ?? false)
         ? const FileDeletingBuilder(['.dart', '.js.map'])
         : const FileDeletingBuilder(['.dart', '.js.map'], isEnabled: false);
+
+const _useIncrementalCompilerOption = 'use-incremental-compiler';
+bool _readUseIncrementalCompilerOption(BuilderOptions options) {
+  validateOptions(options.config, [_useIncrementalCompilerOption],
+      'build_web_compilers:ddc');
+  return options.config[_useIncrementalCompilerOption] as bool ?? true;
+}

--- a/build_web_compilers/lib/src/common.dart
+++ b/build_web_compilers/lib/src/common.dart
@@ -36,6 +36,7 @@ Future<File> createPackagesFile(Iterable<AssetId> allAssets) async {
 void validateOptions(Map<String, dynamic> config, List<String> supportedOptions,
     String builderKey,
     {List<String> deprecatedOptions}) {
+  deprecatedOptions ??= [];
   var unsupported = config.keys.where(
       (o) => !supportedOptions.contains(o) && !deprecatedOptions.contains(o));
   if (unsupported.isNotEmpty) {

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.0.0-alpha.1
+version: 2.0.0-alpha.2
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
@@ -13,7 +13,7 @@ dependencies:
   bazel_worker: ^0.1.18
   build: ">=0.12.8 <2.0.0"
   build_config: ^0.3.0
-  build_modules: ^2.0.0
+  build_modules: ^2.1.0
   crypto: ^2.0.0
   glob: ^1.1.0
   js: ^0.6.1

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   build: ">=0.12.8 <2.0.0"
   build_config: ^0.3.0
   build_modules: ^2.1.0
+  collection: ^1.0.0
   crypto: ^2.0.0
   glob: ^1.1.0
   js: ^0.6.1

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -35,7 +36,8 @@ main() {
     await testBuilderAndCollectAssets(
         MetaModuleCleanBuilder(ddcPlatform), assets);
     await testBuilderAndCollectAssets(ModuleBuilder(ddcPlatform), assets);
-    await testBuilderAndCollectAssets(ddcKernelBuilder(), assets);
+    await testBuilderAndCollectAssets(
+        ddcKernelBuilder(BuilderOptions({})), assets);
     await testBuilderAndCollectAssets(DevCompilerBuilder(), assets);
   });
 

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
@@ -38,7 +39,8 @@ main() {
       await testBuilderAndCollectAssets(
           MetaModuleCleanBuilder(ddcPlatform), assets);
       await testBuilderAndCollectAssets(ModuleBuilder(ddcPlatform), assets);
-      await testBuilderAndCollectAssets(ddcKernelBuilder(), assets);
+      await testBuilderAndCollectAssets(
+          ddcKernelBuilder(BuilderOptions({})), assets);
     });
 
     test('can compile ddc modules under lib and web', () async {
@@ -70,7 +72,8 @@ main() {
         await testBuilderAndCollectAssets(
             MetaModuleCleanBuilder(ddcPlatform), assets);
         await testBuilderAndCollectAssets(ModuleBuilder(ddcPlatform), assets);
-        await testBuilderAndCollectAssets(ddcKernelBuilder(), assets);
+        await testBuilderAndCollectAssets(
+            ddcKernelBuilder(BuilderOptions({})), assets);
       });
 
       test('reports useful messages', () async {


### PR DESCRIPTION
This has some basic checking that the ddc builder is always configured with exactly the same options, which should keep people on the rails although it isn't perfect.