### PR TITLE
Fix documentation of testBuilder and checkOutputs

### DIFF
--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -18,7 +18,7 @@ AssetId _passThrough(AssetId id) => id;
 
 /// Validates that [actualAssets] matches the expected [outputs].
 ///
-/// The keys in [outputs] should be serialized AssetIds in the form
+/// The keys in [outputs] should be serialized [AssetId]s in the form
 /// `'package|path'`. The values should match the expected content for the
 /// written asset and may be a String (for `writeAsString`), a `List<int>` (for
 /// `writeAsBytes`) or a [Matcher] for a String or bytes.
@@ -30,7 +30,7 @@ AssetId _passThrough(AssetId id) => id;
 /// process, they will be ignored. Only the IDs in [actualAssets] are checked.
 ///
 /// If assets are written to a location that does not match their logical
-/// association to a package pass `[mapAssetIds]` to translate from the logical
+/// association to a package pass [mapAssetIds] to translate from the logical
 /// location to the actual written location.
 void checkOutputs(
     Map<String, /*List<int>|String|Matcher<String|List<int>>*/ dynamic> outputs,
@@ -76,13 +76,13 @@ void checkOutputs(
 ///
 /// The test environment supplies in-memory build [sourceAssets] to the builders
 /// under test. [outputs] may be optionally provided to verify that the builders
-/// produce the expected output. If outputs is omitted the only validation this
-/// method provides is that the build did not `throw`.
+/// produce the expected output. If [outputs] is omitted the only validation
+/// this method provides is that the build did not `throw`.
 ///
-/// [generateFor] or the [isInput] call back can specify which assets should be
-/// given as inputs to the builder. These can be omitted if every asset in
-/// [sourceAssets] should be considered an input. [isInput] precedent over
-/// [generateFor] if both are provided.
+/// Either [generateFor] or the [isInput] callback can specify which assets
+/// should be given as inputs to the builder. These can be omitted if every
+/// asset in [sourceAssets] should be considered an input. [generateFor] is
+/// ignored if both [isInput] and [generateFor] are provided.
 ///
 /// The keys in [sourceAssets] and [outputs] are paths to file assets and the
 /// values are file contents. The paths must use the following format:
@@ -95,12 +95,14 @@ void checkOutputs(
 ///
 /// If a [reader] is provided, then any asset not in [sourceAssets] will be
 /// read from the provided reader. This allows you to more easily provide
-/// entire packages source to the test, instead of mocking them out, for
+/// sources of entire packages to the test, instead of mocking them out, for
 /// example, this exposes all assets available to the test itself:
 ///
 ///
-///   testBuilder(yourBuilder, {}/* test assets here */,
-///       reader: await PackageAssetReader.currentIsolate());
+/// ```dart
+/// testBuilder(yourBuilder, {}/* test assets here */,
+///     reader: await PackageAssetReader.currentIsolate());
+/// ```
 ///
 /// Callers may optionally provide a [writer] to stub different behavior or do
 /// more complex validation than what is possible with [outputs].


### PR DESCRIPTION
This fixes documentation for [testBuilder](https://pub.dev/documentation/build_test/latest/build_test/testBuilder.html):

* grammar
* broken example code block
* "[isInput] precedent over [generateFor] if both are provided" makes it sound like both are used, and one takes precedent. In fact, `generateFor` is just ignored if `isInput` is provided.

And documentation for [checkOutputs](https://pub.dev/documentation/build_test/latest/build_test/checkOutputs.html):

* formatting
* links