### PR TITLE
Upstream changes required to land ddc + flutter web

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.4
+## 2.2.0
 
 - Make the `librariesPath` in the `KernelBuilder` configurable.
 - Fixed bug where the configured dart SDK was ignored.

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.4
+
+- Make the `librariesPath` in the `KernelBuilder` configurable.
+- Fixed bug where the configured dart SDK was ignored.
+
 ## 2.1.3
 
 - Skip compiling modules with kernel when the primary source isn't the primary

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -58,11 +58,17 @@ class KernelBuilder implements Builder {
   /// directory, which contains the platform kernel files.
   final String platformSdk;
 
+  /// The libraries file for the current platform.
+  ///
+  /// If not provided, defaults to "lib/libraries.json".
+  final String librariesPath;
+
   KernelBuilder(
       {@required this.platform,
       @required this.summaryOnly,
       @required this.sdkKernelPath,
       @required this.outputExtension,
+      this.librariesPath,
       bool useIncrementalCompiler,
       String platformSdk})
       : platformSdk = platformSdk ?? sdkDir,
@@ -92,6 +98,7 @@ class KernelBuilder implements Builder {
           platform: platform,
           dartSdkDir: platformSdk,
           sdkKernelPath: sdkKernelPath,
+          librariesPath: librariesPath,
           useIncrementalCompiler: useIncrementalCompiler);
     } on MissingModulesException catch (e) {
       log.severe(e.toString());
@@ -114,6 +121,7 @@ Future<void> _createKernel(
     @required DartPlatform platform,
     @required String dartSdkDir,
     @required String sdkKernelPath,
+    @required String librariesPath,
     @required bool useIncrementalCompiler}) async {
   var request = WorkRequest();
   var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
@@ -142,8 +150,9 @@ Future<void> _createKernel(
         module,
         kernelDeps,
         platform,
-        sdkDir,
+        dartSdkDir,
         sdkKernelPath,
+        librariesPath,
         outputFile,
         packagesFile,
         summaryOnly,
@@ -269,6 +278,7 @@ Future<void> _addRequestArguments(
     DartPlatform platform,
     String sdkDir,
     String sdkKernelPath,
+    String librariesPath,
     File outputFile,
     File packagesFile,
     bool summaryOnly,
@@ -286,7 +296,7 @@ Future<void> _addRequestArguments(
     '--exclude-non-sources',
     summaryOnly ? '--summary-only' : '--no-summary-only',
     '--libraries-file',
-    p.toUri(p.join(sdkDir, 'lib', 'libraries.json')).toString(),
+    p.toUri(librariesPath ?? p.join(sdkDir, 'lib', 'libraries.json')).toString(),
   ]);
   if (useIncrementalCompiler) {
     request.arguments.addAll([

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -58,9 +58,9 @@ class KernelBuilder implements Builder {
   /// directory, which contains the platform kernel files.
   final String platformSdk;
 
-  /// The libraries file for the current platform.
+  /// The absolute path to the libraries file for the current platform.
   ///
-  /// If not provided, defaults to "lib/libraries.json".
+  /// If not provided, defaults to "lib/libraries.json" in the sdk directory.
   final String librariesPath;
 
   KernelBuilder(
@@ -68,10 +68,12 @@ class KernelBuilder implements Builder {
       @required this.summaryOnly,
       @required this.sdkKernelPath,
       @required this.outputExtension,
-      this.librariesPath,
+      String librariesPath,
       bool useIncrementalCompiler,
       String platformSdk})
       : platformSdk = platformSdk ?? sdkDir,
+        librariesPath = librariesPath ??
+            p.join(platformSdk ?? sdkDir, 'lib', 'libraries.json'),
         useIncrementalCompiler = useIncrementalCompiler ?? false,
         buildExtensions = {
           moduleExtension(platform): [outputExtension]
@@ -296,9 +298,7 @@ Future<void> _addRequestArguments(
     '--exclude-non-sources',
     summaryOnly ? '--summary-only' : '--no-summary-only',
     '--libraries-file',
-    p
-        .toUri(librariesPath ?? p.join(sdkDir, 'lib', 'libraries.json'))
-        .toString(),
+    p.toUri(librariesPath).toString(),
   ]);
   if (useIncrementalCompiler) {
     request.arguments.addAll([

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -296,7 +296,9 @@ Future<void> _addRequestArguments(
     '--exclude-non-sources',
     summaryOnly ? '--summary-only' : '--no-summary-only',
     '--libraries-file',
-    p.toUri(librariesPath ?? p.join(sdkDir, 'lib', 'libraries.json')).toString(),
+    p
+        .toUri(librariesPath ?? p.join(sdkDir, 'lib', 'libraries.json'))
+        .toString(),
   ]);
   if (useIncrementalCompiler) {
     request.arguments.addAll([

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.1.4
+version: 2.2.0
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.1.3
+version: 2.1.4
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.3
+
+- Make `platformSdk`, `sdkKernelPath`, and `platform` configurable in
+  `DevCompilerBuilder`.
+
 ## 2.0.2
 
 - Prepare for the next sdk release, which changes what the uris look like for

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.3
+## 2.1.0
 
 - Make `platformSdk`, `sdkKernelPath`, and `platform` configurable in
   `DevCompilerBuilder`.

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -22,7 +22,9 @@ Builder ddcMetaModuleBuilder(BuilderOptions options) =>
 Builder ddcMetaModuleCleanBuilder(_) => MetaModuleCleanBuilder(ddcPlatform);
 Builder ddcModuleBuilder([_]) => ModuleBuilder(ddcPlatform);
 Builder ddcBuilder(BuilderOptions options) => DevCompilerBuilder(
-    useIncrementalCompiler: _readUseIncrementalCompilerOption(options));
+    useIncrementalCompiler: _readUseIncrementalCompilerOption(options),
+    platform: ddcPlatform,
+);
 const ddcKernelExtension = '.ddc.dill';
 Builder ddcKernelBuilder(BuilderOptions options) => KernelBuilder(
     summaryOnly: true,

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -22,9 +22,9 @@ Builder ddcMetaModuleBuilder(BuilderOptions options) =>
 Builder ddcMetaModuleCleanBuilder(_) => MetaModuleCleanBuilder(ddcPlatform);
 Builder ddcModuleBuilder([_]) => ModuleBuilder(ddcPlatform);
 Builder ddcBuilder(BuilderOptions options) => DevCompilerBuilder(
-    useIncrementalCompiler: _readUseIncrementalCompilerOption(options),
-    platform: ddcPlatform,
-);
+      useIncrementalCompiler: _readUseIncrementalCompilerOption(options),
+      platform: ddcPlatform,
+    );
 const ddcKernelExtension = '.ddc.dill';
 Builder ddcKernelBuilder(BuilderOptions options) => KernelBuilder(
     summaryOnly: true,

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -23,8 +23,8 @@ var _modulePartialExtension = _context.withoutExtension(jsModuleExtension);
 
 Future<void> bootstrapDdc(BuildStep buildStep, {DartPlatform platform}) async {
   var dartEntrypointId = buildStep.inputId;
-  var moduleId =
-      buildStep.inputId.changeExtension(moduleExtension(platform ?? ddcPlatform));
+  var moduleId = buildStep.inputId
+      .changeExtension(moduleExtension(platform ?? ddcPlatform));
   var module = Module.fromJson(json
       .decode(await buildStep.readAsString(moduleId)) as Map<String, dynamic>);
 

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -21,10 +21,10 @@ _p.Context get _context => _p.url;
 
 var _modulePartialExtension = _context.withoutExtension(jsModuleExtension);
 
-Future<void> bootstrapDdc(BuildStep buildStep) async {
+Future<void> bootstrapDdc(BuildStep buildStep, {DartPlatform platform}) async {
   var dartEntrypointId = buildStep.inputId;
   var moduleId =
-      buildStep.inputId.changeExtension(moduleExtension(ddcPlatform));
+      buildStep.inputId.changeExtension(moduleExtension(platform ?? ddcPlatform));
   var module = Module.fromJson(json
       .decode(await buildStep.readAsString(moduleId)) as Map<String, dynamic>);
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.0.3
+version: 2.1.0
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.0.2
+version: 2.0.3
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -102,5 +102,6 @@ Future<void> runPrerequisites(Map<String, dynamic> assets) async {
   await testBuilderAndCollectAssets(ModuleBuilder(ddcPlatform), assets);
   await testBuilderAndCollectAssets(
       ddcKernelBuilder(BuilderOptions({})), assets);
-  await testBuilderAndCollectAssets(DevCompilerBuilder(), assets);
+  await testBuilderAndCollectAssets(
+      DevCompilerBuilder(platform: ddcPlatform), assets);
 }

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -53,7 +53,8 @@ main() {
         'a|web/index$jsSourceMapExtension':
             decodedMatches(contains('index.dart')),
       };
-      await testBuilder(DevCompilerBuilder(), assets, outputs: expectedOutputs);
+      await testBuilder(DevCompilerBuilder(platform: ddcPlatform), assets,
+          outputs: expectedOutputs);
     });
   });
 
@@ -82,7 +83,7 @@ main() {
               allOf(contains('String'), contains('assigned'), contains('int'))),
         };
         var logs = <LogRecord>[];
-        await testBuilder(DevCompilerBuilder(), assets,
+        await testBuilder(DevCompilerBuilder(platform: ddcPlatform), assets,
             outputs: expectedOutputs, onLog: logs.add);
         expect(
             logs,
@@ -116,7 +117,7 @@ main() {
               contains('Unable to find modules for some sources')),
         };
         var logs = <LogRecord>[];
-        await testBuilder(DevCompilerBuilder(), assets,
+        await testBuilder(DevCompilerBuilder(platform: ddcPlatform), assets,
             outputs: expectedOutputs, onLog: logs.add);
         expect(
             logs,


### PR DESCRIPTION
These changes mostly involve exposing more configuration to the constructor, except in the case of bootstrap ddc where I'm still using a src member.

