### PR TITLE
Allow analyzer 0.37.0 in all packages

### DIFF
--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -12,8 +12,6 @@ dev_dependencies:
     path: pkgs/provides_builder/
 
 dependency_overrides:
-  # Ensures tests run on the latest analyzer, will revert before submitting.
-  analyzer: ^0.37.0
   build:
     path: ../build
   build_config:

--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -5,13 +5,15 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dev_dependencies:
-  analyzer: ">=0.30.0 <0.37.0"
+  analyzer: ">=0.30.0 <0.38.0"
   path: ^1.4.2
   test: ^1.6.2
   provides_builder:
     path: pkgs/provides_builder/
 
 dependency_overrides:
+  # Ensures tests run on the latest analyzer, will revert before submitting.
+  analyzer: ^0.37.0
   build:
     path: ../build
   build_config:
@@ -34,3 +36,4 @@ dependency_overrides:
     path: ../build_web_compilers
   scratch_space:
     path: ../scratch_space
+

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.5
+
+- Allow analyzer version 0.37.0.
+
 ## 1.1.4
 
 - Internal cleanup: use "strict raw types".

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.1.5-dev
+version: 1.1.5
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.35.0 <0.37.0'
+  analyzer: '>=0.35.0 <0.38.0'
   async: ">=1.13.3 <3.0.0"
   convert: ^2.0.0
   crypto: ">=0.9.2 <3.0.0"
@@ -24,3 +24,7 @@ dev_dependencies:
   build_vm_compilers: ">=0.1.0 <2.0.0"
   pedantic: ^1.0.0
   test: ^1.2.0
+
+# Ensures tests run on the latest analyzer, will revert before submitting.
+dependency_overrides:
+  analyzer: ^0.37.0

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -24,7 +24,3 @@ dev_dependencies:
   build_vm_compilers: ">=0.1.0 <2.0.0"
   pedantic: ^1.0.0
   test: ^1.2.0
-
-# Ensures tests run on the latest analyzer, will revert before submitting.
-dependency_overrides:
-  analyzer: ^0.37.0

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+- Allow analyzer version 0.37.0.
+
 ## 2.3.0
 
 - Add a `hasMain` boolean to the `ModuleLibrary` class.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.3.0
+version: 2.3.1
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
-  analyzer: ">0.30.0 <0.37.0"
+  analyzer: ">0.30.0 <0.38.0"
   async: ^2.0.0
   bazel_worker: ^0.1.20
   build: ">=0.12.3 <2.0.0"
@@ -34,3 +34,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+# Ensures tests run on the latest analyzer, will revert before submitting.
+dependency_overrides:
+  analyzer: ^0.37.0

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -34,7 +34,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-# Ensures tests run on the latest analyzer, will revert before submitting.
-dependency_overrides:
-  analyzer: ^0.37.0

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6
+
+- Allow analyzer version 0.37.0.
+
 ## 1.0.5
 
 - Fix a race condition where some assets may be resolved with missing

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.0.5
+version: 1.0.6
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.35.0 <0.37.0'
+  analyzer: '>=0.35.0 <0.38.0'
   build: ">=1.1.0 <1.2.0"
   crypto: ^2.0.0
   graphs: ^0.2.0
@@ -19,3 +19,7 @@ dev_dependencies:
   build_test: ^0.10.1
   build_runner: ^1.0.0
   build_vm_compilers: ">=0.1.0 <2.0.0"
+
+# Ensures tests run on the latest analyzer, will revert before submitting.
+dependency_overrides:
+  analyzer: ^0.37.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -19,7 +19,3 @@ dev_dependencies:
   build_test: ^0.10.1
   build_runner: ^1.0.0
   build_vm_compilers: ">=0.1.0 <2.0.0"
-
-# Ensures tests run on the latest analyzer, will revert before submitting.
-dependency_overrides:
-  analyzer: ^0.37.0

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   watcher: ^0.9.7
 
 dev_dependencies:
-  analyzer: ">=0.35.4 <0.37.0"
+  analyzer: ">=0.35.4 <0.38.0"
   build_runner: ^1.3.3
   build_vm_compilers: '>=0.1.2 <2.0.0'
   collection: ^1.14.0

--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Allow analyzer version 0.37.0.
+
 ## 1.0.0
 
 - Support build_modules 2.0.0

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -21,7 +21,3 @@ dev_dependencies:
   test_descriptor: ^1.1.0
   _test_common:
     path: ../_test_common
-
-# Ensures tests run on the latest analyzer, will revert before submitting.
-dependency_overrides:
-  analyzer: ^0.37.0

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_vm_compilers
-version: 1.0.0
+version: 1.0.1
 description: Builder implementations wrapping Dart VM compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.3.0-dev.0.1 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.30.0 <0.37.0"
+  analyzer: ">=0.30.0 <0.38.0"
   build: '>=0.12.0 <2.0.0'
   build_config: ">=0.3.0 <0.5.0"
   build_modules: ^2.0.0
@@ -21,3 +21,7 @@ dev_dependencies:
   test_descriptor: ^1.1.0
   _test_common:
     path: ../_test_common
+
+# Ensures tests run on the latest analyzer, will revert before submitting.
+dependency_overrides:
+  analyzer: ^0.37.0

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.4
+
+- Allow analyzer version 0.37.0.
+
 ## 2.1.3
 
 - Improve error message when `dart2js_args` is configured improperly.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -35,7 +35,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-# Ensures tests run on the latest analyzer, will revert before submitting.
-dependency_overrides:
-  analyzer: ^0.37.0

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.1.3
+version: 2.1.4
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.30.0 <0.37.0"
+  analyzer: ">=0.30.0 <0.38.0"
   archive: ^2.0.0
   bazel_worker: ^0.1.18
   build: ">=0.12.8 <2.0.0"
@@ -35,3 +35,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+# Ensures tests run on the latest analyzer, will revert before submitting.
+dependency_overrides:
+  analyzer: ^0.37.0


### PR DESCRIPTION
Overriding the versions for now so we can run tests with the new version, will push another commit that removes the overrides if everything is happy.

Closes https://github.com/dart-lang/build/issues/2346