### PR TITLE
Mention applies_builder in docs for runs_before

### DIFF
--- a/build_config/README.md
+++ b/build_config/README.md
@@ -227,7 +227,10 @@ these options should be used rarely.
   outputs which are intended to be inputs to other Builders they may be
   specified here. This guarantees that the specified Builders will be ordered
   later than this one. This will not cause Builders to be applied if they would
-  not otherwise run, it only affects ordering.
+  not otherwise run, it only affects ordering. If a builder emits files that
+  should always be the input to another specific builder, use both `runs_before`
+  and `applies_builder` to configure both ordering and ensure that steps are not
+  skipped.
 
 # Publishing `build.yaml` files
 


### PR DESCRIPTION
We were careful to document that the configuration doesn't impact
builder application, but failed to highlight the proper configuration to
achieve that goal.