### PR TITLE
Allow overriding the kernel worker target name

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+- Allow overriding the target name passed to the kernel worker.
+
 ## 2.3.1
 
 - Allow analyzer version 0.37.0.

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -76,8 +76,9 @@ class KernelBuilder implements Builder {
       String librariesPath,
       bool useIncrementalCompiler,
       String platformSdk,
-      this.kernelTargetName})
+      String kernelTargetName})
       : platformSdk = platformSdk ?? sdkDir,
+        kernelTargetName = kernelTargetName ?? platform.name,
         librariesPath = librariesPath ??
             p.join(platformSdk ?? sdkDir, 'lib', 'libraries.json'),
         useIncrementalCompiler = useIncrementalCompiler ?? false,
@@ -103,7 +104,7 @@ class KernelBuilder implements Builder {
           buildStep: buildStep,
           summaryOnly: summaryOnly,
           outputExtension: outputExtension,
-          targetName: kernelTargetName ?? platform.name,
+          targetName: kernelTargetName,
           dartSdkDir: platformSdk,
           sdkKernelPath: sdkKernelPath,
           librariesPath: librariesPath,

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -63,6 +63,11 @@ class KernelBuilder implements Builder {
   /// If not provided, defaults to "lib/libraries.json" in the sdk directory.
   final String librariesPath;
 
+  /// The `--target` argument passed to the kernel worker.
+  ///
+  /// Optional. When omitted the [platform] name is used.
+  final String kernelTargetName;
+
   KernelBuilder(
       {@required this.platform,
       @required this.summaryOnly,
@@ -70,7 +75,8 @@ class KernelBuilder implements Builder {
       @required this.outputExtension,
       String librariesPath,
       bool useIncrementalCompiler,
-      String platformSdk})
+      String platformSdk,
+      this.kernelTargetName})
       : platformSdk = platformSdk ?? sdkDir,
         librariesPath = librariesPath ??
             p.join(platformSdk ?? sdkDir, 'lib', 'libraries.json'),
@@ -97,7 +103,7 @@ class KernelBuilder implements Builder {
           buildStep: buildStep,
           summaryOnly: summaryOnly,
           outputExtension: outputExtension,
-          platform: platform,
+          targetName: kernelTargetName ?? platform.name,
           dartSdkDir: platformSdk,
           sdkKernelPath: sdkKernelPath,
           librariesPath: librariesPath,
@@ -120,7 +126,7 @@ Future<void> _createKernel(
     @required BuildStep buildStep,
     @required bool summaryOnly,
     @required String outputExtension,
-    @required DartPlatform platform,
+    @required String targetName,
     @required String dartSdkDir,
     @required String sdkKernelPath,
     @required String librariesPath,
@@ -152,7 +158,7 @@ Future<void> _createKernel(
         request,
         module,
         kernelDeps,
-        platform,
+        targetName,
         dartSdkDir,
         sdkKernelPath,
         librariesPath,
@@ -278,7 +284,7 @@ Future<void> _addRequestArguments(
     WorkRequest request,
     Module module,
     Iterable<AssetId> transitiveKernelDeps,
-    DartPlatform platform,
+    String targetName,
     String sdkDir,
     String sdkKernelPath,
     String librariesPath,
@@ -303,7 +309,7 @@ Future<void> _addRequestArguments(
     '--multi-root-scheme=$multiRootScheme',
     '--exclude-non-sources',
     summaryOnly ? '--summary-only' : '--no-summary-only',
-    '--target=${platform.name}',
+    '--target=$targetName',
     '--libraries-file=${p.toUri(librariesPath)}',
     if (useIncrementalCompiler) ...[
       '--reuse-compiler-result',
@@ -319,7 +325,7 @@ Future<void> _addRequestArguments(
     Input()
       ..path = '${Uri.file(p.join(sdkDir, sdkKernelPath))}'
       // Sdk updates fully invalidate the build anyways.
-      ..digest = md5.convert(utf8.encode(platform.name)).bytes,
+      ..digest = md5.convert(utf8.encode(targetName)).bytes,
   ]);
 }
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.3.1
+version: 2.4.0
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules


### PR DESCRIPTION
Fixes #2367

By default the DartPlatform name is used, but in the case of
`flutter_web` they have a distinct platform from `ddc` but need to
compile the kernel as if it was ddc, `flutter_web` is not a target that
the kernel worker understands.