### PR TITLE
Merged metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,16 @@ jobs:
       env: PKGS="build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: 2.8.1; PKGS: build_modules, build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.8.1; PKG: build_modules; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.8.1"
       os: linux
-      env: PKGS="build_modules build_web_compilers"
+      env: PKGS="build_modules"
+      script: ./tool/travis.sh dartanalyzer_1
+    - stage: analyze_and_format
+      name: "SDK: dev; PKG: build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: dev
+      os: linux
+      env: PKGS="build_web_compilers"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.12.0
 
-- Update `build_web_compilers|ddc` builder to produce a `.merged_metadata` file
+- Update `build_web_compilers|ddc` builder to produce a `.metadata` file.
+- Update `build_web_compilers|entrypoint` builder to produce a `.merged_metadata` file
   which consists of new line separated `.metadata` content produced by DDC.
 
 ## 2.11.0

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.12.0
+
+- Update `build_web_compilers|ddc` builder to produce a `.merged_metadata` file
+  which consists of new line separated `.metadata` content produced by DDC.
+
 ## 2.11.0
 
 - Deprecated support for the `experiments` configuration in favor of the

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -71,6 +71,7 @@ builders:
         - .ddc.js.errors
         - .ddc.js
         - .ddc.js.map
+        - .ddc.js.metadata
     is_optional: True
     auto_apply: all_packages
     required_inputs:
@@ -92,9 +93,11 @@ builders:
         - .dart.js.map
         - .dart.js.tar.gz
         - .digests
+        - .merged_metadata
     required_inputs:
       - .dart
       - .ddc.js
+      - .ddc.metadata
       - .ddc.module
       - .dart2js.module
     build_to: cache

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -97,7 +97,7 @@ builders:
     required_inputs:
       - .dart
       - .ddc.js
-      - .ddc.metadata
+      - .ddc.js.metadata
       - .ddc.module
       - .dart2js.module
     build_to: cache

--- a/build_web_compilers/lib/build_web_compilers.dart
+++ b/build_web_compilers/lib/build_web_compilers.dart
@@ -8,7 +8,8 @@ export 'src/dev_compiler_builder.dart'
         DevCompilerBuilder,
         jsModuleErrorsExtension,
         jsModuleExtension,
-        jsSourceMapExtension;
+        jsSourceMapExtension,
+        metadataExtension;
 export 'src/platforms.dart' show dart2jsPlatform, ddcPlatform;
 export 'src/web_entrypoint_builder.dart'
     show WebCompiler, WebEntrypointBuilder, ddcBootstrapExtension;

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -20,6 +20,7 @@ import 'errors.dart';
 const jsModuleErrorsExtension = '.ddc.js.errors';
 const jsModuleExtension = '.ddc.js';
 const jsSourceMapExtension = '.ddc.js.map';
