### PR TITLE
Read assets from same build step

### DIFF
--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -27,7 +27,9 @@ abstract class Resolver {
   /// * Throws [NonLibraryAssetException] if [assetId] is not a Dart library.
   Future<LibraryElement> libraryFor(AssetId assetId);
 
-  /// Returns the first library identified by [libraryName].
+  /// Returns the first resolved library identified by [libraryName]. A library
+  /// is resolved if it's recursively accessible from the entry point or
+  /// subsequent calls to [libraryFor] and [isLibrary].
   ///
   /// If no library can be found, returns `null`.
   ///

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -27,11 +27,11 @@ abstract class Resolver {
   /// * Throws [NonLibraryAssetException] if [assetId] is not a Dart library.
   Future<LibraryElement> libraryFor(AssetId assetId);
 
-  /// Returns the first resolved library identified by [libraryName]. A library
-  /// is resolved if it's recursively accessible from the entry point or
-  /// subsequent calls to [libraryFor] and [isLibrary].
+  /// Returns the first resolved library identified by [libraryName].
   ///
-  /// If no library can be found, returns `null`.
+  /// A library is resolved if it's recursively accessible from the entry point
+  /// or subsequent calls to [libraryFor] and [isLibrary]. If no library can be
+  /// found, returns `null`.
   ///
   /// **NOTE**: In general, its recommended to use [libraryFor] with an absolute
   /// asset id instead of a named identifier that has the possibility of not

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -16,7 +16,8 @@ abstract class Resolver {
   /// or is a `part of` file (not a standalone Dart library).
   Future<bool> isLibrary(AssetId assetId);
 
-  /// All libraries accessible from the entry point, recursively.
+  /// All libraries recursively accessible from the entry point or subsequent
+  /// calls to [libraryFor] and [isLibrary].
   ///
   /// **NOTE**: This includes all Dart SDK libraries as well.
   Stream<LibraryElement> get libraries;

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -52,7 +52,7 @@ class BuildAssetUriResolver extends UriResolver {
       AnalysisDriver driver) async {
     final seenInBuildStep =
         _buildStepAssets.putIfAbsent(buildStep, () => HashSet());
-    final notCrawled = (AssetId asset) => !seenInBuildStep.contains(asset);
+    bool notCrawled(AssetId asset) => !seenInBuildStep.contains(asset);
 
     final changedPaths = await crawlAsync<AssetId, _AssetState>(
             entryPoints.where(notCrawled), (id) async {

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -55,45 +55,45 @@ class BuildAssetUriResolver extends UriResolver {
     final notCrawled = (AssetId asset) => !seenInBuildStep.contains(asset);
 
     final changedPaths = await crawlAsync<AssetId, _AssetState>(
-      entryPoints.where(notCrawled),
-      (id) async {
-        final path = assetPath(id);
-        if (!await buildStep.canRead(id)) {
-          if (globallySeenAssets.contains(id)) {
-            // ignore from this graph, some later build step may still be using it
-            // so it shouldn't be removed from [resourceProvider], but we also
-            // don't care about it's transitive imports.
-            return null;
-          }
-          _cachedAssetDependencies.remove(id);
-          _cachedAssetDigests.remove(id);
-          if (resourceProvider.getFile(path).exists) {
-            resourceProvider.deleteFile(path);
-          }
-          return _AssetState.removed(path);
+            entryPoints.where(notCrawled), (id) async {
+      final path = assetPath(id);
+      if (!await buildStep.canRead(id)) {
+        if (globallySeenAssets.contains(id)) {
+          // ignore from this graph, some later build step may still be using it
+          // so it shouldn't be removed from [resourceProvider], but we also
+          // don't care about it's transitive imports.
+          return null;
         }
-        globallySeenAssets.add(id);
-        seenInBuildStep.add(id);
-        final digest = await buildStep.digest(id);
-        if (_cachedAssetDigests[id] == digest) {
-          return _AssetState.unchanged(path, _cachedAssetDependencies[id]);
+        _cachedAssetDependencies.remove(id);
+        _cachedAssetDigests.remove(id);
+        if (resourceProvider.getFile(path).exists) {
+          resourceProvider.deleteFile(path);
+        }
+        return _AssetState.removed(path);
+      }
+      globallySeenAssets.add(id);
+      seenInBuildStep.add(id);
+      final digest = await buildStep.digest(id);
+      if (_cachedAssetDigests[id] == digest) {
+        return _AssetState.unchanged(path, _cachedAssetDependencies[id]);
+      } else {
+        final isChange = _cachedAssetDigests.containsKey(id);
+        final content = await buildStep.readAsString(id);
+        _cachedAssetDigests[id] = digest;
+        final dependencies =
+            _cachedAssetDependencies[id] = _parseDirectives(content, id);
+        if (isChange) {
+          resourceProvider.updateFile(path, content);
+          return _AssetState.changed(path, dependencies);
         } else {
-          final isChange = _cachedAssetDigests.containsKey(id);
-          final content = await buildStep.readAsString(id);
-          _cachedAssetDigests[id] = digest;
-          final dependencies =
-              _cachedAssetDependencies[id] = _parseDirectives(content, id);
-          if (isChange) {
-            resourceProvider.updateFile(path, content);
-            return _AssetState.changed(path, dependencies);
-          } else {
-            resourceProvider.newFile(path, content);
-            return _AssetState.newAsset(path, dependencies);
-          }
+          resourceProvider.newFile(path, content);
+          return _AssetState.newAsset(path, dependencies);
         }
-      },
-      (id, state) => state.directives.where(notCrawled),
-    ).where((state) => state.isAssetUpdate).map((state) => state.path).toList();
+      }
+    }, (id, state) => state.directives.where(notCrawled))
+        .where((state) => state.isAssetUpdate)
+        .map((state) => state.path)
+        .toList();
     changedPaths.forEach(driver.changeFile);
   }
 

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -117,14 +117,15 @@ class BuildAssetUriResolver extends UriResolver {
     return null;
   }
 
-  void notifyBuildStepFinished(BuildStep step) {
+  void notifyComplete(BuildStep step) {
     _buildStepAssets.remove(step);
   }
 
   /// Clear cached information specific to an individual build.
-  void resetForBuild() {
-    globallySeenAssets?.clear();
-    _buildStepAssets.clear();
+  void reset() {
+    assert(_buildStepAssets.isEmpty,
+        'Reset was called before all build steps completed');
+    globallySeenAssets.clear();
   }
 
   @override

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -38,7 +38,11 @@ class PerActionResolver implements ReleasableResolver {
   Stream<LibraryElement> get libraries async* {
     final seen = Set<LibraryElement>();
     final toVisit = Queue<LibraryElement>();
-    for (final entryPoint in _entryPoints) {
+
+    // keep a copy of entry points in case [_resolveIfNecessary] is called
+    // before this stream is done.
+    final entryPoints = Set.of(_entryPoints);
+    for (final entryPoint in entryPoints) {
       if (!await _delegate.isLibrary(entryPoint)) continue;
       final library = await _delegate.libraryFor(entryPoint);
       toVisit.add(library);

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -69,15 +69,18 @@ class PerActionResolver implements ReleasableResolver {
       _resolveIfNecesssary(assetId).then(_delegate.libraryFor);
 
   Future<AssetId> _resolveIfNecesssary(AssetId id) async {
-    if (!_delegate._uriResolver.seenAssets.contains(id)) {
-      await _delegate._uriResolver
-          .performResolve(_step, [id], _delegate._driver);
-    }
+    // the resolver will only visit assets that haven't been resolved in this
+    // step yet
+    await _delegate._uriResolver.performResolve(_step, [id], _delegate._driver);
+
     return id;
   }
 
   @override
-  void release() => _delegate.release();
+  void release() {
+    _delegate._uriResolver.notifyBuildStepFinished(_step);
+    _delegate.release();
+  }
 
   @override
   Future<AssetId> assetIdForElement(Element element) =>
@@ -181,7 +184,7 @@ class AnalyzerResolvers implements Resolvers {
   /// Must be called between each build.
   @override
   void reset() {
-    _uriResolver?.seenAssets?.clear();
+    _uriResolver?.resetForBuild();
   }
 }
 

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -83,6 +83,8 @@ void main() {
 
       test('are included in library stream', () {
         return _runWith((resolver) async {
+          expect(resolver.libraries.map((l) => l.name), neverEmits('other'));
+
           await resolver.libraryFor(entryPoint);
 
           expect(resolver.libraries.map((l) => l.name), emits('other'));

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -58,6 +58,24 @@ void main() {
       }, resolvers: AnalyzerResolvers());
     });
 
+    test('should resolve files that aren\'t a transitive import of input', () {
+      return resolveSources({
+        'a|web/main.dart': '''
+          main() {}
+        ''',
+        'a|lib/other.dart': '''
+          fun() {}
+        '''
+      }, (resolver) async {
+        final main = await resolver.libraryFor(entryPoint);
+        expect(main, isNotNull);
+
+        final other =
+            await resolver.libraryFor(AssetId.parse('a|lib/other.dart'));
+        expect(other.topLevelElements.any((e) => e.name == 'fun'), isTrue);
+      });
+    });
+
     test('handles missing files', () {
       return resolveSources({
         'a|web/main.dart': '''

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -58,21 +58,43 @@ void main() {
       }, resolvers: AnalyzerResolvers());
     });
 
-    test('should resolve files that aren\'t a transitive import of input', () {
-      return resolveSources({
-        'a|web/main.dart': '''
+    group('assets that aren\'t a transitive import of input', () {
+      Future _runWith(Future Function(Resolver) test) {
+        return resolveSources({
+          'a|web/main.dart': '''
           main() {}
         ''',
-        'a|lib/other.dart': '''
-          fun() {}
+          'a|lib/other.dart': '''
+          library other;
         '''
-      }, (resolver) async {
-        final main = await resolver.libraryFor(entryPoint);
-        expect(main, isNotNull);
+        }, test);
+      }
 
-        final other =
-            await resolver.libraryFor(AssetId.parse('a|lib/other.dart'));
-        expect(other.topLevelElements.any((e) => e.name == 'fun'), isTrue);
+      test('can be resolved', () {
+        return _runWith((resolver) async {
+          final main = await resolver.libraryFor(entryPoint);
+          expect(main, isNotNull);
+
+          final other =
+              await resolver.libraryFor(AssetId.parse('a|lib/other.dart'));
+          expect(other.name, 'other');
+        });
+      });
+
+      test('are included in library stream', () {
+        return _runWith((resolver) async {
+          await resolver.libraryFor(entryPoint);
+
+          expect(resolver.libraries.map((l) => l.name), emits('other'));
+        });
+      });
+
+      test('can be found by name', () {
+        return _runWith((resolver) async {
+          await resolver.libraryFor(entryPoint);
+
+          expect(resolver.findLibraryByName('other'), completion(isNotNull));
+        });
       });
     });
 

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -40,7 +40,7 @@ class Readability {
 }
 
 typedef IsReadable = FutureOr<Readability> Function(
-    AssetNode node, int phaseNum, String fromPackage);
+    AssetNode node, int phaseNum, AssetId primaryInput);
 
 /// An [AssetReader] with a lifetime equivalent to that of a single step in a
 /// build.
@@ -58,6 +58,7 @@ class SingleStepReader implements AssetReader {
   final AssetReader _delegate;
   final int _phaseNumber;
   final String _primaryPackage;
+  final AssetId _primaryInput;
   final IsReadable _isReadableNode;
   final FutureOr<GlobAssetNode> Function(
       Glob glob, String package, int phaseNum) _getGlobNode;
@@ -67,7 +68,7 @@ class SingleStepReader implements AssetReader {
 
   SingleStepReader(this._delegate, this._assetGraph, this._phaseNumber,
       this._primaryPackage, this._isReadableNode,
-      [this._getGlobNode]);
+      [this._getGlobNode, this._primaryInput]);
 
   /// Checks whether [id] can be read by this step - attempting to build the
   /// asset if necessary.
@@ -79,7 +80,7 @@ class SingleStepReader implements AssetReader {
       return false;
     }
 
-    return doAfter(_isReadableNode(node, _phaseNumber, _primaryPackage),
+    return doAfter(_isReadableNode(node, _phaseNumber, _primaryInput),
         (Readability readability) {
       if (readability.addToInputs) {
         assetsRead.add(id);


### PR DESCRIPTION
I've made two changes
1. allow builders to resolve assets that aren't a transitive dependency of their main input. 
2. allow builders to read generated assets written in the same step. There's a special case in `SingleStepReader._isReadable` so that these nodes don't have themselves as primary input in the graph.