### PR TITLE
allow a custom reader to be passed to testBuilder

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.8
+
+- Allow a custom AssetReader to be passed to `testBuilder`. This will be used
+  as a fallback for any sources that don't exist in the `sourceAssets` map.
+
 ## 0.10.7+3
 
 - Handle the case where the root package in a `PackageAssetReader` is a fake

--- a/build_test/README.md
+++ b/build_test/README.md
@@ -66,6 +66,19 @@ Using [`testBuilder`][api:testBuilder], you can run a functional test of a
 `Builder`, including feeding specific assets, and more. It automatically
 creates an in-memory representation of various utility classes.
 
+### Exposing actual package sources to `testBuilder`
+
+You can expose real package sources to the builder in addition to your in
+memory sources, by passing a `PackageAssetReader` to the `reader` parameter:
+
+```dart
+testBuilder(yourBuilder, {}/* test assets here */,
+    reader: await PackageAssetReader.currentIsolate());
+```
+
+You can pass any custom AssetReader here, which will be used as a fallback
+for any source not defined in the source assets map.
+
 ### Resolve source code for testing
 
 Using [`resolveAsset`][api:resolveAsset] and

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.7+3
+version: 0.10.8
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 

--- a/build_test/test/data/hello.txt
+++ b/build_test/test/data/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/build_test/test/test_builder_test.dart
+++ b/build_test/test/test_builder_test.dart
@@ -74,6 +74,23 @@ void main() {
       });
     }
   });
+
+  test('can pass a custom reader', () async {
+    var reader =
+        await PackageAssetReader.currentIsolate(rootPackage: 'build_test');
+    var builder = TestBuilder(
+        buildExtensions: {
+          '.txt': ['.txt.copy']
+        },
+        build: (buildStep, _) async {
+          await buildStep.writeAsString(
+              buildStep.inputId.addExtension('.copy'),
+              buildStep
+                  .readAsString(AssetId('build_test', 'test/data/hello.txt')));
+        });
+    await testBuilder(builder, {'build_test|data/1.txt': ''},
+        outputs: {'build_test|data/1.txt.copy': 'hello world'}, reader: reader);
+  });
 }
 
 /// Concatenates the contents of multiple text files into a single output.


### PR DESCRIPTION
This makes it easier to test builders that parse annotations, or generally need to resolve sources from other real packages.