### PR TITLE
Add support for native non-null asserts to build_web_compilers:entrypoint builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,6 @@ jobs:
       os: linux
       env: PKGS="build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
       script: tool/travis.sh dartanalyzer_2
-    - stage: analyze_and_format
-      name: "SDK: 2.10.0; PKG: build_web_compilers; TASKS: `dartanalyzer --fatal-warnings .`"
-      dart: "2.10.0"
-      os: linux
-      env: PKGS="build_web_compilers"
-      script: tool/travis.sh dartanalyzer_2
     - stage: unit_test
       name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"
       dart: dev

--- a/_test_null_safety/build.yaml
+++ b/_test_null_safety/build.yaml
@@ -33,3 +33,21 @@ targets:
         enabled: true
         options:
           sound_null_safety: false
+  native_null_assertions_test:
+    auto_apply_builders: false
+    sources:
+    - test/native_null_assertions_test.dart
+    builders:
+      build_web_compilers:entrypoint:
+        enabled: true
+        options:
+          native_null_assertions: true
+  no_native_null_assertions_test:
+    auto_apply_builders: false
+    sources:
+    - test/no_native_null_assertions_test.dart
+    builders:
+      build_web_compilers:entrypoint:
+        enabled: true
+        options:
+          native_null_assertions: false

--- a/_test_null_safety/pubspec.yaml
+++ b/_test_null_safety/pubspec.yaml
@@ -5,6 +5,7 @@ environment:
   sdk: ">=2.10.0-0.0 <3.0.0"
 
 dev_dependencies:
+  js: ^0.6.0
   test: ^1.16.0-nullsafety
 
 dependency_overrides:

--- a/_test_null_safety/test/native_null_assertions_test.dart
+++ b/_test_null_safety/test/native_null_assertions_test.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Native null assertions are only supported on the web.
+@TestOn('browser')
+import 'dart:html';
+
+import 'package:js/js_util.dart' as js_util;
+import 'package:test/test.dart';
+
+void main() {
+  late final dynamic performance;
+
+  setUpAll(() {
+    performance = js_util.getProperty(window, 'performance');
+    js_util.setProperty(window, 'performance', null);
+    addTearDown(() => js_util.setProperty(window, 'performance', performance));
+  });
+
+  test('native null assertions can be enabled', () {
+    expect(() => window.performance, throwsA(isA<TypeError>()));
+  });
+}

--- a/_test_null_safety/test/no_native_null_assertions_test.dart
+++ b/_test_null_safety/test/no_native_null_assertions_test.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Native null assertions are only supported on the web.
+@TestOn('browser')
+import 'dart:html';
+
+import 'package:js/js_util.dart' as js_util;
+import 'package:test/test.dart';
+
+void main() {
+  late final dynamic performance;
+
+  setUpAll(() {
+    performance = js_util.getProperty(window, 'performance');
+    js_util.setProperty(window, 'performance', null);
+    addTearDown(() => js_util.setProperty(window, 'performance', performance));
+  });
+
+  test('native null assertions can be disabled', () {
+    expect(window.performance, null);
+  });
+}

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.13.0
+
+- Add `native_null_asserts` boolean option to the
+  `build_web_compilers:entrypoint` builder. This is disabled by default but
+  will be enabled by default in a later release. 
+
 ## 2.12.3
 
 - Fix handling of explicit `sound_null_safety` option for `dart2js` compiles.

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -24,19 +24,28 @@ import 'web_entrypoint_builder.dart';
 ///
 /// If [skipPlatformCheck] is `true` then all `dart:` imports will be
 /// allowed in all packages.
-Future<void> bootstrapDart2Js(BuildStep buildStep, List<String> dart2JsArgs,
-        {@required bool nullAssertions,
-        @required bool soundNullSafety,
-        bool skipPlatformCheck}) =>
+Future<void> bootstrapDart2Js(
+  BuildStep buildStep,
+  List<String> dart2JsArgs, {
+  @required bool nativeNullAssertions,
+  @required bool nullAssertions,
+  @required bool soundNullSafety,
+  bool skipPlatformCheck,
+}) =>
     _resourcePool.withResource(() => _bootstrapDart2Js(buildStep, dart2JsArgs,
+        nativeNullAssertions: nativeNullAssertions,
         nullAssertions: nullAssertions,
         soundNullSafety: soundNullSafety,
         skipPlatformCheck: skipPlatformCheck));
 
