### PR TITLE
add a language version comment to the generated build script keeping it at version 2.9

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -1,3 +1,8 @@
+// Ensure that the build script itself is not opted in to null safety,
+// instead of taking the language version from the current package.
+//
+// @dart=2.9
+//
 // ignore_for_file: directives_ordering
 
 import 'package:build_runner_core/build_runner_core.dart' as _i1;

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.4
+
+- Ensure that the generated build script is opted out of null safety, even if
+  the current package supports it.
+
 ## 1.10.3
 
 - Remove high sdk constraint, allow >=2.9.0.

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -38,6 +38,11 @@ Future<String> _generateBuildScript() async {
   final emitter = DartEmitter(Allocator.simplePrefixing());
   try {
     return DartFormatter().format('''
+      // Ensure that the build script itself is not opted in to null safety,
+      // instead of taking the language version from the current package.
+      //
+      // @dart=2.9
+      //
       // ignore_for_file: directives_ordering
 
       ${library.accept(emitter)}''');

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.10.3
+version: 1.10.4
 description: A build system for Dart code generation and modular compilation.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
This will soon be necessary once packages start opting in to null safety.

cc @kevmoo 