### PR TITLE
Change return types to `Future<void>`

### DIFF
--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+3-dev
+
+- Change returns from `Future<dynamic>` to `Future<void>`.
+
 ## 0.0.4+2
 
 - Fix a race condition bug where `ensureAssets` would complete before all

--- a/scratch_space/README.md
+++ b/scratch_space/README.md
@@ -3,7 +3,7 @@
 
 A [`ScratchSpace`][dartdoc:ScratchSpace] is a thin wrapper around a temporary
 directory. The constructor takes zero arguments, so making one is as simple as
-doing `new ScratchSpace()`.
+doing `ScratchSpace()`.
 
 In general, you should wrap a `ScratchSpace` in a `Resource`, so that you can
 re-use the scratch space across build steps in an individual build. This is
@@ -13,14 +13,14 @@ This should look something like the following:
 
 ```
 final myScratchSpaceResource =
-    new Resource(() => new ScratchSpace(), dispose: (old) => old.delete());
+    Resource(() => ScratchSpace(), dispose: (old) => old.delete());
 ```
 
 And then you can get access to it through the `BuildStep#fetchResource` api:
 
 ```
 class MyBuilder extends Builder {
-  Future build(BuildStep buildStep) async {
+  Future<void> build(BuildStep buildStep) async {
     var scratchSpace = await buildStep.fetchResource(myScratchSpaceResource);
   }
 }

--- a/scratch_space/lib/src/scratch_space.dart
+++ b/scratch_space/lib/src/scratch_space.dart
@@ -54,7 +54,7 @@ class ScratchSpace {
   ///
   /// If [requireContent] is true and the file is empty an
   /// [EmptyOutputException] is thrown.
-  Future copyOutput(AssetId id, AssetWriter writer,
+  Future<void> copyOutput(AssetId id, AssetWriter writer,
       {bool requireContent = false}) async {
     var file = fileFor(id);
     var bytes = await _descriptorPool.withResource(file.readAsBytes);
@@ -66,7 +66,7 @@ class ScratchSpace {
   ///
   /// This class is no longer valid once the directory is deleted, you must
   /// create a new [ScratchSpace].
-  Future delete() async {
+  Future<void> delete() async {
     if (!exists) {
       throw StateError(
           'Tried to delete a ScratchSpace which was already deleted');
@@ -93,7 +93,7 @@ class ScratchSpace {
   /// Any asset that is under a `lib` dir will be output under a `packages`
   /// directory corresponding to its package, and any other assets are output
   /// directly under the temp dir using their unmodified path.
-  Future ensureAssets(Iterable<AssetId> assetIds, AssetReader reader) {
+  Future<void> ensureAssets(Iterable<AssetId> assetIds, AssetReader reader) {
     if (!exists) {
       throw StateError('Tried to use a deleted ScratchSpace!');
     }

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scratch_space
-version: 0.0.4+2
+version: 0.0.4+3-dev
 description: A tool to manage running external executables within package:build
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space
 


### PR DESCRIPTION
Add an explicit generic on some async return types. These never would
resolve with a real value, so make that explicit in the signature.

Also clean up some Dart style in the README, add a generic on a Future
and remove unnecessary `new` keyword.