### PR TITLE
Add ignores for deprecated analyzer APIs

### DIFF
--- a/build_modules/lib/src/errors.dart
+++ b/build_modules/lib/src/errors.dart
@@ -92,6 +92,7 @@ Please check the following imports:\n
 Future<String> _missingImportMessage(
     AssetId sourceId, AssetId missingId, AssetReader reader) async {
   var contents = await reader.readAsString(sourceId);
+  // ignore: deprecated_member_use
   var parsed = parseDirectives(contents, suppressErrors: true);
   var import =
       parsed.directives.whereType<UriBasedDirective>().firstWhere((directive) {

--- a/build_modules/lib/src/module_library.dart
+++ b/build_modules/lib/src/module_library.dart
@@ -133,7 +133,7 @@ class ModuleLibrary {
   /// Parse the directives from [source] and compute the library information.
   static ModuleLibrary fromSource(AssetId id, String source) {
     final isLibDir = id.path.startsWith('lib/');
-  // ignore: deprecated_member_use
+    // ignore: deprecated_member_use
     final parsed = parseCompilationUnit(source,
         name: id.path, suppressErrors: true, parseFunctionBodies: false);
     // Packages within the SDK but published might have libraries that can't be

--- a/build_modules/lib/src/module_library.dart
+++ b/build_modules/lib/src/module_library.dart
@@ -133,6 +133,7 @@ class ModuleLibrary {
   /// Parse the directives from [source] and compute the library information.
   static ModuleLibrary fromSource(AssetId id, String source) {
     final isLibDir = id.path.startsWith('lib/');
+  // ignore: deprecated_member_use
     final parsed = parseCompilationUnit(source,
         name: id.path, suppressErrors: true, parseFunctionBodies: false);
     // Packages within the SDK but published might have libraries that can't be

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -128,6 +128,7 @@ String assetPath(AssetId assetId) =>
 /// Returns all the directives from a Dart library that can be resolved to an
 /// [AssetId].
 Set<AssetId> _parseDirectives(String content, AssetId from) =>
+    // ignore: deprecated_member_use
     HashSet.of(parseDirectives(content, suppressErrors: true)
         .directives
         .whereType<UriBasedDirective>()

--- a/build_vm_compilers/lib/src/vm_entrypoint_builder.dart
+++ b/build_vm_compilers/lib/src/vm_entrypoint_builder.dart
@@ -83,6 +83,7 @@ Future<bool> _isAppEntryPoint(AssetId dartId, AssetReader reader) async {
   assert(dartId.extension == '.dart');
   // Skip reporting errors here, dartdevc will report them later with nicer
   // formatting.
+  // ignore: deprecated_member_use
   var parsed = parseCompilationUnit(await reader.readAsString(dartId),
       suppressErrors: true);
   // Allow two or fewer arguments so that entrypoints intended for use with

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -113,6 +113,7 @@ Future<bool> _isAppEntryPoint(AssetId dartId, AssetReader reader) async {
   assert(dartId.extension == '.dart');
   // Skip reporting errors here, dartdevc will report them later with nicer
   // formatting.
+  // ignore: deprecated_member_use
   var parsed = parseCompilationUnit(await reader.readAsString(dartId),
       suppressErrors: true);
   // Allow two or fewer arguments so that entrypoints intended for use with


### PR DESCRIPTION
We will need to migrate these to newer APIs or rewrite. For now unblock
submits by adding ignores.