### PR TITLE
Update golden for build entrypoint

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -4,13 +4,15 @@ import 'package:build_runner_core/build_runner_core.dart' as _i1;
 import 'package:build_test/builder.dart' as _i2;
 import 'package:build_config/build_config.dart' as _i3;
 import 'package:provides_builder/builders.dart' as _i4;
-import 'package:build_modules/builders.dart' as _i5;
-import 'package:build_vm_compilers/builders.dart' as _i6;
-import 'package:build_web_compilers/builders.dart' as _i7;
-import 'package:build/build.dart' as _i8;
-import 'dart:isolate' as _i9;
-import 'package:build_runner/build_runner.dart' as _i10;
-import 'dart:io' as _i11;
+import 'package:built_value_generator/builder.dart' as _i5;
+import 'package:source_gen/builder.dart' as _i6;
+import 'package:build_modules/builders.dart' as _i7;
+import 'package:build_vm_compilers/builders.dart' as _i8;
+import 'package:build_web_compilers/builders.dart' as _i9;
+import 'package:build/build.dart' as _i10;
+import 'dart:isolate' as _i11;
+import 'package:build_runner/build_runner.dart' as _i12;
+import 'dart:io' as _i13;
 
 final _builders = <_i1.BuilderApplication>[
   _i1.apply(
@@ -26,24 +28,30 @@ final _builders = <_i1.BuilderApplication>[
   _i1.apply('provides_builder:some_not_applied_builder', [_i4.notApplied],
       _i1.toNoneByDefault(),
       hideOutput: true),
-  _i1.apply('build_modules:module_library', [_i5.moduleLibraryBuilder],
+  _i1.apply('built_value_generator:built_value', [_i5.builtValue],
+      _i1.toDependentsOf('built_value_generator'),
+      hideOutput: true, appliesBuilders: ['source_gen:combining_builder']),
+  _i1.apply('source_gen:combining_builder', [_i6.combiningBuilder],
+      _i1.toNoneByDefault(),
+      hideOutput: false, appliesBuilders: ['source_gen:part_cleanup']),
+  _i1.apply('build_modules:module_library', [_i7.moduleLibraryBuilder],
       _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true,
       appliesBuilders: ['build_modules:module_cleanup']),
   _i1.apply(
       'build_vm_compilers:modules',
-      [_i6.metaModuleBuilder, _i6.metaModuleCleanBuilder, _i6.moduleBuilder],
+      [_i8.metaModuleBuilder, _i8.metaModuleCleanBuilder, _i8.moduleBuilder],
       _i1.toNoneByDefault(),
       isOptional: true,
       hideOutput: true,
       appliesBuilders: ['build_modules:module_cleanup']),
   _i1.apply(
-      'build_vm_compilers:vm', [_i6.vmKernelModuleBuilder], _i1.toAllPackages(),
+      'build_vm_compilers:vm', [_i8.vmKernelModuleBuilder], _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true,
       appliesBuilders: ['build_vm_compilers:modules']),
-  _i1.apply('build_vm_compilers:entrypoint', [_i6.vmKernelEntrypointBuilder],
+  _i1.apply('build_vm_compilers:entrypoint', [_i8.vmKernelEntrypointBuilder],
       _i1.toRoot(),
       hideOutput: true,
       defaultGenerateFor: const _i3.InputSet(include: [
@@ -56,9 +64,9 @@ final _builders = <_i1.BuilderApplication>[
   _i1.apply(
       'build_web_compilers:dart2js_modules',
       [
-        _i7.dart2jsMetaModuleBuilder,
-        _i7.dart2jsMetaModuleCleanBuilder,
-        _i7.dart2jsModuleBuilder
+        _i9.dart2jsMetaModuleBuilder,
+        _i9.dart2jsMetaModuleCleanBuilder,
+        _i9.dart2jsModuleBuilder
       ],
       _i1.toNoneByDefault(),
       isOptional: true,
@@ -67,15 +75,15 @@ final _builders = <_i1.BuilderApplication>[
   _i1.apply(
       'build_web_compilers:ddc_modules',
       [
-        _i7.ddcMetaModuleBuilder,
-        _i7.ddcMetaModuleCleanBuilder,
-        _i7.ddcModuleBuilder
+        _i9.ddcMetaModuleBuilder,
+        _i9.ddcMetaModuleCleanBuilder,
+        _i9.ddcModuleBuilder
       ],
       _i1.toNoneByDefault(),
       isOptional: true,
       hideOutput: true,
       appliesBuilders: ['build_modules:module_cleanup']),
-  _i1.apply('build_web_compilers:ddc', [_i7.ddcKernelBuilder, _i7.ddcBuilder],
+  _i1.apply('build_web_compilers:ddc', [_i9.ddcKernelBuilder, _i9.ddcBuilder],
       _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true,
@@ -84,11 +92,11 @@ final _builders = <_i1.BuilderApplication>[
         'build_web_compilers:dart2js_modules',
         'build_web_compilers:dart_source_cleanup'
       ]),
-  _i1.apply('build_web_compilers:sdk_js_copy', [_i7.sdkJsCopyBuilder],
+  _i1.apply('build_web_compilers:sdk_js_copy', [_i9.sdkJsCopyBuilder],
       _i1.toNoneByDefault(),
       hideOutput: true,
       appliesBuilders: ['build_web_compilers:sdk_js_cleanup']),
-  _i1.apply('build_web_compilers:entrypoint', [_i7.webEntrypointBuilder],
+  _i1.apply('build_web_compilers:entrypoint', [_i9.webEntrypointBuilder],
       _i1.toRoot(),
       hideOutput: true,
       defaultGenerateFor: const _i3.InputSet(include: [
@@ -100,10 +108,10 @@ final _builders = <_i1.BuilderApplication>[
         'test/**.node_test.dart',
         'test/**.vm_test.dart'
       ]),
-      defaultOptions: _i8.BuilderOptions({
+      defaultOptions: _i10.BuilderOptions({
         'dart2js_args': ['--minify']
       }),
-      defaultReleaseOptions: _i8.BuilderOptions({'compiler': 'dart2js'}),
+      defaultReleaseOptions: _i10.BuilderOptions({'compiler': 'dart2js'}),
       appliesBuilders: ['build_web_compilers:dart2js_archive_extractor']),
   _i1.apply('provides_builder:throwing_builder', [_i4.throwingBuilder],
       _i1.toDependentsOf('provides_builder'),
@@ -111,23 +119,25 @@ final _builders = <_i1.BuilderApplication>[
   _i1.applyPostProcess(
       'provides_builder:some_post_process_builder', _i4.somePostProcessBuilder,
       defaultGenerateFor: const _i3.InputSet()),
-  _i1.applyPostProcess('build_modules:module_cleanup', _i5.moduleCleanup,
+  _i1.applyPostProcess('source_gen:part_cleanup', _i6.partCleanup,
+      defaultGenerateFor: const _i3.InputSet()),
+  _i1.applyPostProcess('build_modules:module_cleanup', _i7.moduleCleanup,
       defaultGenerateFor: const _i3.InputSet()),
   _i1.applyPostProcess('build_web_compilers:dart2js_archive_extractor',
-      _i7.dart2jsArchiveExtractor,
-      defaultReleaseOptions: _i8.BuilderOptions({'filter_outputs': true}),
+      _i9.dart2jsArchiveExtractor,
+      defaultReleaseOptions: _i10.BuilderOptions({'filter_outputs': true}),
       defaultGenerateFor: const _i3.InputSet()),
   _i1.applyPostProcess(
-      'build_web_compilers:dart_source_cleanup', _i7.dartSourceCleanup,
-      defaultReleaseOptions: _i8.BuilderOptions({'enabled': true}),
+      'build_web_compilers:dart_source_cleanup', _i9.dartSourceCleanup,
+      defaultReleaseOptions: _i10.BuilderOptions({'enabled': true}),
       defaultGenerateFor: const _i3.InputSet()),
   _i1.applyPostProcess(
-      'build_web_compilers:sdk_js_cleanup', _i7.sdkJsCleanupBuilder,
-      defaultReleaseOptions: _i8.BuilderOptions({'enabled': true}),
+      'build_web_compilers:sdk_js_cleanup', _i9.sdkJsCleanupBuilder,
+      defaultReleaseOptions: _i10.BuilderOptions({'enabled': true}),
       defaultGenerateFor: const _i3.InputSet())
 ];
-main(List<String> args, [_i9.SendPort sendPort]) async {
-  var result = await _i10.run(args, _builders);
+main(List<String> args, [_i11.SendPort sendPort]) async {
+  var result = await _i12.run(args, _builders);
   sendPort?.send(result);
-  _i11.exitCode = result;
+  _i13.exitCode = result;
 }


### PR DESCRIPTION
The `built_value` package added a non-dev dependency on
`built_value_generator`, so we now pick up that package for any
transitive dep of `build_daemon`.