### PR TITLE
Fix AnalyzerResolver methods isLibrary and libraryFor 

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.9
+
+- Fix `isLibrary` for unreadable assets to return `false`.
+- Fix `libraryFor` to do an explicit `canRead` check and throw an
+  `AssetNotFound` exception if it cannot be read.
+
 ## 1.3.8
 
 - Enables the `non-nullable` experiment when summarizing the SDK, see

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -138,7 +138,7 @@ class AnalyzerResolver implements ReleasableResolver {
     var uri = assetId.uri;
     var source = _driver.sourceFactory.forUri2(uri);
     if (source == null || !source.exists()) {
-      throw ArgumentError('missing source for $uri');
+      throw AssetNotFoundException(assetId);
     }
     var kind = await _driver.getSourceKind(path);
     if (kind != SourceKind.LIBRARY) throw NonLibraryAssetException(assetId);

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -84,6 +84,7 @@ class PerActionResolver implements ReleasableResolver {
 
   @override
   Future<bool> isLibrary(AssetId assetId) async {
+    if (!await _step.canRead(assetId)) return false;
     await _resolveIfNecesssary(assetId);
     return _delegate.isLibrary(assetId);
   }

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.3.8
+version: 1.3.9
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 
 dev_dependencies:
   test: ^1.0.0
-  build_test: ^0.10.1
+  build_test: ^1.0.0
   build_runner: ^1.0.0
   build_vm_compilers: ">=0.1.0 <2.0.0"
   build_modules: any

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -457,4 +457,24 @@ int? get x => 1;
     await runBuilder(
         builder, [input.changeExtension('.a.dart')], reader, writer, resolvers);
   });
+
+  test('missing files are not considered libraries', () async {
+    var writer = InMemoryAssetWriter();
+    var reader = InMemoryAssetReader.shareAssetCache(writer.assets);
+    var input = AssetId('a', 'lib/input.dart');
+    writer.assets[input] = utf8.encode('void doStuff() {}');
+
+    var builder = TestBuilder(
+        buildExtensions: {
+          '.dart': ['.a.dart']
+        },
+        build: expectAsync2((buildStep, _) async {
+          expect(
+              await buildStep.resolver.isLibrary(
+                  buildStep.inputId.changeExtension('doesnotexist.dart')),
+              false);
+        }));
+    var resolvers = AnalyzerResolvers();
+    await runBuilder(builder, [input], reader, writer, resolvers);
+  });
 }


### PR DESCRIPTION
These now do explicit `canRead` checks to try and keep people on the rails.

Also added `.exists()` checks to sources since we can get an empty source instead of a null source now.