### PR TITLE
Remove some references to transformers

### DIFF
--- a/build_config/README.md
+++ b/build_config/README.md
@@ -83,7 +83,7 @@ arguments.
   depending on the particular builder. The values in this map override all other
   values per-key when the build is done in release mode.
 
-## Defining `Builder`s to apply to dependents (similar to transformers)
+## Defining `Builder`s to apply to dependents
 
 If users of your package need to apply some code generation to their package,
 then you can define `Builder`s and have those applied to packages with a

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -96,35 +96,6 @@ targets:
           - --fast-startup
 ```
 
-## Compatibility with other packages
-
-### Upgrading from transformers
-
-`build_runner` can only run Builders that are published with a `build.yaml`
-file; it can't use legacy `Transformers`. If your pubspec lists transformers,
-switch to a version of the transformer-containing package that has a
-`build.yaml` file.
-
-### Upgrading from manual `build.dart` files
-
-Older versions of `build_runner` were designed to run with manually written
-build scripts referencing the Builders available in the local package or in
-dependencies. This pattern can still be used when customization is needed
-outside of `build.yaml`, but we recommend using the generated build script
-with `pub run build_runner`, because it will be kept up to date with changes
-in the build packages. If your pubspec lists transformers, switch to a version of
-the builder-containing package that has a `build.yaml` file.
-
-## Replacing `dart_to_js_script_rewriter`
-
-When the development process included `dartium` HTML files typically referenced
-`main.dart` and used a transformer to rewrite to `main.dart.js` for deployment.
-The new development process uses DDC and so always compiles to javascript. Any
-script tags should be manually rewritten to always reference `*.dart.js` with a
-`type` of `application/javascript` rather than `application/dart`.
-`dart_to_js_script_rewriter` and `browser` dependencies can be dropped.
-
-
 ## Troubleshooting
 
 <!-- summarize here. -->


### PR DESCRIPTION
We no longer have active documentation that references transformers and
we don't expect most users to be "migrating" from old paths like
transformers or manual build scripts since `pub run build_runner` and
`webdev` have been the golden path for a while.