### PR TITLE
Reduce the chances of different build phase order

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -111,9 +111,6 @@ final _builders = <_i1.BuilderApplication>[
   _i1.apply('provides_builder:throwing_builder', [_i4.throwingBuilder],
       _i1.toDependentsOf('provides_builder'),
       hideOutput: true),
-  _i1.applyPostProcess(
-      'provides_builder:some_post_process_builder', _i4.somePostProcessBuilder,
-      defaultGenerateFor: const _i3.InputSet()),
   _i1.applyPostProcess('build_modules:module_cleanup', _i5.moduleCleanup,
       defaultGenerateFor: const _i3.InputSet()),
   _i1.applyPostProcess('build_web_compilers:dart2js_archive_extractor',
@@ -127,6 +124,9 @@ final _builders = <_i1.BuilderApplication>[
   _i1.applyPostProcess(
       'build_web_compilers:sdk_js_cleanup', _i7.sdkJsCleanupBuilder,
       defaultReleaseOptions: _i8.BuilderOptions({'enabled': true}),
+      defaultGenerateFor: const _i3.InputSet()),
+  _i1.applyPostProcess(
+      'provides_builder:some_post_process_builder', _i4.somePostProcessBuilder,
       defaultGenerateFor: const _i3.InputSet())
 ];
 void main(List<String> args, [_i9.SendPort sendPort]) async {

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 5.1.0-dev
 
 - Add a warning if a package is missing some required placholder files,
-  including `$package$` and `lib/$lib$`. 
+  including `$package$` and `lib/$lib$`.
+- Reduce chances for changing apparent build phases across machines with a
+  different order of packages from `package_config.json`.
 
 ## 5.0.0
 

--- a/build_runner_core/lib/src/package_graph/package_graph.dart
+++ b/build_runner_core/lib/src/package_graph/package_graph.dart
@@ -76,7 +76,9 @@ class PackageGraph {
     final dependencyTypes = _parseDependencyTypes(packagePath);
 
     final nodes = <String, PackageNode>{};
-    for (final package in packageConfig.packages) {
+    final consistentlyOrderedPackages = packageConfig.packages.toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    for (final package in consistentlyOrderedPackages) {
       var isRoot = package.name == rootPackageName;
       nodes[package.name] = PackageNode(
           package.name,


### PR DESCRIPTION
Fixes #2645

Sort the list of packages we get from `PackageConfig`. This won't fully
guarantee consistency since we later have behavior that doesn't make
ordering guarantees, but in practice with a consistent package order to
start with we _should_ get a consistent build phase order.