### PR TITLE
Drop dependency to build from build_config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,9 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.1.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner, build_runner_core; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.1.0; PKGS: build, build_daemon, build_resolvers, build_runner, build_runner_core; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.1.0"
-      env: PKGS="build build_config build_daemon build_resolvers build_runner build_runner_core"
+      env: PKGS="build build_daemon build_resolvers build_runner build_runner_core"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: build; TASKS: `pub run build_runner test`"
@@ -90,6 +90,11 @@ jobs:
       dart: dev
       env: PKGS="scratch_space"
       script: ./tool/travis.sh command_2
+    - stage: analyze_and_format
+      name: "SDK: 2.2.0; PKGS: build_config, build_test; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.2.0"
+      env: PKGS="build_config build_test"
+      script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: build_config; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs`"
       dart: dev
@@ -145,11 +150,6 @@ jobs:
       dart: dev
       env: PKGS="build_runner"
       script: ./tool/travis.sh test_11
-    - stage: analyze_and_format
-      name: "SDK: 2.2.0; PKG: build_test; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.2.0"
-      env: PKGS="build_test"
-      script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.3.0-dev.0.1; PKG: build_vm_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.3.0-dev.0.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,9 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.1.0; PKGS: build, build_daemon, build_resolvers, build_runner, build_runner_core; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.1.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner, build_runner_core; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.1.0"
-      env: PKGS="build build_daemon build_resolvers build_runner build_runner_core"
+      env: PKGS="build build_config build_daemon build_resolvers build_runner build_runner_core"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: build; TASKS: `pub run build_runner test`"
@@ -90,11 +90,6 @@ jobs:
       dart: dev
       env: PKGS="scratch_space"
       script: ./tool/travis.sh command_2
-    - stage: analyze_and_format
-      name: "SDK: 2.0.0; PKGS: build_config, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.0.0"
-      env: PKGS="build_config scratch_space"
-      script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: build_config; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs`"
       dart: dev
@@ -170,6 +165,11 @@ jobs:
       dart: dev
       env: PKGS="build_web_compilers"
       script: ./tool/travis.sh test_12 test_13
+    - stage: analyze_and_format
+      name: "SDK: 2.0.0; PKG: scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.0.0"
+      env: PKGS="scratch_space"
+      script: ./tool/travis.sh dartanalyzer_1
 
 stages:
   - analyze_and_format

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.4.0
+
+- Breaking for build systems - change type of `BuilderOptions` fields to
+  `Map<String, dynamic>` to drop dependency on `build`. Does not impact packages
+  only depending on `build.yaml` parsing.
+- Breaking for build systems - versioning scheme is changing to match
+  `package:build`. Changes which are breaking to _users_ - those with
+  `build.yaml` files will be indicated with a breaking major version bump.
+  Changed which are breaking to build system _implementors_ - those who use the
+  Dart API for this package, will be indicated with a minor version bump.
+
 ## 0.3.2
 
 - Add an explicit error when `buildExtensions` is configured to overwrite it's

