### PR TITLE
Fix handling of changeFile for the analysis driver

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -47,7 +47,6 @@ linter:
     - empty_statements
     - file_names
     - hash_and_equals
-    - invariant_booleans
     - iterable_contains_unrelated_type
     - library_names
     - library_prefixes

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 1.4.2-dev
+## 1.4.2
+
+- Fix a bug around assets that appear missing to the analyzer even when they
+  should be visible to the build step using the resolver.
 
 ## 1.4.1
 

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -34,7 +34,7 @@ class BuildAssetUriResolver extends UriResolver {
 
   /// Asset paths which have been updated in [resourceProvider] but not yet
   /// updated in the analysis driver.
-  final _needsChangeFile = <String>{};
+  final _needsChangeFile = HashSet<AssetId>();
 
   final resourceProvider = MemoryResourceProvider(context: p.posix);
 
@@ -176,6 +176,7 @@ class BuildAssetUriResolver extends UriResolver {
     assert(_buildStepTransitivelyResolvedAssets.isEmpty,
         'Reset was called before all build steps completed');
     globallySeenAssets.clear();
+    _needsChangeFile.clear();
   }
 
   @override

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -113,7 +113,6 @@ class BuildAssetUriResolver extends UriResolver {
     transitivelyResolved?.add(id);
     final digest = await buildStep.digest(id);
     if (_cachedAssetDigests[id] == digest) {
-      print('Cached for $id, ${_needsChangeFile.contains(path)}');
       return _AssetState(path, _cachedAssetDependencies[id]);
     } else {
       final isChange = _cachedAssetDigests.containsKey(id);

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -34,7 +34,7 @@ class BuildAssetUriResolver extends UriResolver {
 
   /// Asset paths which have been updated in [resourceProvider] but not yet
   /// updated in the analysis driver.
-  final _needsChangeFile = HashSet<AssetId>();
+  final _needsChangeFile = HashSet<String>();
 
   final resourceProvider = MemoryResourceProvider(context: p.posix);
 

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -117,8 +117,8 @@ class BuildAssetUriResolver extends UriResolver {
     } else {
       final isChange = _cachedAssetDigests.containsKey(id);
       final content = await buildStep.readAsString(id);
-      // ignore: invariant_booleans
       if (_cachedAssetDigests[id] == digest) {
+        // Cache may have been updated while reading asset content
         return _AssetState(path, _cachedAssetDependencies[id]);
       }
       if (isChange) {

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.4.2-dev
+version: 1.4.2
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 6.0.4-dev
+
 ## 6.0.3
 
 - Fix https://github.com/dart-lang/build/issues/1804.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -34,3 +34,8 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+
+dependency_overrides:
+  build_resolvers:
+    path: ../build_resolvers

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 6.0.3
+version: 6.0.4-dev
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/generate/resolver_reuse_test.dart
+++ b/build_runner_core/test/generate/resolver_reuse_test.dart
@@ -131,6 +131,6 @@ import 'b.slow.dart';
         'a|lib/a.g2.dart': '//Annotation ()',
         'a|lib/b.slow.dart': '',
       });
-    }, skip: 'Currently failing');
+    });
   });
 }

--- a/build_runner_core/test/generate/resolver_reuse_test.dart
+++ b/build_runner_core/test/generate/resolver_reuse_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:build_config/build_config.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
@@ -63,5 +65,72 @@ void main() {
         'a|lib/file.imported.dart': 'class SomeClass {}',
       });
     });
