### PR TITLE
Depend on package language versions instead of entire package_graph.json

### DIFF
--- a/_test_common/lib/matchers.dart
+++ b/_test_common/lib/matchers.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'package:test/test.dart';
 
 import 'package:build_runner_core/src/asset_graph/exceptions.dart';
@@ -181,6 +182,11 @@ class _AssetGraphMatcher extends Matcher {
           }
         }
       }
+    }
+    if (!equals(_expected.packageLanguageVersions).matches(
+        graph.packageLanguageVersions,
+        matchState['packageLanguageVersions'] = {})) {
+      matches = false;
     }
     return matches;
   }

--- a/_test_common/lib/package_graphs.dart
+++ b/_test_common/lib/package_graphs.dart
@@ -18,9 +18,11 @@ PackageGraph buildPackageGraph(Map<PackageNode, Iterable<String>> packages) {
 
 PackageNode package(String packageName,
         {String path, DependencyType type, LanguageVersion languageVersion}) =>
-    PackageNode(packageName, path, type, languageVersion);
+    PackageNode(
+        packageName, path, type, languageVersion ?? LanguageVersion(0, 0));
 
 PackageNode rootPackage(String packageName,
         {String path, LanguageVersion languageVersion}) =>
-    PackageNode(packageName, path, DependencyType.path, languageVersion,
+    PackageNode(packageName, path, DependencyType.path,
+        languageVersion ?? LanguageVersion(0, 0),
         isRoot: true);

--- a/_test_common/lib/package_graphs.dart
+++ b/_test_common/lib/package_graphs.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build_runner_core/build_runner_core.dart';
+import 'package:package_config/package_config.dart';
 
 PackageGraph buildPackageGraph(Map<PackageNode, Iterable<String>> packages) {
   var packagesByName = Map<String, PackageNode>.fromIterable(packages.keys,
@@ -15,8 +16,11 @@ PackageGraph buildPackageGraph(Map<PackageNode, Iterable<String>> packages) {
   return PackageGraph.fromRoot(root);
 }
 
-PackageNode package(String packageName, {String path, DependencyType type}) =>
-    PackageNode(packageName, path, type);
+PackageNode package(String packageName,
+        {String path, DependencyType type, LanguageVersion languageVersion}) =>
+    PackageNode(packageName, path, type, languageVersion);
 
-PackageNode rootPackage(String packageName, {String path}) =>
-    PackageNode(packageName, path, DependencyType.path, isRoot: true);
+PackageNode rootPackage(String packageName,
+        {String path, LanguageVersion languageVersion}) =>
+    PackageNode(packageName, path, DependencyType.path, languageVersion,
+        isRoot: true);

--- a/_test_common/lib/test_phases.dart
+++ b/_test_common/lib/test_phases.dart
@@ -111,6 +111,7 @@ Future<BuildResult> testBuilders(
             'name': pkgNode.name,
             'rootUri': pkgNode.path,
             'packageUri': 'lib/',
+            'languageVersion': pkgNode.languageVersion.toString()
           },
       ],
     };

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.8.1-dev
 
+- Update to `build_runner_core` version `^5.0.0`.
 - Remove dev dependency on `package_resolver`.
 
 ## 1.8.0

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:build_runner_core/build_runner_core.dart';
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
@@ -22,7 +23,8 @@ Future<void> main(List<String> args) async {
   // Use the actual command runner to parse the args and immediately print the
   // usage information if there is no command provided or the help command was
   // explicitly invoked.
-  var commandRunner = BuildCommandRunner([]);
+  var commandRunner =
+      BuildCommandRunner([], await PackageGraph.forThisPackage());
   var localCommands = [CleanCommand(), GenerateBuildScript()];
   var localCommandNames = localCommands.map((c) => c.name).toSet();
   localCommands.forEach(commandRunner.addCommand);

--- a/build_runner/bin/graph_inspector.dart
+++ b/build_runner/bin/graph_inspector.dart
@@ -50,7 +50,7 @@ Future<void> main(List<String> args) async {
   stdout.writeln('Loading asset graph at ${assetGraphFile.path}...');
 
   assetGraph = AssetGraph.deserialize(assetGraphFile.readAsBytesSync());
-  packageGraph = PackageGraph.forThisPackage();
+  packageGraph = await PackageGraph.forThisPackage();
 
   var commandRunner = CommandRunner<bool>(
       '', 'A tool for inspecting the AssetGraph for your build')

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -55,7 +55,7 @@ Future<String> _generateBuildScript() async {
 /// which has a `build.yaml`.
 Future<Iterable<Expression>> _findBuilderApplications() async {
   final builderApplications = <Expression>[];
-  final packageGraph = PackageGraph.forThisPackage();
+  final packageGraph = await PackageGraph.forThisPackage();
   final orderedPackages = stronglyConnectedComponents<PackageNode>(
     [packageGraph.root],
     (node) => node.dependencies,

--- a/build_runner/lib/src/entrypoint/clean.dart
+++ b/build_runner/lib/src/entrypoint/clean.dart
@@ -61,7 +61,7 @@ Future<void> cleanFor(String assetGraphPath, Logger logger) async {
           'Skipping cleanup of generated files in source directories.');
       return;
     }
-    var packageGraph = PackageGraph.forThisPackage();
+    var packageGraph = await PackageGraph.forThisPackage();
     await _cleanUpSourceOutputs(assetGraph, packageGraph);
   });
 

--- a/build_runner/lib/src/entrypoint/doctor.dart
+++ b/build_runner/lib/src/entrypoint/doctor.dart
@@ -50,7 +50,7 @@ class DoctorCommand extends BuildRunnerCommand {
   }
 
   Future<Map<String, BuilderDefinition>> _loadBuilderDefinitions() async {
-    final packageGraph = PackageGraph.forThisPackage();
+    final packageGraph = await PackageGraph.forThisPackage();
     final buildConfigOverrides =
         await findBuildConfigOverrides(packageGraph, null);
     Future<BuildConfig> _packageBuildConfig(PackageNode package) async {
@@ -84,7 +84,7 @@ class DoctorCommand extends BuildRunnerCommand {
   bool _checkBuildExtensions(BuilderApplication builderApplication,
       Map<String, BuilderDefinition> config) {
     var phases = builderApplication.buildPhaseFactories
-        .map((f) => f(PackageNode(null, null, null, isRoot: true),
+        .map((f) => f(PackageNode(null, null, null, null, isRoot: true),
             BuilderOptions.empty, InputSet.anything, InputSet.anything, true))
         .whereType<InBuildPhase>()
         .toList();

--- a/build_runner/lib/src/entrypoint/run.dart
+++ b/build_runner/lib/src/entrypoint/run.dart
@@ -19,7 +19,8 @@ import 'runner.dart';
 /// Returns the exit code that should be set when the calling process exits. `0`
 /// implies success.
 Future<int> run(List<String> args, List<BuilderApplication> builders) async {
-  var runner = BuildCommandRunner(builders)..addCommand(CleanCommand());
+  var runner = BuildCommandRunner(builders, await PackageGraph.forThisPackage())
+    ..addCommand(CleanCommand());
   try {
     var result = await runner.run(args);
     return result ?? 0;

--- a/build_runner/lib/src/entrypoint/runner.dart
+++ b/build_runner/lib/src/entrypoint/runner.dart
@@ -24,9 +24,10 @@ class BuildCommandRunner extends CommandRunner<int> {
 
   final List<BuilderApplication> builderApplications;
 
-  final packageGraph = PackageGraph.forThisPackage();
+  final PackageGraph packageGraph;
 
-  BuildCommandRunner(List<BuilderApplication> builderApplications)
+  BuildCommandRunner(
+      List<BuilderApplication> builderApplications, this.packageGraph)
       : builderApplications = List.unmodifiable(builderApplications),
         super('build_runner', 'Unified interface for running Dart builds.') {
     addCommand(BuildCommand());

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -70,7 +70,7 @@ Future<BuildResult> build(List<BuilderApplication> builders,
     String logPerformanceDir,
     Set<BuildFilter> buildFilters}) async {
   builderConfigOverrides ??= const {};
-  packageGraph ??= PackageGraph.forThisPackage();
+  packageGraph ??= await PackageGraph.forThisPackage();
   var environment = OverrideableEnvironment(
       IOEnvironment(
         packageGraph,

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -54,7 +54,7 @@ Future<ServeHandler> watch(
   Set<BuildFilter> buildFilters,
 }) async {
   builderConfigOverrides ??= const {};
-  packageGraph ??= PackageGraph.forThisPackage();
+  packageGraph ??= await PackageGraph.forThisPackage();
   buildDirs ??= <BuildDirectory>{};
   buildFilters ??= <BuildFilter>{};
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   build_config: ">=0.4.1 <0.4.3"
   build_daemon: ^2.1.0
   build_resolvers: "^1.0.0"
-  build_runner_core: ^4.5.0
+  build_runner_core: ^5.0.0
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
   crypto: ">=0.9.2 <3.0.0"
@@ -51,3 +51,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_runner_core:
+    path: ../build_runner_core

--- a/build_runner/test/watcher/asset_change_test.dart
+++ b/build_runner/test/watcher/asset_change_test.dart
@@ -33,7 +33,7 @@ void main() {
       final pkgBar = p.join('/', 'foo', 'bar');
       final barFile =
           p.join(p.relative(pkgBar, from: p.current), 'lib', 'bar.dart');
-      final nodeBar = PackageNode('bar', pkgBar, null);
+      final nodeBar = PackageNode('bar', pkgBar, null, null);
 
       final event = WatchEvent(ChangeType.ADD, barFile);
       final change = AssetChange.fromEvent(nodeBar, event);
@@ -46,7 +46,7 @@ void main() {
       final pkgBar = p.join('/', 'foo', 'bar');
       final barFile = p.join('/', 'foo', 'bar', 'lib', 'bar.dart');
 
-      final nodeBar = PackageNode('bar', pkgBar, null);
+      final nodeBar = PackageNode('bar', pkgBar, null, null);
       final event = WatchEvent(ChangeType.ADD, barFile);
       final change = AssetChange.fromEvent(nodeBar, event);
 

--- a/build_runner/test/watcher/node_watcher_test.dart
+++ b/build_runner/test/watcher/node_watcher_test.dart
@@ -41,7 +41,7 @@ void main() {
     }
 
     test('should emit a changed asset', () async {
-      var node = PackageNode('a', p.join(tmpDir.path, 'a'), null);
+      var node = PackageNode('a', p.join(tmpDir.path, 'a'), null, null);
       var nodeWatcher = PackageNodeWatcher(node);
 
       initFiles(node);
@@ -70,7 +70,7 @@ void main() {
 
     test('should also respect relative watch URLs', () async {
       var node = PackageNode(
-          'a', p.relative(p.join(tmpDir.path, 'a'), from: p.current), null);
+          'a', p.relative(p.join(tmpDir.path, 'a'), from: p.current), null, null);
       var nodeWatcher = PackageNodeWatcher(node);
 
       initFiles(node);

--- a/build_runner/test/watcher/node_watcher_test.dart
+++ b/build_runner/test/watcher/node_watcher_test.dart
@@ -69,8 +69,8 @@ void main() {
     });
 
     test('should also respect relative watch URLs', () async {
-      var node = PackageNode(
-          'a', p.relative(p.join(tmpDir.path, 'a'), from: p.current), null, null);
+      var node = PackageNode('a',
+          p.relative(p.join(tmpDir.path, 'a'), from: p.current), null, null);
       var nodeWatcher = PackageNodeWatcher(node);
 
       initFiles(node);

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Other changes
 
+- Builds no longer depend on the contents of the package_config.json file,
+  instead they depend only on the language versions inside of it.
+  - This should help CI builds that want to share a cache across runs.
 - Remove unused dev dependency on `package_resolver`.
 
 ## 4.5.3

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 4.5.4-dev
+## 5.0.0-dev
+
+### Breaking changes
+
+- `PackageGraph.forPath` and `PackageGraph.forThisPackage` are now static
+  methods which return a `Future<PackageGraph>` instead of constructors.
+- `PackageNode` now requires a `LanguageVersion`.
+
+### Other changes
 
 - Remove unused dev dependency on `package_resolver`.
 

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -12,6 +12,7 @@ import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:meta/meta.dart';
+import 'package:package_config/package_config.dart';
 import 'package:watcher/watcher.dart';
 
 import '../generate/phase.dart';
@@ -35,7 +36,10 @@ class AssetGraph {
   /// The [Platform.version] this graph was created with.
   final String dartVersion;
 
-  AssetGraph._(this.buildPhasesDigest, this.dartVersion);
+  final Map<String, LanguageVersion> packageLanguageVersions;
+
+  AssetGraph._(
+      this.buildPhasesDigest, this.dartVersion, this.packageLanguageVersions);
 
   /// Deserializes this graph.
   factory AssetGraph.deserialize(List<int> serializedGraph) =>
@@ -47,8 +51,12 @@ class AssetGraph {
       Set<AssetId> internalSources,
       PackageGraph packageGraph,
       AssetReader digestReader) async {
-    var graph =
-        AssetGraph._(computeBuildPhasesDigest(buildPhases), Platform.version);
+    var packageLanguageVersions = {
+      for (var pkg in packageGraph.allPackages.values)
+        pkg.name: pkg.languageVersion
+    };
+    var graph = AssetGraph._(computeBuildPhasesDigest(buildPhases),
+        Platform.version, packageLanguageVersions);
     var placeholders = graph._addPlaceHolderNodes(packageGraph);
     var sourceNodes = graph._addSources(sources);
     graph

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -8,7 +8,7 @@ part of 'graph.dart';
 ///
 /// This should be incremented any time the serialize/deserialize formats
 /// change.
-const _version = 22;
+const _version = 23;
 
 /// Deserializes an [AssetGraph] from a [Map].
 class _AssetGraphDeserializer {
@@ -35,9 +35,17 @@ class _AssetGraphDeserializer {
 
   /// Perform the deserialization, should only be called once.
   AssetGraph deserialize() {
+    var packageLanguageVersions = {
+      for (var entry in (_serializedGraph['packageLanguageVersions']
+              as Map<String, dynamic>)
+          .entries)
+        entry.key: LanguageVersion.parse(entry.value as String)
+    };
     var graph = AssetGraph._(
-        _deserializeDigest(_serializedGraph['buildActionsDigest'] as String),
-        _serializedGraph['dart_version'] as String);
+      _deserializeDigest(_serializedGraph['buildActionsDigest'] as String),
+      _serializedGraph['dart_version'] as String,
+      packageLanguageVersions,
+    );
 
     var packageNames = _serializedGraph['packages'] as List;
 
@@ -218,6 +226,8 @@ class _AssetGraphSerializer {
       'buildActionsDigest': _serializeDigest(_graph.buildPhasesDigest),
       'packages': packages,
       'assetPaths': assetPaths,
+      'packageLanguageVersions': _graph.packageLanguageVersions
+          .map((pkg, version) => MapEntry(pkg, version.toString())),
     };
     return utf8.encode(json.encode(result));
   }

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -39,7 +39,9 @@ class _AssetGraphDeserializer {
       for (var entry in (_serializedGraph['packageLanguageVersions']
               as Map<String, dynamic>)
           .entries)
-        entry.key: LanguageVersion.parse(entry.value as String)
+        entry.key: entry.value != null
+            ? LanguageVersion.parse(entry.value as String)
+            : null
     };
     var graph = AssetGraph._(
       _deserializeDigest(_serializedGraph['buildActionsDigest'] as String),
@@ -227,7 +229,7 @@ class _AssetGraphSerializer {
       'packages': packages,
       'assetPaths': assetPaths,
       'packageLanguageVersions': _graph.packageLanguageVersions
-          .map((pkg, version) => MapEntry(pkg, version.toString())),
+          .map((pkg, version) => MapEntry(pkg, version?.toString())),
     };
     return utf8.encode(json.encode(result));
   }

--- a/build_runner_core/lib/src/changes/build_script_updates.dart
+++ b/build_runner_core/lib/src/changes/build_script_updates.dart
@@ -53,11 +53,6 @@ class _MirrorBuildScriptUpdates implements BuildScriptUpdates {
           .map((id) => _idForUri(id, rootPackage))
           .where((id) => id != null)
           .toSet();
-      var packageConfigId =
-          AssetId(packageGraph.root.name, '.dart_tool/package_config.json');
-      if (await reader.canRead(packageConfigId)) {
-        allSources.add(packageConfigId);
-      }
       var missing = allSources.firstWhere((id) => !graph.contains(id),
           orElse: () => null);
       if (missing != null) {

--- a/build_runner_core/lib/src/package_graph/package_graph.dart
+++ b/build_runner_core/lib/src/package_graph/package_graph.dart
@@ -101,7 +101,8 @@ class PackageGraph {
 
   /// Creates a [PackageGraph] for the package in which you are currently
   /// running.
-  static Future<PackageGraph> forThisPackage() => PackageGraph.forPath('./');
+  static Future<PackageGraph> forThisPackage() =>
+      PackageGraph.forPath(p.current);
 
   /// Shorthand to get a package by name.
   PackageNode operator [](String packageName) => allPackages[packageName];

--- a/build_runner_core/lib/src/package_graph/package_graph.dart
+++ b/build_runner_core/lib/src/package_graph/package_graph.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
@@ -11,8 +12,13 @@ import '../util/constants.dart';
 
 /// The SDK package, we filter this to the core libs and dev compiler
 /// resources.
-final PackageNode _sdkPackageNode =
-    PackageNode(r'$sdk', sdkPath, DependencyType.hosted);
+final _sdkPackageNode = PackageNode(
+    r'$sdk',
+    sdkPath,
+    DependencyType.hosted,
+    // A fake language version for the SDK, we don't allow you to read its
+    // sources anyways, and invalidate the whole build if this changes.
+    LanguageVersion(0, 0));
 
 /// A graph of the package dependencies for an application.
 class PackageGraph {
@@ -53,7 +59,7 @@ class PackageGraph {
 
   /// Creates a [PackageGraph] for the package whose top level directory lives
   /// at [packagePath] (no trailing slash).
-  factory PackageGraph.forPath(String packagePath) {
+  static Future<PackageGraph> forPath(String packagePath) async {
     /// Read in the pubspec file and parse it as yaml.
     final pubspec = File(p.join(packagePath, 'pubspec.yaml'));
     if (!pubspec.existsSync()) {
@@ -64,27 +70,23 @@ class PackageGraph {
     final rootPubspec = _pubspecForPath(packagePath);
     final rootPackageName = rootPubspec['name'] as String;
 
-    final packageLocations = _parsePackageLocations(packagePath)
-      ..remove(rootPackageName);
+    final packageConfig =
+        await findPackageConfig(Directory(packagePath), recurse: false);
 
     final dependencyTypes = _parseDependencyTypes(packagePath);
 
     final nodes = <String, PackageNode>{};
-    final rootNode = PackageNode(
-        rootPackageName, packagePath, DependencyType.path,
-        isRoot: true);
-    nodes[rootPackageName] = rootNode;
-    for (final packageName in packageLocations.keys) {
-      if (packageName == rootPackageName) continue;
-      nodes[packageName] = PackageNode(packageName,
-          packageLocations[packageName], dependencyTypes[packageName],
-          isRoot: false);
+    for (final package in packageConfig.packages) {
+      nodes[package.name] = PackageNode(package.name, package.root.toFilePath(),
+          dependencyTypes[package.name], package.languageVersion,
+          isRoot: package.name == rootPackageName);
     }
-
+    final rootNode = nodes[rootPackageName];
     rootNode.dependencies
         .addAll(_depsFromYaml(rootPubspec, isRoot: true).map((n) => nodes[n]));
 
-    final packageDependencies = _parsePackageDependencies(packageLocations);
+    final packageDependencies = _parsePackageDependencies(
+        packageConfig.packages.where((p) => p.name != rootPackageName));
     for (final packageName in packageDependencies.keys) {
       nodes[packageName]
           .dependencies
@@ -95,7 +97,7 @@ class PackageGraph {
 
   /// Creates a [PackageGraph] for the package in which you are currently
   /// running.
-  factory PackageGraph.forThisPackage() => PackageGraph.forPath('./');
+  static Future<PackageGraph> forThisPackage() => PackageGraph.forPath('./');
 
   /// Shorthand to get a package by name.
   PackageNode operator [](String packageName) => allPackages[packageName];
@@ -131,7 +133,10 @@ class PackageNode {
   /// Whether this node is the [PackageGraph.root].
   final bool isRoot;
 
-  PackageNode(this.name, String path, this.dependencyType, {bool isRoot})
+  final LanguageVersion languageVersion;
+
+  PackageNode(this.name, String path, this.dependencyType, this.languageVersion,
+      {bool isRoot})
       : path = _toAbsolute(path),
         isRoot = isRoot ?? false;
 
@@ -146,34 +151,6 @@ class PackageNode {
   /// `null`.
   static String _toAbsolute(String path) =>
       (path == null) ? null : p.canonicalize(path);
-}
-
-/// Parse the `.packages` file and return a Map from package name to the file
-/// location for that package.
-Map<String, String> _parsePackageLocations(String rootPackagePath) {
-  var packagesFile = File(p.join(rootPackagePath, '.packages'));
-  if (!packagesFile.existsSync()) {
-    throw StateError('Unable to generate package graph, no `.packages` found. '
-        'This program must be ran from the root directory of your package.');
-  }
-  var packageLocations = <String, String>{};
-  for (final line in packagesFile.readAsLinesSync().skip(1)) {
-    var firstColon = line.indexOf(':');
-    var name = line.substring(0, firstColon);
-    assert(line.endsWith('lib/'));
-    // Start after package_name:, and strip out trailing 'lib/'.
-    var uriString = line.substring(firstColon + 1, line.length - 4);
-    // Strip the trailing slash, if present.
-    if (uriString.endsWith('/')) {
-      uriString = uriString.substring(0, uriString.length - 1);
-    }
-    var uri = Uri.tryParse(uriString) ?? Uri.file(uriString);
-    if (!uri.isAbsolute) {
-      uri = p.toUri(p.join(rootPackagePath, uri.path));
-    }
-    packageLocations[name] = uri.toFilePath(windows: Platform.isWindows);
-  }
-  return packageLocations;
 }
 
 /// The type of dependency being used. This dictates how the package should be
@@ -212,14 +189,13 @@ DependencyType _dependencyTypeFromSource(String source) {
   throw ArgumentError('Unable to determine dependency type:\n$source');
 }
 
-/// Read the pubspec for each package in [packageLocations] and finds it's
+/// Read the pubspec for each package in [packages] and finds it's
 /// dependencies.
-Map<String, Set<String>> _parsePackageDependencies(
-    Map<String, String> packageLocations) {
+Map<String, Set<String>> _parsePackageDependencies(Iterable<Package> packages) {
   final dependencies = <String, Set<String>>{};
-  for (final packageName in packageLocations.keys) {
-    final pubspec = _pubspecForPath(packageLocations[packageName]);
-    dependencies[packageName] = _depsFromYaml(pubspec);
+  for (final package in packages) {
+    final pubspec = _pubspecForPath(package.root.toFilePath());
+    dependencies[package.name] = _depsFromYaml(pubspec);
   }
   return dependencies;
 }

--- a/build_runner_core/lib/src/package_graph/package_graph.dart
+++ b/build_runner_core/lib/src/package_graph/package_graph.dart
@@ -77,9 +77,13 @@ class PackageGraph {
 
     final nodes = <String, PackageNode>{};
     for (final package in packageConfig.packages) {
-      nodes[package.name] = PackageNode(package.name, package.root.toFilePath(),
-          dependencyTypes[package.name], package.languageVersion,
-          isRoot: package.name == rootPackageName);
+      var isRoot = package.name == rootPackageName;
+      nodes[package.name] = PackageNode(
+          package.name,
+          package.root.toFilePath(),
+          isRoot ? DependencyType.path : dependencyTypes[package.name],
+          package.languageVersion,
+          isRoot: isRoot);
     }
     final rootNode = nodes[rootPackageName];
     rootNode.dependencies

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 4.5.4-dev
+version: 5.0.0-dev
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 
@@ -20,6 +20,7 @@ dependencies:
   logging: ^0.11.2
   meta: ^1.1.0
   path: ^1.1.0
+  package_config: ^1.9.0
   pedantic: ^1.0.0
   pool: ^1.0.0
   timing: ^0.1.1

--- a/build_runner_core/test/asset/file_based_test.dart
+++ b/build_runner_core/test/asset/file_based_test.dart
@@ -12,11 +12,11 @@ import 'package:build_runner_core/build_runner_core.dart';
 
 import 'package:_test_common/common.dart';
 
-final PackageGraph packageGraph =
-    PackageGraph.forPath('test/fixtures/basic_pkg');
-final String newLine = Platform.isWindows ? '\r\n' : '\n';
+final newLine = Platform.isWindows ? '\r\n' : '\n';
 
-void main() {
+void main() async {
+  final packageGraph = await PackageGraph.forPath('test/fixtures/basic_pkg');
+
   group('FileBasedAssetReader', () {
     final reader = FileBasedAssetReader(packageGraph);
 

--- a/build_runner_core/test/environment/simple_prompt.dart
+++ b/build_runner_core/test/environment/simple_prompt.dart
@@ -8,7 +8,7 @@ import 'package:logging/logging.dart';
 import 'package:build_runner_core/src/environment/io_environment.dart';
 
 void main() async {
-  var env = IOEnvironment(PackageGraph.forThisPackage(), assumeTty: true);
+  var env = IOEnvironment(await PackageGraph.forThisPackage(), assumeTty: true);
   var result = await env.prompt('Select an option!', ['a', 'b', 'c']);
   Logger.root.onRecord.listen(env.onLog);
   Logger('Simple Logger').info(result);

--- a/build_runner_core/test/fixtures/flutter_pkg/.packages
+++ b/build_runner_core/test/fixtures/flutter_pkg/.packages
@@ -6,3 +6,4 @@ flutter_gallery_assets:sdk/flutter/flutter_gallery_assets/lib/
 flutter_test:sdk/flutter/flutter_test/lib/
 intl:pkg/intl/lib/
 string_scanner:pkg/string_scanner/lib/
+flutter_gallery:./lib/

--- a/build_runner_core/test/generate/asset_tracker_test.dart
+++ b/build_runner_core/test/generate/asset_tracker_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';
+import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test/test.dart';
@@ -30,8 +31,8 @@ void main() {
               jsonEncode({'configVersion': 2, 'packages': []})),
         ]),
       ]).create();
-      var packageGraph = PackageGraph.fromRoot(PackageNode(
-          'a', p.join(d.sandbox, 'a'), DependencyType.path,
+      var packageGraph = PackageGraph.fromRoot(PackageNode('a',
+          p.join(d.sandbox, 'a'), DependencyType.path, LanguageVersion(2, 6),
           isRoot: true));
       var reader = FileBasedAssetReader(packageGraph);
       var aId = AssetId('a', 'web/a.txt');

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
 import 'package:logging/logging.dart';
+import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
@@ -29,17 +30,19 @@ import 'package:_test_common/package_graphs.dart';
 import 'package:_test_common/runner_asset_writer_spy.dart';
 
 void main() {
+  final languageVersion = LanguageVersion(2, 0);
   final aPackageGraph = buildPackageGraph({
-    rootPackage('a'): ['b'],
-    package('b'): []
+    rootPackage('a', languageVersion: languageVersion): ['b'],
+    package('b', languageVersion: languageVersion): []
   });
 
   group('BuildDefinition.prepareWorkspace', () {
     BuildOptions options;
     BuildEnvironment environment;
     String pkgARoot;
+    String pkgBRoot;
 
-    Future<void> createFile(String path, dynamic contents) async {
+    Future<File> createFile(String path, dynamic contents) async {
       var file = File(p.join(pkgARoot, path));
       expect(await file.exists(), isFalse);
       await file.create(recursive: true);
@@ -49,6 +52,7 @@ void main() {
         await file.writeAsBytes(contents as List<int>);
       }
       addTearDown(() async => await file.exists() ? await file.delete() : null);
+      return file;
     }
 
     Future<void> deleteFile(String path) async {
@@ -70,6 +74,8 @@ void main() {
     }
 
     setUp(() async {
+      pkgARoot = p.join(d.sandbox, 'pkg_a');
+      pkgBRoot = p.join(d.sandbox, 'pkg_b');
       await d.dir(
         'pkg_a',
         [
@@ -85,8 +91,18 @@ void main() {
                 jsonEncode({
                   'configVersion': 2,
                   'packages': [
-                    {'name': 'a', 'rootUri': './', 'packageUri': 'lib/'},
-                    {'name': 'b', 'rootUri': '../pkg_b/', 'packageUri': 'lib/'},
+                    {
+                      'name': 'a',
+                      'rootUri': pkgARoot,
+                      'packageUri': 'lib/',
+                      'languageVersion': languageVersion.toString()
+                    },
+                    {
+                      'name': 'b',
+                      'rootUri': pkgBRoot,
+                      'packageUri': 'lib/',
+                      'languageVersion': languageVersion.toString()
+                    },
                   ],
                 }))
           ]),
@@ -115,7 +131,6 @@ targets:
         d.dir('test', [d.file('some_test.dart')]),
         d.dir('lib', [d.file('some_lib.dart')]),
       ]).create();
-      pkgARoot = p.join(d.sandbox, 'pkg_a');
       var packageGraph = await PackageGraph.forPath(pkgARoot);
       environment =
           OverrideableEnvironment(IOEnvironment(packageGraph), onLog: (_) {});
@@ -126,7 +141,7 @@ targets:
     });
 
     tearDown(() async {
-      await options.logListener.cancel();
+      await options?.logListener?.cancel();
     });
 
     group('updates the asset graph', () {
@@ -585,6 +600,10 @@ targets:
                 .replaceFirst('name: a', 'name: c'));
         await modifyFile('.packages',
             (await readFile('.packages')).replaceFirst('a:', 'c:'));
+        await modifyFile(
+            '.dart_tool/package_config.json',
+            (await readFile('.dart_tool/package_config.json'))
+                .replaceFirst('"name":"a"', '"name":"c"'));
 
         var packageGraph = await PackageGraph.forPath(pkgARoot);
         environment =
@@ -604,7 +623,7 @@ targets:
         expect(writerSpy.assetsDeleted, contains(AssetId('c', aTxtCopy.path)));
       });
 
-      test('invalidates the graph if the package_config.json file changes',
+      test('invalidates the graph if the language version of a package changes',
           () async {
         var assetGraph = await AssetGraph.build(
             [],
@@ -613,7 +632,7 @@ targets:
             aPackageGraph,
             environment.reader);
 
-        await createFile(assetGraphPath, assetGraph.serialize());
+        var graph = await createFile(assetGraphPath, assetGraph.serialize());
 
         await modifyFile(
             '.dart_tool/package_config.json',
@@ -622,23 +641,31 @@ targets:
               'packages': [
                 {
                   'name': 'a',
-                  'rootUri': './',
+                  'rootUri': pkgARoot,
                   'packageUri': 'lib/',
-                  'languageVersion': '2.0',
+                  'languageVersion': languageVersion.toString(),
                 },
                 {
                   'name': 'b',
-                  'rootUri': '../pkg_b/',
+                  'rootUri': pkgBRoot,
                   'packageUri': 'lib/',
+                  'languageVersion': LanguageVersion(
+                          languageVersion.major, languageVersion.minor + 1)
+                      .toString(),
                 },
               ],
             }));
 
+        var newOptions = await BuildOptions.create(
+            LogSubscription(environment, logLevel: Level.OFF),
+            packageGraph: await PackageGraph.forPath(pkgARoot),
+            skipBuildScriptCheck: true);
+
         await expectLater(
-            () => BuildDefinition.prepareWorkspace(environment, options, []),
+            () => BuildDefinition.prepareWorkspace(environment, newOptions, []),
             throwsA(const TypeMatcher<BuildScriptChangedException>()));
 
-        expect(File(assetGraphPath).existsSync(), isFalse);
+        expect(graph.existsSync(), isFalse);
       });
     });
 

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -93,13 +93,13 @@ void main() {
                   'packages': [
                     {
                       'name': 'a',
-                      'rootUri': pkgARoot,
+                      'rootUri': p.toUri(pkgARoot).toString(),
                       'packageUri': 'lib/',
                       'languageVersion': languageVersion.toString()
                     },
                     {
                       'name': 'b',
-                      'rootUri': pkgBRoot,
+                      'rootUri': p.toUri(pkgBRoot).toString(),
                       'packageUri': 'lib/',
                       'languageVersion': languageVersion.toString()
                     },
@@ -641,13 +641,13 @@ targets:
               'packages': [
                 {
                   'name': 'a',
-                  'rootUri': pkgARoot,
+                  'rootUri': p.toUri(pkgARoot).toString(),
                   'packageUri': 'lib/',
                   'languageVersion': languageVersion.toString(),
                 },
                 {
                   'name': 'b',
-                  'rootUri': pkgBRoot,
+                  'rootUri': p.toUri(pkgBRoot).toString(),
                   'packageUri': 'lib/',
                   'languageVersion': LanguageVersion(
                           languageVersion.major, languageVersion.minor + 1)

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -116,7 +116,7 @@ targets:
         d.dir('lib', [d.file('some_lib.dart')]),
       ]).create();
       pkgARoot = p.join(d.sandbox, 'pkg_a');
-      var packageGraph = PackageGraph.forPath(pkgARoot);
+      var packageGraph = await PackageGraph.forPath(pkgARoot);
       environment =
           OverrideableEnvironment(IOEnvironment(packageGraph), onLog: (_) {});
       options = await BuildOptions.create(
@@ -586,7 +586,7 @@ targets:
         await modifyFile('.packages',
             (await readFile('.packages')).replaceFirst('a:', 'c:'));
 
-        var packageGraph = PackageGraph.forPath(pkgARoot);
+        var packageGraph = await PackageGraph.forPath(pkgARoot);
         environment =
             OverrideableEnvironment(IOEnvironment(packageGraph), onLog: (_) {});
         var writerSpy = RunnerAssetWriterSpy(environment.writer);

--- a/build_runner_core/test/package_graph/package_graph_test.dart
+++ b/build_runner_core/test/package_graph/package_graph_test.dart
@@ -13,7 +13,7 @@ void main() {
   group('PackageGraph', () {
     group('forThisPackage ', () {
       setUp(() async {
-        graph = PackageGraph.forThisPackage();
+        graph = await PackageGraph.forThisPackage();
       });
 
       test('root', () {
@@ -25,7 +25,7 @@ void main() {
       var basicPkgPath = 'test/fixtures/basic_pkg';
 
       setUp(() async {
-        graph = PackageGraph.forPath(basicPkgPath);
+        graph = await PackageGraph.forPath(basicPkgPath);
       });
 
       test('allPackages', () {
@@ -56,7 +56,7 @@ void main() {
       var withDevDepsPkgPath = 'test/fixtures/with_dev_deps';
 
       setUp(() async {
-        graph = PackageGraph.forPath(withDevDepsPkgPath);
+        graph = await PackageGraph.forPath(withDevDepsPkgPath);
       });
 
       test('allPackages contains dev deps of root pkg, but not others', () {
@@ -90,7 +90,7 @@ void main() {
       var withFlutterDeps = 'test/fixtures/flutter_pkg';
 
       setUp(() async {
-        graph = PackageGraph.forPath(withFlutterDeps);
+        graph = await PackageGraph.forPath(withFlutterDeps);
       });
 
       test('allPackages resolved correctly with all packages', () {
@@ -111,10 +111,10 @@ void main() {
     });
 
     test('custom creation via fromRoot', () {
-      var a = PackageNode('a', null, DependencyType.path, isRoot: true);
-      var b = PackageNode('b', null, null);
-      var c = PackageNode('c', null, null);
-      var d = PackageNode('d', null, null);
+      var a = PackageNode('a', null, DependencyType.path, null, isRoot: true);
+      var b = PackageNode('b', null, null, null);
+      var c = PackageNode('c', null, null, null);
+      var d = PackageNode('d', null, null, null);
       a.dependencies.addAll([b, d]);
       b.dependencies.add(c);
       var graph = PackageGraph.fromRoot(a);

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -20,3 +20,9 @@ dev_dependencies:
   test_descriptor: ^1.1.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/2645

This adds a map of package name to language version to the asset graph, and checks that during deserialization. If it changes we throw away the graph and restart.

Note that this is a breaking change in build_runner_core, as some factory methods are now static methods that return a Future, and `PackageNode` now also has a language version.

This also reverts some of the previous logic and moves the check from build_script_updates.dart to build_definition.dart.