### PR TITLE
change the ordering of the concatenated kernel files

### DIFF
--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.2
+
+- Fix kernel concat ordering to be topological instead of reverse
+  topological.
+
 ## 1.0.1
 
 - Allow analyzer version 0.37.0.

--- a/build_vm_compilers/lib/src/vm_entrypoint_builder.dart
+++ b/build_vm_compilers/lib/src/vm_entrypoint_builder.dart
@@ -64,7 +64,7 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
 
       var transitiveKernelModules = [
         module.primarySource.changeExtension(vmKernelModuleExtension)
-      ].followedBy(transitiveModules.map(
+      ].followedBy(transitiveModules.reversed.map(
           (m) => m.primarySource.changeExtension(vmKernelModuleExtension)));
       var appContents = <int>[];
       for (var dependencyId in transitiveKernelModules) {

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_vm_compilers
-version: 1.0.1
+version: 1.0.2
 description: Builder implementations wrapping Dart VM compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers

--- a/build_vm_compilers/test/vm_kernel_integration_test.dart
+++ b/build_vm_compilers/test/vm_kernel_integration_test.dart
@@ -82,6 +82,6 @@ void printAsync() async {
 
       expect(runResult.exitCode, 0, reason: runResult.stderr as String);
       expect(runResult.stdout, 'before\nrunning\nafter\n');
-    }, skip: 'https://github.com/dart-lang/sdk/issues/34852');
+    });
   });
 }


### PR DESCRIPTION
Kernel files are ordered using topological instead of reverse topological order, see https://github.com/dart-lang/sdk/issues/37533 for context