### PR TITLE
Use : over | for builder keys

### DIFF
--- a/_test/build.dart2js.yaml
+++ b/_test/build.dart2js.yaml
@@ -1,7 +1,7 @@
 targets:
   $default:
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         options:
           compiler: dart2js
           dart2js_args:
@@ -20,7 +20,7 @@ targets:
           - test/other_test.dart.browser_test.dart
           - test/sub-dir/subdir_test.dart
           - test/sub-dir/subdir_test.dart.browser_test.dart
-      build_vm_compilers|entrypoint:
+      build_vm_compilers:entrypoint:
         generate_for:
           - test/configurable_uri_test.dart.vm_test.dart
           - test/help_test.dart.vm_test.dart

--- a/_test/build.post_process.yaml
+++ b/_test/build.post_process.yaml
@@ -1,10 +1,10 @@
 targets:
   $default:
     builders:
-      provides_builder|some_post_process_builder:
+      provides_builder:some_post_process_builder:
         options:
           default_content: goodbye
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         generate_for:
           - web/main.dart
           - web/sub/main.dart
@@ -17,6 +17,6 @@ targets:
           - test/other_test.dart.browser_test.dart
           - test/sub-dir/subdir_test.dart
           - test/sub-dir/subdir_test.dart.browser_test.dart
-      build_vm_compilers|entrypoint:
+      build_vm_compilers:entrypoint:
         generate_for:
           - test/help_test.dart.vm_test.dart

--- a/_test/build.throws.yaml
+++ b/_test/build.throws.yaml
@@ -1,10 +1,10 @@
 targets:
   $default:
     builders:
-      provides_builder|some_builder:
+      provides_builder:some_builder:
         options:
           throw_in_constructor: true
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         generate_for:
           - web/main.dart
           - web/sub/main.dart
@@ -17,6 +17,6 @@ targets:
           - test/other_test.dart.browser_test.dart
           - test/sub-dir/subdir_test.dart
           - test/sub-dir/subdir_test.dart.browser_test.dart
-      build_vm_compilers|entrypoint:
+      build_vm_compilers:entrypoint:
         generate_for:
           - test/help_test.dart.vm_test.dart

--- a/_test/build.yaml
+++ b/_test/build.yaml
@@ -1,7 +1,7 @@
 targets:
   $default:
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         generate_for:
           - web/main.dart
           - web/sub/main.dart
@@ -11,7 +11,7 @@ targets:
           - test/hello_world_custom_html_test.dart.browser_test.dart
           - test/other_test.dart.browser_test.dart
           - test/sub-dir/subdir_test.dart.browser_test.dart
-      build_vm_compilers|entrypoint:
+      build_vm_compilers:entrypoint:
         generate_for:
           - test/configurable_uri_test.dart.vm_test.dart
           - test/help_test.dart.vm_test.dart

