### PR TITLE
Fix flakiness with graceful exit test

### DIFF
--- a/build_daemon/test/daemon_test.dart
+++ b/build_daemon/test/daemon_test.dart
@@ -130,8 +130,8 @@ void main() {
       // Wait for the daemon to be running before checking the workspace exits.
       expect(await _statusOf(daemon), 'RUNNING');
       expect(Directory(daemonWorkspace(workspace)).existsSync(), isTrue);
-      // Daemon expects sigint twice before quitting.
-      daemon..kill(ProcessSignal.sigint)..kill(ProcessSignal.sigint);
+      // Sending an interrupt signal will let the daemon gracefully exit.
+      daemon.kill(ProcessSignal.sigint);
       await daemon.exitCode;
       expect(Directory(daemonWorkspace(workspace)).existsSync(), isFalse);
     });


### PR DESCRIPTION
I'm actually surprised this test was passing. We gracefully exit if a single interrupt signal is provided. If multiple are provided we do a hard exit. Updated the test to allow for the cleanup code to completely execute.

Closes https://github.com/dart-lang/build/issues/2212