### PR TITLE
update language version check when using experiments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,17 +112,17 @@ jobs:
       env: PKGS="build_modules"
       script: ./tool/travis.sh command_4
     - stage: unit_test
-      name: "SDK: 2.10.0-110.0.dev; PKG: build_resolvers; TASKS: [`pub run test --test-randomize-ordering-seed=random`, `test/flutter_test.sh`]"
+      name: "SDK: 2.10.0-110.0.dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: "2.10.0-110.0.dev"
       os: linux
       env: PKGS="build_resolvers"
-      script: ./tool/travis.sh test_12 command_5
+      script: ./tool/travis.sh test_12
     - stage: unit_test
-      name: "SDK: 2.10.0-110.0.dev; PKG: build_resolvers; TASKS: [`pub run test --test-randomize-ordering-seed=random`, `test/flutter_test.sh`]"
+      name: "SDK: 2.10.0-110.0.dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: "2.10.0-110.0.dev"
       os: windows
       env: PKGS="build_resolvers"
-      script: ./tool/travis.sh test_12 command_5
+      script: ./tool/travis.sh test_12
     - stage: unit_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -x integration --test-randomize-ordering-seed=random`"
       dart: dev
@@ -194,13 +194,13 @@ jobs:
       dart: dev
       os: linux
       env: PKGS="scratch_space"
-      script: ./tool/travis.sh command_6
+      script: ./tool/travis.sh command_5
     - stage: unit_test
       name: "SDK: dev; PKG: scratch_space; TASKS: `pub run build_runner test -- --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="scratch_space"
