### PR TITLE
Make build_web_compilers output full kernel in debug mode

### DIFF
--- a/build_web_compilers/lib/build_web_compilers.dart
+++ b/build_web_compilers/lib/build_web_compilers.dart
@@ -9,7 +9,8 @@ export 'src/dev_compiler_builder.dart'
         jsModuleErrorsExtension,
         jsModuleExtension,
         jsSourceMapExtension,
-        metadataExtension;
+        metadataExtension,
+        fullKernelExtension;
 export 'src/platforms.dart' show dart2jsPlatform, ddcPlatform;
 export 'src/web_entrypoint_builder.dart'
     show WebCompiler, WebEntrypointBuilder, ddcBootstrapExtension;

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -97,7 +97,7 @@ bool _readUseIncrementalCompilerOption(BuilderOptions options) {
 }
 
 bool _readGenerateFullDillOption(BuilderOptions options) {
-  return options.config[_generateFullDillOption] as bool ?? true;
+  return options.config[_generateFullDillOption] as bool ?? false;
 }
 
 bool _readTrackInputsCompilerOption(BuilderOptions options) {

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -28,6 +28,7 @@ Builder ddcBuilder(BuilderOptions options) {
 
   return DevCompilerBuilder(
     useIncrementalCompiler: _readUseIncrementalCompilerOption(options),
+    generateFullDill: _readGenerateFullDillOption(options),
     trackUnusedInputs: _readTrackInputsCompilerOption(options),
     platform: ddcPlatform,
     environment: _readEnvironmentOption(options),
@@ -95,6 +96,10 @@ bool _readUseIncrementalCompilerOption(BuilderOptions options) {
   return options.config[_useIncrementalCompilerOption] as bool ?? true;
 }
 
+bool _readGenerateFullDillOption(BuilderOptions options) {
+  return options.config[_generateFullDillOption] as bool ?? true;
+}
+
 bool _readTrackInputsCompilerOption(BuilderOptions options) {
   return options.config[_trackUnusedInputsCompilerOption] as bool ?? true;
 }
@@ -123,6 +128,7 @@ List<String> _readExperimentOption(BuilderOptions options) {
 
 Map<String, dynamic> _previousDdcConfig;
 const _useIncrementalCompilerOption = 'use-incremental-compiler';
+const _generateFullDillOption = 'generate-full-dill';
 const _trackUnusedInputsCompilerOption = 'track-unused-inputs';
 const _environmentOption = 'environment';
 const _experimentOption = 'experiments';
@@ -130,5 +136,6 @@ const _supportedOptions = [
   _environmentOption,
   _experimentOption,
   _useIncrementalCompilerOption,
+  _generateFullDillOption,
   _trackUnusedInputsCompilerOption
 ];

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -181,9 +181,9 @@ Future<void> _createDevCompilerModule(
     ..arguments.addAll([
       '--dart-sdk-summary=$sdkSummary',
       '--modules=amd',
-      // output full dill
       '--no-summarize',
-      '--experimental-output-compiled-kernel',
+      if (generateFullDill)
+        '--experimental-output-compiled-kernel',
       '-o',
       jsOutputFile.path,
       debugMode ? '--source-map' : '--no-source-map',

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -130,6 +130,9 @@ Future<void> _createDevCompilerModule(
     Map<String, String> environment,
     Iterable<String> experiments,
     {bool debugMode = true}) async {
+
+  var currentKernelId = module.primarySource.changeExtension(ddcKernelExtension);
+  await buildStep.canRead(currentKernelId);
   var transitiveDeps = await buildStep.trackStage('CollectTransitiveDeps',
       () => module.computeTransitiveDependencies(buildStep));
   var transitiveKernelDeps = [

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -28,10 +28,10 @@ class DevCompilerBuilder implements Builder {
   final bool useIncrementalCompiler;
 
   /// Make ddc generate full dill for libraries it compiles.
-  /// 
+  ///
   /// Full dill is only generated in debug mode and does not include any
-  /// dependent libraries or SDK dill. 
-  /// 
+  /// dependent libraries or SDK dill.
+  ///
   /// Full dill is used by the expression compilation service run by the
   /// debugger to compile expressions in debugging worklows that use modular
   ///  build, such as webdev and google3.
@@ -309,7 +309,7 @@ String _sourceArg(AssetId id) {
 /// - Strips the scheme from the uri
 /// - Strips the top level directory if its not `packages`
 List<String> fixSourceMapSources(List<String> uris) {
-  return uris.map((String source) {
+  return uris.map((source) {
     var uri = Uri.parse(source);
     // We only want to rewrite multi-root scheme uris.
     if (uri.scheme.isEmpty) return source;
@@ -333,6 +333,7 @@ void _fixMetadataSources(Map<String, dynamic> json, String scratchPath) {
   var sourceMapUri = json['sourceMapUri'] as String;
   var moduleUri = json['moduleUri'] as String;
 
-  json['sourceMapUri'] = Uri.parse(sourceMapUri).path.replaceAll(scratchPath, '');
+  json['sourceMapUri'] =
+      Uri.parse(sourceMapUri).path.replaceAll(scratchPath, '');
   json['moduleUri'] = Uri.parse(moduleUri).path.replaceAll(scratchPath, '');
 }

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -27,14 +27,15 @@ const fullKernelExtension = '.ddc.full.dill';
 class DevCompilerBuilder implements Builder {
   final bool useIncrementalCompiler;
 
-  /// Make ddc generate full dill for libraries it compiles.
+  /// Whether to generate full dill file outputs for each module.
   ///
-  /// Full dill is only generated in debug mode and does not include any
-  /// dependent libraries or SDK dill.
-  ///
+  /// Full dill file is an additional file produced by DDC that stores full
+  /// kernel for code compiled for one module, not including dependencies.
+  /// Note that outlines are still produced and used by DDC as dependency
+  /// summaries, independent of this setting.
   /// Full dill is used by the expression compilation service run by the
   /// debugger to compile expressions in debugging worklows that use modular
-  ///  build, such as webdev and google3.
+  /// build, such as webdev.
   final bool generateFullDill;
 
   final bool trackUnusedInputs;

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -138,7 +138,7 @@ Future<void> _createDevCompilerModule(
     Module module,
     BuildStep buildStep,
     bool useIncrementalCompiler,
-    bool createFullDill,
+    bool generateFullDill,
     bool trackUnusedInputs,
     String dartSdk,
     String sdkKernelPath,
@@ -245,10 +245,10 @@ Future<void> _createDevCompilerModule(
     // Copy the output back using the buildStep.
     await scratchSpace.copyOutput(jsId, buildStep);
 
-    if (createFullDill) {
-        var currentFullKernelId =
-            module.primarySource.changeExtension(fullKernelExtension);
-        await scratchSpace.copyOutput(currentFullKernelId, buildStep);
+    if (generateFullDill) {
+      var currentFullKernelId =
+          module.primarySource.changeExtension(fullKernelExtension);
+      await scratchSpace.copyOutput(currentFullKernelId, buildStep);
     }
 
     if (debugMode) {

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -232,7 +232,7 @@ Future<void> _createDevCompilerModule(
     await scratchSpace.copyOutput(jsId, buildStep);
 
     if (debugMode) {
-      // copy and current full kernel
+      // copy current full kernel
       var currentFullKernelId =
           module.primarySource.changeExtension(fullKernelExtension);
       await scratchSpace.copyOutput(currentFullKernelId, buildStep);
@@ -247,7 +247,7 @@ Future<void> _createDevCompilerModule(
       json['sources'] = fixSourceMapSources((json['sources'] as List).cast());
       await buildStep.writeAsString(sourceMapId, jsonEncode(json));
 
-      // rename temp directories in metadata
+      // remove temp directories from metadata
       var metadataId = module.primarySource.changeExtension(metadataExtension);
       file = scratchSpace.fileFor(metadataId);
       content = await file.readAsString();

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -182,8 +182,7 @@ Future<void> _createDevCompilerModule(
       '--dart-sdk-summary=$sdkSummary',
       '--modules=amd',
       '--no-summarize',
-      if (generateFullDill)
-        '--experimental-output-compiled-kernel',
+      if (generateFullDill) '--experimental-output-compiled-kernel',
       '-o',
       jsOutputFile.path,
       debugMode ? '--source-map' : '--no-source-map',

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -4,7 +4,7 @@ description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: ">=2.9.0-10.0.dev <3.0.0"
+  sdk: ">=2.10.0-93.0.dev <3.0.0"
 
 dependencies:
   analyzer: ">=0.36.4 <0.40.0"

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -100,6 +100,43 @@ void main() {
           assets,
           outputs: expectedOutputs);
     });
+
+    test('generates full dill when enabled', () async {
+      var expectedOutputs = {
+        'b|lib/b$jsModuleExtension': isNotEmpty,
+        'b|lib/b$jsSourceMapExtension': isNotEmpty,
+        'b|lib/b$metadataExtension': isNotEmpty,
+        'b|lib/b$fullKernelExtension': isNotEmpty,
+        'a|lib/a$jsModuleExtension': isNotEmpty,
+        'a|lib/a$jsSourceMapExtension': isNotEmpty,
+        'a|lib/a$metadataExtension': isNotEmpty,
+        'a|lib/a$fullKernelExtension': isNotEmpty,
+        'a|web/index$jsModuleExtension': isNotEmpty,
+        'a|web/index$jsSourceMapExtension': isNotEmpty,
+        'a|web/index$metadataExtension': isNotEmpty,
+        'a|web/index$fullKernelExtension': isNotEmpty,
+      };
+      await testBuilder(
+          DevCompilerBuilder(platform: ddcPlatform, generateFullDill: true),
+          assets,
+          outputs: expectedOutputs);
+    });
+
+    test('does not generate full dill by default', () async {
+      var expectedOutputs = {
+        'b|lib/b$jsModuleExtension': isNotEmpty,
+        'b|lib/b$jsSourceMapExtension': isNotEmpty,
+        'b|lib/b$metadataExtension': isNotEmpty,
+        'a|lib/a$jsModuleExtension': isNotEmpty,
+        'a|lib/a$jsSourceMapExtension': isNotEmpty,
+        'a|lib/a$metadataExtension': isNotEmpty,
+        'a|web/index$jsModuleExtension': isNotEmpty,
+        'a|web/index$jsSourceMapExtension': isNotEmpty,
+        'a|web/index$metadataExtension': isNotEmpty,
+      };
+      await testBuilder(DevCompilerBuilder(platform: ddcPlatform), assets,
+          outputs: expectedOutputs);
+    });
   });
 
   group('projects with errors due to', () {


### PR DESCRIPTION
Make build_web_compilers output full kernel files and fixup metadata paths, in preparation for expression 
evaluation feature in webdev:

- make build_web_compilers output full kernel files in debug mode
  This is preparation work for expression evaluation in webdev.
  depends on the following SDK change:
   https://dart-review.googlesource.com/c/sdk/+/160944

- update paths inside metadata to match buildstep copying them to a final
  location