### PR TITLE
Avoid exitCode for detached processes

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.8.1
+
+- Avoid waiting for `exitCode` from detached worker processes. In previous SDKs
+  this was `null` but it was changed to throw.
+
 ## 2.8.0
 
 - Add the ability to pass a list of experiments to enable to the KernelBuilder.

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -238,8 +238,7 @@ class _Dart2JsWorker {
         _jobsSinceLastRestartCount = 0;
         __worker ??= await _spawnWorker();
         _spawningWorker = null;
-        // exitCode can be null: https://github.com/dart-lang/sdk/issues/35874
-        unawaited(__worker.exitCode?.then((_) {
+        unawaited(_workerStdoutLines.drain().whenComplete(() {
           __worker = null;
           __workerStdoutLines = null;
           __workerStderrLines = null;
@@ -317,6 +316,7 @@ class _Dart2JsWorker {
 
   Future<void> terminate() async {
     var worker = __worker ?? await _spawningWorker;
+    var oldStdout = __workerStdoutLines;
     __worker = null;
     __workerStdoutLines = null;
     __workerStderrLines = null;
@@ -324,7 +324,7 @@ class _Dart2JsWorker {
       worker.kill();
       await worker.stdin.close();
     }
-    await worker?.exitCode;
+    await oldStdout?.drain();
   }
 }
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.8.0
+version: 2.8.1
 description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 


### PR DESCRIPTION
Previously the `exitCode` getter would return `null` for a detached
process. With the null safety migration there was a breaking change
where it throws instead.

Waiting for the end of the `stdout` stream is more reliable since it
also works for `detachedWithStdio` processes. Replace listeners on
`exitCode` with listeners that drain the `_workerStdoutLines`.