### PR TITLE
Add compilationUnitFor api to Resolver

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.5.0-dev
+
+Added the `Future<CompilationUnit> compilationUnitFor(AssetId id)` api to the
+`Resolver` class, which returns only the parsed AST for the given asset.
+- Much cheaper than `libraryFor`, because it only reads the given asset instead
+  of touching all transitive deps.
+- Still may be suitable for some builders which don't need the fully resolved
+  `Element` model.
+
 ## 1.4.0
 
 The resolver will now throw an `SyntaxErrorInAssetException` when attempting to

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/error/error.dart';
 
@@ -23,6 +24,16 @@ abstract class Resolver {
   ///
   /// **NOTE**: This includes all Dart SDK libraries as well.
   Stream<LibraryElement> get libraries;
+
+  /// Returns a parsed AST structor representing the file defined in [assetId].
+  ///
+  /// * If the [assetId] has syntax errors, and [allowSyntaxErrors] is set to
+  ///   `false` (the default), throws a [SyntaxErrorInAssetException].
+  ///
+  /// This is a much cheaper api compared to [libraryFor], because it will only
+  /// parse a single file and does not give you a resolved element model.
+  Future<CompilationUnit> compilationUnitFor(AssetId assetId,
+      {bool allowSyntaxErrors = false});
 
   /// Returns a resolved library representing the file defined in [assetId].
   ///
@@ -102,7 +113,7 @@ class SyntaxErrorInAssetException implements Exception {
   ///
   /// In addition to the asset itself, the resolver also considers syntax errors
   /// in part files.
-  final List<ErrorsResult> filesWithErrors;
+  final List<AnalysisResultWithErrors> filesWithErrors;
 
   SyntaxErrorInAssetException(this.assetId, this.filesWithErrors)
       : assert(filesWithErrors.isNotEmpty);
@@ -119,7 +130,7 @@ class SyntaxErrorInAssetException implements Exception {
   }
 
   /// A map from [syntaxErrors] to per-file results
-  Map<AnalysisError, ErrorsResult> get errorToResult {
+  Map<AnalysisError, AnalysisResultWithErrors> get errorToResult {
     return {
       for (final file in filesWithErrors)
         for (final error in file.errors)

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:async/async.dart';
 import 'package:build/src/builder/build_step.dart';
@@ -200,11 +201,16 @@ class _DelayedResolver implements Resolver {
   }
 
   @override
+  Future<CompilationUnit> compilationUnitFor(AssetId assetId,
+          {bool allowSyntaxErrors = false}) async =>
+      (await _delegate)
+          .compilationUnitFor(assetId, allowSyntaxErrors: allowSyntaxErrors);
+
+  @override
   Future<LibraryElement> libraryFor(AssetId assetId,
-      {bool allowSyntaxErrors = false}) async {
-    return (await _delegate)
-        .libraryFor(assetId, allowSyntaxErrors: allowSyntaxErrors);
-  }
+          {bool allowSyntaxErrors = false}) async =>
+      (await _delegate)
+          .libraryFor(assetId, allowSyntaxErrors: allowSyntaxErrors);
 
   @override
   Future<LibraryElement> findLibraryByName(String libraryName) async =>

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.4.0
+version: 1.5.0-dev
 description: A build system for Dart.
 homepage: https://github.com/dart-lang/build/tree/master/build
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.3.12-dev
+## 1.4.0-dev
 
-- Support versions `1.4.x` of the `build` package.
+- Support versions `1.5.x` of the `build` package.
+  - Implements the `compilationUnitFor` method on `Resolver`.
 
 ## 1.3.11
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   logging: ^0.11.2
   path: ^1.1.0
   package_config: ^1.9.3
+  pool: ^1.4.0
   pub_semver: ^1.3.0
 
 dev_dependencies:

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -404,9 +404,13 @@ int? get x => 1;
                String x = ;
              }
           ''',
-        }, (resolver) {
-          return expectLater(
+        }, (resolver) async {
+          await expectLater(
             resolver.libraryFor(AssetId.parse('a|errors.dart')),
+            throwsA(isA<SyntaxErrorInAssetException>()),
+          );
+          await expectLater(
+            resolver.compilationUnitFor(AssetId.parse('a|errors.dart')),
             throwsA(isA<SyntaxErrorInAssetException>()),
           );
         });
@@ -426,9 +430,16 @@ int? get x => 1;
                String x = ;
              }
           ''',
-        }, (resolver) {
-          return expectLater(
+        }, (resolver) async {
+          await expectLater(
             resolver.libraryFor(AssetId.parse('a|lib.dart')),
+            throwsA(
+              isA<SyntaxErrorInAssetException>()
+                  .having((e) => e.syntaxErrors, 'syntaxErrors', hasLength(1)),
+            ),
+          );
+          await expectLater(
+            resolver.compilationUnitFor(AssetId.parse('a|errors.dart')),
             throwsA(
               isA<SyntaxErrorInAssetException>()
                   .having((e) => e.syntaxErrors, 'syntaxErrors', hasLength(1)),
@@ -446,9 +457,14 @@ int? get x => 1;
                String x = ;
              }
           ''',
-        }, (resolver) {
-          return expectLater(
+        }, (resolver) async {
+          await expectLater(
             resolver.libraryFor(AssetId.parse('a|errors.dart'),
+                allowSyntaxErrors: true),
+            completion(isNotNull),
+          );
+          await expectLater(
+            resolver.compilationUnitFor(AssetId.parse('a|errors.dart'),
                 allowSyntaxErrors: true),
             completion(isNotNull),
           );
@@ -468,16 +484,21 @@ int? get x => 1;
                String x = ;
              }
           ''',
-        }, (resolver) {
-          return expectLater(
-            resolver.libraryFor(AssetId.parse('a|errors.dart')),
-            throwsA(
-              isA<SyntaxErrorInAssetException>().having(
-                (e) => e.toString(),
-                'toString()',
-                contains(RegExp(r'And \d more')),
-              ),
+        }, (resolver) async {
+          var expectation = throwsA(
+            isA<SyntaxErrorInAssetException>().having(
+              (e) => e.toString(),
+              'toString()',
+              contains(RegExp(r'And \d more')),
             ),
+          );
+          await expectLater(
+            resolver.libraryFor(AssetId.parse('a|errors.dart')),
+            expectation,
+          );
+          await expectLater(
+            resolver.compilationUnitFor(AssetId.parse('a|errors.dart')),
+            expectation,
           );
         });
       });
@@ -492,9 +513,13 @@ int? get x => 1;
                String x = null;
              }
           ''',
-        }, (resolver) {
-          return expectLater(
+        }, (resolver) async {
+          await expectLater(
             resolver.libraryFor(AssetId.parse('a|errors.dart')),
+            completion(isNotNull),
+          );
+          await expectLater(
+            resolver.compilationUnitFor(AssetId.parse('a|errors.dart')),
             completion(isNotNull),
           );
         });

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:isolate';
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:build/build.dart';
 import 'package:build/experiments.dart';
 import 'package:build_test/build_test.dart';
@@ -152,7 +153,7 @@ void main() {
           'a|lib/other.dart': '''
           library other;
         '''
-        }, test);
+        }, test, resolvers: AnalyzerResolvers());
       }
 
       test('can be resolved', () {
@@ -601,5 +602,21 @@ int? get x => 1;
         }));
     var resolvers = AnalyzerResolvers();
     await runBuilder(builder, [input], reader, writer, resolvers);
+  });
+
+  group('compilationUnitFor', () {
+    test('can parse a given input', () {
+      return resolveSources({
+        'a|web/main.dart': ' main() {}',
+      }, (resolver) async {
+        var unit = await resolver.compilationUnitFor(entryPoint);
+        expect(unit, isNotNull);
+        expect(unit.declarations.length, 1);
+        expect(
+            unit.declarations.first,
+            isA<FunctionDeclaration>()
+                .having((d) => d.name.name, 'main', 'main'));
+      }, resolvers: AnalyzerResolvers());
+    });
   });
 }


### PR DESCRIPTION
- This is a cheap api which does not resolve transitive sources, and only gives you a parsed AST for a single asset
- Updates the `SyntaxErrorInAsset` class to contain a list of `AnalysisResultWithErrors` instead of `ErrorResult`, which is the common base class for errors throws during parsing and resolving (it also has the exact same api surface).
- Also stops the eager resolving of `buildStep.inputId` when creating a `Resolver`, to ensure you can use this api cheaply.
- Also as a side-effect of this the `isLibrary` call is now faster - it does not resolve transitive sources either which it used to.