### PR TITLE
expose librariesPath in DevCompilerBuilder

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0
+- Make `librariesPath` configurable in `DevCompilerBuilder`.
+
 ## 2.1.5
 
 - Add pre-emptive support for an upcoming breaking change in ddc

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 ## 2.2.0
 - Make `librariesPath` configurable in `DevCompilerBuilder`.
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,5 +1,5 @@
-
 ## 2.2.0
+
 - Make `librariesPath` configurable in `DevCompilerBuilder`.
 
 ## 2.1.5

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.1.5
+version: 2.2.0
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
Only change required to resolve import issues with package:http. Mirrors the way libraries was exposed from the kernel builder.

https://github.com/flutter/flutter/issues/34858