### PR TITLE
Put a tight upper bound on SDK

### DIFF
--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: ">=2.2.1-dev.4.0 <3.0.0"
+  sdk: ">=2.2.1-dev.4.0 <2.3.1"
 
 dependencies:
   analyzer: ">=0.30.0 <0.37.0"


### PR DESCRIPTION
Since there are open questions around enabling const inlining in CFE
we're not confident we won't need a new flag or something used for the
kernel worker. Add a tight upper bound constraint so that we can adjust
if necessary.