### PR TITLE
Drop trailing newline

### DIFF
--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -34,4 +34,3 @@ dependency_overrides:
     path: ../build_web_compilers
   scratch_space:
     path: ../scratch_space
-


### PR DESCRIPTION
No need for a blank line at the end of any text file, and this triggers
a warning in my git prechecks.