### PR TITLE
build_config: support the latest pkg:json_annotation, prepare release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ jobs:
       env: PKGS="build build_daemon build_resolvers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: 2.2.0; PKGS: build_config, build_runner_core, build_test; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.2.0"
-      env: PKGS="build_config build_runner_core build_test"
+      name: "SDK: 2.3.0; PKGS: build_config, build_modules, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.3.0"
+      env: PKGS="build_config build_modules build_web_compilers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: 2.3.0; PKGS: build_modules, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.3.0"
-      env: PKGS="build_modules build_web_compilers"
+      name: "SDK: 2.2.0; PKGS: build_runner_core, build_test; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.2.0"
+      env: PKGS="build_runner_core build_test"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.3.0-dev.0.1; PKG: build_vm_compilers; TASKS: `dartanalyzer --fatal-warnings .`"

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.2
+## 0.4.1+1
 
 - Support the latest release of `package:json_annotation`.
 

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+- Support the latest release of `package:json_annotation`.
+
 ## 0.4.1
 
 - Added optional `configYamlPath` parameter to `BuildConfig.parse`. When

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.1+1
 
 - Support the latest release of `package:json_annotation`.
+- Increased the lower bound for the Dart SDK to `>=2.3.0`.
 
 ## 0.4.1
 

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -9,7 +9,7 @@ import 'package:checked_yaml/checked_yaml.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
-import 'package:pubspec_parse/pubspec_parse.dart' hide ParsedYamlException;
+import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'build_target.dart';
 import 'builder_definition.dart';

--- a/build_config/mono_pkg.yaml
+++ b/build_config/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.2.0
+        - 2.3.0
   - unit_test:
     # Run the script directly - running from snapshot has issues for packages
     # that are depended on by build_runner itself.

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.4.1
+version: 0.4.2
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config
@@ -9,21 +9,13 @@ environment:
 
 dependencies:
   checked_yaml: ^1.0.0
-  json_annotation: '>=1.0.0 <3.0.0'
+  json_annotation: '>=1.0.0 <4.0.0'
   meta: ^1.1.0
   path: ^1.4.0
-  pubspec_parse: ^0.1.0
+  pubspec_parse: ^0.1.5
   yaml: ^2.1.11
 
 dev_dependencies:
   build_runner: ^1.0.0
   json_serializable: ^3.0.0
   test: ^1.6.0
-
-dependency_overrides:
-  build_daemon:
-    path: ../build_daemon
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   checked_yaml: ^1.0.0

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.4.2
+version: 0.4.1+1
 description: Support for parsing `build.yaml` configuration.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_config


### PR DESCRIPTION
Bumped the min version of pubspec_parse to remove a class so a
`hide` can be removed, too