### PR TITLE
udpate build_resolvers version back to dev since it can't be published right now

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.12
+## 1.3.12-dev
 
 - Support versions `1.4.x` of the `build` package.
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.3.12
+version: 1.3.12-dev
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 


### PR DESCRIPTION
See https://github.com/dart-lang/build/pull/2806 where I was trying to work things out.

We are in a super bad state right now and I don't have the time to try and resolve it. Given that there is no rush we can circle back to this when 2.10 stable releases.