### PR TITLE
Create a custom summary from the users sdk

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.1.0
+
+### Bug Fix: #38499
+
+Update the `AnalysisResolvers` class to no longer use the SDK summary that is
+shipped with the SDK by default. This is not guaranteed compatible with
+analyzer versions shipped on pub and should not be used by any non-sdk code.
+
+In order to fix this the `AnalysisResolvers` class now takes an optional method
+that returns the path to an arbitrary SDK summary. By default it will lazily
+generate a summary under `.dart_tool/build_resolvers` which is invalidated
+based on the `Platform.version` from `dart:io`.
+
 ## 1.0.8
 
 - Allow `build` version 1.2.x.

--- a/build_resolvers/lib/src/analysis_driver.dart
+++ b/build_resolvers/lib/src/analysis_driver.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:analyzer/src/dart/analysis/byte_store.dart'
     show MemoryByteStore;
 import 'package:analyzer/src/dart/analysis/driver.dart';
@@ -13,7 +11,6 @@ import 'package:analyzer/src/dart/analysis/performance_logger.dart'
 import 'package:analyzer/src/generated/engine.dart'
     show AnalysisOptionsImpl, AnalysisOptions;
 import 'package:analyzer/src/generated/source.dart';
-import 'package:path/path.dart' as p;
 import 'package:analyzer/src/summary/package_bundle_reader.dart';
 import 'package:analyzer/src/summary/summary_sdk.dart' show SummaryBasedDartSdk;
 
@@ -25,17 +22,14 @@ import 'build_asset_uri_resolver.dart';
 /// Any code which is not covered by the summaries must be resolvable through
 /// [buildAssetUriResolver].
 AnalysisDriver analysisDriver(BuildAssetUriResolver buildAssetUriResolver,
-    AnalysisOptions analysisOptions) {
-  var sdkPath = p.dirname(p.dirname(Platform.resolvedExecutable));
-  var sdkSummary = p.join(sdkPath, 'lib', '_internal', 'strong.sum');
-  var sdk = SummaryBasedDartSdk(sdkSummary, true);
+    AnalysisOptions analysisOptions, String sdkSummaryPath) {
+  var sdk = SummaryBasedDartSdk(sdkSummaryPath, true);
   var sdkResolver = DartUriResolver(sdk);
 
   var resolvers = [sdkResolver, buildAssetUriResolver];
   var sourceFactory = SourceFactory(resolvers);
 
-  var dataStore =
-      SummaryDataStore([p.join(sdkPath, 'lib', '_internal', 'strong.sum')]);
+  var dataStore = SummaryDataStore([sdkSummaryPath]);
 
   var logger = PerformanceLog(null);
   var scheduler = AnalysisDriverScheduler(logger);

--- a/build_resolvers/lib/src/human_readable_duration.dart
+++ b/build_resolvers/lib/src/human_readable_duration.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Returns a human readable string for a duration.
+///
+/// Handles durations that span up to hours - this will not be a good fit for
+/// durations that are longer than days.
+///
+/// Always attempts 2 'levels' of precision. Will show hours/minutes,
+/// minutes/seconds, seconds/tenths of a second, or milliseconds depending on
+/// the largest level that needs to be displayed.
+///
+// TODO: This is copied from `package:build_runner_core`, at some point we
+// may want to move this to a shared dependency.
+String humanReadable(Duration duration) {
+  if (duration < const Duration(seconds: 1)) {
+    return '${duration.inMilliseconds}ms';
+  }
+  if (duration < const Duration(minutes: 1)) {
+    return '${(duration.inMilliseconds / 1000.0).toStringAsFixed(1)}s';
+  }
+  if (duration < const Duration(hours: 1)) {
+    final minutes = duration.inMinutes;
+    final remaining = duration - Duration(minutes: minutes);
+    return '${minutes}m ${remaining.inSeconds}s';
+  }
+  final hours = duration.inHours;
+  final remaining = duration - Duration(hours: hours);
+  return '${hours}h ${remaining.inMinutes}m';
+}

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -126,8 +126,6 @@ class AnalyzerResolver implements ReleasableResolver {
   }
 }
 