+const metadataExtension = '.ddc.js.metadata';
 
 /// A builder which can output ddc modules!
 class DevCompilerBuilder implements Builder {
@@ -70,7 +71,8 @@ class DevCompilerBuilder implements Builder {
           moduleExtension(platform): [
             jsModuleExtension,
             jsModuleErrorsExtension,
-            jsSourceMapExtension
+            jsSourceMapExtension,
+            metadataExtension,
           ],
         },
         environment = environment ?? {},
@@ -140,6 +142,7 @@ Future<void> _createDevCompilerModule(
   await buildStep.trackStage(
       'EnsureAssets', () => scratchSpace.ensureAssets(allAssetIds, buildStep));
   var jsId = module.primarySource.changeExtension(jsModuleExtension);
+  var metadataId = module.primarySource.changeExtension(metadataExtension);
   var jsOutputFile = scratchSpace.fileFor(jsId);
   var sdkSummary =
       p.url.join(dartSdk, sdkKernelPath ?? 'lib/_internal/ddc_sdk.dill');
@@ -175,6 +178,7 @@ Future<void> _createDevCompilerModule(
       '--track-widget-creation',
       '--inline-source-map',
       '--libraries-file=${p.toUri(librariesPath)}',
+      '--experimental-emit-debug-metadata',
       if (useIncrementalCompiler) ...[
         '--reuse-compiler-result',
         '--use-incremental-compiler',
@@ -223,6 +227,7 @@ Future<void> _createDevCompilerModule(
 
     // Copy the output back using the buildStep.
     await scratchSpace.copyOutput(jsId, buildStep);
+    await scratchSpace.copyOutput(metadataId, buildStep);
     if (debugMode) {
       // We need to modify the sources in the sourcemap to remove the custom
       // `multiRootScheme` that we use.

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-// ignore: deprecated_member_use
 import 'package:analyzer/analyzer.dart';
 import 'package:build/build.dart';
 import 'package:build_modules/build_modules.dart';
@@ -18,6 +17,7 @@ const jsEntrypointExtension = '.dart.js';
 const jsEntrypointSourceMapExtension = '.dart.js.map';
 const jsEntrypointArchiveExtension = '.dart.js.tar.gz';
 const digestsEntrypointExtension = '.digests';
+const mergedMetadataExtension = '.merged_metadata';
 
 /// Which compiler to use when compiling web entrypoints.
 enum WebCompiler {
@@ -88,6 +88,7 @@ class WebEntrypointBuilder implements Builder {
       jsEntrypointSourceMapExtension,
       jsEntrypointArchiveExtension,
       digestsEntrypointExtension,
+      mergedMetadataExtension,
     ],
   };
 

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/analyzer.dart'; // ignore: deprecated_member_use
 import 'package:build/build.dart';
 import 'package:build_modules/build_modules.dart';
 

--- a/build_web_compilers/mono_pkg.yaml
+++ b/build_web_compilers/mono_pkg.yaml
@@ -7,8 +7,6 @@ stages:
       - dartfmt: sdk
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
-      dart:
-        - 2.8.1
   - unit_test:
     - group:
       - test: --test-randomize-ordering-seed=random

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_web_compilers
-version: 2.11.0
+version: 2.12.0
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: ">=2.8.1 <3.0.0"
+  sdk: ">=2.9.0-10.0.dev <3.0.0"
 
 dependencies:
   analyzer: ">=0.30.0 <0.40.0"

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -3,12 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
-import 'package:build_test/build_test.dart';
-import 'package:test/test.dart';
-
-import 'package:build_web_compilers/builders.dart';
-import 'package:build_web_compilers/build_web_compilers.dart';
 import 'package:build_modules/build_modules.dart';
+import 'package:build_test/build_test.dart';
+import 'package:build_web_compilers/build_web_compilers.dart';
+import 'package:build_web_compilers/builders.dart';
+import 'package:test/test.dart';
 
 import 'util.dart';
 
@@ -40,6 +39,7 @@ void main() {
       var expectedOutputs = {
         'a|web/index.digests': decodedMatches(contains('packages/')),
         'a|web/index.dart.js': decodedMatches(contains('index.dart.bootstrap')),
+        'a|web/index.merged_metadata': isNotEmpty,
         'a|web/index.dart.bootstrap.js': decodedMatches(allOf([
           // Maps non-lib modules to remove the top level dir.
           contains('"web/index": "index.ddc"'),
@@ -86,6 +86,7 @@ void main() {
           contains('if (childName === "b.dart")'),
         ])),
         'a|web/b.digests': isNotEmpty,
+        'a|web/b.merged_metadata': isNotEmpty,
         'a|web/b.dart.js': isNotEmpty,
       };
       await testBuilder(WebEntrypointBuilder(WebCompiler.DartDevc), assets,
@@ -105,6 +106,7 @@ void main() {
           contains('if (childName === "package:a/app.dart")'),
         ])),
         'a|lib/app.digests': isNotEmpty,
+        'a|lib/app.merged_metadata': isNotEmpty,
         'a|lib/app.dart.js': isNotEmpty,
       };
       await testBuilder(WebEntrypointBuilder(WebCompiler.DartDevc), assets,

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -3,13 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
+import 'package:build_modules/build_modules.dart';
 import 'package:build_test/build_test.dart';
-import 'package:logging/logging.dart';
-import 'package:test/test.dart';
-
 import 'package:build_web_compilers/build_web_compilers.dart';
 import 'package:build_web_compilers/builders.dart';
-import 'package:build_modules/build_modules.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
 
 import 'util.dart';
 
@@ -51,11 +50,14 @@ void main() {
         var expectedOutputs = {
           'b|lib/b$jsModuleExtension': decodedMatches(contains('world')),
           'b|lib/b$jsSourceMapExtension': decodedMatches(contains('b.dart')),
+          'b|lib/b$metadataExtension': isNotEmpty,
           'a|lib/a$jsModuleExtension': decodedMatches(contains('hello')),
           'a|lib/a$jsSourceMapExtension': decodedMatches(contains('a.dart')),
+          'a|lib/a$metadataExtension': isNotEmpty,
           'a|web/index$jsModuleExtension': decodedMatches(contains('main')),
           'a|web/index$jsSourceMapExtension':
               decodedMatches(contains('index.dart')),
+          'a|web/index$metadataExtension': isNotEmpty,
         };
         var reportedUnused = <AssetId, Iterable<AssetId>>{};
         await testBuilder(
@@ -83,11 +85,14 @@ void main() {
       var expectedOutputs = {
         'b|lib/b$jsModuleExtension': isNotEmpty,
         'b|lib/b$jsSourceMapExtension': isNotEmpty,
+        'b|lib/b$metadataExtension': isNotEmpty,
         'a|lib/a$jsModuleExtension': isNotEmpty,
         'a|lib/a$jsSourceMapExtension': isNotEmpty,
+        'a|lib/a$metadataExtension': isNotEmpty,
         'a|web/index$jsModuleExtension':
             decodedMatches(contains('print("zap")')),
         'a|web/index$jsSourceMapExtension': isNotEmpty,
+        'a|web/index$metadataExtension': isNotEmpty,
       };
       await testBuilder(
           DevCompilerBuilder(


### PR DESCRIPTION
- Update `build_web_compilers|ddc` builder to produce a `.metadata` file.
- Update `build_web_compilers|entrypoint` builder to produce a `.merged_metadata` file
  which consists of new line separated `.metadata` content produced by DDC.
- Bump the minimum SDK to one in which DDC supports `--experimental-emit-debug-metadata`