### PR TITLE
also check the build_resolvers version when invalidating deps

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+Check the build_resolvers version as a part of sdk summary invalidation.
+
 ## 1.2.0
 
 Add flutters embedded sdk to the summary if available. This has the effect of

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.2.0
+version: 1.2.1
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers


### PR DESCRIPTION
Resolves issues like I highlighted at the bottom of https://github.com/dart-lang/build/issues/733 where you might have to manually bash away your `.dart_tool/build_resolvers` directory if we change the logic around how we generate sdk summaries.

This also unifies all the version checks into one file and makes it easier to add more deps to check in the future.