### PR TITLE
Improve error message for a bad hostname

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.3-dev
+
+- Improve the error message when a `--hostname` argument is invalid.
+
 ## 1.7.2
 
 - Enable the native windows directory watcher by default.

--- a/build_runner/lib/src/entrypoint/serve.dart
+++ b/build_runner/lib/src/entrypoint/serve.dart
@@ -72,10 +72,14 @@ class ServeCommand extends WatchCommand {
       }));
     } on SocketException catch (e) {
       var listener = Logger.root.onRecord.listen(stdIOLogListener());
-      logger.severe(
-          'Error starting server at ${e.address.address}:${e.port}, address '
-          'is already in use. Please kill the server running on that port or '
-          'serve on a different port and restart this process.');
+      if (e.address != null && e.port != null) {
+        logger.severe(
+            'Error starting server at ${e.address.address}:${e.port}, address '
+            'is already in use. Please kill the server running on that port or '
+            'serve on a different port and restart this process.');
+      } else {
+        logger.severe('Error starting server on ${options.hostName}.');
+      }
       await listener.cancel();
       return ExitCode.osError.code;
     }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.7.2
+version: 1.7.3-dev
 description: Tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner


### PR DESCRIPTION
Closes #1941

When using the `--hostname` argument with a name that isn't supported by
the OS the `SocketException` would have a null `address` and `port`
field. In this case we'd get a stack trace trying to emit an error which
makes it look like a bug in `build_runner` rather than a usage error.

Since we don't know all the conditions that lead to a `SocketException`
the message is somewhat vague.