### PR TITLE
invalidate `results` from glob nodes when removing nodes from the graph

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.5
 
 - Explicitly require Dart SDK `>=2.2.0 <3.0.0`.
+- Fix an error that could occur when serializing outdated glob nodes.
 
 ## 3.0.4
 

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -178,6 +178,9 @@ class AssetGraph {
       var inputsNode = get(output) as NodeWithInputs;
       if (inputsNode != null) {
         inputsNode.inputs.remove(id);
+        if (inputsNode is GlobAssetNode) {
+          inputsNode.results.remove(id);
+        }
       }
     }
     if (node is NodeWithInputs) {

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 3.0.5-dev
+version: 3.0.5
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -353,7 +353,7 @@ void main() {
             'glob node and its outputs', () async {
           var globNode = GlobAssetNode(primaryInputId.addExtension('.glob'),
               Glob('lib/*.cool'), 0, NodeState.upToDate,
-              inputs: HashSet());
+              inputs: HashSet(), results: []);
           var primaryOutputNode =
               graph.get(primaryOutputId) as GeneratedAssetNode
                 ..state = NodeState.upToDate
@@ -376,19 +376,27 @@ void main() {
           }
 
           await checkChangeType(ChangeType.ADD);
+
           primaryOutputNode.state = NodeState.upToDate;
           globNode.state = NodeState.upToDate;
-
           await checkChangeType(ChangeType.REMOVE);
+
           primaryOutputNode.state = NodeState.upToDate;
           globNode.state = NodeState.upToDate;
-
           await checkChangeType(ChangeType.ADD);
+
           primaryOutputNode.state = NodeState.upToDate;
           globNode.state = NodeState.upToDate;
           globNode.inputs.add(coolAssetId);
+          globNode.results.add(coolAssetId);
           graph.get(coolAssetId).outputs.add(globNode.id);
           await checkChangeType(ChangeType.MODIFY);
+
+          expect(globNode.inputs, contains(coolAssetId));
+          expect(globNode.results, contains(coolAssetId));
+          await checkChangeType(ChangeType.REMOVE);
+          expect(globNode.inputs, isNot(contains(coolAssetId)));
+          expect(globNode.results, isNot(contains(coolAssetId)));
         });
       });
     });


### PR DESCRIPTION
Potential fix for https://github.com/dart-lang/build/issues/1804, although I will leave that open for a while to make sure we don't find other cases.

:tada: thanks @kevmoo for the solid repro case!