### PR TITLE
Fix up some mono_repo config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,16 @@ jobs:
       env: PKGS="_test _test_common"
       script: ./tool/travis.sh dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.10.0-110.0.dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
-      dart: "2.10.0-110.0.dev"
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
+      dart: dev
       os: linux
       env: PKGS="_test_null_safety"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_runner, build_runner_core, build_test, build_vm_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      name: "SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_runner, build_runner_core, build_test, build_vm_compilers, build_web_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: dev
       os: linux
-      env: PKGS="build build_config build_daemon build_modules build_runner build_runner_core build_test build_vm_compilers example scratch_space"
+      env: PKGS="build build_config build_daemon build_modules build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
       name: "SDK: 2.9.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
@@ -40,17 +40,11 @@ jobs:
       env: PKGS="build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
       script: ./tool/travis.sh dartanalyzer_2
     - stage: analyze_and_format
-      name: "SDK: 2.10.0-110.0.dev; PKGS: build_resolvers, build_web_compilers; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      name: "SDK: 2.10.0-110.0.dev; PKG: build_resolvers; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: "2.10.0-110.0.dev"
       os: linux
-      env: PKGS="build_resolvers build_web_compilers"
+      env: PKGS="build_resolvers"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
-    - stage: analyze_and_format
-      name: "SDK: 2.10.0-110.0.dev; PKG: build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.10.0-110.0.dev"
-      os: linux
-      env: PKGS="build_web_compilers"
-      script: ./tool/travis.sh dartanalyzer_2
     - stage: unit_test
       name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"
       dart: dev
@@ -178,14 +172,14 @@ jobs:
       env: PKGS="build_vm_compilers"
       script: ./tool/travis.sh test_05
     - stage: unit_test
-      name: "SDK: 2.10.0-110.0.dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
-      dart: "2.10.0-110.0.dev"
+      name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+      dart: dev
       os: linux
       env: PKGS="build_web_compilers"
       script: ./tool/travis.sh test_06
     - stage: unit_test
-      name: "SDK: 2.10.0-110.0.dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
-      dart: "2.10.0-110.0.dev"
+      name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+      dart: dev
       os: windows
       env: PKGS="build_web_compilers"
       script: ./tool/travis.sh test_06
@@ -232,8 +226,8 @@ jobs:
       env: PKGS="_test"
       script: ./tool/travis.sh test_04
     - stage: e2e_test
-      name: "SDK: 2.10.0-110.0.dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
-      dart: "2.10.0-110.0.dev"
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
+      dart: dev
       os: linux
       env: PKGS="_test_null_safety"
       script: ./tool/travis.sh command_2

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,16 @@ jobs:
       env: PKGS="_test _test_common"
       script: ./tool/travis.sh dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
+      dart: "2.10.0-110.0.dev"
       os: linux
       env: PKGS="_test_null_safety"
       script: ./tool/travis.sh dartanalyzer_1
     - stage: analyze_and_format
-      name: "SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_runner, build_runner_core, build_test, build_vm_compilers, build_web_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      name: "SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_runner, build_runner_core, build_test, build_vm_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: dev
       os: linux
-      env: PKGS="build build_config build_daemon build_modules build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
+      env: PKGS="build build_config build_daemon build_modules build_runner build_runner_core build_test build_vm_compilers example scratch_space"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
       name: "SDK: 2.9.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
@@ -40,10 +40,10 @@ jobs:
       env: PKGS="build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
       script: ./tool/travis.sh dartanalyzer_2
     - stage: analyze_and_format
-      name: "SDK: 2.10.0-110.0.dev; PKG: build_resolvers; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      name: "SDK: 2.10.0-110.0.dev; PKGS: build_resolvers, build_web_compilers; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: "2.10.0-110.0.dev"
       os: linux
-      env: PKGS="build_resolvers"
+      env: PKGS="build_resolvers build_web_compilers"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: unit_test
       name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"
@@ -172,14 +172,14 @@ jobs:
       env: PKGS="build_vm_compilers"
       script: ./tool/travis.sh test_05
     - stage: unit_test
-      name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+      dart: "2.10.0-110.0.dev"
       os: linux
       env: PKGS="build_web_compilers"
       script: ./tool/travis.sh test_06
     - stage: unit_test
-      name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+      dart: "2.10.0-110.0.dev"
       os: windows
       env: PKGS="build_web_compilers"
       script: ./tool/travis.sh test_06
