### PR TITLE
invalidate the snapshot when build_runner or build_daemon are updated

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.3
+
+- Pre-emptively re-snapshot when the `build_runner` or `build_daemon`
+  packages are updated.
+
 ## 1.6.2
 
 - Support the latest `build_daemon` version.

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -138,9 +138,7 @@ Future<int> _createSnapshotIfNeeded(Logger logger) async {
     if (!await assetGraphFile.exists()) {
       await snapshotFile.delete();
       logger.warning('Deleted previous snapshot due to missing asset graph.');
-    }
-
-    if (!await _checkImportantPackageDeps()) {
+    } else if (!await _checkImportantPackageDeps()) {
       await snapshotFile.delete();
       logger.warning('Deleted previous snapshot due to core package update');
     }

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -131,15 +131,16 @@ Future<int> generateAndRun(List<String> args, {Logger logger}) async {
 Future<int> _createSnapshotIfNeeded(Logger logger) async {
   var assetGraphFile = File(assetGraphPathFor(scriptSnapshotLocation));
   var snapshotFile = File(scriptSnapshotLocation);
+  var snapshotExists = await snapshotFile.exists();
 
   // If we failed to serialize an asset graph for the snapshot, then we don't
   // want to re-use it because we can't check if it is up to date.
-  if (!await assetGraphFile.exists() && await snapshotFile.exists()) {
+  if (snapshotExists && !await assetGraphFile.exists()) {
     await snapshotFile.delete();
     logger.warning('Deleted previous snapshot due to missing asset graph.');
   }
 
-  if (!await _checkImportantPackageDeps()) {
+  if (snapshotExists && !await _checkImportantPackageDeps()) {
     await snapshotFile.delete();
     logger.warning('Deleted previous snapshot due to core package update');
   }

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -131,18 +131,19 @@ Future<int> generateAndRun(List<String> args, {Logger logger}) async {
 Future<int> _createSnapshotIfNeeded(Logger logger) async {
   var assetGraphFile = File(assetGraphPathFor(scriptSnapshotLocation));
   var snapshotFile = File(scriptSnapshotLocation);
-  var snapshotExists = await snapshotFile.exists();
 
-  // If we failed to serialize an asset graph for the snapshot, then we don't
-  // want to re-use it because we can't check if it is up to date.
-  if (snapshotExists && !await assetGraphFile.exists()) {
-    await snapshotFile.delete();
-    logger.warning('Deleted previous snapshot due to missing asset graph.');
-  }
+  if (await snapshotFile.exists()) {
+    // If we failed to serialize an asset graph for the snapshot, then we don't
+    // want to re-use it because we can't check if it is up to date.
+    if (!await assetGraphFile.exists()) {
+      await snapshotFile.delete();
+      logger.warning('Deleted previous snapshot due to missing asset graph.');
+    }
 
-  if (snapshotExists && !await _checkImportantPackageDeps()) {
-    await snapshotFile.delete();
-    logger.warning('Deleted previous snapshot due to core package update');
+    if (!await _checkImportantPackageDeps()) {
+      await snapshotFile.delete();
+      logger.warning('Deleted previous snapshot due to core package update');
+    }
   }
 
   String stderr;

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.6.2
+version: 1.6.3
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Related to https://github.com/dart-lang/build/issues/1929

I ended up going with the build_runner/build_daemon version check since the error handling was going to get pretty gnarly once I looked at what it would actually take.

The check is done by examining where a fake uri resolves to for each package, since that actually catches some cases the version check alone wouldn't catch and it doesn't require reading/parsing any files.

Note that this will not catch cases where you have a path override on these packages as that path won't ever change even if the packages do, but that should only affect us internally.