### PR TITLE
dont exit on package_config.json updates unless running from snapshot

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.3
+
+- Don't throw a `BuildScriptInvalidated` exception on package_config.json
+  updates unless running from snapshot.
+
 ## 4.5.2
 
 - Don't assume the existence of a .dart_tool/package_config.json file when

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 4.5.2
+version: 4.5.3
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 


### PR DESCRIPTION
This should resolve some flakyness in our build_modules bots, which run the generated script directly and not from snapshot. This is now treated the same as normal build script updates.

We only need to exit when running from the snapshot (so we can regenerate it), we don't need to do that when running from source.