-Future<void> _bootstrapDart2Js(BuildStep buildStep, List<String> dart2JsArgs,
-    {@required bool nullAssertions,
-    @required bool soundNullSafety,
-    bool skipPlatformCheck}) async {
+Future<void> _bootstrapDart2Js(
+  BuildStep buildStep,
+  List<String> dart2JsArgs, {
+  @required bool nativeNullAssertions,
+  @required bool nullAssertions,
+  @required bool soundNullSafety,
+  bool skipPlatformCheck,
+}) async {
   skipPlatformCheck ??= false;
   var dartEntrypointId = buildStep.inputId;
   var moduleId =
@@ -86,6 +95,7 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
         '--multi-root=${scratchSpace.tempDir.uri.toFilePath()}',
         for (var experiment in enabledExperiments)
           '--enable-experiment=$experiment',
+        '--${nativeNullAssertions ? '' : 'no-'}native-null-assertions',
         if (nullAssertions) '--null-assertions',
         '--${soundNullSafety ? '' : 'no-'}sound-null-safety',
         '-o$jsOutputPath',

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -95,7 +95,7 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
         '--multi-root=${scratchSpace.tempDir.uri.toFilePath()}',
         for (var experiment in enabledExperiments)
           '--enable-experiment=$experiment',
-        '--${nativeNullAssertions ? '' : 'no-'}native-null-assertions',
+        if (nativeNullAssertions) '--native-null-assertions',
         if (nullAssertions) '--null-assertions',
         '--${soundNullSafety ? '' : 'no-'}sound-null-safety',
         '-o$jsOutputPath',

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -41,6 +41,7 @@ Future<void> bootstrapDdc(
   @deprecated Set<String> skipPlatformCheckPackages = const {},
   Iterable<AssetId> requiredAssets,
   @required bool soundNullSafety,
+  @required bool nativeNullAssertions,
   @required bool nullAssertions,
 }) async {
   requiredAssets ??= [];
@@ -142,6 +143,7 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
             entrypointLibraryName: entrypointLibraryName,
             moduleName: appModuleName,
             moduleScope: appModuleScope,
+            nativeNullAssertions: nativeNullAssertions,
             nullAssertions: nullAssertions,
             oldModuleScope: oldAppModuleScope));
 
