### PR TITLE
Fix scratch paths in metadata

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.12.0-dev.3
+
+- Fix stripping scratch paths in metadata.
+
 ## 2.12.0-dev.2
 
 - Add the `generate-full-dill` option for the `build_web_compilers:ddc`

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -269,7 +269,7 @@ Future<void> _createDevCompilerModule(
       content = await file.readAsString();
       json = jsonDecode(content);
       _fixMetadataSources(
-          json as Map<String, dynamic>, '${scratchSpace.tempDir.path}/');
+          json as Map<String, dynamic>, scratchSpace.tempDir.uri);
       await buildStep.writeAsString(metadataId, jsonEncode(json));
     }
 
@@ -329,11 +329,13 @@ String ddcModuleName(AssetId jsId) {
   return jsPath.substring(0, jsPath.length - jsModuleExtension.length);
 }
 
-void _fixMetadataSources(Map<String, dynamic> json, String scratchPath) {
+void _fixMetadataSources(Map<String, dynamic> json, Uri scratchUri) {
   var sourceMapUri = json['sourceMapUri'] as String;
   var moduleUri = json['moduleUri'] as String;
 
-  json['sourceMapUri'] =
-      Uri.parse(sourceMapUri).path.replaceAll(scratchPath, '');
-  json['moduleUri'] = Uri.parse(moduleUri).path.replaceAll(scratchPath, '');
+  json['sourceMapUri'] = Uri.parse(sourceMapUri)
+      .toFilePath()
+      .replaceAll(scratchUri.toFilePath(), '');
+  json['moduleUri'] =
+      Uri.parse(moduleUri).toFilePath().replaceAll(scratchUri.toFilePath(), '');
 }

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -330,12 +330,27 @@ String ddcModuleName(AssetId jsId) {
 }
 
 void _fixMetadataSources(Map<String, dynamic> json, Uri scratchUri) {
-  var sourceMapUri = json['sourceMapUri'] as String;
-  var moduleUri = json['moduleUri'] as String;
+  String updatePath(String path) =>
+      Uri.parse(path).path.replaceAll(scratchUri.path, '');
 
-  json['sourceMapUri'] = Uri.parse(sourceMapUri)
-      .toFilePath()
-      .replaceAll(scratchUri.toFilePath(), '');
-  json['moduleUri'] =
-      Uri.parse(moduleUri).toFilePath().replaceAll(scratchUri.toFilePath(), '');
+  var sourceMapUri = json['sourceMapUri'] as String;
+  if (sourceMapUri != null) {
+    json['sourceMapUri'] = updatePath(sourceMapUri);
+  }
+
+  var moduleUri = json['moduleUri'] as String;
+  if (moduleUri != null) {
+    json['moduleUri'] = updatePath(moduleUri);
+  }
+
+  var libraries = json['libraries'] as List<dynamic>;
+  if (libraries != null) {
+    for (var lib in libraries) {
+      var libraryJson = lib as Map<String, dynamic>;
+      var fileUri = libraryJson['fileUri'] as String;
+      if (fileUri != null) {
+        libraryJson['fileUri'] = updatePath(fileUri);
+      }
+    }
+  }
 }

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.12.0-dev.2
+version: 2.12.0-dev.3
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -137,6 +137,23 @@ void main() {
       await testBuilder(DevCompilerBuilder(platform: ddcPlatform), assets,
           outputs: expectedOutputs);
     });
+
+    test('strips scratch paths from metadata', () async {
+      var expectedOutputs = {
+        'b|lib/b$jsModuleExtension': isNotEmpty,
+        'b|lib/b$jsSourceMapExtension': isNotEmpty,
+        'b|lib/b$metadataExtension': decodedMatches(isNot(contains('scratch'))),
+        'a|lib/a$jsModuleExtension': isNotEmpty,
+        'a|lib/a$jsSourceMapExtension': isNotEmpty,
+        'a|lib/a$metadataExtension': decodedMatches(isNot(contains('scratch'))),
+        'a|web/index$jsModuleExtension': isNotEmpty,
+        'a|web/index$jsSourceMapExtension': isNotEmpty,
+        'a|web/index$metadataExtension':
+            decodedMatches(isNot(contains('scratch'))),
+      };
+      await testBuilder(DevCompilerBuilder(platform: ddcPlatform), assets,
+          outputs: expectedOutputs);
+    });
   });
 
   group('projects with errors due to', () {


### PR DESCRIPTION
Removing scratch paths from metadata was broken on windows. Fix it by using Uri paths instead, add tests.