### PR TITLE
Add an option to disable builder auto applications on a target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,16 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.3.0; PKGS: build, build_config, build_resolvers, build_runner_core, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.3.0; PKGS: build, build_resolvers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.3.0"
       os: linux
-      env: PKGS="build build_config build_resolvers build_runner_core scratch_space"
+      env: PKGS="build build_resolvers scratch_space"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: 2.6.0; PKGS: build_daemon, build_test; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.6.0; PKGS: build_config, build_daemon, build_runner_core, build_test; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.6.0"
       os: linux
-      env: PKGS="build_daemon build_test"
+      env: PKGS="build_config build_daemon build_runner_core build_test"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.5.0; PKGS: build_modules, build_vm_compilers, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
@@ -121,14 +121,14 @@ jobs:
       env: PKGS="build_runner"
       script: ./tool/travis.sh test_06
     - stage: unit_test
-      name: "SDK: 2.3.0; PKG: build_runner_core; TASKS: `pub run test`"
-      dart: "2.3.0"
+      name: "SDK: 2.6.0; PKG: build_runner_core; TASKS: `pub run test`"
+      dart: "2.6.0"
       os: linux
       env: PKGS="build_runner_core"
       script: ./tool/travis.sh test_05
     - stage: unit_test
-      name: "SDK: 2.3.0; PKG: build_runner_core; TASKS: `pub run test`"
-      dart: "2.3.0"
+      name: "SDK: 2.6.0; PKG: build_runner_core; TASKS: `pub run test`"
+      dart: "2.6.0"
       os: windows
       env: PKGS="build_runner_core"
       script: ./tool/travis.sh test_05

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.2
+
+- Add support for an `auto_apply_builders` option to the `target` config.
+  - Defaults to `true` (the previous behavior), setting it to `false`
+    means all builders have to be explicitly enabled. 
+
 ## 0.4.1+1
 
 - Support the latest release of `package:json_annotation`.

--- a/build_config/lib/src/build_config.g.dart
+++ b/build_config/lib/src/build_config.g.dart
@@ -15,35 +15,33 @@ BuildConfig _$BuildConfigFromJson(Map json) {
       'global_options'
     ]);
     final val = BuildConfig(
-        buildTargets: $checkedConvert(
-            json, 'targets', (v) => _buildTargetsFromJson(v as Map)),
-        globalOptions: $checkedConvert(
-            json,
-            'global_options',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(
-                      k as String,
-                      e == null
-                          ? null
-                          : GlobalBuilderConfig.fromJson(e as Map)),
-                )),
-        builderDefinitions: $checkedConvert(
-            json,
-            'builders',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(k as String,
-                      e == null ? null : BuilderDefinition.fromJson(e as Map)),
-                )),
-        postProcessBuilderDefinitions: $checkedConvert(
-            json,
-            'post_process_builders',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(
-                      k as String,
-                      e == null
-                          ? null
-                          : PostProcessBuilderDefinition.fromJson(e as Map)),
-                )));
+      buildTargets: $checkedConvert(
+          json, 'targets', (v) => _buildTargetsFromJson(v as Map)),
+      globalOptions: $checkedConvert(
+          json,
+          'global_options',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String,
+                    e == null ? null : GlobalBuilderConfig.fromJson(e as Map)),
+              )),
+      builderDefinitions: $checkedConvert(
+          json,
+          'builders',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String,
+                    e == null ? null : BuilderDefinition.fromJson(e as Map)),
+              )),
+      postProcessBuilderDefinitions: $checkedConvert(
+          json,
+          'post_process_builders',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(
+                    k as String,
+                    e == null
+                        ? null
+                        : PostProcessBuilderDefinition.fromJson(e as Map)),
+              )),
+    );
     return val;
   }, fieldKeyMap: const {
     'buildTargets': 'targets',

--- a/build_config/lib/src/build_target.dart
+++ b/build_config/lib/src/build_target.dart
@@ -14,6 +14,9 @@ part 'build_target.g.dart';
 
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)
 class BuildTarget {
+  @JsonKey(name: 'auto_apply_builders')
+  final bool autoApplyBuilders;
+
   /// A map from builder key to the configuration used for this target.
   ///
   /// Builder keys are in the format `"$package|$builder"`. This does not
@@ -31,10 +34,12 @@ class BuildTarget {
   String get package => packageExpando[this];
 
   BuildTarget({
+    bool autoApplyBuilders,
     InputSet sources,
     Iterable<String> dependencies,
     Map<String, TargetBuilderConfig> builders,
-  })  : dependencies = (dependencies ?? currentPackageDefaultDependencies)
+  })  : autoApplyBuilders = autoApplyBuilders ?? true,
+        dependencies = (dependencies ?? currentPackageDefaultDependencies)
             .map((d) => normalizeTargetKeyUsage(d, currentPackage))
             .toList(),
         builders = (builders ?? const {}).map((key, config) =>
@@ -49,6 +54,7 @@ class BuildTarget {
         'sources': sources,
         'dependencies': dependencies,
         'builders': builders,
+        'autoApplyBuilders': autoApplyBuilders,
       }.toString();
 }
 

