### PR TITLE
Improve failure for dart2js args

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+- Improve error message when `dart2js_args` is configured improperly.
+
 ## 2.1.2
 
 - Fix hot restart bootstrapping logic for dart scripts that live in a

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -68,15 +68,16 @@ class WebEntrypointBuilder implements Builder {
             'Only `dartdevc` and `dart2js` are supported.');
     }
 
-    var dart2JsArgs =
-        options.config[_dart2jsArgs]?.cast<String>() ?? const <String>[];
-    if (dart2JsArgs is! List<String>) {
-      throw ArgumentError.value(dart2JsArgs, _dart2jsArgs,
-          'Expected a list of strings, but got a ${dart2JsArgs.runtimeType}:');
+    if (options.config[_dart2jsArgs] is! List) {
+      throw ArgumentError.value(options.config[_dart2jsArgs], _dart2jsArgs,
+          'Expected a list for $_dart2jsArgs.');
     }
+    var dart2JsArgs = (options.config[_dart2jsArgs] as List)
+            ?.map((arg) => '$arg')
+            ?.toList() ??
+        const <String>[];
 
-    return WebEntrypointBuilder(compiler,
-        dart2JsArgs: dart2JsArgs as List<String>);
+    return WebEntrypointBuilder(compiler, dart2JsArgs: dart2JsArgs);
   }
 
   @override

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.1.2
+version: 2.1.3
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
Fixes #2353

Since the yaml parsing may give us something other than a `String` we
can use `toString` instead of a cast which leaves us as agnostic towards
the args that dart2js allows as possible. With this change the user will
see an output from dart2js usage with `Error: Unknown option '-3'.`.
This is still a little confusing because the `-03` turned into `-3`.