### PR TITLE
Migrate off deprecated analyzer API

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.9.1-dev
+
 ## 2.9.0
 
 - Copy the `package_config.json` file to the scratch space directory, which

--- a/build_modules/lib/src/module_library.dart
+++ b/build_modules/lib/src/module_library.dart
@@ -4,8 +4,8 @@
 
 import 'dart:convert';
 
-// ignore: deprecated_member_use
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:build/build.dart';
 import 'package:meta/meta.dart';
 
@@ -133,9 +133,7 @@ class ModuleLibrary {
   /// Parse the directives from [source] and compute the library information.
   static ModuleLibrary fromSource(AssetId id, String source) {
     final isLibDir = id.path.startsWith('lib/');
-    // ignore: deprecated_member_use
-    final parsed = parseCompilationUnit(source,
-        name: id.path, suppressErrors: true, parseFunctionBodies: false);
+    final parsed = parseString(content: source, throwIfDiagnostics: false).unit;
     // Packages within the SDK but published might have libraries that can't be
     // used outside the SDK.
     if (parsed.directives.any((d) =>

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.9.0
+version: 2.9.1-dev
 description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 


### PR DESCRIPTION
Switch from the deprecated `parseCompilationUnit` to the supported
`parseString`. Immediately access the `CompilationUnit` from the result.

This should not have a performance hit despite the missing
`parseFunctionBodies: fase` because that argument has not had an effect
since the analyzer migrated parsers.