### PR TITLE
Pass target name to kernel worker

### DIFF
--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -303,6 +303,7 @@ Future<void> _addRequestArguments(
     '--multi-root-scheme=$multiRootScheme',
     '--exclude-non-sources',
     summaryOnly ? '--summary-only' : '--no-summary-only',
+    '--target=${platform.name}',
     '--libraries-file=${p.toUri(librariesPath)}',
     if (useIncrementalCompiler) ...[
       '--reuse-compiler-result',

--- a/build_modules/test/kernel_builder_test.dart
+++ b/build_modules/test/kernel_builder_test.dart
@@ -15,7 +15,7 @@ import 'util.dart';
 
 main() {
   Map<String, dynamic> assets;
-  final platform = DartPlatform.register('test', ['dart:html']);
+  final platform = DartPlatform.register('ddc', ['dart:html']);
   final kernelOutputExtension = '.test.dill';
 
   group('basic project', () {


### PR DESCRIPTION
Closes #2174

This will be more reliable and surface errors more quickly than relying
on the defaulting depending on other arguments like `--summary-only`.