### PR TITLE
Fix flaky test, change test sharding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -199,21 +199,9 @@ jobs:
       env: PKGS="_test"
       script: ./tool/travis.sh test_00
     - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 0`"
-      dart: dev
-      os: windows
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_00
-    - stage: e2e_test
       name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 1`"
       dart: dev
       os: linux
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_01
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 1`"
-      dart: dev
-      os: windows
       env: PKGS="_test"
       script: ./tool/travis.sh test_01
     - stage: e2e_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,25 +71,25 @@ jobs:
       dart: dev
       os: linux
       env: PKGS="build_config"
-      script: ./tool/travis.sh test_06
+      script: ./tool/travis.sh test_05
     - stage: unit_test
       name: "SDK: dev; PKG: build_config; TASKS: `pub run test`"
       dart: dev
       os: windows
       env: PKGS="build_config"
-      script: ./tool/travis.sh test_06
+      script: ./tool/travis.sh test_05
     - stage: unit_test
       name: "SDK: dev; PKG: build_daemon; TASKS: `pub run test`"
       dart: dev
       os: linux
       env: PKGS="build_daemon"
-      script: ./tool/travis.sh test_06
+      script: ./tool/travis.sh test_05
     - stage: unit_test
       name: "SDK: dev; PKG: build_daemon; TASKS: `pub run test`"
       dart: dev
       os: windows
       env: PKGS="build_daemon"
-      script: ./tool/travis.sh test_06
+      script: ./tool/travis.sh test_05
     - stage: unit_test
       name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit`"
       dart: dev
@@ -119,171 +119,147 @@ jobs:
       dart: dev
       os: linux
       env: PKGS="build_runner"
+      script: ./tool/travis.sh test_06
+    - stage: unit_test
+      name: "SDK: 2.3.0; PKG: build_runner_core; TASKS: `pub run test`"
+      dart: "2.3.0"
+      os: linux
+      env: PKGS="build_runner_core"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: 2.3.0; PKG: build_runner_core; TASKS: `pub run test`"
+      dart: "2.3.0"
+      os: windows
+      env: PKGS="build_runner_core"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: dev; PKG: build_runner_core; TASKS: `pub run test`"
+      dart: dev
+      os: linux
+      env: PKGS="build_runner_core"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: dev; PKG: build_runner_core; TASKS: `pub run test`"
+      dart: dev
+      os: windows
+      env: PKGS="build_runner_core"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: dev; PKG: build_test; TASKS: `pub run build_runner test`"
+      dart: dev
+      os: linux
+      env: PKGS="build_test"
+      script: ./tool/travis.sh command_2
+    - stage: unit_test
+      name: "SDK: dev; PKG: build_test; TASKS: `pub run build_runner test`"
+      dart: dev
+      os: windows
+      env: PKGS="build_test"
+      script: ./tool/travis.sh command_2
+    - stage: unit_test
+      name: "SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
+      dart: dev
+      os: linux
+      env: PKGS="build_vm_compilers"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
+      dart: dev
+      os: windows
+      env: PKGS="build_vm_compilers"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test`"
+      dart: dev
+      os: linux
+      env: PKGS="build_web_compilers"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test`"
+      dart: dev
+      os: windows
+      env: PKGS="build_web_compilers"
+      script: ./tool/travis.sh test_05
+    - stage: unit_test
+      name: "SDK: dev; PKG: scratch_space; TASKS: `pub run build_runner test`"
+      dart: dev
+      os: linux
+      env: PKGS="scratch_space"
+      script: ./tool/travis.sh command_2
+    - stage: unit_test
+      name: "SDK: dev; PKG: scratch_space; TASKS: `pub run build_runner test`"
+      dart: dev
+      os: windows
+      env: PKGS="scratch_space"
+      script: ./tool/travis.sh command_2
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 0`"
+      dart: dev
+      os: linux
+      env: PKGS="_test"
+      script: ./tool/travis.sh test_00
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 0`"
+      dart: dev
+      os: windows
+      env: PKGS="_test"
+      script: ./tool/travis.sh test_00
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 1`"
+      dart: dev
+      os: linux
+      env: PKGS="_test"
+      script: ./tool/travis.sh test_01
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 1`"
+      dart: dev
+      os: windows
+      env: PKGS="_test"
+      script: ./tool/travis.sh test_01
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 0`"
+      dart: dev
+      os: windows
+      env: PKGS="_test"
+      script: ./tool/travis.sh test_02
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 1`"
+      dart: dev
+      os: windows
+      env: PKGS="_test"
+      script: ./tool/travis.sh test_03
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 2`"
+      dart: dev
+      os: windows
+      env: PKGS="_test"
+      script: ./tool/travis.sh test_04
+    - stage: e2e_test
+      name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 0`"
+      dart: dev
+      os: linux
+      env: PKGS="build_runner"
       script: ./tool/travis.sh test_07
