### PR TITLE
s/hide Logger/show AnalysisOptions

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.3-dev
+
+Change a `hide` declaration to a `show` declaration to support a
+`package:analyzer` change.
+
 ## 1.2.2
 
 - Update to `package:analyzer` version `0.39.0`.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -155,7 +155,7 @@ class AnalyzerResolvers implements Resolvers {
       : _sdkSummaryGenerator =
             sdkSummaryGenerator ?? _defaultSdkSummaryGenerator;
 
-  /// Create a Resolvers backed by an [AnalysisContext] using options
+  /// Create a Resolvers backed by an `AnalysisContext` using options
   /// [_analysisOptions].
   Future<void> _ensureInitialized() {
     return _initialized ??= () async {

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -15,7 +15,8 @@ import 'package:analyzer/src/generated/sdk.dart';
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/dart/analysis/driver.dart' show AnalysisDriver;
 import 'package:analyzer/src/dart/sdk/sdk.dart';
-import 'package:analyzer/src/generated/engine.dart' hide Logger;
+import 'package:analyzer/src/generated/engine.dart'
+    show AnalysisOptions, AnalysisOptionsImpl;
 import 'package:build/build.dart';
 import 'package:logging/logging.dart';
 import 'package:package_resolver/package_resolver.dart';

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.2.2
+version: 1.2.3-dev
 description: Resolve Dart code in a Builder
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers


### PR DESCRIPTION
This will unblock us from removing Logger as a part of the analysis engine namespace. (hiding a non-exist term is a build breaking error in g3)