### PR TITLE
Ensure the `pub run test` process exits.

### DIFF
--- a/build_runner/lib/src/entrypoint/test.dart
+++ b/build_runner/lib/src/entrypoint/test.dart
@@ -137,8 +137,7 @@ class TestCommand extends BuildRunnerCommand {
         ]..addAll(extraTestArgs),
         mode: ProcessStartMode.inheritStdio);
     _ensureProcessExit(testProcess);
-    final testExitCode = await testProcess.exitCode;
-    return testExitCode;
+    return testProcess.exitCode;
   }
 }
 
@@ -159,6 +158,7 @@ void _ensureBuildTestDependency(PackageGraph packageGraph) {
 
 void _ensureProcessExit(Process process) {
   var signalsSub = _exitProcessSignals.listen((signal) async {
+    stdout.writeln('waiting for subprocess to exit...');
     await process.exitCode;
   });
   process.exitCode.then((_) {

--- a/build_runner/lib/src/entrypoint/test.dart
+++ b/build_runner/lib/src/entrypoint/test.dart
@@ -159,7 +159,6 @@ void _ensureBuildTestDependency(PackageGraph packageGraph) {
 void _ensureProcessExit(Process process) {
   var signalsSub = _exitProcessSignals.listen((signal) async {
     stdout.writeln('waiting for subprocess to exit...');
-    await process.exitCode;
   });
   process.exitCode.then((_) {
     signalsSub?.cancel();


### PR DESCRIPTION
The `build_runner test` command starts a child `pub run test` process which in some cases consumes the first SIGINT signal without exiting. If the build_runner process doesn't wait for this child process to exit, it may remain running in the background.

The `build_runner test` command now watches for the exit signals (SIGINT and SIGTERM) and prevents its own process from exiting until the child `pub run test` process exits, which should happen after the second SIGINT signal.

@jakemac53 I'm not very familiar with the testing setup in this repo and I'm not sure if there's a clear way to verify that the child process exits via a unit/integration test. Any ideas?

Fixes #2327.