### PR TITLE
use a polling watcher on windows again

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.2
+
+- Use a polling directory watcher by default on windows again.
+
 ## 1.5.1
 
 - Fix an issue where exit codes were not set correctly when running the

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:build/build.dart';
 import 'package:build_daemon/daemon_builder.dart';
@@ -11,6 +10,7 @@ import 'package:build_daemon/data/build_status.dart';
 import 'package:build_daemon/data/build_target.dart' hide OutputLocation;
 import 'package:build_daemon/data/server_log.dart';
 import 'package:build_runner/src/entrypoint/options.dart';
+import 'package:build_runner/src/generate/directory_watcher_factory.dart';
 import 'package:build_runner/src/package_graph/build_config_overrides.dart';
 import 'package:build_runner/src/watcher/asset_change.dart';
 import 'package:build_runner/src/watcher/change_filter.dart';
@@ -182,10 +182,8 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
         isReleaseBuild: sharedOptions.isReleaseBuild);
 
     var graphEvents = PackageGraphWatcher(packageGraph,
-            watch: (node) => PackageNodeWatcher(node,
-                watch: (path) => Platform.isWindows
-                    ? PollingDirectoryWatcher(path)
-                    : DirectoryWatcher(path)))
+            watch: (node) =>
+                PackageNodeWatcher(node, watch: defaultDirectoryWatcherFactory))
         .watch()
         .where((change) => shouldProcess(
               change,

--- a/build_runner/lib/src/entrypoint/serve.dart
+++ b/build_runner/lib/src/entrypoint/serve.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:build_runner/src/generate/directory_watcher_factory.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:io/io.dart';
@@ -94,6 +95,7 @@ class ServeCommand extends WatchCommand {
       builderConfigOverrides: options.builderConfigOverrides,
       isReleaseBuild: options.isReleaseBuild,
       logPerformanceDir: options.logPerformanceDir,
+      directoryWatcherFactory: defaultDirectoryWatcherFactory,
     );
 
     if (handler == null) return ExitCode.config.code;

--- a/build_runner/lib/src/entrypoint/watch.dart
+++ b/build_runner/lib/src/entrypoint/watch.dart
@@ -8,6 +8,7 @@ import 'package:build_runner_core/build_runner_core.dart';
 import 'package:io/io.dart';
 
 import '../generate/build.dart';
+import '../generate/directory_watcher_factory.dart';
 import 'base_command.dart';
 
 /// A command that watches the file system for updates and rebuilds as
@@ -41,6 +42,7 @@ class WatchCommand extends BuildRunnerCommand {
       builderConfigOverrides: options.builderConfigOverrides,
       isReleaseBuild: options.isReleaseBuild,
       logPerformanceDir: options.logPerformanceDir,
+      directoryWatcherFactory: defaultDirectoryWatcherFactory,
     );
     if (handler == null) return ExitCode.config.code;
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.5.1
+version: 1.5.2
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/2161

I am not sure exactly when/why we stopped overriding this, only the daemon command was using the polling watcher on windows and the other commands were not.