-    - stage: unit_test
-      name: "SDK: 2.3.0; PKG: build_runner_core; TASKS: `pub run test`"
-      dart: "2.3.0"
-      os: linux
-      env: PKGS="build_runner_core"
-      script: ./tool/travis.sh test_06
-    - stage: unit_test
-      name: "SDK: 2.3.0; PKG: build_runner_core; TASKS: `pub run test`"
-      dart: "2.3.0"
-      os: windows
-      env: PKGS="build_runner_core"
-      script: ./tool/travis.sh test_06
-    - stage: unit_test
-      name: "SDK: dev; PKG: build_runner_core; TASKS: `pub run test`"
-      dart: dev
-      os: linux
-      env: PKGS="build_runner_core"
-      script: ./tool/travis.sh test_06
-    - stage: unit_test
-      name: "SDK: dev; PKG: build_runner_core; TASKS: `pub run test`"
-      dart: dev
-      os: windows
-      env: PKGS="build_runner_core"
-      script: ./tool/travis.sh test_06
-    - stage: unit_test
-      name: "SDK: dev; PKG: build_test; TASKS: `pub run build_runner test`"
-      dart: dev
-      os: linux
-      env: PKGS="build_test"
-      script: ./tool/travis.sh command_2
-    - stage: unit_test
-      name: "SDK: dev; PKG: build_test; TASKS: `pub run build_runner test`"
-      dart: dev
-      os: windows
-      env: PKGS="build_test"
-      script: ./tool/travis.sh command_2
-    - stage: unit_test
-      name: "SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
-      dart: dev
-      os: linux
-      env: PKGS="build_vm_compilers"
-      script: ./tool/travis.sh test_06
-    - stage: unit_test
-      name: "SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
-      dart: dev
-      os: windows
-      env: PKGS="build_vm_compilers"
-      script: ./tool/travis.sh test_06
-    - stage: unit_test
-      name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test`"
-      dart: dev
-      os: linux
-      env: PKGS="build_web_compilers"
-      script: ./tool/travis.sh test_06
-    - stage: unit_test
-      name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test`"
-      dart: dev
-      os: windows
-      env: PKGS="build_web_compilers"
-      script: ./tool/travis.sh test_06
-    - stage: unit_test
-      name: "SDK: dev; PKG: scratch_space; TASKS: `pub run build_runner test`"
-      dart: dev
-      os: linux
-      env: PKGS="scratch_space"
-      script: ./tool/travis.sh command_2
-    - stage: unit_test
-      name: "SDK: dev; PKG: scratch_space; TASKS: `pub run build_runner test`"
-      dart: dev
-      os: windows
-      env: PKGS="scratch_space"
-      script: ./tool/travis.sh command_2
     - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 0`"
-      dart: dev
-      os: linux
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_00
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 0`"
-      dart: dev
-      os: windows
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_00
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 1`"
-      dart: dev
-      os: linux
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_01
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 1`"
-      dart: dev
-      os: windows
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_01
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 2`"
-      dart: dev
-      os: linux
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_02
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 2`"
-      dart: dev
-      os: windows
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_02
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 3`"
-      dart: dev
-      os: linux
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_03
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 3`"
-      dart: dev
-      os: windows
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_03
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 4`"
-      dart: dev
-      os: linux
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_04
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 4`"
-      dart: dev
-      os: windows
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_04
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 5`"
-      dart: dev
-      os: linux
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_05
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 6 --shard-index 5`"
-      dart: dev
-      os: windows
-      env: PKGS="_test"
-      script: ./tool/travis.sh test_05
-    - stage: e2e_test
-      name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 4 --shard-index 0`"
+      name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 1`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
       script: ./tool/travis.sh test_08
     - stage: e2e_test
-      name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 4 --shard-index 1`"
+      name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 2`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
       script: ./tool/travis.sh test_09
     - stage: e2e_test
