### PR TITLE
Avoid treating AssetId paths as URIs

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.1-dev
+
+- Avoid treating `AssetId` paths as URIs.
+
 ## 4.4.0
 
 - Support the `auto_apply_builders` target configuration added in

--- a/build_runner_core/lib/src/logging/failure_reporter.dart
+++ b/build_runner_core/lib/src/logging/failure_reporter.dart
@@ -28,7 +28,7 @@ class FailureReporter {
   /// This should be called any time the build phases change since the naming
   /// scheme is dependent on the build phases.
   static Future<void> cleanErrorCache() async {
-    final errorCacheDirectory = Directory(p.fromUri(errorCachePath));
+    final errorCacheDirectory = Directory(errorCachePath);
     if (await errorCacheDirectory.exists()) {
       await errorCacheDirectory.delete(recursive: true);
     }
@@ -109,12 +109,17 @@ class ErrorReport {
 String _actionKey(GeneratedAssetNode node) =>
     '${node.builderOptionsId} on ${node.primaryInput}';
 
-String _errorPathForOutput(GeneratedAssetNode output) => p.join(
-    p.fromUri(errorCachePath),
-    output.id.package,
-    '${output.phaseNumber}',
-    p.fromUri(output.primaryInput.path));
+String _errorPathForOutput(GeneratedAssetNode output) => p.joinAll([
+      errorCachePath,
+      output.id.package,
+      '${output.phaseNumber}',
+      ...p.posix.split(output.primaryInput.path)
+    ]);
 
 String _errorPathForPrimaryInput(int phaseNumber, AssetId primaryInput) =>
-    p.join(p.fromUri(errorCachePath), primaryInput.package, '$phaseNumber',
-        p.fromUri(primaryInput.path));
+    p.joinAll([
+      errorCachePath,
+      primaryInput.package,
+      '$phaseNumber',
+      ...p.posix.split(primaryInput.path)
+    ]);

--- a/build_runner_core/lib/src/util/constants.dart
+++ b/build_runner_core/lib/src/util/constants.dart
@@ -18,7 +18,7 @@ String assetGraphPathFor(String path) =>
 /// Relative path to the directory which holds serialized versions of errors
 /// reported during previous builds.
 final errorCachePath =
-    p.url.join(cacheDir, _scriptHashFor(_scriptPath), 'error_cache');
+    p.join(cacheDir, _scriptHashFor(_scriptPath), 'error_cache');
 
 final String _scriptPath = Platform.script.scheme == 'file'
     ? p.url.joinAll(

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 4.4.0
+version: 4.4.1-dev
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 


### PR DESCRIPTION
Fixes #2635

We normalize to URI path separators, and have considered them to be
valid URIs in some places. This isn't safe since do don't do any
encoding so special characters like `#` are not escaped. We can't do
actual URI encoding for AssetIds since `$lib$` is used unencoded in too
many places. We will consider AssetIds to be, as much as possible posix
style instead of URI style. Remove some cases of treating them as URIs.

- Use the current OS style for `errorCacheDirectory` since it is only
  ever used for OS file operations and does not get stored anywhere.
- Use `p.posix.split` over `p.fromUri` when normalizing separators in
  asset ID paths just before an OS file operation.