@@ -210,17 +212,20 @@ Future<List<AssetId>> _ensureTransitiveJsModules(
 /// `[moduleScope].main()` function on it.
 ///
 /// Also performs other necessary initialization.
-String _appBootstrap(
-        {@required String bootstrapModuleName,
-        @required String moduleName,
-        @required String moduleScope,
-        @required String entrypointLibraryName,
-        @required String oldModuleScope,
-        @required bool nullAssertions}) =>
+String _appBootstrap({
+  @required String bootstrapModuleName,
+  @required String moduleName,
+  @required String moduleScope,
+  @required String entrypointLibraryName,
+  @required String oldModuleScope,
+  @required bool nullAssertions,
+  @required bool nativeNullAssertions,
+}) =>
     '''
 define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_sdk) {
   dart_sdk.dart.setStartAsyncSynchronously(true);
   dart_sdk.dart.nonNullAsserts($nullAssertions);
+  dart_sdk.dart.nativeNonNullAsserts($nativeNullAssertions);
   dart_sdk._isolate_helper.startRootIsolate(() => {}, []);
   $_initializeTools
   $_mainExtensionMarker

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -33,12 +33,14 @@ enum WebCompiler {
 const _supportedOptions = [
   _compilerOption,
   _dart2jsArgsOption,
+  _nativeNullAssertionsOption,
   _nullAssertionsOption,
   _soundNullSafetyOption,
 ];
 
 const _compilerOption = 'compiler';
 const _dart2jsArgsOption = 'dart2js_args';
+const _nativeNullAssertionsOption = 'native_null_assertions';
 const _nullAssertionsOption = 'null_assertions';
 const _soundNullSafetyOption = 'sound_null_safety';
 
@@ -64,11 +66,16 @@ class WebEntrypointBuilder implements Builder {
   /// This options can only be enabled in weak mode.
   final bool nullAssertions;
 
+  /// Whether or not to enable runtime non-null assertions for values returned
+  /// from browser apis.
+  final bool nativeNullAssertions;
+
   const WebEntrypointBuilder(
     this.webCompiler, {
     this.dart2JsArgs = const [],
     @required this.nullAssertions,
     @required this.soundNullSafetyOverride,
+    @required this.nativeNullAssertions,
   });
 
   factory WebEntrypointBuilder.fromOptions(BuilderOptions options) {
@@ -101,10 +108,13 @@ class WebEntrypointBuilder implements Builder {
 
     return WebEntrypointBuilder(compiler,
         dart2JsArgs: dart2JsArgs,
+        nativeNullAssertions:
+            options.config[_nativeNullAssertionsOption] as bool /*?*/ ?? false,
         nullAssertions:
             options.config[_nullAssertionsOption] as bool /*?*/ ?? false,
         soundNullSafetyOverride:
-            options.config[_soundNullSafetyOption] as bool /*?*/);
+            options.config[_soundNullSafetyOption] as bool /*?*/
+        );
   }
 
   @override
@@ -131,6 +141,7 @@ class WebEntrypointBuilder implements Builder {
       case WebCompiler.DartDevc:
         try {
           await bootstrapDdc(buildStep,
+              nativeNullAssertions: nativeNullAssertions,
               nullAssertions: nullAssertions,
               requiredAssets: _ddcSdkResources,
               soundNullSafety: soundNullSafety);
@@ -140,7 +151,9 @@ class WebEntrypointBuilder implements Builder {
         break;
       case WebCompiler.Dart2Js:
         await bootstrapDart2Js(buildStep, dart2JsArgs,
-            nullAssertions: nullAssertions, soundNullSafety: soundNullSafety);
+            nativeNullAssertions: nativeNullAssertions,
+            nullAssertions: nullAssertions,
+            soundNullSafety: soundNullSafety);
         break;
     }
   }

--- a/build_web_compilers/mono_pkg.yaml
+++ b/build_web_compilers/mono_pkg.yaml
@@ -6,8 +6,6 @@ stages:
   - group:
     - dartfmt: sdk
     - dartanalyzer: --fatal-infos --fatal-warnings .
-  - dartanalyzer: --fatal-warnings .
-    dart: 2.10.0
 - unit_test:
   - test: --test-randomize-ordering-seed=random
     os:

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_web_compilers
-version: 2.12.3
+version: 2.13.0
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: ">=2.11.0-162.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.36.4 <0.41.0"

--- a/build_web_compilers/test/dart2js_bootstrap_test.dart
+++ b/build_web_compilers/test/dart2js_bootstrap_test.dart
@@ -62,7 +62,9 @@ void main() {
       };
       await testBuilder(
           WebEntrypointBuilder(WebCompiler.Dart2Js,
-              soundNullSafetyOverride: null, nullAssertions: false),
+              soundNullSafetyOverride: null,
+              nullAssertions: false,
+              nativeNullAssertions: false),
           assets,
           outputs: expectedOutputs);
     });
@@ -76,7 +78,8 @@ void main() {
           WebEntrypointBuilder(WebCompiler.Dart2Js,
               dart2JsArgs: ['--no-source-maps'],
               soundNullSafetyOverride: null,
-              nullAssertions: false),
+              nullAssertions: false,
+              nativeNullAssertions: false),
           assets,
           outputs: expectedOutputs);
     });
@@ -106,7 +109,9 @@ void main() {
     };
     await testBuilder(
         WebEntrypointBuilder(WebCompiler.Dart2Js,
-            soundNullSafetyOverride: null, nullAssertions: false),
+            soundNullSafetyOverride: null,
+            nullAssertions: false,
+            nativeNullAssertions: false),
         assets,
         outputs: expectedOutputs);
   });
@@ -156,7 +161,9 @@ void main() {
         };
         await testBuilder(
             WebEntrypointBuilder(WebCompiler.Dart2Js,
-                soundNullSafetyOverride: null, nullAssertions: false),
+                soundNullSafetyOverride: null,
+                nullAssertions: false,
+                nativeNullAssertions: false),
             assets,
             outputs: expectedOutputs);
       }, ['non-nullable']);

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -55,7 +55,9 @@ void main() {
       };
       await testBuilder(
           WebEntrypointBuilder(WebCompiler.DartDevc,
-              soundNullSafetyOverride: null, nullAssertions: false),
+              soundNullSafetyOverride: null,
+              nullAssertions: false,
+              nativeNullAssertions: false),
           assets,
           outputs: expectedOutputs);
     });
@@ -94,7 +96,9 @@ void main() {
       };
       await testBuilder(
           WebEntrypointBuilder(WebCompiler.DartDevc,
-              soundNullSafetyOverride: null, nullAssertions: false),
+              soundNullSafetyOverride: null,
+              nullAssertions: false,
+              nativeNullAssertions: false),
           assets,
           outputs: expectedOutputs);
     });
@@ -117,7 +121,9 @@ void main() {
       };
       await testBuilder(
           WebEntrypointBuilder(WebCompiler.DartDevc,
-              soundNullSafetyOverride: null, nullAssertions: false),
+              soundNullSafetyOverride: null,
+              nullAssertions: false,
+              nativeNullAssertions: false),
           assets,
           outputs: expectedOutputs);
     });


### PR DESCRIPTION
Defaults to disable these for now, but the plan will be to enable them by default later on once things have stabilized a bit and we have good error messages that highlight how to bypass these checks.

Part of https://github.com/dart-lang/sdk/issues/43780

cc @srujzs  