### PR TITLE
Remove the export of constants from _test_common

### DIFF
--- a/_test_common/lib/common.dart
+++ b/_test_common/lib/common.dart
@@ -8,7 +8,6 @@ import 'dart:convert';
 import 'package:build/build.dart';
 import 'package:crypto/crypto.dart';
 
-export 'package:build_runner_core/src/util/constants.dart';
 export 'package:build_test/build_test.dart'
     hide InMemoryAssetReader, InMemoryAssetWriter;
 

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -15,6 +15,7 @@ import 'package:build_daemon/data/build_status.dart';
 import 'package:build_daemon/data/build_target.dart';
 import 'package:build_daemon/data/shutdown_notification.dart';
 import 'package:build_runner/src/daemon/constants.dart';
+import 'package:build_runner_core/src/util/constants.dart' show pubBinary;
 import 'package:path/path.dart' as p;
 import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -12,6 +12,7 @@ import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/util/constants.dart';
 import 'package:build_test/build_test.dart';
 import 'package:glob/glob.dart';
 import 'package:pedantic/pedantic.dart';


### PR DESCRIPTION
This export is overly broad and masks the places where a test _should_
be getting an import from the public library instead of `src/`. This
makes it more clear which tests are using the internal details.

If this had been the pattern before the issue in #2772 _may_ have been
more obvious. Its a better pattern to avoid this in either case.