### PR TITLE
Don't track the .dart.bootstrap library as a module

### DIFF
--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -212,9 +212,6 @@ define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_s
         }
       }
     }
-  dart_sdk.dart.trackLibraries("$bootstrapModuleName", {
-    "$bootstrapModuleName": bootstrap
-  }, '');
   return {
     bootstrap: bootstrap
   };


### PR DESCRIPTION
It doesn't seem like this is required, and it means we have this library showing as a Dart library in DWDS. Deleting it here doesn't cause any of its own tests to fail. The open question is if this affects hot reload. It was introduced in https://github.com/dart-lang/build/commit/ab759a7d3 and it's possible that the bootstrap file could be affected by a code change and need to reload - I'm not sure.

Making a pull request to see if it affects any tests, and seeing if Jake has any insight.