### PR TITLE
Add return type on main in generated build script

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -136,7 +136,7 @@ final _builders = <_i1.BuilderApplication>[
       defaultReleaseOptions: _i10.BuilderOptions({'enabled': true}),
       defaultGenerateFor: const _i3.InputSet())
 ];
-main(List<String> args, [_i11.SendPort sendPort]) async {
+void main(List<String> args, [_i11.SendPort sendPort]) async {
   var result = await _i12.run(args, _builders);
   sendPort?.send(result);
   _i13.exitCode = result;

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -106,6 +106,7 @@ Future<Iterable<Expression>> _findBuilderApplications() async {
 /// A method forwarding to `run`.
 Method _main() => Method((b) => b
   ..name = 'main'
+  ..returns = refer('void')
   ..modifier = MethodModifier.async
   ..requiredParameters.add(Parameter((b) => b
     ..name = 'args'


### PR DESCRIPTION
This will allow all the code under the `_test` directory to analyze
without errors with `strict-inference` enabled.