### PR TITLE
Stop randomizing build_modules tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,13 +97,13 @@ jobs:
       env: PKGS="build_daemon"
       script: ./tool/travis.sh test_12
     - stage: unit_test
-      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit`"
       dart: dev
       os: linux
       env: PKGS="build_modules"
       script: ./tool/travis.sh command_4
     - stage: unit_test
-      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit`"
       dart: dev
       os: windows
       env: PKGS="build_modules"

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -12,7 +12,7 @@ stages:
   - unit_test:
     # Run the script directly - running from snapshot has issues for packages
     # that are depended on by build_runner itself.
-    - command: dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random
+    - command: dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit
       os:
         - linux
         - windows

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -67,8 +67,8 @@ for PKG in ${PKGS}; do
       pub run build_runner test -- --test-randomize-ordering-seed=random || EXIT_CODE=$?
       ;;
     command_4)
-      echo 'dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random'
-      dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random || EXIT_CODE=$?
+      echo 'dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit'
+      dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit || EXIT_CODE=$?
       ;;
     command_5)
       echo 'test/flutter_test.sh'


### PR DESCRIPTION
We are seeing flaky tests on Travis, and when it fails I don't see the
output with the chosen seed. It isn't clear that test randomization is
the cause, remove for now in case it is.