### PR TITLE
Fix null error in _buildAnalyzerPackages when package in packageConfig has a null languageVersion so accessing languageVersion.major leads to a NoSuchMethodError

### DIFF
--- a/build_resolvers/lib/src/analysis_driver.dart
+++ b/build_resolvers/lib/src/analysis_driver.dart
@@ -67,8 +67,10 @@ Packages _buildAnalyzerPackages(
       for (var package in packageConfig.packages)
         package.name: Package(
           name: package.name,
-          languageVersion: Version(package.languageVersion?.major ?? 0,
-              package.languageVersion?.minor ?? 0, 0),
+          languageVersion: package.languageVersion == null
+              ? null
+              : Version(package.languageVersion.major,
+                  package.languageVersion.minor, 0),
           // Analyzer does not see the original file paths at all, we need to
           // make them match the paths that we give it, so we use the `assetPath`
           // function to create those.

--- a/build_resolvers/lib/src/analysis_driver.dart
+++ b/build_resolvers/lib/src/analysis_driver.dart
@@ -67,8 +67,8 @@ Packages _buildAnalyzerPackages(
       for (var package in packageConfig.packages)
         package.name: Package(
           name: package.name,
-          languageVersion: Version(
-              package.languageVersion.major, package.languageVersion.minor, 0),
+          languageVersion: Version(package.languageVersion?.major ?? 0,
+              package.languageVersion?.minor ?? 0, 0),
           // Analyzer does not see the original file paths at all, we need to
           // make them match the paths that we give it, so we use the `assetPath`
           // function to create those.


### PR DESCRIPTION
I originally noticed this when mobx_codegen was failing in my project to generate my store class code. Digging deeper, the exception was this:

```
NoSuchMethodError: The getter 'major' was called on null.
Receiver: null
Tried calling: major
dart:core                                                                                     Object.noSuchMethod
package:build_resolvers/src/analysis_driver.dart 71:39                                        _buildAnalyzerPackages
package:build_resolvers/src/analysis_driver.dart 46:18                                        analysisDriver
package:build_resolvers/src/resolver.dart 218:26                                              AnalyzerResolvers._ensureInitialized.<fn>
package:build_resolvers/src/resolver.dart                                                     AnalyzerResolvers._ensureInitialized.<fn>
package:build_resolvers/src/resolver.dart 221:6                                               AnalyzerResolvers._ensureInitialized
package:build_resolvers/src/resolver.dart 226:11                                              AnalyzerResolvers.get
package:build_runner_core/src/performance_tracking/performance_tracking_resolvers.dart 19:58  PerformanceTrackingResolvers.get.<fn>
package:build_runner_core/src/generate/performance_tracker.dart 302:15                        _NoOpBuilderActionTracker.trackStage
package:build_runner_core/src/performance_tracking/performance_tracking_resolvers.dart 19:16  PerformanceTrackingResolvers.get
package:build                                                                                 BuildStepImpl.resolver
package:source_gen/src/builder.dart 68:32                                                     _Builder.build
package:build                                                                                 runBuilder
package:build_runner_core/src/generate/build_impl.dart 486:19                                 _SingleBuild._runForInput.<fn>.<fn>.<fn>
package:build_runner_core/src/generate/performance_tracker.dart 302:15                        _NoOpBuilderActionTracker.trackStage
package:build_runner_core/src/generate/build_impl.dart 484:23                                 _SingleBuild._runForInput.<fn>.<fn>
package:build_runner_core/src/generate/build_impl.dart                                        _SingleBuild._runForInput.<fn>.<fn>
package:timing/src/timing.dart 222:44                                                         NoOpTimeTracker.track
package:build_runner_core/src/generate/build_impl.dart 441:22                                 _SingleBuild._runForInput.<fn>
package:pool/pool.dart 127:28                                                                 Pool.withResource
package:build_runner_core/src/generate/build_impl.dart 437:17                                 _SingleBuild._runForInput
package:build_runner_core/src/generate/build_impl.dart 375:38                                 _SingleBuild._runBuilder.<fn>
dart:async                                                                                    Future.wait
package:build_runner_core/src/generate/build_impl.dart 374:36                                 _SingleBuild._runBuilder
package:build_runner_core/src/generate/build_impl.dart 320:20                                 _SingleBuild._runPhases.<fn>.<fn>
package:build_runner_core/src/generate/build_impl.dart                                        _SingleBuild._runPhases.<fn>.<fn>
package:build_runner_core/src/generate/performance_tracker.dart 184:15                        _NoOpBuildPerformanceTracker.trackBuildPhase
package:build_runner_core/src/generate/build_impl.dart 316:47                                 _SingleBuild._runPhases.<fn>
package:timing/src/timing.dart 222:44                                                         NoOpTimeTracker.track
package:build_runner_core/src/generate/build_impl.dart 310:32                                 _SingleBuild._runPhases
package:build_runner_core/src/logging/logging.dart 25:30                                      logTimedAsync
package:build_runner_core/src/generate/build_impl.dart 267:26                                 _SingleBuild._safeBuild.<fn>
dart:async                                                                                    runZoned
package:build_runner_core/src/generate/build_impl.dart 262:5                                  _SingleBuild._safeBuild
package:build_runner_core/src/generate/build_impl.dart 209:24                                 _SingleBuild.run
package:build_runner_core/src/generate/build_impl.dart 94:56                                  BuildImpl.run
package:build_runner_core/src/generate/build_runner.dart 25:14                                BuildRunner.run
package:build_runner                                                                          BuildCommand.run
package:args/command_runner.dart 197:27                                                       CommandRunner.runCommand
package:args/command_runner.dart 112:25                                                       CommandRunner.run.<fn>
dart:async                                                                                    new Future.sync
package:args/command_runner.dart 112:14                                                       CommandRunner.run
package:build_runner                                                                          run
.dart_tool/build/entrypoint/build.dart 22:22                                                  main
```

In `build_resolvers/lib/src/analysis_driver.dart` in method `_buildAnalyzerPackages()`, the unsafe access to `package.languageVersion.major` and `package.languageVersion.minor` led to a `NoSuchMethodError` when `languageVersion` was null, which was the case a number of packages in my dependency tree.

Simple fix here to give some default values and use the null-safe `.?` operator, and now my code generators are running fine again.

```
Flutter 1.17.0 • channel beta • https://github.com/flutter/flutter.git
Framework • revision d3ed9ec945 (13 days ago) • 2020-04-06 14:07:34 -0700
Engine • revision c9506cb8e9
Tools • Dart 2.8.0 (build 2.8.0-dev.18.0 eea9717938)
```
```
 mobx_codegen: ^1.0.3
```