### PR TITLE
Support the package_config.json file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,16 @@ jobs:
       env: PKGS="build_config build_daemon build_runner_core build_test"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: 2.5.0; PKGS: build_modules, build_vm_compilers, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.8.0-dev.10.0; PKGS: build_modules, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.8.0-dev.10.0"
+      os: linux
+      env: PKGS="build_modules build_web_compilers"
+      script: ./tool/travis.sh dartanalyzer_1
+    - stage: analyze_and_format
+      name: "SDK: 2.5.0; PKG: build_vm_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.5.0"
       os: linux
-      env: PKGS="build_modules build_vm_compilers build_web_compilers"
+      env: PKGS="build_vm_compilers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.9.0-dev
+
+- Copy the `package_config.json` file to the scratch space directory, which
+  allows us to respect language versions properly during compilation.
+  - Also removes the custom `.packages` files that were previously created for
+    each action.
+
 ## 2.8.0
 
 - Add the ability to pass a list of experiments to enable to the KernelBuilder.

--- a/build_modules/lib/src/common.dart
+++ b/build_modules/lib/src/common.dart
@@ -2,34 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:io';
-
 import 'package:build/build.dart';
-import 'package:path/path.dart' as p;
 import 'package:scratch_space/scratch_space.dart';
-
-import 'kernel_builder.dart';
 
 final defaultAnalysisOptionsId =
     AssetId('build_modules', 'lib/src/analysis_options.default.yaml');
 
 String defaultAnalysisOptionsArg(ScratchSpace scratchSpace) =>
     '--options=${scratchSpace.fileFor(defaultAnalysisOptionsId).path}';
