### PR TITLE
remove build_modules dep override in build_web_compilers

### DIFF
--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -34,7 +34,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  build_modules:
-    path: ../build_modules


### PR DESCRIPTION
build_modules is now published so I can remove the override and publish build_web_compilers