### PR TITLE
Extend timeout to reduce flakiness

### DIFF
--- a/build_daemon/test/daemon_test.dart
+++ b/build_daemon/test/daemon_test.dart
@@ -88,7 +88,7 @@ void main() {
       var daemonTwo = await _runDaemon(workspace2);
       testDaemons.addAll([daemonOne, daemonTwo]);
       expect(await _statusOf(daemonTwo), 'RUNNING');
-    });
+    }, timeout: Timeout.factor(2));
 
     test('can start two daemons at the same time', () async {
       var workspace = uuid.v1();
@@ -98,7 +98,7 @@ void main() {
       expect([await _statusOf(daemonOne), await _statusOf(daemonTwo)],
           containsAll(['RUNNING', 'ALREADY RUNNING']));
       testDaemons.addAll([daemonOne, daemonTwo]);
-    });
+    }, timeout: Timeout.factor(2));
 
     test('logs the version when running', () async {
       var workspace = uuid.v1();

--- a/build_runner/lib/src/entrypoint/daemon.dart
+++ b/build_runner/lib/src/entrypoint/daemon.dart
@@ -119,6 +119,5 @@ $logEndMarker'''));
       // fast exit.
       exit(0);
     }
-    return 0;
   }
 }


### PR DESCRIPTION
These two tests were running close to the default timeout. Extend to prevent flakes.

Fix analysis error with dead code at head.