### PR TITLE
build_runner_core: explicitly require Dart ^2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,14 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.1.0; PKGS: build, build_daemon, build_resolvers, build_runner_core; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.1.0; PKGS: build, build_daemon, build_resolvers; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.1.0"
-      env: PKGS="build build_daemon build_resolvers build_runner_core"
+      env: PKGS="build build_daemon build_resolvers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: 2.2.0; PKGS: build_config, build_test; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.2.0; PKGS: build_config, build_runner_core, build_test; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.2.0"
-      env: PKGS="build_config build_test"
+      env: PKGS="build_config build_runner_core build_test"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.3.0-dev.0.1; PKGS: build_modules, build_vm_compilers, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
@@ -75,6 +75,11 @@ jobs:
       dart: dev
       env: PKGS="build_runner"
       script: ./tool/travis.sh test_07
+    - stage: unit_test
+      name: "SDK: 2.2.0; PKG: build_runner_core; TASKS: `pub run test`"
+      dart: "2.2.0"
+      env: PKGS="build_runner_core"
+      script: ./tool/travis.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_runner_core; TASKS: `pub run test`"
       dart: dev

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.5
+
+- Explicitly require Dart SDK `>=2.2.0 <3.0.0`.
+
 ## 3.0.4
 
 - Add additional error details and a fallback for

--- a/build_runner_core/mono_pkg.yaml
+++ b/build_runner_core/mono_pkg.yaml
@@ -1,4 +1,5 @@
 dart:
+  - 2.2.0
   - dev
 
 stages:
@@ -6,8 +7,8 @@ stages:
     - group:
       - dartfmt: sdk
       - dartanalyzer: --fatal-infos --fatal-warnings .
+      dart: dev
     - dartanalyzer: --fatal-warnings .
-      dart:
-        - 2.1.0
+      dart: 2.2.0
   - unit_test:
     - test

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_runner_core
-version: 3.0.4
+version: 3.0.5-dev
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
@@ -37,7 +37,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build_config:
-    path: ../build_config


### PR DESCRIPTION
drop dependency_override on build_config

Note: this should have been done in https://github.com/dart-lang/build/commit/d0eaecd5f3f3495261daa0b3c5f7824a5f321fd8