### PR TITLE
Ensure sdk dependencies are built as a part of ddc bootstrapping

### DIFF
--- a/_test/test/serve_integration_test.dart
+++ b/_test/test/serve_integration_test.dart
@@ -134,8 +134,6 @@ void main() {
       'web',
       '--build-filter',
       'web/sub/main.dart.js',
-      '--build-filter',
-      'package:build_web_compilers/**/*'
     ]);
 
     addTearDown(() async {

--- a/_test/test/test_integration_test.dart
+++ b/_test/test/test_integration_test.dart
@@ -17,12 +17,7 @@ void main() {
 
   test('Can build and run a single test with --precompiled and --build-filter',
       () async {
-    var buildArgs = [
-      '--build-filter',
-      'test/hello_world_test.*.dart.js',
-      '--build-filter',
-      'package:build_web_compilers/**'
-    ];
+    var buildArgs = ['--build-filter', 'test/hello_world_test.*.dart.js'];
     await expectTestsPass(
         usePrecompiled: true,
         testArgs: ['test/hello_world_test.dart'],

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 2.4.0
+
+### New Feature: Better --build-filter support for building a single test.
+
+You can now build a basic app or test in isolation by only requesting the
+`*.dart.js` file using a build filter, for example adding this argument to any
+build_runner command would build the `web/main.dart` app only:
+`--build-filter=web/main.dart.js`.
+
+For tests you will need to specify the bootstrapped test file, so:
+`--build-filter=test/hello_world.dart.browser_test.dart.js`.
+
+Previously you also had to explicitly require the SDK resources like:
+`--build-filter="package:build_web_compilers/**.js"` or similar.
+
+**Note**: If your app relies on any non-Dart generated files you will likely
+have to ask for those explicitly as well with additinal filters. 
+
 ## 2.3.0
 
 - Add an option to the DDC bootstrap to skip the checks around modules that have

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.3.0
+version: 2.4.0
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -114,6 +114,14 @@ main() {
 
 // Runs all the DDC related builders except the entrypoint builder.
 Future<void> runPrerequisites(Map<String, dynamic> assets) async {
+  // Uses the real sdk copy builder to copy required files from the SDK.
+  //
+  // It is necessary to add a fake asset so that the build_web_compilers
+  // package exists.
+  var sdkAssets = <String, dynamic>{'build_web_compilers|fake.txt': ''};
+  await testBuilderAndCollectAssets(sdkJsCopyBuilder(null), sdkAssets);
+  assets.addAll(sdkAssets);
+
   await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
   await testBuilderAndCollectAssets(MetaModuleBuilder(ddcPlatform), assets);
   await testBuilderAndCollectAssets(


### PR DESCRIPTION
Specifically this allows simple build filters to build any dart web app - you can just ask for the `*.dart.js` file and the entire app will be built.

This works because the SDK files are now inputs to the bootstrapping action. This also has other nice side effects of ensuring that the required SDK files do in fact exist where we expect them.