### PR TITLE
DDC entrypoint update

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.5
+
+- Add pre-emptive support for an upcoming breaking change in ddc
+  around entrypoint naming.
+
 ## 2.1.4
 
 - Allow analyzer version 0.37.0.

--- a/build_web_compilers/lib/src/ddc_names.dart
+++ b/build_web_compilers/lib/src/ddc_names.dart
@@ -2,10 +2,22 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Escape [name] to make it into a valid identifier.
+import 'package:path/path.dart' as _p;
+
+/// Transforms a path to a valid JS identifier.
 ///
-/// This is copied from
-/// https://github.com/dart-lang/sdk/blob/300fd66f5c5e7497674ea4dd9fd21be91ee3c71e/pkg/dev_compiler/lib/src/analyzer/code_generator.dart#L6390
+/// This logic must be synchronized with [pathToJSIdentifier] in DDC at:
+/// pkg/dev_compiler/lib/src/compiler/module_builder.dart
+String pathToJSIdentifier(String path) {
+  path = _p.normalize(path);
+  if (path.startsWith('/') || path.startsWith('\\')) {
+    path = path.substring(1, path.length);
+  }
+  return toJSIdentifier(
+      path.replaceAll('\\', '__').replaceAll('/', '__').replaceAll('..', '__'));
+}
+
+/// Escape [name] to make it into a valid identifier.
 String toJSIdentifier(String name) {
   if (name.isEmpty) return r'$';
 

--- a/build_web_compilers/lib/src/ddc_names.dart
+++ b/build_web_compilers/lib/src/ddc_names.dart
@@ -8,6 +8,10 @@ import 'package:path/path.dart' as p;
 ///
 /// This logic must be synchronized with [pathToJSIdentifier] in DDC at:
 /// pkg/dev_compiler/lib/src/compiler/module_builder.dart
+/// 
+/// For backwards compatibility, if this pattern is changed, 
+/// [dev_compiler_bootstrap.dart] must be updated to accept both old and new
+/// patterns.
 String pathToJSIdentifier(String path) {
   path = p.normalize(path);
   if (path.startsWith('/') || path.startsWith('\\')) {

--- a/build_web_compilers/lib/src/ddc_names.dart
+++ b/build_web_compilers/lib/src/ddc_names.dart
@@ -8,8 +8,8 @@ import 'package:path/path.dart' as p;
 ///
 /// This logic must be synchronized with [pathToJSIdentifier] in DDC at:
 /// pkg/dev_compiler/lib/src/compiler/module_builder.dart
-/// 
-/// For backwards compatibility, if this pattern is changed, 
+///
+/// For backwards compatibility, if this pattern is changed,
 /// [dev_compiler_bootstrap.dart] must be updated to accept both old and new
 /// patterns.
 String pathToJSIdentifier(String path) {

--- a/build_web_compilers/lib/src/ddc_names.dart
+++ b/build_web_compilers/lib/src/ddc_names.dart
@@ -13,8 +13,11 @@ String pathToJSIdentifier(String path) {
   if (path.startsWith('/') || path.startsWith('\\')) {
     path = path.substring(1, path.length);
   }
-  return toJSIdentifier(
-      path.replaceAll('\\', '__').replaceAll('/', '__').replaceAll('..', '__'));
+  return toJSIdentifier(path
+      .replaceAll('\\', '__')
+      .replaceAll('/', '__')
+      .replaceAll('..', '__')
+      .replaceAll('-', '_'));
 }
 
 /// Escape [name] to make it into a valid identifier.

--- a/build_web_compilers/lib/src/ddc_names.dart
+++ b/build_web_compilers/lib/src/ddc_names.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as _p;
+import 'package:path/path.dart' as p;
 
 /// Transforms a path to a valid JS identifier.
 ///

--- a/build_web_compilers/lib/src/ddc_names.dart
+++ b/build_web_compilers/lib/src/ddc_names.dart
@@ -10,7 +10,7 @@ import 'package:path/path.dart' as p;
 /// pkg/dev_compiler/lib/src/compiler/module_builder.dart
 ///
 /// For backwards compatibility, if this pattern is changed,
-/// [dev_compiler_bootstrap.dart] must be updated to accept both old and new
+/// dev_compiler_bootstrap.dart must be updated to accept both old and new
 /// patterns.
 String pathToJSIdentifier(String path) {
   path = p.normalize(path);

--- a/build_web_compilers/lib/src/ddc_names.dart
+++ b/build_web_compilers/lib/src/ddc_names.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart' as _p;
 /// This logic must be synchronized with [pathToJSIdentifier] in DDC at:
 /// pkg/dev_compiler/lib/src/compiler/module_builder.dart
 String pathToJSIdentifier(String path) {
-  path = _p.basenameWithoutExtension(_p.normalize(path));
+  path = p.normalize(path);
   if (path.startsWith('/') || path.startsWith('\\')) {
     path = path.substring(1, path.length);
   }

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -62,10 +62,10 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
   // See https://github.com/dart-lang/sdk/issues/27262 for the root issue
   // which will allow us to not rely on the naming schemes that dartdevc uses
   // internally, but instead specify our own.
-  var simpleAppModuleScope = toJSIdentifier(
+  var oldAppModuleScope = toJSIdentifier(
       _context.withoutExtension(_context.basename(buildStep.inputId.path)));
 
-  // Like above but with a more modern module-relative entrypoint.
+  // Like above but with a package-relative entrypoint.
   var appModuleScope =
       pathToJSIdentifier(_context.withoutExtension(buildStep.inputId.path));
 
@@ -106,7 +106,7 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
         ..write(_requireJsConfig)
         ..write(_appBootstrap(
             bootstrapModuleName, appModuleName, appModuleScope, appModuleUri,
-            oldModuleScope: simpleAppModuleScope));
+            oldModuleScope: oldAppModuleScope));
 
   await buildStep.writeAsString(bootstrapId, bootstrapContent.toString());
 

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -62,8 +62,12 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
   // See https://github.com/dart-lang/sdk/issues/27262 for the root issue
   // which will allow us to not rely on the naming schemes that dartdevc uses
   // internally, but instead specify our own.
-  var appModuleScope = toJSIdentifier(
+  var simpleAppModuleScope = toJSIdentifier(
       _context.withoutExtension(_context.basename(buildStep.inputId.path)));
+
+  // Like above but with a more modern module-relative entrypoint.
+  var appModuleScope =
+      pathToJSIdentifier(_context.withoutExtension(buildStep.inputId.path));
 
   // Map from module name to module path for custom modules.
   var modulePaths = SplayTreeMap.of(
@@ -101,7 +105,11 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
                 from: _p.url.dirname(bootstrapId.path))))
         ..write(_requireJsConfig)
         ..write(_appBootstrap(
-            bootstrapModuleName, appModuleName, appModuleScope, appModuleUri));
+            bootstrapModuleName,
+            appModuleName,
+            appModuleScope,
+            appModuleUri,
+            oldModuleScope = simpleAppModuleScope));
 
   await buildStep.writeAsString(bootstrapId, bootstrapContent.toString());
 
@@ -158,14 +166,15 @@ Future<List<AssetId>> _ensureTransitiveJsModules(
 ///
 /// Also performs other necessary initialization.
 String _appBootstrap(String bootstrapModuleName, String moduleName,
-        String moduleScope, String appModuleUri) =>
+        String moduleScope, String appModuleUri,
+        {String oldModuleScope}) =>
     '''
 define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_sdk) {
   dart_sdk.dart.setStartAsyncSynchronously(true);
   dart_sdk._isolate_helper.startRootIsolate(() => {}, []);
   $_initializeTools
   $_mainExtensionMarker
-  app.$moduleScope.main();
+  (app.$moduleScope || app.$oldModuleScope).main();
   var bootstrap = {
       hot\$onChildUpdate: function(childName, child) {
         // Special handling for the multi-root scheme uris. We need to strip

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.1.4
+version: 2.1.5
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -49,7 +49,7 @@ main() {
           // Requires the top level module and dart sdk.
           contains('define("index.dart.bootstrap", ["web/index", "dart_sdk"]'),
           // Calls main on the top level module.
-          contains('index.main()'),
+          contains('(app.web__index || app.index).main()'),
           isNot(contains('lib/a')),
         ])),
       };
@@ -82,7 +82,7 @@ main() {
           // And `b.dart` is the application, but its module is `web/a`.
           contains('define("b.dart.bootstrap", ["web/a", "dart_sdk"]'),
           // Calls main on the `b.dart` library, not the `a.dart` library.
-          contains('app.b.main()'),
+          contains('(app.web__b || app.b).main()'),
         ])),
         'a|web/b.digests': isNotEmpty,
         'a|web/b.dart.js': isNotEmpty,


### PR DESCRIPTION
An upcoming SDK release changes DDC's entrypoints to be package-relative, which will break compatibility with older build_web_compilers versions. This change makes build_web_compilers compatible with both the old and new entrypoints. 

See: https://dart-review.googlesource.com/c/sdk/+/108942

Fixes https://github.com/dart-lang/build/issues/2395