### PR TITLE
Merge revert of build_modules 2.11.0, prep for release of 2.11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,10 @@ jobs:
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.9.0; PKGS: build, build_config, build_daemon, build_modules, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
+      name: "SDK: 2.9.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.9.0"
       os: linux
-      env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
+      env: PKGS="build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
       script: ./tool/travis.sh dartanalyzer_2
     - stage: analyze_and_format
       name: "SDK: dev; PKG: build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.11.1
+
+- Reverts 2.11.0 for older sdks than <2.10.0-93.0.dev.
+
 ## 2.10.1
 
 - Fix a bug where file names with spaces were not escaped before being passed

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.11.2
+
+- Re-release 2.11.0 with a min sdk constraint of `2.10.0-93.0.dev`
+
 ## 2.11.1
 
 - Reverts 2.11.0 for older sdks than <2.10.0-93.0.dev.

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -6,9 +6,6 @@ stages:
     - group:
         - dartfmt: sdk
         - dartanalyzer: --fatal-infos --fatal-warnings .
-    - dartanalyzer: --fatal-warnings .
-      dart:
-        - 2.9.0
   - unit_test:
     # Run the script directly - running from snapshot has issues for packages
     # that are depended on by the generated build script.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -32,6 +32,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  analyzer: ^0.40.0

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_modules
-version: 2.11.1
+version: 2.11.2
 description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: ">=2.9.0 <2.10.0-93.0.dev"
+  sdk: ">=2.10.0-93.0.dev <3.0.0"
 
 dependencies:
   analyzer: ">0.36.4 <0.41.0"

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_modules
-version: 2.10.1
+version: 2.11.1
 description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: ">=2.8.1 <3.0.0"
+  sdk: ">=2.8.1 <2.10.0-93.0.dev"
 
 dependencies:
   analyzer: ">0.35.0 <0.40.0"

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.8.1 <2.10.0-93.0.dev"
 
 dependencies:
-  analyzer: ">0.35.0 <0.40.0"
+  analyzer: ">0.35.0 <0.41.0"
   async: ^2.0.0
   bazel_worker: ^0.1.20
   build: ">=1.3.0 <2.0.0"
@@ -32,3 +32,6 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  analyzer: ^0.40.0


### PR DESCRIPTION
This merges in the 2.11.1 version which reverted 2.11.0 (on old sdks only) due to a bad sdk constraint.

It also preps to release 2.11.2 with a proper sdk constraint.