### PR TITLE
build_config: add configYamlPath parameter to BuildConfig.parse

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.1
+
+- Added optional `configYamlPath` parameter to `BuildConfig.parse`. When
+  provided, errors reported when parsing build configuration will include
+  the file path.
+
 ## 0.4.0
 
 - Breaking for build systems - change type of `BuilderOptions` fields to

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -43,7 +43,11 @@ class BuildConfig {
     final file = File(configPath);
     if (await file.exists()) {
       return BuildConfig.parse(
-          packageName, dependencies, await file.readAsString());
+        packageName,
+        dependencies,
+        await file.readAsString(),
+        configYamlPath: file.path,
+      );
     } else {
       return BuildConfig.useDefault(packageName, dependencies);
     }
@@ -87,14 +91,22 @@ class BuildConfig {
   }
 
   /// Create a [BuildConfig] by parsing [configYaml].
+  ///
+  /// If [configYamlPath] is passed, it's used as the URL from which
+  /// [configYaml] for error reporting.
   factory BuildConfig.parse(
-      String packageName, Iterable<String> dependencies, String configYaml) {
+    String packageName,
+    Iterable<String> dependencies,
+    String configYaml, {
+    String configYamlPath,
+  }) {
     try {
       return checkedYamlDecode(
         configYaml,
         (map) =>
             BuildConfig.fromMap(packageName, dependencies, map ?? const {}),
         allowNull: true,
+        sourceUrl: configYamlPath,
       );
     } on ParsedYamlException catch (e) {
       throw ArgumentError(e.formattedMessage);

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.4.0
+version: 0.4.1-dev
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config
@@ -19,3 +19,9 @@ dev_dependencies:
   build_runner: ^1.0.0
   json_serializable: ^2.0.0
   test: ^1.6.0
+
+dependency_overrides:
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core


### PR DESCRIPTION
When provided, errors reported when parsing build configuration will
include the build config file path