### PR TITLE
pass explicit feature set based on current sdk and warn about incompatible language versions

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.7-dev
+
+- Pass an explicit `FeatureSet` to the analyzer based on the current sdk
+  version.
+- Added a warning if the current analyzers language version does not support
+  the current SDK language version.
+
 ## 1.3.6
 
 - Fix bug when a package has no language version (as a result of having no sdk

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.3.6
+version: 1.3.7-dev
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/2673 based on conversations yesterday with the analyzer team.

I realized while doing this that we also need to support our own --enable-experiment flag so I filed https://github.com/dart-lang/build/issues/2675 for that and will follow up with it in the same release.