@@ -226,8 +226,8 @@ jobs:
       env: PKGS="_test"
       script: ./tool/travis.sh test_04
     - stage: e2e_test
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
-      dart: dev
+      name: "SDK: 2.10.0-110.0.dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
+      dart: "2.10.0-110.0.dev"
       os: linux
       env: PKGS="_test_null_safety"
       script: ./tool/travis.sh command_2

--- a/_test/mono_pkg.yaml
+++ b/_test/mono_pkg.yaml
@@ -1,31 +1,31 @@
 dart:
-  - dev
+- dev
 
 os:
-  - linux
-  - windows
+- linux
+- windows
 
 stages:
-  - analyze_and_format:
-    - dartanalyzer: --fatal-infos --fatal-warnings .
-      os: linux
-  - unit_test:
-    - group:
-      - command: pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random
-      - command: pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random
-  - e2e_test:
-    - test: --total-shards 2 --shard-index 0 --test-randomize-ordering-seed=random
-      os: linux
-    - test: --total-shards 2 --shard-index 1 --test-randomize-ordering-seed=random
-      os: linux
-    - test: --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random
-      os: windows
-    - test: --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random
-      os: windows
-    - test: --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random
-      os: windows
-  - e2e_test_cron:
-    - test:
-      dart:
-        - be/raw/latest
-        - dev
+- analyze_and_format:
+  - dartanalyzer: --fatal-infos --fatal-warnings .
+    os: linux
+- unit_test:
+  - group:
+    - command: pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random
+    - command: pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random
+- e2e_test:
+  - test: --total-shards 2 --shard-index 0 --test-randomize-ordering-seed=random
+    os: linux
+  - test: --total-shards 2 --shard-index 1 --test-randomize-ordering-seed=random
+    os: linux
+  - test: --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random
+    os: windows
+  - test: --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random
+    os: windows
+  - test: --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random
+    os: windows
+- e2e_test_cron:
+  - test:
+    dart:
+    - be/raw/latest
+    - dev

--- a/_test_common/mono_pkg.yaml
+++ b/_test_common/mono_pkg.yaml
@@ -1,6 +1,6 @@
 dart:
-  - dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - dartanalyzer: --fatal-infos --fatal-warnings .
+- analyze_and_format:
+  - dartanalyzer: --fatal-infos --fatal-warnings .

--- a/_test_null_safety/mono_pkg.yaml
+++ b/_test_null_safety/mono_pkg.yaml
@@ -1,20 +1,19 @@
 dart:
-  # TODO: Update to `dev` https://github.com/dart-lang/build/issues/2841
-  - 2.10.0-110.0.dev
+- dev
 
 os:
-  - linux
-  - windows
+- linux
+- windows
 
 stages:
-  - analyze_and_format:
-    - dartanalyzer: --enable-experiment=non-nullable --fatal-infos --fatal-warnings .
-      os: linux
-  - e2e_test:
-    - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
-      os: linux
-  - e2e_test_cron:
-    - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
-      dart:
-        - be/raw/latest
-        - dev
+- analyze_and_format:
+  - dartanalyzer: --enable-experiment=non-nullable --fatal-infos --fatal-warnings .
+    os: linux
+- e2e_test:
+  - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
+    os: linux
+- e2e_test_cron:
+  - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
+    dart:
+    - be/raw/latest
+    - dev

--- a/_test_null_safety/mono_pkg.yaml
+++ b/_test_null_safety/mono_pkg.yaml
@@ -1,5 +1,6 @@
 dart:
-- dev
+# TODO: Update to `dev` https://github.com/dart-lang/build/issues/2841
+- 2.10.0-110.0.dev
 
 os:
 - linux

--- a/build/mono_pkg.yaml
+++ b/build/mono_pkg.yaml
@@ -1,19 +1,18 @@
 dart:
-  - dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-      - dartfmt: sdk
-      - dartanalyzer: --fatal-infos --fatal-warnings .
-    - dartanalyzer: --fatal-warnings .
-      dart:
-        - 2.9.0
-  - unit_test:
-    - test: --test-randomize-ordering-seed=random
-      os:
-        - linux
-        - windows
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+  - dartanalyzer: --fatal-warnings .
+    dart: 2.9.0
+- unit_test:
+  - test: --test-randomize-ordering-seed=random
+    os:
+    - linux
+    - windows
 
 cache:
   directories:

