### PR TITLE
Cache modules while writing them

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.1.4
+version: 1.1.5-dev
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build

--- a/build_modules/lib/src/meta_module_builder.dart
+++ b/build_modules/lib/src/meta_module_builder.dart
@@ -3,13 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 
 import 'common.dart';
 import 'meta_module.dart';
+import 'module_cache.dart';
 import 'module_library_builder.dart';
 import 'platform.dart';
 
@@ -50,6 +50,7 @@ class MetaModuleBuilder implements Builder {
         buildStep, libraryAssets, strategy, _platform);
     var id = AssetId(
         buildStep.inputId.package, 'lib/${metaModuleExtension(_platform)}');
-    await buildStep.writeAsString(id, json.encode(metaModule.toJson()));
+    var metaModules = await buildStep.fetchResource(metaModuleCache);
+    await metaModules.write(id, buildStep, metaModule);
   }
 }

--- a/build_modules/lib/src/module_builder.dart
+++ b/build_modules/lib/src/module_builder.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:build/build.dart';
 
@@ -51,8 +50,10 @@ class ModuleBuilder implements Builder {
       }
     }
     if (outputModule == null) return;
-    await buildStep.writeAsString(
+    final modules = await buildStep.fetchResource(moduleCache);
+    await modules.write(
         buildStep.inputId.changeExtension(moduleExtension(_platform)),
-        jsonEncode(outputModule.toJson()));
+        buildStep,
+        outputModule);
   }
 }


### PR DESCRIPTION
Today every module which is read must be deserialized at least once from
the asset. If the module was also written during the same build we can
skip this step by writing to the cache directly in addition to the
asset.

- Update the interface to operate on `List<int>` instead of a `Map` and
  let the client deal with all aspects of serialization. This will be
  useful if we want to promote this class to `package:build`.
- Add a `toBytes` argument and a `write` method.
- Write through the cache in `ModuleBuilder` and `MetaModuleBuilder`.