--- a/build_config/lib/src/build_target.g.dart
+++ b/build_config/lib/src/build_target.g.dart
@@ -8,25 +8,29 @@ part of 'build_target.dart';
 
 BuildTarget _$BuildTargetFromJson(Map json) {
   return $checkedNew('BuildTarget', json, () {
-    $checkKeys(json,
-        allowedKeys: const ['builders', 'dependencies', 'sources']);
+    $checkKeys(json, allowedKeys: const [
+      'auto_apply_builders',
+      'builders',
+      'dependencies',
+      'sources'
+    ]);
     final val = BuildTarget(
-        sources: $checkedConvert(
-            json, 'sources', (v) => v == null ? null : InputSet.fromJson(v)),
-        dependencies: $checkedConvert(
-            json, 'dependencies', (v) => (v as List)?.map((e) => e as String)),
-        builders: $checkedConvert(
-            json,
-            'builders',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(
-                      k as String,
-                      e == null
-                          ? null
-                          : TargetBuilderConfig.fromJson(e as Map)),
-                )));
+      autoApplyBuilders:
+          $checkedConvert(json, 'auto_apply_builders', (v) => v as bool),
+      sources: $checkedConvert(
+          json, 'sources', (v) => v == null ? null : InputSet.fromJson(v)),
+      dependencies: $checkedConvert(
+          json, 'dependencies', (v) => (v as List)?.map((e) => e as String)),
+      builders: $checkedConvert(
+          json,
+          'builders',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String,
+                    e == null ? null : TargetBuilderConfig.fromJson(e as Map)),
+              )),
+    );
     return val;
