### PR TITLE
Use caret deps in build_test

### DIFF
--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 
 dependencies:
   async: ">=1.2.0 <3.0.0"
-  build: ">=1.3.0 <2.0.0"
+  build: ^1.3.0
   build_config: ">=0.2.0 <0.5.0"
-  build_resolvers: ">=1.3.5 <2.0.0"
+  build_resolvers: ^1.3.5
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0
   html: ">=0.9.0 <0.15.0"


### PR DESCRIPTION
Replace `>= <` constraints with caret constraints where they are already
limited to a single major version.