### PR TITLE
Fix the app digest path in the bootstrap

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.2
+
+- Fix hot restart bootstrapping logic for dart scripts that live in a
+  different directory than the html file.
+
 ## 2.1.1
 
 - Prepare for source map change from dartdevc, don't modify relative paths in

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -267,11 +267,12 @@ var _currentDirectory = (function () {
 /// Sets up `window.$dartLoader` based on [modulePaths].
 String _dartLoaderSetup(Map<String, String> modulePaths, String appDigests) =>
     '''
+$_currentDirectoryScript
 $_baseUrlScript
 let modulePaths = ${const JsonEncoder.withIndent(" ").convert(modulePaths)};
 if(!window.\$dartLoader) {
    window.\$dartLoader = {
-     appDigests: '$appDigests',
+     appDigests: _currentDirectory + '$appDigests',
      moduleIdToUrl: new Map(),
      urlToModuleId: new Map(),
      rootDirectories: new Array(),

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.1.1
+version: 2.1.2
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
Previously we would just insert the path relative to script file, but it really needs to be relative to the page being served. This actually changes it to end up doing an absolute uri request, but it will be dynamically built based on where the script is served in relation to the server root (so effectively the same as the relative path from the app). It is the identical logic we use for injecting the bootstrap script which has the same problem.

Fixes https://github.com/dart-lang/build/issues/2333