### PR TITLE
Enable prefer_for_elements_to_map_fromIterable

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -72,6 +72,7 @@ linter:
     - prefer_contains
     - prefer_equal_for_default_values
     - prefer_final_fields
+    - prefer_for_elements_to_map_fromIterable
     - prefer_generic_function_type_aliases
     - prefer_initializing_formals
     #- prefer_interpolation_to_compose_strings

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -112,8 +112,9 @@ List<Module> _mergeModules(Iterable<Module> modules, Set<AssetId> entrypoints) {
       modules.where((m) => m.sources.any(entrypoints.contains)).toList();
 
   // Groups of modules that can be merged into an existing entrypoint module.
-  var entrypointModuleGroups = Map.fromIterable(entrypointModules,
-      key: (m) => (m as Module).primarySource, value: (m) => [m as Module]);
+  var entrypointModuleGroups = {
+    for (var m in entrypointModules) m.primarySource: [m],
+  };
 
   // Maps modules to entrypoint modules that transitively depend on them.
   var modulesToEntryPoints =

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.6.3
+version: 2.6.4-dev
 description: Builders for Dart modules
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_modules

--- a/build_runner/test/integration_tests/utils/build_descriptor.dart
+++ b/build_runner/test/integration_tests/utils/build_descriptor.dart
@@ -89,18 +89,16 @@ Future<BuildTool> package(Iterable<d.Descriptor> otherPackages,
       .dir(
           'a',
           <d.Descriptor>[
-            await _pubspecWithDeps('a',
-                currentIsolateDependencies: [
-                  'build',
-                  'build_config',
-                  'build_daemon',
-                  'build_resolvers',
-                  'build_runner',
-                  'build_runner_core',
-                ],
-                pathDependencies: Map.fromIterable(otherPackages,
-                    key: (o) => (o as d.Descriptor).name,
-                    value: (o) => p.join(d.sandbox, (o as d.Descriptor).name))),
+            await _pubspecWithDeps('a', currentIsolateDependencies: [
+              'build',
+              'build_config',
+              'build_daemon',
+              'build_resolvers',
+              'build_runner',
+              'build_runner_core',
+            ], pathDependencies: {
+              for (var o in otherPackages) o.name: p.join(d.sandbox, o.name),
+            }),
           ].followedBy(packageContents))
       .create();
   await Future.wait(otherPackages.map((d) => d.create()));


### PR DESCRIPTION
The map literal version doesn't require casts and the `key: value`
association is more clear in this format.