### PR TITLE
Fix hot restart bug

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7.2
+
+- Fix a bug with hot restart,
+  [#2586](https://github.com/dart-lang/build/issues/2586).
+
 ## 2.7.1
 
 - Allow analyzer version `0.39.x`.

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -113,13 +113,13 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
       bootstrapId.path,
       from: _context.dirname(dartEntrypointId.path)));
 
-  var primarySourceParts = _context.split(module.primarySource.path);
-  var appModuleUri = _context.joinAll([
+  var dartEntrypointParts = _context.split(dartEntrypointId.path);
+  var entrypointLibraryName = _context.joinAll([
     // Convert to a package: uri for files under lib.
-    if (primarySourceParts.first == 'lib')
+    if (dartEntrypointParts.first == 'lib')
       'package:${module.primarySource.package}',
     // Strip top-level directory from the path.
-    ...primarySourceParts.skip(1),
+    ...dartEntrypointParts.skip(1),
   ]);
 
   var bootstrapContent =
@@ -129,8 +129,8 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
             _p.url.relative(appDigestsOutput.path,
                 from: _p.url.dirname(bootstrapId.path))))
         ..write(_requireJsConfig)
-        ..write(_appBootstrap(
-            bootstrapModuleName, appModuleName, appModuleScope, appModuleUri,
+        ..write(_appBootstrap(bootstrapModuleName, appModuleName,
+            appModuleScope, entrypointLibraryName,
             oldModuleScope: oldAppModuleScope));
 
   await buildStep.writeAsString(bootstrapId, bootstrapContent.toString());
@@ -192,7 +192,7 @@ Future<List<AssetId>> _ensureTransitiveJsModules(
 ///
 /// Also performs other necessary initialization.
 String _appBootstrap(String bootstrapModuleName, String moduleName,
-        String moduleScope, String appModuleUri,
+        String moduleScope, String entrypointLibraryName,
         {String oldModuleScope}) =>
     '''
 define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_sdk) {
@@ -212,7 +212,7 @@ define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_s
           if (firstSlash == -1) return false;
           childName = childName.substring(firstSlash + 1);
         }
-        if (childName === "$appModuleUri") {
+        if (childName === "$entrypointLibraryName") {
           // Clear static caches.
           dart_sdk.dart.hotRestart();
           child.main();

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.7.1
+version: 2.7.2
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -83,6 +83,7 @@ main() {
           contains('define("b.dart.bootstrap", ["web/a", "dart_sdk"]'),
           // Calls main on the `b.dart` library, not the `a.dart` library.
           contains('(app.web__b || app.b).main()'),
+          contains('if (childName === "b.dart")'),
         ])),
         'a|web/b.digests': isNotEmpty,
         'a|web/b.dart.js': isNotEmpty,


### PR DESCRIPTION
When the entrypoint isn't the primary asset of the module we would handle the hot restart at the wrong place (the primary asset), which would either run the wrong app (if it had a main and was available) or give a runtime failure.

Fixes https://github.com/dart-lang/build/issues/2586