### PR TITLE
fix command line arg for build_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
       env: PKGS="build_daemon"
       script: ./tool/travis.sh test_06
     - stage: unit_test
-      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs-- -P presubmit`"
+      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit`"
       dart: dev
       env: PKGS="build_modules"
       script: ./tool/travis.sh command_4

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.0
+
+- Add a `hasMain` boolean to the `ModuleLibrary` class.
+  - This is now used instead of `isEntrypoint` for determining whether or not
+    to copy module files for application discovery.
+
 ## 2.2.0
 
 - Make the `librariesPath` in the `KernelBuilder` configurable.

--- a/build_modules/lib/src/module_builder.dart
+++ b/build_modules/lib/src/module_builder.dart
@@ -45,7 +45,7 @@ class ModuleBuilder implements Builder {
           buildStep.inputId.changeExtension(moduleLibraryExtension));
       final libraryModule =
           ModuleLibrary.deserialize(buildStep.inputId, serializedLibrary);
-      if (libraryModule.isEntryPoint) {
+      if (libraryModule.hasMain) {
         outputModule = metaModule.modules
             .firstWhere((m) => m.sources.contains(buildStep.inputId));
       }

--- a/build_modules/lib/src/module_library.dart
+++ b/build_modules/lib/src/module_library.dart
@@ -51,12 +51,16 @@ class ModuleLibrary {
   /// The `dart:` libraries that this library directly depends on.
   final Set<String> sdkDeps;
 
+  /// Whether this library has a `main` function.
+  final bool hasMain;
+
   ModuleLibrary._(this.id,
       {@required this.isEntryPoint,
       @required Set<AssetId> deps,
       @required this.parts,
       @required this.conditionalDeps,
-      @required this.sdkDeps})
+      @required this.sdkDeps,
+      @required this.hasMain})
       : _deps = deps,
         isImportable = true;
 
@@ -66,7 +70,8 @@ class ModuleLibrary {
         _deps = null,
         parts = null,
         conditionalDeps = null,
-        sdkDeps = null;
+        sdkDeps = null,
+        hasMain = false;
 
   factory ModuleLibrary._fromCompilationUnit(
       AssetId id, bool isEntryPoint, CompilationUnit parsed) {
@@ -116,12 +121,18 @@ class ModuleLibrary {
         deps.add(linkedId);
       }
     }
+    // Allow two or fewer arguments so that entrypoints intended for use with
+    // [spawnUri] get counted.
+    //
+    // TODO: This misses the case where a Dart file doesn't contain main(),
+    // but has a part that does, or it exports a `main` from another library.
     return ModuleLibrary._(id,
         isEntryPoint: isEntryPoint,
         deps: deps,
         parts: parts,
         sdkDeps: sdkDeps,
-        conditionalDeps: conditionalDeps);
+        conditionalDeps: conditionalDeps,
+        hasMain: _hasMainMethod(parsed));
   }
 
   /// Parse the directives from [source] and compute the library information.
@@ -164,7 +175,8 @@ class ModuleLibrary {
             (json['conditionalDeps'] as Iterable).map((conditions) {
           return Map.of((conditions as Map<String, dynamic>)
               .map((k, v) => MapEntry(k, AssetId.parse(v as String))));
-        }).toList());
+        }).toList(),
+        hasMain: json['hasMain'] as bool);
   }
 
   String serialize() => jsonEncode({
@@ -176,6 +188,7 @@ class ModuleLibrary {
                 conditions.map((k, v) => MapEntry(k, v.toString())))
             .toList(),
         'sdkDeps': sdkDeps.toList(),
+        'hasMain': hasMain,
       });
 
   List<AssetId> depsForPlatform(DartPlatform platform) {

--- a/build_modules/lib/src/module_library.dart
+++ b/build_modules/lib/src/module_library.dart
@@ -121,11 +121,6 @@ class ModuleLibrary {
         deps.add(linkedId);
       }
     }
