### PR TITLE
Dart2js cleanup

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.15.0
+
+- Add some warnings for manual dart2js args that should be configured using
+  explicit options, and add back dart2js argument logging which was
+  accidentally removed.
+
 ## 2.14.0
 
 - Strip scratch directory paths from a new metadata field `fullKernelUri`.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.14.0
+version: 2.15.0
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 


### PR DESCRIPTION
Restores support for the BUILD_DART2JS_VM_ARGS environment variable and the logging of dart2js arguments.

Adds warnings when configuring things through `dart2js_args` that should be configured through top level options.

Closes https://github.com/dart-lang/build/issues/2878