### PR TITLE
Update ManualChangeProvider to do a lazy file system scan

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.8-dev
+
+- Improve the manual change detector to do a file system scan on demand instead
+  of using a file watcher. 
+
 ## 1.6.7
 
 - Set the `charset` to `utf-8` for Dart content returned by the `AssetHandler`.

--- a/build_runner/lib/src/daemon/change_providers.dart
+++ b/build_runner/lib/src/daemon/change_providers.dart
@@ -25,13 +25,13 @@ class AutoChangeProvider implements ChangeProvider {
 /// Computes changes with a file scan when requested by a call to
 /// [collectChanges].
 class ManualChangeProvider implements ChangeProvider {
-  final AssetManager _assetManager;
+  final AssetTracker _assetTracker;
 
-  ManualChangeProvider(this._assetManager);
+  ManualChangeProvider(this._assetTracker);
 
   @override
   Future<List<WatchEvent>> collectChanges() async {
-    var updates = await _assetManager.collectChanges();
+    var updates = await _assetTracker.collectChanges();
     return List.of(updates.entries
         .map((entry) => WatchEvent(entry.value, '${entry.key}')));
   }

--- a/build_runner/lib/src/daemon/change_providers.dart
+++ b/build_runner/lib/src/daemon/change_providers.dart
@@ -3,8 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build_daemon/change_provider.dart';
+import 'package:build_runner_core/src/generate/build_definition.dart';
 import 'package:watcher/src/watch_event.dart';
 
+/// Continually updates the [changes] stream as watch events are seen on the
+/// input stream.
+///
+/// The [collectChanges] method is a no-op for this implementation.
 class AutoChangeProvider implements ChangeProvider {
   final Stream<List<WatchEvent>> _changes;
 
@@ -17,21 +22,18 @@ class AutoChangeProvider implements ChangeProvider {
   Future<List<WatchEvent>> collectChanges() async => [];
 }
 
-// TODO(grouma) - collect changes through a one time file scan instead of
-// buffering changes from a change stream. This will have better performance
-// on Windows.
+/// Computes changes with a file scan when requested by a call to
+/// [collectChanges].
 class ManualChangeProvider implements ChangeProvider {
-  final _changes = <WatchEvent>[];
+  final AssetManager _assetManager;
 
-  ManualChangeProvider(Stream<List<WatchEvent>> changes) {
-    changes.listen(_changes.addAll);
-  }
+  ManualChangeProvider(this._assetManager);
 
   @override
   Future<List<WatchEvent>> collectChanges() async {
-    var result = _changes.toList();
-    _changes.clear();
-    return result;
+    var updates = await _assetManager.collectChanges();
+    return List.of(updates.entries
+        .map((entry) => WatchEvent(entry.value, '${entry.key}')));
   }
 
   @override

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -212,7 +212,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
 
     var changeProvider = daemonOptions.buildMode == BuildMode.Auto
         ? AutoChangeProvider(graphEvents())
-        : ManualChangeProvider(AssetManager(builder.assetGraph,
+        : ManualChangeProvider(AssetTracker(builder.assetGraph,
             daemonEnvironment.reader, buildOptions.targetGraph));
 
     return BuildRunnerDaemonBuilder._(

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -195,7 +195,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
         isReleaseBuild: daemonOptions.isReleaseBuild);
 
     // Only actually used for the AutoChangeProvider.
-    Stream<WatchEvent> graphEvents() => PackageGraphWatcher(packageGraph,
+    Stream<List<WatchEvent>> graphEvents() => PackageGraphWatcher(packageGraph,
             watch: (node) =>
                 PackageNodeWatcher(node, watch: defaultDirectoryWatcherFactory))
         .watch()
@@ -207,11 +207,11 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
               true,
               expectedDeletes,
             ))
-        .map((data) => WatchEvent(data.type, '${data.id}'));
+        .map((data) => WatchEvent(data.type, '${data.id}'))
+        .transform(debounceBuffer(buildOptions.debounceDelay));
 
     var changeProvider = daemonOptions.buildMode == BuildMode.Auto
-        ? AutoChangeProvider(
-            graphEvents().transform(debounceBuffer(buildOptions.debounceDelay)))
+        ? AutoChangeProvider(graphEvents())
         : ManualChangeProvider(AssetManager(builder.assetGraph,
             daemonEnvironment.reader, buildOptions.targetGraph));
 

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -195,7 +195,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
         isReleaseBuild: daemonOptions.isReleaseBuild);
 
     // Only actually used for the AutoChangeProvider.
-    Stream<List<WatchEvent>> graphEvents() => PackageGraphWatcher(packageGraph,
+    Stream<WatchEvent> graphEvents() => PackageGraphWatcher(packageGraph,
             watch: (node) =>
                 PackageNodeWatcher(node, watch: defaultDirectoryWatcherFactory))
         .watch()
@@ -207,13 +207,11 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
               true,
               expectedDeletes,
             ))
-        .map((data) => WatchEvent(data.type, '${data.id}'))
-        .map((change) => [change]);
+        .map((data) => WatchEvent(data.type, '${data.id}'));
 
     var changeProvider = daemonOptions.buildMode == BuildMode.Auto
-        ? AutoChangeProvider(graphEvents()
-            .transform(debounceBuffer(buildOptions.debounceDelay))
-            .map((changeLists) => changeLists.expand((l) => l).toList()))
+        ? AutoChangeProvider(
+            graphEvents().transform(debounceBuffer(buildOptions.debounceDelay)))
         : ManualChangeProvider(AssetManager(builder.assetGraph,
             daemonEnvironment.reader, buildOptions.targetGraph));
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.6.7
+version: 1.6.8-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -14,7 +14,7 @@ dependencies:
   build_config: ">=0.4.1 <0.4.2"
   build_daemon: ^2.0.0
   build_resolvers: "^1.0.0"
-  build_runner_core: ^3.0.0
+  build_runner_core: ^3.1.0
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
   crypto: ">=0.9.2 <3.0.0"
@@ -52,3 +52,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_runner_core:
+    path: ../build_runner_core

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -191,9 +191,9 @@ main() {
       await d.dir('a', [
         d.dir('web', [
           d.file('main.dart', '''
-                main() {
-                  print('hello world');
-                }'''),
+main() {
+  print('goodbye world');
+}'''),
         ])
       ]).create();
       expect(client.buildResults,
@@ -212,15 +212,25 @@ main() {
       await d.dir('a', [
         d.dir('web', [
           d.file('main.dart', '''
-                main() {
-                  print('hello world');
-                }'''),
+main() {
+  print('goodbye world');
+}'''),
         ])
       ]).create();
       // There shouldn't be any build results.
       var buildResults = await client.buildResults.first
           .timeout(Duration(seconds: 2), onTimeout: () => null);
       expect(buildResults, isNull);
+      client.startBuild();
+      var startedResult = await client.buildResults.first;
+      expect(startedResult.results.first.status, BuildStatus.started,
+          reason: 'Should do a build once requested');
+      var succeededResult = await client.buildResults.first;
+      expect(succeededResult.results.first.status, BuildStatus.succeeded);
+      var ddcContent = await File(p.join(d.sandbox, 'a', '.dart_tool', 'build',
+              'generated', 'a', 'web', 'main.ddc.js'))
+          .readAsString();
+      expect(ddcContent, contains('goodbye world'));
     });
 
     test('can build to outputs', () async {

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.1.0
+
+- Factor out the logic to do a manual file system scan for changes into a
+  new `AssetManager` class.
+  - This is not exposed publicly and is only intended to be used from the
+    `build_runner` package.
+
 ## 3.0.9
 
 - Support the latest release of `package:json_annotation`.

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.1.0
 
 - Factor out the logic to do a manual file system scan for changes into a
-  new `AssetManager` class.
+  new `AssetTracker` class.
   - This is not exposed publicly and is only intended to be used from the
     `build_runner` package.
 

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -76,6 +76,8 @@ class AssetTracker {
 
   AssetTracker(this._assetGraph, this._reader, this._targetGraph);
 
+  /// Checks for and returns any file system changes compared to the current
+  /// state of the asset graph.
   Future<Map<AssetId, ChangeType>> collectChanges() async {
     var inputSources = await _findInputSources();
     var generatedSources = await _findCacheDirSources();

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 3.0.9
+version: 3.1.0
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core

--- a/build_runner_core/test/generate/asset_tracker_test.dart
+++ b/build_runner_core/test/generate/asset_tracker_test.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:path/path.dart' as p;
+import 'package:test_descriptor/test_descriptor.dart' as d;
+import 'package:test/test.dart';
+import 'package:watcher/watcher.dart';
+
+import 'package:build_runner_core/build_runner_core.dart';
+import 'package:build_runner_core/src/asset_graph/graph.dart';
+import 'package:build_runner_core/src/generate/build_definition.dart';
+import 'package:build_runner_core/src/package_graph/target_graph.dart';
+
+main() {
+  group('AssetTracker.collectChanges()', () {
+    AssetTracker assetTracker;
+
+    setUp(() async {
+      await d.dir('a', [
+        d.dir('web', [
+          d.file('a.txt', 'hello'),
+        ]),
+      ]).create();
+      var packageGraph = PackageGraph.fromRoot(PackageNode(
+          'a', p.join(d.sandbox, 'a'), DependencyType.path,
+          isRoot: true));
+      var reader = FileBasedAssetReader(packageGraph);
+      var aId = AssetId('a', 'web/a.txt');
+      var assetGraph =
+          await AssetGraph.build([], {aId}, {}, packageGraph, reader);
+      // We need to pre-emptively assign a digest so we determine that the
+      // node is "interesting".
+      assetGraph.get(aId).lastKnownDigest = await reader.digest(aId);
+
+      var targetGraph = await TargetGraph.forPackageGraph(packageGraph,
+          defaultRootPackageWhitelist: ['web/**']);
+      assetTracker = AssetTracker(assetGraph, reader, targetGraph);
+      var updates = await assetTracker.collectChanges();
+      await assetGraph.updateAndInvalidate([], updates, 'a', null, reader);
+      // We should see no changes initially other than new sdk sources
+      expect(
+          updates
+            ..removeWhere(
+                (id, type) => id.package == r'$sdk' && type == ChangeType.ADD),
+          isEmpty);
+    });
+
+    test('Collects file edits', () async {
+      File(p.join(d.sandbox, 'a', 'web', 'a.txt')).writeAsStringSync('goodbye');
+
+      expect(await assetTracker.collectChanges(),
+          {AssetId('a', 'web/a.txt'): ChangeType.MODIFY});
+    });
+
+    test('Collects new files', () async {
+      File(p.join(d.sandbox, 'a', 'web', 'b.txt')).writeAsStringSync('yo!');
+
+      expect(await assetTracker.collectChanges(),
+          {AssetId('a', 'web/b.txt'): ChangeType.ADD});
+    });
+
+    test('Collects deleted files', () async {
+      File(p.join(d.sandbox, 'a', 'web', 'a.txt')).deleteSync();
+
+      expect(await assetTracker.collectChanges(),
+          {AssetId('a', 'web/a.txt'): ChangeType.REMOVE});
+    });
+  });
+}

--- a/build_runner_core/test/generate/asset_tracker_test.dart
+++ b/build_runner_core/test/generate/asset_tracker_test.dart
@@ -31,7 +31,7 @@ main() {
       var reader = FileBasedAssetReader(packageGraph);
       var aId = AssetId('a', 'web/a.txt');
       var assetGraph =
-          await AssetGraph.build([], {aId}, {}, packageGraph, reader);
+          await AssetGraph.build([], {aId}, <AssetId>{}, packageGraph, reader);
       // We need to pre-emptively assign a digest so we determine that the
       // node is "interesting".
       assetGraph.get(aId).lastKnownDigest = await reader.digest(aId);


### PR DESCRIPTION
Should solve https://github.com/flutter/flutter/issues/39696

- Extracted existing file system scanning logic into an `AssetManager` class (in build_runner_core)
- Updated the ManualChangeProvider to use an `AssetManager` to lazily scan the file system instead of using a file watcher and collecting changes.
- Updated the existing test to verify changes were actually picked up by the new build.