### PR TITLE
release build_modules version 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,13 +94,13 @@ jobs:
       env: PKGS="build_daemon"
       script: ./tool/travis.sh test_12
     - stage: unit_test
-      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner help >/dev/null; pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_modules"
       script: ./tool/travis.sh command_4
     - stage: unit_test
-      name: "SDK: dev; PKG: build_modules; TASKS: `dart $(pub run build_runner help >/dev/null; pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_modules"

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0
+
+- Re-release of 2.11.2 but as a breaking change.
+
 ## 2.11.2
 
 - Re-release 2.11.0 with a min sdk constraint of `2.10.0-93.0.dev`

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -7,13 +7,7 @@ stages:
         - dartfmt: sdk
         - dartanalyzer: --fatal-infos --fatal-warnings .
   - unit_test:
-    # Run the script directly - running from snapshot has issues for packages
-    # that are depended on by the generated build script.
-    - command: >-
-        dart $(pub run build_runner help >/dev/null;
-        pub run build_runner generate-build-script)
-        test --delete-conflicting-outputs
-        -- -P presubmit --test-randomize-ordering-seed=random
+    - command: pub run test -P presubmit --test-randomize-ordering-seed=random
       os:
         - linux
         - windows

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
   scratch_space: ^0.0.4
 
 dev_dependencies:
+  # Used inside tests
+  build_runner: ^1.0.0
   build_test: ^1.0.0
   test: ^1.6.0
   a:

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 2.11.2
+version: 3.0.0
 description: Builders for Dart modules
 homepage: https://github.com/dart-lang/build/tree/master/build_modules
 
@@ -24,9 +24,7 @@ dependencies:
   scratch_space: ^0.0.4
 
 dev_dependencies:
-  build_runner: ^1.0.0
   build_test: ^1.0.0
-  build_vm_compilers: ^1.0.0
   test: ^1.6.0
   a:
     path: test/fixtures/a

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.12.1
+
+- Require `build_modules` version `^3.0.0`.
+
 ## 2.12.0
 
 - Support sound null safety in ddc/dart2js, based on the standard entrypoint

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.12.0
+version: 2.12.1
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
@@ -12,7 +12,7 @@ dependencies:
   bazel_worker: ^0.1.18
   build: ">=1.5.0 <2.0.0"
   build_config: ">=0.3.0 <0.5.0"
-  build_modules: ^2.11.0
+  build_modules: ^3.0.0
   collection: ^1.0.0
   glob: ^1.1.0
   js: ^0.6.1
@@ -33,3 +33,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  build_modules:
+    path: ../build_modules

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -67,8 +67,8 @@ for PKG in ${PKGS}; do
       pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random || EXIT_CODE=$?
       ;;
     command_4)
-      echo 'dart $(pub run build_runner help >/dev/null; pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random'
-      dart $(pub run build_runner help >/dev/null; pub run build_runner generate-build-script) test --delete-conflicting-outputs -- -P presubmit --test-randomize-ordering-seed=random || EXIT_CODE=$?
+      echo 'pub run test -P presubmit --test-randomize-ordering-seed=random'
+      pub run test -P presubmit --test-randomize-ordering-seed=random || EXIT_CODE=$?
       ;;
     command_5)
       echo 'test/flutter_test.sh'


### PR DESCRIPTION
Also update build_web_compilers to require it.

After this we will be reverting the `2.11.2` release and republishing `2.10.1` as `2.11.3` to try and resolve some additional unintentional breakage with this version of build_modules.