--- a/build_config/lib/src/build_target.dart
+++ b/build_config/lib/src/build_target.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:build/build.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 import 'builder_definition.dart';
@@ -84,27 +83,26 @@ class TargetBuilderConfig {
   ///
   /// Individual keys may be overridden by either [devOptions] or
   /// [releaseOptions].
-  @JsonKey(fromJson: builderOptionsFromJson)
-  final BuilderOptions options;
+  final Map<String, dynamic> options;
 
   /// Overrides for [options] in dev mode.
-  @JsonKey(name: 'dev_options', fromJson: builderOptionsFromJson)
-  final BuilderOptions devOptions;
+  @JsonKey(name: 'dev_options')
+  final Map<String, dynamic> devOptions;
 
   /// Overrides for [options] in release mode.
-  @JsonKey(name: 'release_options', fromJson: builderOptionsFromJson)
-  final BuilderOptions releaseOptions;
+  @JsonKey(name: 'release_options')
+  final Map<String, dynamic> releaseOptions;
 
   TargetBuilderConfig({
     bool isEnabled,
     this.generateFor,
-    BuilderOptions options,
-    BuilderOptions devOptions,
-    BuilderOptions releaseOptions,
+    Map<String, dynamic> options,
+    Map<String, dynamic> devOptions,
+    Map<String, dynamic> releaseOptions,
   })  : isEnabled = isEnabled ?? true,
-        options = options ?? BuilderOptions.empty,
-        devOptions = devOptions ?? BuilderOptions.empty,
-        releaseOptions = releaseOptions ?? BuilderOptions.empty;
+        options = options ?? const {},
+        devOptions = devOptions ?? const {},
+        releaseOptions = releaseOptions ?? const {};
 
   factory TargetBuilderConfig.fromJson(Map json) =>
       _$TargetBuilderConfigFromJson(json);
@@ -113,9 +111,9 @@ class TargetBuilderConfig {
   String toString() => {
         'isEnabled': isEnabled,
         'generateFor': generateFor,
-        'options': options.config,
-        'devOptions': devOptions.config,
-        'releaseOptions': releaseOptions.config,
+        'options': options,
+        'devOptions': devOptions,
+        'releaseOptions': releaseOptions,
       }.toString();
 }
 
@@ -129,32 +127,31 @@ class GlobalBuilderConfig {
   ///
   /// Individual keys may be overridden by either [devOptions] or
   /// [releaseOptions].
-  @JsonKey(fromJson: builderOptionsFromJson)
-  final BuilderOptions options;
+  final Map<String, dynamic> options;
 
   /// Overrides for [options] in dev mode.
-  @JsonKey(name: 'dev_options', fromJson: builderOptionsFromJson)
-  final BuilderOptions devOptions;
+  @JsonKey(name: 'dev_options')
+  final Map<String, dynamic> devOptions;
 
   /// Overrides for [options] in release mode.
-  @JsonKey(name: 'release_options', fromJson: builderOptionsFromJson)
-  final BuilderOptions releaseOptions;
+  @JsonKey(name: 'release_options')
+  final Map<String, dynamic> releaseOptions;
 
   GlobalBuilderConfig({
-    BuilderOptions options,
-    BuilderOptions devOptions,
-    BuilderOptions releaseOptions,
-  })  : options = options ?? BuilderOptions.empty,
-        devOptions = devOptions ?? BuilderOptions.empty,
-        releaseOptions = releaseOptions ?? BuilderOptions.empty;
+    Map<String, dynamic> options,
+    Map<String, dynamic> devOptions,
+    Map<String, dynamic> releaseOptions,
+  })  : options = options ?? const {},
+        devOptions = devOptions ?? const {},
+        releaseOptions = releaseOptions ?? const {};
 
   factory GlobalBuilderConfig.fromJson(Map json) =>
       _$GlobalBuilderConfigFromJson(json);
 
   @override
   String toString() => {
-        'options': options.config,
-        'devOptions': devOptions.config,
-        'releaseOptions': releaseOptions.config,
+        'options': options,
+        'devOptions': devOptions,
+        'releaseOptions': releaseOptions,
       }.toString();
 }

