### PR TITLE
add flutter sdk support to build_resolvers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,13 +103,13 @@ jobs:
       env: PKGS="build_modules"
       script: ./tool/travis.sh command_4
     - stage: unit_test
-      name: "SDK: dev; PKG: build_resolvers; TASKS: [`pub run build_runner test`, `tool/flutter_test.sh`]"
+      name: "SDK: dev; PKG: build_resolvers; TASKS: [`pub run build_runner test`, `test/flutter_test.sh`]"
       dart: dev
       os: linux
       env: PKGS="build_resolvers"
       script: ./tool/travis.sh command_2 command_5
     - stage: unit_test
-      name: "SDK: dev; PKG: build_resolvers; TASKS: [`pub run build_runner test`, `tool/flutter_test.sh`]"
+      name: "SDK: dev; PKG: build_resolvers; TASKS: [`pub run build_runner test`, `test/flutter_test.sh`]"
       dart: dev
       os: windows
       env: PKGS="build_resolvers"

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,17 +103,17 @@ jobs:
       env: PKGS="build_modules"
       script: ./tool/travis.sh command_4
     - stage: unit_test
-      name: "SDK: dev; PKG: build_resolvers; TASKS: `pub run build_runner test`"
+      name: "SDK: dev; PKG: build_resolvers; TASKS: [`pub run build_runner test`, `tool/flutter_test.sh`]"
       dart: dev
       os: linux
       env: PKGS="build_resolvers"
-      script: ./tool/travis.sh command_2
+      script: ./tool/travis.sh command_2 command_5
     - stage: unit_test
-      name: "SDK: dev; PKG: build_resolvers; TASKS: `pub run build_runner test`"
+      name: "SDK: dev; PKG: build_resolvers; TASKS: [`pub run build_runner test`, `tool/flutter_test.sh`]"
       dart: dev
       os: windows
       env: PKGS="build_resolvers"
