### PR TITLE
Use extensions from package:stream_transform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,16 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.3.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner_core, build_test, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.3.0; PKGS: build, build_config, build_resolvers, build_runner_core, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.3.0"
       os: linux
-      env: PKGS="build build_config build_daemon build_resolvers build_runner_core build_test scratch_space"
+      env: PKGS="build build_config build_resolvers build_runner_core scratch_space"
+      script: ./tool/travis.sh dartanalyzer_1
+    - stage: analyze_and_format
+      name: "SDK: 2.6.0; PKGS: build_daemon, build_test; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.6.0"
+      os: linux
+      env: PKGS="build_daemon build_test"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.5.0; PKGS: build_modules, build_vm_compilers, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.1-dev
+
+- Require SDK version `2.6.0` to enable extension methods.
+
 ## 2.1.0
 
 - Added optional `DefaultBuildTarget.buildFilters` field.

--- a/build_daemon/lib/src/server.dart
+++ b/build_daemon/lib/src/server.dart
@@ -11,7 +11,7 @@ import 'package:http_multi_server/http_multi_server.dart';
 import 'package:pool/pool.dart';
 import 'package:shelf/shelf_io.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart';
-import 'package:stream_transform/stream_transform.dart' hide concat;
+import 'package:stream_transform/stream_transform.dart';
 import 'package:watcher/watcher.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -139,14 +139,14 @@ class Server {
   }
 
   void _handleChanges(Stream<List<WatchEvent>> changes) {
-    _subs.add(changes.transform(asyncMapBuffer((changesLists) async {
+    _subs.add(changes.asyncMapBuffer((changesLists) async {
       var changes = changesLists.expand((x) => x).toList();
       if (changes.isEmpty) return;
       if (_buildTargetManager.targets.isEmpty) return;
       var buildTargets = _buildTargetManager.targetsForChanges(changes);
       if (buildTargets.isEmpty) return;
       await _build(buildTargets, changes);
-    })).listen((_) {}));
+    }).listen((_) {}));
   }
 
   void _removeChannel(WebSocketChannel channel) async {

--- a/build_daemon/mono_pkg.yaml
+++ b/build_daemon/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.3.0
+        - 2.6.0
   - unit_test:
     - command: pub run test
       os:

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 2.1.0
+version: 2.1.1-dev
 description: A daemon for running Dart builds.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   built_collection: ^4.1.0
@@ -18,7 +18,7 @@ dependencies:
   pool: ^1.3.6
   shelf: ^0.7.4
   shelf_web_socket: ^0.2.2+4
-  stream_transform: ^0.0.14+1
+  stream_transform: ^0.0.20
   watcher: ^0.9.7
   web_socket_channel: ^1.0.9
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.7.3-dev
 
 - Improve the error message when a `--hostname` argument is invalid.
+- Require SDK version `2.6.0` to enable extension methods.
 
 ## 1.7.2
 

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -25,7 +25,7 @@ import 'package:build_runner_core/build_runner_core.dart' as core
     show BuildStatus;
 import 'package:build_runner_core/src/generate/build_definition.dart';
 import 'package:build_runner_core/src/generate/build_impl.dart';
-import 'package:stream_transform/stream_transform.dart' show debounceBuffer;
+import 'package:stream_transform/stream_transform.dart';
 import 'package:watcher/watcher.dart';
 
 import 'change_providers.dart';
@@ -220,7 +220,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
               expectedDeletes,
             ))
         .map((data) => WatchEvent(data.type, '${data.id}'))
-        .transform(debounceBuffer(buildOptions.debounceDelay));
+        .debounceBuffer(buildOptions.debounceDelay);
 
     var changeProvider = daemonOptions.buildMode == BuildMode.Auto
         ? AutoChangeProvider(graphEvents())

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -297,10 +297,10 @@ class WatchImpl implements BuildState {
             _expectedDeletes,
           );
         })
-        .transform(debounceBuffer(_debounceDelay))
-        .transform(takeUntil(terminate))
-        .transform(asyncMapBuffer((changes) => currentBuild = doBuild(changes)
-          ..whenComplete(() => currentBuild = null)))
+        .debounceBuffer(_debounceDelay)
+        .takeUntil(terminate)
+        .asyncMapBuffer((changes) => currentBuild = doBuild(changes)
+          ..whenComplete(() => currentBuild = null))
         .listen((BuildResult result) {
           if (controller.isClosed) return;
           controller.add(result);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 
 environment:
-  sdk: ">=2.6.0-dev.8.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   args: ">=1.4.0 <2.0.0"
@@ -35,7 +35,7 @@ dependencies:
   shelf: ">=0.6.5 <0.8.0"
   shelf_web_socket: ^0.2.2+4
   stack_trace: ^1.9.0
-  stream_transform: ^0.0.9
+  stream_transform: ^0.0.20
   timing: ^0.1.1
   watcher: ^0.9.7
   web_socket_channel: ^1.0.9

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.9+2-dev
+
+- Require SDK version `2.6.0` to enable extension methods.
+
 ## 0.10.9+1
 
 - Fix the `DebugTestBuilder` on windows.

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -111,15 +111,15 @@ class PackageAssetReader extends AssetReader
 
     var packageFiles = Directory.fromUri(packageLibDir)
         .list(recursive: true)
-        .where((e) => e is File)
+        .whereType<File>()
         .map((f) =>
             p.join('lib', p.relative(f.path, from: p.fromUri(packageLibDir))));
     if (package == _rootPackage) {
-      packageFiles = packageFiles.transform(merge(Directory(_rootPackagePath)
+      packageFiles = packageFiles.merge(Directory(_rootPackagePath)
           .list(recursive: true)
-          .where((e) => e is File)
+          .whereType<File>()
           .map((f) => p.relative(f.path, from: _rootPackagePath))
-          .where((p) => !(p.startsWith('packages/') || p.startsWith('lib/')))));
+          .where((p) => !(p.startsWith('packages/') || p.startsWith('lib/'))));
     }
     return packageFiles.where(glob.matches).map((p) => AssetId(package, p));
   }

--- a/build_test/mono_pkg.yaml
+++ b/build_test/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.3.0
+        - 2.6.0
   - unit_test:
     - command: pub run build_runner test
       os:

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   async: ">=1.2.0 <3.0.0"
@@ -20,7 +20,7 @@ dependencies:
   package_resolver: ^1.0.2
   path: ^1.4.1
   pedantic: ^1.0.0
-  stream_transform: ^0.0.11
+  stream_transform: ^0.0.20
   test: '>=0.12.42 <2.0.0'
   test_core: ^0.2.4
   watcher: ^0.9.7

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.9+1
+version: 0.10.9+2-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 


### PR DESCRIPTION
- Bump the minimum SDK constraint on the packages that use
  `package:stream_transform` to 2.6.0 with support for extension
  methods.
- Migrate usages of `.transform(something())` to `.something()`.
- Migrate some `.where((e) => e is File)` to `.whereType<File>()`.