--- a/build_config/lib/src/build_target.g.dart
+++ b/build_config/lib/src/build_target.g.dart
@@ -38,11 +38,11 @@ TargetBuilderConfig _$TargetBuilderConfigFromJson(Map json) {
         generateFor: $checkedConvert(json, 'generate_for',
             (v) => v == null ? null : InputSet.fromJson(v)),
         options: $checkedConvert(json, 'options',
-            (v) => v == null ? null : builderOptionsFromJson(v as Map)),
+            (v) => (v as Map)?.map((k, e) => MapEntry(k as String, e))),
         devOptions: $checkedConvert(json, 'dev_options',
-            (v) => v == null ? null : builderOptionsFromJson(v as Map)),
+            (v) => (v as Map)?.map((k, e) => MapEntry(k as String, e))),
         releaseOptions: $checkedConvert(json, 'release_options',
-            (v) => v == null ? null : builderOptionsFromJson(v as Map)));
+            (v) => (v as Map)?.map((k, e) => MapEntry(k as String, e))));
     return val;
   }, fieldKeyMap: const {
     'isEnabled': 'enabled',
@@ -58,11 +58,11 @@ GlobalBuilderConfig _$GlobalBuilderConfigFromJson(Map json) {
         allowedKeys: const ['options', 'dev_options', 'release_options']);
     final val = GlobalBuilderConfig(
         options: $checkedConvert(json, 'options',
-            (v) => v == null ? null : builderOptionsFromJson(v as Map)),
+            (v) => (v as Map)?.map((k, e) => MapEntry(k as String, e))),
         devOptions: $checkedConvert(json, 'dev_options',
-            (v) => v == null ? null : builderOptionsFromJson(v as Map)),
+            (v) => (v as Map)?.map((k, e) => MapEntry(k as String, e))),
         releaseOptions: $checkedConvert(json, 'release_options',
-            (v) => v == null ? null : builderOptionsFromJson(v as Map)));
+            (v) => (v as Map)?.map((k, e) => MapEntry(k as String, e))));
     return val;
   }, fieldKeyMap: const {
     'devOptions': 'dev_options',

--- a/build_config/lib/src/builder_definition.dart
+++ b/build_config/lib/src/builder_definition.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:build/build.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
@@ -176,7 +175,7 @@ class PostProcessBuilderDefinition {
   String get key => builderKeyExpando[this];
 
   /// The name of the top-level method in [import] from
-  /// BuilderOptions -> Builder.
+  /// Map<String, dynamic> -> Builder.
   @JsonKey(
       name: 'builder_factory',
       nullable: false,
@@ -229,24 +228,23 @@ class TargetBuilderConfigDefaults {
   @JsonKey(name: 'generate_for')
   final InputSet generateFor;
 
-  @JsonKey(fromJson: builderOptionsFromJson)
-  final BuilderOptions options;
+  final Map<String, dynamic> options;
 
-  @JsonKey(name: 'dev_options', fromJson: builderOptionsFromJson)
-  final BuilderOptions devOptions;
+  @JsonKey(name: 'dev_options')
+  final Map<String, dynamic> devOptions;
 
-  @JsonKey(name: 'release_options', fromJson: builderOptionsFromJson)
-  final BuilderOptions releaseOptions;
+  @JsonKey(name: 'release_options')
+  final Map<String, dynamic> releaseOptions;
 
   const TargetBuilderConfigDefaults({
     InputSet generateFor,
-    BuilderOptions options,
-    BuilderOptions devOptions,
-    BuilderOptions releaseOptions,
+    Map<String, dynamic> options,
+    Map<String, dynamic> devOptions,
+    Map<String, dynamic> releaseOptions,
   })  : generateFor = generateFor ?? InputSet.anything,
-        options = options ?? BuilderOptions.empty,
-        devOptions = devOptions ?? BuilderOptions.empty,
-        releaseOptions = releaseOptions ?? BuilderOptions.empty;
+        options = options ?? const {},
+        devOptions = devOptions ?? const {},
+        releaseOptions = releaseOptions ?? const {};
 
   factory TargetBuilderConfigDefaults.fromJson(Map json) =>
       _$TargetBuilderConfigDefaultsFromJson(json);

--- a/build_config/lib/src/builder_definition.g.dart
+++ b/build_config/lib/src/builder_definition.g.dart
@@ -148,11 +148,11 @@ TargetBuilderConfigDefaults _$TargetBuilderConfigDefaultsFromJson(Map json) {
         generateFor: $checkedConvert(json, 'generate_for',
             (v) => v == null ? null : InputSet.fromJson(v)),
         options: $checkedConvert(json, 'options',
-            (v) => v == null ? null : builderOptionsFromJson(v as Map)),
+            (v) => (v as Map)?.map((k, e) => MapEntry(k as String, e))),
         devOptions: $checkedConvert(json, 'dev_options',
-            (v) => v == null ? null : builderOptionsFromJson(v as Map)),
+            (v) => (v as Map)?.map((k, e) => MapEntry(k as String, e))),
         releaseOptions: $checkedConvert(json, 'release_options',
-            (v) => v == null ? null : builderOptionsFromJson(v as Map)));
+            (v) => (v as Map)?.map((k, e) => MapEntry(k as String, e))));
     return val;
   }, fieldKeyMap: const {
     'generateFor': 'generate_for',

--- a/build_config/lib/src/common.dart
+++ b/build_config/lib/src/common.dart
@@ -4,11 +4,6 @@
 
 import 'dart:async';
 
-import 'package:build/build.dart';
-
-BuilderOptions builderOptionsFromJson(Map config) =>
-    BuilderOptions(Map<String, dynamic>.from(config));
-
 final _defaultDependenciesZoneKey = Symbol('buildConfigDefaultDependencies');
 final _packageZoneKey = Symbol('buildConfigPackage');
 

--- a/build_config/mono_pkg.yaml
+++ b/build_config/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.1.0
+        - 2.2.0
   - unit_test:
     # Run the script directly - running from snapshot has issues for packages
     # that are depended on by build_runner itself.

--- a/build_config/mono_pkg.yaml
+++ b/build_config/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.0.0
+        - 2.1.0
   - unit_test:
     # Run the script directly - running from snapshot has issues for packages
     # that are depended on by build_runner itself.

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.3.2
+version: 0.4.0
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config
@@ -8,7 +8,6 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  build: '>=0.12.1 <2.0.0'
   json_annotation: '>=1.0.0 <3.0.0'
   meta: ^1.1.0
   path: ^1.4.0
@@ -21,3 +20,16 @@ dev_dependencies:
   build_vm_compilers: ^0.1.0
   json_serializable: ^2.0.0
   test: ^1.0.0
+
+dependency_overrides:
+  json_serializable: ^2.0.0
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core
+  build_vm_compilers:
+    path: ../build_vm_compilers
+  build_modules:
+    path: ../build_modules
+  build_test:
+    path: ../build_test

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
   json_annotation: '>=1.0.0 <3.0.0'

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:build/build.dart';
 import 'package:test/test.dart';
 
 import 'package:build_config/build_config.dart';
@@ -20,10 +19,10 @@ void main() {
           'b:b': TargetBuilderConfig(
               isEnabled: true, generateFor: InputSet(include: ['lib/a.dart'])),
           'c:c': TargetBuilderConfig(isEnabled: false),
-          'example:h': TargetBuilderConfig(
-              isEnabled: true, options: BuilderOptions({'foo': 'bar'})),
-          'example:p': TargetBuilderConfig(
-              isEnabled: true, options: BuilderOptions({'baz': 'zap'})),
+          'example:h':
+              TargetBuilderConfig(isEnabled: true, options: {'foo': 'bar'}),
+          'example:p':
+              TargetBuilderConfig(isEnabled: true, options: {'baz': 'zap'}),
         },
         // Expecting $default => example:example
         dependencies: ['example:example', 'b:b', 'c:d'],
@@ -57,8 +56,8 @@ void main() {
         appliesBuilders: ['foo_builder:foo_builder'].toSet(),
         defaults: TargetBuilderConfigDefaults(
           generateFor: const InputSet(include: ['lib/**']),
-          options: const BuilderOptions({'foo': 'bar'}),
-          releaseOptions: const BuilderOptions({'baz': 'bop'}),
+          options: const {'foo': 'bar'},
+          releaseOptions: const {'baz': 'bop'},
         ),
       ),
     });
