### PR TITLE
Add warning for override config on missing package

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.4-dev
+
+- Give a warning instead of a stack trace when using a build config override
+  file for a package that does not exist.
+
 ## 1.7.3
 
 - Improve the error message when a `--hostname` argument is invalid.

--- a/build_runner/lib/src/package_graph/build_config_overrides.dart
+++ b/build_runner/lib/src/package_graph/build_config_overrides.dart
@@ -20,14 +20,14 @@ Future<Map<String, BuildConfig>> findBuildConfigOverrides(
   await for (final file in configFiles) {
     if (file is File) {
       final packageName = p.basename(file.path).split('.').first;
-      if (!packageGraph.allPackages.containsKey(packageName)) {
+      final packageNode = packageGraph.allPackages[packageName];
+      if (packageNode == null) {
         _log.warning('A build config override is provided for $packageName but '
             'that package does not exist. '
             'Remove the ${p.basename(file.path)} override or add a dependency '
             'on $packageName.');
         continue;
       }
-      final packageNode = packageGraph.allPackages[packageName];
       final yaml = file.readAsStringSync();
       final config = BuildConfig.parse(
         packageName,

--- a/build_runner/lib/src/package_graph/build_config_overrides.dart
+++ b/build_runner/lib/src/package_graph/build_config_overrides.dart
@@ -20,6 +20,13 @@ Future<Map<String, BuildConfig>> findBuildConfigOverrides(
   await for (final file in configFiles) {
     if (file is File) {
       final packageName = p.basename(file.path).split('.').first;
+      if (!packageGraph.allPackages.containsKey(packageName)) {
+        _log.warning('A build config override is provided for $packageName but '
+            'that package does not exist. '
+            'Remove the ${p.basename(file.path)} override or add a dependency '
+            'on $packageName.');
+        continue;
+      }
       final packageNode = packageGraph.allPackages[packageName];
       final yaml = file.readAsStringSync();
       final config = BuildConfig.parse(

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.7.3
+version: 1.7.4-dev
 description: Tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
Fixes #2569

When the user creates a `package.build.yaml` file, but `package` does
not exist as a dependency, warn and continue instead of dumping a stack
trace.