### PR TITLE
Use iterable.expand.take over iterable.fold.take

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.2.1-dev
+
 ## 5.2.0
 
 - Dart language experiments are now tracked on the asset graph and will

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -188,10 +188,9 @@ class _SingleBuild {
     hungActionsHeartbeat = HungActionsHeartbeat(() {
       final message = StringBuffer();
       const actionsToLogMax = 5;
-      var descriptions = pendingActions.values.fold(
-          <String>[],
-          (combined, actions) =>
-              combined..addAll(actions)).take(actionsToLogMax);
+      final descriptions = pendingActions.values
+          .expand((actions) => actions)
+          .take(actionsToLogMax);
       for (final description in descriptions) {
         message.writeln('  - $description');
       }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 5.2.0
+version: 5.2.1-dev
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 


### PR DESCRIPTION
Previously we would iterate over _all_ of `pendingActions.values` and
collect them to a list, only to throw all but 5 away. Now we only
iterate as far in `values` as it takes to reach `actionsToLogMax` since
there is no `List`, it's all iterables.