-
-// TODO: better solution for a .packages file, today we just create a new one
-// for every kernel build action.
-Future<File> createPackagesFile(Iterable<AssetId> allAssets) async {
-  var allPackages = allAssets.map((id) => id.package).toSet();
-  var packagesFileDir =
-      await Directory.systemTemp.createTemp('kernel_builder_');
-  var packagesFile = File(p.join(packagesFileDir.path, '.packages'));
-  await packagesFile.create();
-  await packagesFile.writeAsString(allPackages
-      .map((pkg) => '$pkg:$multiRootScheme:///packages/$pkg')
-      .join('\r\n'));
-  return packagesFile;
-}
 
 enum ModuleStrategy { fine, coarse }
 

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -382,7 +382,7 @@ Future<void> _addRequestArguments(
   request.arguments.addAll([
     '--dart-sdk-summary=${Uri.file(p.join(sdkDir, sdkKernelPath))}',
     '--output=${outputFile.path}',
-    '--packages-file=.dart_tool/package_config.json',
+    '--packages-file=${p.join('.dart_tool', 'package_config.json')}',
     '--multi-root-scheme=$multiRootScheme',
     '--exclude-non-sources',
     summaryOnly ? '--summary-only' : '--no-summary-only',

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -15,7 +15,6 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:scratch_space/scratch_space.dart';
 
-import 'common.dart';
 import 'errors.dart';
 import 'module_builder.dart';
 import 'module_cache.dart';
@@ -149,8 +148,6 @@ Future<void> _createKernel(
   var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
   var outputId = module.primarySource.changeExtension(outputExtension);
   var outputFile = scratchSpace.fileFor(outputId);
-
-  File packagesFile;
   var kernelDeps = <AssetId>[];
 
   // Maps the inputs paths we provide to the kernel worker to asset ids,
@@ -173,7 +170,6 @@ Future<void> _createKernel(
     };
     await scratchSpace.ensureAssets(allAssetIds, buildStep);
 
-    packagesFile = await createPackagesFile(allAssetIds);
     if (trackUnusedInputs) {
       usedInputsFile = await File(p.join(
               (await Directory.systemTemp.createTemp('kernel_builder_')).path,
@@ -191,7 +187,6 @@ Future<void> _createKernel(
         sdkKernelPath,
         librariesPath,
         outputFile,
-        packagesFile,
         summaryOnly,
         useIncrementalCompiler,
         buildStep,
@@ -225,7 +220,6 @@ Future<void> _createKernel(
           usedInputsFile, kernelDeps, kernelInputPathToId, buildStep);
     }
   } finally {
-    await packagesFile.parent.delete(recursive: true);
     await usedInputsFile?.parent?.delete(recursive: true);
   }
 }
@@ -366,7 +360,6 @@ Future<void> _addRequestArguments(
   String sdkKernelPath,
   String librariesPath,
   File outputFile,
-  File packagesFile,
   bool summaryOnly,
   bool useIncrementalCompiler,
   AssetReader reader,
@@ -389,7 +382,7 @@ Future<void> _addRequestArguments(
   request.arguments.addAll([
     '--dart-sdk-summary=${Uri.file(p.join(sdkDir, sdkKernelPath))}',
     '--output=${outputFile.path}',
-    '--packages-file=${packagesFile.uri}',
+    '--packages-file=.dart_tool/package_config.json',
     '--multi-root-scheme=$multiRootScheme',
     '--exclude-non-sources',
     summaryOnly ? '--summary-only' : '--no-summary-only',

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 
 import 'package:bazel_worker/bazel_worker.dart';
 import 'package:build/build.dart';
+import 'package:build_modules/build_modules.dart';
 import 'package:crypto/crypto.dart';
 import 'package:graphs/graphs.dart' show crawlAsync;
 import 'package:meta/meta.dart';
@@ -382,7 +383,7 @@ Future<void> _addRequestArguments(
   request.arguments.addAll([
     '--dart-sdk-summary=${Uri.file(p.join(sdkDir, sdkKernelPath))}',
     '--output=${outputFile.path}',
-    '--packages-file=${p.join('.dart_tool', 'package_config.json')}',
+    '--packages-file=$multiRootScheme:///${p.join('.dart_tool', 'package_config.json')}',
     '--multi-root-scheme=$multiRootScheme',
     '--exclude-non-sources',
     summaryOnly ? '--summary-only' : '--no-summary-only',

--- a/build_modules/lib/src/scratch_space.dart
+++ b/build_modules/lib/src/scratch_space.dart
@@ -12,7 +12,6 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:scratch_space/scratch_space.dart';
 
-import 'kernel_builder.dart' show multiRootScheme;
 import 'workers.dart';
 
 final _logger = Logger('BuildModules');
@@ -31,7 +30,7 @@ final scratchSpaceResource = Resource<ScratchSpace>(() {
   var packageConfigFile = File(
       p.join(scratchSpace.tempDir.path, '.dart_tool', 'package_config.json'));
   if (!packageConfigFile.existsSync()) {
-    var packageConfigContents = _multiRootPackageConfig(
+    var packageConfigContents = _scratchSpacePackageConfig(
         File(p.join('.dart_tool', 'package_config.json')).readAsStringSync());
     packageConfigFile
       ..createSync(recursive: true)
@@ -74,15 +73,15 @@ final scratchSpaceResource = Resource<ScratchSpace>(() {
   }
 });
 
-/// Modifies all package uris in [rootConfig] to be multi-root uris of
-/// the form [multiRootScheme]:///packages/<package-name>.
+/// Modifies all package uris in [rootConfig] to work with the sctrach_space
+/// layout. These are uris of the form `../packages/<package-name>`.
 ///
 /// Also modifies the `packageUri` for each package to be empty since the
 /// `lib/` directory is hoisted directly into the `packages/<package>`
 /// directory.
 ///
 /// Returns the new file contents.
-String _multiRootPackageConfig(String rootConfig) {
+String _scratchSpacePackageConfig(String rootConfig) {
   var parsedRootConfig = jsonDecode(rootConfig) as Map<String, dynamic>;
   var version = parsedRootConfig['configVersion'] as int;
   if (version != 2) {
@@ -93,7 +92,7 @@ String _multiRootPackageConfig(String rootConfig) {
   var packages =
       (parsedRootConfig['packages'] as List).cast<Map<String, dynamic>>();
   for (var package in packages) {
-    package['rootUri'] = '$multiRootScheme:///packages/${package['name']}';
+    package['rootUri'] = '../packages/${package['name']}';
     package['packageUri'] = '';
   }
   return jsonEncode(parsedRootConfig);

--- a/build_modules/lib/src/scratch_space.dart
+++ b/build_modules/lib/src/scratch_space.dart
@@ -91,10 +91,10 @@ String _multiRootPackageConfig(String rootConfig) {
         'version 2 is supported.');
   }
   var packages =
-      List<Map<String, dynamic>>.from(parsedRootConfig['packages'] as List);
+      (parsedRootConfig['packages'] as List).cast<Map<String, dynamic>>();
   for (var package in packages) {
     package['rootUri'] = '$multiRootScheme:///packages/${package['name']}';
     package['packageUri'] = '';
   }
-  return jsonEncode(packages);
+  return jsonEncode(parsedRootConfig);
 }

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.5.0
+        - 2.8.0-dev.10.0
   - unit_test:
     # Run the script directly - running from snapshot has issues for packages
     # that are depended on by build_runner itself.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.8.0
+version: 2.9.0-dev
 description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -4,7 +4,7 @@ description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: ">=2.5.0 <3.0.0"
+  sdk: ">=2.8.0-dev.10.0 <3.0.0"
 
 dependencies:
   analyzer: ">0.35.0 <0.40.0"

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.8.0-dev
+
+- Kill the watcher script when we see edits to the package_config.json file in
+  the same way that we already do for the .packages file.
+
 ## 1.7.4
 
 - Give a warning instead of a stack trace when using a build config override

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -72,6 +72,14 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
         .map<AssetChange>(
             (change) => AssetChange(AssetId.parse(change.path), change.type))
         .toList();
+
+    var packageConfig = AssetId(
+        _buildOptions.packageGraph.root.name, '.dart_tool/package_config.json');
+    if (changes.any((change) => change.id == packageConfig)) {
+      _buildScriptUpdateCompleter.complete();
+      return;
+    }
+
     if (!_buildOptions.skipBuildScriptCheck &&
         _builder.buildScriptUpdates.hasBeenUpdated(
             changes.map<AssetId>((change) => change.id).toSet())) {

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.7.4
+version: 1.8.0-dev
 description: Tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/generate/serve_test.dart
+++ b/build_runner/test/generate/serve_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:async/async.dart';
 import 'package:logging/logging.dart';
@@ -29,6 +30,18 @@ void main() {
 # Fake packages file
 a:file://fake/pkg/path
 ''');
+      await writer.writeAsString(
+          makeAssetId('a|.dart_tool/package_config.json'),
+          jsonEncode({
+            'configVersion': 2,
+            'packages': [
+              {
+                'name': 'a',
+                'rootUri': 'file://fake/pkg/path',
+                'packageUri': 'lib/'
+              },
+            ],
+          }));
     });
 
     tearDown(() async {

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -379,7 +379,7 @@ a:file://different/fake/pkg/path
 ''');
 
         expect(await results.hasNext, isFalse);
-        expect(logs.length, 1);
+        expect(logs, hasLength(1));
         expect(
             logs.first.message,
             contains('Terminating builds due to package graph update, '
@@ -405,7 +405,7 @@ a:file://different/fake/pkg/path
             jsonEncode(newConfig));
 
         expect(await results.hasNext, isFalse);
-        expect(logs.length, 1);
+        expect(logs, hasLength(1));
         expect(
             logs.first.message,
             contains('Terminating builds due to package graph update, '
@@ -439,7 +439,7 @@ a:file://different/fake/pkg/path
             var next = await results.next;
             expect(next.status, BuildStatus.failure);
             expect(next.failureType, FailureType.buildConfigChanged);
-            expect(logs.length, 1);
+            expect(logs, hasLength(1));
             expect(logs.first.message,
                 contains('Terminating builds due to a:build.yaml update'));
           });
@@ -452,7 +452,7 @@ a:file://different/fake/pkg/path
             var next = await results.next;
             expect(next.status, BuildStatus.failure);
             expect(next.failureType, FailureType.buildConfigChanged);
-            expect(logs.length, 1);
+            expect(logs, hasLength(1));
             expect(logs.first.message,
                 contains('Terminating builds due to b:build.yaml update'));
           });
@@ -464,7 +464,7 @@ a:file://different/fake/pkg/path
             var next = await results.next;
             expect(next.status, BuildStatus.failure);
             expect(next.failureType, FailureType.buildConfigChanged);
-            expect(logs.length, 1);
+            expect(logs, hasLength(1));
             expect(logs.first.message,
                 contains('Terminating builds due to a:b.build.yaml update'));
           });
@@ -490,7 +490,7 @@ a:file://different/fake/pkg/path
             var next = await results.next;
             expect(next.status, BuildStatus.failure);
             expect(next.failureType, FailureType.buildConfigChanged);
-            expect(logs.length, 1);
+            expect(logs, hasLength(1));
             expect(logs.first.message,
                 contains('Terminating builds due to a:build.yaml update'));
           });
@@ -503,7 +503,7 @@ a:file://different/fake/pkg/path
             var next = await results.next;
             expect(next.status, BuildStatus.failure);
             expect(next.failureType, FailureType.buildConfigChanged);
-            expect(logs.length, 1);
+            expect(logs, hasLength(1));
             expect(logs.first.message,
                 contains('Terminating builds due to b:build.yaml update'));
           });
@@ -533,7 +533,7 @@ a:file://different/fake/pkg/path
             var next = await results.next;
             expect(next.status, BuildStatus.failure);
             expect(next.failureType, FailureType.buildConfigChanged);
-            expect(logs.length, 1);
+            expect(logs, hasLength(1));
             expect(logs.first.message,
                 contains('Terminating builds due to a:build.yaml update'));
           });
@@ -556,7 +556,7 @@ a:file://different/fake/pkg/path
             var next = await results.next;
             expect(next.status, BuildStatus.failure);
             expect(next.failureType, FailureType.buildConfigChanged);
-            expect(logs.length, 1);
+            expect(logs, hasLength(1));
             expect(logs.first.message,
                 contains('Terminating builds due to a:build.cool.yaml update'));
           });

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -829,7 +829,7 @@ Future terminateWatch() async {
   _terminateWatchController = null;
 }
 
-final _packageConfig = {
+const _packageConfig = {
   'configVersion': 2,
   'packages': [
     {'name': 'a', 'rootUri': 'file://fake/pkg/path', 'packageUri': 'lib/'},

--- a/build_runner/test/server/serve_integration_test.dart
+++ b/build_runner/test/server/serve_integration_test.dart
@@ -39,7 +39,20 @@ void main() {
       ..cacheStringAsset(
           AssetId('example', '.packages'),
           '# Fake packages file\n'
-          'example:file://fake/pkg/path');
+          'example:file://fake/pkg/path')
+      ..cacheStringAsset(
+          makeAssetId('example|.dart_tool/package_config.json'),
+          jsonEncode({
+            'configVersion': 2,
+            'packages': [
+              {
+                'name': 'example',
+                'rootUri': 'file://fake/pkg/path',
+                'packageUri': 'lib/'
+              },
+            ],
+          }));
+
     terminateController = StreamController();
     final server = await watch_impl.watch(
       [applyToRoot(const UppercaseBuilder())],

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.0-dev
+
+- Add the `package_config.json` file as an internal source, and invalidate
+  builds when it changes.
+
 ## 4.4.0
 
 - Support the `auto_apply_builders` target configuration added in

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -113,12 +113,12 @@ Future<bool> _createMergedOutputDir(
         await outputDir.create(recursive: true);
       }
 
-      outputAssets
-        ..addAll(await Future.wait(builtAssets.map((id) => _writeAsset(
-            id, outputDir, root, packageGraph, reader, symlinkOnly, hoist))))
-        ..add(await _writeCustomPackagesFile(packageGraph, outputDir))
-        ..add(await _writeModifiedPackageConfig(
-            packageGraph.root.name, reader, outputDir));
+      outputAssets.addAll(await Future.wait([
+          for(var id in builtAssets)
+             _writeAsset(id, outputDir, root, packageGraph, reader, symlinkOnly, hoist),
+           _writeCustomPackagesFile(packageGraph, outputDir),
+           _writeModifiedPackageConfig(packageGraph.root.name, reader, outputDir),
+       ]);
 
       if (!hoist) {
         for (var dir in _findRootDirs(builtAssets, outputPath)) {

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -114,11 +114,12 @@ Future<bool> _createMergedOutputDir(
       }
 
       outputAssets.addAll(await Future.wait([
-          for(var id in builtAssets)
-             _writeAsset(id, outputDir, root, packageGraph, reader, symlinkOnly, hoist),
-           _writeCustomPackagesFile(packageGraph, outputDir),
-           _writeModifiedPackageConfig(packageGraph.root.name, reader, outputDir),
-       ]);
+        for (var id in builtAssets)
+          _writeAsset(
+              id, outputDir, root, packageGraph, reader, symlinkOnly, hoist),
+        _writeCustomPackagesFile(packageGraph, outputDir),
+        _writeModifiedPackageConfig(packageGraph.root.name, reader, outputDir),
+      ]));
 
       if (!hoist) {
         for (var dir in _findRootDirs(builtAssets, outputPath)) {

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';
@@ -112,15 +113,12 @@ Future<bool> _createMergedOutputDir(
         await outputDir.create(recursive: true);
       }
 
-      outputAssets.addAll(await Future.wait(builtAssets.map((id) => _writeAsset(
-          id, outputDir, root, packageGraph, reader, symlinkOnly, hoist))));
-
-      var packagesFileContent = packageGraph.allPackages.keys
-          .map((p) => '$p:packages/$p/')
-          .join('\r\n');
-      var packagesAsset = AssetId(packageGraph.root.name, '.packages');
-      await _writeAsString(outputDir, packagesAsset, packagesFileContent);
-      outputAssets.add(packagesAsset);
+      outputAssets
+        ..addAll(await Future.wait(builtAssets.map((id) => _writeAsset(
+            id, outputDir, root, packageGraph, reader, symlinkOnly, hoist))))
+        ..add(await _writeCustomPackagesFile(packageGraph, outputDir))
+        ..add(await _writeModifiedPackageConfig(
+            packageGraph.root.name, reader, outputDir));
 
       if (!hoist) {
         for (var dir in _findRootDirs(builtAssets, outputPath)) {
@@ -150,6 +148,52 @@ Future<bool> _createMergedOutputDir(
         'privileges or enable developer mode (see $devModeLink).');
     return false;
   }
+}
+
+/// Creates a custom `.packages` file in [outputDir] containing all the
+/// packages in [packageGraph].
+///
+/// All package root uris are of the form `packages/<package>/`.
+Future<AssetId> _writeCustomPackagesFile(
+    PackageGraph packageGraph, Directory outputDir) async {
+  var packagesFileContent =
+      packageGraph.allPackages.keys.map((p) => '$p:packages/$p/').join('\r\n');
+  var packagesAsset = AssetId(packageGraph.root.name, '.packages');
+  await _writeAsString(outputDir, packagesAsset, packagesFileContent);
+  return packagesAsset;
+}
+
+/// Creates a modified `.dart_tool/package_config.json` file in [outputDir]
+/// based on the current one but with modified root and package uris.
+///
+/// All `rootUri`s are of the form `packages/<package>` and the `packageUri`
+/// is always the empty string. This is because only the lib directory is
+/// exposed when using a `packages` directory layout so the root uri and
+/// package uri are equivalent.
+///
+/// All other fields are left as is.
+Future<AssetId> _writeModifiedPackageConfig(
+    String rootPackage, AssetReader reader, Directory outputDir) async {
+  var packageConfigAsset =
+      AssetId(rootPackage, '.dart_tool/package_config.json');
+  var packageConfig = jsonDecode(await reader.readAsString(packageConfigAsset))
+      as Map<String, dynamic>;
+
+  var version = packageConfig['configVersion'] as int;
+  if (version != 2) {
+    throw UnsupportedError(
+        'Unsupported package_config.json version, got $version but only '
+        'version 2 is supported.');
+  }
+  var packages =
+      (packageConfig['packages'] as List).cast<Map<String, dynamic>>();
+  for (var package in packages) {
+    package['rootUri'] = 'packages/${package['name']}';
+    package['packageUri'] = '';
+  }
+  await _writeAsString(
+      outputDir, packageConfigAsset, jsonEncode(packageConfig));
+  return packageConfigAsset;
 }
 
 Set<String> _findRootDirs(Iterable<AssetId> allAssets, String outputPath) {

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -98,8 +98,12 @@ class AssetTracker {
   }
 
   /// Returns all the internal sources, such as those under [entryPointDir].
-  Future<Set<AssetId>> _findInternalSources() =>
-      _listIdsSafe(Glob('$entryPointDir/**')).toSet();
+  Future<Set<AssetId>> _findInternalSources() async {
+    var ids = await _listIdsSafe(Glob('$entryPointDir/**')).toSet();
+    ids.add(AssetId(_targetGraph.rootPackageConfig.packageName,
+        '.dart_tool/package_config.json'));
+    return ids;
+  }
 
   /// Finds the asset changes which have happened while unwatched between builds
   /// by taking a difference between the assets in the graph and the assets on

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -213,6 +213,12 @@ class _Loader {
           'Checking for updates since last build',
           () => _updateAssetGraph(assetGraph, assetTracker, _buildPhases,
               inputSources, cacheDirSources, internalSources));
+      if (updates.containsKey(AssetId(
+          _options.packageGraph.root.name, '.dart_tool/package_config.json'))) {
+        await _cleanupOldOutputs(assetGraph);
+        await FailureReporter.cleanErrorCache();
+        throw BuildScriptChangedException();
+      }
 
       buildScriptUpdates = await BuildScriptUpdates.create(
           _environment.reader, _options.packageGraph, assetGraph,

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -100,8 +100,17 @@ class AssetTracker {
   /// Returns all the internal sources, such as those under [entryPointDir].
   Future<Set<AssetId>> _findInternalSources() async {
     var ids = await _listIdsSafe(Glob('$entryPointDir/**')).toSet();
-    ids.add(AssetId(_targetGraph.rootPackageConfig.packageName,
-        '.dart_tool/package_config.json'));
+    var packageConfigId = AssetId(_targetGraph.rootPackageConfig.packageName,
+        '.dart_tool/package_config.json');
+
+    if (await _reader.canRead(packageConfigId)) {
+      ids.add(packageConfigId);
+    } else {
+      _logger.severe(
+          'No .dart_tool/package_config.json found - compilation will not '
+          'work.');
+      throw CannotBuildException();
+    }
     return ids;
   }
 

--- a/build_runner_core/lib/src/generate/finalized_assets_view.dart
+++ b/build_runner_core/lib/src/generate/finalized_assets_view.dart
@@ -61,5 +61,6 @@ bool _shouldSkipNode(AssetNode node, String rootDir,
     return !optionalOutputTracker.isRequired(node.id);
   }
   if (node.id.path == '.packages') return true;
+  if (node.id.path == '.dart_tool/package_config.json') return true;
   return false;
 }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 4.4.0
+version: 4.5.0-dev
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/environment/create_merged_dir_test.dart
+++ b/build_runner_core/test/environment/create_merged_dir_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:_test_common/common.dart';
@@ -35,6 +36,22 @@ void main() {
       makeAssetId('a|web/b.txt'): 'b',
       makeAssetId('b|lib/c.txt'): 'c',
       makeAssetId('a|foo/d.txt'): 'd',
+      makeAssetId('a|.dart_tool/package_config.json'): '''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "a",
+      "rootUri": "file:///packages/a",
+      "packageUri": "lib/"
+    }, {
+      "name": "b",
+      "rootUri": "file:///packages/b",
+      "packageUri": "lib/"
+    }
+  ]
+}
+'''
     };
     final packageGraph = buildPackageGraph({
       rootPackage('a'): ['b'],
@@ -185,6 +202,7 @@ void main() {
         'packages/b/c.txt': 'c',
         'packages/b/c.txt.copy': 'c',
         '.packages': 'a:packages/a/\r\nb:packages/b/\r\n\$sdk:packages/\$sdk/',
+        '.dart_tool/package_config.json': _expectedPackageConfig(['a', 'b']),
       };
 
       _expectFiles(webFiles, tmpDir);
@@ -267,6 +285,7 @@ void main() {
         'packages/b/c.txt': 'c',
         'web/b.txt': 'b',
         '.packages': 'a:packages/a/\r\nb:packages/b/\r\n\$sdk:packages/\$sdk/',
+        '.dart_tool/package_config.json': _expectedPackageConfig(['a', 'b'])
       };
       _expectFiles(expectedFiles, tmpDir);
     });
@@ -407,6 +426,18 @@ void main() {
   });
 }
 
+String _expectedPackageConfig(List<String> packages) => jsonEncode({
+      'configVersion': 2,
+      'packages': [
+        for (var package in packages)
+          {
+            'name': '$package',
+            'rootUri': 'packages/$package',
+            'packageUri': '',
+          },
+      ]
+    });
+
 void _expectFiles(Map<String, dynamic> expectedFiles, Directory dir) {
   expectedFiles['.build.manifest'] =
       allOf(expectedFiles.keys.map(contains).toList());
@@ -436,6 +467,7 @@ void _expectAllFiles(Directory dir) {
     'web/b.txt': 'b',
     'web/b.txt.copy': 'b',
     '.packages': 'a:packages/a/\r\nb:packages/b/\r\n\$sdk:packages/\$sdk/',
+    '.dart_tool/package_config.json': _expectedPackageConfig(['a', 'b'])
   };
   _expectFiles(expectedFiles, dir);
 }

--- a/build_runner_core/test/generate/asset_tracker_test.dart
+++ b/build_runner_core/test/generate/asset_tracker_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';
@@ -24,7 +25,10 @@ void main() {
         d.dir('web', [
           d.file('a.txt', 'hello'),
         ]),
-        d.dir('.dart_tool'),
+        d.dir('.dart_tool', [
+          d.file('package_config.json',
+              jsonEncode({'configVersion': 2, 'packages': []})),
+        ]),
       ]).create();
       var packageGraph = PackageGraph.fromRoot(PackageNode(
           'a', p.join(d.sandbox, 'a'), DependencyType.path,

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -12,6 +12,7 @@ import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_test/build_test.dart';
 import 'package:glob/glob.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
@@ -262,7 +263,6 @@ void main() {
           'a': {
             'targets': {
               'a': {
-                'sources': ['**'],
                 'builders': {
                   'a:clone_txt': {
                     'generate_for': ['**/*.txt']
@@ -407,6 +407,7 @@ void main() {
               makeAssetId('a|Phase0.builderOptions'),
               makeAssetId('a|Phase1.builderOptions'),
               ...placeholders,
+              makeAssetId('a|.dart_tool/package_config.json'),
             ]));
         expect(cachedGraph.sources, [makeAssetId('a|web/a.txt')]);
         expect(
@@ -860,8 +861,12 @@ void main() {
     expect(writer.assets, contains(graphId));
     var cachedGraph = AssetGraph.deserialize(writer.assets[graphId]);
 
-    var expectedGraph = await AssetGraph.build([], <AssetId>{}, <AssetId>{},
-        buildPackageGraph({rootPackage('a'): []}), null);
+    var expectedGraph = await AssetGraph.build(
+        [],
+        <AssetId>{},
+        {makeAssetId('a|.dart_tool/package_config.json')},
+        buildPackageGraph({rootPackage('a'): []}),
+        InMemoryAssetReader(sourceAssets: writer.assets));
 
     // Source nodes
     var aSourceNode = makeAssetNode(

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.10.0
+
+- Pass the package_config.json file when compiling with ddc/dart2js instead of
+  the .packages file.
+
 ## 2.9.0
 
 - Add support for enabling experiments through the `experiments` option on the

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -66,6 +66,8 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
     args = dart2JsArgs.toList()
       ..addAll([
         '--packages=${p.join('.dart_tool', 'package_config.json')}',
+        '--multi-root-scheme=$multiRootScheme',
+        '--multi-root=./',
         '-o$jsOutputPath',
         dartPath,
       ]);

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -66,8 +66,6 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
     args = dart2JsArgs.toList()
       ..addAll([
         '--packages=${p.join('.dart_tool', 'package_config.json')}',
-        '--multi-root-scheme=$multiRootScheme',
-        '--multi-root=./',
         '-o$jsOutputPath',
         dartPath,
       ]);

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -168,7 +168,7 @@ Future<void> _createDevCompilerModule(
       jsOutputFile.path,
       debugMode ? '--source-map' : '--no-source-map',
       for (var dep in transitiveDeps) _summaryArg(dep),
-      '--packages=.dart_tool/package_config.json',
+      '--packages=${p.join('.dart_tool', 'package_config.json')}',
       '--module-name=${ddcModuleName(jsId)}',
       '--multi-root-scheme=$multiRootScheme',
       '--multi-root=.',

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -159,7 +159,6 @@ Future<void> _createDevCompilerModule(
     kernelInputPathToId = {};
   }
 
-  var packagesFile = await createPackagesFile(allAssetIds);
   var request = WorkRequest()
     ..arguments.addAll([
       '--dart-sdk-summary=$sdkSummary',
@@ -169,7 +168,7 @@ Future<void> _createDevCompilerModule(
       jsOutputFile.path,
       debugMode ? '--source-map' : '--no-source-map',
       for (var dep in transitiveDeps) _summaryArg(dep),
-      '--packages=${packagesFile.absolute.uri}',
+      '--packages=.dart_tool/package_config.json',
       '--module-name=${ddcModuleName(jsId)}',
       '--multi-root-scheme=$multiRootScheme',
       '--multi-root=.',
@@ -243,7 +242,6 @@ Future<void> _createDevCompilerModule(
           usedInputsFile, transitiveKernelDeps, kernelInputPathToId, buildStep);
     }
   } finally {
-    await packagesFile.parent.delete(recursive: true);
     await usedInputsFile?.parent?.delete(recursive: true);
   }
 }

--- a/build_web_compilers/mono_pkg.yaml
+++ b/build_web_compilers/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.5.0
+        - 2.8.0-dev.10.0
   - unit_test:
     - group:
       - test: --test-randomize-ordering-seed=random

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.9.0
+version: 2.10.0-dev
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
@@ -12,9 +12,8 @@ dependencies:
   bazel_worker: ^0.1.18
   build: ">=1.2.0 <2.0.0"
   build_config: ">=0.3.0 <0.5.0"
-  build_modules: ^2.8.0
+  build_modules: ^2.9.0-dev
   collection: ^1.0.0
-  crypto: ^2.0.0
   glob: ^1.1.0
   js: ^0.6.1
   logging: ^0.11.2
@@ -34,3 +33,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  build_modules:
+    path: ../build_modules

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -4,7 +4,7 @@ description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: ">=2.5.0 <3.0.0"
+  sdk: ">=2.8.0-dev.10.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.30.0 <0.40.0"

--- a/build_web_compilers/test/dart2js_bootstrap_test.dart
+++ b/build_web_compilers/test/dart2js_bootstrap_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -27,6 +29,13 @@ void main() {
           print(hello);
         }
       ''',
+      'a|.dart_tool/package_config.json': jsonEncode({
+        'configVersion': 2,
+        'packages': [
+          for (var pkg in ['a', 'b'])
+            {'name': pkg, 'rootUri': 'packages/a', 'packageUri': ''}
+        ]
+      }),
     };
 
     // Set up all the other required inputs for this test.


### PR DESCRIPTION
Updates create_merged_dir and scratch_space to copy a modified version of the package_config.json file into their directories.

This file is modified by changing the `rootUri` and the `packageUri`. The `packageUri` is always the empty string, and the `rootUri` is either `<multiRootScheme>:///packages/<package-name>` (for the scratch_space) or `packages/<package-name>` (for merged output directories).

Note that for the shared scratch_space resource used by `build_modules` and the `build_*_compilers` packages, we now create a single package_config.json file and use that instead of a unique one per action.

## Invalidation

The package_config.json file is added as an internal source so it always exists as a part of the build.

Because a package_config.json change can arbitrarily change the build by changing the language version some package should use, we throw a `BuildScriptChanged` exception and delete the entire previous build whenever that file changes.