-  });
+  }, fieldKeyMap: const {'autoApplyBuilders': 'auto_apply_builders'});
 }
 
 TargetBuilderConfig _$TargetBuilderConfigFromJson(Map json) {
@@ -39,27 +43,28 @@ TargetBuilderConfig _$TargetBuilderConfigFromJson(Map json) {
       'release_options'
     ]);
     final val = TargetBuilderConfig(
-        isEnabled: $checkedConvert(json, 'enabled', (v) => v as bool),
-        generateFor: $checkedConvert(json, 'generate_for',
-            (v) => v == null ? null : InputSet.fromJson(v)),
-        options: $checkedConvert(
-            json,
-            'options',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(k as String, e),
-                )),
-        devOptions: $checkedConvert(
-            json,
-            'dev_options',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(k as String, e),
-                )),
-        releaseOptions: $checkedConvert(
-            json,
-            'release_options',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(k as String, e),
-                )));
+      isEnabled: $checkedConvert(json, 'enabled', (v) => v as bool),
+      generateFor: $checkedConvert(
+          json, 'generate_for', (v) => v == null ? null : InputSet.fromJson(v)),
+      options: $checkedConvert(
+          json,
+          'options',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String, e),
+              )),
+      devOptions: $checkedConvert(
+          json,
+          'dev_options',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String, e),
+              )),
+      releaseOptions: $checkedConvert(
+          json,
+          'release_options',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String, e),
+              )),
+    );
     return val;
   }, fieldKeyMap: const {
     'isEnabled': 'enabled',
@@ -74,24 +79,25 @@ GlobalBuilderConfig _$GlobalBuilderConfigFromJson(Map json) {
     $checkKeys(json,
         allowedKeys: const ['options', 'dev_options', 'release_options']);
     final val = GlobalBuilderConfig(
-        options: $checkedConvert(
-            json,
-            'options',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(k as String, e),
-                )),
-        devOptions: $checkedConvert(
-            json,
-            'dev_options',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(k as String, e),
-                )),
-        releaseOptions: $checkedConvert(
-            json,
-            'release_options',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(k as String, e),
-                )));
+      options: $checkedConvert(
+          json,
+          'options',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String, e),
+              )),
+      devOptions: $checkedConvert(
+          json,
+          'dev_options',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String, e),
+              )),
+      releaseOptions: $checkedConvert(
+          json,
+          'release_options',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String, e),
+              )),
+    );
     return val;
   }, fieldKeyMap: const {
     'devOptions': 'dev_options',

--- a/build_config/lib/src/builder_definition.g.dart
+++ b/build_config/lib/src/builder_definition.g.dart
@@ -30,34 +30,35 @@ BuilderDefinition _$BuilderDefinitionFromJson(Map json) {
       'build_extensions'
     ]);
     final val = BuilderDefinition(
-        builderFactories: $checkedConvert(json, 'builder_factories',
-            (v) => (v as List).map((e) => e as String).toList()),
-        buildExtensions: $checkedConvert(
-            json,
-            'build_extensions',
-            (v) => (v as Map).map(
-                  (k, e) => MapEntry(k as String,
-                      (e as List).map((e) => e as String).toList()),
-                )),
-        import: $checkedConvert(json, 'import', (v) => v as String),
-        target: $checkedConvert(json, 'target', (v) => v as String),
-        autoApply: $checkedConvert(json, 'auto_apply',
-            (v) => _$enumDecodeNullable(_$AutoApplyEnumMap, v)),
-        requiredInputs: $checkedConvert(json, 'required_inputs',
-            (v) => (v as List)?.map((e) => e as String)),
-        runsBefore: $checkedConvert(
-            json, 'runs_before', (v) => (v as List)?.map((e) => e as String)),
-        appliesBuilders: $checkedConvert(json, 'applies_builders',
-            (v) => (v as List)?.map((e) => e as String)),
-        isOptional: $checkedConvert(json, 'is_optional', (v) => v as bool),
-        buildTo: $checkedConvert(
-            json, 'build_to', (v) => _$enumDecodeNullable(_$BuildToEnumMap, v)),
-        defaults: $checkedConvert(
-            json,
-            'defaults',
-            (v) => v == null
-                ? null
-                : TargetBuilderConfigDefaults.fromJson(v as Map)));
+      builderFactories: $checkedConvert(json, 'builder_factories',
+          (v) => (v as List).map((e) => e as String).toList()),
+      buildExtensions: $checkedConvert(
+          json,
+          'build_extensions',
+          (v) => (v as Map).map(
+                (k, e) => MapEntry(
+                    k as String, (e as List).map((e) => e as String).toList()),
+              )),
+      import: $checkedConvert(json, 'import', (v) => v as String),
+      target: $checkedConvert(json, 'target', (v) => v as String),
+      autoApply: $checkedConvert(json, 'auto_apply',
+          (v) => _$enumDecodeNullable(_$AutoApplyEnumMap, v)),
+      requiredInputs: $checkedConvert(
+          json, 'required_inputs', (v) => (v as List)?.map((e) => e as String)),
+      runsBefore: $checkedConvert(
+          json, 'runs_before', (v) => (v as List)?.map((e) => e as String)),
+      appliesBuilders: $checkedConvert(json, 'applies_builders',
+          (v) => (v as List)?.map((e) => e as String)),
+      isOptional: $checkedConvert(json, 'is_optional', (v) => v as bool),
+      buildTo: $checkedConvert(
+          json, 'build_to', (v) => _$enumDecodeNullable(_$BuildToEnumMap, v)),
+      defaults: $checkedConvert(
+          json,
+          'defaults',
+          (v) => v == null
+              ? null
+              : TargetBuilderConfigDefaults.fromJson(v as Map)),
+    );
     return val;
   }, fieldKeyMap: const {
     'builderFactories': 'builder_factories',
@@ -71,36 +72,48 @@ BuilderDefinition _$BuilderDefinitionFromJson(Map json) {
   });
 }
 
