### PR TITLE
add the `assets` directory to the default sources whitelist

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.0-dev
+
+- Add the `assets` directory to the default sources whitelist.
+
 ## 4.2.1
 
 - Bug fix: Changing the root package name will no longer cause subsequent

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -21,6 +21,7 @@ import 'exceptions.dart';
 /// The default list of files to include when an explicit include is not
 /// provided.
 const List<String> defaultRootPackageWhitelist = [
+  'assets/**',
   'benchmark/**',
   'bin/**',
   'example/**',

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 4.2.1
+version: 4.3.0-dev
 description: Core tools to write binaries that run builders.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/2571

Going to wait to publish until we make a decision on the $assets$ synthetic input which we might want to publish together with this..