### PR TITLE
check for placeholders when building a target graph from a package graph

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,10 @@
+## 5.1.0-dev
+
+- Add a warning if a package is missing some required placholder files,
+  including `$package$` and `lib/$lib$`. 
+
 ## 5.0.0
+
 ### Breaking changes
 
 - `PackageGraph.forPath` and `PackageGraph.forThisPackage` are now static

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -166,7 +166,9 @@ class BuildOptions {
     try {
       targetGraph = await TargetGraph.forPackageGraph(packageGraph,
           overrideBuildConfig: overrideBuildConfig,
-          defaultRootPackageWhitelist: defaultRootPackageWhitelist);
+          defaultRootPackageWhitelist: defaultRootPackageWhitelist,
+          requiredSourcePaths: [r'lib/$lib$'],
+          requiredRootSourcePaths: [r'$package$', r'lib/$lib$']);
     } on BuildConfigParseException catch (e, s) {
       _logger.severe('''
 Failed to parse `build.yaml` for ${e.packageName}.

--- a/build_runner_core/lib/src/package_graph/target_graph.dart
+++ b/build_runner_core/lib/src/package_graph/target_graph.dart
@@ -131,7 +131,7 @@ class BuildConfigParseException implements Exception {
   BuildConfigParseException(this.packageName, this.exception);
 }
 
-/// Returns whether [sources] are included in any [targets].
+/// Returns the [sources] are not included in any [targets].
 Iterable<AssetId> _missingSources(
         Iterable<TargetNode> targets, Iterable<AssetId> sources) =>
     sources.where((s) => !targets.any((t) => t.matchesSource(s)));

--- a/build_runner_core/lib/src/package_graph/target_graph.dart
+++ b/build_runner_core/lib/src/package_graph/target_graph.dart
@@ -25,9 +25,25 @@ class TargetGraph {
 
   TargetGraph._(this.allModules, this.modulesByPackage, this.rootPackageConfig);
 
+  /// Builds a [TargetGraph] from [packageGraph].
+  ///
+  /// The [overrideBuildConfig] map overrides the config for packages by name.
+  ///
+  /// The [defaultRootPackageWhitelist] is the default `sources` list to use
+  /// for targets in the root package.
+  ///
+  /// All [requiredSourcePaths] should appear in non-root packages. A warning
+  /// is logged if this condition is not met.
+  ///
+  /// All [requiredRootSourcePaths] should appear in the root package. A
+  /// warning is logged if this condition is not met.
   static Future<TargetGraph> forPackageGraph(PackageGraph packageGraph,
       {Map<String, BuildConfig> overrideBuildConfig,
-      List<String> defaultRootPackageWhitelist}) async {
+      List<String> defaultRootPackageWhitelist,
+      List<String> requiredSourcePaths,
+      List<String> requiredRootSourcePaths}) async {
+    requiredSourcePaths ??= const [];
+    requiredRootSourcePaths ??= const [];
     overrideBuildConfig ??= const {};
     final modulesByKey = <String, TargetNode>{};
     final modulesByPackage = <String, List<TargetNode>>{};
@@ -49,6 +65,20 @@ class TargetGraph {
       }
       final nodes = config.buildTargets.values.map((target) =>
           TargetNode(target, package, defaultInclude: defaultInclude));
+      if (package.name != r'$sdk') {
+        var requiredPackagePaths =
+            package.isRoot ? requiredRootSourcePaths : requiredSourcePaths;
+        var requiredIds =
+            requiredPackagePaths.map((path) => AssetId(package.name, path));
+        var missing = _missingSources(nodes, requiredIds);
+        if (missing.isNotEmpty) {
+          log.warning(
+              'The package `${package.name}` does not include some required '
+              'sources in any of its targets (see their build.yaml file).\n'
+              'The missing sources are:\n'
+              '${missing.map((s) => '  - ${s.path}').join('\n')}');
+        }
+      }
       for (final node in nodes) {
         modulesByKey[node.target.key] = node;
         modulesByPackage.putIfAbsent(node.target.package, () => []).add(node);
@@ -100,3 +130,8 @@ class BuildConfigParseException implements Exception {
 
   BuildConfigParseException(this.packageName, this.exception);
 }
+
+/// Returns whether [sources] are included in any [targets].
+Iterable<AssetId> _missingSources(
+        Iterable<TargetNode> targets, Iterable<AssetId> sources) =>
+    sources.where((s) => !targets.any((t) => t.matchesSource(s)));

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 5.0.0
+version: 5.1.0-dev
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/package_graph/target_graph_test.dart
+++ b/build_runner_core/test/package_graph/target_graph_test.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+import 'package:build_config/build_config.dart';
+import 'package:logging/logging.dart';
+import 'package:package_config/package_config.dart';
+import 'package:test/test.dart';
+
+import 'package:build_runner_core/build_runner_core.dart';
+import 'package:build_runner_core/src/package_graph/target_graph.dart';
+
+void main() {
+  group('TargetGraph.forPackageGraph', () {
+    test('warns if required sources are missing', () {
+      var logs = <LogRecord>[];
+      var listener = Logger.root.onRecord.listen(logs.add);
+      addTearDown(listener.cancel);
+
+      var packageB = PackageNode(
+          'b', '/fakeB', DependencyType.path, LanguageVersion(0, 0));
+      var packageA = PackageNode(
+          'a', '/fakeA', DependencyType.path, LanguageVersion(0, 0),
+          isRoot: true)
+        ..dependencies.add(packageB);
+      var packageGraph = PackageGraph.fromRoot(packageA);
+
+      TargetGraph.forPackageGraph(packageGraph, overrideBuildConfig: {
+        'a': BuildConfig.fromMap('a', [
+          'b'
+        ], {
+          'targets': {
+            r'$default': {
+              'sources': ['lib/**']
+            }
+          }
+        }),
+        'b': BuildConfig.fromMap('b', [], {
+          'targets': {
+            r'$default': {
+              'sources': ['web/**']
+            }
+          }
+        }),
+      }, requiredSourcePaths: [
+        r'lib/$lib$',
+      ], requiredRootSourcePaths: [
+        r'lib/$lib$',
+        r'$package$'
+      ]);
+
+      expect(
+          logs,
+          containsAll([
+            isA<LogRecord>()
+                .having((r) => r.level, 'level', equals(Level.WARNING))
+                .having(
+                    (r) => r.message,
+                    'message',
+                    allOf(
+                        contains(
+                            'The package `a` does not include some required '
+                            'sources in any of its targets'),
+                        contains(r'$package$'),
+                        isNot(contains(r'lib/$lib$')))),
+            isA<LogRecord>()
+                .having((r) => r.level, 'level', equals(Level.WARNING))
+                .having(
+                    (r) => r.message,
+                    'message',
+                    allOf(
+                        contains(
+                            'The package `b` does not include some required '
+                            'sources in any of its targets'),
+                        contains(r'lib/$lib$'),
+                        isNot(contains(r'$package$')))),
+          ]));
+    });
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/2531

Logs a warning if any required placeholders are not included in any target for a package.