### PR TITLE
Fix exceptions in PackageAssetReader

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.7+2
+
+- Avoid throwing for missing files from `PackageAssetReader.canRead`.
+
 ## 0.10.7+1
 
 - Allow `build_config` `0.4.x`.

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -83,7 +83,7 @@ class PackageAssetReader extends AssetReader
     if (id.package == _rootPackage) {
       return File(p.canonicalize(p.join(_rootPackagePath, id.path)));
     }
-    throw UnsupportedError('Unable to resolve $id');
+    return null;
   }
 
   String get _rootPackagePath {
@@ -125,29 +125,15 @@ class PackageAssetReader extends AssetReader
   }
 
   @override
-  Future<bool> canRead(AssetId id) {
-    final file = _resolve(id);
-    if (file == null) {
-      return Future.value(false);
-    }
-    return file.exists();
-  }
+  Future<bool> canRead(AssetId id) =>
+      _resolve(id)?.exists() ?? Future.value(false);
 
   @override
-  Future<List<int>> readAsBytes(AssetId id) {
-    final file = _resolve(id);
-    if (file == null) {
-      throw ArgumentError('Could not read $id.');
-    }
-    return file.readAsBytes();
-  }
+  Future<List<int>> readAsBytes(AssetId id) =>
+      _resolve(id)?.readAsBytes() ?? (throw AssetNotFoundException(id));
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) {
-    final file = _resolve(id);
-    if (file == null) {
-      throw ArgumentError('Could not read $id.');
-    }
-    return file.readAsString(encoding: encoding);
-  }
+  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) =>
+      _resolve(id)?.readAsString(encoding: encoding) ??
+      (throw AssetNotFoundException(id));
 }

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.7+1
+version: 0.10.7+2
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 


### PR DESCRIPTION
- Don't throw for missing files from `canRead` - the correct behavior is
  to return `false`.
- Change `ArgumentError` to `AssetNotFoundException` in read methods.
- Shorten the implementations to use `??` fallbacks.