### PR TITLE
add sound_null_safety and null_assertions options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ jobs:
       env: PKGS="_test _test_common"
       script: ./tool/travis.sh dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: 2.10.0-110.0.dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
-      dart: "2.10.0-110.0.dev"
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
+      dart: dev
       os: linux
       env: PKGS="_test_null_safety"
       script: ./tool/travis.sh dartanalyzer_1
@@ -226,11 +226,29 @@ jobs:
       env: PKGS="_test"
       script: ./tool/travis.sh test_04
     - stage: e2e_test
-      name: "SDK: 2.10.0-110.0.dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
-      dart: "2.10.0-110.0.dev"
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
+      dart: dev
       os: linux
       env: PKGS="_test_null_safety"
       script: ./tool/travis.sh command_2
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
+      dart: dev
+      os: windows
+      env: PKGS="_test_null_safety"
+      script: ./tool/travis.sh command_2
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      dart: dev
+      os: linux
+      env: PKGS="_test_null_safety"
+      script: ./tool/travis.sh command_3
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      dart: dev
+      os: windows
+      env: PKGS="_test_null_safety"
+      script: ./tool/travis.sh command_3
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random`"
       dart: dev
@@ -286,18 +304,6 @@ jobs:
       env: PKGS="_test"
       script: ./tool/travis.sh test_05
     - stage: e2e_test_cron
-      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
-      dart: be/raw/latest
-      os: linux
-      env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_2
-    - stage: e2e_test_cron
-      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
-      dart: be/raw/latest
-      os: windows
-      env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_2
-    - stage: e2e_test_cron
       name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
@@ -309,6 +315,30 @@ jobs:
       os: windows
       env: PKGS="_test_null_safety"
       script: ./tool/travis.sh command_2
+    - stage: e2e_test_cron
+      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      dart: be/raw/latest
+      os: linux
+      env: PKGS="_test_null_safety"
+      script: ./tool/travis.sh command_3
+    - stage: e2e_test_cron
+      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      dart: be/raw/latest
+      os: windows
+      env: PKGS="_test_null_safety"
+      script: ./tool/travis.sh command_3
+    - stage: e2e_test_cron
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      dart: dev
+      os: linux
+      env: PKGS="_test_null_safety"
+      script: ./tool/travis.sh command_3
+    - stage: e2e_test_cron
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      dart: dev
+      os: windows
+      env: PKGS="_test_null_safety"
+      script: ./tool/travis.sh command_3
 
 stages:
   - analyze_and_format

--- a/.travis.yml
+++ b/.travis.yml
@@ -226,29 +226,11 @@ jobs:
       env: PKGS="_test"
       script: ./tool/travis.sh test_04
     - stage: e2e_test
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: dev
       os: linux
       env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_2
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
-      dart: dev
-      os: windows
-      env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_2
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
-      dart: dev
-      os: linux
-      env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_3
-    - stage: e2e_test
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
-      dart: dev
-      os: windows
-      env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_3
+      script: ./tool/travis.sh command_2 command_3
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random`"
       dart: dev
