### PR TITLE
Unskip "generated part files are not considered libraries"

### DIFF
--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -354,5 +354,5 @@ void main() {
 
     await runBuilder(
         builder, [input.changeExtension('.a.dart')], reader, writer, resolvers);
-  }, skip: 'https://github.com/dart-lang/source_gen/issues/447');
+  });
 }


### PR DESCRIPTION
The test was skipped because of an analyzer bug. Now that `build_resolvers` depends on `^0.39.5`, it passes.

Fixes #2623.