### PR TITLE
Add an option to skip the platform check for specific packages

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.5.0
+
+- Add an option to skip the unsupported module check for modules in specified
+  packages.
+
 ## 2.4.3
 
 - Allow analyzer version 0.38.0.

--- a/build_modules/lib/src/modules.dart
+++ b/build_modules/lib/src/modules.dart
@@ -138,8 +138,10 @@ class Module {
   /// If [throwIfUnsupported] is `true`, then an [UnsupportedModules]
   /// will be thrown if there are any modules that are not supported.
   Future<List<Module>> computeTransitiveDependencies(BuildStep buildStep,
-      {bool throwIfUnsupported = false}) async {
+      {bool throwIfUnsupported = false,
+      Set<String> skipPlatformCheckPackages = const {}}) async {
     throwIfUnsupported ??= false;
+    skipPlatformCheckPackages ??= const {};
     final modules = await buildStep.fetchResource(moduleCache);
     var transitiveDeps = <AssetId, Module>{};
     var modulesToCrawl = {primarySource};
@@ -156,7 +158,9 @@ class Module {
         missingModuleSources.add(next);
         continue;
       }
-      if (throwIfUnsupported && !module.isSupported) {
+      if (throwIfUnsupported &&
+          !module.isSupported &&
+          !skipPlatformCheckPackages.contains(module.primarySource.package)) {
         unsupportedModules.add(module);
       }
       // Don't include the root module in the transitive deps.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.4.3
+version: 2.5.0
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.0
+
+- Add an option to the DDC bootstrap to skip the checks around modules that have
+  imports to unsupported SDK libraries like `dart:io`. This is not used in the
+  default build, but is available for custom DDC integrations.
+
 ## 2.2.3
 
 - Allow analyzer version 0.38.0.

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 2.3.0
 
 - Add an option to the DDC bootstrap to skip the checks around modules that have
-  imports to unsupported SDK libraries like `dart:io`. This is not used in the
-  default build, but is available for custom DDC integrations.
+  imports to unsupported SDK libraries like `dart:io` when the module is from a
+  specified package. This is not used in the default build, but is available for
+  custom DDC integrations.
 
 ## 2.2.3
 

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -21,7 +21,8 @@ _p.Context get _context => _p.url;
 
 var _modulePartialExtension = _context.withoutExtension(jsModuleExtension);
 
-Future<void> bootstrapDdc(BuildStep buildStep, {DartPlatform platform}) async {
+Future<void> bootstrapDdc(BuildStep buildStep,
+    {DartPlatform platform, bool checkPlatformSupport = true}) async {
   var dartEntrypointId = buildStep.inputId;
   var moduleId = buildStep.inputId
       .changeExtension(moduleExtension(platform ?? ddcPlatform));
@@ -31,7 +32,8 @@ Future<void> bootstrapDdc(BuildStep buildStep, {DartPlatform platform}) async {
   // First, ensure all transitive modules are built.
   List<AssetId> transitiveJsModules;
   try {
-    transitiveJsModules = await _ensureTransitiveJsModules(module, buildStep);
+    transitiveJsModules = await _ensureTransitiveJsModules(module, buildStep,
+        checkPlatformSupport: checkPlatformSupport);
   } on UnsupportedModules catch (e) {
     var librariesString = (await e.exactLibraries(buildStep).toList())
         .map((lib) => AssetId(lib.id.package,
@@ -134,10 +136,11 @@ final _lazyBuildPool = Pool(16);
 /// Throws an [UnsupportedModules] exception if there are any
 /// unsupported modules.
 Future<List<AssetId>> _ensureTransitiveJsModules(
-    Module module, BuildStep buildStep) async {
+    Module module, BuildStep buildStep,
+    {bool checkPlatformSupport = true}) async {
   // Collect all the modules this module depends on, plus this module.
   var transitiveDeps = await module.computeTransitiveDependencies(buildStep,
-      throwIfUnsupported: true);
+      throwIfUnsupported: checkPlatformSupport);
 
   var jsModules = [
     module.primarySource.changeExtension(jsModuleExtension),

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.2.3
+version: 2.3.0
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.3.0
+version: 2.3.0-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
@@ -13,7 +13,7 @@ dependencies:
   bazel_worker: ^0.1.18
   build: ">=0.12.8 <2.0.0"
   build_config: ">=0.3.0 <0.5.0"
-  build_modules: ^2.1.0
+  build_modules: ^2.5.0
   collection: ^1.0.0
   crypto: ^2.0.0
   glob: ^1.1.0

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -35,3 +35,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  build_modules:
+    path: ../build_modules


### PR DESCRIPTION
Flutter web must allow some `dart:io` import in `package:flutter`, but
adding `dart:io` to the `DartPlatform` causes the module crawling to
pick the imports in some cases - we want the `DartPlatform` to match the
`libraries.json` that will be used by DDC and kernel in terms of which
libraries are supported, but to avoid the failures for bad imports.

The kernel and DDC workers have always allowed imports to missing
`dart:` libraries with stubbed implementations that will throw if they are
used at runtime. The restrictions on imports are implemented in the
build systems instead of the compilers. This argument allows loosening
the restriction in specific flutter packages while keeping the handrails for
user code.