### PR TITLE
Prepare to publish build_modules

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.6.3-dev
+## 2.6.3
 
 - Keep cached deserialized module instances in more cases. This may improve
   performance of incremental builds in watch mode.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -33,12 +33,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-  dart_style: any
 
 dependency_overrides:
-  dart_style:
-    git:
-      url: git://github.com/dart-lang/dart_style.git
-      ref: upgrade-analyzer
   build_vm_compilers:
     path: ../build_vm_compilers

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.6.3-dev
+version: 2.6.3
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
@@ -33,8 +33,12 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+  dart_style: any
 
 dependency_overrides:
-  analyzer: ^0.39.0
-  build_resolvers:
-    path: ../build_resolvers
+  dart_style:
+    git:
+      url: git://github.com/dart-lang/dart_style.git
+      ref: upgrade-analyzer
+  build_vm_compilers:
+    path: ../build_vm_compilers

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -22,7 +22,6 @@ dev_dependencies:
   build_test: ^0.10.1
   build_runner: ^1.0.0
   build_vm_compilers: ">=0.1.0 <2.0.0"
-  dart_style: any
   build_modules: any
 
 dependency_overrides:
@@ -30,7 +29,3 @@ dependency_overrides:
     path: ../build_vm_compilers
   build_modules:
     path: ../build_modules
-  dart_style:
-    git:
-      url: git://github.com/dart-lang/dart_style.git
-      ref: upgrade-analyzer


### PR DESCRIPTION
Towards #2513

Add dependency overrides on dev dependencies so that `pub get` works
locally.

Remove override from `build_resolvers` since the `dart_style` branch has
been removed.