-      script: ./tool/travis.sh command_6
+      script: ./tool/travis.sh command_5
     - stage: e2e_test
       name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 0 --test-randomize-ordering-seed=random`"
       dart: dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,16 @@ jobs:
       env: PKGS="_test _test_common"
       script: ./tool/travis.sh dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
+      dart: "2.10.0-110.0.dev"
       os: linux
       env: PKGS="_test_null_safety"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_resolvers, build_runner, build_runner_core, build_test, build_vm_compilers, build_web_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      name: "SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_runner, build_runner_core, build_test, build_vm_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: dev
       os: linux
-      env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
+      env: PKGS="build build_config build_daemon build_modules build_runner build_runner_core build_test build_vm_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
       name: "SDK: 2.9.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
@@ -40,8 +40,14 @@ jobs:
       env: PKGS="build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
       script: ./tool/travis.sh dartanalyzer_2
     - stage: analyze_and_format
-      name: "SDK: dev; PKG: build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKGS: build_resolvers, build_web_compilers; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      dart: "2.10.0-110.0.dev"
+      os: linux
+      env: PKGS="build_resolvers build_web_compilers"
+      script: ./tool/travis.sh dartfmt dartanalyzer_0
+    - stage: analyze_and_format
+      name: "SDK: 2.10.0-110.0.dev; PKG: build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
+      dart: "2.10.0-110.0.dev"
       os: linux
       env: PKGS="build_web_compilers"
       script: ./tool/travis.sh dartanalyzer_2
@@ -106,14 +112,14 @@ jobs:
       env: PKGS="build_modules"
       script: ./tool/travis.sh command_4
     - stage: unit_test
-      name: "SDK: dev; PKG: build_resolvers; TASKS: [`pub run test --test-randomize-ordering-seed=random`, `test/flutter_test.sh`]"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKG: build_resolvers; TASKS: [`pub run test --test-randomize-ordering-seed=random`, `test/flutter_test.sh`]"
+      dart: "2.10.0-110.0.dev"
       os: linux
       env: PKGS="build_resolvers"
       script: ./tool/travis.sh test_12 command_5
     - stage: unit_test
-      name: "SDK: dev; PKG: build_resolvers; TASKS: [`pub run test --test-randomize-ordering-seed=random`, `test/flutter_test.sh`]"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKG: build_resolvers; TASKS: [`pub run test --test-randomize-ordering-seed=random`, `test/flutter_test.sh`]"
+      dart: "2.10.0-110.0.dev"
       os: windows
       env: PKGS="build_resolvers"
       script: ./tool/travis.sh test_12 command_5
@@ -172,14 +178,14 @@ jobs:
       env: PKGS="build_vm_compilers"
       script: ./tool/travis.sh test_05
     - stage: unit_test
-      name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+      dart: "2.10.0-110.0.dev"
       os: linux
       env: PKGS="build_web_compilers"
       script: ./tool/travis.sh test_12
     - stage: unit_test
-      name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+      dart: "2.10.0-110.0.dev"
       os: windows
       env: PKGS="build_web_compilers"
       script: ./tool/travis.sh test_12
@@ -226,8 +232,8 @@ jobs:
       env: PKGS="_test"
       script: ./tool/travis.sh test_04
     - stage: e2e_test
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
+      dart: "2.10.0-110.0.dev"
       os: linux
       env: PKGS="_test_null_safety"
       script: ./tool/travis.sh command_2

--- a/_test_null_safety/mono_pkg.yaml
+++ b/_test_null_safety/mono_pkg.yaml
@@ -1,5 +1,5 @@
 dart:
-  - dev
+  - 2.10.0-110.0.dev
 
 os:
   - linux

--- a/_test_null_safety/mono_pkg.yaml
+++ b/_test_null_safety/mono_pkg.yaml
@@ -1,4 +1,5 @@
 dart:
+  # TODO: Update to `dev` https://github.com/dart-lang/build/issues/2841
   - 2.10.0-110.0.dev
 
 os:

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.4.1-dev
+## 1.4.1
+
+- Update the exception thrown when using experiments without an exactly
+  matching analyzer version to instead ensure that the sdk version is not
+  ahead of the analyzer version.
 
 ## 1.4.0
 

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -433,13 +433,8 @@ final _dartUiPath =
 /// experiments.
 FeatureSet _featureSet({List<String> enableExperiments}) {
   enableExperiments ??= [];
-  if (enableExperiments.isEmpty) {
-    return FeatureSet.fromEnableFlags2(
-        sdkLanguageVersion: sdkLanguageVersion, flags: []);
-  } else if (sdkLanguageVersion == ExperimentStatus.currentVersion) {
-    return FeatureSet.fromEnableFlags2(
-        sdkLanguageVersion: sdkLanguageVersion, flags: enableExperiments);
-  } else {
+  if (enableExperiments.isNotEmpty &&
+      sdkLanguageVersion > ExperimentStatus.currentVersion) {
     throw StateError('''
 Attempting to enable experiments `$enableExperiments`, but the current SDK
 language version does not match your `analyzer` package language version:
@@ -456,6 +451,8 @@ package in your `pubspec.yaml`, so you may have to add that. You can see your
 current version by running `pub deps`.
 ''');
   }
+  return FeatureSet.fromEnableFlags2(
+      sdkLanguageVersion: sdkLanguageVersion, flags: enableExperiments);
 }
 
 /// Path to the running dart's SDK root.

--- a/build_resolvers/mono_pkg.yaml
+++ b/build_resolvers/mono_pkg.yaml
@@ -1,5 +1,5 @@
 dart:
-  - dev
+  - 2.10.0-110.0.dev
 
 stages:
   - analyze_and_format:

--- a/build_resolvers/mono_pkg.yaml
+++ b/build_resolvers/mono_pkg.yaml
@@ -1,4 +1,5 @@
 dart:
+  # TODO: Update to `dev` https://github.com/dart-lang/build/issues/2841
   - 2.10.0-110.0.dev
 
 stages:
@@ -12,7 +13,8 @@ stages:
   - unit_test:
     - group:
       - command: pub run test --test-randomize-ordering-seed=random
-      - command: test/flutter_test.sh
+      # TODO: Restore this https://github.com/dart-lang/build/issues/2841
+      # - command: test/flutter_test.sh
       os:
         - linux
         - windows

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.4.1-dev
+version: 1.4.1
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -165,7 +165,7 @@ void main() {
         var originalLevel = Logger.root.level;
         Logger.root.level = Level.WARNING;
         var listener = Logger.root.onRecord.listen((record) {
-          fail('Got an unexpected warning during analyzsis:\n\n$record');
+          fail('Got an unexpected warning during analysis:\n\n$record');
         });
         addTearDown(() {
           Logger.root.level = originalLevel;
@@ -176,7 +176,7 @@ void main() {
         }, (resolver) async {
           await resolver.libraryFor(entryPoint);
         }, resolvers: AnalyzerResolvers());
-      });
+      }, skip: 'https://github.com/dart-lang/sdk/issues/43550');
     });
 
     group('assets that aren\'t a transitive import of input', () {
@@ -412,7 +412,7 @@ int? get x => 1;
                 expect(errors.errors, isEmpty);
               }, resolvers: AnalyzerResolvers()),
           ['non-nullable']);
-    });
+    }, skip: 'https://github.com/dart-lang/sdk/issues/43550');
 
     test('can get a new analysis session after resolving additional assets',
         () async {

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -176,7 +176,7 @@ void main() {
         }, (resolver) async {
           await resolver.libraryFor(entryPoint);
         }, resolvers: AnalyzerResolvers());
-      }, skip: 'https://github.com/dart-lang/sdk/issues/43550');
+      });
     });
 
     group('assets that aren\'t a transitive import of input', () {
@@ -412,7 +412,7 @@ int? get x => 1;
                 expect(errors.errors, isEmpty);
               }, resolvers: AnalyzerResolvers()),
           ['non-nullable']);
-    }, skip: 'https://github.com/dart-lang/sdk/issues/43550');
+    });
 
     test('can get a new analysis session after resolving additional assets',
         () async {

--- a/build_web_compilers/mono_pkg.yaml
+++ b/build_web_compilers/mono_pkg.yaml
@@ -1,5 +1,5 @@
 dart:
-  - dev
+  - 2.10.0-110.0.dev
 
 stages:
   - analyze_and_format:

--- a/build_web_compilers/mono_pkg.yaml
+++ b/build_web_compilers/mono_pkg.yaml
@@ -1,4 +1,5 @@
 dart:
+  # TODO: Update to `dev` https://github.com/dart-lang/build/issues/2841
   - 2.10.0-110.0.dev
 
 stages:

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -71,10 +71,6 @@ for PKG in ${PKGS}; do
       pub run test -P presubmit --test-randomize-ordering-seed=random || EXIT_CODE=$?
       ;;
     command_5)
-      echo 'test/flutter_test.sh'
-      test/flutter_test.sh || EXIT_CODE=$?
-      ;;
-    command_6)
       echo 'pub run build_runner test -- --test-randomize-ordering-seed=random'
       pub run build_runner test -- --test-randomize-ordering-seed=random || EXIT_CODE=$?
       ;;


### PR DESCRIPTION
We no longer require an exact match, only that the sdk version is not ahead of the analyzer version.

Also:

* Prepares to release build_resolvers 1.4.1
* Run all packages that have tests which require experiment flags on 2.10 dev instead of 2.11 dev since analyzer doesn't yet have an analyzer version for 2.11.
* Closes https://github.com/dart-lang/build/issues/2787