### PR TITLE
prep packages for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,10 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.7.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.7.0"
+      name: "SDK: 2.9.0; PKGS: build, build_config, build_daemon, build_modules, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.9.0"
       os: linux
-      env: PKGS="build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
-      script: ./tool/travis.sh dartanalyzer_1
-    - stage: analyze_and_format
-      name: "SDK: 2.8.1; PKG: build_modules; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.8.1"
-      os: linux
-      env: PKGS="build_modules"
+      env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: dev; PKG: build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
@@ -121,14 +115,14 @@ jobs:
       env: PKGS="build_runner"
       script: ./tool/travis.sh test_06
     - stage: unit_test
-      name: "SDK: 2.7.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
-      dart: "2.7.0"
+      name: "SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+      dart: "2.9.0"
       os: linux
       env: PKGS="build_runner_core"
       script: ./tool/travis.sh test_12
     - stage: unit_test
-      name: "SDK: 2.7.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
-      dart: "2.7.0"
+      name: "SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+      dart: "2.9.0"
       os: windows
       env: PKGS="build_runner_core"
       script: ./tool/travis.sh test_12

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+Allow the latest analyzer version `0.40.x`.
+
 ## 1.4.0
 
 The resolver will now throw an `SyntaxErrorInAssetException` when attempting to

--- a/build/mono_pkg.yaml
+++ b/build/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.7.0
+        - 2.9.0
   - unit_test:
     - command: pub run build_runner test -- --test-randomize-ordering-seed=random
       os:

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -33,3 +33,5 @@ dependency_overrides:
     path: ../build_runner_core
   build_vm_compilers:
     path: ../build_vm_compilers
+  build_modules:
+    path: ../build_modules

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.4.0
+version: 1.4.1
 description: A build system for Dart.
 homepage: https://github.com/dart-lang/build/tree/master/build
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=0.35.0 <0.40.0'
+  analyzer: '>=0.35.0 <0.41.0'
   async: ">=1.13.3 <3.0.0"
   convert: ^2.0.0
   crypto: ">=0.9.2 <3.0.0"

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -4,7 +4,7 @@ description: A build system for Dart.
 homepage: https://github.com/dart-lang/build/tree/master/build
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.9.0 <3.0.0"
 
 dependencies:
   analyzer: '>=0.35.0 <0.41.0'

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -31,3 +31,5 @@ dependency_overrides:
     path: ../build_runner
   build_runner_core:
     path: ../build_runner_core
+  build_vm_compilers:
+    path: ../build_vm_compilers

--- a/build_config/mono_pkg.yaml
+++ b/build_config/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.7.0
+        - 2.9.0
   - unit_test:
     - command: pub run test --test-randomize-ordering-seed=random
       os:

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -4,7 +4,7 @@ description: Support for parsing `build.yaml` configuration.
 homepage: https://github.com/dart-lang/build/tree/master/build_config
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.9.0 <3.0.0'
 
 dependencies:
   checked_yaml: ^1.0.0

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -26,3 +26,8 @@ dependency_overrides:
     path: ../build_runner
   build_runner_core:
     path: ../build_runner_core
+  build_resolvers:
+    path: ../build_resolvers
+  build:
+    path: ../build
+  analyzer: ^0.40.0

--- a/build_daemon/mono_pkg.yaml
+++ b/build_daemon/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.7.0
+        - 2.9.0
   - unit_test:
     - command: pub run test --test-randomize-ordering-seed=random
       os:

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -4,7 +4,7 @@ description: A daemon for running Dart builds.
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.9.0 <3.0.0"
 
 dependencies:
   built_collection: ^4.1.0

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.10.2-dev
+## 2.10.2
 
 - Stop using deprecated analyzer apis.
+- Allow the latest analyzer version `0.40.x`.
 
 ## 2.10.1
 

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.8.1
+        - 2.9.0
   - unit_test:
     # Run the script directly - running from snapshot has issues for packages
     # that are depended on by the generated build script.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.10.2-dev
+version: 2.10.2
 description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.8.1 <3.0.0"
 
 dependencies:
