### PR TITLE
Throw when resolving files with syntax errors

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0
+
+The resolver will now throw an `SyntaxErrorInAssetException` when attempting to
+resolve an asset with syntax errors. You can opt-out of this new behavior by
+passing `allowSyntaxErrors: true` to `libraryFor`.
+
 ## 1.3.0
 
 Added a new experiments library which exposes a list of language experiments

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -110,8 +110,8 @@ class SyntaxErrorInAssetException implements Exception {
   /// The errors reported by the parser when trying to resolve the [assetId].
   ///
   /// This only contains syntax errors since most semantic errors are expected
-  /// during a builder (e.g. due to missing part files that are yet to be
-  /// generated).
+  /// during a build (e.g. due to missing part files that haven't been generated
+  /// yet).
   Iterable<AnalysisError> get syntaxErrors {
     return filesWithErrors
         .expand((result) => result.errors)

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -24,6 +24,16 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   /// Resolved library defined by [inputId].
   ///
   /// Throws [NonLibraryAssetException] if [inputId] is not a Dart library file.
+  /// Throws [SyntaxErrorInAssetException] if [inputId] contains syntax errors.
+  /// If you want to support libraries with syntax errors, resolve the library
+  /// manually instead of using [inputLibrary]:
+  /// ```dart
+  /// Future<void> build(BuildStep step) async {
+  ///   // Resolve the input library, allowing syntax errors
+  ///   final inputLibrary =
+  ///     await step.resolver.libraryFor(step.inputId, allowSyntaxErrors: true);
+  /// }
+  /// ```
   Future<LibraryElement> get inputLibrary;
 
   /// Gets an instance provided by [resource] which is guaranteed to be unique

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -200,8 +200,11 @@ class _DelayedResolver implements Resolver {
   }
 
   @override
-  Future<LibraryElement> libraryFor(AssetId assetId) async =>
-      (await _delegate).libraryFor(assetId);
+  Future<LibraryElement> libraryFor(AssetId assetId,
+      {bool allowSyntaxErrors = false}) async {
+    return (await _delegate)
+        .libraryFor(assetId, allowSyntaxErrors: allowSyntaxErrors);
+  }
 
   @override
   Future<LibraryElement> findLibraryByName(String libraryName) async =>

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.4.0-dev
+version: 1.4.0
 description: A build system for Dart.
 homepage: https://github.com/dart-lang/build/tree/master/build
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -23,3 +23,11 @@ dev_dependencies:
   build_vm_compilers: ">=0.1.0 <2.0.0"
   pedantic: ^1.0.0
   test: ^1.2.0
+
+dependency_overrides:
+  build_resolvers:
+    path: ../build_resolvers
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.3.0
+version: 1.4.0-dev
 description: A build system for Dart.
 homepage: https://github.com/dart-lang/build/tree/master/build
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.12
+
+- Support versions `1.4.x` of the `build` package.
+
 ## 1.3.11
 
 - Use the public `buildSdkSummary` api from the analyzer instead of the 

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -156,7 +156,7 @@ class AnalyzerResolver implements ReleasableResolver {
 
   /// Finds syntax errors in files related to the [element].
   ///
-  /// This includes the main library files and existing part files.
+  /// This includes the main library and existing part files.
   Future<List<ErrorsResult>> _syntacticErrorsFor(LibraryElement element) async {
     final existingElements = [
       element,

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.3.12-dev
+version: 1.3.12
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   analyzer: ^0.39.13
-  build: ">=1.4.0-dev <1.5.0"
+  build: ">=1.4.0 <1.5.0"
   crypto: ^2.0.0
   graphs: ^0.2.0
   logging: ^0.11.2

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.3.11
+version: 1.3.12-dev
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   analyzer: ^0.39.13
-  build: ">=1.3.0 <1.4.0"
+  build: ">=1.4.0-dev <1.5.0"
   crypto: ^2.0.0
   graphs: ^0.2.0
   logging: ^0.11.2
@@ -22,3 +22,7 @@ dev_dependencies:
   build_runner: ^1.0.0
   build_vm_compilers: ">=0.1.0 <2.0.0"
   build_modules: any
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -411,6 +411,31 @@ int? get x => 1;
         });
       });
 
+      test('are reported for part files with errors', () {
+        return resolveSources({
+          'a|lib.dart': '''
+            library a_library;
+            part 'errors.dart';
+            part 'does_not_exist.dart';
+          ''',
+          'a|errors.dart': '''
+             part of 'lib.dart';
+
+             void withSyntaxErrors() {
+               String x = ;
+             }
+          ''',
+        }, (resolver) {
+          return expectLater(
+            resolver.libraryFor(AssetId.parse('a|lib.dart')),
+            throwsA(
+              isA<SyntaxErrorInAssetException>()
+                  .having((e) => e.syntaxErrors, 'syntaxErrors', hasLength(1)),
+            ),
+          );
+        });
+      });
+
       test('are not reported when disabled', () {
         return resolveSources({
           'a|errors.dart': '''


### PR DESCRIPTION
I added a new `SyntaxErrorInAssetException` that will be thrown when attempting to use `libraryFor` on an asset id that contains syntax errors. The `allowSyntaxErrors` flag can be used to opt-out of this new behavior. This fixes #2624.

One potential UX issue that came to mind is how this behaves when using numerous builders that resolve everything (not uncommon with `source_gen`). In those cases, we'd print the same error many times if some file contains syntax errors. Maybe the `source_gen` package could keep track of files with syntax errors to avoid duplicate logs then. 