### PR TITLE
[DISCUSSION ONLY] make the build apis return FutureOr

### DIFF
--- a/build/lib/src/asset/reader.dart
+++ b/build/lib/src/asset/reader.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
@@ -18,7 +19,7 @@ abstract class AssetReader {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws a `AssetNotFoundException` if `id.path` is not found.
-  Future<List<int>> readAsBytes(AssetId id);
+  FutureOr<List<int>> readAsBytes(AssetId id);
 
   /// Returns a [Future] that completes with the contents of a text asset.
   ///
@@ -26,10 +27,10 @@ abstract class AssetReader {
   ///
   /// * Throws a `PackageNotFoundException` if `id.package` is not found.
   /// * Throws a `AssetNotFoundException` if `id.path` is not found.
-  Future<String> readAsString(AssetId id, {Encoding encoding});
+  FutureOr<String> readAsString(AssetId id, {Encoding encoding});
 
   /// Indicates whether asset at [id] is readable.
-  Future<bool> canRead(AssetId id);
+  FutureOr<bool> canRead(AssetId id);
 
   /// Returns all readable assets matching [glob] under the current package.
   Stream<AssetId> findAssets(Glob glob);
@@ -42,7 +43,7 @@ abstract class AssetReader {
   ///
   /// This should be treated as a transparent [Digest] and the implementation
   /// may differ based on the current build system being used.
-  Future<Digest> digest(AssetId id) async {
+  FutureOr<Digest> digest(AssetId id) async {
     var digestSink = AccumulatorSink<Digest>();
     md5.startChunkedConversion(digestSink)
       ..add(await readAsBytes(id))

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -77,7 +77,7 @@ class BuildStepImpl implements BuildStep {
   Future<ReleasableResolver> _resolver;
 
   @override
-  Future<bool> canRead(AssetId id) {
+  FutureOr<bool> canRead(AssetId id) {
     if (_isComplete) throw BuildStepCompletedException();
     _checkInput(id);
     return _reader.canRead(id);
@@ -90,14 +90,14 @@ class BuildStepImpl implements BuildStep {
   }
 
   @override
-  Future<List<int>> readAsBytes(AssetId id) {
+  FutureOr<List<int>> readAsBytes(AssetId id) {
     if (_isComplete) throw BuildStepCompletedException();
     _checkInput(id);
     return _reader.readAsBytes(id);
   }
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) {
+  FutureOr<String> readAsString(AssetId id, {Encoding encoding = utf8}) {
     if (_isComplete) throw BuildStepCompletedException();
     _checkInput(id);
     return _reader.readAsString(id, encoding: encoding);
@@ -136,7 +136,7 @@ class BuildStepImpl implements BuildStep {
   }
 
   @override
-  Future<Digest> digest(AssetId id) {
+  FutureOr<Digest> digest(AssetId id) {
     if (_isComplete) throw BuildStepCompletedException();
     _checkInput(id);
     return _reader.digest(id);

--- a/build/lib/src/builder/post_process_build_step.dart
+++ b/build/lib/src/builder/post_process_build_step.dart
@@ -34,13 +34,12 @@ class PostProcessBuildStep {
   PostProcessBuildStep._(this.inputId, this._reader, this._writer,
       this._addAsset, this._deleteAsset);
 
-  Future<Digest> digest(AssetId id) => inputId == id
-      ? _reader.digest(id)
-      : Future.error(InvalidInputException(id));
+  FutureOr<Digest> digest(AssetId id) =>
+      inputId == id ? _reader.digest(id) : throw InvalidInputException(id);
 
-  Future<List<int>> readInputAsBytes() => _reader.readAsBytes(inputId);
+  FutureOr<List<int>> readInputAsBytes() => _reader.readAsBytes(inputId);
 
-  Future<String> readInputAsString({Encoding encoding = utf8}) =>
+  FutureOr<String> readInputAsString({Encoding encoding = utf8}) =>
       _reader.readAsString(inputId, encoding: encoding);
 
   Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes) {

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -32,3 +32,7 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -21,3 +21,7 @@ dependencies:
 dev_dependencies:
   test: ^1.0.0
   build_test: ^1.0.0
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -51,3 +51,9 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build:
+    path: ../build
+  build_runner_core:
+    path: ../build_runner_core

--- a/build_runner_core/lib/src/asset/build_cache.dart
+++ b/build_runner_core/lib/src/asset/build_cache.dart
@@ -27,19 +27,19 @@ class BuildCacheReader implements AssetReader {
           : BuildCacheReader._(delegate, assetGraph, rootPackage);
 
   @override
-  Future<bool> canRead(AssetId id) =>
+  FutureOr<bool> canRead(AssetId id) =>
       _delegate.canRead(_cacheLocation(id, _assetGraph, _rootPackage));
 
   @override
-  Future<Digest> digest(AssetId id) =>
+  FutureOr<Digest> digest(AssetId id) =>
       _delegate.digest(_cacheLocation(id, _assetGraph, _rootPackage));
 
   @override
-  Future<List<int>> readAsBytes(AssetId id) =>
+  FutureOr<List<int>> readAsBytes(AssetId id) =>
       _delegate.readAsBytes(_cacheLocation(id, _assetGraph, _rootPackage));
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) =>
+  FutureOr<String> readAsString(AssetId id, {Encoding encoding = utf8}) =>
       _delegate.readAsString(_cacheLocation(id, _assetGraph, _rootPackage),
           encoding: encoding);
 

--- a/build_runner_core/lib/src/asset/finalized_reader.dart
+++ b/build_runner_core/lib/src/asset/finalized_reader.dart
@@ -32,7 +32,7 @@ class FinalizedReader implements AssetReader {
       this._delegate, this._assetGraph, this._buildPhases, this._rootPackage);
 
   /// Returns a reason why [id] is not readable, or null if it is readable.
-  Future<UnreadableReason> unreadableReason(AssetId id) async {
+  FutureOr<UnreadableReason> unreadableReason(AssetId id) async {
     if (!_assetGraph.contains(id)) return UnreadableReason.notFound;
     var node = _assetGraph.get(id);
     if (node.isDeleted) return UnreadableReason.deleted;
@@ -48,17 +48,23 @@ class FinalizedReader implements AssetReader {
   }
 
   @override
-  Future<bool> canRead(AssetId id) async =>
-      (await unreadableReason(id)) == null;
+  FutureOr<bool> canRead(AssetId id) {
+    var reason = unreadableReason(id);
+    if (reason is Future<UnreadableReason>) {
+      return reason.then((result) => result == null);
+    } else {
+      return reason == null;
+    }
+  }
 
   @override
-  Future<Digest> digest(AssetId id) => _delegate.digest(id);
+  FutureOr<Digest> digest(AssetId id) => _delegate.digest(id);
 
   @override
-  Future<List<int>> readAsBytes(AssetId id) => _delegate.readAsBytes(id);
+  FutureOr<List<int>> readAsBytes(AssetId id) => _delegate.readAsBytes(id);
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) async {
+  FutureOr<String> readAsString(AssetId id, {Encoding encoding = utf8}) {
     if (_assetGraph.get(id)?.isDeleted ?? true) {
       throw AssetNotFoundException(id);
     }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -34,3 +34,10 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
+
+
+dependency_overrides:
+  build_resolvers:
+    path: ../build_resolvers
+  build:
+    path: ../build


### PR DESCRIPTION
This is an investigation into making `canRead`, `readAsString`, `readAsBytes`, and `digest` return a `FutureOr`. The primary motivation is to investigate the performance impact if we are able to take advantage of this in a few key places (namely, in build_resolvers which is done here).

On the angular_forms repo I saw around a 10% performance improvement here - from ~22 seconds to ~20 seconds.

If we actually were to roll this out we may want to create entirely new apis, to avoid breaking existing `Builder` code, and we could also then possibly avoid a breaking change in the `build` package - although that would be a bit questionable.