@@ -71,17 +70,16 @@ void main() {
         import: 'package:example/p.dart',
         defaults: TargetBuilderConfigDefaults(
           generateFor: const InputSet(include: ['web/**']),
-          options: const BuilderOptions({'foo': 'bar'}),
-          releaseOptions: const BuilderOptions({'baz': 'bop'}),
+          options: const {'foo': 'bar'},
+          releaseOptions: const {'baz': 'bop'},
         ),
       ),
     });
     expectGlobalOptions(buildConfig.globalOptions, {
-      'example:h':
-          GlobalBuilderConfig(options: const BuilderOptions({'foo': 'global'})),
+      'example:h': GlobalBuilderConfig(options: const {'foo': 'global'}),
       'b:b': GlobalBuilderConfig(
-          devOptions: const BuilderOptions({'foo': 'global_dev'}),
-          releaseOptions: const BuilderOptions({'foo': 'global_release'}))
+          devOptions: const {'foo': 'global_dev'},
+          releaseOptions: const {'foo': 'global_release'})
     });
   });
 
@@ -284,12 +282,10 @@ Matcher _matchesPostProcessBuilderDefinition(
 
 Matcher _matchesGlobalBuilderConfig(GlobalBuilderConfig config) =>
     TypeMatcher<GlobalBuilderConfig>()
+        .having((c) => c.options, 'options', config.options)
+        .having((c) => c.devOptions, 'devOptions', config.devOptions)
         .having(
-            (c) => c.options.config, 'options.config', config.options.config)
-        .having((c) => c.devOptions.config, 'devOptions.config',
-            config.devOptions.config)
-        .having((c) => c.releaseOptions.config, 'releaseOptions.config',
-            config.releaseOptions.config);
+            (c) => c.releaseOptions, 'releaseOptions', config.releaseOptions);
 
 Matcher _matchesBuilderConfigDefaults(TargetBuilderConfigDefaults defaults) =>
     TypeMatcher<TargetBuilderConfigDefaults>()