-typedef ResolverFactory = Future<Resolver> Function();
-
 class AnalyzerResolvers implements Resolvers {
   /// Nullable, the default analysis options are used if not provided.
   final AnalysisOptions _analysisOptions;

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -135,7 +135,7 @@ class AnalyzerResolvers implements Resolvers {
   /// Defaults to [_defaultSdkSummaryGenerator].
   final Future<String> Function() _sdkSummaryGenerator;
 
-  /// Lazy, all access must be preceded by a call to [_ensureInitialized].
+  // Lazy, all access must be preceded by a call to `_ensureInitialized`.
   AnalyzerResolver _resolver;
   BuildAssetUriResolver _uriResolver;
 
@@ -191,7 +191,7 @@ Future<String> _defaultSdkSummaryGenerator() async {
 
   var cacheDir = p.join(dartToolPath, 'build_resolvers');
   var summaryPath = p.join(cacheDir, 'sdk.sum');
-  var versionFile = File(summaryPath + '.version');
+  var versionFile = File('$summaryPath.version');
   var summaryFile = File(summaryPath);
 
   // Invalidate existing summary/version files if present.
@@ -206,7 +206,7 @@ Future<String> _defaultSdkSummaryGenerator() async {
     await summaryFile.delete();
   }
 
-  /// Generate the summary and version files if necessary.
+  // Generate the summary and version files if necessary.
   if (!await summaryFile.exists()) {
     var watch = Stopwatch()..start();
     _logger.info('Generating SDK summary...');

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -4,19 +4,22 @@
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:io';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/src/dart/analysis/driver.dart' show AnalysisDriver;
-import 'package:analyzer/src/generated/engine.dart';
+import 'package:analyzer/src/generated/engine.dart' hide Logger;
 import 'package:analyzer/src/generated/source.dart';
+import 'package:analyzer/src/summary/summary_file_builder.dart';
 import 'package:build/build.dart';
-import 'package:path/path.dart' as native_path;
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 
 import 'analysis_driver.dart';
 import 'build_asset_uri_resolver.dart';
+import 'human_readable_duration.dart';
 
-// We should always be using url paths here since it's always Dart/pub code.
-final path = native_path.url;
+final _logger = Logger('build_resolvers');
 
 /// Implements [Resolver.libraries] and [Resolver.findLibraryByName] by crawling
 /// down from entrypoints.
@@ -123,25 +126,44 @@ class AnalyzerResolver implements ReleasableResolver {
   }
 }
 
-class AnalyzerResolvers implements Resolvers {
-  final AnalyzerResolver _resolver;
-  final BuildAssetUriResolver _uriResolver;
+typedef ResolverFactory = Future<Resolver> Function();
 
-  AnalyzerResolvers._(this._resolver, this._uriResolver);
+class AnalyzerResolvers implements Resolvers {
+  /// Nullable, the default analysis options are used if not provided.
+  final AnalysisOptions _analysisOptions;
+
+  /// A function that returns the path to the SDK summary when invoked.
+  ///
+  /// Defaults to [_defaultSdkSummaryGenerator].
+  final Future<String> Function() _sdkSummaryGenerator;
+
+  /// Lazy, all access must be preceded by a call to [_ensureInitialized].
+  AnalyzerResolver _resolver;
+  BuildAssetUriResolver _uriResolver;
+
+  /// Nullable, should not be accessed outside of [_ensureInitialized].
+  Future<void> _initialized;
+
+  AnalyzerResolvers(
+      [this._analysisOptions, Future<String> Function() sdkSummaryGenerator])
+      : _sdkSummaryGenerator =
+            sdkSummaryGenerator ?? _defaultSdkSummaryGenerator;
 
   /// Create a Resolvers backed by an [AnalysisContext] using options
-  /// [analysisOptions].
-  ///
-  /// If no argument is passed a default AnalysisOptions is used.
-  factory AnalyzerResolvers([AnalysisOptions analysisOptions]) {
-    var uriResolver = BuildAssetUriResolver();
-    var driver = analysisDriver(uriResolver, analysisOptions);
-    return AnalyzerResolvers._(
-        AnalyzerResolver(driver, uriResolver), uriResolver);
+  /// [_analysisOptions].
+  Future<void> _ensureInitialized() {
+    return _initialized ??= () async {
+      _uriResolver = BuildAssetUriResolver();
+      var driver = analysisDriver(
+          _uriResolver, _analysisOptions, await _sdkSummaryGenerator());
+      _resolver = AnalyzerResolver(driver, _uriResolver);
+    }();
   }
 
   @override
   Future<ReleasableResolver> get(BuildStep buildStep) async {
+    await _ensureInitialized();
+
     await _uriResolver.performResolve(
         buildStep, [buildStep.inputId], _resolver._driver);
     return PerActionResolver(_resolver, [buildStep.inputId]);
@@ -149,5 +171,57 @@ class AnalyzerResolvers implements Resolvers {
 
   /// Must be called between each build.
   @override
-  void reset() => _uriResolver.seenAssets.clear();
+  void reset() {
+    _uriResolver?.seenAssets?.clear();
+  }
+}
+
+/// Lazily creates a summary of the users SDK and caches it under
+/// `.dart_tool/build_resolvers`.
+///
+/// This is only intended for use in typical dart packages, which must
+/// have an already existing `.dart_tool` directory (this is how we
+/// validate we are running under a typical dart package and not a custom
+/// environment).
+Future<String> _defaultSdkSummaryGenerator() async {
+  var dartToolPath = '.dart_tool';
+  if (!await Directory(dartToolPath).exists()) {
+    throw StateError(
+        'The default analyzer resolver can only be used when the current '
+        'working directory is a standard pub package.');
+  }
+
+  var cacheDir = p.join(dartToolPath, 'build_resolvers');
+  var summaryPath = p.join(cacheDir, 'sdk.sum');
+  var versionFile = File(summaryPath + '.version');
+  var summaryFile = File(summaryPath);
+
+  // Invalidate existing summary/version files if present.
+  if (await versionFile.exists()) {
+    var lastVersion = await versionFile.readAsString();
+    if (lastVersion != Platform.version) {
+      await versionFile.delete();
+      if (await summaryFile.exists()) await summaryFile.delete();
+    }
+  } else if (await summaryFile.exists()) {
+    // If there is no version file we can't validate the version here.
+    await summaryFile.delete();
+  }
+
+  /// Generate the summary and version files if necessary.
+  if (!await summaryFile.exists()) {
+    var watch = Stopwatch()..start();
+    _logger.info('Generating SDK summary...');
+    await summaryFile.create(recursive: true);
+    var sdkPath = p.dirname(p.dirname(Platform.resolvedExecutable));
+    await summaryFile.writeAsBytes(SummaryBuilder.forSdk(sdkPath).build());
+
+    await versionFile.create(recursive: true);
+    await versionFile.writeAsString(Platform.version);
+    watch.stop();
+    _logger.info('Generating SDK summary completed, took '
+        '${humanReadable(watch.elapsed)}\n');
+  }
+
+  return p.absolute(summaryPath);
 }

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.0.8
+version: 1.1.0
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
@@ -12,6 +12,7 @@ dependencies:
   build: ">=1.1.0 <1.3.0"
   crypto: ^2.0.0
   graphs: ^0.2.0
+  logging: ^0.11.2
   path: ^1.1.0
 
 dev_dependencies:
@@ -19,7 +20,3 @@ dev_dependencies:
   build_test: ^0.10.1
   build_runner: ^1.0.0
   build_vm_compilers: ">=0.1.0 <2.0.0"
-
-dependency_overrides:
-  # https://github.com/dart-lang/build/issues/2450
-  front_end: "0.1.23"


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/38499.
Fixes https://github.com/dart-lang/build/issues/2451.

Lazily generates an sdk summary from the users SDK files and caches it under `.dart_tool/build_resolvers`. On my machine this adds ~3 seconds on first use.

The summary is invalidated based on the `Platform.version` which is cached in a file next to the summary.

A custom summary can also be provided (for non-pub package scenarios). I am going to validate this can be rolled successfully internally before landing.

Note that this has one nice property of allowing build_runner and build_test to share the summary file, which is one advantage over implementing this with a Builder. 