### PR TITLE
Don't track the build script if the check is skipped

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.1
+
+- When skipping build script updates, don't check if the build script is a
+  part of the asset graph either.
+
 ## 3.1.0
 
 - Factor out the logic to do a manual file system scan for changes into a

--- a/build_runner_core/lib/src/changes/build_script_updates.dart
+++ b/build_runner_core/lib/src/changes/build_script_updates.dart
@@ -23,14 +23,13 @@ abstract class BuildScriptUpdates {
   /// Creates a [BuildScriptUpdates] object, using [reader] to ensure that
   /// the [assetGraph] is tracking digests for all transitive sources.
   ///
-  /// If [skipUpdatesCheck] is `true` then all checks are skipped and
+  /// If [disabled] is `true` then all checks are skipped and
   /// [hasBeenUpdated] will always return `false`.
-  static Future<BuildScriptUpdates> create(
-      RunnerAssetReader reader,
-      PackageGraph packageGraph,
-      AssetGraph assetGraph,
-      bool skipUpdatesCheck) async {
-    if (skipUpdatesCheck) return _NoopBuildScriptUpdates();
+  static Future<BuildScriptUpdates> create(RunnerAssetReader reader,
+      PackageGraph packageGraph, AssetGraph assetGraph,
+      {bool disabled = false}) async {
+    disabled ??= false;
+    if (disabled) return _NoopBuildScriptUpdates();
     return _MirrorBuildScriptUpdates.create(reader, packageGraph, assetGraph);
   }
 }

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -210,8 +210,8 @@ class _Loader {
           () => _updateAssetGraph(assetGraph, assetTracker, _buildPhases,
               inputSources, cacheDirSources, internalSources));
 
-      buildScriptUpdates = await BuildScriptUpdates.create(
-          _environment.reader, _options.packageGraph, assetGraph);
+      buildScriptUpdates = await BuildScriptUpdates.create(_environment.reader,
+          _options.packageGraph, assetGraph, _options.skipBuildScriptCheck);
       if (!_options.skipBuildScriptCheck &&
           buildScriptUpdates.hasBeenUpdated(updates.keys.toSet())) {
         _logger.warning('Invalidating asset graph due to build script update!');
@@ -240,7 +240,10 @@ class _Loader {
           throw CannotBuildException();
         }
         buildScriptUpdates = await BuildScriptUpdates.create(
-            _environment.reader, _options.packageGraph, assetGraph);
+            _environment.reader,
+            _options.packageGraph,
+            assetGraph,
+            _options.skipBuildScriptCheck);
         conflictingOutputs = assetGraph.outputs
             .where((n) => n.package == _options.packageGraph.root.name)
             .where(inputSources.contains)

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -210,8 +210,9 @@ class _Loader {
           () => _updateAssetGraph(assetGraph, assetTracker, _buildPhases,
               inputSources, cacheDirSources, internalSources));
 
-      buildScriptUpdates = await BuildScriptUpdates.create(_environment.reader,
-          _options.packageGraph, assetGraph, _options.skipBuildScriptCheck);
+      buildScriptUpdates = await BuildScriptUpdates.create(
+          _environment.reader, _options.packageGraph, assetGraph,
+          disabled: _options.skipBuildScriptCheck);
       if (!_options.skipBuildScriptCheck &&
           buildScriptUpdates.hasBeenUpdated(updates.keys.toSet())) {
         _logger.warning('Invalidating asset graph due to build script update!');
@@ -240,10 +241,8 @@ class _Loader {
           throw CannotBuildException();
         }
         buildScriptUpdates = await BuildScriptUpdates.create(
-            _environment.reader,
-            _options.packageGraph,
-            assetGraph,
-            _options.skipBuildScriptCheck);
+            _environment.reader, _options.packageGraph, assetGraph,
+            disabled: _options.skipBuildScriptCheck);
         conflictingOutputs = assetGraph.outputs
             .where((n) => n.package == _options.packageGraph.root.name)
             .where(inputSources.contains)

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 3.1.0
+version: 3.1.1
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/621.

When passing --skip-build-script-check we will now stop attempting to track the build script entirely, and thus won't warn if there are sources that don't exist in the asset graph.  