### PR TITLE
Remove usages of deprecated `named` function

### DIFF
--- a/build_runner/test/server/build_updates_client/module_test.dart
+++ b/build_runner/test/server/build_updates_client/module_test.dart
@@ -12,11 +12,8 @@ void main() {
   Module module;
 
   setUp(() {
-    var libs = <String, MockLibrary>{};
-    libs['1'] = named(MockLibrary(), name: '1');
-    libs['2'] = named(MockLibrary(), name: '2');
-    libs['3'] = named(MockLibrary(), name: '3');
-    module = Module(libs);
+    module =
+        Module({'1': MockLibrary(), '2': MockLibrary(), '3': MockLibrary()});
   });
 
   test('onDestroy should run on all and collect data', () {
@@ -72,10 +69,7 @@ void main() {
     Module child;
 
     setUp(() {
-      var libs = <String, MockLibrary>{};
-      libs['one'] = named(MockLibrary(), name: 'one');
-      libs['two'] = named(MockLibrary(), name: 'two');
-      child = Module(libs);
+      child = Module({'one': MockLibrary(), 'two': MockLibrary()});
     });
 
     test('onChildUpdate returns true if all are true', () {

--- a/build_runner/test/server/build_updates_client/reloading_manager_test.dart
+++ b/build_runner/test/server/build_updates_client/reloading_manager_test.dart
@@ -34,8 +34,8 @@ void main() {
           () => moduleParentsGraph.keys)
         ..updateGraph();
 
-  MockModule mockModule(String prefix, String name) => modules.putIfAbsent(
-      '$prefix-$name', () => named(MockModule(), name: '$prefix-$name'));
+  MockModule mockModule(String prefix, String name) =>
+      modules.putIfAbsent('$prefix-$name', () => MockModule());
   MockModule mockModuleNew(String name) => mockModule('new', name);
   MockModule mockModuleOld(String name) => mockModule('old', name);
 


### PR DESCRIPTION
We were not relying on any of the behavior. Change initialization to
fully use Map literal syntax.