### PR TITLE
Update timeouts

### DIFF
--- a/_test/test/dart2js_integration_test.dart
+++ b/_test/test/dart2js_integration_test.dart
@@ -3,7 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
-@Timeout(Duration(minutes: 5))
+@Tags(['integration'])
+
 import 'dart:async';
 import 'dart:io';
 

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@Timeout(Duration(minutes: 2))
 @Tags(['integration'])
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/build_runner/test/entrypoint/run_test.dart
+++ b/build_runner/test/entrypoint/run_test.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-@Timeout(Duration(minutes: 1))
+
 @Tags(['integration'])
 
 import 'dart:async';


### PR DESCRIPTION
We already have configuration for integration tests to extend the timeout by 16x. This stacks with the annotations. If there is a timeout issue we are needlessly waiting for up to 32 minutes and taking up Travis resources. Fix this.