### PR TITLE
Refactor resolver crawling

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.5
+
+- Fix a race condition where some assets may be resolved with missing
+  dependencies. This was likely to have only manifested in tests using
+  `resolveSource`.
+
 ## 1.0.4
 
 - Increase lower bound sdk constraint to 2.1.0.

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -21,7 +21,7 @@ const _ignoredSchemes = ['dart', 'dart-ext'];
 class BuildAssetUriResolver extends UriResolver {
   /// A cache of the directives for each Dart library.
   ///
-  /// This stored across builds and is only invalidated if we read a file and
+  /// This is stored across builds and is only invalidated if we read a file and
   /// see that it's content is different from what it was last time it was read.
   final _cachedAssetDependencies = <AssetId, Set<AssetId>>{};
 
@@ -42,6 +42,8 @@ class BuildAssetUriResolver extends UriResolver {
   /// later). If this happens we don't want to hide the asset from the analyzer.
   final seenAssets = HashSet<AssetId>();
 
+  /// Crawl the transitive imports from [entryPoints] and ensure that the
+  /// content of each asset is updated in [resourceProvider] and [driver].
   Future<void> performResolve(BuildStep buildStep, List<AssetId> entryPoints,
       AnalysisDriver driver) async {
     final changes =

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -30,7 +30,6 @@ class BuildAssetUriResolver extends UriResolver {
   /// changed.
   final _cachedAssetContents = <AssetId, String>{};
 
-  /// The [ResourceProvider] given to the analyzer.
   final resourceProvider = MemoryResourceProvider(context: p.posix);
 
   /// The assets which are known to be readable at some point during the build.

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -11,13 +11,26 @@ import 'package:analyzer/file_system/memory_file_system.dart';
 import 'package:analyzer/src/dart/analysis/driver.dart' show AnalysisDriver;
 import 'package:analyzer/src/generated/source.dart';
 import 'package:build/build.dart' show AssetId, BuildStep;
+import 'package:graphs/graphs.dart';
 import 'package:path/path.dart' as p;
 
 const _ignoredSchemes = ['dart', 'dart-ext'];
 
 class BuildAssetUriResolver extends UriResolver {
+  /// A cache of the directives for each Dart library.
+  ///
+  /// This stored across builds and is only invalidated if we read a file and
+  /// see that it's content is different from what it was last time it was read.
   final _cachedAssetDependencies = <AssetId, Set<AssetId>>{};
+
+  /// A cache of the full content for each Dart asset.
+  ///
+  /// This is stored across builds and used to invalidate the values in
+  /// [_cachedAssetDependencies] only when the actual content of the library
+  /// changed.
   final _cachedAssetContents = <AssetId, String>{};
+
+  /// The [ResourceProvider] given to the analyzer.
   final resourceProvider = MemoryResourceProvider(context: p.posix);
 
   /// The assets which are known to be readable at some point during the build.
@@ -27,54 +40,47 @@ class BuildAssetUriResolver extends UriResolver {
   /// later). If this happens we don't want to hide the asset from the analyzer.
   final seenAssets = Set<AssetId>();
 
-  Future<void> performResolve(
-      BuildStep buildStep, List<AssetId> entryPoints, AnalysisDriver driver) {
-    // Basic approach is to start at the first file, update it's contents
-    // and see if it changed, then walk all files accessed by it.
-    var visited = Set<AssetId>();
-    var visiting = _FutureGroup();
-
-    void processAsset(AssetId assetId) {
-      visited.add(assetId);
-
-      visiting.add(buildStep.readAsString(assetId).then((contents) {
-        if (_cachedAssetContents[assetId] != contents) {
-          if (_cachedAssetContents.containsKey(assetId)) {
-            var path = assetPath(assetId);
-            resourceProvider.updateFile(path, contents);
-            driver.changeFile(path);
-          } else {
-            resourceProvider.newFile(assetPath(assetId), contents);
-          }
-          _cachedAssetContents[assetId] = contents;
-          var unit = parseDirectives(contents, suppressErrors: true);
-          var dependencies = unit.directives
-              .whereType<UriBasedDirective>()
-              .where((directive) {
-                var uri = Uri.parse(directive.uri.stringValue);
-                return !_ignoredSchemes.any(uri.isScheme);
-              })
-              .map((d) => AssetId.resolve(d.uri.stringValue, from: assetId))
-              .where((id) => id != null)
-              .toSet();
-          _cachedAssetDependencies[assetId] = dependencies;
+  Future<void> performResolve(BuildStep buildStep, List<AssetId> entryPoints,
+      AnalysisDriver driver) async {
+    final states =
+        await crawlAsync<AssetId, _AssetState>(entryPoints, (id) async {
+      try {
+        return _AssetState(id, await buildStep.readAsString(id));
+      } catch (e) {
+        if (seenAssets.contains(id)) {
+          // ignore from this graph, some later build step may still be using it
+          // so it shouldn't be removed from [resourceProvider], but we also
+          // don't care about it's transitive imports.
+          return null;
         }
-        _cachedAssetDependencies[assetId]
-            .where((id) => !visited.contains(id))
-            .forEach(processAsset);
-      }, onError: (e) {
-        if (seenAssets.contains(assetId)) return;
-        _cachedAssetDependencies.remove(assetId);
-        _cachedAssetContents.remove(assetId);
-        final path = assetPath(assetId);
+        _cachedAssetDependencies.remove(id);
+        _cachedAssetContents.remove(id);
+        return _AssetState.removed(id);
+      }
+    }, (id, state) {
+      if (state.isRemoved) return const [];
+      if (_cachedAssetContents[id] == state.content) {
+        return _cachedAssetDependencies[id];
+      }
+      _cachedAssetContents[id] = state.content;
+      return _cachedAssetDependencies[id] = _parseDirectives(state);
+    }).toList();
+
+    for (final state in states) {
+      final path = assetPath(state.id);
+      if (state.isRemoved) {
         if (resourceProvider.getFile(path).exists) {
           resourceProvider.deleteFile(path);
         }
-      }));
+      } else {
+        if (resourceProvider.getFile(path).exists) {
+          resourceProvider.updateFile(path, state.content);
+          driver.changeFile(path);
+        } else {
+          resourceProvider.newFile(path, state.content);
+        }
+      }
     }
-
-    entryPoints.forEach(processAsset);
-    return visiting.future;
   }
 
   /// Attempts to parse [uri] into an [AssetId] and returns it if it is cached.
@@ -111,54 +117,30 @@ class BuildAssetUriResolver extends UriResolver {
       lookupAsset(source.uri)?.uri ?? source.uri;
 }
 
+/// Returns all the directives from a Dart library that can be resolved to an
+/// [AssetId].
+Set<AssetId> _parseDirectives(_AssetState state) =>
+    parseDirectives(state.content, suppressErrors: true)
+        .directives
+        .whereType<UriBasedDirective>()
+        .where((directive) {
+          var uri = Uri.parse(directive.uri.stringValue);
+          return !_ignoredSchemes.any(uri.isScheme);
+        })
+        .map((d) => AssetId.resolve(d.uri.stringValue, from: state.id))
+        .where((id) => id != null)
+        .toSet();
+
+class _AssetState {
+  final AssetId id;
+  final String content;
+  final bool isRemoved;
+
+  _AssetState(this.id, this.content) : isRemoved = false;
+  _AssetState.removed(this.id)
+      : isRemoved = true,
+        content = null;
+}
+
 String assetPath(AssetId assetId) =>
     p.posix.join('/${assetId.package}', assetId.path);
-
-/// A completer that waits until all added [Future]s complete.
-class _FutureGroup<E> {
-  static const _FINISHED = -1;
-
-  int _pending = 0;
-  Future _failedTask;
-  final Completer<List<E>> _completer = Completer<List<E>>();
-  final List<E> results = [];
-
-  /// The task that failed, if any.
-  Future get failedTask => _failedTask;
-
-  /// Wait for [task] to complete.
-  ///
-  /// If this group has already been marked as completed, a [StateError] will
-  /// be thrown.
-  ///
-  /// If this group has a [failedTask], new tasks will be ignored, because the
-  /// error has already been signaled.
-  void add(Future<E> task) {
-    if (_failedTask != null) return;
-    if (_pending == _FINISHED) throw StateError('Future already completed');
-
-    _pending++;
-    var i = results.length;
-    results.add(null);
-    task.then((res) {
-      results[i] = res;
-      if (_failedTask != null) return;
-      _pending--;
-      if (_pending == 0) {
-        _pending = _FINISHED;
-        _completer.complete(results);
-      }
-    }, onError: (e, s) {
-      if (_failedTask != null) return;
-      _failedTask = task;
-      _completer.completeError(e, s as StackTrace);
-    });
-  }
-
-  /// A Future that completes with a List of the values from all the added
-  /// tasks, when they have all completed.
-  ///
-  /// If any task fails, this Future will receive the error. Only the first
-  /// error will be sent to the Future.
-  Future<List<E>> get future => _completer.future;
-}

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.0.4
+version: 1.0.5
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
@@ -10,6 +10,7 @@ environment:
 dependencies:
   analyzer: '>=0.35.0 <0.37.0'
   build: ">=1.1.0 <1.2.0"
+  graphs: ^0.2.0
   path: ^1.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/36773

Previously the crawling was intermingled with handling changes and we
had a single use implementation of `FutureGroup` to capture all the work
happening. Refactor to use `crawlAsync` from `package:graphs` for the
crawling portion, and separate out the crawling from notifying the driver
that the contents have been changed. By the time `driver.changeFile` is
called the `resourceProvider` should have updated content for imported
libraries.

Since the `_cache*` maps are used to know what specifically needs to be
changed in the `resourceProvider`, the updates to both places needs to
happen synchronously. 

Update the invalidation of dependency cache to store asset digests
instead of contents.