### PR TITLE
Fix strict-inference failures in build_runner_core

### DIFF
--- a/build_runner_core/lib/src/asset/cache.dart
+++ b/build_runner_core/lib/src/asset/cache.dart
@@ -58,7 +58,7 @@ class CachingAssetReader implements AssetReader {
       _canReadCache.putIfAbsent(id, () => _delegate.canRead(id));
 
   @override
-  Future<Digest> digest(id) => _delegate.digest(id);
+  Future<Digest> digest(AssetId id) => _delegate.digest(id);
 
   @override
   Stream<AssetId> findAssets(Glob glob) =>

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -312,7 +312,7 @@ class _WrappedAssetNode extends Object with ListMixin implements List {
   int get length => _length;
 
   @override
-  set length(_) => throw UnsupportedError(
+  set length(void _) => throw UnsupportedError(
       'length setter not unsupported for WrappedAssetNode');
 
   @override
@@ -365,7 +365,7 @@ class _WrappedAssetNode extends Object with ListMixin implements List {
   }
 
   @override
-  operator []=(_, __) =>
+  operator []=(void _,void __) =>
       throw UnsupportedError('[]= not supported for WrappedAssetNode');
 }
 

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -365,7 +365,7 @@ class _WrappedAssetNode extends Object with ListMixin implements List {
   }
 
   @override
-  operator []=(void _,void __) =>
+  operator []=(void _, void __) =>
       throw UnsupportedError('[]= not supported for WrappedAssetNode');
 }
 

--- a/build_runner_core/lib/src/changes/build_script_updates.dart
+++ b/build_runner_core/lib/src/changes/build_script_updates.dart
@@ -123,5 +123,5 @@ class _MirrorBuildScriptUpdates implements BuildScriptUpdates {
 /// the build script checks.
 class _NoopBuildScriptUpdates implements BuildScriptUpdates {
   @override
-  bool hasBeenUpdated(_) => false;
+  bool hasBeenUpdated(void _) => false;
 }

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -179,7 +179,7 @@ class AssetTracker {
   /// Ideally we would warn but in practice the default whitelist will give this
   /// error a lot and it would be noisy.
   Stream<AssetId> _listIdsSafe(Glob glob, {String package}) =>
-      _reader.findAssets(glob, package: package).handleError((e) {},
+      _reader.findAssets(glob, package: package).handleError((void _) {},
           test: (e) => e is FileSystemException && e.osError.errorCode == 2);
 }
 

--- a/build_runner_core/lib/src/generate/build_directory.dart
+++ b/build_runner_core/lib/src/generate/build_directory.dart
@@ -10,7 +10,7 @@ class BuildDirectory {
   BuildDirectory(this.directory, {this.outputLocation});
 
   @override
-  operator ==(other) =>
+  operator ==(Object other) =>
       other is BuildDirectory &&
       other.directory == directory &&
       other.outputLocation == outputLocation;
@@ -37,7 +37,7 @@ class OutputLocation {
   }
 
   @override
-  operator ==(other) =>
+  operator ==(Object other) =>
       other is OutputLocation &&
       other.path == path &&
       other.useSymlinks == useSymlinks &&

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -294,7 +294,7 @@ class _SingleBuild {
       }
 
       if (!done.isCompleted) done.complete(result);
-    }, onError: (e, StackTrace st) {
+    }, onError: (Object e, StackTrace st) {
       if (!done.isCompleted) {
         _logger.severe('Unhandled build failure!', e, st);
         done.complete(BuildResult(BuildStatus.failure, []));
@@ -486,7 +486,7 @@ class _SingleBuild {
                   stageTracker: tracker,
                   reportUnusedAssetsForInput: (_, assets) =>
                       unusedAssets.addAll(assets),
-                ).catchError((_) {
+                ).catchError((void _) {
                   // Errors tracked through the logger
                 }));
         actionsCompletedCount++;
@@ -603,7 +603,7 @@ class _SingleBuild {
         throw InvalidOutputException(assetId, 'Can only delete primary input');
       }
       _assetGraph.get(assetId).deletedBy.add(anchorNode.id);
-    }).catchError((_) {
+    }).catchError((void _) {
       // Errors tracked through the logger
     });
     actionsCompletedCount++;

--- a/build_runner_core/lib/src/generate/heartbeat.dart
+++ b/build_runner_core/lib/src/generate/heartbeat.dart
@@ -65,7 +65,7 @@ abstract class Heartbeat {
     _timer = null;
   }
 
-  void _checkDuration(_) {
+  void _checkDuration(void _) {
     if (_intervalWatch.elapsed < waitDuration) return;
     onTimeout(_intervalWatch.elapsed);
     ping();
@@ -107,7 +107,7 @@ class HeartbeatLogger extends Heartbeat {
 
   /// Logs a heartbeat message if we reach the timeout.
   @override
-  void onTimeout(_) {
+  void onTimeout(void _) {
     var formattedTime = humanReadable(_totalWatch.elapsed);
     var message = '$formattedTime elapsed';
     if (transformLog != null) {

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -106,7 +106,7 @@ class BuildFilter {
   }
 
   @override
-  operator ==(other) =>
+  operator ==(Object other) =>
       other is BuildFilter &&
       other._path.context == _path.context &&
       other._path.pattern == _path.pattern &&

--- a/build_runner_core/lib/src/logging/build_for_input_logger.dart
+++ b/build_runner_core/lib/src/logging/build_for_input_logger.dart
@@ -30,33 +30,33 @@ class BuildForInputLogger implements Logger {
   void clearListeners() => _delegate.clearListeners();
 
   @override
-  void config(message, [Object error, StackTrace stackTrace]) =>
+  void config(Object message, [Object error, StackTrace stackTrace]) =>
       _delegate.config(message, error, stackTrace);
 
   @override
-  void fine(message, [Object error, StackTrace stackTrace]) =>
+  void fine(Object message, [Object error, StackTrace stackTrace]) =>
       _delegate.fine(message, error, stackTrace);
 
   @override
-  void finer(message, [Object error, StackTrace stackTrace]) =>
+  void finer(Object message, [Object error, StackTrace stackTrace]) =>
       _delegate.finer(message, error, stackTrace);
 
   @override
-  void finest(message, [Object error, StackTrace stackTrace]) =>
+  void finest(Object message, [Object error, StackTrace stackTrace]) =>
       _delegate.finest(message, error, stackTrace);
 
   @override
   String get fullName => _delegate.fullName;
 
   @override
-  void info(message, [Object error, StackTrace stackTrace]) =>
+  void info(Object message, [Object error, StackTrace stackTrace]) =>
       _delegate.info(message, error, stackTrace);
 
   @override
   bool isLoggable(Level value) => _delegate.isLoggable(value);
 
   @override
-  void log(Level logLevel, message,
+  void log(Level logLevel, Object message,
       [Object error, StackTrace stackTrace, Zone zone]) {
     if (logLevel >= Level.SEVERE) {
       errorsSeen.add(ErrorReport('$message', '${error ?? ''}', stackTrace));
@@ -74,18 +74,18 @@ class BuildForInputLogger implements Logger {
   Logger get parent => _delegate.parent;
 
   @override
-  void severe(message, [Object error, StackTrace stackTrace]) {
+  void severe(Object message, [Object error, StackTrace stackTrace]) {
     errorsSeen.add(ErrorReport('$message', '${error ?? ''}', stackTrace));
     _delegate.severe(message, error, stackTrace);
   }
 
   @override
-  void shout(message, [Object error, StackTrace stackTrace]) {
+  void shout(Object message, [Object error, StackTrace stackTrace]) {
     errorsSeen.add(ErrorReport('$message', '${error ?? ''}', stackTrace));
     _delegate.shout(message, error, stackTrace);
   }
 
   @override
-  void warning(message, [Object error, StackTrace stackTrace]) =>
+  void warning(Object message, [Object error, StackTrace stackTrace]) =>
       _delegate.warning(message, error, stackTrace);
 }

--- a/build_runner_core/test/asset/cache_test.dart
+++ b/build_runner_core/test/asset/cache_test.dart
@@ -66,7 +66,7 @@ void main() {
     test('can be invalidated with invalidate', () async {
       expect(await reader.readAsBytes(fooTxt), fooutf8Bytes);
       delegate.assetsRead.clear();
-      expect(delegate.assetsRead, []);
+      expect(delegate.assetsRead, isEmpty);
 
       reader.invalidate([fooTxt]);
       expect(await reader.readAsBytes(fooTxt), fooutf8Bytes);
@@ -93,13 +93,13 @@ void main() {
       expect(await reader.readAsString(fooTxt), fooContent);
       delegate.assetsRead.clear();
       expect(await reader.readAsString(fooTxt), fooContent);
-      expect(delegate.assetsRead, []);
+      expect(delegate.assetsRead, isEmpty);
     });
 
     test('can be invalidated with invalidate', () async {
       expect(await reader.readAsString(fooTxt), fooContent);
       delegate.assetsRead.clear();
-      expect(delegate.assetsRead, []);
+      expect(delegate.assetsRead, isEmpty);
 
       reader.invalidate([fooTxt]);
       expect(await reader.readAsString(fooTxt), fooContent);
@@ -112,7 +112,7 @@ void main() {
       delegate.assetsRead.clear();
 
       expect(await reader.readAsString(fooTxt), fooContent);
-      expect(delegate.assetsRead, []);
+      expect(delegate.assetsRead, isEmpty);
     });
   });
 

--- a/build_runner_core/test/asset/cache_test.dart
+++ b/build_runner_core/test/asset/cache_test.dart
@@ -36,13 +36,13 @@ void main() {
       expect(await reader.canRead(fooTxt), isTrue);
       delegate.assetsRead.clear();
       expect(await reader.canRead(fooTxt), isTrue);
-      expect(delegate.assetsRead, []);
+      expect(delegate.assetsRead, isEmpty);
     });
 
     test('can be invalidated with invalidate', () async {
       expect(await reader.canRead(fooTxt), isTrue);
       delegate.assetsRead.clear();
-      expect(delegate.assetsRead, []);
+      expect(delegate.assetsRead, isEmpty);
 
       reader.invalidate([fooTxt]);
       expect(await reader.canRead(fooTxt), isTrue);
@@ -60,7 +60,7 @@ void main() {
       expect(await reader.readAsBytes(fooTxt), fooutf8Bytes);
       delegate.assetsRead.clear();
       expect(await reader.readAsBytes(fooTxt), fooutf8Bytes);
-      expect(delegate.assetsRead, []);
+      expect(delegate.assetsRead, isEmpty);
     });
 
     test('can be invalidated with invalidate', () async {

--- a/build_runner_core/test/asset/lru_cache_test.dart
+++ b/build_runner_core/test/asset/lru_cache_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 
 import 'package:build_runner_core/src/asset/lru_cache.dart';
 
-main() {
+void main() {
   LruCache<String, int> cache;
   final maxIndividualWeight = 10;
   final maxTotalWeight = 100;

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -53,12 +53,10 @@ void main() {
       });
 
       test('add, contains, get, allNodes', () {
-        var expectedNodes = [];
-        for (var i = 0; i < 5; i++) {
-          expectedNodes.add(testAddNode());
-        }
-        expectedNodes.addAll(
-            placeholderIdsFor(fooPackageGraph).map((id) => graph.get(id)));
+        var expectedNodes = [
+          for (var i = 0; i < 5; i++) testAddNode(),
+          for (var id in placeholderIdsFor(fooPackageGraph)) graph.get(id),
+        ];
         expect(graph.allNodes, unorderedEquals(expectedNodes));
       });
 
@@ -215,7 +213,7 @@ void main() {
             ]..addAll(placeholders)));
         var node = graph.get(primaryInputId);
         expect(node.primaryOutputs, [primaryOutputId]);
-        expect(node.outputs, []);
+        expect(node.outputs, isEmpty);
         expect(node.lastKnownDigest, isNotNull,
             reason: 'Nodes with outputs should get an eager digest.');
 
@@ -283,7 +281,7 @@ void main() {
           expect(graph.contains(primaryInputId), isTrue);
           expect(graph.contains(primaryOutputId), isTrue);
           // We don't pre-emptively delete the file in the case of modifications
-          expect(deletes, equals([]));
+          expect(deletes, isEmpty);
           var outputNode = graph.get(primaryOutputId) as GeneratedAssetNode;
           // But we should mark it as needing an update
           expect(outputNode.state, NodeState.mayNeedUpdate);

--- a/build_runner_core/test/environment/create_merged_dir_test.dart
+++ b/build_runner_core/test/environment/create_merged_dir_test.dart
@@ -19,7 +19,7 @@ import 'package:build_test/build_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('createMergedDir', () {
     AssetGraph graph;
     final phases = [

--- a/build_runner_core/test/environment/simple_prompt.dart
+++ b/build_runner_core/test/environment/simple_prompt.dart
@@ -7,7 +7,7 @@ import 'package:logging/logging.dart';
 
 import 'package:build_runner_core/src/environment/io_environment.dart';
 
-main() async {
+void main() async {
   var env = IOEnvironment(PackageGraph.forThisPackage(), assumeTty: true);
   var result = await env.prompt('Select an option!', ['a', 'b', 'c']);
   Logger.root.onRecord.listen(env.onLog);

--- a/build_runner_core/test/generate/asset_tracker_test.dart
+++ b/build_runner_core/test/generate/asset_tracker_test.dart
@@ -15,7 +15,7 @@ import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/generate/build_definition.dart';
 import 'package:build_runner_core/src/package_graph/target_graph.dart';
 
-main() {
+void main() {
   group('AssetTracker.collectChanges()', () {
     AssetTracker assetTracker;
 

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -28,7 +28,7 @@ import 'package:_test_common/common.dart';
 import 'package:_test_common/package_graphs.dart';
 import 'package:_test_common/runner_asset_writer_spy.dart';
 
-main() {
+void main() {
   final aPackageGraph = buildPackageGraph({
     rootPackage('a'): ['b'],
     package('b'): []
@@ -565,7 +565,7 @@ targets:
             overrideBuildConfig: {
               rootPkg: BuildConfig.fromMap(rootPkg, [], {
                 'targets': {
-                  'another': {},
+                  'another': <String, dynamic>{},
                   '\$default': {
                     'sources': {
                       'exclude': [
@@ -593,7 +593,7 @@ targets:
             overrideBuildConfig: {
               rootPkg: BuildConfig.fromMap(rootPkg, [], {
                 'targets': {
-                  'another': {},
+                  'another': <String, dynamic>{},
                   '\$default': {
                     'sources': {
                       'exclude': [
@@ -621,9 +621,9 @@ targets:
             overrideBuildConfig: {
               rootPkg: BuildConfig.fromMap(rootPkg, [], {
                 'targets': {
-                  'another': {},
+                  'another': <String, dynamic>{},
                   '\$default': {
-                    'sources': {'include': []}
+                    'sources': {'include': <String>[]}
                   }
                 }
               })

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -117,7 +117,7 @@ void main() {
                           math.max(concurrentCount, maxConcurrentCount);
                       if (concurrentCount >= buildPhasePoolSize &&
                           !reachedMax.isCompleted) {
-                        await Future.delayed(Duration(milliseconds: 100));
+                        await Future<void>.delayed(Duration(milliseconds: 100));
                         if (!reachedMax.isCompleted) reachedMax.complete(null);
                       }
                       await reachedMax.future;
@@ -340,7 +340,7 @@ void main() {
 
       test('asset is deleted mid-build, use cached canRead result', () async {
         var aTxtId = AssetId('a', 'lib/file.a');
-        var ready = Completer();
+        var ready = Completer<void>();
         var firstBuilder = TestBuilder(
             buildExtensions: appendExtension('.exists', from: '.a'),
             build: writeCanRead(aTxtId));
@@ -988,7 +988,7 @@ void main() {
     var done = testBuilders([copyABuilderApplication], inputs,
         outputs: outputs, writer: writer);
     // Should block on user input.
-    await Future.delayed(Duration(seconds: 1));
+    await Future<void>.delayed(Duration(seconds: 1));
     // Now it should complete!
     await done;
   });

--- a/build_runner_core/test/generate/custom_generated_dir_test.dart
+++ b/build_runner_core/test/generate/custom_generated_dir_test.dart
@@ -10,7 +10,7 @@ import 'package:build_runner_core/build_runner_core.dart';
 import 'package:_test_common/common.dart';
 import 'package:_test_common/package_graphs.dart';
 
-main() {
+void main() {
   final customGeneratedDir = 'my-custom-dir';
   overrideGeneratedOutputDirectory(customGeneratedDir);
 

--- a/build_runner_core/test/generate/performance_tracker_test.dart
+++ b/build_runner_core/test/generate/performance_tracker_test.dart
@@ -12,7 +12,7 @@ import 'package:build_runner_core/src/generate/performance_tracker.dart';
 import 'package:build_test/build_test.dart';
 import 'package:timing/src/clock.dart';
 
-main() {
+void main() {
   group('PerformanceTracker', () {
     DateTime time;
     final startTime = DateTime(2017);


### PR DESCRIPTION
- Type annotate unused arguments with `void`.
- Annotate return types for all `main` in tests as `void`.
- Type annotate used arguments with `Object`.
- Replace some empty list literals in text expectations with the
  `isEmpty` matcher.
- Replace an untyped empty list literal with a list literal using
  for-loop elements so that the type can be inferred from the elements.
- Change some untyped `Future` and `Completer` to be explicitly
  `<void>`.
- Add generics to some unimportant collection literals in test data.