### PR TITLE
Remove uses of the term whitelist

### DIFF
--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -87,7 +87,7 @@ a:file://fake/pkg/path
                 'Nothing can be built, yet a build was requested.'))));
       });
 
-      test('rebuilds on file updates outside hardcoded whitelist', () async {
+      test('rebuilds on file updates outside hardcoded sources', () async {
         var buildState = await startWatch(
             [copyABuildApplication], {'a|test_files/a.txt': 'a'}, writer,
             overrideBuildConfig: parseBuildConfigs({
@@ -129,7 +129,7 @@ a:file://fake/pkg/path
             decodedMatches('a'));
       });
 
-      test('rebuilds on new files outside hardcoded whitelist', () async {
+      test('rebuilds on new files outside hardcoded sources', () async {
         var buildState = await startWatch(
             [copyABuildApplication], {'a|test_files/a.txt': 'a'}, writer,
             overrideBuildConfig: parseBuildConfigs({
@@ -188,7 +188,7 @@ a:file://fake/pkg/path
             decodedMatches('b'));
       });
 
-      test('rebuilds on deleted files outside hardcoded whitelist', () async {
+      test('rebuilds on deleted files outside hardcoded sources', () async {
         var buildState = await startWatch([
           copyABuildApplication
         ], {

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 5.2.1-dev
+## 6.0.0
+
+-   Remove some constants and utilities which are implementation details:
+    `defaultRootPackageWhitelist`, `errorCachePath`, `generatedOutputDirectory`,
+    `lockGeneratedOutputDirectory`, `overrideGeneratedOutputDirectory`,
+    `sdkPath`, `buildPhasePoolSize`.
 
 ## 5.2.0
 

--- a/build_runner_core/lib/build_runner_core.dart
+++ b/build_runner_core/lib/build_runner_core.dart
@@ -21,11 +21,7 @@ export 'src/generate/exceptions.dart'
         CannotBuildException;
 export 'src/generate/finalized_assets_view.dart' show FinalizedAssetsView;
 export 'src/generate/options.dart'
-    show
-        defaultRootPackageWhitelist,
-        LogSubscription,
-        BuildOptions,
-        BuildFilter;
+    show BuildFilter, BuildOptions, LogSubscription;
 export 'src/generate/performance_tracker.dart'
     show BuildPerformance, BuilderActionPerformance, BuildPhasePerformance;
 export 'src/logging/human_readable_duration.dart';
@@ -44,4 +40,11 @@ export 'src/package_graph/apply_builders.dart'
         toPackages,
         toRoot;
 export 'src/package_graph/package_graph.dart';
-export 'src/util/constants.dart';
+export 'src/util/constants.dart'
+    show
+        assetGraphPath,
+        assetGraphPathFor,
+        cacheDir,
+        entryPointDir,
+        pubBinary,
+        sdkBin;

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -185,10 +185,10 @@ class AssetTracker {
     }).where((id) => id != null);
   }
 
-  /// Lists asset ids and swallows file not found errors.
+  /// Lists asset IDs and swallows file not found errors.
   ///
-  /// Ideally we would warn but in practice the default whitelist will give this
-  /// error a lot and it would be noisy.
+  /// Ideally we would warn but in practice the default sources list will give
+  /// this error a lot and it would be noisy.
   Stream<AssetId> _listIdsSafe(Glob glob, {String package}) =>
       _reader.findAssets(glob, package: package).handleError((void _) {},
           test: (e) => e is FileSystemException && e.osError.errorCode == 2);

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -21,7 +21,7 @@ import 'exceptions.dart';
 
 /// The default list of files to include when an explicit include is not
 /// provided.
-const List<String> defaultRootPackageWhitelist = [
+const List<String> defaultRootPackageSources = [
   'assets/**',
   'benchmark/**',
   'bin/**',
@@ -171,7 +171,7 @@ class BuildOptions {
     try {
       targetGraph = await TargetGraph.forPackageGraph(packageGraph,
           overrideBuildConfig: overrideBuildConfig,
-          defaultRootPackageWhitelist: defaultRootPackageWhitelist,
+          defaultRootPackageSources: defaultRootPackageSources,
           requiredSourcePaths: [r'lib/$lib$'],
           requiredRootSourcePaths: [r'$package$', r'lib/$lib$']);
     } on BuildConfigParseException catch (e, s) {

--- a/build_runner_core/lib/src/package_graph/target_graph.dart
+++ b/build_runner_core/lib/src/package_graph/target_graph.dart
@@ -29,7 +29,7 @@ class TargetGraph {
   ///
   /// The [overrideBuildConfig] map overrides the config for packages by name.
   ///
-  /// The [defaultRootPackageWhitelist] is the default `sources` list to use
+  /// The [defaultRootPackageSources] is the default `sources` list to use
   /// for targets in the root package.
   ///
   /// All [requiredSourcePaths] should appear in non-root packages. A warning
@@ -39,7 +39,7 @@ class TargetGraph {
   /// warning is logged if this condition is not met.
   static Future<TargetGraph> forPackageGraph(PackageGraph packageGraph,
       {Map<String, BuildConfig> overrideBuildConfig,
-      List<String> defaultRootPackageWhitelist,
+      List<String> defaultRootPackageSources,
       List<String> requiredSourcePaths,
       List<String> requiredRootSourcePaths}) async {
     requiredSourcePaths ??= const [];
@@ -53,7 +53,7 @@ class TargetGraph {
           await _packageBuildConfig(package);
       List<String> defaultInclude;
       if (package.isRoot) {
-        defaultInclude = defaultRootPackageWhitelist;
+        defaultInclude = defaultRootPackageSources;
         rootPackageConfig = config;
       } else if (package.name == r'$sdk') {
         defaultInclude = const [

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 5.2.1-dev
+version: 6.0.0
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/generate/asset_tracker_test.dart
+++ b/build_runner_core/test/generate/asset_tracker_test.dart
@@ -43,7 +43,7 @@ void main() {
       assetGraph.get(aId).lastKnownDigest = await reader.digest(aId);
 
       var targetGraph = await TargetGraph.forPackageGraph(packageGraph,
-          defaultRootPackageWhitelist: ['web/**']);
+          defaultRootPackageSources: ['web/**']);
       assetTracker = AssetTracker(assetGraph, reader, targetGraph);
       var updates = await assetTracker.collectChanges();
       await assetGraph.updateAndInvalidate([], updates, 'a', null, reader);

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -730,7 +730,7 @@ targets:
             isNotEmpty);
       });
 
-      test('a missing sources/include results in the default whitelist',
+      test('a missing sources/include results in the default sources',
           () async {
         var rootPkg = options.packageGraph.root.name;
         options = await BuildOptions.create(LogSubscription(environment),
@@ -752,11 +752,11 @@ targets:
         expect(
             options.targetGraph.allModules['$rootPkg:another'].sourceIncludes
                 .map((glob) => glob.pattern),
-            defaultRootPackageWhitelist);
+            defaultRootPackageSources);
         expect(
             options.targetGraph.allModules['$rootPkg:$rootPkg'].sourceIncludes
                 .map((glob) => glob.pattern),
-            defaultRootPackageWhitelist);
+            defaultRootPackageSources);
       });
 
       test('allows a target config with empty sources list', () async {

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -646,7 +646,7 @@ void main() {
           });
     });
 
-    test('can build on files outside the hardcoded whitelist', () async {
+    test('can build on files outside the hardcoded sources', () async {
       await testBuilders(
           [applyToRoot(TestBuilder())], {'a|test_files/a.txt': 'a'},
           overrideBuildConfig: parseBuildConfigs({

--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -22,7 +22,7 @@ key | value | default
 auto_apply_builders | bool | true
 builders | Map<[BuilderKey](#builderkey), [TargetBuilderConfig](#targetbuilderconfig)> | empty
 dependencies | List<[TargetKey](#targetkey)> | all default targets from all dependencies in your pubspec
-sources | [InputSet](#inputset) | all whitelisted directories
+sources | [InputSet](#inputset) | all defaults sources
 
 ## BuilderDefinition
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,11 +40,11 @@ targets:
 
 ## How can I include additional sources in my build?
 
-By default, the `build_runner` package only includes some specifically
-whitelisted directories, derived from the [package layout conventions](
-https://dart.dev/tools/pub/package-layout).
+The `build_runner` package defaults the included source files to directories
+derived from the
+[package layout conventions](https://dart.dev/tools/pub/package-layout).
 
-If you have some additional files which you would like to be included as part of
+If you have additional files which you would like to be included as part of
 the build, you will need a custom `build.yaml` file. You will want to modify the
 `sources` field on the `$default` target:
 


### PR DESCRIPTION
Rename to "sources" where applicable. The term "default" already conveys
the meaning we need, the "whitelist" term isn't useful since it's not
used as a filter, only as a default set of sources.

`defaultRootPackageWhitelist` was not used outside the package anyway,
so remove it from the public API. Also do an audit of other public
members from `constants.dart` that aren't used outside of the package
and add an explicit `show` to the export.