### PR TITLE
Run prebuilt configurable_uri_test on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ build: off
 test_script:
   - cd _test
   - pub run test -j 1
+  - pub run build_runner test -- -p vm test/configurable_uri_test.dart
   - cd ..\build_resolvers
   - pub run test
   - cd ..\build_runner


### PR DESCRIPTION
Ensures that there is at least one test covering running on the VM with
`build_vm_compilers` to get coverage for changes like #2350