### PR TITLE
handle symlink creation failures, link to dev mode docs

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.6
+
+- Handle symlink creation failures and link to dev mode docs for windows.
+
 ## 3.0.5
 
 - Explicitly require Dart SDK `>=2.2.0 <3.0.0`.

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -141,7 +141,7 @@ Future<bool> _createMergedOutputDir(
 
     return true;
   } on FileSystemException catch (e) {
-    if (e.osError.errorCode != 1314) rethrow;
+    if (e.osError?.errorCode != 1314) rethrow;
     var devModeLink =
         'https://docs.microsoft.com/en-us/windows/uwp/get-started/'
         'enable-your-device-for-development';

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -147,7 +147,7 @@ Future<bool> _createMergedOutputDir(
         'enable-your-device-for-development';
     _logger.severe('Unable to create symlink ${e.path}. Note that to create '
         'symlinks on windows you need to either run in a console with admin '
-        'priviledges or enable developer mode (see $devModeLink).');
+        'privileges or enable developer mode (see $devModeLink).');
     return false;
   }
 }

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -88,57 +88,68 @@ Future<bool> _createMergedOutputDir(
     FinalizedAssetsView finalizedOutputsView,
     bool symlinkOnly,
     bool hoist) async {
-  if (root == null) return false;
-  var outputDir = Directory(outputPath);
-  var outputDirExists = await outputDir.exists();
-  if (outputDirExists) {
-    if (!await _cleanUpOutputDir(outputDir, environment)) return false;
-  }
-  var builtAssets = finalizedOutputsView.allAssets(rootDir: root).toList();
-  if (root != '' &&
-      !builtAssets
-          .where((id) => id.package == packageGraph.root.name)
-          .any((id) => p.isWithin(root, id.path))) {
-    _logger.severe('No assets exist in $root, skipping output');
-    return false;
-  }
-
-  var outputAssets = <AssetId>[];
-
-  await logTimedAsync(_logger, 'Creating merged output dir `$outputPath`',
-      () async {
-    if (!outputDirExists) {
-      await outputDir.create(recursive: true);
+  try {
+    if (root == null) return false;
+    var outputDir = Directory(outputPath);
+    var outputDirExists = await outputDir.exists();
+    if (outputDirExists) {
+      if (!await _cleanUpOutputDir(outputDir, environment)) return false;
+    }
+    var builtAssets = finalizedOutputsView.allAssets(rootDir: root).toList();
+    if (root != '' &&
+        !builtAssets
+            .where((id) => id.package == packageGraph.root.name)
+            .any((id) => p.isWithin(root, id.path))) {
+      _logger.severe('No assets exist in $root, skipping output');
+      return false;
     }
 
-    outputAssets.addAll(await Future.wait(builtAssets.map((id) => _writeAsset(
-        id, outputDir, root, packageGraph, reader, symlinkOnly, hoist))));
+    var outputAssets = <AssetId>[];
 
-    var packagesFileContent = packageGraph.allPackages.keys
-        .map((p) => '$p:packages/$p/')
-        .join('\r\n');
-    var packagesAsset = AssetId(packageGraph.root.name, '.packages');
-    await _writeAsString(outputDir, packagesAsset, packagesFileContent);
-    outputAssets.add(packagesAsset);
+    await logTimedAsync(_logger, 'Creating merged output dir `$outputPath`',
+        () async {
+      if (!outputDirExists) {
+        await outputDir.create(recursive: true);
+      }
 
-    if (!hoist) {
-      for (var dir in _findRootDirs(builtAssets, outputPath)) {
-        var link = Link(p.join(outputDir.path, dir, 'packages'));
-        if (!link.existsSync()) {
-          link.createSync(p.join('..', 'packages'), recursive: true);
+      outputAssets.addAll(await Future.wait(builtAssets.map((id) => _writeAsset(
+          id, outputDir, root, packageGraph, reader, symlinkOnly, hoist))));
+
+      var packagesFileContent = packageGraph.allPackages.keys
+          .map((p) => '$p:packages/$p/')
+          .join('\r\n');
+      var packagesAsset = AssetId(packageGraph.root.name, '.packages');
+      await _writeAsString(outputDir, packagesAsset, packagesFileContent);
+      outputAssets.add(packagesAsset);
+
+      if (!hoist) {
+        for (var dir in _findRootDirs(builtAssets, outputPath)) {
+          var link = Link(p.join(outputDir.path, dir, 'packages'));
+          if (!link.existsSync()) {
+            link.createSync(p.join('..', 'packages'), recursive: true);
+          }
         }
       }
-    }
-  });
+    });
 
-  await logTimedAsync(_logger, 'Writing asset manifest', () async {
-    var paths = outputAssets.map((id) => id.path).toList()..sort();
-    var content = paths.join(_manifestSeparator);
-    await _writeAsString(
-        outputDir, AssetId(packageGraph.root.name, _manifestName), content);
-  });
+    await logTimedAsync(_logger, 'Writing asset manifest', () async {
+      var paths = outputAssets.map((id) => id.path).toList()..sort();
+      var content = paths.join(_manifestSeparator);
+      await _writeAsString(
+          outputDir, AssetId(packageGraph.root.name, _manifestName), content);
+    });
 
-  return true;
+    return true;
+  } on FileSystemException catch (e) {
+    if (e.osError.errorCode != 1314) rethrow;
+    var devModeLink =
+        'https://docs.microsoft.com/en-us/windows/uwp/get-started/'
+        'enable-your-device-for-development';
+    _logger.severe('Unable to create symlink ${e.path}. Note that to create '
+        'symlinks on windows you need to either run in a console with admin '
+        'priviledges or enable developer mode (see $devModeLink).');
+    return false;
+  }
 }
 
 Set<String> _findRootDirs(Iterable<AssetId> allAssets, String outputPath) {

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 3.0.5
+version: 3.0.6
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/2270

Below is some example output:

```
> pub run build_runner build -o build
[INFO] Generating build script completed, took 451ms
[INFO] Reading cached asset graph completed, took 260ms
[INFO] Checking for updates since last build completed, took 919ms
[INFO] Running build completed, took 264ms
[INFO] Caching finalized dependency graph completed, took 166ms
[SEVERE] Unable to create symlink build\web\packages. Note that to create symlinks on windows you need to either run in a console with admin priviledges or enable developer mode (see https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development).
[SEVERE] Unable to create merged directory for build.
[SEVERE] Failed after 2.1s
```