-T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+T _$enumDecode<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
   if (source == null) {
     throw ArgumentError('A value must be provided. Supported values: '
         '${enumValues.values.join(', ')}');
   }
-  return enumValues.entries
-      .singleWhere((e) => e.value == source,
-          orElse: () => throw ArgumentError(
-              '`$source` is not one of the supported values: '
-              '${enumValues.values.join(', ')}'))
-      .key;
+
+  final value = enumValues.entries
+      .singleWhere((e) => e.value == source, orElse: () => null)
+      ?.key;
+
+  if (value == null && unknownValue == null) {
+    throw ArgumentError('`$source` is not one of the supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return value ?? unknownValue;
 }
 
-T _$enumDecodeNullable<T>(Map<T, dynamic> enumValues, dynamic source) {
+T _$enumDecodeNullable<T>(
+  Map<T, dynamic> enumValues,
+  dynamic source, {
+  T unknownValue,
+}) {
   if (source == null) {
     return null;
   }
-  return _$enumDecode<T>(enumValues, source);
+  return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
 }
 
-const _$AutoApplyEnumMap = <AutoApply, dynamic>{
+const _$AutoApplyEnumMap = {
   AutoApply.none: 'none',
   AutoApply.dependents: 'dependents',
   AutoApply.allPackages: 'all_packages',
-  AutoApply.rootPackage: 'root_package'
+  AutoApply.rootPackage: 'root_package',
 };
 
-const _$BuildToEnumMap = <BuildTo, dynamic>{
+const _$BuildToEnumMap = {
   BuildTo.source: 'source',
-  BuildTo.cache: 'cache'
+  BuildTo.cache: 'cache',
 };
 
 PostProcessBuilderDefinition _$PostProcessBuilderDefinitionFromJson(Map json) {
@@ -119,18 +132,19 @@ PostProcessBuilderDefinition _$PostProcessBuilderDefinitionFromJson(Map json) {
       'import'
     ]);
     final val = PostProcessBuilderDefinition(
-        builderFactory:
-            $checkedConvert(json, 'builder_factory', (v) => v as String),
-        import: $checkedConvert(json, 'import', (v) => v as String),
-        inputExtensions: $checkedConvert(json, 'input_extensions',
-            (v) => (v as List)?.map((e) => e as String)),
-        target: $checkedConvert(json, 'target', (v) => v as String),
-        defaults: $checkedConvert(
-            json,
-            'defaults',
-            (v) => v == null
-                ? null
-                : TargetBuilderConfigDefaults.fromJson(v as Map)));
+      builderFactory:
+          $checkedConvert(json, 'builder_factory', (v) => v as String),
+      import: $checkedConvert(json, 'import', (v) => v as String),
+      inputExtensions: $checkedConvert(json, 'input_extensions',
+          (v) => (v as List)?.map((e) => e as String)),
+      target: $checkedConvert(json, 'target', (v) => v as String),
+      defaults: $checkedConvert(
+          json,
+          'defaults',
+          (v) => v == null
+              ? null
+              : TargetBuilderConfigDefaults.fromJson(v as Map)),
+    );
     return val;
   }, fieldKeyMap: const {
     'builderFactory': 'builder_factory',
@@ -147,26 +161,27 @@ TargetBuilderConfigDefaults _$TargetBuilderConfigDefaultsFromJson(Map json) {
       'release_options'
     ]);
     final val = TargetBuilderConfigDefaults(
-        generateFor: $checkedConvert(json, 'generate_for',
-            (v) => v == null ? null : InputSet.fromJson(v)),
-        options: $checkedConvert(
-            json,
-            'options',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(k as String, e),
-                )),
-        devOptions: $checkedConvert(
-            json,
-            'dev_options',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(k as String, e),
-                )),
-        releaseOptions: $checkedConvert(
-            json,
-            'release_options',
-            (v) => (v as Map)?.map(
-                  (k, e) => MapEntry(k as String, e),
-                )));
+      generateFor: $checkedConvert(
+          json, 'generate_for', (v) => v == null ? null : InputSet.fromJson(v)),
+      options: $checkedConvert(
+          json,
+          'options',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String, e),
+              )),
+      devOptions: $checkedConvert(
+          json,
+          'dev_options',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String, e),
+              )),
+      releaseOptions: $checkedConvert(
+          json,
+          'release_options',
+          (v) => (v as Map)?.map(
+                (k, e) => MapEntry(k as String, e),
+              )),
+    );
     return val;
   }, fieldKeyMap: const {
     'generateFor': 'generate_for',

--- a/build_config/lib/src/input_set.g.dart
+++ b/build_config/lib/src/input_set.g.dart
@@ -10,10 +10,11 @@ InputSet _$InputSetFromJson(Map json) {
   return $checkedNew('InputSet', json, () {
     $checkKeys(json, allowedKeys: const ['include', 'exclude']);
     final val = InputSet(
-        include: $checkedConvert(json, 'include',
-            (v) => (v as List)?.map((e) => e as String)?.toList()),
-        exclude: $checkedConvert(json, 'exclude',
-            (v) => (v as List)?.map((e) => e as String)?.toList()));
+      include: $checkedConvert(json, 'include',
+          (v) => (v as List)?.map((e) => e as String)?.toList()),
+      exclude: $checkedConvert(json, 'exclude',
+          (v) => (v as List)?.map((e) => e as String)?.toList()),
+    );
     return val;
   });
 }

