### PR TITLE
Fix the declared outputs of sdk_js_copy

### DIFF
--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -22,8 +22,8 @@ builders:
       - sdkJsCopyBuilder
     build_extensions:
       $lib$:
-        - lib/src/dev_compiler/dart_sdk.js
-        - lib/src/dev_compiler/require.js
+        - src/dev_compiler/dart_sdk.js
+        - src/dev_compiler/require.js
     is_optional: False
     auto_apply: none
     applies_builders: ["build_web_compilers|sdk_js_cleanup"]

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.6.3
+version: 2.6.4-dev
 description: Builder implementations wrapping Dart compilers.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers


### PR DESCRIPTION
The input is `$lib$` which already makes the outputs relative to this
directory. This doesn't have a material impact on the build today but
could issue warnings in the future if we start enforcing correct build
extension declarations. This is surfaced by running the `doctor`
command.