--- a/build_config/mono_pkg.yaml
+++ b/build_config/mono_pkg.yaml
@@ -1,19 +1,18 @@
 dart:
-  - dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-        - dartfmt: sdk
-        - dartanalyzer: --fatal-infos --fatal-warnings .
-    - dartanalyzer: --fatal-warnings .
-      dart:
-        - 2.9.0
-  - unit_test:
-    - test: --test-randomize-ordering-seed=random
-      os:
-        - linux
-        - windows
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+  - dartanalyzer: --fatal-warnings .
+    dart: 2.9.0
+- unit_test:
+  - test: --test-randomize-ordering-seed=random
+    os:
+    - linux
+    - windows
 
 cache:
   directories:

--- a/build_daemon/mono_pkg.yaml
+++ b/build_daemon/mono_pkg.yaml
@@ -1,16 +1,15 @@
 dart:
-  - dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-      - dartfmt: sdk
-      - dartanalyzer: --fatal-infos --fatal-warnings .
-    - dartanalyzer: --fatal-warnings .
-      dart:
-        - 2.9.0
-  - unit_test:
-    - test: --test-randomize-ordering-seed=random
-      os:
-        - linux
-        - windows
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+  - dartanalyzer: --fatal-warnings .
+    dart: 2.9.0
+- unit_test:
+  - test: --test-randomize-ordering-seed=random
+    os:
+    - linux
+    - windows

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -1,17 +1,17 @@
 dart:
-  - dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-        - dartfmt: sdk
-        - dartanalyzer: --fatal-infos --fatal-warnings .
-  - unit_test:
-    - test: -P presubmit --test-randomize-ordering-seed=random
-      os:
-        - linux
-        - windows
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+- unit_test:
+  - test: -P presubmit --test-randomize-ordering-seed=random
+    os:
+    - linux
+    - windows
 
 cache:
   directories:
-    - .dart_tool/build
+  - .dart_tool/build

--- a/build_resolvers/mono_pkg.yaml
+++ b/build_resolvers/mono_pkg.yaml
@@ -1,24 +1,23 @@
 dart:
-  # TODO: Update to `dev` https://github.com/dart-lang/build/issues/2841
-  - 2.10.0-110.0.dev
+# TODO: Update to `dev` https://github.com/dart-lang/build/issues/2841
+- 2.10.0-110.0.dev
 
 stages:
-  - analyze_and_format:
-    - group:
-        - dartfmt: sdk
-        - dartanalyzer: --fatal-infos --fatal-warnings .
-    - dartanalyzer: --fatal-warnings .
-      dart:
-        - 2.9.0
-  - unit_test:
-    - group:
-      - test: --test-randomize-ordering-seed=random
-      # TODO: Restore this https://github.com/dart-lang/build/issues/2841
-      # - command: test/flutter_test.sh
-      os:
-        - linux
-        - windows
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+  - dartanalyzer: --fatal-warnings .
+    dart: 2.9.0
+- unit_test:
+  - group:
+    - test: --test-randomize-ordering-seed=random
+    # TODO: Restore this https://github.com/dart-lang/build/issues/2841
+    # - command: test/flutter_test.sh
+    os:
+    - linux
+    - windows
 
 cache:
   directories:
-    - .dart_tool/build
+  - .dart_tool/build

--- a/build_runner/mono_pkg.yaml
+++ b/build_runner/mono_pkg.yaml
@@ -1,16 +1,16 @@
 dart:
-  - dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-      - dartfmt: sdk
-      - dartanalyzer: --fatal-infos --fatal-warnings .
-  - unit_test:
-    - test: -x integration --test-randomize-ordering-seed=random
-  - e2e_test:
-    - test: -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random
-    - test: -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random
-    - test: -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random
-    - test: -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random
-    - test: -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+- unit_test:
+  - test: -x integration --test-randomize-ordering-seed=random
+- e2e_test:
+  - test: -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random
+  - test: -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random
+  - test: -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random
+  - test: -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random
+  - test: -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random

--- a/build_runner_core/mono_pkg.yaml
+++ b/build_runner_core/mono_pkg.yaml
@@ -1,17 +1,17 @@
 dart:
-  - 2.9.0
-  - dev
+- 2.9.0
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-      - dartfmt: sdk
-      - dartanalyzer: --fatal-infos --fatal-warnings .
-      dart: dev
-    - dartanalyzer: --fatal-warnings .
-      dart: 2.9.0
-  - unit_test:
-    - test: --test-randomize-ordering-seed=random
-      os:
-        - linux
-        - windows
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+    dart: dev
+  - dartanalyzer: --fatal-warnings .
+    dart: 2.9.0
+- unit_test:
+  - test: --test-randomize-ordering-seed=random
+    os:
+    - linux
+    - windows