--- a/build_config/mono_pkg.yaml
+++ b/build_config/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.3.0
+        - 2.6.0
   - unit_test:
     - command: pub run test
       os:

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -4,7 +4,7 @@ description: Support for parsing `build.yaml` configuration.
 homepage: https://github.com/dart-lang/build/tree/master/build_config
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   checked_yaml: ^1.0.0
@@ -16,6 +16,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.0.0
+  json_serializable: ^3.0.0
   term_glyph: ^1.0.0
   test: ^1.6.0
 

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -18,3 +18,9 @@ dev_dependencies:
   build_runner: ^1.0.0
   term_glyph: ^1.0.0
   test: ^1.6.0
+
+dependency_overrides:
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.4.1+2-dev
+version: 0.4.2
 description: Support for parsing `build.yaml` configuration.
 homepage: https://github.com/dart-lang/build/tree/master/build_config
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Give a warning instead of a stack trace when using a build config override
   file for a package that does not exist.
+- Allow the latest build_config version.
 
 ## 1.7.3
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
   build: ">=1.0.0 <1.3.0"
-  build_config: ">=0.4.1 <0.4.2"
+  build_config: ">=0.4.1 <0.4.3"
   build_daemon: ^2.1.0
   build_resolvers: "^1.0.0"
   build_runner_core: ^4.0.0

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 4.3.1-dev
+## 4.4.0-dev
 
-- Internal changes.
+- Support the `auto_apply_builders` target configuration added in
+  `build_config` version `0.4.2`.
 
 ## 4.3.0
 

--- a/build_runner_core/lib/src/package_graph/apply_builders.dart
+++ b/build_runner_core/lib/src/package_graph/apply_builders.dart
@@ -366,10 +366,13 @@ bool _shouldApply(
   if (builderConfig?.isEnabled != null) {
     return builderConfig.isEnabled;
   }
-  return builderApplication.filter(node.package) ||
-      (applyWith[builderApplication.builderKey] ?? const []).any(
-          (anchorBuilder) =>
-              _shouldApply(anchorBuilder, node, applyWith, allBuilders));
+  if (node.target.autoApplyBuilders) {
+    return builderApplication.filter(node.package) ||
+        (applyWith[builderApplication.builderKey] ?? const []).any(
+            (anchorBuilder) =>
+                _shouldApply(anchorBuilder, node, applyWith, allBuilders));
+  }
+  return false;
 }
 
 /// Inverts the dependency map from 'applies builders' to 'applied with

