### PR TITLE
Support getting the language version for libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,16 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.6.0; PKGS: build, build_resolvers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.6.0; PKGS: build, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.6.0"
       os: linux
-      env: PKGS="build build_resolvers scratch_space"
+      env: PKGS="build scratch_space"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: 2.7.0; PKGS: build_config, build_daemon, build_runner_core, build_test, build_vm_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.7.0; PKGS: build_config, build_daemon, build_resolvers, build_runner_core, build_test, build_vm_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.7.0"
       os: linux
-      env: PKGS="build_config build_daemon build_runner_core build_test build_vm_compilers"
+      env: PKGS="build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: 2.8.0-dev.10.0; PKGS: build_modules, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.5
+
+- Create and pass a correct `Packages` argument to analysis driver, this
+  enables getting the proper language version for a given `LibraryElement`
+  using the `languageVersionMajor` and `languageVersionMinor` getters.
+
 ## 1.3.4
 
 - Remove dependency on `package_resolver`.

--- a/build_resolvers/lib/src/analysis_driver.dart
+++ b/build_resolvers/lib/src/analysis_driver.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/src/dart/analysis/byte_store.dart'
     show MemoryByteStore;
 import 'package:analyzer/src/dart/analysis/driver.dart';
 import 'package:analyzer/src/dart/analysis/file_state.dart';
+import 'package:analyzer/src/context/packages.dart' show Packages, Package;
 import 'package:analyzer/src/dart/analysis/performance_logger.dart'
     show PerformanceLog;
 import 'package:analyzer/src/generated/engine.dart'
@@ -13,6 +14,10 @@ import 'package:analyzer/src/generated/engine.dart'
 import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/summary/package_bundle_reader.dart';
 import 'package:analyzer/src/summary/summary_sdk.dart' show SummaryBasedDartSdk;
+import 'package:build/build.dart';
+import 'package:package_config/package_config.dart' show PackageConfig;
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 
 import 'build_asset_uri_resolver.dart';
 
@@ -21,8 +26,12 @@ import 'build_asset_uri_resolver.dart';
 ///
 /// Any code which is not covered by the summaries must be resolvable through
 /// [buildAssetUriResolver].
