### PR TITLE
Remove dependencies on package_resolver

### DIFF
--- a/_test_common/pubspec.yaml
+++ b/_test_common/pubspec.yaml
@@ -10,8 +10,13 @@ dependencies:
   build_config: any
   build_runner_core: any
   build_test: any
-  test_descriptor: ^1.0.0
+  crypto: ^2.0.0
+  logging: ^0.11.0
+  package_resolver: ^1.0.0
+  path: ^1.6.0
   test: '>=0.12.42 <2.0.0'
+  test_descriptor: ^1.0.0
+  watcher: ^0.9.7
 
 dependency_overrides:
   build:

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.4-dev
+
+- Remove dependency on `package:package_resolver`.
+
 # 2.1.3
 
 - Allow the latest `stream_transform`.

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 2.1.3
+version: 2.1.4-dev
 description: A daemon for running Dart builds.
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon
 
@@ -12,7 +12,6 @@ dependencies:
   http_multi_server: ^2.0.0
   logging: ^0.11.0
   pedantic: ^1.0.0
-  package_resolver: ^1.0.6
   path: ^1.6.2
   pool: ^1.3.6
   shelf: ^0.7.4
@@ -25,6 +24,7 @@ dev_dependencies:
   build_runner: ^1.0.0
   built_value_generator: ^7.0.0
   mockito: ^4.0.0
+  package_resolver: ^1.0.6
   test: ^1.3.3
   test_descriptor: ^1.1.1
   uuid: ^2.0.0

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ## 1.3.2
 
-- Improve detection of the flutter SDK for older flutter versions.  
+- Improve detection of the flutter SDK for older flutter versions.
 
 ## 1.3.1
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.4-dev
+
+- Remove dependency on `package_resolver`.
+
 ## 1.3.3
 
 - Fix an issue where non-existing Dart assets weren't visible to the analyzer, even

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.3.3
+version: 1.3.4-dev
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 
@@ -12,7 +12,6 @@ dependencies:
   crypto: ^2.0.0
   graphs: ^0.2.0
   logging: ^0.11.2
-  package_resolver: ^1.0.0
   path: ^1.1.0
   yaml: ^2.0.0
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.12+2-dev
+
+- Remove dependency on `package:package_resolver`.
+
 ## 0.10.12+1
 
 - Allow the latest test_core package (`0.3.x`).

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 0.10.12+1
+version: 0.10.12+2-dev
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
@@ -16,7 +16,6 @@ dependencies:
   html: ">=0.9.0 <0.15.0"
   logging: ^0.11.2
   matcher: ^0.12.0
-  package_resolver: ^1.0.2
   path: ^1.4.1
   pedantic: ^1.0.0
   stream_transform: ">=0.0.20 <2.0.0"
@@ -29,3 +28,4 @@ dev_dependencies:
   build_runner: ^1.3.3
   build_vm_compilers: '>=0.1.2 <2.0.0'
   collection: ^1.14.0
+  package_resolver: ^1.0.2


### PR DESCRIPTION
Towards #2640

Remove the only non-test dependency from `package:build_resolvers`.
Replace with directly using `Isolate.resolvePackageUri` which
is what `PackageResolver.current` does for the API we are using.

Move some other dependencies to `dev_dependencies` since the package is
only used in tests. We will want to follow up with removing it
completely.