### PR TITLE
Updated changelog with --generate-full-dill option

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -5,7 +5,7 @@
   which consists of new line separated `.metadata` content produced by DDC.
 - Migrate off of deprecated analyzer apis.
 - Update `build_web_compilers|ddc` builder to produce a `.full.dill` file
-  with `--generate-full-dill` flag
+  with `--generate-full-dill` flag.
 
 ## 2.11.0
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Update `build_web_compilers|entrypoint` builder to produce a `.ddc_merged_metadata` file
   which consists of new line separated `.metadata` content produced by DDC.
 - Migrate off of deprecated analyzer apis.
+- Update `build_web_compilers|ddc` builder to produce a `.full.dill` file
+  with `--generate-full-dill` flag
 
 ## 2.11.0
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,11 +1,21 @@
 ## 2.12.0-dev.1
 
 - Update `build_web_compilers|ddc` builder to produce a `.metadata` file.
-- Update `build_web_compilers|entrypoint` builder to produce a `.ddc_merged_metadata` file
-  which consists of new line separated `.metadata` content produced by DDC.
+- Update `build_web_compilers|entrypoint` builder to produce a
+  `.ddc_merged_metadata` file which consists of new line separated
+  `.metadata` content produced by DDC.
 - Migrate off of deprecated analyzer apis.
-- Update `build_web_compilers|ddc` builder to produce a `.full.dill` file
-  with `--generate-full-dill` flag.
+- Add the `generate-full-dill` option for the `build_web_compilers:ddc`
+  builder. The full dill output is used by expression evaluation service
+  in webdev for expression evaluation feature. This setting is disabled by
+  default but can be enabled by setting it to `true` globally:
+
+```yaml
+global_options:
+  build_web_compilers:ddc:
+    options:
+      generate-full-dill: false
+```
 
 ## 2.11.0
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -14,7 +14,7 @@
 global_options:
   build_web_compilers:ddc:
     options:
-      generate-full-dill: false
+      generate-full-dill: true
 ```
 
 ## 2.11.0


### PR DESCRIPTION
Updated changelog to include the new information about --generate-full-dill option and 'full.dill' files it generates.