### PR TITLE
check the analyzer path in addition to sdk version before reusing the summary

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.1
+
+### Bug Fix
+
+Check the analyzer path before reading cached summaries in addition to the
+SDK version.
+
 ## 1.1.0
 
 ### Bug Fix: #38499

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.1.0
+version: 1.1.1
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
@@ -13,6 +13,7 @@ dependencies:
   crypto: ^2.0.0
   graphs: ^0.2.0
   logging: ^0.11.2
+  package_resolver: ^1.0.0
   path: ^1.1.0
 
 dev_dependencies:


### PR DESCRIPTION
At lunch I realized that we also need to check the analyzer version and invalidate if that changes :sob: .