### PR TITLE
update build_web_compilers for org-dartlang-app uris

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.2
+
+- Prepare for the next sdk release, which changes what the uris look like for
+  non-package sources, and breaks our existing hot restart logic.
+
 ## 2.0.1
 
 - Fix issue #2269, which could cause applications to fail to properly bootstrap.

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -164,6 +164,15 @@ define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_s
   app.$moduleScope.main();
   var bootstrap = {
       hot\$onChildUpdate: function(childName, child) {
+        // Special handling for the multi-root scheme uris. We need to strip
+        // out the scheme and the top level directory, to match the source path
+        // that chrome sees.
+        if (childName.startsWith('$multiRootScheme:///')) {
+          childName = childName.substring('$multiRootScheme:///'.length);
+          var firstSlash = childName.indexOf('/');
+          if (firstSlash == -1) return false;
+          childName = childName.substring(firstSlash + 1);
+        }
         if (childName === "$appModuleSource") {
           // Clear static caches.
           dart_sdk.dart.hotRestart();

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.0.1
+version: 2.0.2
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
This gets hot restart working with the previous fix in https://github.com/dart-lang/sdk/issues/36736.

We should probably discuss if we need to backport a 1.x fix as well.