### PR TITLE
Strip temp directory from full kernel path in metadata

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.14.0
+
+- Strip stratch directory paths from a new metadata field `fullKernelUri`
+
 ## 2.13.0
 
 - Add `native_null_asserts` boolean option to the

--- a/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -363,6 +363,11 @@ void _fixMetadataSources(Map<String, dynamic> json, Uri scratchUri) {
     json['moduleUri'] = updatePath(moduleUri);
   }
 
+  var fullKernelUri = json['fullKernelUri'] as String;
+  if (fullKernelUri != null) {
+    json['fullKernelUri'] = updatePath(fullKernelUri);
+  }
+
   var libraries = json['libraries'] as List<dynamic>;
   if (libraries != null) {
     for (var lib in libraries) {

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.13.0
+version: 2.14.0
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 


### PR DESCRIPTION
Strip temp directory from full kernel path in metadata, 
in preparation to addition of full kernel path to metadata.

Related: https://github.com/dart-lang/sdk/issues/43684