### PR TITLE
Add debouncing to build daemon

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.6
+
+- Added watch event debouncing to the `daemon` command to line up with the
+  `watch` command. This makes things work more nicely with swap files as well
+  as "save all" type scenarios (you will only get a single build most times). 
+
 ## 1.6.5
 
 - Require `package:build_config` `">=0.4.1 <0.4.2"`. Use new API that improves

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.6.5
+version: 1.6.6
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/2403

This brings the behavior in line with normal `watch` mode, and fixes issues with swap files and save all scenarios where we get lots of watch events in quick succession.