### PR TITLE
Add an FAQ entry on missing files

### DIFF
--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -378,10 +378,19 @@ class AssetHandler {
     var glob = p.url.join(directoryPath, '*');
     var result =
         await _reader.findAssets(Glob(glob)).map((a) => a.path).toList();
-    return (result.isEmpty)
-        ? 'Could not find ${from.path} or any files in $directoryPath.'
-        : 'Could not find ${from.path}. $directoryPath contains:\n'
-            '${result.join('\n')}';
+    var message = StringBuffer('Could not find ${from.path}');
+    if (result.isEmpty) {
+      message.write(' or any files in $directoryPath. ');
+    } else {
+      message
+        ..write('. $directoryPath contains:')
+        ..writeAll(result, '\n')
+        ..writeln();
+    }
+    message
+        .write(' See https://github.com/dart-lang/build/blob/master/docs/faq.md'
+            '#why-cant-i-see-a-file-i-know-exists');
+    return '$message';
   }
 }
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -156,3 +156,18 @@ targets:
         - test/vm/**_test.dart
         - bin/**.dart
 ```
+
+## Why can't I see a file I know exists?
+
+A file may not be served or be present in the output of a build because:
+
+-   You may be looking for it in the wrong place. For example if a server for
+    the `web/` directory is running on port `8080` then the file at
+    `web/index.html` will be loaded from `localhost:8080/index.html`.
+-   It may have be excluded from the build entirely because it isn't present as
+    in the `sources` for any `target` in `build.yaml`. Only assets that are
+    present in the build (as either a source or a generated output from a
+    source) can be served.
+-   It may have been removed by a `PostProcessBuilder`. For example in release
+    modes, by default, the `build_web_compilers` package enables a
+    `dart_source_cleanup` builder that removes all `.dart` source files.


### PR DESCRIPTION
Closes https://github.com/dart-lang/webdev/issues/824

Users may be confused when they don't see an expected file available
from the asset server, or present in an output directory. Add an FAQ
entry with some common reasons. Add a link to the FAQ in the output of
the asset server for a missing file.