### PR TITLE
prepare to publish all build_* packages with enable experiment support

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.0-dev
+## 1.3.0
 
 Added a new experiments library which exposes a list of language experiments
 through a Zone variable. This should only be used by builders which are

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.3.0-dev
+version: 1.3.0
 description: A build system for Dart.
 homepage: https://github.com/dart-lang/build/tree/master/build
 

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.10.0-dev
+## 2.10.0
 
 - Deprecated the `experiments` argument to `KernelBuilder` and default it to
   use the value from the current zone.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.10.0-dev
+version: 2.10.0
 description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.8-dev
+## 1.3.8
 
 - Enables the `non-nullable` experiment when summarizing the SDK, see
   https://github.com/dart-lang/sdk/issues/41820.

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.3.8-dev
+version: 1.3.8
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.10.0-dev
+## 1.10.0
 
 - Add an `--enable-experiment` flag which enables running builders on code that
   requires a language experiment to be enabled.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.10.0-dev
+version: 1.10.0
 description: A build system for Dart code generation and modular compilation.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.2.0-dev
+## 5.2.0
 
 - Dart language experiments are now tracked on the asset graph and will
   invalidate the build if they change.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 5.2.0-dev
+version: 5.2.0
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.11.0-dev
+## 2.11.0
 
 - Deprecated support for the `experiments` configuration in favor of the
   general mechanism exposed by the build package(exposed through the 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.11.0-dev
+version: 2.11.0
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 


### PR DESCRIPTION
I plan on publishing these all and then sending out a new PR to remove all the overrides to expedite the process a bit.