### PR TITLE
Change build_web_compilers to dev version

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.12.0
+## 2.12.0-dev.1
 
 - Update `build_web_compilers|ddc` builder to produce a `.metadata` file.
 - Update `build_web_compilers|entrypoint` builder to produce a `.ddc_merged_metadata` file

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.12.0
+version: 2.12.0-dev.1
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 


### PR DESCRIPTION
Since it now depends on a dev SDK we must release it as a dev version.