### PR TITLE
Fix per breaking change to HttpRequest and HttpClientResponse

### DIFF
--- a/_test/test/serve_integration_test.dart
+++ b/_test/test/serve_integration_test.dart
@@ -39,7 +39,7 @@ void main() {
     var request = await httpClient.get('localhost', 8080, 'dir_without_index/');
     var firstResponse = await request.close();
     expect(firstResponse.statusCode, HttpStatus.notFound);
-    expect(await utf8.decodeStream(firstResponse),
+    expect(await utf8.decodeStream(firstResponse.cast<List<int>>()),
         contains('dir_without_index/hello.txt'));
   });
 


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900