### PR TITLE
Prepare to publish build_runner

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.8.2-dev
+## 1.9.0
+
+- Add a warning if a package is missing some required placholder files,
+  including `$package$` and `lib/$lib$`.
+- Reduce chances for changing apparent build phases across machines with a
+  different order of packages from `package_config.json`.
 
 ## 1.8.1
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_runner
-version: 1.8.2-dev
-description: Tools to write binaries that run builders.
+version: 1.9.0
+description: A build system for Dart code generation and modular compilation.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
   build_config: ">=0.4.1 <0.4.3"
   build_daemon: ^2.1.0
   build_resolvers: "^1.0.0"
-  build_runner_core: ^5.0.0
+  build_runner_core: ^5.1.0
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
   crypto: ">=0.9.2 <3.0.0"


### PR DESCRIPTION
- Make it a feature bump since we decided on a feature bump in
  `build_runner_core`.
- Update the dependency on `build_runner_core`. Copy over the changelog.
- Update the description. The "write a binary" approach is no longer the
  golden path.