### PR TITLE
Unpins the analyzer and sets the min sdk constraint to 2.10 dev

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.2
+
+Unpin analyzer and set the min sdk to 2.10 to resolve the subsequent issue
+https://github.com/dart-lang/sdk/issues/42887.
+
 ## 1.10.1
 
 Pin `analyzer` to `0.39.14` to work around Issue #2763.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,14 +1,14 @@
 name: build_runner
-version: 1.10.1
+version: 1.10.2
 description: A build system for Dart code generation and modular compilation.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  # The min sdk can be reduced once analyzer releases a fix for
+  # https://github.com/dart-lang/build/issues/2763
+  sdk: ">=2.10.0-0.0 <3.0.0"
 
 dependencies:
-  # Temporary workaround for https://github.com/dart-lang/build/issues/2763
-  analyzer: "0.39.14"
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
   build: ">=1.3.0 <1.4.0"
@@ -53,7 +53,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build_resolvers:
-    path: ../build_resolvers


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/42887