--- a/_test/test/dart2js_integration_test.dart
+++ b/_test/test/dart2js_integration_test.dart
@@ -34,9 +34,9 @@ void main() {
     test('via --define flag', () async {
       await expectTestsPass(usePrecompiled: true, buildArgs: [
         '--define',
-        'build_web_compilers|entrypoint=compiler=dart2js',
+        'build_web_compilers:entrypoint=compiler=dart2js',
         '--define',
-        'build_web_compilers|entrypoint=dart2js_args=["--minify"]',
+        'build_web_compilers:entrypoint=dart2js_args=["--minify"]',
         '--output=$_outputDir',
       ]);
       await _expectWasCompiledWithDart2JS(minified: true);
@@ -55,9 +55,9 @@ void main() {
         '--config',
         'dart2js',
         '--define',
-        'build_web_compilers|entrypoint=compiler=dart2js',
+        'build_web_compilers:entrypoint=compiler=dart2js',
         '--define',
-        'build_web_compilers|entrypoint=dart2js_args=["--minify"]',
+        'build_web_compilers:entrypoint=dart2js_args=["--minify"]',
         '--output=$_outputDir',
       ]);
       await _expectWasCompiledWithDart2JS(minified: true);

--- a/_test_null_safety/build.yaml
+++ b/_test_null_safety/build.yaml
@@ -1,9 +1,9 @@
 targets:
   $default:
     builders:
-      build_vm_compilers|entrypoint:
+      build_vm_compilers:entrypoint:
         enabled: false
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         enabled: false
   regular_tests:
     auto_apply_builders: false
@@ -11,16 +11,16 @@ targets:
     - test/opted_in_test.dart
     - test/opted_out_test.dart
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         enabled: true
-      build_vm_compilers|entrypoint:
+      build_vm_compilers:entrypoint:
         enabled: true
   null_assertion_test:
     auto_apply_builders: false
     sources:
     - test/null_assertions_test.dart
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         enabled: true
         options:
           null_assertions: true
@@ -29,8 +29,7 @@ targets:
     sources:
     - test/disable_sound_null_safety_test.dart
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         enabled: true
         options:
           sound_null_safety: false
-      

--- a/_test_null_safety/mono_pkg.yaml
+++ b/_test_null_safety/mono_pkg.yaml
@@ -12,12 +12,12 @@ stages:
 - e2e_test:
   - group:
     - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
-    - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers|entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
+    - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
     os: linux 
 - e2e_test_cron:
   - group:
     - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
-    - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers|entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
+    - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
     dart:
       - be/raw/latest
       - dev

--- a/build_test/README.md
+++ b/build_test/README.md
@@ -58,7 +58,7 @@ can do this in your build.yaml file, with something like the following:
 targets:
   $default:
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         generate_for:
         - test/**_test.dart
         - web/**.dart

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -1,7 +1,7 @@
 targets:
   $default:
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         options:
           compiler: dart2js
           dart2js_args:
@@ -29,7 +29,7 @@ builders:
         - lib/src/dev_compiler/require.js
     is_optional: True
     auto_apply: none
-    runs_before: ["build_web_compilers|entrypoint"]
+    runs_before: ["build_web_compilers:entrypoint"]
   dart2js_modules:
     import: "package:build_web_compilers/builders.dart"
     builder_factories:

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -131,14 +131,14 @@ Map<String, String> _readEnvironmentOption(BuilderOptions options) {
 List<String> _readExperimentOption(BuilderOptions options) {
   var deprecatedConfig = options.config[_experimentOption] as List;
   if (deprecatedConfig != null) {
-    log.warning('The `experiments` option to build_web_compilers|entrypoint '
+    log.warning('The `experiments` option to build_web_compilers:entrypoint '
         'has been deprecated in favor of the new `--enable-experiment` '
         'command line argument which matches other dart tooling and is shared '
         'across all builders.');
     if (enabledExperiments.isNotEmpty &&
         !const ListEquality().equals(deprecatedConfig, enabledExperiments)) {
       throw ArgumentError('The (deprecated) `experiments` option to the '
-          'build_web_compilers|entrypoint builder cannot be used in '
+          'build_web_compilers:entrypoint builder cannot be used in '
           'conjunction with the `--enable-experiment` command line option.');
     }
     return List.from(deprecatedConfig);

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -73,7 +73,7 @@ class WebEntrypointBuilder implements Builder {
 
   factory WebEntrypointBuilder.fromOptions(BuilderOptions options) {
     validateOptions(
-        options.config, _supportedOptions, 'build_web_compilers|entrypoint',
+        options.config, _supportedOptions, 'build_web_compilers:entrypoint',
         deprecatedOptions: _deprecatedOptions);
     var compilerOption =
         options.config[_compilerOption] as String ?? 'dartdevc';

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ mode compiler to `dart2js`. You can either do this using the `--define` command
 line option:
 
 ```text
---define "build_web_compilers|entrypoint=compiler=dart2js"
+--define "build_web_compilers:entrypoint=compiler=dart2js"
 ```
 
 Or by editing your `build.yaml` file:
@@ -33,7 +33,7 @@ Or by editing your `build.yaml` file:
 targets:
   $default:
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         options:
           compiler: dart2js
 ```
@@ -63,7 +63,7 @@ in dev mode, and passed `-O3` in release mode:
 targets:
   $default:
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         options:
           compiler: dart2js
         dev_options:
@@ -230,7 +230,7 @@ These generally come up in the context of a multi-platform package (generally
 due to a mixture of vm and web tests), and look something like this:
 
 ```text
-[WARNING] build_vm_compilers|entrypoint on example|test/my_test.dart:
+[WARNING] build_vm_compilers:entrypoint on example|test/my_test.dart:
 
 Skipping compiling example|test/my_test.dart for the vm because some of its
 transitive libraries have sdk dependencies that not supported on this platform:
@@ -253,12 +253,12 @@ For example, your `build.yaml` might look like this:
 targets:
   $default:
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         generate_for:
         - test/multiplatform/**_test.dart
         - test/web/**_test.dart
         - web/**.dart
-      build_vm_compilers|entrypoint:
+      build_vm_compilers:entrypoint:
         generate_for:
         - test/multiplatform/**_test.dart
         - test/vm/**_test.dart

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -85,7 +85,7 @@ by creating a `build.yaml` file.
 targets:
   $default:
     builders:
-      build_web_compilers|entrypoint:
+      build_web_compilers:entrypoint:
         options:
           dart2js_args:
           - --minify


### PR DESCRIPTION
We have had the ability to parse `:` for a while but did not update
documentation to use it since users on older versions of
`package:build_config` would have issues. Since it has been out for a
long time we expect most users to be on the latest. Update docs to use
`:` instead of `|` for the `build_web_compilers:entrypoint` builder.
There may still be other uses for other builders in docs.

The important update is that the arguments passed on windows on travis
use the `:` character since `|` causes problems with argument passing.