### PR TITLE
Fix scratch space race condition with pending writes

### DIFF
--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.4+2
+
+- Fix a race condition bug where `ensureAssets` would complete before all
+  pending writes were completed. If the next build was scheduled before these
+  writes finished then they would get the old result.
+
 ## 0.0.4+1
 
 - Fix `ScratchSpace.fileFor` on windows to normalize the paths so they dont

--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -66,7 +66,7 @@ class ScratchSpace {
   ///
   /// This class is no longer valid once the directory is deleted, you must
   /// create a new [ScratchSpace].
-  Future<void> delete() async {
+  Future delete() async {
     if (!exists) {
       throw StateError(
           'Tried to delete a ScratchSpace which was already deleted');

--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -66,13 +66,21 @@ class ScratchSpace {
   ///
   /// This class is no longer valid once the directory is deleted, you must
   /// create a new [ScratchSpace].
-  Future delete() {
+  Future<void> delete() async {
     if (!exists) {
       throw StateError(
           'Tried to delete a ScratchSpace which was already deleted');
     }
     exists = false;
     _digests.clear();
+    if (_pendingWrites.isNotEmpty) {
+      try {
+        await Future.wait(_pendingWrites.values);
+      } catch (_) {
+        // Ignore any errors, we are essentially just draining this queue
+        // of pending writes but don't care about the result.
+      }
+    }
     return tempDir.delete(recursive: true);
   }
 
@@ -115,7 +123,7 @@ class ScratchSpace {
       }
     }).toList();
 
-    return Future.wait(futures, eagerError: true);
+    return Future.wait(futures);
   }
 
   /// Returns the actual [File] in this environment corresponding to [id].

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scratch_space
-version: 0.0.4+1
+version: 0.0.4+2
 description: A tool to manage running external executables within package:build
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space
 


### PR DESCRIPTION
Fixes the potential root cause of https://github.com/dart-lang/sdk/issues/38102

If we failed to write one file we would previously eagerly return that error, but still have a bunch of other pending writes which are cached.

If we then scheduled another build while those writes were still pending they could end up with the cached result.

The fix is to not eagerly fail and make sure we wait for all pending writes before returning.