### PR TITLE
Update build packages to allow for analyzer 0.38.0.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.6
+
+- Allow analyzer version 0.38.0.
+
 ## 1.1.5
 
 - Allow analyzer version 0.37.0.

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.1.6-dev
+version: 1.1.6
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.35.0 <0.38.0'
+  analyzer: '>=0.35.0 <0.39.0'
   async: ">=1.13.3 <3.0.0"
   convert: ^2.0.0
   crypto: ">=0.9.2 <3.0.0"
@@ -24,3 +24,4 @@ dev_dependencies:
   build_vm_compilers: ">=0.1.0 <2.0.0"
   pedantic: ^1.0.0
   test: ^1.2.0
+

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.3
+
+- Allow analyzer version 0.38.0.
+
 ## 2.4.2
 
 - Support the latest release of `package:json_annotation`.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.4.2
+version: 2.4.3
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
-  analyzer: ">0.30.0 <0.38.0"
+  analyzer: ">0.30.0 <0.39.0"
   async: ^2.0.0
   bazel_worker: ^0.1.20
   build: ">=0.12.3 <2.0.0"

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7
+
+- Allow analyzer version 0.38.0.
+
 ## 1.0.6
 
 - Allow analyzer version 0.37.0.

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.0.6
+version: 1.0.7
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.35.0 <0.38.0'
+  analyzer: '>=0.35.0 <0.39.0'
   build: ">=1.1.0 <1.2.0"
   crypto: ^2.0.0
   graphs: ^0.2.0
@@ -19,3 +19,4 @@ dev_dependencies:
   build_test: ^0.10.1
   build_runner: ^1.0.0
   build_vm_compilers: ">=0.1.0 <2.0.0"
+

--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- Allow analyzer version 0.38.0.
+
 ## 1.0.2
 
 - Fix kernel concat ordering to be topological instead of reverse

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_vm_compilers
-version: 1.0.2
+version: 1.0.3
 description: Builder implementations wrapping Dart VM compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.3.0-dev.0.1 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.30.0 <0.38.0"
+  analyzer: ">=0.30.0 <0.39.0"
   build: '>=0.12.0 <2.0.0'
   build_config: ">=0.3.0 <0.5.0"
   build_modules: ^2.0.0

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.3
+
+- Allow analyzer version 0.38.0.
+
 ## 2.2.2
 
 - Re-publish 2.2.0 with proper minimum sdk constraint of >=2.4.0.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.2.2
+version: 2.2.3
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.4.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.30.0 <0.38.0"
+  analyzer: ">=0.30.0 <0.39.0"
   archive: ^2.0.0
   bazel_worker: ^0.1.18
   build: ">=0.12.8 <2.0.0"


### PR DESCRIPTION
and ready packages for publish.

Tested using dependency override, ran tests in each of the packages and the integration tests in the `_test` folder.