### PR TITLE
Enforce ordering between SDK JS copier and DDC

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.6.3
+
+- Enforce builder application ordering between the SDK JS copy builder and the
+  DDC entrypoint builder.
+
 ## 2.6.2
 
 Fix the skipPlatformCheck option which was accidentally doing the opposite

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -27,6 +27,7 @@ builders:
     is_optional: False
     auto_apply: none
     applies_builders: ["build_web_compilers|sdk_js_cleanup"]
+    runs_before: ["build_web_compilers|entrypoint"]
   dart2js_modules:
     import: "package:build_web_compilers/builders.dart"
     builder_factories:

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.6.2
+version: 2.6.3
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
The DDC entrypoint builder will ensure that the SDK resources are
available with `buildStep.canRead` and so they will be required to exist
in an earlier phase. This is going to be true for almost all packages
anyway since the `sdk_js_copy` builder only applies to
`build_web_compilers` will will almost always be non-root and not in a
dependency cycle with the root. For the dependencies of
`build_web_compilers` we can make it a guarantee.