### PR TITLE
Fix per breaking change to HttpRequest and HttpClientResponse

### DIFF
--- a/build_runner/test/integration_tests/utils/build_descriptor.dart
+++ b/build_runner/test/integration_tests/utils/build_descriptor.dart
@@ -321,7 +321,7 @@ class BuildServer {
     final request = await _client.get('localhost', 8080, path);
     final response = await request.close();
     expect(response.statusCode, 200);
-    expect(await utf8.decodeStream(response), content);
+    expect(await utf8.decodeStream(response.cast<List<int>>()), content);
   }
 
   StreamQueue<String> get stdout => _process.stdout;


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

dart-lang/sdk#36900