### PR TITLE
Stop plumbing unused `verbose` through options

### DIFF
--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -67,7 +67,6 @@ class BuildImpl {
   final ResourceManager _resourceManager;
   final RunnerAssetWriter _writer;
   final bool _trackPerformance;
-  final bool _verbose;
   final BuildEnvironment _environment;
   final String _logPerformanceDir;
 
@@ -84,7 +83,6 @@ class BuildImpl {
         _writer = buildDefinition.writer,
         assetGraph = buildDefinition.assetGraph,
         _resourceManager = buildDefinition.resourceManager,
-        _verbose = options.verbose,
         _environment = buildDefinition.environment,
         _trackPerformance = options.trackPerformance,
         _logPerformanceDir = options.logPerformanceDir;
@@ -158,7 +156,6 @@ class _SingleBuild {
   final AssetReader _reader;
   final Resolvers _resolvers;
   final ResourceManager _resourceManager;
-  final bool _verbose;
   final RunnerAssetWriter _writer;
   final Set<BuildDirectory> _buildDirs;
   final String _logPerformanceDir;
@@ -186,7 +183,6 @@ class _SingleBuild {
         _reader = buildImpl._reader,
         _resolvers = buildImpl._resolvers,
         _resourceManager = buildImpl._resourceManager,
-        _verbose = buildImpl._verbose,
         _writer = buildImpl._writer,
         _buildDirs = buildDirs,
         _logPerformanceDir = buildImpl._logPerformanceDir {

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -39,6 +39,7 @@ class LogSubscription {
   factory LogSubscription(BuildEnvironment environment,
       {bool verbose, Level logLevel}) {
     // Set up logging
+    verbose ??= false;
     logLevel ??= verbose ? Level.ALL : Level.INFO;
 
     // Severe logs can fail the build and should always be shown.

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -39,7 +39,6 @@ class LogSubscription {
   factory LogSubscription(BuildEnvironment environment,
       {bool verbose, Level logLevel}) {
     // Set up logging
-    verbose ??= false;
     logLevel ??= verbose ? Level.ALL : Level.INFO;
 
     // Severe logs can fail the build and should always be shown.
@@ -48,12 +47,11 @@ class LogSubscription {
     Logger.root.level = logLevel;
 
     var logListener = Logger.root.onRecord.listen(environment.onLog);
-    return LogSubscription._(verbose, logListener);
+    return LogSubscription._(logListener);
   }
 
-  LogSubscription._(this.verbose, this.logListener);
+  LogSubscription._(this.logListener);
 
-  final bool verbose;
   final StreamSubscription<LogRecord> logListener;
 }
 
@@ -129,7 +127,6 @@ class BuildOptions {
   final Resolvers resolvers;
   final TargetGraph targetGraph;
   final bool trackPerformance;
-  final bool verbose;
 
   // Watch mode options.
   Duration debounceDelay;
@@ -145,7 +142,6 @@ class BuildOptions {
     @required this.packageGraph,
     @required this.skipBuildScriptCheck,
     @required this.trackPerformance,
-    @required this.verbose,
     @required this.targetGraph,
     @required this.logPerformanceDir,
     @required this.resolvers,
@@ -200,7 +196,6 @@ class BuildOptions {
       packageGraph: packageGraph,
       skipBuildScriptCheck: skipBuildScriptCheck,
       trackPerformance: trackPerformance,
-      verbose: logSubscription.verbose,
       targetGraph: targetGraph,
       logPerformanceDir: logPerformanceDir,
       resolvers: resolvers,

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 4.2.0
+version: 4.2.1-dev
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
This used to have other meaning, however now it is only used to set a
default log level.

Fixes a failing travis since the analyzer recently started reporting
this as a hint.