### PR TITLE
Prepare to publish build_runner and build_daemon

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.3
+
+- Allow the latest `stream_transform`.
+
 # 2.1.2
 
 - Depend on the latest `built_value`.

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 2.1.3-dev
+version: 2.1.3
 description: A daemon for running Dart builds.
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 1.7.3-dev
+## 1.7.3
 
 - Improve the error message when a `--hostname` argument is invalid.
 - Require SDK version `2.6.0` to enable extension methods.
+- Allow the latest `stream_transform`.
 
 ## 1.7.2
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.7.3-dev
+version: 1.7.3
 description: Tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
There are no published versions of these packages that allow the latest
`stream_transform`.