### PR TITLE
Add support for directly debugging browser test

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.3.0
+
+- Add support for running generated `.browser_test.dart` directly instead of
+  expecting the test runner with the query string `directRun=true`. It is no
+  longer necessary to create a build config which generates for `*_test.dart`
+  files in `build_web_compilers`, the default config generates for
+  `.browser_test.dart` files which are used by `debug.html`.
+
 ## 1.2.2
 
 - Allow package:build versions through `1.5.x`.

--- a/build_test/lib/src/debug_test_builder.dart
+++ b/build_test/lib/src/debug_test_builder.dart
@@ -22,7 +22,8 @@ AssetId _customHtmlId(AssetId test) => test.changeExtension('.html');
 AssetId _debugHtmlId(AssetId test) => test.changeExtension('.debug.html');
 
 /// Returns the JS script path for the browser for [dartTest].
-String _jsScriptPath(AssetId dartTest) => '${p.url.basename(dartTest.path)}.js';
+String _jsScriptPath(AssetId dartTest) =>
+    '${p.url.basename(dartTest.path)}.browser_test.dart.js';
 
 /// Generates a `*.debug.html` for every file in `test/**/*_test.dart`.
 ///
@@ -98,9 +99,10 @@ class DebugIndexBuilder implements Builder {
     }
     final buffer = StringBuffer('    <ul>');
     for (final test in tests) {
-      final path =
-          p.url.joinAll(p.url.split(_debugHtmlId(test).path)..removeAt(0));
-      buffer.writeln('      <li><a href="/$path">${test.path}</a></li>');
+      final pathSegments = p.url.split(_debugHtmlId(test).path).skip(1);
+      final uri = Uri(
+          pathSegments: pathSegments, queryParameters: {'directRun': 'true'});
+      buffer.writeln('      <li><a href="/$uri">${test.path}</a></li>');
     }
     buffer.writeln('    </ul>');
     return buffer.toString();

--- a/build_test/lib/src/test_bootstrap_builder.dart
+++ b/build_test/lib/src/test_bootstrap_builder.dart
@@ -91,7 +91,11 @@ class TestBootstrapBuilder extends Builder {
           import "${p.url.basename(id.path)}" as test;
 
           void main() {
-            internalBootstrapBrowserTest(() => test.main);
+            if (Uri.base.queryParameters['directRun'] == 'true') {
+              test.main();
+            } else {
+              internalBootstrapBrowserTest(() => test.main);
+            }
           }
         ''');
     }

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 1.2.2
+version: 1.3.0
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:

--- a/build_test/test/debug_test_builder_test.dart
+++ b/build_test/test/debug_test_builder_test.dart
@@ -18,7 +18,7 @@ void main() {
         'a|test/hello_test.debug.html': _equalsTextWithoutWhitespace('''
           <html>
             <head>
-              <script src="hello_test.dart.js"></script>
+              <script src="hello_test.dart.browser_test.dart.js"></script>
             </head>
           </html>
         ''')
@@ -43,7 +43,7 @@ void main() {
         'a|test/hello_test.debug.html': _equalsTextWithoutWhitespace('''
           <html>
             <head>
-              <script src="hello_test.dart.js"></script>
+              <script src="hello_test.dart.browser_test.dart.js"></script>
             </head>
             <body>
               <cool-element>I am awesome</cool-element>
@@ -65,15 +65,17 @@ void main() {
         'a|test/sub/4_test.dart': '',
       }, outputs: {
         'a|test/index.html': _equalsTextWithoutWhitespace('''
-          <html>
-            <body>
-              <ul>
-                <li><a href="/1_test.debug.html">test/1_test.dart</a></li>
-                <li><a href="/2_test.debug.html">test/2_test.dart</a></li>
-                <li><a href="/sub/4_test.debug.html">test/sub/4_test.dart</a></li>
-              </ul>
-            </body>
-          </html>
+<html>
+  <body>
+    <ul>
+      <li><a href="/1_test.debug.html?directRun=true">test/1_test.dart</a></li>
+      <li><a href="/2_test.debug.html?directRun=true">test/2_test.dart</a></li>
+      <li>
+        <a href="/sub/4_test.debug.html?directRun=true">test/sub/4_test.dart</a>
+      </li>
+    </ul>
+  </body>
+</html>
         '''),
       });
     });


### PR DESCRIPTION
Closes #2749

In the generated `debug.html` file append the query parameter
`directRun=true`, and check for this parameter in the generated
`.browser_test.dart` files to determine whether to bootstrap through the
test runner, or to run the test directly.

Use the `.browser_test.dart.js` file as the JS script to load from the
`.debug.html` file.

Refactor a `p.url.join` to `Uri(pathSegments)`. This also URL encodes
the segments if necessary, and allows adding the query parameter.