### PR TITLE
skip the daemon tests until they are less flaky

### DIFF
--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @Tags(['integration'])
+@Skip('Flaky tests https://github.com/dart-lang/build/issues/2413')
 
 import 'dart:async';
 import 'dart:convert';


### PR DESCRIPTION
Filed https://github.com/dart-lang/build/issues/2413 to track unskipping