### PR TITLE
Invalidate cached modules by digest

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.6.3-dev
 
+- Keep cached deserialized module instances in more cases. This may improve
+  performance of incremental builds in watch mode.
 - **Deprecated**: The package specific unsupported module whitelist option
   provided by `computeTransitiveDependencies`. The only known uses are being
   removed.

--- a/build_modules/lib/src/module_cache.dart
+++ b/build_modules/lib/src/module_cache.dart
@@ -68,7 +68,7 @@ class DecodingCache<T> {
     } else {
       entry = _cached[id];
       if (entry.needsCheck) {
-        entry.onGoingCheck ??= () async {
+        await (entry.onGoingCheck ??= () async {
           var previousDigest = await Result.release(entry.digest);
           entry.digest = Result.capture(reader.digest(id));
           if (await Result.release(entry.digest) != previousDigest) {
@@ -78,8 +78,7 @@ class DecodingCache<T> {
           entry
             ..needsCheck = false
             ..onGoingCheck = null;
-        }();
-        await entry.onGoingCheck;
+        }());
       }
     }
     return Result.release(entry.value);

--- a/build_modules/test/decoding_cache_test.dart
+++ b/build_modules/test/decoding_cache_test.dart
@@ -1,0 +1,93 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+import 'package:build_modules/src/module_cache.dart';
+
+void main() {
+  group(DecodingCache, () {
+    Map<String, int> toBytesCalls;
+    Map<String, int> fromBytesCalls;
+    DecodingCache<String> cache;
+    ResourceManager resourceManager;
+
+    setUp(() async {
+      toBytesCalls = {};
+      fromBytesCalls = {};
+      final resource = DecodingCache.resource<String>((bytes) {
+        var decoded = utf8.decode(bytes);
+        fromBytesCalls.putIfAbsent(decoded, () => 0);
+        fromBytesCalls[decoded] += 1;
+        return decoded;
+      }, (value) {
+        toBytesCalls.putIfAbsent(value, () => 0);
+        toBytesCalls[value] += 1;
+        return utf8.encode(value);
+      });
+      resourceManager = ResourceManager();
+      cache = await resourceManager.fetch(resource);
+    });
+
+    tearDown(() async {
+      await resourceManager.beforeExit();
+    });
+
+    test('can fetch from disk', () async {
+      final id = AssetId('foo', 'lib/foo');
+      final reader = InMemoryAssetReader(sourceAssets: {id: 'foo'});
+      expect(await cache.find(id, reader), 'foo');
+      expect(reader.assetsRead, contains(id));
+      expect(fromBytesCalls, contains('foo'));
+    });
+
+    test('skips read for value written this build', () async {
+      final id = AssetId('foo', 'lib/foo');
+      final reader = InMemoryAssetReader(sourceAssets: {id: 'foo'});
+      await cache.write(id, InMemoryAssetWriter(), 'bar');
+      expect(await cache.find(id, reader), 'bar');
+      expect(reader.assetsRead, contains(id), reason: 'Should call canRead');
+      expect(fromBytesCalls, isNot(contains('bar')));
+    });
+
+    test('skips read on subsequent fetches', () async {
+      final id = AssetId('foo', 'lib/foo');
+      final reader1 = InMemoryAssetReader(sourceAssets: {id: 'foo'});
+      await cache.find(id, reader1);
+      expect(fromBytesCalls['foo'], 1);
+      final reader2 = InMemoryAssetReader(sourceAssets: {id: 'foo'});
+      expect(await cache.find(id, reader2), 'foo');
+      expect(reader2.assetsRead, contains(id), reason: 'Should call canRead');
+      expect(fromBytesCalls['foo'], 1, reason: 'No extra call to deserialize');
+    });
+
+    test('skips read on subsequent builds if digest has not changed', () async {
+      final id = AssetId('foo', 'lib/foo');
+      final reader1 = InMemoryAssetReader(sourceAssets: {id: 'foo'});
+      await cache.find(id, reader1);
+      expect(fromBytesCalls['foo'], 1);
+      await resourceManager.disposeAll();
+      final reader2 = InMemoryAssetReader(sourceAssets: {id: 'foo'});
+      expect(await cache.find(id, reader2), 'foo');
+      expect(reader2.assetsRead, contains(id), reason: 'Should call canRead');
+      expect(fromBytesCalls['foo'], 1, reason: 'No extra call to deserialize');
+    });
+
+    test('rereads on subsequent builds if digest has changed', () async {
+      final id = AssetId('foo', 'lib/foo');
+      final reader1 = InMemoryAssetReader(sourceAssets: {id: 'foo'});
+      await cache.find(id, reader1);
+      expect(fromBytesCalls['foo'], 1);
+      await resourceManager.disposeAll();
+      final reader2 = InMemoryAssetReader(sourceAssets: {id: 'bar'});
+      expect(await cache.find(id, reader2), 'bar');
+      expect(reader2.assetsRead, contains(id));
+      expect(fromBytesCalls['bar'], 1, reason: 'Deserialize with new value');
+    });
+  });
+}


### PR DESCRIPTION
Within the build that writes a new value we don't have the digest so at
the end of the build the value will be cleared away and must be read
from the file at least once.
As soon as a value is read from a file we also track the digest and only
invalidate the deserialized value when the digest has changed.