### PR TITLE
Support custom platforms in build_test

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+- Add support for recognizing custom platforms in TestOn annotations during
+  bootstrapping.
+
 ## 1.1.0
 
 - Add support for enabling experiments via `withEnabledExperiments` zones from

--- a/build_test/lib/src/test_bootstrap_builder.dart
+++ b/build_test/lib/src/test_bootstrap_builder.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:build/build.dart';

--- a/build_test/lib/src/test_bootstrap_builder.dart
+++ b/build_test/lib/src/test_bootstrap_builder.dart
@@ -64,7 +64,7 @@ class TestBootstrapBuilder extends Builder {
         vmRuntimes
             .followedBy(browserRuntimes)
             .followedBy(nodeRuntimes)
-            .map((r) => r.name)
+            .map((r) => r.identifier)
             .toSet());
 
     if (vmRuntimes.any((r) => metadata.testOn.evaluate(SuitePlatform(r)))) {

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   pedantic: ^1.0.0
   stream_transform: ">=0.0.20 <2.0.0"
   test: '>=0.12.42 <2.0.0'
-  test_core: '>=0.2.4 <0.4.0'
+  test_core: '>=0.3.6 <0.4.0'
   watcher: ^0.9.7
 
 dev_dependencies:

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:

--- a/build_test/test/test_bootstrap_builder_test.dart
+++ b/build_test/test/test_bootstrap_builder_test.dart
@@ -24,6 +24,28 @@ void main() {
     });
   });
 
+  test('bootstraps custom platforms', () async {
+    await testBuilder(TestBootstrapBuilder(), {
+      'a|test/hello_test.dart': '''
+      @TestOn("no_headless")
+      import 'package:test/test.dart';
+      main() {}
+''',
+      'a|dart_test.yaml': '''
+define_platforms:
+  no_headless:
+    name: NoHeadless
+    extends: chrome
+    settings:
+      arguments: --no-headless
+'''
+    }, outputs: {
+      'a|test/hello_test.dart.browser_test.dart': decodedMatches(allOf(
+          contains('import "hello_test.dart" as test;'),
+          contains('import "package:test/bootstrap/browser.dart";'))),
+    });
+  });
+
   group('Browser tests', () {
     test('TestOn("browser")', () async {
       await testBuilder(TestBootstrapBuilder(), {


### PR DESCRIPTION
Adds support for recognizing custom platforms in TestOn annotations during bootstrapping.

Fixes https://github.com/dart-lang/build/issues/2684