### PR TITLE
Ensure all help is handled in outer binary

### DIFF
--- a/_test/test/help_test.dart
+++ b/_test/test/help_test.dart
@@ -4,7 +4,6 @@
 
 @TestOn('vm')
 import 'dart:async';
-import 'dart:io';
 
 import 'package:test/test.dart';
 
@@ -12,32 +11,43 @@ import 'common/utils.dart';
 
 void main() {
   test('pub run build_runner help', () async {
-    await _testHelpCommand(() => runCommand(['help']));
-  });
-
-  test('pub run build_runner --help', () async {
-    await _testHelpCommand(() => runCommand(['--help']));
+    await _testHelpCommand(['help'],
+        checkContent: 'Unified interface for running Dart builds.');
+    await _testHelpCommand(['--help'],
+        checkContent: 'Unified interface for running Dart builds.');
   });
 
   test('pub run build_runner build --help', () async {
-    await _testHelpCommand(() => runCommand(['build', '--help']));
+    await _testHelpCommand(['build', '--help'],
+        checkContent: 'Performs a single build on the specified targets');
+    await _testHelpCommand(['help', 'build'],
+        checkContent: 'Performs a single build on the specified targets');
   });
 
   test('pub run build_runner serve --help', () async {
-    await _testHelpCommand(() => runCommand(['serve', '--help']));
+    await _testHelpCommand(['serve', '--help'],
+        checkContent: 'Runs a development server');
+    await _testHelpCommand(['help', 'serve'],
+        checkContent: 'Runs a development server');
   });
 
   test('pub run build_runner test --help', () async {
-    await _testHelpCommand(() => runCommand(['test', '--help']));
+    await _testHelpCommand(['test', '--help'],
+        checkContent: 'and then runs tests using');
+    await _testHelpCommand(['help', 'test'],
+        checkContent: 'and then runs tests using');
   });
 
   test('pub run build_runner watch --help', () async {
-    await _testHelpCommand(() => runCommand(['watch', '--help']));
+    await _testHelpCommand(['watch', '--help'],
+        checkContent: 'watching the file system for updates');
+    await _testHelpCommand(['help', 'watch'],
+        checkContent: 'watching the file system for updates');
   });
 }
 
-Future<void> _testHelpCommand(Future<ProcessResult> runCommand()) async {
-  var asyncResult = runCommand();
+Future<void> _testHelpCommand(List<String> args, {String checkContent}) async {
+  var asyncResult = runCommand(args);
   expect(asyncResult, completes,
       reason: 'should not cause the auto build script to hang');
   var result = await asyncResult;
@@ -46,4 +56,7 @@ Future<void> _testHelpCommand(Future<ProcessResult> runCommand()) async {
   expect(result.stderr, isEmpty, reason: 'Should output nothing on stderr');
   expect(result.stdout, isNot(contains('"Unhandled exception"')),
       reason: 'Should not print an unhandled exception');
+  if (checkContent != null) {
+    expect(result.stdout, contains(checkContent));
+  }
 }

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Give a more consistent ordering for Builders when their ordering is allowed to
   be arbitrary.
+- Handle more `--help` invocations without generating the build script.
 
 ## 1.7.1
 

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -49,8 +49,16 @@ Future<void> main(List<String> args) async {
     return;
   }
 
-  if (commandName == null || commandName == 'help') {
+  if (commandName == 'help' ||
+      parsedArgs.wasParsed('help') ||
+      (parsedArgs.command?.wasParsed('help') ?? false)) {
+    await commandRunner.runCommand(parsedArgs);
+    return;
+  }
+
+  if (commandName == null) {
     commandRunner.printUsage();
+    exitCode = ExitCode.usage.code;
     return;
   }
 


### PR DESCRIPTION
Fixes #2498, fixes #2499

Previously we'd only handle help in the outer binary if it was invoked
specifically as the `help` command, or if no command was given. If we
passed `-h` as a sub argument to another command we wouldn't recognize
it and would still generate the build script. We also always printed the
top level usage rather than the usage that would be printed by the real
help command, which may be specific to a sub command.

- Dig 2 levels deep for the `-h` or `--help` flags. This way it can be
  passed as either a top level flag, or a flag for the specific sub
  command.
- When printing usage for help specifically, use the command runner
  since it already implements figuring out whether the print outer usage
  or usage for a sub command.
- Handle the missing command as it's own case after we know we didn't
  handle help. Set the exit code to `ExitCode.usage` for this case, and
  print the top level usage.

This pattern won't work if we start adding nested commands more deeply
within other commands since we only pick up the `-h` from the top level
or 1 command deep.