### PR TITLE
Override build_web_compilers in integration tests

### DIFF
--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -40,9 +40,6 @@ main() {
           'build_web_compilers',
           'test',
         ],
-        versionDependencies: {
-          'build_web_compilers': 'any',
-        },
       ),
       d.dir('test', [
         d.file('hello_test.dart', '''

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -37,6 +37,7 @@ main() {
           'build_runner',
           'build_runner_core',
           'build_test',
+          'build_web_compilers',
           'test',
         ],
         versionDependencies: {

--- a/build_runner/test/entrypoint/run_test.dart
+++ b/build_runner/test/entrypoint/run_test.dart
@@ -30,6 +30,7 @@ main() {
           'build_runner',
           'build_runner_core',
           'build_test',
+          'build_web_compilers',
           'test',
         ],
         versionDependencies: {

--- a/build_runner/test/entrypoint/run_test.dart
+++ b/build_runner/test/entrypoint/run_test.dart
@@ -33,9 +33,6 @@ main() {
           'build_web_compilers',
           'test',
         ],
-        versionDependencies: {
-          'build_web_compilers': 'any',
-        },
       ),
       d.dir('test', [
         d.file('hello_test.dart', '''


### PR DESCRIPTION
Since we're using the outer pub solve for `build_modules` we also need
to use it for `build_web_compilers`.