### PR TITLE
Eagerly report writes to build step

### DIFF
--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0-dev
+
+- Change `copyOutput` to take a `BuildStep` instead of an `AssetWriter`. This
+  shouldn't break most uses which are likely already passing in a `BuildStep`.
+
 ## 0.0.4+2
 
 - Fix a race condition bug where `ensureAssets` would complete before all

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scratch_space
-version: 0.0.4+2
+version: 0.1.0-dev
 description: A tool to manage running external executables within package:build
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space
 


### PR DESCRIPTION
Solves a potential bug if a builder does not `await` the future returned
by `copyOutput` then the build step may finish before the asset is read
from the temp directory and the `writeAsString` call may be rejected.