-    // Allow two or fewer arguments so that entrypoints intended for use with
-    // [spawnUri] get counted.
-    //
-    // TODO: This misses the case where a Dart file doesn't contain main(),
-    // but has a part that does, or it exports a `main` from another library.
     return ModuleLibrary._(id,
         isEntryPoint: isEntryPoint,
         deps: deps,
@@ -217,6 +212,11 @@ Set<AssetId> _deserializeAssetIds(Iterable serlialized) =>
 bool _isPart(CompilationUnit dart) =>
     dart.directives.any((directive) => directive is PartOfDirective);
 
+/// Allows two or fewer arguments to `main` so that entrypoints intended for
+/// use with `spawnUri` get counted.
+//
+// TODO: This misses the case where a Dart file doesn't contain main(),
+// but has a part that does, or it exports a `main` from another library.
 bool _hasMainMethod(CompilationUnit dart) => dart.declarations.any((node) =>
     node is FunctionDeclaration &&
     node.name.name == 'main' &&

--- a/build_modules/lib/src/module_library.dart
+++ b/build_modules/lib/src/module_library.dart
@@ -138,10 +138,8 @@ class ModuleLibrary {
   /// Parse the directives from [source] and compute the library information.
   static ModuleLibrary fromSource(AssetId id, String source) {
     final isLibDir = id.path.startsWith('lib/');
-    final parsed = isLibDir
-        ? parseDirectives(source, name: id.path, suppressErrors: true)
-        : parseCompilationUnit(source,
-            name: id.path, suppressErrors: true, parseFunctionBodies: false);
+    final parsed = parseCompilationUnit(source,
+        name: id.path, suppressErrors: true, parseFunctionBodies: false);
     // Packages within the SDK but published might have libraries that can't be
     // used outside the SDK.
     if (parsed.directives.any((d) =>

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -12,7 +12,7 @@ stages:
   - unit_test:
     # Run the script directly - running from snapshot has issues for packages
     # that are depended on by build_runner itself.
-    - command: dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs-- -P presubmit
+    - command: dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit
 
 cache:
   directories:

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.2.0
+version: 2.3.0
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_modules/test/module_builder_test.dart
+++ b/build_modules/test/module_builder_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'package:build_modules/build_modules.dart';
 import 'package:build_modules/src/meta_module.dart';
 import 'package:build_modules/src/modules.dart';
+import 'package:build_modules/src/module_library.dart';
 
 import 'matchers.dart';
 
@@ -35,6 +36,10 @@ main() {
       'a|lib/e.dart': '',
       'a|lib/${metaModuleCleanExtension(platform)}':
           jsonEncode(metaModule.toJson()),
+      'a|lib/c$moduleLibraryExtension':
+          ModuleLibrary.fromSource(assetC, '').serialize(),
+      'a|lib/e$moduleLibraryExtension':
+          ModuleLibrary.fromSource(assetE, '').serialize(),
     }, outputs: {
       'a|lib/a${moduleExtension(platform)}': encodedMatchesModule(moduleA),
       'a|lib/b${moduleExtension(platform)}': encodedMatchesModule(moduleB),

--- a/build_modules/test/module_library_test.dart
+++ b/build_modules/test/module_library_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -121,5 +122,14 @@ void main() {
         Set.of([
           makeAssetId('myapp|lib/for_web.dart'),
         ]));
+  });
+
+  test('can detect a `main` method', () async {
+    var id = AssetId('myapp', 'lib/a.dart');
+    expect(ModuleLibrary.fromSource(id, '').hasMain, false);
+    expect(ModuleLibrary.fromSource(id, 'main() {}').hasMain, true);
+    expect(ModuleLibrary.fromSource(id, 'main(args) {}').hasMain, true);
+    expect(ModuleLibrary.fromSource(id, 'main(args, receivePort) {}').hasMain,
+        true);
   });
 }

--- a/build_modules/test/module_library_test.dart
+++ b/build_modules/test/module_library_test.dart
@@ -124,7 +124,7 @@ void main() {
         ]));
   });
 
-  test('can detect a `main` method', () async {
+  test('can detect a main method', () async {
     var id = AssetId('myapp', 'lib/a.dart');
     expect(ModuleLibrary.fromSource(id, '').hasMain, false);
     expect(ModuleLibrary.fromSource(id, 'main() {}').hasMain, true);

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -35,8 +35,8 @@ for PKG in ${PKGS}; do
       pub run build_runner test || EXIT_CODE=$?
       ;;
     command_4)
-      echo 'dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs-- -P presubmit'
-      dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs-- -P presubmit || EXIT_CODE=$?
+      echo 'dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit'
+      dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit || EXIT_CODE=$?
       ;;
     dartanalyzer_0)
       echo 'dartanalyzer --fatal-infos --fatal-warnings .'


### PR DESCRIPTION
This also fixes the failing test by adding a `hasMain` boolean to `ModuleLibrary` and using that instead of `isEntrypoint` when copying over modules.