### PR TITLE
support language versioning and experiments in build_test apis

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.1.0
+
+- Add support for enabling experiments via `withEnabledExperiments` zones from
+  package:build, as well as forwarding the `packageConfig` argument from
+  `resolve*` apis through to the default `Resolver`.
+  - **Note**: If passing your own `Resolver` these things are still your
+    responsibility.
+- Added the ability to pass a `PackageConfig` to `testBuilder`, which is used
+  to set the language version of each package.
+  - The resolver created from `testBuilder` will also now respect the
+    `withEnabledExperiments` zone. 
+
 ## 1.0.0
 
 - Removed dependency on `package:package_resolver`, changed to 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ">=1.2.0 <3.0.0"
-  build: ">=1.2.0 <2.0.0"
+  build: ">=1.3.0 <2.0.0"
   build_config: ">=0.2.0 <0.5.0"
   build_resolvers: ">=0.2.0 <2.0.0"
   crypto: ">=0.9.2 <3.0.0"


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/2343

Adds support to the `resolve*` and `testBuilder` apis for passing a `PackageConfig` object which is used for setting language versions.

Also respects the `withEnabledExperiments` zone if running in one to allow enabling of experiments. Note that the experiment support is untested as there is no way to write a test that won't break in the future.

cc @srawlins 