### PR TITLE
generalize the required resources feature when bootstrapping ddc apps

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.4.1
+
+Make the required assets for DDC applications configurable in the
+`bootstrapDdc` method instead of hard coded. This allows custom integrations
+like flutter web to not require the same assets, or require additional custom
+assets.
+
 ## 2.4.0
 
 ### New Feature: Better --build-filter support for building a single test.

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -98,7 +98,7 @@ class WebEntrypointBuilder implements Builder {
     if (!isAppEntrypoint) return;
     if (webCompiler == WebCompiler.DartDevc) {
       try {
-        await bootstrapDdc(buildStep);
+        await bootstrapDdc(buildStep, requiredAssets: _ddcSdkResources);
       } on MissingModulesException catch (e) {
         log.severe('$e');
       }
@@ -128,3 +128,10 @@ Future<bool> _isAppEntryPoint(AssetId dartId, AssetReader reader) async {
         node.functionExpression.parameters.parameters.length <= 2;
   });
 }
+
+/// Files copied from the SDK that are required at runtime to run a DDC
+/// application.
+final _ddcSdkResources = [
+  AssetId('build_web_compilers', 'lib/src/dev_compiler/dart_sdk.js'),
+  AssetId('build_web_compilers', 'lib/src/dev_compiler/require.js'),
+];

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.4.0
+version: 2.4.1
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
I noticed that when rolling the latest build_web_compilers into flutter_web this was throwing since they handle sdk resources differently.

cc @jonahwilliams 