### PR TITLE
Prepare to publish build_modules

### DIFF
--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -34,7 +34,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  scratch_space:
-    path: ../scratch_space


### PR DESCRIPTION
Remove override on `scratch_space` since `0.0.4` has been published.