### PR TITLE
Handle fake package roots in PackageAssetReader

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.7+3
+
+- Handle the case where the root package in a `PackageAssetReader` is a fake
+  package.
+
 ## 0.10.7+2
 
 - Avoid throwing for missing files from `PackageAssetReader.canRead`.

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -89,7 +89,7 @@ class PackageAssetReader extends AssetReader
   String get _rootPackagePath {
     // If the root package has a pub layout, use `packagePath`.
     final root = _packageResolver.packagePath(_rootPackage);
-    if (Directory(p.join(root, 'lib')).existsSync()) {
+    if (root != null && Directory(p.join(root, 'lib')).existsSync()) {
       return root;
     }
     // Assume the cwd is the package root.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.7+2
+version: 0.10.7+3
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 


### PR DESCRIPTION
Fixes another case where `canRead` would throw instead of return false.