--- a/build_test/mono_pkg.yaml
+++ b/build_test/mono_pkg.yaml
@@ -1,20 +1,19 @@
 dart:
-  - dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-        - dartfmt: sdk
-        - dartanalyzer: --fatal-infos --fatal-warnings .
-    - dartanalyzer: --fatal-warnings .
-      dart:
-        - 2.9.0
-  - unit_test:
-    - test: --test-randomize-ordering-seed=random
-      os:
-        - linux
-        - windows
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+  - dartanalyzer: --fatal-warnings .
+    dart: 2.9.0
+- unit_test:
+  - test: --test-randomize-ordering-seed=random
+    os:
+    - linux
+    - windows
 
 cache:
   directories:
-    - .dart_tool/build
+  - .dart_tool/build

--- a/build_vm_compilers/mono_pkg.yaml
+++ b/build_vm_compilers/mono_pkg.yaml
@@ -1,16 +1,15 @@
 dart:
-  - dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-        - dartfmt: sdk
-        - dartanalyzer: --fatal-infos --fatal-warnings .
-    - dartanalyzer: --fatal-warnings .
-      dart:
-        - 2.9.0
-  - unit_test:
-    - test:
-      os:
-        - linux
-        - windows
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+  - dartanalyzer: --fatal-warnings .
+    dart: 2.9.0
+- unit_test:
+  - test:
+    os:
+    - linux
+    - windows

--- a/build_web_compilers/mono_pkg.yaml
+++ b/build_web_compilers/mono_pkg.yaml
@@ -1,16 +1,13 @@
 dart:
-  # TODO: Update to `dev` https://github.com/dart-lang/build/issues/2841
-  - 2.10.0-110.0.dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-      - dartfmt: sdk
-      - dartanalyzer: --fatal-infos --fatal-warnings .
-    - dartanalyzer: --fatal-warnings .
-  - unit_test:
-    - group:
-      - test: --test-randomize-ordering-seed=random
-      os:
-        - linux
-        - windows
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+- unit_test:
+  - test: --test-randomize-ordering-seed=random
+    os:
+    - linux
+    - windows

--- a/build_web_compilers/mono_pkg.yaml
+++ b/build_web_compilers/mono_pkg.yaml
@@ -1,5 +1,6 @@
 dart:
-- dev
+# TODO: Update to `dev` https://github.com/dart-lang/build/issues/2841
+- 2.10.0-110.0.dev
 
 stages:
 - analyze_and_format:

--- a/example/mono_pkg.yaml
+++ b/example/mono_pkg.yaml
@@ -1,10 +1,8 @@
 dart:
-  - dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-      - dartfmt: sdk
-      - dartanalyzer: --fatal-infos --fatal-warnings .
-  #- unit_test:
-  #  - test: --run-skipped
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .

--- a/scratch_space/mono_pkg.yaml
+++ b/scratch_space/mono_pkg.yaml
@@ -1,20 +1,19 @@
 dart:
-  - dev
+- dev
 
 stages:
-  - analyze_and_format:
-    - group:
-        - dartfmt: sdk
-        - dartanalyzer: --fatal-infos --fatal-warnings .
-    - dartanalyzer: --fatal-warnings .
-      dart:
-        - 2.9.0
-  - unit_test:
-    - test: --test-randomize-ordering-seed=random
-      os:
-        - linux
-        - windows
+- analyze_and_format:
+  - group:
+    - dartfmt: sdk
+    - dartanalyzer: --fatal-infos --fatal-warnings .
+  - dartanalyzer: --fatal-warnings .
+    dart: 2.9.0
+- unit_test:
+  - test: --test-randomize-ordering-seed=random
+    os:
+    - linux
+    - windows
 
 cache:
   directories:
-    - .dart_tool/build
+  - .dart_tool/build


### PR DESCRIPTION
- Indent lists to the same position as their containing key. This
  matches the style of other Google yaml files.
- Remove the extra `dartanalyzer` command from the `build_web_compilers`
  config.
- Remove an unnecessary `group` usage for a `test` job that does not
  have multiple tasks.
- Skip using a list when specifying a single Dart version for a job.