### PR TITLE
Fix strict-raw-types violations in build

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.1.4
 
-- Use "strict raw types".
+- Internal cleanup: use "strict raw types".
+- Some return types for interfaces to implement changed from `Future<dynamic>`
+  to `Future<void>`.
 
 ## 1.1.3
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.4
+
+- Use "strict raw types".
+
 ## 1.1.3
 
 - Update the minimum sdk constraint to 2.1.0.

--- a/build/lib/src/asset/id.dart
+++ b/build/lib/src/asset/id.dart
@@ -107,7 +107,7 @@ class AssetId implements Comparable<AssetId> {
 
   /// Deserializes an [AssetId] from [data], which must be the result of
   /// calling [serialize] on an existing [AssetId].
-  AssetId.deserialize(List data)
+  AssetId.deserialize(List<dynamic> data)
       : package = data[0] as String,
         path = data[1] as String;
 

--- a/build/lib/src/asset/writer.dart
+++ b/build/lib/src/asset/writer.dart
@@ -14,7 +14,7 @@ abstract class AssetWriter {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws an `InvalidOutputException` if the output was not valid.
-  Future writeAsBytes(AssetId id, List<int> bytes);
+  Future<void> writeAsBytes(AssetId id, List<int> bytes);
 
   /// Writes [contents] to a text file located at [id] with [encoding].
   ///
@@ -22,7 +22,8 @@ abstract class AssetWriter {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws an `InvalidOutputException` if the output was not valid.
-  Future writeAsString(AssetId id, String contents, {Encoding encoding = utf8});
+  Future<void> writeAsString(AssetId id, String contents,
+      {Encoding encoding = utf8});
 }
 
 /// An [AssetWriter] which tracks all [assetsWritten] during its lifetime.
@@ -35,13 +36,13 @@ class AssetWriterSpy implements AssetWriter {
   Iterable<AssetId> get assetsWritten => _assetsWritten;
 
   @override
-  Future writeAsBytes(AssetId id, List<int> bytes) {
+  Future<void> writeAsBytes(AssetId id, List<int> bytes) {
     _assetsWritten.add(id);
     return _delegate.writeAsBytes(id, bytes);
   }
 
   @override
-  Future writeAsString(AssetId id, String contents,
+  Future<void> writeAsString(AssetId id, String contents,
       {Encoding encoding = utf8}) {
     _assetsWritten.add(id);
     return _delegate.writeAsString(id, contents, encoding: encoding);

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -45,7 +45,7 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   /// Future since the runner will be responsible for waiting until all outputs
   /// are written.
   @override
-  Future writeAsBytes(AssetId id, FutureOr<List<int>> bytes);
+  Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes);
 
   /// Writes [contents] to a text file located at [id] with [encoding].
   ///
@@ -58,7 +58,7 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   /// Future since the runner will be responsible for waiting until all outputs
   /// are written.
   @override
-  Future writeAsString(AssetId id, FutureOr<String> contents,
+  Future<void> writeAsString(AssetId id, FutureOr<String> contents,
       {Encoding encoding = utf8});
 
   /// A [Resolver] for [inputId].

--- a/build/lib/src/builder/multiplexing_builder.dart
+++ b/build/lib/src/builder/multiplexing_builder.dart
@@ -22,7 +22,7 @@ class MultiplexingBuilder implements Builder {
         .where((builder) =>
             builder.buildExtensions.keys.any(buildStep.inputId.path.endsWith))
         .map((builder) => builder.build(buildStep))
-        .whereType<Future>());
+        .whereType<Future<void>>());
   }
 
   /// Merges output extensions from all builders.

--- a/build/lib/src/resource/resource.dart
+++ b/build/lib/src/resource/resource.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 
 typedef CreateInstance<T> = FutureOr<T> Function();
-typedef DisposeInstance<T> = FutureOr Function(T instance);
-typedef BeforeExit = FutureOr Function();
+typedef DisposeInstance<T> = FutureOr<void> Function(T instance);
+typedef BeforeExit = FutureOr<void> Function();
 
 /// A [Resource] encapsulates the logic for creating and disposing of some
 /// expensive object which has a lifecycle.
@@ -42,7 +42,7 @@ class Resource<T> {
       _instanceByManager.putIfAbsent(manager, () async => await _create());
 
   /// Disposes the actual instance of this resource for [manager] if present.
-  Future _dispose(ResourceManager manager) {
+  Future<void> _dispose(ResourceManager manager) {
     if (!_instanceByManager.containsKey(manager)) return Future.value(null);
     var oldInstance = _fetch(manager);
     _instanceByManager.remove(manager);
@@ -60,14 +60,14 @@ class Resource<T> {
 /// implementations and not general end users. Instead end users should use
 /// the `buildStep#fetchResource` method to get [Resource]s.
 class ResourceManager {
-  final _resources = Set<Resource>();
+  final _resources = Set<Resource<void>>();
 
   /// The [Resource]s that we need to call `beforeExit` on.
   ///
   /// We have to hang on to these forever, but they should be small in number,
   /// and we don't hold on to the actual created instances, just the [Resource]
   /// instances.
-  final _resourcesWithBeforeExit = Set<Resource>();
+  final _resourcesWithBeforeExit = Set<Resource<void>>();
 
   /// Fetches an instance of [resource].
   Future<T> fetch<T>(Resource<T> resource) async {

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.1.3
+version: 1.1.4
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -221,11 +221,11 @@ class SlowAssetWriter implements AssetWriter {
   }
 
   @override
-  Future writeAsBytes(AssetId id, FutureOr<List<int>> bytes) =>
+  Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes) =>
       _writeCompleter.future;
 
   @override
-  Future writeAsString(AssetId id, FutureOr<String> contents,
+  Future<void> writeAsString(AssetId id, FutureOr<String> contents,
           {Encoding encoding = utf8}) =>
       _writeCompleter.future;
 }

--- a/build/test/resource/resource_test.dart
+++ b/build/test/resource/resource_test.dart
@@ -68,7 +68,7 @@ main() {
     test('can fetch and dispose multiple resources', () async {
       var numDisposed = 0;
       final length = 10;
-      var resources = List<Resource>.generate(
+      var resources = List<Resource<int>>.generate(
           length,
           (i) => Resource(() => i, dispose: (instance) {
                 expect(instance, i);


### PR DESCRIPTION
Makes types more explicit. Change more `Future` to `Future<void>`, this
is not breaking for implementations of these interfaces since
`Future<dynamic>` is a subtype of `Future<void>`.