### PR TITLE
Add support for dependency pruning to build/build_runner_core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.2.0; PKGS: build, build_test; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.2.0"
-      env: PKGS="build build_test"
+      name: "SDK: 2.2.2; PKGS: build, build_daemon, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.2.2"
+      env: PKGS="build build_daemon scratch_space"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.3.0; PKGS: build_config, build_modules, build_runner_core; TASKS: `dartanalyzer --fatal-warnings .`"
@@ -31,9 +31,14 @@ jobs:
       env: PKGS="build_config build_modules build_runner_core"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: 2.1.0; PKGS: build_daemon, build_resolvers; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.1.0; PKG: build_resolvers; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.1.0"
-      env: PKGS="build_daemon build_resolvers"
+      env: PKGS="build_resolvers"
+      script: ./tool/travis.sh dartanalyzer_1
+    - stage: analyze_and_format
+      name: "SDK: 2.2.0; PKG: build_test; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.2.0"
+      env: PKGS="build_test"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.3.0-dev.0.1; PKG: build_vm_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
@@ -44,11 +49,6 @@ jobs:
       name: "SDK: 2.4.0; PKG: build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.4.0"
       env: PKGS="build_web_compilers"
-      script: ./tool/travis.sh dartanalyzer_1
-    - stage: analyze_and_format
-      name: "SDK: 2.0.0; PKG: scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.0.0"
-      env: PKGS="scratch_space"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart`]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.1.0; PKGS: build, build_daemon, build_resolvers; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.1.0"
-      env: PKGS="build build_daemon build_resolvers"
+      name: "SDK: 2.2.0; PKGS: build, build_test; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.2.0"
+      env: PKGS="build build_test"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.3.0; PKGS: build_config, build_modules, build_runner_core; TASKS: `dartanalyzer --fatal-warnings .`"
@@ -31,9 +31,9 @@ jobs:
       env: PKGS="build_config build_modules build_runner_core"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: 2.2.0; PKG: build_test; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.2.0"
-      env: PKGS="build_test"
+      name: "SDK: 2.1.0; PKGS: build_daemon, build_resolvers; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.1.0"
+      env: PKGS="build_daemon build_resolvers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.3.0-dev.0.1; PKG: build_vm_compilers; TASKS: `dartanalyzer --fatal-warnings .`"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,9 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.2.2; PKGS: build, build_daemon, build_resolvers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.2.2"
-      env: PKGS="build build_daemon build_resolvers scratch_space"
-      script: ./tool/travis.sh dartanalyzer_1
-    - stage: analyze_and_format
-      name: "SDK: 2.3.0; PKGS: build_config, build_modules, build_runner_core; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.3.0; PKGS: build, build_config, build_daemon, build_modules, build_resolvers, build_runner_core, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.3.0"
-      env: PKGS="build_config build_modules build_runner_core"
+      env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner_core scratch_space"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.2.0; PKG: build_test; TASKS: `dartanalyzer --fatal-warnings .`"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,19 +21,14 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.2.2; PKGS: build, build_daemon, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.2.2; PKGS: build, build_daemon, build_resolvers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.2.2"
-      env: PKGS="build build_daemon scratch_space"
+      env: PKGS="build build_daemon build_resolvers scratch_space"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.3.0; PKGS: build_config, build_modules, build_runner_core; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.3.0"
       env: PKGS="build_config build_modules build_runner_core"
-      script: ./tool/travis.sh dartanalyzer_1
-    - stage: analyze_and_format
-      name: "SDK: 2.1.0; PKG: build_resolvers; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.1.0"
-      env: PKGS="build_resolvers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.2.0; PKG: build_test; TASKS: `dartanalyzer --fatal-warnings .`"

--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -5,24 +5,24 @@ import 'package:provides_builder/builders.dart' as _i2;
 import 'package:build_test/builder.dart' as _i3;
 import 'package:build_config/build_config.dart' as _i4;
 import 'package:build_modules/builders.dart' as _i5;
-import 'package:build_web_compilers/builders.dart' as _i6;
-import 'package:build/build.dart' as _i7;
-import 'package:build_vm_compilers/builders.dart' as _i8;
+import 'package:build_vm_compilers/builders.dart' as _i6;
+import 'package:build_web_compilers/builders.dart' as _i7;
+import 'package:build/build.dart' as _i8;
 import 'dart:isolate' as _i9;
 import 'package:build_runner/build_runner.dart' as _i10;
 import 'dart:io' as _i11;
 
 final _builders = <_i1.BuilderApplication>[
+  _i1.apply('provides_builder:some_builder', [_i2.someBuilder],
+      _i1.toDependentsOf('provides_builder'),
+      hideOutput: true,
+      appliesBuilders: ['provides_builder:some_post_process_builder']),
   _i1.apply('provides_builder:some_not_applied_builder', [_i2.notApplied],
       _i1.toNoneByDefault(),
       hideOutput: true),
   _i1.apply('provides_builder:throwing_builder', [_i2.throwingBuilder],
       _i1.toDependentsOf('provides_builder'),
       hideOutput: true),
-  _i1.apply('provides_builder:some_builder', [_i2.someBuilder],
-      _i1.toDependentsOf('provides_builder'),
-      hideOutput: true,
-      appliesBuilders: ['provides_builder:some_post_process_builder']),
   _i1.apply(
       'build_test:test_bootstrap',
       [_i3.debugIndexBuilder, _i3.debugTestBuilder, _i3.testBootstrapBuilder],
@@ -35,28 +35,54 @@ final _builders = <_i1.BuilderApplication>[
       hideOutput: true,
       appliesBuilders: ['build_modules:module_cleanup']),
   _i1.apply(
-      'build_web_compilers:ddc_modules',
+      'build_vm_compilers:modules',
+      [_i6.metaModuleBuilder, _i6.metaModuleCleanBuilder, _i6.moduleBuilder],
+      _i1.toNoneByDefault(),
+      isOptional: true,
+      hideOutput: true,
+      appliesBuilders: ['build_modules:module_cleanup']),
+  _i1.apply(
+      'build_vm_compilers:vm', [_i6.vmKernelModuleBuilder], _i1.toAllPackages(),
+      isOptional: true,
+      hideOutput: true,
+      appliesBuilders: ['build_vm_compilers:modules']),
+  _i1.apply('build_vm_compilers:entrypoint', [_i6.vmKernelEntrypointBuilder],
+      _i1.toRoot(),
+      hideOutput: true,
+      defaultGenerateFor: const _i4.InputSet(include: [
+        'bin/**',
+        'tool/**',
+        'test/**.dart.vm_test.dart',
+        'example/**',
+        'benchmark/**'
+      ])),
+  _i1.apply('build_web_compilers:sdk_js_copy', [_i7.sdkJsCopyBuilder],
+      _i1.toNoneByDefault(),
+      hideOutput: true,
+      appliesBuilders: ['build_web_compilers:sdk_js_cleanup']),
+  _i1.apply(
+      'build_web_compilers:dart2js_modules',
       [
-        _i6.ddcMetaModuleBuilder,
-        _i6.ddcMetaModuleCleanBuilder,
-        _i6.ddcModuleBuilder
+        _i7.dart2jsMetaModuleBuilder,
+        _i7.dart2jsMetaModuleCleanBuilder,
+        _i7.dart2jsModuleBuilder
       ],
       _i1.toNoneByDefault(),
       isOptional: true,
       hideOutput: true,
       appliesBuilders: ['build_modules:module_cleanup']),
   _i1.apply(
-      'build_web_compilers:dart2js_modules',
+      'build_web_compilers:ddc_modules',
       [
-        _i6.dart2jsMetaModuleBuilder,
-        _i6.dart2jsMetaModuleCleanBuilder,
-        _i6.dart2jsModuleBuilder
+        _i7.ddcMetaModuleBuilder,
+        _i7.ddcMetaModuleCleanBuilder,
+        _i7.ddcModuleBuilder
       ],
       _i1.toNoneByDefault(),
       isOptional: true,
       hideOutput: true,
       appliesBuilders: ['build_modules:module_cleanup']),
-  _i1.apply('build_web_compilers:ddc', [_i6.ddcKernelBuilder, _i6.ddcBuilder],
+  _i1.apply('build_web_compilers:ddc', [_i7.ddcKernelBuilder, _i7.ddcBuilder],
       _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true,
@@ -65,7 +91,7 @@ final _builders = <_i1.BuilderApplication>[
         'build_web_compilers:dart2js_modules',
         'build_web_compilers:dart_source_cleanup'
       ]),
-  _i1.apply('build_web_compilers:entrypoint', [_i6.webEntrypointBuilder],
+  _i1.apply('build_web_compilers:entrypoint', [_i7.webEntrypointBuilder],
       _i1.toRoot(),
       hideOutput: true,
       defaultGenerateFor: const _i4.InputSet(include: [
@@ -77,53 +103,27 @@ final _builders = <_i1.BuilderApplication>[
         'test/**.node_test.dart',
         'test/**.vm_test.dart'
       ]),
-      defaultOptions: _i7.BuilderOptions({
+      defaultOptions: _i8.BuilderOptions({
         'dart2js_args': ['--minify']
       }),
-      defaultReleaseOptions: _i7.BuilderOptions({'compiler': 'dart2js'}),
+      defaultReleaseOptions: _i8.BuilderOptions({'compiler': 'dart2js'}),
       appliesBuilders: ['build_web_compilers:dart2js_archive_extractor']),
-  _i1.apply('build_web_compilers:sdk_js_copy', [_i6.sdkJsCopyBuilder],
-      _i1.toNoneByDefault(),
-      hideOutput: true,
-      appliesBuilders: ['build_web_compilers:sdk_js_cleanup']),
-  _i1.apply(
-      'build_vm_compilers:modules',
-      [_i8.metaModuleBuilder, _i8.metaModuleCleanBuilder, _i8.moduleBuilder],
-      _i1.toNoneByDefault(),
-      isOptional: true,
-      hideOutput: true,
-      appliesBuilders: ['build_modules:module_cleanup']),
-  _i1.apply(
-      'build_vm_compilers:vm', [_i8.vmKernelModuleBuilder], _i1.toAllPackages(),
-      isOptional: true,
-      hideOutput: true,
-      appliesBuilders: ['build_vm_compilers:modules']),
-  _i1.apply('build_vm_compilers:entrypoint', [_i8.vmKernelEntrypointBuilder],
-      _i1.toRoot(),
-      hideOutput: true,
-      defaultGenerateFor: const _i4.InputSet(include: [
-        'bin/**',
-        'tool/**',
-        'test/**.dart.vm_test.dart',
-        'example/**',
-        'benchmark/**'
-      ])),
   _i1.applyPostProcess(
       'provides_builder:some_post_process_builder', _i2.somePostProcessBuilder,
       defaultGenerateFor: const _i4.InputSet()),
   _i1.applyPostProcess('build_modules:module_cleanup', _i5.moduleCleanup,
       defaultGenerateFor: const _i4.InputSet()),
-  _i1.applyPostProcess(
-      'build_web_compilers:sdk_js_cleanup', _i6.sdkJsCleanupBuilder,
-      defaultReleaseOptions: _i7.BuilderOptions({'enabled': true}),
-      defaultGenerateFor: const _i4.InputSet()),
-  _i1.applyPostProcess(
-      'build_web_compilers:dart_source_cleanup', _i6.dartSourceCleanup,
-      defaultReleaseOptions: _i7.BuilderOptions({'enabled': true}),
-      defaultGenerateFor: const _i4.InputSet()),
   _i1.applyPostProcess('build_web_compilers:dart2js_archive_extractor',
-      _i6.dart2jsArchiveExtractor,
-      defaultReleaseOptions: _i7.BuilderOptions({'filter_outputs': true}),
+      _i7.dart2jsArchiveExtractor,
+      defaultReleaseOptions: _i8.BuilderOptions({'filter_outputs': true}),
+      defaultGenerateFor: const _i4.InputSet()),
+  _i1.applyPostProcess(
+      'build_web_compilers:dart_source_cleanup', _i7.dartSourceCleanup,
+      defaultReleaseOptions: _i8.BuilderOptions({'enabled': true}),
+      defaultGenerateFor: const _i4.InputSet()),
+  _i1.applyPostProcess(
+      'build_web_compilers:sdk_js_cleanup', _i7.sdkJsCleanupBuilder,
+      defaultReleaseOptions: _i8.BuilderOptions({'enabled': true}),
       defaultGenerateFor: const _i4.InputSet())
 ];
 main(List<String> args, [_i9.SendPort sendPort]) async {

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.2.0
+
+- Add `BuildStep.removeDependency(AssetId id)` method to `BuildStep` which
+  allows you to delete a dependency on some input after the fact.
+  - This should be used very carefully as it can easily lead to correctness
+    issues if abused.
+- Add the `BuildStep.removedDependencies` iterable which gives access to all
+  the removed deps.
+
 ## 1.1.6
 
 - Allow analyzer version 0.38.0.

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## 1.2.0
 
-- Add `BuildStep.removeDependency(AssetId id)` method to `BuildStep` which
-  allows you to delete a dependency on some input after the fact.
-  - This should be used very carefully as it can easily lead to correctness
-    issues if abused.
-- Add the `BuildStep.removedDependencies` iterable which gives access to all
-  the removed deps.
+- Add the `void reportUnusedAssets(Iterable<AssetId> ids)` method to the
+  `BuildStep` class.
+  - **WARNING**: Using this introduces serious risk of non-hermetic builds.
+  - Indicates to the build system that `ids` were read but their content has
+    no impact on the outputs of the build.
+  - Build system implementations can choose to support this feature or not,
+    and it should be assumed to be a no-op by default.
 
 ## 1.1.6
 

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -81,12 +81,10 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   /// [action] can be async function returning [Future].
   T trackStage<T>(String label, T Function() action, {bool isExternal = false});
 
-  /// **WARNING**: Expert level feature only, use at your own risk.
+  /// Indicates that [ids] were read but their content has no impact on the
+  /// outputs of this step.
   ///
-  /// Marks a set of ids as unused even if they were read by this build step.
-  ///
-  /// This should only be used if an asset was read, but none of it's content,
-  /// or the fact that it exists, actually has an impact on the output.
+  /// **WARNING**: Using this introduces serious risk of non-hermetic builds.
   ///
   /// If this file changes or becomes unreadable on the next build this build
   /// step may not run.
@@ -94,7 +92,7 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   /// **Note**: This is not guaranteed to have any effect and it should be
   /// assumed to be a no-op by default. Implementations must explicitly
   /// choose to support this feature.
-  void reportUnusedAssets(Iterable<AssetId> id);
+  void reportUnusedAssets(Iterable<AssetId> ids);
 }
 
 abstract class StageTracker {

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -81,9 +81,20 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   /// [action] can be async function returning [Future].
   T trackStage<T>(String label, T Function() action, {bool isExternal = false});
 
-  void removeDependency(AssetId id);
-
-  Iterable<AssetId> get removedDependencies;
+  /// **WARNING**: Expert level feature only, use at your own risk.
+  ///
+  /// Marks a set of ids as unused even if they were read by this build step.
+  ///
+  /// This should only be used if an asset was read, but none of it's content,
+  /// or the fact that it exists, actually has an impact on the output.
+  ///
+  /// If this file changes or becomes unreadable on the next build this build
+  /// step may not run.
+  ///
+  /// **Note**: This is not guaranteed to have any effect and it should be
+  /// assumed to be a no-op by default. Implementations must explicitly
+  /// choose to support this feature.
+  void reportUnusedAssets(Iterable<AssetId> id);
 }
 
 abstract class StageTracker {

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -80,6 +80,10 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   /// Returns value returned by [action].
   /// [action] can be async function returning [Future].
   T trackStage<T>(String label, T Function() action, {bool isExternal = false});
+
+  void removeDependency(AssetId id);
+
+  Iterable<AssetId> get removedDependencies;
 }
 
 abstract class StageTracker {

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -86,7 +86,7 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   ///
   /// **WARNING**: Using this introduces serious risk of non-hermetic builds.
   ///
-  /// If this file changes or becomes unreadable on the next build this build
+  /// If these files change or become unreadable on the next build this build
   /// step may not run.
   ///
   /// **Note**: This is not guaranteed to have any effect and it should be

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -57,17 +57,15 @@ class BuildStepImpl implements BuildStep {
 
   bool _isComplete = false;
 
-  @override
-  final removedDependencies = <AssetId>{};
+  final void Function(Iterable<AssetId>) _reportUnusedAssets;
 
   BuildStepImpl(this.inputId, Iterable<AssetId> expectedOutputs, this._reader,
       this._writer, this._rootPackage, this._resolvers, this._resourceManager,
-      [this._stageTracker = NoOpStageTracker.instance])
-      : _expectedOutputs = expectedOutputs.toSet();
-
-  @override
-  void removeDependency(AssetId id) =>
-      (removedDependencies as Set<AssetId>).add(id);
+      {StageTracker stageTracker,
+      void Function(Iterable<AssetId>) reportUnusedAssets})
+      : _expectedOutputs = expectedOutputs.toSet(),
+        _stageTracker = stageTracker ?? NoOpStageTracker.instance,
+        _reportUnusedAssets = reportUnusedAssets;
 
   @override
   Resolver get resolver {
@@ -176,6 +174,11 @@ class BuildStepImpl implements BuildStep {
     if (!_expectedOutputs.contains(id)) {
       throw UnexpectedOutputException(id, expected: _expectedOutputs);
     }
+  }
+
+  @override
+  void reportUnusedAssets(Iterable<AssetId> assets) {
+    if (_reportUnusedAssets != null) _reportUnusedAssets(assets);
   }
 }
 

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -57,10 +57,17 @@ class BuildStepImpl implements BuildStep {
 
   bool _isComplete = false;
 
+  @override
+  final removedDependencies = <AssetId>{};
+
   BuildStepImpl(this.inputId, Iterable<AssetId> expectedOutputs, this._reader,
       this._writer, this._rootPackage, this._resolvers, this._resourceManager,
       [this._stageTracker = NoOpStageTracker.instance])
       : _expectedOutputs = expectedOutputs.toSet();
+
+  @override
+  void removeDependency(AssetId id) =>
+      (removedDependencies as Set<AssetId>).add(id);
 
   @override
   Resolver get resolver {

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -26,12 +26,16 @@ import 'expected_outputs.dart';
 /// automatically disposed of (its up to the caller to dispose of it later). If
 /// one is not provided then one will be created and disposed at the end of
 /// this function call.
+///
+/// If [removedDependencies] is provided an entry will be added for each input
+/// which gives all the removed dependencies for that input.
 Future<void> runBuilder(Builder builder, Iterable<AssetId> inputs,
     AssetReader reader, AssetWriter writer, Resolvers resolvers,
     {Logger logger,
     ResourceManager resourceManager,
     String rootPackage,
-    StageTracker stageTracker = NoOpStageTracker.instance}) async {
+    StageTracker stageTracker = NoOpStageTracker.instance,
+    Map<AssetId, Iterable<AssetId>> removedDependencies}) async {
   var shouldDisposeResourceManager = resourceManager == null;
   resourceManager ??= ResourceManager();
   logger ??= Logger('runBuilder');
@@ -45,6 +49,7 @@ Future<void> runBuilder(Builder builder, Iterable<AssetId> inputs,
       await builder.build(buildStep);
     } finally {
       await buildStep.complete();
+      removedDependencies[input] = buildStep.removedDependencies;
     }
   }
 

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -28,7 +28,7 @@ import 'expected_outputs.dart';
 /// this function call.
 ///
 /// If [reportUnusedAssetsForInput] is provided then all calls to
-/// `BuildStep.reportUnusedAsests` in [builder] will be forwarded to this
+/// `BuildStep.reportUnusedAssets` in [builder] will be forwarded to this
 /// function with the associated primary input.
 Future<void> runBuilder(Builder builder, Iterable<AssetId> inputs,
     AssetReader reader, AssetWriter writer, Resolvers resolvers,

--- a/build/mono_pkg.yaml
+++ b/build/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.2.0
+        - 2.2.2
   - unit_test:
     - command: pub run build_runner test
 

--- a/build/mono_pkg.yaml
+++ b/build/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.2.2
+        - 2.3.0
   - unit_test:
     - command: pub run build_runner test
 

--- a/build/mono_pkg.yaml
+++ b/build/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.1.0
+        - 2.2.0
   - unit_test:
     - command: pub run build_runner test
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -33,4 +33,4 @@ dependency_overrides:
   build_runner_core:
     path: ../build_runner_core
   # https://github.com/dart-lang/build/issues/2450
-  front_end: "<0.1.24"
+  front_end: "0.1.23"

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -32,3 +32,5 @@ dependency_overrides:
     path: ../build_runner
   build_runner_core:
     path: ../build_runner_core
+  # https://github.com/dart-lang/build/issues/2450
+  front_end: "<0.1.24"

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -25,3 +25,6 @@ dev_dependencies:
   pedantic: ^1.0.0
   test: ^1.2.0
 
+dependency_overrides:
+  build_resolvers:
+    path: ../build_resolvers

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build
-version: 1.1.6
+version: 1.2.0
 description: A build system for Dart.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
   analyzer: '>=0.35.0 <0.39.0'

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   analyzer: '>=0.35.0 <0.39.0'

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -28,3 +28,7 @@ dev_dependencies:
 dependency_overrides:
   build_resolvers:
     path: ../build_resolvers
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -218,7 +218,7 @@ void main() {
       makeAssetId(),
       makeAssetId(),
     ];
-    buildStep.reportUnusedAssets(unused);
+    buildStep.reportUnusedAssets(reported);
     expect(unused, equals(reported));
   });
 }

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -205,6 +205,22 @@ void main() {
       expect(buildStep.complete(), throwsA('error'));
     });
   });
+
+  test('reportUnusedAssets forwards calls if provided', () {
+    var reader = StubAssetReader();
+    var writer = StubAssetWriter();
+    var unused = <AssetId>{};
+    var buildStep = BuildStepImpl(makeAssetId(), [], reader, writer, 'a',
+        AnalyzerResolvers(), resourceManager,
+        reportUnusedAssets: unused.addAll);
+    var reported = [
+      makeAssetId(),
+      makeAssetId(),
+      makeAssetId(),
+    ];
+    buildStep.reportUnusedAssets(unused);
+    expect(unused, equals(reported));
+  });
 }
 
 class SlowAssetWriter implements AssetWriter {

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -195,15 +195,9 @@ void main() {
       var writer = StubAssetWriter();
       primary = makeAssetId();
       output = makeAssetId();
-      buildStep = BuildStepImpl(
-          primary,
-          [output],
-          reader,
-          writer,
-          primary.package,
-          AnalyzerResolvers(),
-          resourceManager,
-          NoOpStageTracker.instance);
+      buildStep = BuildStepImpl(primary, [output], reader, writer,
+          primary.package, AnalyzerResolvers(), resourceManager,
+          stageTracker: NoOpStageTracker.instance);
     });
 
     test('Captures failed asynchronous writes', () {

--- a/build_daemon/mono_pkg.yaml
+++ b/build_daemon/mono_pkg.yaml
@@ -8,6 +8,6 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.1.0
+        - 2.2.2
   - unit_test:
     - command: pub run test

--- a/build_daemon/mono_pkg.yaml
+++ b/build_daemon/mono_pkg.yaml
@@ -8,6 +8,6 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.2.2
+        - 2.3.0
   - unit_test:
     - command: pub run test

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   built_collection: ^4.1.0

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   built_collection: ^4.1.0

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -34,3 +34,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  # https://github.com/dart-lang/build/issues/2450
+  front_end: "0.1.23"

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.8
+
+- Allow `build` version 1.2.0.
+
 ## 1.0.7
 
 - Allow analyzer version 0.38.0.

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.8
 
-- Allow `build` version 1.2.0.
+- Allow `build` version 1.2.x.
 
 ## 1.0.7
 

--- a/build_resolvers/mono_pkg.yaml
+++ b/build_resolvers/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.2.2
+        - 2.3.0
   - unit_test:
     - command: pub run build_runner test
 

--- a/build_resolvers/mono_pkg.yaml
+++ b/build_resolvers/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.1.0
+        - 2.2.2
   - unit_test:
     - command: pub run build_runner test
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.0.7
+version: 1.0.8
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: '>=0.35.0 <0.39.0'
-  build: ">=1.1.0 <1.2.0"
+  build: ">=1.1.0 <1.3.0"
   crypto: ^2.0.0
   graphs: ^0.2.0
   path: ^1.1.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   analyzer: '>=0.35.0 <0.39.0'

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   analyzer: '>=0.35.0 <0.39.0'

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -20,3 +20,6 @@ dev_dependencies:
   build_runner: ^1.0.0
   build_vm_compilers: ">=0.1.0 <2.0.0"
 
+dependency_overrides:
+  # https://github.com/dart-lang/build/issues/2450
+  front_end: "0.1.23"

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.1
+
+- Allow `build` version 1.2.x.
+
 ## 1.7.0
 
 ### New Feature: Build Filters

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.7.0
+version: 1.7.1
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.0.0 <1.2.0"
+  build: ">=1.0.0 <1.3.0"
   build_config: ">=0.4.1 <0.4.2"
   build_daemon: ^2.1.0
   build_resolvers: "^1.0.0"

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 4.1.0-dev
 
-- Add support for trimming builds based on `BuildStep.removeDependency`
-  calls.
+- Add support for trimming builds based on `BuildStep.reportUnusedAssets`
+  calls. See the `build` package for more details.
 
 ## 4.0.0
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.0-dev
+
+- Add support for trimming builds based on `BuildStep.removeDependency`
+  calls.
+
 ## 4.0.0
 
 ### New Feature: Build Filters

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -472,16 +472,21 @@ class _SingleBuild {
             .putIfAbsent(phaseNumber, () => Set<String>())
             .add(actionDescription);
 
-        var removedDependencies = <AssetId, Iterable<AssetId>>{};
+        var unusedAssets = Set<AssetId>();
         await tracker.trackStage(
             'Build',
-            () => runBuilder(builder, [input], wrappedReader, wrappedWriter,
-                        PerformanceTrackingResolvers(_resolvers, tracker),
-                        logger: logger,
-                        resourceManager: _resourceManager,
-                        stageTracker: tracker,
-                        removedDependencies: removedDependencies)
-                    .catchError((_) {
+            () => runBuilder(
+                  builder,
+                  [input],
+                  wrappedReader,
+                  wrappedWriter,
+                  PerformanceTrackingResolvers(_resolvers, tracker),
+                  logger: logger,
+                  resourceManager: _resourceManager,
+                  stageTracker: tracker,
+                  reportUnusedAssetsForInput: (_, assets) =>
+                      unusedAssets.addAll(assets),
+                ).catchError((_) {
                   // Errors tracked through the logger
                 }));
         actionsCompletedCount++;
@@ -498,7 +503,7 @@ class _SingleBuild {
                   wrappedWriter,
                   actionDescription,
                   logger.errorsSeen,
-                  removedDependencies: removedDependencies[input],
+                  unusedAssets: unusedAssets,
                 ));
 
         return wrappedWriter.assetsWritten;
@@ -790,14 +795,14 @@ class _SingleBuild {
       AssetWriterSpy writer,
       String actionDescription,
       Iterable<ErrorReport> errors,
-      {Iterable<AssetId> removedDependencies}) async {
+      {Set<AssetId> unusedAssets}) async {
     if (outputs.isEmpty) return;
-    var actualInputs = removedDependencies != null
-        ? reader.assetsRead.difference(removedDependencies as Set<AssetId>)
+    var usedInputs = unusedAssets != null
+        ? reader.assetsRead.difference(unusedAssets)
         : reader.assetsRead;
 
     final inputsDigest = await _computeCombinedDigest(
-        actualInputs,
+        usedInputs,
         (_assetGraph.get(outputs.first) as GeneratedAssetNode).builderOptionsId,
         reader);
 
@@ -811,8 +816,8 @@ class _SingleBuild {
       // **IMPORTANT**: All updates to `node` must be synchronous. With lazy
       // builders we can run arbitrary code between updates otherwise, at which
       // time a node might not be in a valid state.
-      _removeOldInputs(node, actualInputs);
-      _addNewInputs(node, actualInputs);
+      _removeOldInputs(node, usedInputs);
+      _addNewInputs(node, usedInputs);
       node
         ..state = NodeState.upToDate
         ..wasOutput = wasOutput

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 4.0.0
+version: 4.1.0-dev
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.1.0 <1.2.0"
+  build: ">=1.2.0 <1.3.0"
   build_config: ">=0.4.0 <0.4.2"
   build_resolvers: ^1.0.0
   collection: ^1.14.0
@@ -37,3 +37,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -41,3 +41,5 @@ dev_dependencies:
 dependency_overrides:
   build:
     path: ../build
+  build_resolvers:
+    path: ../build_resolvers

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -43,3 +43,5 @@ dependency_overrides:
     path: ../build
   build_resolvers:
     path: ../build_resolvers
+  # https://github.com/dart-lang/sdk/issues/38499
+  analyzer: 0.38.2

--- a/scratch_space/mono_pkg.yaml
+++ b/scratch_space/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.0.0
+        - 2.2.2
   - unit_test:
     - command: pub run build_runner test
 

--- a/scratch_space/mono_pkg.yaml
+++ b/scratch_space/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.2.2
+        - 2.3.0
   - unit_test:
     - command: pub run build_runner test
 

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   build: ">=0.10.0 <2.0.0"

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   build: ">=0.10.0 <2.0.0"

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -19,3 +19,7 @@ dev_dependencies:
   build_test: ^0.10.0
   build_vm_compilers: ">=0.1.0 <2.0.0"
   test: ^1.0.0
+
+dependency_overrides:
+  # https://github.com/dart-lang/build/issues/2450
+  front_end: "0.1.23"


### PR DESCRIPTION
~Sending out for early design review - this is my current prototype for dependency pruning.~ Ready for primetime now!

cc @evanweible-wf @jonahwilliams 

## Current api overview

Added ~two~ one new api to the `BuildStep` abstract class:

- ~`void removeDependency(AssetId id);`~
- ~`Iterable<AssetId> get removedDependencies;`~
- `void reportUnusedAssets(Iterable<AssetId> ids);`

~I am not super happy with the exact api here, definitely looking for suggestions for improvement.~ I am much  happier now with the api here, based on suggestions.

## General concept

Gives `Builder` implementations the power to remove some of their input dependencies, even though they did actually check for the existence of or read the contents of some input.

This is a port of an experimental feature in `bazel`, which has been proven to dramatically reduce build times when making edits to heavily shared libraries.

Specifically, the Dart compilers can take advantage of this feature to not depend on all transitively imported packages when compiling a given module - they can "prune" their dependencies to only the transitive inputs that the module actually uses. In practice it is common to see an order of magnitude fewer dependencies for any given module as a result.

## Trying out the full proof of concept

You can experiment with this feature by depending on the `unused-inputs-kernel` branch of this package, by adding the following to your pubspec:

```yaml
dependency_overrides:
  build:
    git:
      url: https://github.com/dart-lang/build.git
      ref: unused-inputs-kernel
      path: build
  build_runner_core:
    git:
      url: https://github.com/dart-lang/build.git
      ref: unused-inputs-kernel
      path: build_runner_core
  build_modules:
    git:
      url: https://github.com/dart-lang/build.git
      ref: unused-inputs-kernel
      path: build_modules
  build_web_compilers:
    git:
      url: https://github.com/dart-lang/build.git
      ref: unused-inputs-kernel
      path: build_web_compilers
```

## Isn't this non-hermetic?

Yes, this allows for potential non-hermetic builds for badly behaved builders. It is up to the builder to make sure they really didn't depend on the contents of that file, and that no change to that file (or the existence thereof) could affect the output of the builder.

This is an explicit tradeoff being made because the performance gains are such that it is worth the risk.