@@ -304,41 +286,29 @@ jobs:
       env: PKGS="_test"
       script: ./tool/travis.sh test_05
     - stage: e2e_test_cron
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
-      dart: dev
-      os: linux
-      env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_2
-    - stage: e2e_test_cron
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`"
-      dart: dev
-      os: windows
-      env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_2
-    - stage: e2e_test_cron
-      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: be/raw/latest
       os: linux
       env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_3
+      script: ./tool/travis.sh command_2 command_3
     - stage: e2e_test_cron
-      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: be/raw/latest
       os: windows
       env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_3
+      script: ./tool/travis.sh command_2 command_3
     - stage: e2e_test_cron
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: dev
       os: linux
       env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_3
+      script: ./tool/travis.sh command_2 command_3
     - stage: e2e_test_cron
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers|entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: dev
       os: windows
       env: PKGS="_test_null_safety"
-      script: ./tool/travis.sh command_3
+      script: ./tool/travis.sh command_2 command_3
 
 stages:
   - analyze_and_format

--- a/_test_null_safety/build.yaml
+++ b/_test_null_safety/build.yaml
@@ -1,0 +1,36 @@
+targets:
+  $default:
+    builders:
+      build_vm_compilers|entrypoint:
+        enabled: false
+      build_web_compilers|entrypoint:
+        enabled: false
+  regular_tests:
+    auto_apply_builders: false
+    sources:
+    - test/opted_in_test.dart
+    - test/opted_out_test.dart
+    builders:
+      build_web_compilers|entrypoint:
+        enabled: true
+      build_vm_compilers|entrypoint:
+        enabled: true
+  null_assertion_test:
+    auto_apply_builders: false
+    sources:
+    - test/null_assertions_test.dart
+    builders:
+      build_web_compilers|entrypoint:
+        enabled: true
+        options:
+          null_assertions: true
+  disable_sound_null_safety_test:
+    auto_apply_builders: false
+    sources:
+    - test/disable_sound_null_safety_test.dart
+    builders:
+      build_web_compilers|entrypoint:
+        enabled: true
+        options:
+          sound_null_safety: false
+      

--- a/_test_null_safety/mono_pkg.yaml
+++ b/_test_null_safety/mono_pkg.yaml
@@ -10,11 +10,14 @@ stages:
   - dartanalyzer: --enable-experiment=non-nullable --fatal-infos --fatal-warnings .
     os: linux
 - e2e_test:
-  - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
-  - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers|entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
+  - group:
+    - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
+    - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers|entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
+    os: linux 
 - e2e_test_cron:
-  - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
-  - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers|entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
+  - group:
+    - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
+    - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers|entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
     dart:
-    - be/raw/latest
-    - dev
+      - be/raw/latest
+      - dev

--- a/_test_null_safety/mono_pkg.yaml
+++ b/_test_null_safety/mono_pkg.yaml
@@ -1,6 +1,5 @@
 dart:
-# TODO: Update to `dev` https://github.com/dart-lang/build/issues/2841
-- 2.10.0-110.0.dev
+- dev
 
 os:
 - linux
@@ -12,9 +11,10 @@ stages:
     os: linux
 - e2e_test:
   - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
-    os: linux
+  - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers|entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
 - e2e_test_cron:
   - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
+  - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers|entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
     dart:
     - be/raw/latest
     - dev

--- a/_test_null_safety/test/common/message.dart
+++ b/_test_null_safety/test/common/message.dart
@@ -5,5 +5,5 @@
 // Uses `?` to ensure null safety is enabled
 final String? message = 'hello';
 
-// Prints a non-nullable message, used in null assertion tests.
-void printString(String message) => print(message);
+// Used in null assertion tests.
+void printNonNullable(String message) => print(message);

--- a/_test_null_safety/test/common/message.dart
+++ b/_test_null_safety/test/common/message.dart
@@ -4,3 +4,6 @@
 
 // Uses `?` to ensure null safety is enabled
 final String? message = 'hello';
+
+// Prints a non-nullable message, used in null assertion tests.
+void printString(String message) => print(message);

--- a/_test_null_safety/test/disable_sound_null_safety_test.dart
+++ b/_test_null_safety/test/disable_sound_null_safety_test.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Disabling sound null safety is only supported on the web right now.
+@TestOn('browser')
+import 'package:test/test.dart';
+
+const weakMode = <int?>[] is List<int>;
+
+void main() {
+  test('sound null safety is disabled', () {
+    expect(weakMode, isTrue);
+  });
+}

--- a/_test_null_safety/test/null_assertions_test.dart
+++ b/_test_null_safety/test/null_assertions_test.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// Opt out of null safety
+// @dart=2.9
+
+// Null assertions are only supported on the web right now.
+@TestOn('browser')
+import 'package:test/test.dart';
+
+import 'common/message.dart';
+
+void main() {
+  test('null assertions work in weak mode', () {
+    expect(() => printString(null), throwsA(isA<AssertionError>()));
+  });
+}

--- a/_test_null_safety/test/null_assertions_test.dart
+++ b/_test_null_safety/test/null_assertions_test.dart
@@ -13,6 +13,6 @@ import 'common/message.dart';
 
 void main() {
   test('null assertions work in weak mode', () {
-    expect(() => printString(null), throwsA(isA<AssertionError>()));
+    expect(() => printNonNullable(null), throwsA(isA<AssertionError>()));
   });
 }

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Fix parsing of `environment` config for DDC when using a bool or numeric
   value.
+- Add `sound_null_safety` and `null_assertions` boolean options to the
+  `build_web_compilers|entrypoint` builder.
 
 ## 2.12.1
 

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -157,5 +157,5 @@ const _supportedOptions = [
   _experimentOption,
   _useIncrementalCompilerOption,
   _generateFullDillOption,
-  _trackUnusedInputsCompilerOption
+  _trackUnusedInputsCompilerOption,
 ];

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -12,6 +12,7 @@ import 'package:build/experiments.dart';
 import 'package:build_modules/build_modules.dart';
 import 'package:build_modules/src/workers.dart';
 import 'package:glob/glob.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 import 'package:scratch_space/scratch_space.dart';
@@ -24,12 +25,12 @@ import 'web_entrypoint_builder.dart';
 /// If [skipPlatformCheck] is `true` then all `dart:` imports will be
 /// allowed in all packages.
 Future<void> bootstrapDart2Js(BuildStep buildStep, List<String> dart2JsArgs,
-        {bool skipPlatformCheck}) =>
+        {@required bool nullAssertions, bool skipPlatformCheck}) =>
     _resourcePool.withResource(() => _bootstrapDart2Js(buildStep, dart2JsArgs,
-        skipPlatformCheck: skipPlatformCheck));
+        nullAssertions: nullAssertions, skipPlatformCheck: skipPlatformCheck));
 
 Future<void> _bootstrapDart2Js(BuildStep buildStep, List<String> dart2JsArgs,
-    {bool skipPlatformCheck}) async {
+    {@required bool nullAssertions, bool skipPlatformCheck}) async {
   skipPlatformCheck ??= false;
   var dartEntrypointId = buildStep.inputId;
   var moduleId =
@@ -79,6 +80,7 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
         '--multi-root=${scratchSpace.tempDir.uri.toFilePath()}',
         for (var experiment in enabledExperiments)
           '--enable-experiment=$experiment',
+        if (nullAssertions) '--null-assertions',
         '-o$jsOutputPath',
         '$dartUri',
       ]);

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -41,6 +41,7 @@ Future<void> bootstrapDdc(
   @deprecated Set<String> skipPlatformCheckPackages = const {},
   Iterable<AssetId> requiredAssets,
   @required bool soundNullSafety,
+  @required bool nullAssertions,
 }) async {
   requiredAssets ??= [];
   skipPlatformCheck ??= false;
@@ -136,8 +137,12 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
                 from: _p.url.dirname(bootstrapId.path)),
             soundNullSafety))
         ..write(_requireJsConfig(soundNullSafety))
-        ..write(_appBootstrap(bootstrapModuleName, appModuleName,
-            appModuleScope, entrypointLibraryName,
+        ..write(_appBootstrap(
+            bootstrapModuleName: bootstrapModuleName,
+            entrypointLibraryName: entrypointLibraryName,
+            moduleName: appModuleName,
+            moduleScope: appModuleScope,
+            nullAssertions: nullAssertions,
             oldModuleScope: oldAppModuleScope));
 
   await buildStep.writeAsString(bootstrapId, bootstrapContent.toString());
@@ -205,12 +210,17 @@ Future<List<AssetId>> _ensureTransitiveJsModules(
 /// `[moduleScope].main()` function on it.
 ///
 /// Also performs other necessary initialization.
-String _appBootstrap(String bootstrapModuleName, String moduleName,
-        String moduleScope, String entrypointLibraryName,
-        {String oldModuleScope}) =>
+String _appBootstrap(
+        {@required String bootstrapModuleName,
+        @required String moduleName,
+        @required String moduleScope,
+        @required String entrypointLibraryName,
+        @required String oldModuleScope,
+        @required bool nullAssertions}) =>
     '''
 define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_sdk) {
   dart_sdk.dart.setStartAsyncSynchronously(true);
+  dart_sdk.dart.nonNullAsserts($nullAssertions);
   dart_sdk._isolate_helper.startRootIsolate(() => {}, []);
   $_initializeTools
   $_mainExtensionMarker

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:build/build.dart';
 import 'package:build_modules/build_modules.dart';
+import 'package:meta/meta.dart';
 
 import 'common.dart';
 import 'dart2js_bootstrap.dart';
@@ -30,12 +31,16 @@ enum WebCompiler {
 /// The top level keys supported for the `options` config for the
 /// [WebEntrypointBuilder].
 const _supportedOptions = [
-  _compiler,
-  _dart2jsArgs,
+  _compilerOption,
+  _dart2jsArgsOption,
+  _nullAssertionsOption,
+  _soundNullSafetyOption,
 ];
 
-const _compiler = 'compiler';
-const _dart2jsArgs = 'dart2js_args';
+const _compilerOption = 'compiler';
+const _dart2jsArgsOption = 'dart2js_args';
+const _nullAssertionsOption = 'null_assertions';
+const _soundNullSafetyOption = 'sound_null_safety';
 
 /// The deprecated keys for the `options` config for the [WebEntrypointBuilder].
 const _deprecatedOptions = [
@@ -50,13 +55,28 @@ class WebEntrypointBuilder implements Builder {
   final WebCompiler webCompiler;
   final List<String> dart2JsArgs;
 
-  const WebEntrypointBuilder(this.webCompiler, {this.dart2JsArgs = const []});
+  /// Explicit configuration from the user to enable or disable sound null
+  /// safety if provided, otherwise `null`.
+  final bool /*?*/ soundNullSafetyOverride;
+
+  /// Whether or not to enable runtime null assertions in unsound mode.
+  ///
+  /// This options can only be enabled in weak mode.
+  final bool nullAssertions;
+
+  const WebEntrypointBuilder(
+    this.webCompiler, {
+    this.dart2JsArgs = const [],
+    @required this.nullAssertions,
+    @required this.soundNullSafetyOverride,
+  });
 
   factory WebEntrypointBuilder.fromOptions(BuilderOptions options) {
     validateOptions(
         options.config, _supportedOptions, 'build_web_compilers|entrypoint',
         deprecatedOptions: _deprecatedOptions);
-    var compilerOption = options.config[_compiler] as String ?? 'dartdevc';
+    var compilerOption =
+        options.config[_compilerOption] as String ?? 'dartdevc';
     WebCompiler compiler;
     switch (compilerOption) {
       case 'dartdevc':
@@ -66,20 +86,25 @@ class WebEntrypointBuilder implements Builder {
         compiler = WebCompiler.Dart2Js;
         break;
       default:
-        throw ArgumentError.value(compilerOption, _compiler,
+        throw ArgumentError.value(compilerOption, _compilerOption,
             'Only `dartdevc` and `dart2js` are supported.');
     }
 
-    if (options.config[_dart2jsArgs] is! List) {
-      throw ArgumentError.value(options.config[_dart2jsArgs], _dart2jsArgs,
-          'Expected a list for $_dart2jsArgs.');
+    if (options.config[_dart2jsArgsOption] is! List) {
+      throw ArgumentError.value(options.config[_dart2jsArgsOption],
+          _dart2jsArgsOption, 'Expected a list for $_dart2jsArgsOption.');
     }
-    var dart2JsArgs = (options.config[_dart2jsArgs] as List)
+    var dart2JsArgs = (options.config[_dart2jsArgsOption] as List)
             ?.map((arg) => '$arg')
             ?.toList() ??
         const <String>[];
 
-    return WebEntrypointBuilder(compiler, dart2JsArgs: dart2JsArgs);
+    return WebEntrypointBuilder(compiler,
+        dart2JsArgs: dart2JsArgs,
+        nullAssertions:
+            options.config[_nullAssertionsOption] as bool /*?*/ ?? false,
+        soundNullSafetyOverride:
+            options.config[_soundNullSafetyOption] as bool /*?*/);
   }
 
   @override
@@ -99,12 +124,14 @@ class WebEntrypointBuilder implements Builder {
     var dartEntrypointId = buildStep.inputId;
     var isAppEntrypoint = await _isAppEntryPoint(dartEntrypointId, buildStep);
     if (!isAppEntrypoint) return;
-    var soundNullSafety =
+    var soundNullSafety = soundNullSafetyOverride ??
         await _supportsNullSafety(buildStep, buildStep.inputId);
+    var nullAssertions = !soundNullSafety && this.nullAssertions;
     switch (webCompiler) {
       case WebCompiler.DartDevc:
         try {
           await bootstrapDdc(buildStep,
+              nullAssertions: nullAssertions,
               requiredAssets: _ddcSdkResources,
               soundNullSafety: soundNullSafety);
         } on MissingModulesException catch (e) {
@@ -114,7 +141,8 @@ class WebEntrypointBuilder implements Builder {
       case WebCompiler.Dart2Js:
         // Dart2js already supports opting in/out of null safety by default so
         // we don't have to inform it of what to do.
-        await bootstrapDart2Js(buildStep, dart2JsArgs);
+        await bootstrapDart2Js(buildStep, dart2JsArgs,
+            nullAssertions: nullAssertions);
         break;
     }
   }

--- a/build_web_compilers/test/dart2js_bootstrap_test.dart
+++ b/build_web_compilers/test/dart2js_bootstrap_test.dart
@@ -60,7 +60,10 @@ void main() {
         'a|web/index.dart.js.map': anything,
         'a|web/index.dart.js.tar.gz': anything,
       };
-      await testBuilder(WebEntrypointBuilder(WebCompiler.Dart2Js), assets,
+      await testBuilder(
+          WebEntrypointBuilder(WebCompiler.Dart2Js,
+              soundNullSafetyOverride: null, nullAssertions: false),
+          assets,
           outputs: expectedOutputs);
     });
 
@@ -71,7 +74,9 @@ void main() {
       };
       await testBuilder(
           WebEntrypointBuilder(WebCompiler.Dart2Js,
-              dart2JsArgs: ['--no-source-maps']),
+              dart2JsArgs: ['--no-source-maps'],
+              soundNullSafetyOverride: null,
+              nullAssertions: false),
           assets,
           outputs: expectedOutputs);
     });
@@ -99,7 +104,10 @@ void main() {
       'a|lib/index.dart.js.map': anything,
       'a|lib/index.dart.js.tar.gz': anything,
     };
-    await testBuilder(WebEntrypointBuilder(WebCompiler.Dart2Js), assets,
+    await testBuilder(
+        WebEntrypointBuilder(WebCompiler.Dart2Js,
+            soundNullSafetyOverride: null, nullAssertions: false),
+        assets,
         outputs: expectedOutputs);
   });
 
@@ -146,7 +154,10 @@ void main() {
           'a|web/unsound.dart.js.map': anything,
           'a|web/unsound.dart.js.tar.gz': anything,
         };
-        await testBuilder(WebEntrypointBuilder(WebCompiler.Dart2Js), assets,
+        await testBuilder(
+            WebEntrypointBuilder(WebCompiler.Dart2Js,
+                soundNullSafetyOverride: null, nullAssertions: false),
+            assets,
             outputs: expectedOutputs);
       }, ['non-nullable']);
     });

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -53,7 +53,10 @@ void main() {
           isNot(contains('lib/a')),
         ])),
       };
-      await testBuilder(WebEntrypointBuilder(WebCompiler.DartDevc), assets,
+      await testBuilder(
+          WebEntrypointBuilder(WebCompiler.DartDevc,
+              soundNullSafetyOverride: null, nullAssertions: false),
+          assets,
           outputs: expectedOutputs);
     });
   });
@@ -89,7 +92,10 @@ void main() {
         'a|web/b.dart.ddc_merged_metadata': isNotEmpty,
         'a|web/b.dart.js': isNotEmpty,
       };
-      await testBuilder(WebEntrypointBuilder(WebCompiler.DartDevc), assets,
+      await testBuilder(
+          WebEntrypointBuilder(WebCompiler.DartDevc,
+              soundNullSafetyOverride: null, nullAssertions: false),
+          assets,
           outputs: expectedOutputs);
     });
 
@@ -109,7 +115,10 @@ void main() {
         'a|lib/app.dart.ddc_merged_metadata': isNotEmpty,
         'a|lib/app.dart.js': isNotEmpty,
       };
-      await testBuilder(WebEntrypointBuilder(WebCompiler.DartDevc), assets,
+      await testBuilder(
+          WebEntrypointBuilder(WebCompiler.DartDevc,
+              soundNullSafetyOverride: null, nullAssertions: false),
+          assets,
           outputs: expectedOutputs);
     });
   });

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -66,6 +66,10 @@ for PKG in ${PKGS}; do
       echo 'pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random'
       pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random || EXIT_CODE=$?
       ;;
+    command_3)
+      echo 'pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers|entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random'
+      pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers|entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random || EXIT_CODE=$?
+      ;;
     dartanalyzer_0)
       echo 'dartanalyzer --fatal-infos --fatal-warnings .'
       dartanalyzer --fatal-infos --fatal-warnings . || EXIT_CODE=$?


### PR DESCRIPTION
- Only supported for the to the build_web_compilers|entrypoint builder
- Works for ddc and dart2js
- Adds some basic e2e tests