-      name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 4 --shard-index 2`"
+      name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 3`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
       script: ./tool/travis.sh test_10
     - stage: e2e_test
-      name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 4 --shard-index 3`"
+      name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 4`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
@@ -293,25 +269,25 @@ jobs:
       dart: be/raw/latest
       os: linux
       env: PKGS="_test"
-      script: ./tool/travis.sh test_06
+      script: ./tool/travis.sh test_05
     - stage: e2e_test_cron
       name: "SDK: be/raw/latest; PKG: _test; TASKS: `pub run test`"
       dart: be/raw/latest
       os: windows
       env: PKGS="_test"
-      script: ./tool/travis.sh test_06
+      script: ./tool/travis.sh test_05
     - stage: e2e_test_cron
       name: "SDK: dev; PKG: _test; TASKS: `pub run test`"
       dart: dev
       os: linux
       env: PKGS="_test"
-      script: ./tool/travis.sh test_06
+      script: ./tool/travis.sh test_05
     - stage: e2e_test_cron
       name: "SDK: dev; PKG: _test; TASKS: `pub run test`"
       dart: dev
       os: windows
       env: PKGS="_test"
-      script: ./tool/travis.sh test_06
+      script: ./tool/travis.sh test_05
 
 stages:
   - analyze_and_format

--- a/_test/mono_pkg.yaml
+++ b/_test/mono_pkg.yaml
@@ -15,7 +15,9 @@ stages:
       - command: pub run build_runner test -- -p vm test/configurable_uri_test.dart
   - e2e_test:
     - test: --total-shards 2 --shard-index 0
+      os: linux
     - test: --total-shards 2 --shard-index 1
+      os: linux
     - test: --total-shards 3 --shard-index 0
       os: windows
     - test: --total-shards 3 --shard-index 1

--- a/_test/mono_pkg.yaml
+++ b/_test/mono_pkg.yaml
@@ -14,12 +14,14 @@ stages:
       - command: pub run build_runner test -- -p chrome
       - command: pub run build_runner test -- -p vm test/configurable_uri_test.dart
   - e2e_test:
-    - test: --total-shards 6 --shard-index 0
-    - test: --total-shards 6 --shard-index 1
-    - test: --total-shards 6 --shard-index 2
-    - test: --total-shards 6 --shard-index 3
-    - test: --total-shards 6 --shard-index 4
-    - test: --total-shards 6 --shard-index 5
+    - test: --total-shards 2 --shard-index 0
+    - test: --total-shards 2 --shard-index 1
+    - test: --total-shards 3 --shard-index 0
+      os: windows
+    - test: --total-shards 3 --shard-index 1
+      os: windows
+    - test: --total-shards 3 --shard-index 2
+      os: windows
   - e2e_test_cron:
     - test:
       dart:

--- a/build_runner/mono_pkg.yaml
+++ b/build_runner/mono_pkg.yaml
@@ -9,7 +9,8 @@ stages:
   - unit_test:
     - test: -x integration
   - e2e_test:
-    - test: -t integration --total-shards 4 --shard-index 0
-    - test: -t integration --total-shards 4 --shard-index 1
-    - test: -t integration --total-shards 4 --shard-index 2
-    - test: -t integration --total-shards 4 --shard-index 3
+    - test: -t integration --total-shards 5 --shard-index 0
+    - test: -t integration --total-shards 5 --shard-index 1
+    - test: -t integration --total-shards 5 --shard-index 2
+    - test: -t integration --total-shards 5 --shard-index 3
+    - test: -t integration --total-shards 5 --shard-index 4

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -104,6 +104,7 @@ void main() {
       }
       var concurrentCount = 0;
       var maxConcurrentCount = 0;
+      var reachedMax = Completer<Null>();
       await testBuilders(
           [
             apply(
@@ -114,7 +115,12 @@ void main() {
                       concurrentCount += 1;
                       maxConcurrentCount =
                           math.max(concurrentCount, maxConcurrentCount);
-                      await Future.delayed(Duration(milliseconds: 100));
+                      if (concurrentCount >= buildPhasePoolSize &&
+                          !reachedMax.isCompleted) {
+                        await Future.delayed(Duration(milliseconds: 100));
+                        if (!reachedMax.isCompleted) reachedMax.complete(null);
+                      }
+                      await reachedMax.future;
                       concurrentCount -= 1;
                     });
                   }

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -83,52 +83,52 @@ for PKG in ${PKGS}; do
       dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
       ;;
     test_00)
