### PR TITLE
Fix loss of edges when replacing synthetic nodes with generated ones

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.0.2+1
+## 6.0.3
 
 - Fix https://github.com/dart-lang/build/issues/1804.
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.2+1
+
+- Fix https://github.com/dart-lang/build/issues/1804.
+
 ## 6.0.2
 
 - Require the latest build version (1.5.x).

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -525,10 +525,7 @@ class AssetGraph {
       if (existing != null) {
         newNode.outputs.addAll(existing.outputs);
         // Ensure we set up the reverse link for NodeWithInput nodes.
-        existing.outputs
-            .map(get)
-            .whereType<NodeWithInputs>()
-            .forEach((node) => node.inputs.add(output));
+        _addInput(existing.outputs, output);
       }
       builderOptionsNode.outputs.add(output);
       _add(newNode);
@@ -542,6 +539,14 @@ class AssetGraph {
   // TODO remove once tests are updated
   void add(AssetNode node) => _add(node);
   Set<AssetId> remove(AssetId id) => _removeRecursive(id);
+
+  /// Adds [input] to all [outputs] if they represent [NodeWithInputs] nodes.
+  void _addInput(Iterable<AssetId> outputs, AssetId input) {
+    for (var output in outputs) {
+      var node = get(output);
+      if (node is NodeWithInputs) node.inputs.add(input);
+    }
+  }
 }
 
 /// Computes a [Digest] for [buildPhases] which can be used to compare one set

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -524,6 +524,11 @@ class AssetGraph {
           isHidden: isHidden);
       if (existing != null) {
         newNode.outputs.addAll(existing.outputs);
+        // Ensure we set up the reverse link for NodeWithInput nodes.
+        existing.outputs
+            .map(get)
+            .whereType<NodeWithInputs>()
+            .forEach((node) => node.inputs.add(output));
       }
       builderOptionsNode.outputs.add(output);
       _add(newNode);

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 6.0.2
+version: 6.0.2+1
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 6.0.2+1
+version: 6.0.3
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -541,9 +541,9 @@ void main() {
                   buildExtensions: replaceExtension('.g.part', '.g.dart')),
               'a'),
         ];
-        final fooPackageGraph = buildPackageGraph({rootPackage('a'): []});
+        final packageGraph = buildPackageGraph({rootPackage('a'): []});
         final graph = await AssetGraph.build(
-            buildPhases, {source}, <AssetId>{}, fooPackageGraph, digestReader);
+            buildPhases, {source}, <AssetId>{}, packageGraph, digestReader);
 
         // Pretend a build happened
         graph.add(SyntheticSourceAssetNode(toBeGeneratedDart)
@@ -566,7 +566,7 @@ void main() {
         // The generated part file should not exist in outputs of the new
         // generated dart file
         expect(graph.get(toBeGeneratedDart).outputs,
-            isNot(contains(predicate((id) => id == generatedPart))));
+            isNot(contains(generatedPart)));
       });
     });
   });


### PR DESCRIPTION
When we replace a synthetic node with a generated node, we first delete the synthetic node which deletes the node from the `inputs` sets of its `outputs`. This re-adds those when we are building up the `outputs` again for the new generated asset node.

- Also adds a regression test

Fixes https://github.com/dart-lang/build/issues/1804