@@ -297,12 +293,10 @@ Matcher _matchesBuilderConfigDefaults(TargetBuilderConfigDefaults defaults) =>
             defaults.generateFor.include)
         .having((d) => d.generateFor.exclude, 'generateFor.exclude',
             defaults.generateFor.exclude)
+        .having((d) => d.options, 'options', defaults.options)
+        .having((d) => d.devOptions, 'devOptions', defaults.devOptions)
         .having(
-            (d) => d.options.config, 'options.config', defaults.options.config)
-        .having((d) => d.devOptions.config, 'devOptions.config',
-            defaults.devOptions.config)
-        .having((d) => d.releaseOptions.config, 'releaseOptions.config',
-            defaults.releaseOptions.config);
+            (d) => d.releaseOptions, 'releaseOptions', defaults.releaseOptions);
 
 void expectBuildTargets(
     Map<String, BuildTarget> actual, Map<String, BuildTarget> expected) {
@@ -327,12 +321,10 @@ Matcher _matchesBuilderConfigs(Map<String, TargetBuilderConfig> configs) =>
 Matcher _matchesBuilderConfig(TargetBuilderConfig expected) =>
     TypeMatcher<TargetBuilderConfig>()
         .having((c) => c.isEnabled, 'isEnabled', expected.isEnabled)
+        .having((c) => c.options, 'options', expected.options)
+        .having((c) => c.devOptions, 'devOptions', expected.devOptions)
         .having(
-            (c) => c.options.config, 'options.config', expected.options.config)
-        .having((c) => c.devOptions.config, 'devOptions.config',
-            expected.devOptions.config)
-        .having((c) => c.releaseOptions.config, 'releaseOptions.config',
-            expected.releaseOptions.config)
+            (c) => c.releaseOptions, 'releaseOptions', expected.releaseOptions)
         .having((c) => c.generateFor?.include, 'generateFor.include',
             expected.generateFor?.include)
         .having((c) => c.generateFor?.exclude, 'generateFor.exclude',

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   async: ^2.0.0
   bazel_worker: ^0.1.20
   build: ">=0.12.3 <2.0.0"
-  build_config: ^0.3.0
+  build_config: ">=0.3.0 <0.5.0"
   collection: ^1.0.0
   crypto: ^2.0.0
   glob: ^1.0.0

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -151,15 +151,15 @@ Expression _applyBuilder(BuilderDefinition definition) {
         refer('InputSet', 'package:build_config/build_config.dart')
             .constInstance([], inputSetArgs);
   }
-  if (!identical(definition.defaults?.options, BuilderOptions.empty)) {
+  if (definition.defaults?.options?.isNotEmpty ?? false) {
     namedArgs['defaultOptions'] =
         _constructBuilderOptions(definition.defaults.options);
   }
-  if (!identical(definition.defaults?.devOptions, BuilderOptions.empty)) {
+  if (definition.defaults?.devOptions?.isNotEmpty ?? false) {
     namedArgs['defaultDevOptions'] =
         _constructBuilderOptions(definition.defaults.devOptions);
   }
-  if (!identical(definition.defaults?.releaseOptions, BuilderOptions.empty)) {
+  if (definition.defaults?.releaseOptions?.isNotEmpty ?? false) {
     namedArgs['defaultReleaseOptions'] =
         _constructBuilderOptions(definition.defaults.releaseOptions);
   }
@@ -190,15 +190,15 @@ Expression _applyPostProcessBuilder(PostProcessBuilderDefinition definition) {
       inputSetArgs['exclude'] =
           literalConstList(definition.defaults.generateFor.exclude);
     }
-    if (!identical(definition.defaults?.options, BuilderOptions.empty)) {
+    if (definition.defaults?.options?.isNotEmpty ?? false) {
       namedArgs['defaultOptions'] =
           _constructBuilderOptions(definition.defaults.options);
     }
-    if (!identical(definition.defaults?.devOptions, BuilderOptions.empty)) {
+    if (definition.defaults?.devOptions?.isNotEmpty ?? false) {
       namedArgs['defaultDevOptions'] =
           _constructBuilderOptions(definition.defaults.devOptions);
     }
-    if (!identical(definition.defaults?.releaseOptions, BuilderOptions.empty)) {
+    if (definition.defaults?.releaseOptions?.isNotEmpty ?? false) {
       namedArgs['defaultReleaseOptions'] =
           _constructBuilderOptions(definition.defaults.releaseOptions);
     }

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -252,6 +252,6 @@ Expression _findToExpression(BuilderDefinition definition) {
 }
 
 /// An expression creating a [BuilderOptions] from a json string.
-Expression _constructBuilderOptions(BuilderOptions options) =>
+Expression _constructBuilderOptions(Map<String, dynamic> options) =>
     refer('BuilderOptions', 'package:build/build.dart')
-        .newInstance([literalMap(options.config)]);
+        .newInstance([literalMap(options)]);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -57,3 +57,5 @@ dev_dependencies:
 dependency_overrides:
   build_config:
     path: ../build_config
+  build_runner_core:
+    path: ../build_runner_core

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
   build: ">=1.0.0 <1.2.0"
-  build_config: ^0.3.1
+  build_config: ">=0.4.0 <0.4.1"
   build_daemon: ^0.5.0
   build_resolvers: "^1.0.0"
   build_runner_core: ^3.0.0
@@ -53,3 +53,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_config:
+    path: ../build_config

--- a/build_runner_core/lib/src/package_graph/apply_builders.dart
+++ b/build_runner_core/lib/src/package_graph/apply_builders.dart
@@ -260,8 +260,9 @@ Future<List<BuildPhase>> createBuildPhases(
   final globalOptions = targetGraph.rootPackageConfig.globalOptions.map(
       (key, config) => MapEntry(
           key,
-          (config?.options ?? BuilderOptions.empty).overrideWith(
-              isReleaseMode ? config?.releaseOptions : config?.devOptions)));
+          _options(config?.options).overrideWith(isReleaseMode
+              ? _options(config?.releaseOptions)
+              : _options(config?.devOptions))));
   for (final key in builderConfigOverrides.keys) {
     final overrides = BuilderOptions(builderConfigOverrides[key]);
     globalOptions[key] =
@@ -340,10 +341,10 @@ Iterable<BuildPhase> _createBuildPhasesForBuilderInCycle(
               builderApplication, targetNode, applyWith, allBuilders))
           .map((node) {
         final builderConfig = targetConfig(node);
-        final options = (builderConfig?.options ?? BuilderOptions.empty)
+        final options = _options(builderConfig?.options)
             .overrideWith(isReleaseMode
-                ? builderConfig?.releaseOptions
-                : builderConfig?.devOptions)
+                ? _options(builderConfig?.releaseOptions)
+                : _options(builderConfig?.devOptions))
             .overrideWith(globalOptionOverrides);
         return createPhase(node.package, options, node.target.sources,
             builderConfig?.generateFor, isReleaseMode);
@@ -403,3 +404,6 @@ T _scopeLogSync<T>(T fn(), Logger log) {
 String _factoryFailure(String packageName, BuilderOptions options) =>
     'Failed to instantiate builder for $packageName with configuration:\n'
     '${JsonEncoder.withIndent(' ').convert(options.config)}';
+
+BuilderOptions _options(Map<String, dynamic> options) =>
+    options?.isEmpty ?? true ? BuilderOptions.empty : BuilderOptions(options);

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ">=1.1.0 <1.2.0"
-  build_config: ^0.3.1
+  build_config: ">=0.4.0 <0.4.1"
   build_resolvers: ^1.0.0
   collection: ^1.14.0
   convert: ^2.0.1
@@ -37,3 +37,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_config:
+    path: ../build_config

--- a/build_runner_core/test/package_graph/apply_builders_test.dart
+++ b/build_runner_core/test/package_graph/apply_builders_test.dart
@@ -56,10 +56,8 @@ void main() {
             },
             globalOptions: {
               'b:cool_builder': GlobalBuilderConfig(
-                options: const BuilderOptions(
-                    {'option_a': 'global a', 'option_b': 'global b'}),
-                releaseOptions:
-                    const BuilderOptions({'option_b': 'release global b'}),
+                options: const {'option_a': 'global a', 'option_b': 'global b'},
+                releaseOptions: const {'option_b': 'release global b'},
               ),
             },
           )

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   async: ">=1.2.0 <3.0.0"
   build: ">=0.12.0 <2.0.0"
-  build_config: ">=0.2.0 <0.4.0"
+  build_config: ">=0.2.0 <0.5.0"
   build_resolvers: ">=0.2.0 <2.0.0"
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   analyzer: ">=0.30.0 <0.37.0"
   build: '>=0.12.0 <2.0.0'
+  build_config: ">=0.3.0 <0.5.0"
   build_modules: ^2.0.0
   path: ^1.6.0
   pool: ^1.3.0

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   archive: ^2.0.0
   bazel_worker: ^0.1.18
   build: ">=0.12.8 <2.0.0"
-  build_config: ^0.3.0
+  build_config: ">=0.3.0 <0.5.0"
   build_modules: ^2.1.0
   collection: ^1.0.0
   crypto: ^2.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,12 +1,12 @@
 name: example
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   build: ^1.0.0
   # Not imported in code, but used to constrain `build.yaml` requirements
-  build_config: ^0.3.0
+  build_config: ">=0.3.0 <0.5.0"
 
 dev_dependencies:
   build_runner: ^1.0.0
@@ -27,3 +27,5 @@ dependency_overrides:
     path: ../build_modules
   build_web_compilers:
     path: ../build_web_compilers
+  build_config:
+    path: ../build_config


### PR DESCRIPTION
Closes #2192

Since we want published packages with a `build.yaml` file to have a
dependency on `build_config` to ensure parsing compatibility we want the
dependency to be as lightweight as possible. `package:build` brings in
`package:analyzer` and too many transitive dependencies for this use
case.

- Replace `BuilderOptions` fields with `Map<String, dynamic>` fields.
- Update places reading these fields.
- Tighten dependencies through to `build_config` to consider feature
  releases as breaking for `build_runner` and `build_runner_core` so
  that we can roll out future changes without updating all pubspecs
  across the world for packages using `build.yaml`.