-AnalysisDriver analysisDriver(BuildAssetUriResolver buildAssetUriResolver,
-    AnalysisOptions analysisOptions, String sdkSummaryPath) {
+Future<AnalysisDriver> analysisDriver(
+  BuildAssetUriResolver buildAssetUriResolver,
+  AnalysisOptions analysisOptions,
+  String sdkSummaryPath,
+  PackageConfig packageConfig,
+) async {
   var sdk = SummaryBasedDartSdk(sdkSummaryPath, true);
   var sdkResolver = DartUriResolver(sdk);
 
@@ -33,17 +42,32 @@ AnalysisDriver analysisDriver(BuildAssetUriResolver buildAssetUriResolver,
 
   var logger = PerformanceLog(null);
   var scheduler = AnalysisDriverScheduler(logger);
+  var packages = Packages({
+    for (var package in packageConfig.packages)
+      package.name: Package(
+        name: package.name,
+        languageVersion: Version(
+            package.languageVersion.major, package.languageVersion.minor, 0),
+        // Analyzer does not see the original file paths at all, we need to
+        // make them match the paths that we give it, so we use the `assetPath`
+        // function to create those.
+        rootFolder: buildAssetUriResolver.resourceProvider
+            .getFolder(p.normalize(assetPath(AssetId(package.name, '')))),
+        libFolder: buildAssetUriResolver.resourceProvider
+            .getFolder(p.normalize(assetPath(AssetId(package.name, 'lib')))),
+      ),
+  });
   var driver = AnalysisDriver(
-    scheduler,
-    logger,
-    buildAssetUriResolver.resourceProvider,
-    MemoryByteStore(),
-    FileContentOverlay(),
-    null,
-    sourceFactory,
-    (analysisOptions as AnalysisOptionsImpl) ?? AnalysisOptionsImpl(),
-    externalSummaries: dataStore,
-  );
+      scheduler,
+      logger,
+      buildAssetUriResolver.resourceProvider,
+      MemoryByteStore(),
+      FileContentOverlay(),
+      null,
+      sourceFactory,
+      analysisOptions as AnalysisOptionsImpl,
+      externalSummaries: dataStore,
+      packages: packages);
 
   scheduler.start();
   return driver;

--- a/build_resolvers/lib/src/analysis_driver.dart
+++ b/build_resolvers/lib/src/analysis_driver.dart
@@ -73,8 +73,8 @@ Packages _buildAnalyzerPackages(
           // make them match the paths that we give it, so we use the `assetPath`
           // function to create those.
           rootFolder: resourceProvider
-              .getFolder(p.normalize(assetPath(AssetId(package.name, '')))),
-          libFolder: resourceProvider
-              .getFolder(p.normalize(assetPath(AssetId(package.name, 'lib')))),
+              .getFolder(p.url.normalize(assetPath(AssetId(package.name, '')))),
+          libFolder: resourceProvider.getFolder(
+              p.url.normalize(assetPath(AssetId(package.name, 'lib')))),
         ),
     });

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -197,9 +197,9 @@ class AnalyzerResolvers implements Resolvers {
   /// If no [_packageConfig] is provided, then one is created from the current
   /// [Isolate.packageConfig].
   ///
-  /// **NOTE**: The [_packageConfig] is used only for language versions, we
-  /// have provide custom fake paths to the analyzer for packages so the root
-  /// uri and package uri are ignored.
+  /// **NOTE**: The [_packageConfig] is not used for path resolution, it is
+  /// primarily used to get the language versions. Any other data (including
+  /// extra data), may be passed to the analyzer on an as needed basis.
   AnalyzerResolvers(
       [AnalysisOptions analysisOptions,
       Future<String> Function() sdkSummaryGenerator,

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -21,6 +21,7 @@ import 'package:analyzer/src/generated/engine.dart'
     show AnalysisOptions, AnalysisOptionsImpl;
 import 'package:build/build.dart';
 import 'package:logging/logging.dart';
+import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
@@ -183,9 +184,28 @@ class AnalyzerResolvers implements Resolvers {
   /// Nullable, should not be accessed outside of [_ensureInitialized].
   Future<void> _initialized;
 
+  PackageConfig _packageConfig;
+
+  /// Lazily creates and manages a single [AnalysisDriver], that can be shared
+  /// across [BuildStep]s.
+  ///
+  /// If no [_analysisOptions] is provided, then an empty one is used.
+  ///
+  /// If no [sdkSummaryGenerator] is provided, a default one is used that only
+  /// works for typical `pub` packages.
+  ///
+  /// If no [_packageConfig] is provided, then one is created from the current
+  /// [Isolate.packageConfig].
+  ///
+  /// **NOTE**: The [_packageConfig] is used only for language versions, we
+  /// have provide custom fake paths to the analyzer for packages so the root
+  /// uri and package uri are ignored.
   AnalyzerResolvers(
-      [this._analysisOptions, Future<String> Function() sdkSummaryGenerator])
-      : _sdkSummaryGenerator =
+      [AnalysisOptions analysisOptions,
+      Future<String> Function() sdkSummaryGenerator,
+      this._packageConfig])
+      : _analysisOptions = analysisOptions ?? AnalysisOptionsImpl(),
+        _sdkSummaryGenerator =
             sdkSummaryGenerator ?? _defaultSdkSummaryGenerator;
 
   /// Create a Resolvers backed by an `AnalysisContext` using options
@@ -193,8 +213,10 @@ class AnalyzerResolvers implements Resolvers {
   Future<void> _ensureInitialized() {
     return _initialized ??= () async {
       _uriResolver = BuildAssetUriResolver();
-      var driver = analysisDriver(
-          _uriResolver, _analysisOptions, await _sdkSummaryGenerator());
+      _packageConfig ??=
+          await loadPackageConfigUri(await Isolate.packageConfig);
+      var driver = await analysisDriver(_uriResolver, _analysisOptions,
+          await _sdkSummaryGenerator(), _packageConfig);
       _resolver = AnalyzerResolver(driver, _uriResolver);
     }();
   }

--- a/build_resolvers/mono_pkg.yaml
+++ b/build_resolvers/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.6.0
+        - 2.7.0
   - unit_test:
     - group:
       - command: pub run build_runner test -- --test-randomize-ordering-seed=random

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.3.4
+version: 1.3.5
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -4,7 +4,7 @@ description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   analyzer: ^0.39.5

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   graphs: ^0.2.0
   logging: ^0.11.2
   path: ^1.1.0
+  package_config: ^1.9.3
   pub_semver: ^1.3.0
   yaml: ^2.0.0
 


### PR DESCRIPTION
Part of https://github.com/dart-lang/build/issues/2658

Adds a required `PackageConfig` argument to the internal `analysisDriver` method and convert that into the analyzers `Packages` object.

- Note that we have to use our internal custom paths for the rootDir and packageDir when we do the conversion, since those are the paths the analyzer sees.

Also supports passing a custom `PackageConfig` to `AnalyzerResolvers` (defaults to the current isolates package config).