### PR TITLE
Ignore deprecation on test_core import

### DIFF
--- a/build_test/lib/src/test_bootstrap_builder.dart
+++ b/build_test/lib/src/test_bootstrap_builder.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:build/build.dart';
 import 'package:path/path.dart' as p;
+// ignore: deprecated_member_use
 import 'package:test_core/backend.dart';
 
 /// A [Builder] that injects bootstrapping code used by the test runner to run


### PR DESCRIPTION
This was deprecated to avoid accidental uses of `package:test_core`
instead of `package:test`. This is an intentional use.