### PR TITLE
Make resolver throw an exception on non-libraries

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 1.3.1-dev
+## 1.3.1
 
-- Internal changes.
+- Add an exception on trying to resolve an `AssetId` that is not a Dart
+  library with `libraryFor` to fit the contract expressed by the doc comment on
+  `Resolver`.
 
 ## 1.3.0
 

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -127,7 +127,7 @@ class AnalyzerResolver implements ReleasableResolver {
     var source = _driver.sourceFactory.forUri2(uri);
     if (source == null) throw ArgumentError('missing source for $uri');
     var kind = await _driver.getSourceKind(path);
-    if (kind != SourceKind.LIBRARY) return null;
+    if (kind != SourceKind.LIBRARY) throw NonLibraryAssetException(assetId);
     return _driver.getLibraryByUri(assetId.uri.toString());
   }
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.3.1-dev
+version: 1.3.1
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -240,6 +240,27 @@ void main() {
     });
   });
 
+  test('throws when reading a part-of file', () {
+    return resolveSources(
+      {
+        'a|lib/a.dart': '''
+          part 'b.dart';
+        ''',
+        'a|lib/b.dart': '''
+          part of 'a.dart';
+        '''
+      },
+      (resolver) async {
+        final assetId = AssetId.parse('a|lib/b.dart');
+        await expectLater(
+          () => resolver.libraryFor(assetId),
+          throwsA(const TypeMatcher<NonLibraryAssetException>()
+              .having((e) => e.assetId, 'assetId', equals(assetId))),
+        );
+      },
+    );
+  });
+
   group('The ${_isFlutter ? 'flutter' : 'dart'} sdk', () {
     test('can${_isFlutter ? '' : ' not'} resolve types from dart:ui', () async {
       return resolveSources({


### PR DESCRIPTION
From the docs of [`Resolver.libraryFor`](https://pub.dev/documentation/build/latest/build/Resolver/libraryFor.html):
> Throws `NonLibraryAssetException` if assetId is not a Dart library.

Contrary to the docs, the most common resolver from `build_resolvers` actually returns null instead of throwing said exception.
I think the actual behavior should match the docs here, so I've changed the behavior of `AnalyzerResolver`. I think this behavior can be useful, but I'm not sure if some users might rely on that implementation now (e.g. doing `!= null` checks instead of wrapping it in a try block). Personally I'd also be fine with the alternative of changing the documentation, if that's what you prefer.