### PR TITLE
Fix check for core package locations changing

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.9
+- Fix bugs in snapshot invalidation logic that prevented invalidation when
+  core packages changed and always created a new snapshot on the second build.
+
 ## 1.6.8
 
 - Improve the manual change detector to do a file system scan on demand instead

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -189,10 +189,10 @@ final _previousLocationsFile = File(
 /// pre-emptively resolve them by resnapshotting, see
 /// https://github.com/dart-lang/build/issues/1929.
 Future<bool> _checkImportantPackageDeps() async {
-  var currentLocationsContent = await Stream.fromIterable(_importantPackages)
-      .asyncMap((pkg) => Isolate.resolvePackageUri(
-          Uri(scheme: 'package', path: '$pkg/fake.dart')))
-      .join('\n');
+  var currentLocations = await Future.wait(_importantPackages.map((pkg) =>
+      Isolate.resolvePackageUri(
+          Uri(scheme: 'package', path: '$pkg/fake.dart'))));
+  var currentLocationsContent = currentLocations.join('\n');
 
   if (!_previousLocationsFile.existsSync()) {
     _logger.fine('Core package locations file does not exist');

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.6.8
+version: 1.6.9
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner

--- a/build_runner/test/integration_tests/build_invalidation_test.dart
+++ b/build_runner/test/integration_tests/build_invalidation_test.dart
@@ -144,4 +144,31 @@ main() {
       await server.shutDown();
     });
   });
+
+  test('Recreates snapshot for changed core dependency path', () async {
+    // Run a first build before invalidation.
+    await buildTool.build();
+
+    final locationsFile = File(p.join(d.sandbox, 'a', '.dart_tool', 'build',
+        'entrypoint', '.packageLocations'));
+    // Modify the contents in some way
+    await locationsFile.writeAsString('${await locationsFile.readAsString()}'
+        '\nmodified!');
+
+    final secondBuild = await buildTool.build();
+
+    await expectOutput(secondBuild, [
+      'Deleted previous snapshot due to core package update',
+      'Creating build script snapshot',
+    ]);
+  });
+
+  test('Does not recreate snapshot if nothing changes', () async {
+    // Run a first build before invalidation.
+    await buildTool.build();
+
+    final secondBuild = await buildTool.build();
+    await expectLater(secondBuild, neverEmits('Creating build script snapshot'),
+        reason: 'should not invalidate the previous snapshot');
+  });
 }


### PR DESCRIPTION
### Problem
1. Due to not awaiting futures, the contents of `.packageLocations` used to be:
    ```
    Instance of 'Future<String>'
    Instance of 'Future<String>'
    ```
1. `.packageLocations` wasn't written on the first build, which resulted in the snapshots always being incorrectly invalidated on the second build due to "Deleted previous snapshot due to core package update"

<details>
<summary>
Example output for the second ever build after deleting `.dart_tool`, without changing anything:
</summary>

```
$ pub run build_runner build --verbose
[INFO] Generating build script completed, took 334ms
[WARNING] Deleted previous snapshot due to core package update
[INFO] Creating build script snapshot... completed, took 11.3s
[INFO] BuildDefinition:Initializing inputs
[INFO] BuildDefinition:Reading cached asset graph...
[INFO] BuildDefinition:Reading cached asset graph completed, took 296ms

[INFO] BuildDefinition:Checking for updates since last build...
[INFO] BuildDefinition:Checking for updates since last build completed, took 783ms

[INFO] Build:Running build...
[INFO] Build:Running build completed, took 271ms

[INFO] Build:Caching finalized dependency graph...
[INFO] Build:Caching finalized dependency graph completed, took 180ms

[INFO] Build:Succeeded after 460ms with 0 outputs (0 actions)
```

</details>

## Solution
- Write `.packageLocations` on first build, fix output
- Add regression tests for invalidation on second build