### PR TITLE
Ensure the daemonProcess exits

### DIFF
--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -64,6 +64,7 @@ main() {
   tearDown(() async {
     stdoutLines = null;
     daemonProcess?.kill(ProcessSignal.sigkill);
+    await daemonProcess?.exitCode;
     await runPub('a', 'run', args: ['build_runner', 'clean']);
   });
 


### PR DESCRIPTION
We have been seeing somewhat frequent flakes like this:
https://travis-ci.org/dart-lang/build/builds/563298251

The theory is that the daemon process is not fully exiting and therefore is causing conflicting options.
