### PR TITLE
Enable sound null safety for web builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ before_install:
   - tool/travis_setup.sh
 after_failure:
   - tool/report_failure.sh
+branches:
+  only:
+    - master
+    - "sound-null-safety-ddc"
 
 jobs:
   include:
@@ -283,11 +287,6 @@ stages:
   - e2e_test
   - name: e2e_test_cron
     if: "type IN (api, cron)"
-
-# Only building master means that we don't run two builds for each pull request.
-branches:
-  only:
-    - master
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ after_failure:
 branches:
   only:
     - master
-    - "sound-null-safety-ddc"
 
 jobs:
   include:

--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -75,7 +75,14 @@ final _builders = <_i1.BuilderApplication>[
       isOptional: true,
       hideOutput: true,
       appliesBuilders: ['build_modules:module_cleanup']),
-  _i1.apply('build_web_compilers:ddc', [_i7.ddcKernelBuilder, _i7.ddcBuilder],
+  _i1.apply(
+      'build_web_compilers:ddc',
+      [
+        _i7.ddcKernelBuilderUnsound,
+        _i7.ddcBuilderUnsound,
+        _i7.ddcKernelBuilderSound,
+        _i7.ddcBuilderSound
+      ],
       _i1.toAllPackages(),
       isOptional: true,
       hideOutput: true,

--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -84,10 +84,12 @@ final _builders = <_i1.BuilderApplication>[
         'build_web_compilers:dart2js_modules',
         'build_web_compilers:dart_source_cleanup'
       ]),
-  _i1.apply('build_web_compilers:sdk_js_copy', [_i7.sdkJsCopyBuilder],
+  _i1.apply(
+      'build_web_compilers:sdk_js',
+      [_i7.sdkJsCompileUnsound, _i7.sdkJsCompileSound, _i7.sdkJsCopyRequirejs],
       _i1.toNoneByDefault(),
-      hideOutput: true,
-      appliesBuilders: ['build_web_compilers:sdk_js_cleanup']),
+      isOptional: true,
+      hideOutput: true),
   _i1.apply('build_web_compilers:entrypoint', [_i7.webEntrypointBuilder],
       _i1.toRoot(),
       hideOutput: true,
@@ -119,10 +121,6 @@ final _builders = <_i1.BuilderApplication>[
       defaultGenerateFor: const _i3.InputSet()),
   _i1.applyPostProcess(
       'build_web_compilers:dart_source_cleanup', _i7.dartSourceCleanup,
-      defaultReleaseOptions: _i8.BuilderOptions({'enabled': true}),
-      defaultGenerateFor: const _i3.InputSet()),
-  _i1.applyPostProcess(
-      'build_web_compilers:sdk_js_cleanup', _i7.sdkJsCleanupBuilder,
       defaultReleaseOptions: _i8.BuilderOptions({'enabled': true}),
       defaultGenerateFor: const _i3.InputSet()),
   _i1.applyPostProcess(

--- a/_test/test/serve_integration_test.dart
+++ b/_test/test/serve_integration_test.dart
@@ -33,7 +33,9 @@ void main() {
     });
 
     test('Doesn\'t compile submodules into the root module', () {
-      expect(readGeneratedFileAsString('_test/test/hello_world_test.ddc.js'),
+      expect(
+          readGeneratedFileAsString(
+              '_test/test/hello_world_test.unsound.ddc.js'),
           isNot(contains('Hello World!')));
     });
 
@@ -59,7 +61,7 @@ void main() {
       test('ddc errors can be fixed', () async {
         var path = p.join('test', 'common', 'message.dart');
         var error = nextStdOutLine('Error compiling dartdevc module:'
-            '_test|test/common/message.ddc.js');
+            '_test|test/common/message.unsound.ddc.js');
         var nextBuild = nextFailedBuild;
         await replaceAllInFile(path, "'Hello World!'", '1');
         await error;
@@ -152,7 +154,7 @@ void main() {
     expect(badResponse.statusCode, HttpStatus.notFound);
 
     var ddcFileResponse =
-        await (await httpClient.get('localhost', 8080, 'main.ddc.js')).close();
+        await (await httpClient.get('localhost', 8080, 'main.unsound.ddc.js')).close();
     expect(await utf8.decodeStream(ddcFileResponse), contains('"goodbye"'));
   });
 }

--- a/_test/web/main.dart
+++ b/_test/web/main.dart
@@ -8,5 +8,7 @@ import 'sub/message.dart' deferred as message;
 
 void main() async {
   await message.loadLibrary();
-  startApp(text: const String.fromEnvironment('message') ?? message.message);
+  var text = const String.fromEnvironment('message');
+  if (text.isEmpty) text = message.message;
+  startApp(text: text);
 }

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 2.10.2-dev
+## 2.11.0-dev
 
+- Add support for building null safe kernel modules to `KernelBuilder`.
 - Stop using deprecated analyzer apis.
 - Stop passing the deprecated `--kernel` flag to the dev compiler.
 

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.10.2-dev
 
 - Stop using deprecated analyzer apis.
+- Stop passing the deprecated `--kernel` flag to the dev compiler.
 
 ## 2.10.1
 

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -62,7 +62,6 @@ BazelWorkerDriver get _dartdevkDriver {
           p.join(sdkDir, 'bin', 'dart'),
           [
             p.join(sdkDir, 'bin', 'snapshots', 'dartdevc.dart.snapshot'),
-            '--kernel',
             '--persistent_worker'
           ],
           mode: _processMode,

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.10.2-dev
+version: 2.11.0-dev
 description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.13.0-dev
+
+- Support sound null safety in ddc/dart2js, based on the standard entrypoint
+  detection (enable null safety if the entrypoint opts in).
+
 ## 2.12.0-dev.2
 
 - Add the `generate-full-dill` option for the `build_web_compilers:ddc`

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -65,15 +65,22 @@ builders:
   ddc:
     import: "package:build_web_compilers/builders.dart"
     builder_factories:
-      - ddcKernelBuilder
-      - ddcBuilder
+      - ddcKernelBuilderUnsound
+      - ddcBuilderUnsound
+      - ddcKernelBuilderSound
+      - ddcBuilderSound
     build_extensions:
       .ddc.module:
-        - .ddc.dill
-        - .ddc.js.errors
-        - .ddc.js
-        - .ddc.js.map
-        - .ddc.js.metadata
+        - .unsound.ddc.dill
+        - .unsound.ddc.js.errors
+        - .unsound.ddc.js
+        - .unsound.ddc.js.map
+        - .unsound.ddc.js.metadata
+        - .sound.ddc.dill
+        - .sound.ddc.js.errors
+        - .sound.ddc.js
+        - .sound.ddc.js.map
+        - .sound.ddc.js.metadata
     is_optional: True
     auto_apply: all_packages
     required_inputs:
@@ -98,8 +105,8 @@ builders:
         - .merged_metadata
     required_inputs:
       - .dart
-      - .ddc.js
-      - .ddc.js.metadata
+      - .unsound.ddc.js
+      - .sound.ddc.js
       - .ddc.module
       - .dart2js.module
     build_to: cache

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -11,22 +11,24 @@ targets:
           - web/stack_trace_mapper.dart
       build_web_compilers|_stack_trace_mapper_copy:
         enabled: true
-      build_web_compilers|sdk_js_copy:
-        enabled: true
-      build_web_compilers|sdk_js_cleanup:
+      build_web_compilers|sdk_js:
         enabled: true
 builders:
-  sdk_js_copy:
+  sdk_js:
     import: "package:build_web_compilers/builders.dart"
     builder_factories:
-      - sdkJsCopyBuilder
+      - sdkJsCompileUnsound
+      - sdkJsCompileSound
+      - sdkJsCopyRequirejs
     build_extensions:
-      $lib$:
-        - src/dev_compiler/dart_sdk.js
-        - src/dev_compiler/require.js
-    is_optional: False
+      $package$:
+        - lib/src/dev_compiler/dart_sdk.js
+        - lib/src/dev_compiler/dart_sdk.js.map
+        - lib/src/dev_compiler/dart_sdk.sound.js
+        - lib/src/dev_compiler/dart_sdk.sound.js.map
+        - lib/src/dev_compiler/require.js
+    is_optional: True
     auto_apply: none
-    applies_builders: ["build_web_compilers|sdk_js_cleanup"]
     runs_before: ["build_web_compilers|entrypoint"]
   dart2js_modules:
     import: "package:build_web_compilers/builders.dart"
@@ -141,12 +143,6 @@ post_process_builders:
   dart_source_cleanup:
     import: "package:build_web_compilers/builders.dart"
     builder_factory: dartSourceCleanup
-    defaults:
-      release_options:
-        enabled: true
-  sdk_js_cleanup:
-    import: "package:build_web_compilers/builders.dart"
-    builder_factory: sdkJsCleanupBuilder
     defaults:
       release_options:
         enabled: true

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -6,7 +6,6 @@ import 'package:build/build.dart';
 import 'package:build/experiments.dart';
 import 'package:build_modules/build_modules.dart';
 import 'package:collection/collection.dart';
-import 'package:path/path.dart' as p;
 
 import 'build_web_compilers.dart';
 import 'src/common.dart';
@@ -23,7 +22,13 @@ Builder ddcMetaModuleBuilder(BuilderOptions options) =>
     MetaModuleBuilder.forOptions(ddcPlatform, options);
 Builder ddcMetaModuleCleanBuilder(_) => MetaModuleCleanBuilder(ddcPlatform);
 Builder ddcModuleBuilder([_]) => ModuleBuilder(ddcPlatform);
-Builder ddcBuilder(BuilderOptions options) {
+
+Builder ddcBuilderSound(BuilderOptions options) =>
+    ddcBuilder(options, soundNullSafety: true);
+Builder ddcBuilderUnsound(BuilderOptions options) =>
+    ddcBuilder(options, soundNullSafety: false);
+
+Builder ddcBuilder(BuilderOptions options, {bool soundNullSafety = false}) {
   validateOptions(options.config, _supportedOptions, 'build_web_compilers:ddc');
   _ensureSameDdcOptions(options);
 
@@ -34,23 +39,32 @@ Builder ddcBuilder(BuilderOptions options) {
     platform: ddcPlatform,
     environment: _readEnvironmentOption(options),
     experiments: _readExperimentOption(options),
+    soundNullSafety: soundNullSafety,
   );
 }
 
-const ddcKernelExtension = '.ddc.dill';
-Builder ddcKernelBuilder(BuilderOptions options) {
+String ddcKernelExtension(bool soundNullSafety) =>
+    '${soundnessExt(soundNullSafety)}.ddc.dill';
+Builder ddcKernelBuilderUnsound(BuilderOptions options) =>
+    ddcKernelBuilder(options, soundNullSafety: false);
+Builder ddcKernelBuilderSound(BuilderOptions options) =>
+    ddcKernelBuilder(options, soundNullSafety: true);
+
+Builder ddcKernelBuilder(BuilderOptions options,
+    {bool soundNullSafety = false}) {
   validateOptions(options.config, _supportedOptions, 'build_web_compilers:ddc');
   _ensureSameDdcOptions(options);
 
   return KernelBuilder(
       summaryOnly: true,
-      sdkKernelPath: p.url.join('lib', '_internal', 'ddc_sdk.dill'),
-      outputExtension: ddcKernelExtension,
+      sdkKernelPath: sdkDdcKernelPath(soundNullSafety),
+      outputExtension: ddcKernelExtension(soundNullSafety),
       platform: ddcPlatform,
       useIncrementalCompiler: _readUseIncrementalCompilerOption(options),
       trackUnusedInputs: _readTrackInputsCompilerOption(options),
       // ignore: deprecated_member_use
-      experiments: _readExperimentOption(options));
+      experiments: _readExperimentOption(options),
+      soundNullSafety: soundNullSafety);
 }
 
 Builder sdkJsCopyRequirejs(_) => SdkJsCopyBuilder();

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as p;
 import 'build_web_compilers.dart';
 import 'src/common.dart';
 import 'src/platforms.dart';
+import 'src/sdk_js_compile_builder.dart';
 import 'src/sdk_js_copy_builder.dart';
 
 // Shared entrypoint builder
@@ -52,11 +53,15 @@ Builder ddcKernelBuilder(BuilderOptions options) {
       experiments: _readExperimentOption(options));
 }
 
-Builder sdkJsCopyBuilder(_) => SdkJsCopyBuilder();
-PostProcessBuilder sdkJsCleanupBuilder(BuilderOptions options) =>
-    FileDeletingBuilder(
-        ['lib/src/dev_compiler/dart_sdk.js', 'lib/src/dev_compiler/require.js'],
-        isEnabled: options.config['enabled'] as bool ?? false);
+Builder sdkJsCopyRequirejs(_) => SdkJsCopyBuilder();
+Builder sdkJsCompileSound(_) => SdkJsCompileBuilder(
+    sdkKernelPath: 'lib/_internal/ddc_platform_sound.dill',
+    outputPath: 'lib/src/dev_compiler/dart_sdk.sound.js',
+    soundNullSafety: true);
+Builder sdkJsCompileUnsound(_) => SdkJsCompileBuilder(
+    sdkKernelPath: 'lib/_internal/ddc_platform.dill',
+    outputPath: 'lib/src/dev_compiler/dart_sdk.js',
+    soundNullSafety: false);
 
 // Dart2js related builders
 Builder dart2jsMetaModuleBuilder(BuilderOptions options) =>

--- a/build_web_compilers/lib/src/common.dart
+++ b/build_web_compilers/lib/src/common.dart
@@ -18,6 +18,12 @@ final sdkDir = p.dirname(p.dirname(Platform.resolvedExecutable));
 String defaultAnalysisOptionsArg(ScratchSpace scratchSpace) =>
     '--options=${scratchSpace.fileFor(defaultAnalysisOptionsId).path}';
 
+String sdkDdcKernelPath(bool soundNullSafety) => p.url.join('lib', '_internal',
+    soundNullSafety ? 'ddc_outline_sound.dill' : 'ddc_sdk.dill');
+
+String soundnessExt(bool soundNullSafety) =>
+    soundNullSafety ? '.sound' : '.unsound';
+
 // TODO: better solution for a .packages file, today we just create a new one
 // for every kernel build action.
 Future<File> createPackagesFile(Iterable<AssetId> allAssets) async {

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 
 import 'package:archive/archive.dart';
 import 'package:build/build.dart';
+import 'package:build/experiments.dart';
 import 'package:build_modules/build_modules.dart';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' as p;
@@ -65,6 +66,8 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
         '$jsEntrypointExtension';
     args = dart2JsArgs.toList()
       ..addAll([
+        for (var experiment in enabledExperiments)
+          '--enable-experiment=$experiment',
         '--packages=${p.join('.dart_tool', 'package_config.json')}',
         '-o$jsOutputPath',
         dartPath,

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -20,7 +20,8 @@ import 'web_entrypoint_builder.dart';
 /// Alias `_p.url` to `p`.
 _p.Context get _context => _p.url;
 
-var _modulePartialExtension = _context.withoutExtension(jsModuleExtension);
+String _modulePartialExtension(bool soundNullSafety) =>
+    _context.withoutExtension(jsModuleExtension(soundNullSafety));
 
 /// Bootstraps a ddc application, creating the main entrypoint as well as the
 /// bootstrap and digest entrypoints.
@@ -39,6 +40,7 @@ Future<void> bootstrapDdc(
   bool skipPlatformCheck = false,
   @deprecated Set<String> skipPlatformCheckPackages = const {},
   Iterable<AssetId> requiredAssets,
+  @required bool soundNullSafety,
 }) async {
   requiredAssets ??= [];
   skipPlatformCheck ??= false;
@@ -56,7 +58,8 @@ Future<void> bootstrapDdc(
   try {
     transitiveJsModules = await _ensureTransitiveJsModules(module, buildStep,
         skipPlatformCheck: skipPlatformCheck,
-        skipPlatformCheckPackages: skipPlatformCheckPackages);
+        skipPlatformCheckPackages: skipPlatformCheckPackages,
+        soundNullSafety: soundNullSafety);
   } on UnsupportedModules catch (e) {
     var librariesString = (await e.exactLibraries(buildStep).toList())
         .map((lib) => AssetId(lib.id.package,
@@ -72,8 +75,9 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
 ''');
     return;
   }
-  var jsId = module.primarySource.changeExtension(jsModuleExtension);
-  var appModuleName = ddcModuleName(jsId);
+  var jsId =
+      module.primarySource.changeExtension(jsModuleExtension(soundNullSafety));
+  var appModuleName = ddcModuleName(jsId, soundNullSafety);
   var appDigestsOutput =
       dartEntrypointId.changeExtension(digestsEntrypointExtension);
   var mergedMetadataOutput =
@@ -103,10 +107,10 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
     // Strip out the top level dir from the path for any module, and set it to
     // `packages/` for lib modules. We set baseUrl to `/` to simplify things,
     // and we only allow you to serve top level directories.
-    var moduleName = ddcModuleName(jsId);
+    var moduleName = ddcModuleName(jsId, soundNullSafety);
     modulePaths[moduleName] = _context.withoutExtension(
         jsId.path.startsWith('lib')
-            ? '$moduleName$jsModuleExtension'
+            ? '$moduleName${jsModuleExtension(soundNullSafety)}'
             : _context.joinAll(_context.split(jsId.path).skip(1)));
   }
 
@@ -129,8 +133,9 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
         ..write(_dartLoaderSetup(
             modulePaths,
             _p.url.relative(appDigestsOutput.path,
-                from: _p.url.dirname(bootstrapId.path))))
-        ..write(_requireJsConfig)
+                from: _p.url.dirname(bootstrapId.path)),
+            soundNullSafety))
+        ..write(_requireJsConfig(soundNullSafety))
         ..write(_appBootstrap(bootstrapModuleName, appModuleName,
             appModuleScope, entrypointLibraryName,
             oldModuleScope: oldAppModuleScope));
@@ -149,15 +154,16 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
   for (var jsId in transitiveJsModules) {
     mergedMetadataContent.writeln(
         await buildStep.readAsString(jsId.changeExtension('.js.metadata')));
-    moduleDigests[_moduleDigestKey(jsId)] = '${await buildStep.digest(jsId)}';
+    moduleDigests[_moduleDigestKey(jsId, soundNullSafety)] =
+        '${await buildStep.digest(jsId)}';
   }
   await buildStep.writeAsString(appDigestsOutput, jsonEncode(moduleDigests));
   await buildStep.writeAsString(
       mergedMetadataOutput, mergedMetadataContent.toString());
 }
 
-String _moduleDigestKey(AssetId jsId) =>
-    '${ddcModuleName(jsId)}$jsModuleExtension';
+String _moduleDigestKey(AssetId jsId, bool soundNullSafety) =>
+    '${ddcModuleName(jsId, soundNullSafety)}${jsModuleExtension(soundNullSafety)}';
 
 final _lazyBuildPool = Pool(16);
 
@@ -168,7 +174,8 @@ final _lazyBuildPool = Pool(16);
 Future<List<AssetId>> _ensureTransitiveJsModules(
     Module module, BuildStep buildStep,
     {@required bool skipPlatformCheck,
-    @required Set<String> skipPlatformCheckPackages}) async {
+    @required Set<String> skipPlatformCheckPackages,
+    @required bool soundNullSafety}) async {
   // Collect all the modules this module depends on, plus this module.
   var transitiveDeps = await module.computeTransitiveDependencies(buildStep,
       throwIfUnsupported: !skipPlatformCheck,
@@ -176,9 +183,9 @@ Future<List<AssetId>> _ensureTransitiveJsModules(
       skipPlatformCheckPackages: skipPlatformCheckPackages);
 
   var jsModules = [
-    module.primarySource.changeExtension(jsModuleExtension),
+    module.primarySource.changeExtension(jsModuleExtension(soundNullSafety)),
     for (var dep in transitiveDeps)
-      dep.primarySource.changeExtension(jsModuleExtension),
+      dep.primarySource.changeExtension(jsModuleExtension(soundNullSafety)),
   ];
   // Check that each module is readable, and warn otherwise.
   await Future.wait(jsModules.map((jsId) async {
@@ -307,7 +314,8 @@ var _currentDirectory = (function () {
 ''';
 
 /// Sets up `window.$dartLoader` based on [modulePaths].
-String _dartLoaderSetup(Map<String, String> modulePaths, String appDigests) =>
+String _dartLoaderSetup(Map<String, String> modulePaths, String appDigests,
+        bool soundNullSafety) =>
     '''
 $_currentDirectoryScript
 $_baseUrlScript
@@ -324,8 +332,8 @@ if(!window.\$dartLoader) {
      forceLoadModule: function (moduleName, callback, onError) {
        // dartdevc only strips the final extension when adding modules to source
        // maps, so we need to do the same.
-       if (moduleName.endsWith('$_modulePartialExtension')) {
-         moduleName = moduleName.substring(0, moduleName.length - ${_modulePartialExtension.length});
+       if (moduleName.endsWith('${_modulePartialExtension(soundNullSafety)}')) {
+         moduleName = moduleName.substring(0, moduleName.length - ${_modulePartialExtension(soundNullSafety).length});
        }
        if (typeof onError != 'undefined') {
          var errorCallbacks = \$dartLoader.moduleLoadingErrorCallbacks;
@@ -398,7 +406,7 @@ $_baseUrlScript
 ///
 /// Adds error handler code for require.js which requests a `.errors` file for
 /// any failed module, and logs it to the console.
-final _requireJsConfig = '''
+String _requireJsConfig(bool soundNullSafety) => '''
 // Whenever we fail to load a JS module, try to request the corresponding
 // `.errors` file, and log it to the console.
 (function() {
@@ -454,8 +462,8 @@ require.config({
 
 const modulesGraph = new Map();
 function getRegisteredModuleName(moduleMap) {
-  if (\$dartLoader.moduleIdToUrl.has(moduleMap.name + '$_modulePartialExtension')) {
-    return moduleMap.name + '$_modulePartialExtension';
+  if (\$dartLoader.moduleIdToUrl.has(moduleMap.name + '${_modulePartialExtension(soundNullSafety)}')) {
+    return moduleMap.name + '${_modulePartialExtension(soundNullSafety)}';
   }
   return moduleMap.name;
 }

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -17,11 +17,16 @@ import '../builders.dart';
 import 'common.dart';
 import 'errors.dart';
 
-const jsModuleErrorsExtension = '.ddc.js.errors';
-const jsModuleExtension = '.ddc.js';
-const jsSourceMapExtension = '.ddc.js.map';
-const metadataExtension = '.ddc.js.metadata';
-const fullKernelExtension = '.ddc.full.dill';
+String jsModuleErrorsExtension(bool soundNullSafety) =>
+    '${soundnessExt(soundNullSafety)}.ddc.js.errors';
+String jsModuleExtension(bool soundNullSafety) =>
+    '${soundnessExt(soundNullSafety)}.ddc.js';
+String jsSourceMapExtension(bool soundNullSafety) =>
+    '${soundnessExt(soundNullSafety)}.ddc.js.map';
+String metadataExtension(bool soundNullSafety) =>
+    '${soundnessExt(soundNullSafety)}.ddc.js.metadata';
+String fullKernelExtension(bool soundNullSafety) =>
+    '${soundnessExt(soundNullSafety)}.ddc.full.dill';
 
 /// A builder which can output ddc modules!
 class DevCompilerBuilder implements Builder {
@@ -65,6 +70,9 @@ class DevCompilerBuilder implements Builder {
   /// Experiments to pass to ddc (as --enable-experiment=<experiment> args).
   final Iterable<String> experiments;
 
+  /// Whether or not strong null safety should be enabled.
+  final bool soundNullSafety;
+
   DevCompilerBuilder(
       {bool useIncrementalCompiler,
       bool generateFullDill,
@@ -74,7 +82,8 @@ class DevCompilerBuilder implements Builder {
       String librariesPath,
       String platformSdk,
       Map<String, String> environment,
-      Iterable<String> experiments})
+      Iterable<String> experiments,
+      bool soundNullSafety = false})
       : useIncrementalCompiler = useIncrementalCompiler ?? true,
         generateFullDill = generateFullDill ?? false,
         platformSdk = platformSdk ?? sdkDir,
@@ -83,15 +92,16 @@ class DevCompilerBuilder implements Builder {
         trackUnusedInputs = trackUnusedInputs ?? false,
         buildExtensions = {
           moduleExtension(platform): [
-            jsModuleExtension,
-            jsModuleErrorsExtension,
-            jsSourceMapExtension,
-            metadataExtension,
-            fullKernelExtension,
+            jsModuleExtension(soundNullSafety),
+            jsModuleErrorsExtension(soundNullSafety),
+            jsSourceMapExtension(soundNullSafety),
+            metadataExtension(soundNullSafety),
+            fullKernelExtension(soundNullSafety),
           ],
         },
         environment = environment ?? {},
-        experiments = experiments ?? {};
+        experiments = experiments ?? {},
+        soundNullSafety = soundNullSafety ?? false;
 
   @override
   final Map<String, List<String>> buildExtensions;
@@ -110,7 +120,9 @@ class DevCompilerBuilder implements Builder {
 
     Future<void> handleError(e) async {
       await buildStep.writeAsString(
-          module.primarySource.changeExtension(jsModuleErrorsExtension), '$e');
+          module.primarySource
+              .changeExtension(jsModuleErrorsExtension(soundNullSafety)),
+          '$e');
       log.severe('$e');
     }
 
@@ -125,7 +137,8 @@ class DevCompilerBuilder implements Builder {
           sdkKernelPath,
           librariesPath,
           environment,
-          experiments);
+          experiments,
+          soundNullSafety);
     } on DartDevcCompilationException catch (e) {
       await handleError(e);
     } on MissingModulesException catch (e) {
@@ -146,22 +159,24 @@ Future<void> _createDevCompilerModule(
     String librariesPath,
     Map<String, String> environment,
     Iterable<String> experiments,
+    bool soundNullSafety,
     {bool debugMode = true}) async {
   var transitiveDeps = await buildStep.trackStage('CollectTransitiveDeps',
       () => module.computeTransitiveDependencies(buildStep));
   var transitiveKernelDeps = [
     for (var dep in transitiveDeps)
-      dep.primarySource.changeExtension(ddcKernelExtension)
+      dep.primarySource.changeExtension(ddcKernelExtension(soundNullSafety)),
   ];
   var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
 
   var allAssetIds = <AssetId>{...module.sources, ...transitiveKernelDeps};
   await buildStep.trackStage(
       'EnsureAssets', () => scratchSpace.ensureAssets(allAssetIds, buildStep));
-  var jsId = module.primarySource.changeExtension(jsModuleExtension);
+  var jsId =
+      module.primarySource.changeExtension(jsModuleExtension(soundNullSafety));
   var jsOutputFile = scratchSpace.fileFor(jsId);
   var sdkSummary =
-      p.url.join(dartSdk, sdkKernelPath ?? 'lib/_internal/ddc_sdk.dill');
+      p.url.join(dartSdk, sdkKernelPath ?? sdkDdcKernelPath(soundNullSafety));
 
   // Maps the inputs paths we provide to the ddc worker to asset ids, if
   // `trackUnusedInputs` is `true`.
@@ -187,9 +202,9 @@ Future<void> _createDevCompilerModule(
       '-o',
       jsOutputFile.path,
       debugMode ? '--source-map' : '--no-source-map',
-      for (var dep in transitiveDeps) _summaryArg(dep),
+      for (var dep in transitiveDeps) _summaryArg(dep, soundNullSafety),
       '--packages=${p.join('.dart_tool', 'package_config.json')}',
-      '--module-name=${ddcModuleName(jsId)}',
+      '--module-name=${ddcModuleName(jsId, soundNullSafety)}',
       '--multi-root-scheme=$multiRootScheme',
       '--multi-root=.',
       '--track-widget-creation',
@@ -205,6 +220,7 @@ Future<void> _createDevCompilerModule(
       for (var source in module.sources) _sourceArg(source),
       for (var define in environment.entries) '-D${define.key}=${define.value}',
       for (var experiment in experiments) '--enable-experiment=$experiment',
+      '--${soundNullSafety ? '' : 'no-'}sound-null-safety',
     ])
     ..inputs.add(Input()
       ..path = sdkSummary
@@ -246,16 +262,16 @@ Future<void> _createDevCompilerModule(
     await scratchSpace.copyOutput(jsId, buildStep);
 
     if (generateFullDill) {
-      var currentFullKernelId =
-          module.primarySource.changeExtension(fullKernelExtension);
+      var currentFullKernelId = module.primarySource
+          .changeExtension(fullKernelExtension(soundNullSafety));
       await scratchSpace.copyOutput(currentFullKernelId, buildStep);
     }
 
     if (debugMode) {
       // We need to modify the sources in the sourcemap to remove the custom
       // `multiRootScheme` that we use.
-      var sourceMapId =
-          module.primarySource.changeExtension(jsSourceMapExtension);
+      var sourceMapId = module.primarySource
+          .changeExtension(jsSourceMapExtension(soundNullSafety));
       var file = scratchSpace.fileFor(sourceMapId);
       var content = await file.readAsString();
       var json = jsonDecode(content);
@@ -264,7 +280,8 @@ Future<void> _createDevCompilerModule(
 
       // Copy the metadata output, modifying its contents to remove the temp
       // directory from paths
-      var metadataId = module.primarySource.changeExtension(metadataExtension);
+      var metadataId = module.primarySource
+          .changeExtension(metadataExtension(soundNullSafety));
       file = scratchSpace.fileFor(metadataId);
       content = await file.readAsString();
       json = jsonDecode(content);
@@ -285,10 +302,12 @@ Future<void> _createDevCompilerModule(
 }
 
 /// Returns the `--summary=` argument for a dependency.
-String _summaryArg(Module module) {
-  final kernelAsset = module.primarySource.changeExtension(ddcKernelExtension);
-  final moduleName =
-      ddcModuleName(module.primarySource.changeExtension(jsModuleExtension));
+String _summaryArg(Module module, bool soundNullSafety) {
+  final kernelAsset =
+      module.primarySource.changeExtension(ddcKernelExtension(soundNullSafety));
+  final moduleName = ddcModuleName(
+      module.primarySource.changeExtension(jsModuleExtension(soundNullSafety)),
+      soundNullSafety);
   return '--summary=${scratchSpace.fileFor(kernelAsset).path}=$moduleName';
 }
 
@@ -322,11 +341,12 @@ List<String> fixSourceMapSources(List<String> uris) {
 
 /// The module name according to ddc for [jsId] which represents the real js
 /// module file.
-String ddcModuleName(AssetId jsId) {
+String ddcModuleName(AssetId jsId, bool soundNullSafety) {
   var jsPath = jsId.path.startsWith('lib/')
       ? jsId.path.replaceFirst('lib/', 'packages/${jsId.package}/')
       : jsId.path;
-  return jsPath.substring(0, jsPath.length - jsModuleExtension.length);
+  return jsPath.substring(
+      0, jsPath.length - jsModuleExtension(soundNullSafety).length);
 }
 
 void _fixMetadataSources(Map<String, dynamic> json, String scratchPath) {

--- a/build_web_compilers/lib/src/sdk_js_compile_builder.dart
+++ b/build_web_compilers/lib/src/sdk_js_compile_builder.dart
@@ -1,0 +1,132 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bazel_worker/bazel_worker.dart';
+import 'package:build/build.dart';
+import 'package:build_modules/build_modules.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+
+import 'common.dart';
+import 'dev_compiler_builder.dart' show fixSourceMapSources;
+import 'errors.dart';
+
+const _jsSourceMapExtension = '.js.map';
+
+/// A builder which can compile the SDK to JS from kernel.
+class SdkJsCompileBuilder implements Builder {
+  /// The SDK kernel file for the current sdk and configuration (sound vs
+  /// unsound, etc).
+  ///
+  /// This is exactly what will be compiled into the resulting JS file.
+  final String sdkKernelPath;
+
+  /// The root directory of the platform's dart SDK.
+  ///
+  /// If not provided, defaults to the directory of
+  /// [Platform.resolvedExecutable].
+  ///
+  /// On flutter this is the path to the root of the flutter_patched_sdk
+  /// directory, which contains the platform kernel files.
+  final String platformSdk;
+
+  /// The absolute path to the libraries file for the current platform.
+  ///
+  /// If not provided, defaults to "lib/libraries.json" in the sdk directory.
+  final String librariesPath;
+
+  /// The final destination for the compiled JS file.
+  final AssetId jsOutputId;
+
+  final bool soundNullSafety;
+
+  SdkJsCompileBuilder({
+    @required this.sdkKernelPath,
+    @required String outputPath,
+    @required this.soundNullSafety,
+    String librariesPath,
+    String platformSdk,
+  })  : platformSdk = platformSdk ?? sdkDir,
+        librariesPath = librariesPath ??
+            p.join(platformSdk ?? sdkDir, 'lib', 'libraries.json'),
+        buildExtensions = {
+          r'$package$': [
+            outputPath,
+            p.setExtension(outputPath, _jsSourceMapExtension),
+          ],
+        },
+        jsOutputId = AssetId('build_web_compilers', outputPath);
+
+  @override
+  final Map<String, List<String>> buildExtensions;
+
+  @override
+  Future build(BuildStep buildStep) async {
+    await _createDevCompilerModule(buildStep, platformSdk, sdkKernelPath,
+        librariesPath, jsOutputId, soundNullSafety);
+  }
+}
+
+/// Compile the sdk module with the dev compiler.
+Future<void> _createDevCompilerModule(
+  BuildStep buildStep,
+  String dartSdk,
+  String sdkKernelPath,
+  String librariesPath,
+  AssetId jsOutputId,
+  bool soundNullSafety,
+) async {
+  var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
+  var jsOutputFile = scratchSpace.fileFor(jsOutputId);
+
+  var request = WorkRequest()
+    ..arguments.addAll([
+      '--multi-root-scheme=org-dartlang-sdk',
+      '--modules=amd',
+      '--module-name=dart_sdk',
+      '--${soundNullSafety ? '' : 'no-'}sound-null-safety',
+      '-o',
+      jsOutputFile.path,
+      p.url.join(dartSdk, sdkKernelPath),
+    ]);
+
+  var driverResource = dartdevkDriverResource;
+  var driver = await buildStep.fetchResource(driverResource);
+  WorkResponse response;
+  try {
+    response = await driver.doWork(request,
+        trackWork: (response) =>
+            buildStep.trackStage('Compile', () => response, isExternal: true));
+  } catch (e) {
+    throw DartDevcCompilationException(jsOutputId, e.toString());
+  }
+
+  var message = response.output
+      .replaceAll('${scratchSpace.tempDir.path}/', '')
+      .replaceAll('org-dartlang-sdk:///', '');
+  if (response.exitCode != EXIT_CODE_OK ||
+      !jsOutputFile.existsSync() ||
+      message.contains('Error:')) {
+    throw DartDevcCompilationException(jsOutputId, message);
+  }
+
+  if (message.isNotEmpty) {
+    log.info('\n$message');
+  }
+
+  // Copy the output back using the buildStep.
+  await scratchSpace.copyOutput(jsOutputId, buildStep);
+  // We need to modify the sources in the sourcemap to remove the custom
+  // `multiRootScheme` that we use.
+  var sourceMapId = jsOutputId.changeExtension(_jsSourceMapExtension);
+  var file = scratchSpace.fileFor(sourceMapId);
+  var content = await file.readAsString();
+  var json = jsonDecode(content);
+  json['sources'] = fixSourceMapSources((json['sources'] as List).cast());
+  await buildStep.writeAsString(sourceMapId, jsonEncode(json));
+}

--- a/build_web_compilers/lib/src/sdk_js_copy_builder.dart
+++ b/build_web_compilers/lib/src/sdk_js_copy_builder.dart
@@ -10,17 +10,13 @@ import 'package:path/path.dart' as p;
 
 import 'common.dart';
 
-/// Copies the dart_sdk.js and require.js files from the sdk itself, into the
-/// build_web_compilers package at `lib/dart_sdk.js` and `lib/require.js`.
+/// Copies the require.js file from the sdk itself, into the
+/// build_web_compilers package at `lib/require.js`.
 class SdkJsCopyBuilder implements Builder {
   @override
   final buildExtensions = {
-    r'$lib$': ['src/dev_compiler/dart_sdk.js', 'src/dev_compiler/require.js']
+    r'$lib$': ['src/dev_compiler/require.js']
   };
-
-  /// Path to the dart_sdk.js file that should be used for all ddc web apps.
-  final _sdkJsLocation =
-      p.join(sdkDir, 'lib', 'dev_compiler', 'kernel', 'amd', 'dart_sdk.js');
 
   /// Path to the require.js file that should be used for all ddc web apps.
   final _sdkRequireJsLocation =
@@ -32,9 +28,6 @@ class SdkJsCopyBuilder implements Builder {
       throw StateError('This builder should only be applied to the '
           'build_web_compilers package');
     }
-    await buildStep.writeAsBytes(
-        AssetId('build_web_compilers', 'lib/src/dev_compiler/dart_sdk.js'),
-        await File(_sdkJsLocation).readAsBytes());
     await buildStep.writeAsBytes(
         AssetId('build_web_compilers', 'lib/src/dev_compiler/require.js'),
         await File(_sdkRequireJsLocation).readAsBytes());

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -112,6 +112,8 @@ class WebEntrypointBuilder implements Builder {
         }
         break;
       case WebCompiler.Dart2Js:
+        // Dart2js already supports opting in/out of null safety by default so
+        // we don't have to inform it of what to do.
         await bootstrapDart2Js(buildStep, dart2JsArgs);
         break;
     }

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -135,5 +135,6 @@ Future<bool> _isAppEntryPoint(AssetId dartId, AssetReader reader) async {
 /// application.
 final _ddcSdkResources = [
   AssetId('build_web_compilers', 'lib/src/dev_compiler/dart_sdk.js'),
+  AssetId('build_web_compilers', 'lib/src/dev_compiler/dart_sdk.sound.js'),
   AssetId('build_web_compilers', 'lib/src/dev_compiler/require.js'),
 ];

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -10,9 +10,9 @@ dependencies:
   analyzer: ">=0.36.4 <0.40.0"
   archive: ^2.0.0
   bazel_worker: ^0.1.18
-  build: ">=1.3.0 <2.0.0"
+  build: ">=1.5.0 <2.0.0"
   build_config: ">=0.3.0 <0.5.0"
-  build_modules: ^2.10.2
+  build_modules: ^2.11.0
   collection: ^1.0.0
   glob: ^1.1.0
   js: ^0.6.1
@@ -37,3 +37,7 @@ dev_dependencies:
 dependency_overrides:
   build_modules:
     path: ../build_modules
+  build_resolvers:
+    path: ../build_resolvers
+  build:
+    path: ../build

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   bazel_worker: ^0.1.18
   build: ">=1.3.0 <2.0.0"
   build_config: ">=0.3.0 <0.5.0"
-  build_modules: ^2.9.0
+  build_modules: ^2.10.2
   collection: ^1.0.0
   glob: ^1.1.0
   js: ^0.6.1
@@ -33,3 +33,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  build_modules:
+    path: ../build_modules

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.12.0-dev.2
+version: 2.13.0-dev
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 

--- a/build_web_compilers/test/dart2js_bootstrap_test.dart
+++ b/build_web_compilers/test/dart2js_bootstrap_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:build/experiments.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -16,56 +17,108 @@ void main() {
   Map<String, dynamic> assets;
   final platform = dart2jsPlatform;
 
-  setUp(() async {
-    assets = {
-      'b|lib/b.dart': '''final world = 'world';''',
-      'a|lib/a.dart': '''
+  group('dart2js', () {
+    setUp(() async {
+      assets = {
+        'b|lib/b.dart': '''final world = 'world';''',
+        'a|lib/a.dart': '''
         import 'package:b/b.dart';
         final hello = world;
       ''',
-      'a|web/index.dart': '''
+        'a|web/index.dart': '''
         import "package:a/a.dart";
         main() {
           print(hello);
         }
       ''',
-      'a|.dart_tool/package_config.json': jsonEncode({
-        'configVersion': 2,
-        'packages': [
-          for (var pkg in ['a', 'b'])
-            {'name': pkg, 'rootUri': 'packages/a', 'packageUri': ''}
-        ]
-      }),
-    };
+        'a|.dart_tool/package_config.json': jsonEncode({
+          'configVersion': 2,
+          'packages': [
+            for (var pkg in ['a', 'b'])
+              {'name': pkg, 'rootUri': 'packages/a', 'packageUri': ''}
+          ]
+        }),
+      };
 
-    // Set up all the other required inputs for this test.
-    await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
-    await testBuilderAndCollectAssets(MetaModuleBuilder(platform), assets);
-    await testBuilderAndCollectAssets(MetaModuleCleanBuilder(platform), assets);
-    await testBuilderAndCollectAssets(ModuleBuilder(platform), assets);
+      // Set up all the other required inputs for this test.
+      await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
+      await testBuilderAndCollectAssets(MetaModuleBuilder(platform), assets);
+      await testBuilderAndCollectAssets(
+          MetaModuleCleanBuilder(platform), assets);
+      await testBuilderAndCollectAssets(ModuleBuilder(platform), assets);
+    });
+
+    test('can bootstrap dart entrypoints', () async {
+      // Just do some basic sanity checking, integration tests will validate
+      // things actually work.
+      var expectedOutputs = {
+        'a|web/index.dart.js': decodedMatches(contains('world')),
+        'a|web/index.dart.js.map': anything,
+        'a|web/index.dart.js.tar.gz': anything,
+      };
+      await testBuilder(WebEntrypointBuilder(WebCompiler.Dart2Js), assets,
+          outputs: expectedOutputs);
+    });
+
+    test('works with --no-sourcemap', () async {
+      var expectedOutputs = {
+        'a|web/index.dart.js': anything,
+        'a|web/index.dart.js.tar.gz': anything,
+      };
+      await testBuilder(
+          WebEntrypointBuilder(WebCompiler.Dart2Js,
+              dart2JsArgs: ['--no-source-maps']),
+          assets,
+          outputs: expectedOutputs);
+    });
   });
 
-  test('can bootstrap dart entrypoints', () async {
-    // Just do some basic sanity checking, integration tests will validate
-    // things actually work.
-    var expectedOutputs = {
-      'a|web/index.dart.js': decodedMatches(contains('world')),
-      'a|web/index.dart.js.map': anything,
-      'a|web/index.dart.js.tar.gz': anything,
-    };
-    await testBuilder(WebEntrypointBuilder(WebCompiler.Dart2Js), assets,
-        outputs: expectedOutputs);
-  });
+  group('null safety', () {
+    test('sound null safety is defaulted based on the entrypoint', () async {
+      assets = {
+        'a|lib/is_sound.dart': '''
+        // @dart=2.10
+        const unsoundMode = <int?>[] is List<int>;
+        ''',
+        'a|web/sound.dart': '''
+        // @dart=2.10
+        import 'package:a/is_sound.dart';
+        void main() {
+          print(unsoundMode);
+        }
+      ''',
+        'a|web/unsound.dart': '''
+        // @dart=2.9
+        import 'package:a/is_sound.dart';
+        void main() {
+          print(unsoundMode);
+        }
+      ''',
+      };
 
-  test('works with --no-sourcemap', () async {
-    var expectedOutputs = {
-      'a|web/index.dart.js': anything,
-      'a|web/index.dart.js.tar.gz': anything,
-    };
-    await testBuilder(
-        WebEntrypointBuilder(WebCompiler.Dart2Js,
-            dart2JsArgs: ['--no-source-maps']),
-        assets,
-        outputs: expectedOutputs);
+      await withEnabledExperiments(() async {
+        // Set up all the other required inputs for this test.
+        await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
+        await testBuilderAndCollectAssets(MetaModuleBuilder(platform), assets);
+        await testBuilderAndCollectAssets(
+            MetaModuleCleanBuilder(platform), assets);
+        await testBuilderAndCollectAssets(ModuleBuilder(platform), assets);
+        // Check the inlined constant value for soundness
+        var expectedOutputs = {
+          'a|web/sound.dart.js': decodedMatches(allOf(
+              contains('printString(String(false))'),
+              isNot(contains('printString(String(true))')))),
+          'a|web/sound.dart.js.map': anything,
+          'a|web/sound.dart.js.tar.gz': anything,
+          'a|web/unsound.dart.js': decodedMatches(allOf(
+              contains('printString(String(true))'),
+              isNot(contains('printString(String(false))')))),
+          'a|web/unsound.dart.js.map': anything,
+          'a|web/unsound.dart.js.tar.gz': anything,
+        };
+        await testBuilder(WebEntrypointBuilder(WebCompiler.Dart2Js), assets,
+            outputs: expectedOutputs);
+      }, ['non-nullable']);
+    });
   });
 }

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -42,10 +42,10 @@ void main() {
         'a|web/index.dart.ddc_merged_metadata': isNotEmpty,
         'a|web/index.dart.bootstrap.js': decodedMatches(allOf([
           // Maps non-lib modules to remove the top level dir.
-          contains('"web/index": "index.ddc"'),
+          contains('"web/index": "index.unsound.ddc"'),
           // Maps lib modules to packages path
-          contains('"packages/a/a": "packages/a/a.ddc"'),
-          contains('"packages/b/b": "packages/b/b.ddc"'),
+          contains('"packages/a/a": "packages/a/a.unsound.ddc"'),
+          contains('"packages/b/b": "packages/b/b.unsound.ddc"'),
           // Requires the top level module and dart sdk.
           contains('define("index.dart.bootstrap", ["web/index", "dart_sdk"]'),
           // Calls main on the top level module.
@@ -78,7 +78,7 @@ void main() {
       var expectedOutputs = {
         'a|web/b.dart.bootstrap.js': decodedMatches(allOf([
           // Confirm that `a.dart` is the actual primary source.
-          contains('"web/a": "a.ddc"'),
+          contains('"web/a": "a.unsound.ddc"'),
           // And `b.dart` is the application, but its module is `web/a`.
           contains('define("b.dart.bootstrap", ["web/a", "dart_sdk"]'),
           // Calls main on the `b.dart` library, not the `a.dart` library.

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -122,7 +122,9 @@ Future<void> runPrerequisites(Map<String, dynamic> assets) async {
   // It is necessary to add a fake asset so that the build_web_compilers
   // package exists.
   var sdkAssets = <String, dynamic>{'build_web_compilers|fake.txt': ''};
-  await testBuilderAndCollectAssets(sdkJsCopyBuilder(null), sdkAssets);
+  await testBuilderAndCollectAssets(sdkJsCopyRequirejs(null), sdkAssets);
+  await testBuilderAndCollectAssets(sdkJsCompileUnsound(null), sdkAssets);
+  await testBuilderAndCollectAssets(sdkJsCompileSound(null), sdkAssets);
   assets.addAll(sdkAssets);
 
   await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
+import 'package:build/experiments.dart';
 import 'package:build_modules/build_modules.dart';
 import 'package:build_test/build_test.dart';
 import 'package:build_web_compilers/build_web_compilers.dart';
@@ -15,129 +16,162 @@ import 'util.dart';
 void main() {
   Map<String, dynamic> assets;
 
-  group('error free project', () {
-    setUp(() async {
-      assets = {
-        'build_modules|lib/src/analysis_options.default.yaml': '',
-        'b|lib/b.dart': '''final world = 'world';''',
-        'a|lib/a.dart': r'''
+  for (var soundNullSafety in [true, false]) {
+    group('error free project (${soundNullSafety ? 'sound' : 'unsound'})', () {
+      setUp(() async {
+        var listener = Logger.root.onRecord
+            .listen((r) => printOnFailure('$r\n${r.error}\n${r.stackTrace}'));
+        addTearDown(listener.cancel);
+        assets = {
+          'b|lib/b.dart': '''
+        // @dart=2.10
+        final world = 'world';''',
+          'a|lib/a.dart': r'''
+        // @dart=2.10
         import 'package:b/b.dart';
         final hello = 'hello $world';
       ''',
-        'a|web/index.dart': '''
+          'a|web/index.dart': '''
+        // @dart=2.10
         import "package:a/a.dart";
-        main() {
+        void main() {
           print(hello);
           print(const String.fromEnvironment('foo', defaultValue: 'bar'));
         }
       ''',
-      };
-
-      // Set up all the other required inputs for this test.
-      await testBuilderAndCollectAssets(const ModuleLibraryBuilder(), assets);
-      await testBuilderAndCollectAssets(MetaModuleBuilder(ddcPlatform), assets);
-      await testBuilderAndCollectAssets(
-          MetaModuleCleanBuilder(ddcPlatform), assets);
-      await testBuilderAndCollectAssets(ModuleBuilder(ddcPlatform), assets);
-      await testBuilderAndCollectAssets(
-          ddcKernelBuilder(BuilderOptions({})), assets);
-    });
-
-    for (var trackUnusedInputs in [true, false]) {
-      test(
-          'can compile ddc modules under lib and web'
-          '${trackUnusedInputs ? ' and track unused inputs' : ''}', () async {
-        var expectedOutputs = {
-          'b|lib/b$jsModuleExtension': decodedMatches(contains('world')),
-          'b|lib/b$jsSourceMapExtension': decodedMatches(contains('b.dart')),
-          'b|lib/b$metadataExtension': isNotEmpty,
-          'a|lib/a$jsModuleExtension': decodedMatches(contains('hello')),
-          'a|lib/a$jsSourceMapExtension': decodedMatches(contains('a.dart')),
-          'a|lib/a$metadataExtension': isNotEmpty,
-          'a|web/index$jsModuleExtension': decodedMatches(contains('main')),
-          'a|web/index$jsSourceMapExtension':
-              decodedMatches(contains('index.dart')),
-          'a|web/index$metadataExtension': isNotEmpty,
         };
-        var reportedUnused = <AssetId, Iterable<AssetId>>{};
+
+        await withEnabledExperiments(() async {
+          // Set up all the other required inputs for this test.
+          await testBuilderAndCollectAssets(
+              const ModuleLibraryBuilder(), assets);
+          await testBuilderAndCollectAssets(
+              MetaModuleBuilder(ddcPlatform), assets);
+          await testBuilderAndCollectAssets(
+              MetaModuleCleanBuilder(ddcPlatform), assets);
+          await testBuilderAndCollectAssets(ModuleBuilder(ddcPlatform), assets);
+          await testBuilderAndCollectAssets(
+              ddcKernelBuilder(BuilderOptions({}),
+                  soundNullSafety: soundNullSafety),
+              assets);
+        }, ['non-nullable']);
+      });
+
+      for (var trackUnusedInputs in [true, false]) {
+        test(
+            'can compile ddc modules under lib and web'
+            '${trackUnusedInputs ? ' and track unused inputs' : ''}', () async {
+          var expectedOutputs = {
+            'b|lib/b${jsModuleExtension(soundNullSafety)}':
+                decodedMatches(contains('world')),
+            'b|lib/b${jsSourceMapExtension(soundNullSafety)}':
+                decodedMatches(contains('b.dart')),
+            'b|lib/b${metadataExtension(soundNullSafety)}': isNotEmpty,
+            'a|lib/a${jsModuleExtension(soundNullSafety)}':
+                decodedMatches(contains('hello')),
+            'a|lib/a${jsSourceMapExtension(soundNullSafety)}':
+                decodedMatches(contains('a.dart')),
+            'a|lib/a${metadataExtension(soundNullSafety)}': isNotEmpty,
+            'a|web/index${jsModuleExtension(soundNullSafety)}':
+                decodedMatches(contains('main')),
+            'a|web/index${jsSourceMapExtension(soundNullSafety)}':
+                decodedMatches(contains('index.dart')),
+            'a|web/index${metadataExtension(soundNullSafety)}': isNotEmpty,
+          };
+          var reportedUnused = <AssetId, Iterable<AssetId>>{};
+          await withEnabledExperiments(() async {
+            await testBuilder(
+                DevCompilerBuilder(
+                    platform: ddcPlatform,
+                    useIncrementalCompiler: trackUnusedInputs,
+                    trackUnusedInputs: trackUnusedInputs,
+                    soundNullSafety: soundNullSafety),
+                assets,
+                outputs: expectedOutputs,
+                reportUnusedAssetsForInput: (input, unused) =>
+                    reportedUnused[input] = unused);
+          }, ['non-nullable']);
+
+          expect(
+              reportedUnused[
+                  AssetId('a', 'web/index${moduleExtension(ddcPlatform)}')],
+              equals(trackUnusedInputs
+                  ? [
+                      AssetId(
+                          'b', 'lib/b${ddcKernelExtension(soundNullSafety)}')
+                    ]
+                  : null),
+              reason: 'Should${trackUnusedInputs ? '' : ' not'} report unused '
+                  'transitive deps.');
+        });
+      }
+
+      test('allows a custom environment', () async {
+        var expectedOutputs = {
+          'b|lib/b${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'b|lib/b${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'b|lib/b${metadataExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${metadataExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${jsModuleExtension(soundNullSafety)}':
+              decodedMatches(contains('print("zap")')),
+          'a|web/index${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${metadataExtension(soundNullSafety)}': isNotEmpty,
+        };
         await testBuilder(
             DevCompilerBuilder(
                 platform: ddcPlatform,
-                useIncrementalCompiler: trackUnusedInputs,
-                trackUnusedInputs: trackUnusedInputs),
+                environment: {'foo': 'zap'},
+                soundNullSafety: soundNullSafety),
             assets,
-            outputs: expectedOutputs,
-            reportUnusedAssetsForInput: (input, unused) =>
-                reportedUnused[input] = unused);
-
-        expect(
-            reportedUnused[
-                AssetId('a', 'web/index${moduleExtension(ddcPlatform)}')],
-            equals(trackUnusedInputs
-                ? [AssetId('b', 'lib/b.${ddcPlatform.name}.dill')]
-                : null),
-            reason: 'Should${trackUnusedInputs ? '' : ' not'} report unused '
-                'transitive deps.');
+            outputs: expectedOutputs);
       });
-    }
 
-    test('allows a custom environment', () async {
-      var expectedOutputs = {
-        'b|lib/b$jsModuleExtension': isNotEmpty,
-        'b|lib/b$jsSourceMapExtension': isNotEmpty,
-        'b|lib/b$metadataExtension': isNotEmpty,
-        'a|lib/a$jsModuleExtension': isNotEmpty,
-        'a|lib/a$jsSourceMapExtension': isNotEmpty,
-        'a|lib/a$metadataExtension': isNotEmpty,
-        'a|web/index$jsModuleExtension':
-            decodedMatches(contains('print("zap")')),
-        'a|web/index$jsSourceMapExtension': isNotEmpty,
-        'a|web/index$metadataExtension': isNotEmpty,
-      };
-      await testBuilder(
-          DevCompilerBuilder(
-              platform: ddcPlatform, environment: {'foo': 'zap'}),
-          assets,
-          outputs: expectedOutputs);
-    });
+      test('generates full dill when enabled', () async {
+        var expectedOutputs = {
+          'b|lib/b${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'b|lib/b${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'b|lib/b${metadataExtension(soundNullSafety)}': isNotEmpty,
+          'b|lib/b${fullKernelExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${metadataExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${fullKernelExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${metadataExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${fullKernelExtension(soundNullSafety)}': isNotEmpty,
+        };
+        await testBuilder(
+            DevCompilerBuilder(
+                platform: ddcPlatform,
+                generateFullDill: true,
+                soundNullSafety: soundNullSafety),
+            assets,
+            outputs: expectedOutputs);
+      });
 
-    test('generates full dill when enabled', () async {
-      var expectedOutputs = {
-        'b|lib/b$jsModuleExtension': isNotEmpty,
-        'b|lib/b$jsSourceMapExtension': isNotEmpty,
-        'b|lib/b$metadataExtension': isNotEmpty,
-        'b|lib/b$fullKernelExtension': isNotEmpty,
-        'a|lib/a$jsModuleExtension': isNotEmpty,
-        'a|lib/a$jsSourceMapExtension': isNotEmpty,
-        'a|lib/a$metadataExtension': isNotEmpty,
-        'a|lib/a$fullKernelExtension': isNotEmpty,
-        'a|web/index$jsModuleExtension': isNotEmpty,
-        'a|web/index$jsSourceMapExtension': isNotEmpty,
-        'a|web/index$metadataExtension': isNotEmpty,
-        'a|web/index$fullKernelExtension': isNotEmpty,
-      };
-      await testBuilder(
-          DevCompilerBuilder(platform: ddcPlatform, generateFullDill: true),
-          assets,
-          outputs: expectedOutputs);
+      test('does not generate full dill by default', () async {
+        var expectedOutputs = {
+          'b|lib/b${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'b|lib/b${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'b|lib/b${metadataExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${metadataExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${metadataExtension(soundNullSafety)}': isNotEmpty,
+        };
+        await testBuilder(
+            DevCompilerBuilder(
+                platform: ddcPlatform, soundNullSafety: soundNullSafety),
+            assets,
+            outputs: expectedOutputs);
+      });
     });
-
-    test('does not generate full dill by default', () async {
-      var expectedOutputs = {
-        'b|lib/b$jsModuleExtension': isNotEmpty,
-        'b|lib/b$jsSourceMapExtension': isNotEmpty,
-        'b|lib/b$metadataExtension': isNotEmpty,
-        'a|lib/a$jsModuleExtension': isNotEmpty,
-        'a|lib/a$jsSourceMapExtension': isNotEmpty,
-        'a|lib/a$metadataExtension': isNotEmpty,
-        'a|web/index$jsModuleExtension': isNotEmpty,
-        'a|web/index$jsSourceMapExtension': isNotEmpty,
-        'a|web/index$metadataExtension': isNotEmpty,
-      };
-      await testBuilder(DevCompilerBuilder(platform: ddcPlatform), assets,
-          outputs: expectedOutputs);
-    });
-  });
+  }
 
   group('projects with errors due to', () {
     group('invalid assignements', () {
@@ -160,7 +194,7 @@ void main() {
 
       test('reports useful messages', () async {
         var expectedOutputs = {
-          'a|web/index$jsModuleErrorsExtension': decodedMatches(
+          'a|web/index${jsModuleErrorsExtension(false)}': decodedMatches(
               allOf(contains('String'), contains('assigned'), contains('int'))),
         };
         var logs = <LogRecord>[];
@@ -194,7 +228,7 @@ void main() {
 
       test('reports useful messages', () async {
         var expectedOutputs = {
-          'a|web/index$jsModuleErrorsExtension': decodedMatches(
+          'a|web/index${jsModuleErrorsExtension(false)}': decodedMatches(
               contains('Unable to find modules for some sources')),
         };
         var logs = <LogRecord>[];

--- a/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -173,20 +173,23 @@ void main() {
 
       test('strips scratch paths from metadata', () async {
         var expectedOutputs = {
-          'b|lib/b$jsModuleExtension': isNotEmpty,
-          'b|lib/b$jsSourceMapExtension': isNotEmpty,
-          'b|lib/b$metadataExtension':
+          'b|lib/b${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'b|lib/b${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'b|lib/b${metadataExtension(soundNullSafety)}':
               decodedMatches(isNot(contains('scratch'))),
-          'a|lib/a$jsModuleExtension': isNotEmpty,
-          'a|lib/a$jsSourceMapExtension': isNotEmpty,
-          'a|lib/a$metadataExtension':
+          'a|lib/a${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'a|lib/a${metadataExtension(soundNullSafety)}':
               decodedMatches(isNot(contains('scratch'))),
-          'a|web/index$jsModuleExtension': isNotEmpty,
-          'a|web/index$jsSourceMapExtension': isNotEmpty,
-          'a|web/index$metadataExtension':
+          'a|web/index${jsModuleExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${jsSourceMapExtension(soundNullSafety)}': isNotEmpty,
+          'a|web/index${metadataExtension(soundNullSafety)}':
               decodedMatches(isNot(contains('scratch'))),
         };
-        await testBuilder(DevCompilerBuilder(platform: ddcPlatform), assets,
+        await testBuilder(
+            DevCompilerBuilder(
+                platform: ddcPlatform, soundNullSafety: soundNullSafety),
+            assets,
             outputs: expectedOutputs);
       });
     });

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -13,7 +13,6 @@ travis:
   branches:
     only:
       - master
-      - sound-null-safety-ddc
 
 merge_stages:
 - analyze_and_format

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -10,6 +10,10 @@ travis:
   stages:
     - name: e2e_test_cron
       if: type IN (api, cron)
+  branches:
+    only:
+      - master
+      - sound-null-safety-ddc
 
 merge_stages:
 - analyze_and_format


### PR DESCRIPTION
Merges the `sound-null-safety-ddc` branch (all prs already reviewed).

- Builds the SDK JS files from dill including both sound and unsound modes
- Supports sound null safety in the KernelBuilder
- Supports sound null safety in the DevCompilerBuilder
- Adds entrypoint detection to require the sound or unsound dependent modules
- Enables experiment support for dart2js

Closes https://github.com/dart-lang/build/issues/2723