### PR TITLE
Add a check for empty kernel files

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1
+
+- Require non-empty output from kernel build steps.
+
 ## 2.4.0
 
 - Allow overriding the target name passed to the kernel worker.

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -186,7 +186,7 @@ Future<void> _createKernel(
     }
 
     // Copy the output back using the buildStep.
-    await scratchSpace.copyOutput(outputId, buildStep);
+    await scratchSpace.copyOutput(outputId, buildStep, requireContent: true);
   } finally {
     await packagesFile.parent.delete(recursive: true);
   }

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.4.0
+version: 2.4.1
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
@@ -22,7 +22,7 @@ dependencies:
   meta: ^1.1.0
   path: ^1.4.2
   pedantic: ^1.0.0
-  scratch_space: ^0.0.3
+  scratch_space: ^0.0.4
 
 dev_dependencies:
   build_runner: ^1.0.0
@@ -34,3 +34,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  scratch_space:
+    path: ../scratch_space

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -29,3 +29,5 @@ dependency_overrides:
     path: ../build_web_compilers
   build_config:
     path: ../build_config
+  scratch_space:
+    path: ../scratch_space

--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.4
+
+- Add `requireContent` argument to `copyOutput` to allow asserting that a file
+  produced in a scratch space is not empty.
+
 ## 0.0.3+2
 
 - Declare support for `package:build` version `1.x.x`.

--- a/scratch_space/lib/scratch_space.dart
+++ b/scratch_space/lib/scratch_space.dart
@@ -2,4 +2,5 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/scratch_space.dart' show ScratchSpace, canonicalUriFor;
+export 'src/scratch_space.dart'
+    show ScratchSpace, canonicalUriFor, EmptyOutputException;

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scratch_space
-version: 0.0.3+2
+version: 0.0.4
 description: A tool to manage running external executables within package:build
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space


### PR DESCRIPTION
Towards #2362

We don't know where the zero byte files are being introduced to the
system - if they are coming from the kernel worker try to catch them
earlier by checking for when we copy a file with no content. This won't
solve the issue but if errors surface through this they should be more
clear.

- Add a `requireContent` argument to `copyOutput`. In the future we
  might consider making the default either with or without an output -
  we don't know of any use cases where we want to allow copying a zero
  byte file.
- Use the new argument from the kernel builder to check earlier whether
  a kernel file is empty.