### PR TITLE
use addTearDown instead of tearDown to fix race condition

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.8.2-dev
+
 ## 1.8.1
 
 - Update to `build_runner_core` version `^5.0.0`.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.8.1
+version: 1.8.2-dev
 description: Tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -61,16 +61,18 @@ main() {
     ]).create();
 
     await pubGet('a', offline: false);
-  });
 
-  tearDown(() async {
-    for (var client in clients) {
-      await client.close();
-    }
-    clients.clear();
-    stdoutLines = null;
-    daemonProcess?.kill(ProcessSignal.sigkill);
-    await daemonProcess?.exitCode;
+    // We use `addTearDown` to ensure this runs before the temp dir gets
+    // cleaned up, otherwise there is a race condition that causes flaky tests.
+    addTearDown(() async {
+      for (var client in clients) {
+        await client.close();
+      }
+      clients.clear();
+      stdoutLines = null;
+      daemonProcess?.kill(ProcessSignal.sigkill);
+      await daemonProcess?.exitCode;
+    });
   });
 
   Future<BuildDaemonClient> _startClient(


### PR DESCRIPTION
Fixes flaky build_daemon tests.

The `test_descriptor` package uses `addTearDown`, which always runs before `tearDown`. This makes it attempt to clean up the temp directory while the daemon is still running. As it deletes files the daemon tries to recreate them and if it does that before the recursive delete is finished then the delete fails.

By using `addTearDown` ourselves - and after creating the test descriptor dir, we ensure the daemon process is cleaned up _first_.