### PR TITLE
Prep to publish

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,7 +1,10 @@
+# 2.1.2
+
+- Depend on the latest `built_value`.
+
 # 2.1.1
 
 - Require SDK version `2.6.0` to enable extension methods.
-- Depend on the latest `built_value`.
 
 ## 2.1.0
 

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 2.1.1
+version: 2.1.2
 description: A daemon for running Dart builds.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon


### PR DESCRIPTION
Looks like `2.1.1` was already published.

See https://github.com/dart-lang/build/pull/2546