### PR TITLE
Refactor argument handling for DDC builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,14 @@ jobs:
       env: PKGS="build_config build_runner_core build_test"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: 2.3.0-dev.0.1; PKGS: build_modules, build_vm_compilers, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.3.0-dev.0.1; PKGS: build_modules, build_vm_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.3.0-dev.0.1"
-      env: PKGS="build_modules build_vm_compilers build_web_compilers"
+      env: PKGS="build_modules build_vm_compilers"
+      script: ./tool/travis.sh dartanalyzer_1
+    - stage: analyze_and_format
+      name: "SDK: 2.3.0; PKG: build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.3.0"
+      env: PKGS="build_web_compilers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.0.0; PKG: scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -109,11 +109,13 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
   // These can be consumed for hot reloads.
   var moduleDigests = <String, String>{
     for (var jsId in transitiveJsModules)
-      jsId.path.replaceFirst('lib/', 'packages/${jsId.package}/'):
-          '${await buildStep.digest(jsId)}',
+      _moduleDigestKey(jsId): '${await buildStep.digest(jsId)}',
   };
   await buildStep.writeAsString(appDigestsOutput, jsonEncode(moduleDigests));
 }
+
+String _moduleDigestKey(AssetId jsId) =>
+    '${ddcModuleName(jsId)}$jsModuleExtension';
 
 final _lazyBuildPool = Pool(16);
 

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -29,9 +29,9 @@ Future<void> bootstrapDdc(BuildStep buildStep, {DartPlatform platform}) async {
       .decode(await buildStep.readAsString(moduleId)) as Map<String, dynamic>);
 
   // First, ensure all transitive modules are built.
-  List<Module> transitiveDeps;
+  List<AssetId> transitiveJsModules;
   try {
-    transitiveDeps = await _ensureTransitiveModules(module, buildStep);
+    transitiveJsModules = await _ensureTransitiveJsModules(module, buildStep);
   } on UnsupportedModules catch (e) {
     var librariesString = (await e.exactLibraries(buildStep).toList())
         .map((lib) => AssetId(lib.id.package,
@@ -68,8 +68,6 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
   // Map from module name to module path for custom modules.
   var modulePaths = SplayTreeMap.of(
       {'dart_sdk': r'packages/build_web_compilers/src/dev_compiler/dart_sdk'});
-  var transitiveJsModules = [jsId]..addAll(transitiveDeps
-      .map((dep) => dep.primarySource.changeExtension(jsModuleExtension)));
   for (var jsId in transitiveJsModules) {
     // Strip out the top level dir from the path for any module, and set it to
     // `packages/` for lib modules. We set baseUrl to `/` to simplify things,
@@ -109,14 +107,11 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
 
   // Output the digests for transitive modules.
   // These can be consumed for hot reloads.
-  var moduleDigests = <String, String>{};
-  for (var dep in transitiveDeps.followedBy([module])) {
-    var assetId = dep.primarySource.changeExtension(jsModuleExtension);
-    moduleDigests[
-            assetId.path.replaceFirst('lib/', 'packages/${assetId.package}/')] =
-        (await buildStep.digest(assetId)).toString();
-  }
-
+  var moduleDigests = <String, String>{
+    for (var jsId in transitiveJsModules)
+      jsId.path.replaceFirst('lib/', 'packages/${jsId.package}/'):
+          '${await buildStep.digest(jsId)}',
+  };
   await buildStep.writeAsString(appDigestsOutput, jsonEncode(moduleDigests));
 }
 
@@ -126,15 +121,17 @@ final _lazyBuildPool = Pool(16);
 ///
 /// Throws an [UnsupportedModules] exception if there are any
 /// unsupported modules.
-Future<List<Module>> _ensureTransitiveModules(
+Future<List<AssetId>> _ensureTransitiveJsModules(
     Module module, BuildStep buildStep) async {
   // Collect all the modules this module depends on, plus this module.
   var transitiveDeps = await module.computeTransitiveDependencies(buildStep,
       throwIfUnsupported: true);
-  var jsModules = transitiveDeps
-      .map((module) => module.primarySource.changeExtension(jsModuleExtension))
-      .toList()
-        ..add(module.primarySource.changeExtension(jsModuleExtension));
+
+  var jsModules = [
+    module.primarySource.changeExtension(jsModuleExtension),
+    for (var dep in transitiveDeps)
+      dep.primarySource.changeExtension(jsModuleExtension),
+  ];
   // Check that each module is readable, and warn otherwise.
   await Future.wait(jsModules.map((jsId) async {
     if (await _lazyBuildPool.withResource(() => buildStep.canRead(jsId))) {
@@ -146,7 +143,7 @@ Future<List<Module>> _ensureTransitiveModules(
         '`.dart_tool/build/generated/${errorsId.package}/${errorsId.path}` '
         'log file.');
   }));
-  return transitiveDeps;
+  return jsModules;
 }
 
 /// Code that actually imports the [moduleName] module, and calls the

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -98,7 +98,7 @@ Future<void> _createDevCompilerModule(Module module, BuildStep buildStep,
   ];
   var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
 
-  var allAssetIds = {...module.sources, ...transitiveKernelDeps};
+  var allAssetIds = <AssetId>{...module.sources, ...transitiveKernelDeps};
   await buildStep.trackStage(
       'EnsureAssets', () => scratchSpace.ensureAssets(allAssetIds, buildStep));
   var jsId = module.primarySource.changeExtension(jsModuleExtension);

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -126,14 +126,7 @@ Future<void> _createDevCompilerModule(Module module, BuildStep buildStep,
         '--reuse-compiler-result',
         '--use-incremental-compiler',
       ],
-      // The urls to compile, using the package: path for files under lib and the
-      // full absolute path for other files.
-      ...module.sources.map((id) {
-        var uri = canonicalUriFor(id);
-        return uri.startsWith('package:')
-            ? uri
-            : '$multiRootScheme:///${id.path}';
-      }),
+      for (var source in module.sources) _sourceArg(source),
     ])
     ..inputs.add(Input()
       ..path = sdkSummary
@@ -190,6 +183,15 @@ String _summaryArg(Module module) {
   final moduleName =
       ddcModuleName(module.primarySource.changeExtension(jsModuleExtension));
   return '--summary=${scratchSpace.fileFor(kernelAsset).path}=$moduleName';
+}
+
+/// The url to compile for a source.
+///
+/// Use the package: path for files under lib and the full absolute path for
+/// other files.
+String _sourceArg(AssetId id) {
+  var uri = canonicalUriFor(id);
+  return uri.startsWith('package:') ? uri : '$multiRootScheme:///${id.path}';
 }
 
 /// Copied to `web/stack_trace_mapper.dart`, these need to be kept in sync.

--- a/build_web_compilers/mono_pkg.yaml
+++ b/build_web_compilers/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.3.0-dev.0.1
+        - 2.3.0
   - unit_test:
     - group:
       - test: -x presubmit-only

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_web_compilers
-version: 2.1.0
+version: 2.1.1-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: ">=2.3.0-dev.0.1 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.30.0 <0.37.0"


### PR DESCRIPTION
- Use conditional and spread collection elements to replace some of the
  code that looked more iterative.
- Replace `transitiveDeps` with `transitiveJsModules` since we were
  otherwise always changing their extensions repeatedly.
- Drop `allDeps` variable which was otherwise an identical collection as
  `allAssetIds`.
- Make more arguments use the `--name=value` pattern so that it is clear
  how they are related as opposed to subsequent arguments.