### PR TITLE
Increase upper bound for stream_transform deps

### DIFF
--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 2.1.2
+version: 2.1.3-dev
 description: A daemon for running Dart builds.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon
@@ -18,7 +18,7 @@ dependencies:
   pool: ^1.3.6
   shelf: ^0.7.4
   shelf_web_socket: ^0.2.2+4
-  stream_transform: ^0.0.20
+  stream_transform: ">=0.0.20 <2.0.0"
   watcher: ^0.9.7
   web_socket_channel: ^1.0.9
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   shelf: ">=0.6.5 <0.8.0"
   shelf_web_socket: ^0.2.2+4
   stack_trace: ^1.9.0
-  stream_transform: ^0.0.20
+  stream_transform: ">=0.0.20 <2.0.0"
   timing: ^0.1.1
   watcher: ^0.9.7
   web_socket_channel: ^1.0.9

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   package_resolver: ^1.0.2
   path: ^1.4.1
   pedantic: ^1.0.0
-  stream_transform: ^0.0.20
+  stream_transform: ">=0.0.20 <2.0.0"
   test: '>=0.12.42 <2.0.0'
   test_core: ^0.2.4
   watcher: ^0.9.7


### PR DESCRIPTION
Version `1.0.0` is non breaking for all packages that already migrated
to use the extension methods.