-  analyzer: ">0.36.4 <0.40.0"
+  analyzer: ">0.36.4 <0.41.0"
   async: ^2.0.0
   bazel_worker: ^0.1.20
   build: ">=1.3.0 <2.0.0"

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -4,7 +4,7 @@ description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: ">=2.8.1 <3.0.0"
+  sdk: ">=2.9.0 <3.0.0"
 
 dependencies:
   analyzer: ">0.36.4 <0.41.0"

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -399,9 +399,11 @@ final _dartUiPath =
 FeatureSet _featureSet({List<String> enableExperiments}) {
   enableExperiments ??= [];
   if (enableExperiments.isEmpty) {
-    return FeatureSet.fromEnableFlags([]).restrictToVersion(sdkLanguageVersion);
+    return FeatureSet.fromEnableFlags2(
+        sdkLanguageVersion: sdkLanguageVersion, flags: []);
   } else if (sdkLanguageVersion == ExperimentStatus.currentVersion) {
-    return FeatureSet.fromEnableFlags(enableExperiments);
+    return FeatureSet.fromEnableFlags2(
+        sdkLanguageVersion: sdkLanguageVersion, flags: enableExperiments);
   } else {
     throw StateError('''
 Attempting to enable experiments `$enableExperiments`, but the current SDK

--- a/build_resolvers/mono_pkg.yaml
+++ b/build_resolvers/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.7.0
+        - 2.9.0
   - unit_test:
     - group:
       - command: pub run build_runner test -- --test-randomize-ordering-seed=random

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -4,7 +4,7 @@ description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.9.0 <3.0.0"
 
 dependencies:
   analyzer: ^0.40.1

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -24,5 +24,11 @@ dev_dependencies:
   build_modules: any
 
 dependency_overrides:
+  build:
+    path: ../build
   build_runner:
     path: ../build_runner
+  build_vm_compilers:
+    path: ../build_vm_compilers
+  build_modules:
+    path: ../build_modules

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  analyzer: ^0.39.13
+  analyzer: ^0.40.1
   build: ">=1.4.0 <1.5.0"
   crypto: ^2.0.0
   graphs: ^0.2.0
@@ -24,5 +24,5 @@ dev_dependencies:
   build_modules: any
 
 dependency_overrides:
-  build:
-    path: ../build
+  build_runner:
+    path: ../build_runner

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -32,3 +32,5 @@ dependency_overrides:
     path: ../build_vm_compilers
   build_modules:
     path: ../build_modules
+  build_test:
+    path: ../build_test

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -231,7 +231,8 @@ void main() {
         var clazz = lib.getType('A');
         expect(clazz, isNotNull);
         expect(clazz.interfaces, hasLength(1));
-        expect(clazz.interfaces.first.getDisplayString(), 'B');
+        expect(clazz.interfaces.first.getDisplayString(withNullability: false),
+            'B');
       }, resolvers: resolvers);
     });
 
@@ -293,7 +294,7 @@ void main() {
       }, resolvers: AnalyzerResolvers());
     });
 
-    test('does not resolve constants transitively', () {
+    test('resolves constants transitively', () {
       return resolveSources({
         'a|web/main.dart': '''
               library web.main;
@@ -313,7 +314,7 @@ void main() {
         var main = await resolver.findLibraryByName('web.main');
         var meta = main.getType('Foo').supertype.element.metadata[0];
         expect(meta, isNotNull);
-        expect(meta.constantValue, isNull);
+        expect(meta.computeConstantValue(), isNull);
       }, resolvers: AnalyzerResolvers());
     });
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.10.3
+
+- Remove high sdk constraint, allow >=2.9.0.
+- Require latest build_resolvers (which requires the latest analyzer).
+- Require the latest build version (1.4.x).
+
 ## 1.10.2
 
 Unpin analyzer and set the min sdk to 2.10 to resolve the subsequent issue

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,20 +1,20 @@
 name: build_runner
-version: 1.10.2
+version: 1.10.3
 description: A build system for Dart code generation and modular compilation.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 
 environment:
   # The min sdk can be reduced once analyzer releases a fix for
   # https://github.com/dart-lang/build/issues/2763
-  sdk: ">=2.10.0-0.0 <3.0.0"
+  sdk: ">=2.9.0 <3.0.0"
 
 dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.3.0 <1.4.0"
+  build: ">=1.4.0 <1.5.0"
   build_config: ">=0.4.1 <0.4.3"
   build_daemon: ^2.1.0
