### PR TITLE
Expand readable assets for non-root packages, make them configurable

### DIFF
--- a/_test_common/lib/test_phases.dart
+++ b/_test_common/lib/test_phases.dart
@@ -96,7 +96,7 @@ Future<BuildResult> testBuilders(
   String logPerformanceDir,
   String expectedGeneratedDir,
 }) async {
-  packageGraph ??= buildPackageGraph({rootPackage('a'): []});
+  packageGraph ??= _packageGraphFromInputs(inputs.keys);
   writer ??= InMemoryRunnerAssetWriter();
   reader ??= InMemoryRunnerAssetReader.shareAssetCache(writer.assets,
       rootPackage: packageGraph?.root?.name);
@@ -162,6 +162,27 @@ Future<BuildResult> testBuilders(
         expectedGeneratedDir: expectedGeneratedDir);
   }
   return result;
+}
+
+/// Builds the default package graph from input names.
+///
+/// The package graph will contain a root package named `a` depending on every
+/// other package present in [inputIds].
+PackageGraph _packageGraphFromInputs(Iterable<String> inputIds) {
+  final root = rootPackage('a');
+  final additionalPackageNames = <String>{};
+
+  for (final id in inputIds) {
+    final assetId = makeAssetId(id);
+    if (assetId.package != root.name) {
+      additionalPackageNames.add(assetId.package);
+    }
+  }
+
+  return buildPackageGraph({
+    root: additionalPackageNames.toList(),
+    for (final name in additionalPackageNames) package(name): [],
+  });
 }
 
 /// Translates expected outptus which start with `$$` to the build cache and

--- a/_test_common/lib/test_phases.dart
+++ b/_test_common/lib/test_phases.dart
@@ -96,7 +96,7 @@ Future<BuildResult> testBuilders(
   String logPerformanceDir,
   String expectedGeneratedDir,
 }) async {
-  packageGraph ??= _packageGraphFromInputs(inputs.keys);
+  packageGraph ??= buildPackageGraph({rootPackage('a'): []});
   writer ??= InMemoryRunnerAssetWriter();
   reader ??= InMemoryRunnerAssetReader.shareAssetCache(writer.assets,
       rootPackage: packageGraph?.root?.name);
@@ -162,27 +162,6 @@ Future<BuildResult> testBuilders(
         expectedGeneratedDir: expectedGeneratedDir);
   }
   return result;
-}
-
-/// Builds the default package graph from input names.
-///
-/// The package graph will contain a root package named `a` depending on every
-/// other package present in [inputIds].
-PackageGraph _packageGraphFromInputs(Iterable<String> inputIds) {
-  final root = rootPackage('a');
-  final additionalPackageNames = <String>{};
-
-  for (final id in inputIds) {
-    final assetId = makeAssetId(id);
-    if (assetId.package != root.name) {
-      additionalPackageNames.add(assetId.package);
-    }
-  }
-
-  return buildPackageGraph({
-    root: additionalPackageNames.toList(),
-    for (final name in additionalPackageNames) package(name): [],
-  });
 }
 
 /// Translates expected outptus which start with `$$` to the build cache and

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.0-dev
+## 1.5.1-dev
 
 - Expose a set of valid inputs in `InvalidInputException`.
 - Build implementations are now expected to throw `InvalidInputException`s, the

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.0-dev
+
+- Expose a set of valid inputs in `InvalidInputException`.
+- Build implementations are now expected to throw `InvalidInputException`s, the
+  check has been removed from this package.
+
 ## 1.5.0
 - Allow the latest analyzer version `0.40.x`.
 - Added the `Future<CompilationUnit> compilationUnitFor(AssetId id)` api to the

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 1.5.1-dev
 
 - Expose a set of valid inputs in `InvalidInputException`.
-- Build implementations are now expected to throw `InvalidInputException`s, the
-  check has been removed from this package.
+- `AssetReader` implementations are now expected to throw 
+  `InvalidInputException`s when reading invalid inputs.
+  The check has been removed from the build step implementation.
 
 ## 1.5.0
 - Allow the latest analyzer version `0.40.x`.