-      echo 'pub run test --total-shards 6 --shard-index 0'
-      pub run test --total-shards 6 --shard-index 0 || EXIT_CODE=$?
+      echo 'pub run test --total-shards 2 --shard-index 0'
+      pub run test --total-shards 2 --shard-index 0 || EXIT_CODE=$?
       ;;
     test_01)
-      echo 'pub run test --total-shards 6 --shard-index 1'
-      pub run test --total-shards 6 --shard-index 1 || EXIT_CODE=$?
+      echo 'pub run test --total-shards 2 --shard-index 1'
+      pub run test --total-shards 2 --shard-index 1 || EXIT_CODE=$?
       ;;
     test_02)
-      echo 'pub run test --total-shards 6 --shard-index 2'
-      pub run test --total-shards 6 --shard-index 2 || EXIT_CODE=$?
+      echo 'pub run test --total-shards 3 --shard-index 0'
+      pub run test --total-shards 3 --shard-index 0 || EXIT_CODE=$?
       ;;
     test_03)
-      echo 'pub run test --total-shards 6 --shard-index 3'
-      pub run test --total-shards 6 --shard-index 3 || EXIT_CODE=$?
+      echo 'pub run test --total-shards 3 --shard-index 1'
+      pub run test --total-shards 3 --shard-index 1 || EXIT_CODE=$?
       ;;
     test_04)
-      echo 'pub run test --total-shards 6 --shard-index 4'
-      pub run test --total-shards 6 --shard-index 4 || EXIT_CODE=$?
+      echo 'pub run test --total-shards 3 --shard-index 2'
+      pub run test --total-shards 3 --shard-index 2 || EXIT_CODE=$?
       ;;
     test_05)
-      echo 'pub run test --total-shards 6 --shard-index 5'
-      pub run test --total-shards 6 --shard-index 5 || EXIT_CODE=$?
-      ;;
-    test_06)
       echo 'pub run test'
       pub run test || EXIT_CODE=$?
       ;;
-    test_07)
+    test_06)
       echo 'pub run test -x integration'
       pub run test -x integration || EXIT_CODE=$?
       ;;
+    test_07)
+      echo 'pub run test -t integration --total-shards 5 --shard-index 0'
+      pub run test -t integration --total-shards 5 --shard-index 0 || EXIT_CODE=$?
+      ;;
     test_08)
-      echo 'pub run test -t integration --total-shards 4 --shard-index 0'
-      pub run test -t integration --total-shards 4 --shard-index 0 || EXIT_CODE=$?
+      echo 'pub run test -t integration --total-shards 5 --shard-index 1'
+      pub run test -t integration --total-shards 5 --shard-index 1 || EXIT_CODE=$?
       ;;
     test_09)
-      echo 'pub run test -t integration --total-shards 4 --shard-index 1'
-      pub run test -t integration --total-shards 4 --shard-index 1 || EXIT_CODE=$?
+      echo 'pub run test -t integration --total-shards 5 --shard-index 2'
+      pub run test -t integration --total-shards 5 --shard-index 2 || EXIT_CODE=$?
       ;;
     test_10)
-      echo 'pub run test -t integration --total-shards 4 --shard-index 2'
-      pub run test -t integration --total-shards 4 --shard-index 2 || EXIT_CODE=$?
+      echo 'pub run test -t integration --total-shards 5 --shard-index 3'
+      pub run test -t integration --total-shards 5 --shard-index 3 || EXIT_CODE=$?
       ;;
     test_11)
-      echo 'pub run test -t integration --total-shards 4 --shard-index 3'
-      pub run test -t integration --total-shards 4 --shard-index 3 || EXIT_CODE=$?
+      echo 'pub run test -t integration --total-shards 5 --shard-index 4'
+      pub run test -t integration --total-shards 5 --shard-index 4 || EXIT_CODE=$?
       ;;
     *)
       echo -e "\033[31mNot expecting TASK '${TASK}'. Error!\033[0m"


### PR DESCRIPTION
Fixes the flaky test by making it explicitly wait until it has gotten up to max allowed concurrency before continuing.

Also changes test sharding - give one more shard to the build_runner_core integration tests and significantly reduce the `_test` integration test shards, with 3 shards for windows and 2 for linux. Total number of shards is now 10 which is max concurrency for travis right now.