### PR TITLE
Use the kernel version of dart_sdk.js

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1
+
+- Use the kernel version of `dart_sdk.js` rather than the analyzer version.
+
 ## 2.6.0
 
 Add an option to globally skip the platform checks instead of only skipping

--- a/build_web_compilers/lib/src/sdk_js_copy_builder.dart
+++ b/build_web_compilers/lib/src/sdk_js_copy_builder.dart
@@ -20,11 +20,11 @@ class SdkJsCopyBuilder implements Builder {
 
   /// Path to the dart_sdk.js file that should be used for all ddc web apps.
   final _sdkJsLocation =
-      p.join(sdkDir, 'lib', 'dev_compiler', 'amd', 'dart_sdk.js');
+      p.join(sdkDir, 'lib', 'dev_compiler', 'kernel', 'amd', 'dart_sdk.js');
 
   /// Path to the require.js file that should be used for all ddc web apps.
   final _sdkRequireJsLocation =
-      p.join(sdkDir, 'lib', 'dev_compiler', 'amd', 'require.js');
+      p.join(sdkDir, 'lib', 'dev_compiler', 'kernel', 'amd', 'require.js');
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.6.0
+version: 2.6.1
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
We ship with two copies of the SDk, one compiled with kernel and the
other with analyzer. There may be subtle behavior differences between
the two.