### PR TITLE
Use the native windows directory watcher by default

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,10 @@
-## 1.7.2-dev
+## 1.7.2
 
+- Enable the native windows directory watcher by default.
+  - Added a --use-polling-watcher option which overrides this to use a polling
+    watcher again.
+  - Increased the lower bound for the SDK to a version which contains various
+    fixes for the native windows directory watcher.
 - Give a more consistent ordering for Builders when their ordering is allowed to
   be arbitrary.
 - Handle more `--help` invocations without generating the build script.

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -12,7 +12,6 @@ import 'package:build_daemon/data/build_status.dart';
 import 'package:build_daemon/data/build_target.dart' hide OutputLocation;
 import 'package:build_daemon/data/server_log.dart';
 import 'package:build_runner/src/entrypoint/options.dart';
-import 'package:build_runner/src/generate/directory_watcher_factory.dart';
 import 'package:build_runner/src/package_graph/build_config_overrides.dart';
 import 'package:build_runner/src/watcher/asset_change.dart';
 import 'package:build_runner/src/watcher/change_filter.dart';
@@ -209,8 +208,8 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
 
     // Only actually used for the AutoChangeProvider.
     Stream<List<WatchEvent>> graphEvents() => PackageGraphWatcher(packageGraph,
-            watch: (node) =>
-                PackageNodeWatcher(node, watch: defaultDirectoryWatcherFactory))
+            watch: (node) => PackageNodeWatcher(node,
+                watch: daemonOptions.directoryWatcherFactory))
         .watch()
         .where((change) => shouldProcess(
               change,

--- a/build_runner/lib/src/entrypoint/daemon.dart
+++ b/build_runner/lib/src/entrypoint/daemon.dart
@@ -16,11 +16,11 @@ import 'package:pedantic/pedantic.dart';
 
 import '../daemon/asset_server.dart';
 import '../daemon/daemon_builder.dart';
-import 'base_command.dart';
 import 'options.dart';
+import 'watch.dart';
 
 /// A command that starts the Build Daemon.
-class DaemonCommand extends BuildRunnerCommand {
+class DaemonCommand extends WatchCommand {
   @override
   String get description => 'Starts the build daemon.';
 

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -102,8 +102,10 @@ class SharedOptions {
 
   factory SharedOptions.fromParsedArgs(ArgResults argResults,
       Iterable<String> positionalArgs, String rootPackage, Command command) {
-    var buildDirs = _parseBuildDirs(argResults)
-      ..addAll(_parsePositionalBuildDirs(positionalArgs, command));
+    var buildDirs = {
+      ..._parseBuildDirs(argResults),
+      ..._parsePositionalBuildDirs(positionalArgs, command),
+    };
     var buildFilters = _parseBuildFilters(argResults, rootPackage);
 
     return SharedOptions._(
@@ -161,8 +163,10 @@ class DaemonOptions extends WatchOptions {
 
   factory DaemonOptions.fromParsedArgs(ArgResults argResults,
       Iterable<String> positionalArgs, String rootPackage, Command command) {
-    var buildDirs = _parseBuildDirs(argResults)
-      ..addAll(_parsePositionalBuildDirs(positionalArgs, command));
+    var buildDirs = {
+      ..._parseBuildDirs(argResults),
+      ..._parsePositionalBuildDirs(positionalArgs, command),
+    };
     var buildFilters = _parseBuildFilters(argResults, rootPackage);
 
     var buildModeValue = argResults[buildModeFlag] as String;
@@ -236,8 +240,10 @@ class WatchOptions extends SharedOptions {
 
   factory WatchOptions.fromParsedArgs(ArgResults argResults,
       Iterable<String> positionalArgs, String rootPackage, Command command) {
-    var buildDirs = _parseBuildDirs(argResults)
-      ..addAll(_parsePositionalBuildDirs(positionalArgs, command));
+    var buildDirs = {
+      ..._parseBuildDirs(argResults),
+      ..._parsePositionalBuildDirs(positionalArgs, command),
+    };
     var buildFilters = _parseBuildFilters(argResults, rootPackage);
 
     return WatchOptions._(
@@ -473,25 +479,26 @@ Set<BuildDirectory> _parseBuildDirs(ArgResults argResults) {
   return result;
 }
 
-/// Parses positional arguments as plain build directories.
-///
-/// Only allows top level directories as arguments, otherwise a
-/// [UsageException] is thrown.
-Set<BuildDirectory> _parsePositionalBuildDirs(
-    Iterable<String> positionalArgs, Command command) {
-  var buildDirs = <BuildDirectory>{};
-  for (var arg in positionalArgs) {
-    var parts = p.split(arg);
-    if (parts.length > 1 || arg == '.') {
-      throw UsageException(
-          'Only top level directories such as `web` or `test` are allowed as '
-          'positional args, but got `$arg`',
-          command.usage);
-    }
-    buildDirs.add(BuildDirectory(arg));
+/// Throws a [UsageException] if [arg] looks like anything other than a top
+/// level directory.
+String _checkTopLevel(String arg, Command command) {
+  var parts = p.split(arg);
+  if (parts.length > 1 || arg == '.') {
+    throw UsageException(
+        'Only top level directories such as `web` or `test` are allowed as '
+        'positional args, but got `$arg`',
+        command.usage);
   }
-  return buildDirs;
+  return arg;
 }
+
+/// Parses positional arguments as plain build directories.
+Set<BuildDirectory> _parsePositionalBuildDirs(
+        Iterable<String> positionalArgs, Command command) =>
+    {
+      for (var arg in positionalArgs)
+        BuildDirectory(_checkTopLevel(arg, command))
+    };
 
 /// Returns build filters parsed from [buildFilterOption] arguments.
 ///

--- a/build_runner/lib/src/entrypoint/serve.dart
+++ b/build_runner/lib/src/entrypoint/serve.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:build_runner/src/generate/directory_watcher_factory.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:io/io.dart';
@@ -95,7 +94,7 @@ class ServeCommand extends WatchCommand {
       builderConfigOverrides: options.builderConfigOverrides,
       isReleaseBuild: options.isReleaseBuild,
       logPerformanceDir: options.logPerformanceDir,
-      directoryWatcherFactory: defaultDirectoryWatcherFactory,
+      directoryWatcherFactory: options.directoryWatcherFactory,
       buildFilters: options.buildFilters,
     );
 

--- a/build_runner/lib/src/entrypoint/watch.dart
+++ b/build_runner/lib/src/entrypoint/watch.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 
+import 'package:build_runner/src/entrypoint/options.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:io/io.dart';
 
 import '../generate/build.dart';
-import '../generate/directory_watcher_factory.dart';
 import 'base_command.dart';
 
 /// A command that watches the file system for updates and rebuilds as
@@ -24,6 +24,18 @@ class WatchCommand extends BuildRunnerCommand {
   String get description =>
       'Builds the specified targets, watching the file system for updates and '
       'rebuilding as appropriate.';
+
+  WatchCommand() {
+    argParser.addFlag(usePollingWatcherOption,
+        help: 'Use a polling watcher instead of the current platforms default '
+            'watcher implementation. This should generally only be used if '
+            'you are having problems with the default watcher, as it is '
+            'generally less efficient.');
+  }
+
+  @override
+  WatchOptions readOptions() => WatchOptions.fromParsedArgs(
+      argResults, argResults.rest, packageGraph.root.name, this);
 
   @override
   Future<int> run() async {
@@ -42,7 +54,7 @@ class WatchCommand extends BuildRunnerCommand {
       builderConfigOverrides: options.builderConfigOverrides,
       isReleaseBuild: options.isReleaseBuild,
       logPerformanceDir: options.logPerformanceDir,
-      directoryWatcherFactory: defaultDirectoryWatcherFactory,
+      directoryWatcherFactory: options.directoryWatcherFactory,
       buildFilters: options.buildFilters,
     );
     if (handler == null) return ExitCode.config.code;

--- a/build_runner/lib/src/generate/directory_watcher_factory.dart
+++ b/build_runner/lib/src/generate/directory_watcher_factory.dart
@@ -2,12 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:watcher/watcher.dart';
 
 DirectoryWatcher defaultDirectoryWatcherFactory(String path) =>
-    // TODO: Use `DirectoryWatcher` on windows. See the following issues:
-    // - https://github.com/dart-lang/build/issues/1031
-    // - https://github.com/dart-lang/watcher/issues/52
-    Platform.isWindows ? PollingDirectoryWatcher(path) : DirectoryWatcher(path);
+    DirectoryWatcher(path);
+
+DirectoryWatcher pollingDirectoryWatcherFactory(String path) =>
+    PollingDirectoryWatcher(path);

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -51,7 +51,17 @@ class PackageGraphWatcher {
         .map(_strategy)
         .toList();
     final filteredEvents = allWatchers
-        .map((w) => w.watch().where(_nestedPathFilter(w.node)))
+        .map((w) => w
+                .watch()
+                .where(_nestedPathFilter(w.node))
+                .handleError((e, StackTrace s) {
+              _logger.severe(
+                  'Error from directory watcher for package:${w.node.name}\n\n'
+                  'If you see this consistently then it is recommended that '
+                  'you enable the polling file watcher with '
+                  '--use-polling-watcher.');
+              throw e;
+            }))
         .toList();
     // Asynchronously complete the `_readyCompleter` once all the watchers
     // are done.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_runner
-version: 1.7.2-dev
+version: 1.7.2
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 
 environment:
-  sdk: ">=2.3.0-dev.0.1 <3.0.0"
+  sdk: ">=2.6.0-dev.8.0 <3.0.0"
 
 dependencies:
   args: ">=1.4.0 <2.0.0"


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/436

Updates the `daemon`, `serve` and `watch` commands to use the native watcher on windows by default, as well as adding a `--use-polling-watcher` flag which reverts to the old watcher.

If we see an exception coming from the directory watcher we log a severe warning pointing users at that flag (as of https://github.com/dart-lang/sdk/commit/8866cdb8be58f9228548436a3bfee939bc1887e4 it will throw if the native watcher stops working).

Updates the min sdk to the not-yet-released 2.6.0-dev.8.0 which has the new exception. I will wait for that to actually be released before merging/publishing this.

cc @supermuka @mnordine you can try this out in the meantime with this dependency override:

```yaml
dependency_overrides:
  build_runner:
    git:
      url: https://github.com/dart-lang/build.git
      ref: windows-file-watcher
      path: build_runner
```