+
+    test('A hidden generated file does not poison resolving', () async {
+      final slowBuilderCompleter = Completer<void>();
+      final builders = [
+        applyToRoot(
+            TestBuilder(
+                buildExtensions: replaceExtension('.dart', '.g1.dart'),
+                build: (buildStep, _) async {
+                  // Put the analysis driver into the bad state.
+                  await buildStep.inputLibrary;
+                  await buildStep.writeAsString(
+                      buildStep.inputId.changeExtension('.g1.dart'),
+                      'class Annotation {const Annotation();}');
+                }),
+            generateFor: InputSet(include: ['lib/a.dart'])),
+        applyToRoot(
+            TestBuilder(
+                buildExtensions: replaceExtension('.dart', '.g2.dart'),
+                build: (buildStep, _) async {
+                  var library = await buildStep.inputLibrary;
+                  var annotation = library
+                      .topLevelElements.single.metadata.single
+                      .computeConstantValue();
+                  await buildStep.writeAsString(
+                      buildStep.inputId.changeExtension('.g2.dart'),
+                      '//$annotation');
+                  slowBuilderCompleter.complete();
+                }),
+            isOptional: true,
+            generateFor: InputSet(include: ['lib/a.dart'])),
+        applyToRoot(
+            TestBuilder(
+                buildExtensions: replaceExtension('.dart', '.slow.dart'),
+                build: (buildStep, _) async {
+                  await slowBuilderCompleter.future;
+                  await buildStep.writeAsString(
+                      buildStep.inputId.changeExtension('.slow.dart'), '');
+                }),
+            isOptional: true,
+            generateFor: InputSet(include: ['lib/b.dart'])),
+        applyToRoot(
+            TestBuilder(
+                buildExtensions: replaceExtension('.dart', '.root'),
+                build: (buildStep, _) async {
+                  await buildStep.inputLibrary;
+                }),
+            generateFor: InputSet(include: ['lib/b.dart'])),
+      ];
+      await testBuilders(builders, {
+        'a|lib/a.dart': '''
+import 'a.g1.dart';
+import 'a.g2.dart';
+
+@Annotation()
+int x() => 1;
+''',
+        'a|lib/b.dart': r'''
+import 'a.g1.dart';
+import 'a.g2.dart';
+import 'b.slow.dart';
+'''
+      }, outputs: {
+        'a|lib/a.g1.dart': 'class Annotation {const Annotation();}',
+        'a|lib/a.g2.dart': '//Annotation ()',
+        'a|lib/b.slow.dart': '',
+      });
+    }, skip: 'Currently failing');
   });
 }


### PR DESCRIPTION
Fixes an issue where we may fail to notify the `AnalysisDriver` of a
newly available asset that it has previously read as missing before we
provided it. This could happen in some versions of the analyzer package
when calling `parseFile`, and it can happen in all versions when we use
the resolver with an import to an asset that is not generated yet, so
not visible to the build step.

See https://github.com/dart-lang/sdk/issues/43744

From the standpoint of the analyzer, we need to perform two steps in
order for the AnalysisDriver to see the correct content for a file after
it has previously tried to read it and it was missing:
1 - MemoryResourceManager.newFile
2 - AnalysisDriver.changeFile

In the case where the analyzer had never cached any state for that file,
we can get by with just `newFile`. We do currently guarantee that
`newFile` is called in time for analysis, but we don't guarantee that
`changeFile` has been called.

Remove the concept of deciding concretely whether to call `changeFile`
during the crawl. Instead track the asset paths that currently need to
be updated in the `AnalysisDriver` in a separate set. The first build
step to see the asset, or changed asset, during a transitive crawl will
record it as needing an update, and the first build step to finish a
crawl that visited that asset will call `changeFile`. Often these will
be the same build step.

Resolver changes to fix:
- Add a `_needsChangeFile` set. The extra memory used should scale with
  ongoing work, not with the total size of the project.
- Simplify the `_AssetState` class.
- After any crawl, find the intersection between the transitive
  dependencies crawled, and the assets that need an update, and call
  `changeFile` for each.

Also, as a separate optimization: Add an extra check against the cached
digests after reading the file content. This prevents duplicate work of
`_parseDirectives` in the case where multiple build steps saw an
uncached digest and start to await the `readAsString` call.

Add a test with builders forcing a specific series of interactions that
demonstrates this problem:

- g1 builder: reads a file which imports the out it has not yet written.
  Puts the analyzer into the cached bad state.
- root builder: (next non-optional builder) uses the resolver and starts
  a transitive crawl.
  - This crawl sees `.g1.dart` and calls `newFile`. It also caches the
    digest.
  - This crawl asks for `.slow.dart` and`.g2.dart`. This triggers a
    lazy build in both.
- The builder for `.slow.dart` won't complete, therefore the
  `crawlAsync` being done for the resolver intended for the "root"
  builder won't complete, therefore no `changeFile` are called.
- The builder for `.g2.dart` tries to use the resolver. During it's
  transitive dependency crawl it found that the digest for `.g1.dart`
  was cached, so it skips this asset for `changeFile`. It sees "null"
  for the annotation value, instead of what it would get if the
  `.g1.dart` import were correctly visible.

Remove the `invariant_booleans` lint rule for false positives.