### PR TITLE
add additional context to build config parsing errors

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,5 +1,4 @@
-## 5.0.0-dev
-
+## 5.0.0
 ### Breaking changes
 
 - `PackageGraph.forPath` and `PackageGraph.forThisPackage` are now static
@@ -11,6 +10,8 @@
 - Builds no longer depend on the contents of the package_config.json file,
   instead they depend only on the language versions inside of it.
   - This should help CI builds that want to share a cache across runs.
+- Improve the error message for build.yaml parsing errors, suggesting a clean
+  build if you believe the parse error is incorrect.
 - Remove unused dev dependency on `package_resolver`.
 
 ## 4.5.3

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -168,8 +168,12 @@ class BuildOptions {
           overrideBuildConfig: overrideBuildConfig,
           defaultRootPackageWhitelist: defaultRootPackageWhitelist);
     } on BuildConfigParseException catch (e, s) {
-      _logger.severe(
-          'Failed to parse `build.yaml` for ${e.packageName}.', e.exception, s);
+      _logger.severe('''
+Failed to parse `build.yaml` for ${e.packageName}.
+
+If you believe you have gotten this message in error, especially if using a new
+feature, you may need to run `pub run build_runner clean` and then rebuilding.
+''', e.exception, s);
       throw CannotBuildException();
     }
 

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -172,7 +172,7 @@ class BuildOptions {
 Failed to parse `build.yaml` for ${e.packageName}.
 
 If you believe you have gotten this message in error, especially if using a new
-feature, you may need to run `pub run build_runner clean` and then rebuilding.
+feature, you may need to run `pub run build_runner clean` and then rebuild.
 ''', e.exception, s);
       throw CannotBuildException();
     }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 5.0.0-dev
+version: 5.0.0
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 


### PR DESCRIPTION
We now suggest a clean build if you think you think the parse error is incorrect.

Closes https://github.com/dart-lang/build/issues/2652 (not in an ideal way but all we plan on doing)

Also prep build_runner_core for publishing.