### PR TITLE
Add synthetic $package$ file, and update docs

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 4.3.0-dev
+## 4.3.0
 
-- Add the `assets` directory to the default sources whitelist.
+- Add the `$package$` synthetic placeholder file and update the docs to prefer
+  using only that or `lib/$lib$`.
+- Add the `assets` directory and `$package$` placeholders to the default
+  sources whitelist.
 
 ## 4.2.1
 

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -552,4 +552,5 @@ Set<AssetId> placeholderIdsFor(PackageGraph packageGraph) =>
           AssetId(package, r'lib/$lib$'),
           AssetId(package, r'test/$test$'),
           AssetId(package, r'web/$web$'),
+          AssetId(package, r'$package$'),
         ]));

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -32,6 +32,7 @@ const List<String> defaultRootPackageWhitelist = [
   'node/**',
   'pubspec.yaml',
   'pubspec.lock',
+  r'$package$',
 ];
 
 final _logger = Logger('BuildOptions');

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 4.3.0-dev
+version: 4.3.0
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -158,9 +158,13 @@ void main() {
 
       test('with placeholder as input', () async {
         await testBuilders([
-          applyToRoot(PlaceholderBuilder({'placeholder.txt': 'sometext'}))
+          applyToRoot(PlaceholderBuilder({'lib.txt': 'libText'},
+              inputExtension: r'$lib$')),
+          applyToRoot(PlaceholderBuilder({'root.txt': 'rootText'},
+              inputExtension: r'$package$')),
         ], {}, outputs: {
-          'a|lib/placeholder.txt': 'sometext'
+          'a|lib/lib.txt': 'libText',
+          'a|root.txt': 'rootText',
         });
       });
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.10.11
+
+- Add support for the new `$package$` placeholder.
+
+### Potentially Breaking Change
+
+- Only add the non-lib placeholders when a root package is specified
+  - Infer the root package when there is only one package in the sources
+  - This is being released as a non-breaking change because the only expected
+    use cases already would have been broken - `findAssets` calls already
+    required a root package.
+
 ## 0.10.10
 
 - Allow reading of assets written from the same build step.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.10
+version: 0.10.11
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/1132

The docs have been updated to clarify when to use `$package$` versus `lib/$lib$`, as well as adding a deprecation message to the other placeholder files.

Also updates `build_test`. See CHANGELOG.md notes about the potentially breaking change there, which we are choosing to release as a non-breaking change.