### PR TITLE
Run a silent help before generate-build-script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,13 +85,13 @@ jobs:
       env: PKGS="build_daemon"
       script: ./tool/travis.sh test_12
     - stage: unit_test
-      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner help >/dev/null; pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_modules"
       script: ./tool/travis.sh command_4
     - stage: unit_test
-      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner help >/dev/null; pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_modules"

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -11,8 +11,12 @@ stages:
         - 2.8.1
   - unit_test:
     # Run the script directly - running from snapshot has issues for packages
-    # that are depended on by build_runner itself.
-    - command: dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random
+    # that are depended on by the generated build script.
+    - command: >-
+        dart $(pub run build_runner help >/dev/null;
+        pub run build_runner generate-build-script)
+        test --delete-conflicting-outputs
+        -- -P presubmit --test-randomize-ordering-seed=random
       os:
         - linux
         - windows

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -67,8 +67,8 @@ for PKG in ${PKGS}; do
       pub run build_runner test -- --test-randomize-ordering-seed=random || EXIT_CODE=$?
       ;;
     command_4)
-      echo 'dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random'
-      dart $(pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random || EXIT_CODE=$?
+      echo 'dart $(pub run build_runner help >/dev/null; pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random'
+      dart $(pub run build_runner help >/dev/null; pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random || EXIT_CODE=$?
       ;;
     command_5)
       echo 'test/flutter_test.sh'


### PR DESCRIPTION
Fixes #2725

The first `pub run build_runner` after a `pub get` will print some lines
about "Precompiling" the target. This throws off the VM when it's passed
as the argument to the `dart` command. Prefix with a `pub run
build_runner help` but send the output to `/dev/null` to suppress it.
This is the command that will print the "Precompiling" message, then the
next one will print only the path to the script.