### PR TITLE
only emit severe logs during daemon startup to stderr

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.4
+
+- Fix an issue where warning logs on startup were accidentally upgraded to
+  severe logs in the daemon mode.
+
 ## 1.6.3
 
 - Pre-emptively re-snapshot when the `build_runner` or `build_daemon`

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -59,7 +59,7 @@ Future<void> main(List<String> args) async {
     // Simple logs only in daemon mode. These get converted into info or
     // severe logs by the client.
     logListener = Logger.root.onRecord.listen((record) {
-      if (record.level > Level.INFO) {
+      if (record.level >= Level.SEVERE) {
         var buffer = StringBuffer(record.message);
         if (record.error != null) buffer.writeln(record.error);
         if (record.stackTrace != null) buffer.writeln(record.stackTrace);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.6.3
+version: 1.6.4
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Anything on stderr gets treated as a SEVERE log during daemon startup, so we should only emit severe logs there.

As some backstory here until the actual connection with the daemon is established we don't have proper logs, so we rely on just stdout/stderr to communicate the severity of the log. So we only have a binary choice between info and severe.

cc @jacob314 