--- a/build/lib/src/asset/exceptions.dart
+++ b/build/lib/src/asset/exceptions.dart
@@ -41,7 +41,7 @@ class InvalidInputException implements Exception {
   /// choose to allow additional assets via a `build.yaml` file.
   final List<String> allowedGlobs;
 
-  InvalidInputException(this.assetId, [this.allowedGlobs = const ['lib/**']]);
+  InvalidInputException(this.assetId, {this.allowedGlobs = const ['lib/**']});
 
   @override
   String toString() {

--- a/build/lib/src/asset/exceptions.dart
+++ b/build/lib/src/asset/exceptions.dart
@@ -40,8 +40,8 @@ class InvalidInputException implements Exception {
   String toString() => 'InvalidInputException: $assetId\n'
       'For package dependencies, only public files like `lib/**` may be used '
       'as inputs.\n'
-      'A package can mark a file as public by adding it to its `public_assets` '
-      'in a build.yaml file.';
+      'A package can mark a file as public by including it in its'
+      '`additional_public_assets` in a build.yaml file.';
 }
 
 class BuildStepCompletedException implements Exception {

--- a/build/lib/src/asset/exceptions.dart
+++ b/build/lib/src/asset/exceptions.dart
@@ -48,10 +48,12 @@ class InvalidInputException implements Exception {
     final allowedBuffer = StringBuffer();
 
     for (var i = 0; i < allowedGlobs.length; i++) {
-      if (i == allowedGlobs.length - 1) {
-        allowedBuffer.write(' and ');
-      } else if (i != 0) {
-        allowedBuffer.write(', ');
+      if (i > 0) {
+        if (i == allowedGlobs.length - 1) {
+          allowedBuffer.write(' or ');
+        } else {
+          allowedBuffer.write(', ');
+        }
       }
 
       allowedBuffer.write(allowedGlobs[i]);

--- a/build/lib/src/asset/exceptions.dart
+++ b/build/lib/src/asset/exceptions.dart
@@ -32,16 +32,37 @@ class InvalidOutputException implements Exception {
 }
 
 class InvalidInputException implements Exception {
+  /// The invalid asset that couldn't be read.
   final AssetId assetId;
 
-  InvalidInputException(this.assetId);
+  /// The list of readable globs in the package dependency.
+  ///
+  /// This includes public files like `lib/` by default, but a package can
+  /// choose to allow additional assets via a `build.yaml` file.
+  final List<String> allowedGlobs;
+
+  InvalidInputException(this.assetId, [this.allowedGlobs = const ['lib/**']]);
 
   @override
-  String toString() => 'InvalidInputException: $assetId\n'
-      'For package dependencies, only public files like `lib/**` may be used '
-      'as inputs.\n'
-      'A package can mark a file as public by including it in its '
-      '`additional_public_assets` in a build.yaml file.';
+  String toString() {
+    final allowedBuffer = StringBuffer();
+
+    for (var i = 0; i < allowedGlobs.length; i++) {
+      if (i == allowedGlobs.length - 1) {
+        allowedBuffer.write(' and ');
+      } else if (i != 0) {
+        allowedBuffer.write(', ');
+      }
+
+      allowedBuffer.write(allowedGlobs[i]);
+    }
+
+    return 'InvalidInputException: $assetId\n'
+        'For this package, only assets matching $allowedBuffer can be used as '
+        'inputs. \n'
+        'A package can mark a file as public by including it in its '
+        '`additional_public_assets` in a build.yaml file.';
+  }
 }
 
 class BuildStepCompletedException implements Exception {

--- a/build/lib/src/asset/exceptions.dart
+++ b/build/lib/src/asset/exceptions.dart
@@ -40,7 +40,7 @@ class InvalidInputException implements Exception {
   String toString() => 'InvalidInputException: $assetId\n'
       'For package dependencies, only public files like `lib/**` may be used '
       'as inputs.\n'
-      'A package can mark a file as public by including it in its'
+      'A package can mark a file as public by including it in its '
       '`additional_public_assets` in a build.yaml file.';
 }
 

--- a/build/lib/src/asset/exceptions.dart
+++ b/build/lib/src/asset/exceptions.dart
@@ -38,7 +38,10 @@ class InvalidInputException implements Exception {
 
   @override
   String toString() => 'InvalidInputException: $assetId\n'
-      'For package dependencies, only files under `lib` may be used as inputs.';
+      'For package dependencies, only public files like `lib/**` may be used '
+      'as inputs.\n'
+      'A package can mark a file as public by adding it to its `public_assets` '
+      'in a build.yaml file.';
 }
 
 class BuildStepCompletedException implements Exception {

--- a/build/lib/src/asset/reader.dart
+++ b/build/lib/src/asset/reader.dart
@@ -31,8 +31,6 @@ abstract class AssetReader {
   Future<String> readAsString(AssetId id, {Encoding encoding});
 
   /// Indicates whether asset at [id] is readable.
-  ///
-  /// Throws an `InvalidInputException` if [id] is an invalid input.
   Future<bool> canRead(AssetId id);
 
   /// Returns all readable assets matching [glob] under the current package.

--- a/build/lib/src/asset/reader.dart
+++ b/build/lib/src/asset/reader.dart
@@ -19,6 +19,7 @@ abstract class AssetReader {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws a `AssetNotFoundException` if `id.path` is not found.
+  /// * Throws an `InvalidInputException` if `id.path` is an invalid input.
   Future<List<int>> readAsBytes(AssetId id);
 
   /// Returns a [Future] that completes with the contents of a text asset.
@@ -27,6 +28,7 @@ abstract class AssetReader {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws a `AssetNotFoundException` if `id.path` is not found.
+  /// * Throws an `InvalidInputException` if `id.path` is an invalid input.
   Future<String> readAsString(AssetId id, {Encoding encoding});
 
   /// Indicates whether asset at [id] is readable.
@@ -43,6 +45,9 @@ abstract class AssetReader {
   ///
   /// This should be treated as a transparent [Digest] and the implementation
   /// may differ based on the current build system being used.
+  ///
+  /// Similar to [readAsBytes], `digest` throws an exception if the asset can't
+  /// be found or if it's an invalid input.
   Future<Digest> digest(AssetId id) async {
     var digestSink = AccumulatorSink<Digest>();
     md5.startChunkedConversion(digestSink)

--- a/build/lib/src/asset/reader.dart
+++ b/build/lib/src/asset/reader.dart
@@ -27,10 +27,12 @@ abstract class AssetReader {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws a `AssetNotFoundException` if `id.path` is not found.
-  /// * Throws an `InvalidInputException` if `id.path` is an invalid input.
+  /// * Throws an `InvalidInputException` if [id] is an invalid input.
   Future<String> readAsString(AssetId id, {Encoding encoding});
 
   /// Indicates whether asset at [id] is readable.
+  ///
+  /// Throws an `InvalidInputException` if [id] is an invalid input.
   Future<bool> canRead(AssetId id);
 
   /// Returns all readable assets matching [glob] under the current package.

--- a/build/lib/src/asset/reader.dart
+++ b/build/lib/src/asset/reader.dart
@@ -18,7 +18,7 @@ abstract class AssetReader {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws a `AssetNotFoundException` if `id.path` is not found.
-  /// * Throws an `InvalidInputException` if `id.path` is an invalid input.
+  /// * Throws an `InvalidInputException` if [id] is an invalid input.
   Future<List<int>> readAsBytes(AssetId id);
 
   /// Returns a [Future] that completes with the contents of a text asset.

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -51,9 +51,6 @@ class BuildStepImpl implements BuildStep {
   /// Used internally for writing files.
   final AssetWriter _writer;
 
-  /// The current root package, used for input/output validation.
-  final String _rootPackage;
-
   final ResourceManager _resourceManager;
 
   bool _isComplete = false;
@@ -61,7 +58,7 @@ class BuildStepImpl implements BuildStep {
   final void Function(Iterable<AssetId>) _reportUnusedAssets;
 
   BuildStepImpl(this.inputId, Iterable<AssetId> expectedOutputs, this._reader,
-      this._writer, this._rootPackage, this._resolvers, this._resourceManager,
+      this._writer, this._resolvers, this._resourceManager,
       {StageTracker stageTracker,
       void Function(Iterable<AssetId>) reportUnusedAssets})
       : _expectedOutputs = expectedOutputs.toSet(),
@@ -105,7 +102,7 @@ class BuildStepImpl implements BuildStep {
     if (_isComplete) throw BuildStepCompletedException();
     if (_reader is MultiPackageAssetReader) {
       return (_reader as MultiPackageAssetReader)
-          .findAssets(glob, package: inputId?.package ?? _rootPackage);
+          .findAssets(glob, package: inputId.package);
     } else {
       return _reader.findAssets(glob);
     }

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -79,7 +79,6 @@ class BuildStepImpl implements BuildStep {
   @override
   Future<bool> canRead(AssetId id) {
     if (_isComplete) throw BuildStepCompletedException();
-    _checkInput(id);
     return _reader.canRead(id);
   }
 
@@ -92,14 +91,12 @@ class BuildStepImpl implements BuildStep {
   @override
   Future<List<int>> readAsBytes(AssetId id) {
     if (_isComplete) throw BuildStepCompletedException();
-    _checkInput(id);
     return _reader.readAsBytes(id);
   }
 
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) {
     if (_isComplete) throw BuildStepCompletedException();
-    _checkInput(id);
     return _reader.readAsString(id, encoding: encoding);
   }
 
@@ -138,7 +135,6 @@ class BuildStepImpl implements BuildStep {
   @override
   Future<Digest> digest(AssetId id) {
     if (_isComplete) throw BuildStepCompletedException();
-    _checkInput(id);
     return _reader.digest(id);
   }
 
@@ -160,14 +156,6 @@ class BuildStepImpl implements BuildStep {
     _isComplete = true;
     await Future.wait(_writeResults.map(Result.release));
     (await _resolver)?.release();
-  }
-
-  /// Checks that [id] is a valid input, and throws an [InvalidInputException]
-  /// if its not.
-  void _checkInput(AssetId id) {
-    if (id.package != _rootPackage && !id.path.startsWith('lib/')) {
-      throw InvalidInputException(id);
-    }
   }
 
   /// Checks that [id] is an expected output, and throws an

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -34,7 +34,7 @@ Future<void> runBuilder(Builder builder, Iterable<AssetId> inputs,
     AssetReader reader, AssetWriter writer, Resolvers resolvers,
     {Logger logger,
     ResourceManager resourceManager,
-    String rootPackage,
+    @Deprecated('The rootPackage argument is unused') String rootPackage,
     StageTracker stageTracker = NoOpStageTracker.instance,
     void Function(AssetId input, Iterable<AssetId> assets)
         reportUnusedAssetsForInput}) async {
@@ -45,8 +45,8 @@ Future<void> runBuilder(Builder builder, Iterable<AssetId> inputs,
   Future<void> buildForInput(AssetId input) async {
     var outputs = expectedOutputs(builder, input);
     if (outputs.isEmpty) return;
-    var buildStep = BuildStepImpl(input, outputs, reader, writer,
-        rootPackage ?? input.package, resolvers, resourceManager,
+    var buildStep = BuildStepImpl(
+        input, outputs, reader, writer, resolvers, resourceManager,
         stageTracker: stageTracker,
         reportUnusedAssets: reportUnusedAssetsForInput == null
             ? null

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.5.0
+version: 1.6.0-dev
 description: A build system for Dart.
 homepage: https://github.com/dart-lang/build/tree/master/build
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.6.0-dev
+version: 1.5.1-dev
 description: A build system for Dart.
 homepage: https://github.com/dart-lang/build/tree/master/build
 

--- a/build/test/asset/exceptions_test.dart
+++ b/build/test/asset/exceptions_test.dart
@@ -4,8 +4,8 @@ import 'package:test/test.dart';
 void main() {
   test('InvalidInputException.toString() reports available assets', () {
     final onlyLib = InvalidInputException(AssetId('a', 'test/foo.bar'));
-    final libReadmeAndTest = InvalidInputException(
-        AssetId('a', 'test/foo.bar'), ['lib/**', 'README*', 'test/**']);
+    final libReadmeAndTest = InvalidInputException(AssetId('a', 'test/foo.bar'),
+        allowedGlobs: ['lib/**', 'README*', 'test/**']);
 
     expect(onlyLib.toString(), contains('only assets matching lib/**'));
     expect(libReadmeAndTest.toString(),

--- a/build/test/asset/exceptions_test.dart
+++ b/build/test/asset/exceptions_test.dart
@@ -1,0 +1,14 @@
+import 'package:build/build.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('InvalidInputException.toString() reports available assets', () {
+    final onlyLib = InvalidInputException(AssetId('a', 'test/foo.bar'));
+    final libReadmeAndTest = InvalidInputException(
+        AssetId('a', 'test/foo.bar'), ['lib/**', 'README*', 'test/**']);
+
+    expect(onlyLib.toString(), contains('only assets matching lib/**'));
+    expect(libReadmeAndTest.toString(),
+        contains('only assets matching lib/**, README* or test/**'));
+  });
+}

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -33,8 +33,8 @@ void main() {
       var reader = StubAssetReader();
       var writer = StubAssetWriter();
       primary = makeAssetId();
-      buildStep = BuildStepImpl(primary, [], reader, writer, primary.package,
-          AnalyzerResolvers(), resourceManager);
+      buildStep = BuildStepImpl(
+          primary, [], reader, writer, AnalyzerResolvers(), resourceManager);
     });
 
     test('doesnt allow non-expected outputs', () {
@@ -70,7 +70,7 @@ void main() {
       };
       addAssets(inputs, writer);
       var outputId = AssetId.parse('$primary.copy');
-      var buildStep = BuildStepImpl(primary, [outputId], reader, writer, 'a',
+      var buildStep = BuildStepImpl(primary, [outputId], reader, writer,
           AnalyzerResolvers(), resourceManager);
 
       await builder.build(buildStep);
@@ -95,8 +95,8 @@ void main() {
         addAssets(inputs, writer);
 
         var primary = makeAssetId('a|web/a.dart');
-        var buildStep = BuildStepImpl(primary, [], reader, writer,
-            primary.package, AnalyzerResolvers(), resourceManager);
+        var buildStep = BuildStepImpl(
+            primary, [], reader, writer, AnalyzerResolvers(), resourceManager);
         var resolver = buildStep.resolver;
 
         var aLib = await resolver.libraryFor(primary);
@@ -126,7 +126,7 @@ void main() {
       outputId = makeAssetId('a|test.txt');
       outputContent = '$outputId';
       buildStep = BuildStepImpl(primary, [outputId], StubAssetReader(),
-          assetWriter, primary.package, AnalyzerResolvers(), resourceManager);
+          assetWriter, AnalyzerResolvers(), resourceManager);
     });
 
     test('Completes only after writes finish', () async {
@@ -174,7 +174,7 @@ void main() {
       primary = makeAssetId();
       output = makeAssetId();
       buildStep = BuildStepImpl(primary, [output], reader, writer,
-          primary.package, AnalyzerResolvers(), resourceManager,
+          AnalyzerResolvers(), resourceManager,
           stageTracker: NoOpStageTracker.instance);
     });
 
@@ -188,8 +188,8 @@ void main() {
     var reader = StubAssetReader();
     var writer = StubAssetWriter();
     var unused = <AssetId>{};
-    var buildStep = BuildStepImpl(makeAssetId(), [], reader, writer, 'a',
-        AnalyzerResolvers(), resourceManager,
+    var buildStep = BuildStepImpl(
+        makeAssetId(), [], reader, writer, AnalyzerResolvers(), resourceManager,
         reportUnusedAssets: unused.addAll);
     var reported = [
       makeAssetId(),

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -45,28 +45,6 @@ void main() {
           throwsA(TypeMatcher<UnexpectedOutputException>()));
     });
 
-    test('canRead throws invalidInputExceptions', () async {
-      expect(() => buildStep.canRead(makeAssetId('b|web/a.txt')),
-          throwsA(invalidInputException));
-      expect(() => buildStep.canRead(makeAssetId('b|a.txt')),
-          throwsA(invalidInputException));
-      expect(() => buildStep.canRead(makeAssetId('foo|bar.txt')),
-          throwsA(invalidInputException));
-    });
-
-    test('readAs* throws InvalidInputExceptions', () async {
-      var invalidInputs = [
-        makeAssetId('b|web/a.txt'),
-        makeAssetId('b|a.txt'),
-        makeAssetId('foo|bar.txt')
-      ];
-      for (var id in invalidInputs) {
-        expect(
-            () => buildStep.readAsString(id), throwsA(invalidInputException));
-        expect(() => buildStep.readAsBytes(id), throwsA(invalidInputException));
-      }
-    });
-
     test('fetchResource can fetch resources', () async {
       var expected = 1;
       var intResource = Resource(() => expected);

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.4.3-dev
 
+- Added the `public_assets` option, which describes the assets readable when
+  the configured package is not the root of the build.
+
 ## 0.4.2
 
 - Add support for an `auto_apply_builders` option to the `target` config.

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.4.3-dev
 
-- Added the `public_assets` option, which describes the assets readable when
-  the configured package is not the root of the build.
+- Added the `additional_public_assets` option, which describes the assets
+  readable when the configured package is not the root of the build.
 
 ## 0.4.2
 

--- a/build_config/lib/build_config.dart
+++ b/build_config/lib/build_config.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/build_config.dart' show BuildConfig, defaultPublicAssets;
+export 'src/build_config.dart' show BuildConfig;
 export 'src/build_target.dart'
     show BuildTarget, TargetBuilderConfig, GlobalBuilderConfig;
 export 'src/builder_definition.dart'

--- a/build_config/lib/build_config.dart
+++ b/build_config/lib/build_config.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-export 'src/build_config.dart' show BuildConfig;
+export 'src/build_config.dart' show BuildConfig, defaultPublicAssets;
 export 'src/build_target.dart'
     show BuildTarget, TargetBuilderConfig, GlobalBuilderConfig;
 export 'src/builder_definition.dart'

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -71,8 +71,8 @@ class BuildConfig {
   @JsonKey(name: 'global_options')
   final Map<String, GlobalBuilderConfig> globalOptions;
 
-  @JsonKey(name: 'public_assets')
-  final InputSet publicAssets;
+  @JsonKey(name: 'additional_public_assets')
+  final List<String> additionalPublicAssets;
 
   /// The default config if you have no `build.yaml` file.
   factory BuildConfig.useDefault(
@@ -130,7 +130,7 @@ class BuildConfig {
     Map<String, BuilderDefinition> builderDefinitions,
     Map<String, PostProcessBuilderDefinition> postProcessBuilderDefinitions =
         const {},
-    this.publicAssets = const InputSet(),
+    this.additionalPublicAssets = const [],
   })  : buildTargets = buildTargets ??
             {
               _defaultTarget(packageName ?? currentPackage): BuildTarget(

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -130,7 +130,7 @@ class BuildConfig {
     Map<String, BuilderDefinition> builderDefinitions,
     Map<String, PostProcessBuilderDefinition> postProcessBuilderDefinitions =
         const {},
-    this.publicAssets = defaultPublicAssets,
+    this.publicAssets = const InputSet(),
   })  : buildTargets = buildTargets ??
             {
               _defaultTarget(packageName ?? currentPackage): BuildTarget(
@@ -163,12 +163,6 @@ class BuildConfig {
 
   factory BuildConfig._fromJson(Map json) => _$BuildConfigFromJson(json);
 }
-
-const InputSet defaultPublicAssets = InputSet(include: [
-  'lib/**',
-  'LICENSE',
-  'pubspec.yaml',
-]);
 
 String _defaultTarget(String package) => '$package:$package';
 

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -71,6 +71,9 @@ class BuildConfig {
   @JsonKey(name: 'global_options')
   final Map<String, GlobalBuilderConfig> globalOptions;
 
+  @JsonKey(name: 'public_assets')
+  final InputSet publicAssets;
+
   /// The default config if you have no `build.yaml` file.
   factory BuildConfig.useDefault(
       String packageName, Iterable<String> dependencies) {
@@ -127,6 +130,7 @@ class BuildConfig {
     Map<String, BuilderDefinition> builderDefinitions,
     Map<String, PostProcessBuilderDefinition> postProcessBuilderDefinitions =
         const {},
+    this.publicAssets = defaultPublicAssets,
   })  : buildTargets = buildTargets ??
             {
               _defaultTarget(packageName ?? currentPackage): BuildTarget(
@@ -159,6 +163,12 @@ class BuildConfig {
 
   factory BuildConfig._fromJson(Map json) => _$BuildConfigFromJson(json);
 }
+
+const InputSet defaultPublicAssets = InputSet(include: [
+  'lib/**',
+  'LICENSE',
+  'pubspec.yaml',
+]);
 
 String _defaultTarget(String package) => '$package:$package';
 

--- a/build_config/lib/src/build_config.g.dart
+++ b/build_config/lib/src/build_config.g.dart
@@ -13,7 +13,7 @@ BuildConfig _$BuildConfigFromJson(Map json) {
       'post_process_builders',
       'targets',
       'global_options',
-      'public_assets'
+      'additional_public_assets'
     ]);
     final val = BuildConfig(
       buildTargets: $checkedConvert(
@@ -42,8 +42,8 @@ BuildConfig _$BuildConfigFromJson(Map json) {
                         ? null
                         : PostProcessBuilderDefinition.fromJson(e as Map)),
               )),
-      publicAssets: $checkedConvert(json, 'public_assets',
-          (v) => v == null ? null : InputSet.fromJson(v)),
+      additionalPublicAssets: $checkedConvert(json, 'additional_public_assets',
+          (v) => (v as List)?.map((e) => e as String)?.toList()),
     );
     return val;
   }, fieldKeyMap: const {
@@ -51,6 +51,6 @@ BuildConfig _$BuildConfigFromJson(Map json) {
     'globalOptions': 'global_options',
     'builderDefinitions': 'builders',
     'postProcessBuilderDefinitions': 'post_process_builders',
-    'publicAssets': 'public_assets'
+    'additionalPublicAssets': 'additional_public_assets'
   });
 }

--- a/build_config/lib/src/build_config.g.dart
+++ b/build_config/lib/src/build_config.g.dart
@@ -12,7 +12,8 @@ BuildConfig _$BuildConfigFromJson(Map json) {
       'builders',
       'post_process_builders',
       'targets',
-      'global_options'
+      'global_options',
+      'public_assets'
     ]);
     final val = BuildConfig(
       buildTargets: $checkedConvert(
@@ -41,12 +42,15 @@ BuildConfig _$BuildConfigFromJson(Map json) {
                         ? null
                         : PostProcessBuilderDefinition.fromJson(e as Map)),
               )),
+      publicAssets: $checkedConvert(json, 'public_assets',
+          (v) => v == null ? null : InputSet.fromJson(v)),
     );
     return val;
   }, fieldKeyMap: const {
     'buildTargets': 'targets',
     'globalOptions': 'global_options',
     'builderDefinitions': 'builders',
-    'postProcessBuilderDefinitions': 'post_process_builders'
+    'postProcessBuilderDefinitions': 'post_process_builders',
+    'publicAssets': 'public_assets'
   });
 }

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -27,3 +27,6 @@ dependency_overrides:
   build_runner_core:
     path: ../build_runner_core
   analyzer: ^0.40.0
+  # Temporarily required until build version 1.5.1 is released
+  build:
+    path: ../build

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -90,6 +90,13 @@ void main() {
           devOptions: const {'foo': 'global_dev'},
           releaseOptions: const {'foo': 'global_release'})
     });
+
+    expect(
+      buildConfig.publicAssets,
+      isA<InputSet>()
+          .having((e) => e.include, 'publicAssets.include', ['test/**']).having(
+              (e) => e.exclude, 'publicAssets.exclude', anyOf(isNull, isEmpty)),
+    );
   });
 
   test('build.yaml can omit a targets section', () {
@@ -233,6 +240,8 @@ post_process_builders:
         foo: bar
       release_options:
         baz: bop
+public_assets:
+  - "test/**"
 ''';
 
 var buildYamlNoTargets = '''

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -91,12 +91,7 @@ void main() {
           releaseOptions: const {'foo': 'global_release'})
     });
 
-    expect(
-      buildConfig.publicAssets,
-      isA<InputSet>()
-          .having((e) => e.include, 'publicAssets.include', ['test/**']).having(
-              (e) => e.exclude, 'publicAssets.exclude', anyOf(isNull, isEmpty)),
-    );
+    expect(buildConfig.additionalPublicAssets, ['test/**']);
   });
 
   test('build.yaml can omit a targets section', () {
@@ -240,7 +235,7 @@ post_process_builders:
         foo: bar
       release_options:
         baz: bop
-public_assets:
+additional_public_assets:
   - "test/**"
 ''';
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.4-dev
+
+- Require the latest build version (1.6.x).
+
 ## 6.0.3
 
 - Fix https://github.com/dart-lang/build/issues/1804.

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 6.0.4-dev
+## 6.1.0-dev
 
-- Require the latest build version (1.6.x).
+- Require the latest build version (1.5.1).
+- Support the `additional_public_assets` option in build configurations.
 
 ## 6.0.3
 

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -86,13 +86,11 @@ class SingleStepReader implements AssetReader {
   /// [InvalidInputException], this method will return `false` instead of
   /// throwing.
   FutureOr<bool> _isReadable(AssetId id, {bool catchInvalidInputs = false}) {
-    try {
-      _checkInvalidInput(id);
-    } on InvalidInputException {
-      if (catchInvalidInputs) {
+    if (catchInvalidInputs) {
+      try {
+        _checkInvalidInput(id);
+      } on InvalidInputException {
         return false;
-      } else {
-        rethrow;
       }
     }
 

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -86,12 +86,13 @@ class SingleStepReader implements AssetReader {
   /// [InvalidInputException], this method will return `false` instead of
   /// throwing.
   FutureOr<bool> _isReadable(AssetId id, {bool catchInvalidInputs = false}) {
-    if (catchInvalidInputs) {
-      try {
-        _checkInvalidInput(id);
-      } on InvalidInputException {
+    try {
+      _checkInvalidInput(id);
+    } on InvalidInputException {
+      if (catchInvalidInputs) {
         return false;
       }
+      rethrow;
     }
 
     final node = _assetGraph.get(id);

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -163,14 +163,15 @@ class AssetTracker {
     return updates;
   }
 
-  Stream<AssetId> _listAssetIds(TargetNode targetNode) => targetNode
-          .sourceIncludes.isEmpty
-      ? Stream<AssetId>.empty()
-      : StreamGroup.merge(targetNode.sourceIncludes.map((glob) =>
-          _listIdsSafe(glob, package: targetNode.package.name)
-              .where((id) =>
-                  targetNode.package.isRoot || id.pathSegments.first == 'lib')
-              .where((id) => !targetNode.excludesSource(id))));
+  Stream<AssetId> _listAssetIds(TargetNode targetNode) {
+    return targetNode.sourceIncludes.isEmpty
+        ? Stream<AssetId>.empty()
+        : StreamGroup.merge(targetNode.sourceIncludes.map((glob) =>
+            _listIdsSafe(glob, package: targetNode.package.name)
+                .where((id) =>
+                    _targetGraph.isVisibleInBuild(id, targetNode.package))
+                .where((id) => !targetNode.excludesSource(id))));
+  }
 
   Stream<AssetId> _listGeneratedAssetIds() {
     var glob = Glob('$generatedOutputDirectory/**');

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -474,15 +474,14 @@ class _SingleBuild {
         var wrappedWriter = AssetWriterSpy(_writer);
 
         var wrappedReader = SingleStepReader(
-          _reader,
-          _assetGraph,
-          phaseNumber,
-          input.package,
-          _isReadableNode,
-          _isInvalidInput,
-          _getUpdatedGlobNode,
-          wrappedWriter,
-        );
+            _reader,
+            _assetGraph,
+            phaseNumber,
+            input.package,
+            _isReadableNode,
+            _isInvalidInput,
+            _getUpdatedGlobNode,
+            wrappedWriter);
 
         if (!await tracker.trackStage(
             'Setup', () => _buildShouldRun(builderOutputs, wrappedReader))) {

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -156,7 +156,7 @@ CheckInvalidInput _checkInvalidInputFactory(
 
     // The id is an invalid input if it's not part of the build.
     if (!targetGraph.isVisibleInBuild(id, packageNode)) {
-      final allowed = targetGraph.getValidInputs(packageNode);
+      final allowed = targetGraph.validInputsFor(packageNode);
 
       throw InvalidInputException(id, allowed);
     }

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -158,7 +158,7 @@ CheckInvalidInput _checkInvalidInputFactory(
     if (!targetGraph.isVisibleInBuild(id, packageNode)) {
       final allowed = targetGraph.validInputsFor(packageNode);
 
-      throw InvalidInputException(id, allowed);
+      throw InvalidInputException(id, allowedGlobs: allowed);
     }
   };
 }

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -535,7 +535,6 @@ class _SingleBuild {
                   stageTracker: tracker,
                   reportUnusedAssetsForInput: (_, assets) =>
                       unusedAssets.addAll(assets),
-                  rootPackage: _packageGraph.root.name,
                 ).catchError((void _) {
                   // Errors tracked through the logger
                 }));

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -248,7 +248,7 @@ class _SingleBuild {
     await _resourceManager.disposeAll();
     result = await _environment.finalizeBuild(
         result,
-        FinalizedAssetsView(_assetGraph, optionalOutputTracker),
+        FinalizedAssetsView(_assetGraph, _packageGraph, optionalOutputTracker),
         _reader,
         _buildDirs);
     if (result.status == BuildStatus.success) {

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -124,7 +124,7 @@ class BuildImpl {
         buildDefinition.assetGraph,
         buildPhases.length,
         options.packageGraph.root.name,
-        _isReadableAfterBuildFactory(buildPhases));
+        _isReadableAfterBuildFactory(buildDefinition, buildPhases));
     var finalizedReader = FinalizedReader(
         singleStepReader,
         buildDefinition.assetGraph,
@@ -135,8 +135,14 @@ class BuildImpl {
     return build;
   }
 
-  static IsReadable _isReadableAfterBuildFactory(List<BuildPhase> buildPhases) {
+  static IsReadable _isReadableAfterBuildFactory(
+      BuildDefinition definition, List<BuildPhase> buildPhases) {
     return (AssetNode node, int phaseNum, AssetWriterSpy writtenAssets) {
+      final package = definition.packageGraph[node.id.package];
+      if (!definition.targetGraph.isVisibleInBuild(node.id, package)) {
+        return Readability.invalidAsset;
+      }
+
       if (node is GeneratedAssetNode) {
         return _readabilityOf(node.wasOutput && !node.isFailure);
       }

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -24,6 +24,7 @@ import 'exceptions.dart';
 /// This is also the default list of files for targets in non-root packages when
 /// an explicit include is not provided.
 const List<String> defaultNonRootVisibleAssets = [
+  'CHANGELOG*',
   'lib/**',
   'bin/**',
   'LICENSE*',
@@ -39,6 +40,7 @@ const List<String> defaultRootPackageSources = [
   'assets/**',
   'benchmark/**',
   'bin/**',
+  'CHANGELOG*',
   'example/**',
   'lib/**',
   'test/**',

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -19,8 +19,22 @@ import '../package_graph/target_graph.dart';
 import '../util/hash.dart';
 import 'exceptions.dart';
 
+/// The default list of files visible for non-root packages.
+///
+/// This is also the default list of files for targets in non-root packages when
+/// an explicit include is not provided.
+const List<String> defaultNonRootVisibleAssets = [
+  'lib/**',
+  'bin/**',
+  'LICENSE*',
+  'pubspec.yaml',
+  'README*',
+];
+
 /// The default list of files to include when an explicit include is not
 /// provided.
+///
+/// This should be a superset of [defaultNonRootVisibleAssets].
 const List<String> defaultRootPackageSources = [
   'assets/**',
   'benchmark/**',
@@ -31,8 +45,10 @@ const List<String> defaultRootPackageSources = [
   'tool/**',
   'web/**',
   'node/**',
+  'LICENSE*',
   'pubspec.yaml',
   'pubspec.lock',
+  'README*',
   r'$package$',
 ];
 

--- a/build_runner_core/lib/src/package_graph/target_graph.dart
+++ b/build_runner_core/lib/src/package_graph/target_graph.dart
@@ -15,7 +15,7 @@ import 'package_graph.dart';
 /// based on build config.
 class TargetGraph {
   static final InputMatcher _defaultMatcherForNonRoot =
-      InputMatcher(defaultPublicAssets);
+      InputMatcher(const InputSet(), defaultInclude: _defaultPublicAssets);
 
   /// All [TargetNode]s indexed by `"$packageName:$targetName"`.
   final Map<String, TargetNode> allModules;
@@ -66,7 +66,8 @@ class TargetGraph {
     for (final package in packageGraph.allPackages.values) {
       final config = overrideBuildConfig[package.name] ??
           await _packageBuildConfig(package);
-      publicAssetsByPackage[package.name] = InputMatcher(config.publicAssets);
+      publicAssetsByPackage[package.name] = InputMatcher(config.publicAssets,
+          defaultInclude: _defaultPublicAssets);
       List<String> defaultInclude;
       if (package.isRoot) {
         defaultInclude = defaultRootPackageSources;
@@ -159,6 +160,14 @@ Future<BuildConfig> _packageBuildConfig(PackageNode package) async {
     throw BuildConfigParseException(package.name, e);
   }
 }
+
+const _defaultPublicAssets = [
+  'lib/**',
+  'bin/**',
+  'LICENSE',
+  'README',
+  'pubspec.yaml',
+];
 
 class BuildConfigParseException implements Exception {
   final String packageName;

--- a/build_runner_core/lib/src/package_graph/target_graph.dart
+++ b/build_runner_core/lib/src/package_graph/target_graph.dart
@@ -7,9 +7,9 @@ import 'dart:async';
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
 import 'package:glob/glob.dart';
-import 'package:meta/meta.dart';
 
 import '../generate/input_matcher.dart';
+import '../generate/options.dart' show defaultNonRootVisibleAssets;
 import 'package_graph.dart';
 
 /// Like a [PackageGraph] but packages are further broken down into modules
@@ -17,7 +17,7 @@ import 'package_graph.dart';
 class TargetGraph {
   static final InputMatcher _defaultMatcherForNonRoot = InputMatcher(
       const InputSet(),
-      defaultInclude: defaultPublicAssetsForNonRoot);
+      defaultInclude: defaultNonRootVisibleAssets);
 
   /// All [TargetNode]s indexed by `"$packageName:$targetName"`.
   final Map<String, TargetNode> allModules;
@@ -79,7 +79,7 @@ class TargetGraph {
         ];
       } else {
         defaultInclude = [
-          ...defaultPublicAssetsForNonRoot,
+          ...defaultNonRootVisibleAssets,
           ...?config.additionalPublicAssets
         ];
         publicAssetsByPackage[package.name] =
@@ -188,15 +188,6 @@ Future<BuildConfig> _packageBuildConfig(PackageNode package) async {
     throw BuildConfigParseException(package.name, e);
   }
 }
-
-@visibleForTesting
-const defaultPublicAssetsForNonRoot = [
-  'lib/**',
-  'bin/**',
-  'LICENSE*',
-  'README*',
-  'pubspec.yaml',
-];
 
 class BuildConfigParseException implements Exception {
   final String packageName;

--- a/build_runner_core/lib/src/package_graph/target_graph.dart
+++ b/build_runner_core/lib/src/package_graph/target_graph.dart
@@ -120,7 +120,7 @@ class TargetGraph {
 
   /// Obtains a list of glob patterns describing all valid input assets defined
   /// in the [package].
-  List<String> getValidInputs(PackageNode package) {
+  List<String> validInputsFor(PackageNode package) {
     if (package.isRoot) {
       // There are no restrictions for the root package
       return ['**/*'];
@@ -141,6 +141,11 @@ class TargetGraph {
   /// asset is visible if it's in a conceptually public folders of a Dart
   /// package (like `lib/` or `bin/`), or if the enclosing package made that
   /// asset public by including it in [BuildConfig.additionalPublicAssets].
+  ///
+  /// Note that an asset being visible does not imply that it's readable too.
+  /// For instance, an asset id can be visible in the build even if the
+  /// referenced asset doesn't exist. Assets that aren't part of any target
+  /// would also be visible without being readable.
   bool isVisibleInBuild(AssetId id, PackageNode enclosingPackage) {
     assert(id.package == enclosingPackage.name);
 

--- a/build_runner_core/lib/src/package_graph/target_graph.dart
+++ b/build_runner_core/lib/src/package_graph/target_graph.dart
@@ -120,8 +120,9 @@ class TargetGraph {
   /// Whether the [id] is visible in a build.
   ///
   /// All assets in the root package are visible. For non-root packages, an
-  /// asset is visible if it's included in the [BuildConfig.publicAssets] of
-  /// that package.
+  /// asset is visible if it's in a conceptually public folders of a Dart
+  /// package (like `lib/` or `bin/`), or if the enclosing package made that
+  /// asset public by including it in [BuildConfig.additionalPublicAssets].
   bool isVisibleInBuild(AssetId id, PackageNode enclosingPackage) {
     assert(id.package == enclosingPackage.name);
 
@@ -171,7 +172,7 @@ const _defaultPublicAssetsForNonRoot = [
   'lib/**',
   'bin/**',
   'LICENSE',
-  'README',
+  'README*',
   'pubspec.yaml',
 ];
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 6.0.3
+version: 6.0.4
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.5.0 <1.6.0"
+  build: ">=1.6.0 <1.7.0"
   build_config: ">=0.4.2 <0.4.3"
   build_resolvers: ^1.4.0
   collection: ^1.14.0

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -35,3 +35,9 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_config:
+    path: ../build_config

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ">=1.5.1 <1.6.0"
-  build_config: ">=0.4.2 <0.4.3"
+  build_config: ">=0.4.3 <0.4.4"
   build_resolvers: ^1.4.0
   collection: ^1.14.0
   convert: ^2.0.1

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 6.0.4
+version: 6.1.0-dev
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.6.0 <1.7.0"
+  build: ">=1.5.1 <1.6.0"
   build_config: ">=0.4.2 <0.4.3"
   build_resolvers: ^1.4.0
   collection: ^1.14.0

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -40,5 +40,3 @@ dependency_overrides:
     path: ../build
   build_config:
     path: ../build_config
-  build_test:
-    path: ../build_test

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -40,3 +40,5 @@ dependency_overrides:
     path: ../build
   build_config:
     path: ../build_config
+  build_test:
+    path: ../build_test

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ">=1.3.0 <1.4.0"
   build_config: ">=0.4.2 <0.4.3"
-  build_resolvers: ^1.3.8
+  build_resolvers: ^1.4.0
   collection: ^1.14.0
   convert: ^2.0.1
   crypto: ">=0.9.2 <3.0.0"

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -495,8 +495,11 @@ void main() {
             '.txt': ['.copy']
           },
           build: (step, _) {
+            final invalidInput = AssetId.parse('b|test/my_test.dart');
+
+            expect(step.canRead(invalidInput), completion(isFalse));
             return expectLater(
-              () => step.readAsBytes(AssetId.parse('b|test/my_test.dart')),
+              () => step.readAsBytes(invalidInput),
               throwsA(isA<InvalidInputException>().having((e) => e.allowedGlobs,
                   'allowedGlobs', defaultNonRootVisibleAssets)),
             );

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -12,6 +12,8 @@ import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/package_graph/target_graph.dart'
+    show defaultPublicAssetsForNonRoot;
 import 'package:build_runner_core/src/util/constants.dart';
 import 'package:build_test/build_test.dart';
 import 'package:glob/glob.dart';
@@ -462,15 +464,7 @@ void main() {
         });
 
         final builder = TestBuilder(
-          buildExtensions: const {
-            '.foo': ['.bar']
-          },
-          build: (step, _) {
-            final input = step.inputId;
-            final fromB = step.readAsString(AssetId.parse('b|test/foo.bar'));
-
-            return step.writeAsString(input.changeExtension('.bar'), fromB);
-          },
+          build: copyFrom(makeAssetId('b|test/foo.bar')),
         );
 
         await testBuilders(
@@ -486,7 +480,7 @@ void main() {
                 'b', [], 'additional_public_assets: ["test/**"]')
           },
           packageGraph: packageGraph,
-          outputs: {r'$$a|lib/a.bar': 'content'},
+          outputs: {r'$$a|lib/a.foo.copy': 'content'},
         );
       });
 
@@ -503,7 +497,8 @@ void main() {
           build: (step, _) {
             return expectLater(
               () => step.readAsBytes(AssetId.parse('b|test/my_test.dart')),
-              throwsA(isA<InvalidInputException>()),
+              throwsA(isA<InvalidInputException>().having((e) => e.allowedGlobs,
+                  'allowedGlobs', defaultPublicAssetsForNonRoot)),
             );
           },
         );

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -459,21 +459,16 @@ void main() {
         rootPackage('a', path: 'a/'): ['b'],
         package('b', path: 'a/b'): []
       });
-      final writer = InMemoryRunnerAssetWriter();
-      final reader = InMemoryRunnerAssetReader.shareAssetCache(writer.assets,
-          rootPackage: 'a')
-        ..cacheStringAsset(
-            AssetId.parse('b|build.yaml'), 'public_assets: ["test/**"]');
 
       final builder = TestBuilder(
         buildExtensions: {
           '.foo': ['.bar']
         },
-        build: (step, _) async {
+        build: (step, _) {
           final input = step.inputId;
           final fromB = step.readAsString(AssetId.parse('b|test/foo.bar'));
 
-          await step.writeAsString(input.changeExtension('.bar'), fromB);
+          return step.writeAsString(input.changeExtension('.bar'), fromB);
         },
       );
 
@@ -485,9 +480,12 @@ void main() {
           'a|lib/a.foo': '',
           'b|test/foo.bar': 'content',
         },
+        overrideBuildConfig: {
+          'b': BuildConfig.parse(
+              'b', [], 'additional_public_assets: ["test/**"]')
+        },
         packageGraph: packageGraph,
-        reader: reader,
-        writer: writer,
+        outputs: {r'$$a|lib/a.bar': 'content'},
       );
     });
 

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -12,8 +12,8 @@ import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
-import 'package:build_runner_core/src/package_graph/target_graph.dart'
-    show defaultPublicAssetsForNonRoot;
+import 'package:build_runner_core/src/generate/options.dart'
+    show defaultNonRootVisibleAssets;
 import 'package:build_runner_core/src/util/constants.dart';
 import 'package:build_test/build_test.dart';
 import 'package:glob/glob.dart';
@@ -498,7 +498,7 @@ void main() {
             return expectLater(
               () => step.readAsBytes(AssetId.parse('b|test/my_test.dart')),
               throwsA(isA<InvalidInputException>().having((e) => e.allowedGlobs,
-                  'allowedGlobs', defaultPublicAssetsForNonRoot)),
+                  'allowedGlobs', defaultNonRootVisibleAssets)),
             );
           },
         );

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -634,6 +634,11 @@ void main() {
     });
 
     test('can read files from external packages', () async {
+      var packageGraph = buildPackageGraph({
+        rootPackage('a'): ['b'],
+        package('b'): []
+      });
+
       var builders = [
         apply(
             '',
@@ -645,12 +650,14 @@ void main() {
             toRoot(),
             hideOutput: false)
       ];
-      await testBuilders(builders, {
-        'a|lib/a.txt': 'a',
-        'b|lib/b.txt': 'b'
-      }, outputs: {
-        'a|lib/a.txt.copy': 'a',
-      });
+      await testBuilders(
+        builders,
+        {'a|lib/a.txt': 'a', 'b|lib/b.txt': 'b'},
+        outputs: {
+          'a|lib/a.txt.copy': 'a',
+        },
+        packageGraph: packageGraph,
+      );
     });
 
     test('can glob files from packages', () async {

--- a/build_runner_core/test/package_graph/target_graph_test.dart
+++ b/build_runner_core/test/package_graph/target_graph_test.dart
@@ -2,8 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:_test_common/package_graphs.dart';
+import 'package:build/build.dart';
 @TestOn('vm')
 import 'package:build_config/build_config.dart';
+import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/test.dart';
@@ -76,6 +79,61 @@ void main() {
                         contains(r'lib/$lib$'),
                         isNot(contains(r'$package$')))),
           ]));
+    });
+  });
+
+  group('target graph reports visible assets', () {
+    final a = rootPackage('a');
+    final b = package('b');
+    final packages = buildPackageGraph({
+      a: ['b'],
+      b: []
+    });
+
+    test('for root package', () async {
+      final targetGraph = await TargetGraph.forPackageGraph(packages);
+
+      expect(targetGraph.isVisibleInBuild(AssetId('a', 'web/index.html'), a),
+          isTrue);
+      expect(
+          targetGraph.isVisibleInBuild(AssetId('a', 'lib/a.dart'), a), isTrue);
+      expect(targetGraph.isVisibleInBuild(AssetId('a', 'test/my_test.dart'), a),
+          isTrue);
+      expect(targetGraph.getValidInputs(a), ['**/*']);
+    });
+
+    test('for non-root package with default configuration', () async {
+      final targetGraph = await TargetGraph.forPackageGraph(packages);
+
+      expect(targetGraph.isVisibleInBuild(AssetId('b', 'web/index.html'), b),
+          isFalse);
+      expect(
+          targetGraph.isVisibleInBuild(AssetId('b', 'lib/b.dart'), b), isTrue);
+      expect(
+          targetGraph.isVisibleInBuild(AssetId('b', 'LICENSE.txt'), b), isTrue);
+      expect(targetGraph.isVisibleInBuild(AssetId('b', 'README'), b), isTrue);
+      expect(targetGraph.isVisibleInBuild(AssetId('b', 'test/my_test.dart'), b),
+          isFalse);
+
+      expect(targetGraph.getValidInputs(b), contains('lib/**'));
+    });
+
+    test('for non-root package exposing additional assets', () async {
+      final targetGraph =
+          await TargetGraph.forPackageGraph(packages, overrideBuildConfig: {
+        'b':
+            BuildConfig.parse('b', [], 'additional_public_assets: ["test/**"]'),
+      });
+
+      expect(
+          targetGraph.isVisibleInBuild(AssetId('b', 'lib/b.dart'), b), isTrue);
+      expect(targetGraph.isVisibleInBuild(AssetId('b', 'test/my_test.dart'), b),
+          isTrue);
+
+      expect(targetGraph.getValidInputs(b), contains('test/**'));
+      // The additional input should also be included in the default target
+      expect(targetGraph.allModules['b:b'].sourceIncludes,
+          contains(isA<Glob>().having((e) => e.pattern, 'pattern', 'test/**')));
     });
   });
 }

--- a/build_runner_core/test/package_graph/target_graph_test.dart
+++ b/build_runner_core/test/package_graph/target_graph_test.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn('vm')
 import 'package:_test_common/package_graphs.dart';
 import 'package:build/build.dart';
-@TestOn('vm')
 import 'package:build_config/build_config.dart';
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
@@ -99,7 +99,7 @@ void main() {
           targetGraph.isVisibleInBuild(AssetId('a', 'lib/a.dart'), a), isTrue);
       expect(targetGraph.isVisibleInBuild(AssetId('a', 'test/my_test.dart'), a),
           isTrue);
-      expect(targetGraph.getValidInputs(a), ['**/*']);
+      expect(targetGraph.validInputsFor(a), ['**/*']);
     });
 
     test('for non-root package with default configuration', () async {
@@ -115,7 +115,7 @@ void main() {
       expect(targetGraph.isVisibleInBuild(AssetId('b', 'test/my_test.dart'), b),
           isFalse);
 
-      expect(targetGraph.getValidInputs(b), contains('lib/**'));
+      expect(targetGraph.validInputsFor(b), contains('lib/**'));
     });
 
     test('for non-root package exposing additional assets', () async {
@@ -130,7 +130,7 @@ void main() {
       expect(targetGraph.isVisibleInBuild(AssetId('b', 'test/my_test.dart'), b),
           isTrue);
 
-      expect(targetGraph.getValidInputs(b), contains('test/**'));
+      expect(targetGraph.validInputsFor(b), contains('test/**'));
       // The additional input should also be included in the default target
       expect(targetGraph.allModules['b:b'].sourceIncludes,
           contains(isA<Glob>().having((e) => e.pattern, 'pattern', 'test/**')));

--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -8,13 +8,13 @@ to see examples or goal oriented docs you may want to look at the
 
 ## BuildConfig
 
-key                   | value                                                                      | default
---------------------- | -------------------------------------------------------------------------- | -------
-targets               | Map<String, [BuildTarget](#buildtarget)>                                   | a single target with the same name as the package
-builders              | Map<String, [BuilderDefinition](#builderdefinition)>                       | empty
-post_process_builders | Map<String, [PostProcessBuilderDefinition](#postprocessbuilderdefinition)> | empty
-global_options        | Map<String, [GlobalBuilderOptions](#globalBuilderOptions)>                 | empty
-public_assets         | [InputSet](#inputset)                                                      | `lib/**`, `LICENSE` and `pubspec.yaml`
+key                      | value                                                                      | default
+---------------------    | -------------------------------------------------------------------------- | -------
+targets                  | Map<String, [BuildTarget](#buildtarget)>                                   | a single target with the same name as the package
+builders                 | Map<String, [BuilderDefinition](#builderdefinition)>                       | empty
+post_process_builders    | Map<String, [PostProcessBuilderDefinition](#postprocessbuilderdefinition)> | empty
+global_options           | Map<String, [GlobalBuilderOptions](#globalBuilderOptions)>                 | empty
+additional_public_assets | `List<String>`                                                             | empty
 
 ## BuildTarget
 

--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -9,7 +9,7 @@ to see examples or goal oriented docs you may want to look at the
 ## BuildConfig
 
 key                      | value                                                                      | default
----------------------    | -------------------------------------------------------------------------- | -------
+------------------------ | -------------------------------------------------------------------------- | -------
 targets                  | Map<String, [BuildTarget](#buildtarget)>                                   | a single target with the same name as the package
 builders                 | Map<String, [BuilderDefinition](#builderdefinition)>                       | empty
 post_process_builders    | Map<String, [PostProcessBuilderDefinition](#postprocessbuilderdefinition)> | empty

--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -14,7 +14,7 @@ targets                  | Map<String, [BuildTarget](#buildtarget)>             
 builders                 | Map<String, [BuilderDefinition](#builderdefinition)>                       | empty
 post_process_builders    | Map<String, [PostProcessBuilderDefinition](#postprocessbuilderdefinition)> | empty
 global_options           | Map<String, [GlobalBuilderOptions](#globalBuilderOptions)>                 | empty
-additional_public_assets | `List<String>`                                                             | empty
+additional_public_assets | List<String>                                                               | empty
 
 ## BuildTarget
 

--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -14,6 +14,7 @@ targets               | Map<String, [BuildTarget](#buildtarget)>                
 builders              | Map<String, [BuilderDefinition](#builderdefinition)>                       | empty
 post_process_builders | Map<String, [PostProcessBuilderDefinition](#postprocessbuilderdefinition)> | empty
 global_options        | Map<String, [GlobalBuilderOptions](#globalBuilderOptions)>                 | empty
+public_assets         | [InputSet](#inputset)                                                      | `lib/**`, `LICENSE` and `pubspec.yaml`
 
 ## BuildTarget
 


### PR DESCRIPTION
Instead of throwing an `InvalidInputException` for non-lib, non-root packages, we now allow the following files by default:
- `lib/**`
- `bin/**`
- `LICENSE`
- `README*`
- `pubspec.yaml`

Each package can expose additional globs with the `additional_public_assets` build option. I opted to not support exluding assets because
- excluding `lib/` might lead to unexpected behavior
- that package's default target includes `additional_public_assets` by default. If there were two `excludes`, it's not clear in which priority they should interfere with each other

In the root package, all files are still allowed of course. I moved the check to throw an `InvalidInputException` down to the `SingleStepReader`. Computing the globs of available sources per package now happens in the `TargetGraph` since that's where the build config is read. That feels a bit unclean since the _target_ graph now decides which assets are visible for a _package_, please let me know if I should move that logic to the `PackageGraph` or elsewhere.

Closes #2819. I also wrote [an example](https://github.com/simolus3/build_license_collector/blob/main/lib/src/crawler.dart) to crawl licenses across dependencies.