-  build_resolvers: ^1.3.8
+  build_resolvers: ^1.3.12
   build_runner_core: ">=5.2.0 <7.0.0"
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
@@ -53,3 +53,13 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_resolvers:
+    path: ../build_resolvers
+  build_web_compilers:
+    path: ../build_web_compilers
+  build_modules:
+    path: ../build_modules

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.2
+
+- Require the latest build version (1.4.x).
+
 ## 6.0.1
 
 - Add back the `overrideGeneratedOutputDirectory` method.

--- a/build_runner_core/mono_pkg.yaml
+++ b/build_runner_core/mono_pkg.yaml
@@ -1,5 +1,5 @@
 dart:
-  - 2.7.0
+  - 2.9.0
   - dev
 
 stages:
@@ -9,7 +9,7 @@ stages:
       - dartanalyzer: --fatal-infos --fatal-warnings .
       dart: dev
     - dartanalyzer: --fatal-warnings .
-      dart: 2.7.0
+      dart: 2.9.0
   - unit_test:
     - test: --test-randomize-ordering-seed=random
       os:

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -4,7 +4,7 @@ description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.9.0 <3.0.0"
 
 dependencies:
   async: ">=1.13.3 <3.0.0"

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 6.0.1
+version: 6.0.2
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.3.0 <1.4.0"
+  build: ">=1.4.0 <1.5.0"
   build_config: ">=0.4.2 <0.4.3"
   build_resolvers: ^1.3.8
   collection: ^1.14.0
@@ -35,3 +35,7 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_test/mono_pkg.yaml
+++ b/build_test/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.7.0
+        - 2.9.0
   - unit_test:
     - command: pub run build_runner test -- --test-randomize-ordering-seed=random
       os:

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.2.1
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.9.0 <3.0.0"
 
 dependencies:
   async: ">=1.2.0 <3.0.0"

--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 1.0.5-dev
+## 1.0.5
 
 - Increase min sdk constraint to `>=2.7.0`.
 - Migrate off of deprecated analyzer apis.
+- Allow the latest analyzer `0.40.x`.
 
 ## 1.0.4
 

--- a/build_vm_compilers/mono_pkg.yaml
+++ b/build_vm_compilers/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.7.0
+        - 2.9.0
   - unit_test:
     - test:
       os:

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -4,7 +4,7 @@ description: Builder implementations wrapping Dart VM compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.9.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.36.4 <0.41.0"

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_vm_compilers
-version: 1.0.5-dev
+version: 1.0.5
 description: Builder implementations wrapping Dart VM compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=0.36.4 <0.40.0"
+  analyzer: ">=0.36.4 <0.41.0"
   build: ^1.0.0
   build_config: ">=0.3.0 <0.5.0"
   build_modules: ^2.0.0

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 2.12.0-dev.1
+## 2.12.0
 
 - Update `build_web_compilers|ddc` builder to produce a `.metadata` file.
 - Update `build_web_compilers|entrypoint` builder to produce a `.ddc_merged_metadata` file
   which consists of new line separated `.metadata` content produced by DDC.
 - Migrate off of deprecated analyzer apis.
+- Allow the latest analyzer version `0.40.x`.
 
 ## 2.11.0
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.12.0-dev.1
+version: 2.12.0
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.10.0-93.0.dev <3.0.0"
 
 dependencies:
-  analyzer: ">=0.36.4 <0.40.0"
+  analyzer: ">=0.36.4 <0.41.0"
   archive: ^2.0.0
   bazel_worker: ^0.1.18
   build: ">=1.3.0 <2.0.0"

--- a/scratch_space/mono_pkg.yaml
+++ b/scratch_space/mono_pkg.yaml
@@ -8,7 +8,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
     - dartanalyzer: --fatal-warnings .
       dart:
-        - 2.7.0
+        - 2.9.0
   - unit_test:
     - command: pub run build_runner test -- --test-randomize-ordering-seed=random
       os:

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -4,7 +4,7 @@ description: A tool to manage running external executables within package:build
 homepage: https://github.com/dart-lang/build/tree/master/scratch_space
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.9.0 <3.0.0"
 
 dependencies:
   build: ">=0.10.0 <2.0.0"


### PR DESCRIPTION
We need to update all packages to allow the latest `build` release, and I also updated them to the latest `analyzer` so that we can get the sdk/experiment version fixes and lower the sdk constraint in build_runner.

Note that this does mean I will need to publish a new build version (1.4.1) which I created here, and effectively `1.4.0` will be a dead version.