-      script: ./tool/travis.sh command_2
+      script: ./tool/travis.sh command_2 command_5
     - stage: unit_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -x integration`"
       dart: dev

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+Add flutters embedded sdk to the summary if available. This has the effect of
+making `dart:ui` and any future libraries available if using the flutter sdk
+instead of the dart sdk.
+
 ## 1.1.1
 
 ### Bug Fix

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -280,10 +280,8 @@ void _addFlutterLibraries(AbstractDartSdk sdk,
   var embedderYamlFile =
       resourceProvider.getFile(p.join(embedderSdkPath, '_embedder.yaml'));
   if (!embedderYamlFile.exists) {
-    _logger.warning(
-        'Unable to find flutter _embedder.yaml file, flutter types will not '
-        'be resolvable.');
-    return;
+    throw StateError('Unable to find flutter libraries, please run '
+        '`flutter precache` and try again.');
   }
 
   var embedderYaml = loadYaml(embedderYamlFile.readAsStringSync()) as YamlMap;

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -6,15 +6,20 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:io';
 
-import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/src/dart/analysis/driver.dart' show AnalysisDriver;
-import 'package:analyzer/src/generated/engine.dart' hide Logger;
-import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/summary/summary_file_builder.dart';
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/file_system/physical_file_system.dart';
+import 'package:analyzer/src/generated/sdk.dart';
+import 'package:analyzer/src/generated/source.dart';
+import 'package:analyzer/src/dart/analysis/driver.dart' show AnalysisDriver;
+import 'package:analyzer/src/dart/sdk/sdk.dart';
+import 'package:analyzer/src/generated/engine.dart' hide Logger;
 import 'package:build/build.dart';
 import 'package:logging/logging.dart';
 import 'package:package_resolver/package_resolver.dart';
 import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
 
 import 'analysis_driver.dart';
 import 'build_asset_uri_resolver.dart';
@@ -215,7 +220,7 @@ Future<String> _defaultSdkSummaryGenerator() async {
     _logger.info('Generating SDK summary...');
     await summaryFile.create(recursive: true);
     var sdkPath = p.dirname(p.dirname(Platform.resolvedExecutable));
-    await summaryFile.writeAsBytes(SummaryBuilder.forSdk(sdkPath).build());
+    await summaryFile.writeAsBytes(buildSdkSummary(sdkPath));
 
     await _createSdkVersionFile(sdkVersionFile);
     await _createAnalyzerPathFile(analyzerPathFile);
@@ -248,4 +253,39 @@ Future<bool> _checkSdkVersion(File sdkVersionFile) async {
 Future<void> _createSdkVersionFile(File sdkVersionFile) async {
   await sdkVersionFile.create(recursive: true);
   await sdkVersionFile.writeAsString(Platform.version);
+}
+
+List<int> buildSdkSummary(String dartSdkPath) {
+  // Prepare the Dart SDK.
+  var resourceProvider = PhysicalResourceProvider.INSTANCE;
+  var dartSdkFolder = resourceProvider.getFolder(dartSdkPath);
+  var dartSdk = FolderBasedDartSdk(resourceProvider, dartSdkFolder, true)
+    ..useSummary = false
+    ..analysisOptions = AnalysisOptionsImpl();
+
+  // Try to load the flutter engine _embedder.yaml file and add any missing
+  // libraries to the dart sdk.
+  var embedderSdkPath =
+      p.join(p.dirname(dartSdkPath), 'pkg', 'sky_engine', 'lib');
+  var embedderYamlFile =
+      resourceProvider.getFile(p.join(embedderSdkPath, '_embedder.yaml'));
+  if (embedderYamlFile.exists) {
+    var embedderYaml = loadYaml(embedderYamlFile.readAsStringSync()) as YamlMap;
+    var flutterSdk = EmbedderSdk(resourceProvider,
+        {resourceProvider.getFolder(embedderSdkPath): embedderYaml});
+
+    for (var library in flutterSdk.sdkLibraries) {
+      if (dartSdk.libraryMap.getLibrary(library.shortName) != null) continue;
+      dartSdk.libraryMap
+          .setLibrary(library.shortName, library as SdkLibraryImpl);
+    }
+  }
+
+  // Prepare 'dart:' libraries for serialization.
+  var librarySources = {
+    for (var library in dartSdk.sdkLibraries)
+      dartSdk.mapDartUri(library.shortName),
+  };
+
+  return SummaryBuilder(librarySources, dartSdk.context).build();
 }

--- a/build_resolvers/mono_pkg.yaml
+++ b/build_resolvers/mono_pkg.yaml
@@ -10,7 +10,9 @@ stages:
       dart:
         - 2.3.0
   - unit_test:
-    - command: pub run build_runner test
+    - group:
+      - command: pub run build_runner test
+      - command: tool/flutter_test.sh
       os:
         - linux
         - windows

--- a/build_resolvers/mono_pkg.yaml
+++ b/build_resolvers/mono_pkg.yaml
@@ -12,7 +12,7 @@ stages:
   - unit_test:
     - group:
       - command: pub run build_runner test
-      - command: tool/flutter_test.sh
+      - command: test/flutter_test.sh
       os:
         - linux
         - windows

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.1.1
+version: 1.2.0
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers

--- a/build_resolvers/test/flutter_test.sh
+++ b/build_resolvers/test/flutter_test.sh
@@ -7,7 +7,11 @@ set -e
 echo "Cloning master Flutter branch"
 git clone https://github.com/flutter/flutter.git ./flutter
 
-./flutter/bin/flutter config --no-analytics
+if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+  ./flutter/bin/flutter.bat precache
+else
+  ./flutter/bin/flutter precache
+fi
 
 ./flutter/bin/cache/dart-sdk/bin/dart test/resolver_test.dart
 

--- a/build_resolvers/test/flutter_test.sh
+++ b/build_resolvers/test/flutter_test.sh
@@ -8,9 +8,9 @@ echo "Cloning master Flutter branch"
 git clone https://github.com/flutter/flutter.git ./flutter
 
 if [[ $TRAVIS_OS_NAME == "windows" ]]; then
-  ./flutter/bin/flutter.bat precache
+  ./flutter/bin/flutter.bat precache --no-ios --no-android
 else
-  ./flutter/bin/flutter precache
+  ./flutter/bin/flutter precache --no-ios --no-android
 fi
 
 ./flutter/bin/cache/dart-sdk/bin/dart test/resolver_test.dart

--- a/build_resolvers/test/flutter_test.sh
+++ b/build_resolvers/test/flutter_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Fast fail the script on failures.
+set -ex
+
+# Get Flutter.
+echo "Cloning master Flutter branch"
+git clone https://github.com/flutter/flutter.git ./flutter
+
+./flutter/bin/cache/dart-sdk/bin/dart test/resolver_test

--- a/build_resolvers/test/flutter_test.sh
+++ b/build_resolvers/test/flutter_test.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
 # Fast fail the script on failures.
-set -ex
+set -e
 
 # Get Flutter.
 echo "Cloning master Flutter branch"
 git clone https://github.com/flutter/flutter.git ./flutter
 
-./flutter/bin/cache/dart-sdk/bin/dart test/resolver_test
+./flutter/bin/flutter config --no-analytics
+
+./flutter/bin/cache/dart-sdk/bin/dart test/resolver_test.dart
+
+rm -rf ./flutter

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -229,4 +229,4 @@ void main() {
   });
 }
 
-final bool _isFlutter = Platform.version.contains('flutter');
+final _isFlutter = Platform.version.contains('flutter');

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -70,6 +70,10 @@ for PKG in ${PKGS}; do
       echo 'dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit'
       dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit || EXIT_CODE=$?
       ;;
+    command_5)
+      echo 'tool/flutter_test.sh'
+      tool/flutter_test.sh || EXIT_CODE=$?
+      ;;
     dartanalyzer_0)
       echo 'dartanalyzer --fatal-infos --fatal-warnings .'
       dartanalyzer --fatal-infos --fatal-warnings . || EXIT_CODE=$?

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -71,8 +71,8 @@ for PKG in ${PKGS}; do
       dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit || EXIT_CODE=$?
       ;;
     command_5)
-      echo 'tool/flutter_test.sh'
-      tool/flutter_test.sh || EXIT_CODE=$?
+      echo 'test/flutter_test.sh'
+      test/flutter_test.sh || EXIT_CODE=$?
       ;;
     dartanalyzer_0)
       echo 'dartanalyzer --fatal-infos --fatal-warnings .'


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/733

We always start with the Dart sdk, but now if we can find the `_embedder.yaml` file for the flutter sdk then we add any libraries found in that to the Dart sdk before summarization.

This has the effect of making any flutter libraries available to builds that are using the flutter sdk.

~WIP: Still thinking the best way to test this, we probably have to download the whole flutter sdk and run a test using that.~ Test has been added now.