--- a/build_runner_core/lib/src/package_graph/apply_builders.dart
+++ b/build_runner_core/lib/src/package_graph/apply_builders.dart
@@ -366,13 +366,12 @@ bool _shouldApply(
   if (builderConfig?.isEnabled != null) {
     return builderConfig.isEnabled;
   }
-  if (node.target.autoApplyBuilders) {
-    return builderApplication.filter(node.package) ||
-        (applyWith[builderApplication.builderKey] ?? const []).any(
-            (anchorBuilder) =>
-                _shouldApply(anchorBuilder, node, applyWith, allBuilders));
-  }
-  return false;
+  final shouldAutoApply =
+      node.target.autoApplyBuilders && builderApplication.filter(node.package);
+  return shouldAutoApply ||
+      (applyWith[builderApplication.builderKey] ?? const []).any(
+          (anchorBuilder) =>
+              _shouldApply(anchorBuilder, node, applyWith, allBuilders));
 }
 
 /// Inverts the dependency map from 'applies builders' to 'applied with

--- a/build_runner_core/mono_pkg.yaml
+++ b/build_runner_core/mono_pkg.yaml
@@ -1,5 +1,5 @@
 dart:
-  - 2.3.0
+  - 2.6.0
   - dev
 
 stages:
@@ -9,7 +9,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
       dart: dev
     - dartanalyzer: --fatal-warnings .
-      dart: 2.3.0
+      dart: 2.6.0
   - unit_test:
     - test:
       os:

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 4.3.1-dev
+version: 4.4.0-dev
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 
@@ -9,7 +9,7 @@ environment:
 dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ">=1.2.0 <1.3.0"
-  build_config: ">=0.4.0 <0.4.2"
+  build_config: ">=0.4.2 <0.4.3"
   build_resolvers: ^1.0.0
   collection: ^1.14.0
   convert: ^2.0.1
@@ -35,3 +35,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_config:
+    path: ../build_config

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -4,7 +4,7 @@ description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   async: ">=1.13.3 <3.0.0"

--- a/build_runner_core/test/package_graph/apply_builders_test.dart
+++ b/build_runner_core/test/package_graph/apply_builders_test.dart
@@ -214,7 +214,8 @@ void main() {
             []);
         var builderApplications = [
           apply('b:cool_builder', [(options) => CoolBuilder(options)],
-              toDependentsOf('b')),
+              toDependentsOf('b'),
+              appliesBuilders: ['b:cool_builder_2']),
           apply('b:cool_builder_2', [(options) => CoolBuilder(options)],
               toDependentsOf('b')),
         ];
@@ -236,6 +237,26 @@ void main() {
             phases.first,
             isA<InBuildPhase>().having((p) => p.package, 'package', 'a').having(
                 (p) => p.builderLabel, 'builderLabel', 'b:cool_builder_2'));
+      });
+
+      test('enabling a builder also enables other builders it applies',
+          () async {
+        var phases = await _createPhases(builderConfigs: {
+          'b:cool_builder': TargetBuilderConfig(isEnabled: true)
+        });
+        expect(phases, hasLength(2));
+        expect(
+            phases,
+            equals([
+              isA<InBuildPhase>()
+                  .having((p) => p.package, 'package', 'a')
+                  .having(
+                      (p) => p.builderLabel, 'builderLabel', 'b:cool_builder'),
+              isA<InBuildPhase>()
+                  .having((p) => p.package, 'package', 'a')
+                  .having((p) => p.builderLabel, 'builderLabel',
+                      'b:cool_builder_2'),
+            ]));
       });
     });
   });

--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -19,6 +19,7 @@ global_options | Map<String, [GlobalBuilderOptions](#globalBuilderOptions)> | em
 
 key | value | default
 --- | --- | ---
+auto_apply_builders | bool | true
 builders | Map<[BuilderKey](#builderkey), [TargetBuilderConfig](#targetbuilderconfig)> | empty
 dependencies | List<[TargetKey](#targetkey)> | all default targets from all dependencies in your pubspec
 sources | [InputSet](#inputset) | all whitelisted directories


### PR DESCRIPTION
Adds the `auto_apply_builders` option to `target` configuration. Disables normal automatic builder application for all builders for that target when set to `false`.

Any builder which is explicitly configured is also implicitly enabled. 

Closes https://github.com/dart-lang/build/issues/2601.