### PR TITLE
Dont assume the existence of a .dart_tool/package_config.json file

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.2
+
+- Don't assume the existence of a .dart_tool/package_config.json file when
+  creating output directories.
+
 ## 4.5.1
 
 - Don't fail if there is no .dart_tool/package_config.json file.

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -118,7 +118,9 @@ Future<bool> _createMergedOutputDir(
           _writeAsset(
               id, outputDir, root, packageGraph, reader, symlinkOnly, hoist),
         _writeCustomPackagesFile(packageGraph, outputDir),
-        _writeModifiedPackageConfig(packageGraph.root.name, reader, outputDir),
+        if (await reader.canRead(_packageConfigId(packageGraph.root.name)))
+          _writeModifiedPackageConfig(
+              packageGraph.root.name, reader, outputDir),
       ]));
 
       if (!hoist) {
@@ -164,6 +166,9 @@ Future<AssetId> _writeCustomPackagesFile(
   return packagesAsset;
 }
 
+AssetId _packageConfigId(String rootPackage) =>
+    AssetId(rootPackage, '.dart_tool/package_config.json');
+
 /// Creates a modified `.dart_tool/package_config.json` file in [outputDir]
 /// based on the current one but with modified root and package uris.
 ///
@@ -175,8 +180,7 @@ Future<AssetId> _writeCustomPackagesFile(
 /// All other fields are left as is.
 Future<AssetId> _writeModifiedPackageConfig(
     String rootPackage, AssetReader reader, Directory outputDir) async {
-  var packageConfigAsset =
-      AssetId(rootPackage, '.dart_tool/package_config.json');
+  var packageConfigAsset = _packageConfigId(rootPackage);
   var packageConfig = jsonDecode(await reader.readAsString(packageConfigAsset))
       as Map<String, dynamic>;
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 4.5.1
+version: 4.5.2
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 


### PR DESCRIPTION
When creating a merged output dir we were assuming the file exists, this changes it to only create a copy of that file if it exists.