### PR TITLE
change experiment error to warning with mismatched sdk/analyzer versions

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.3
+
+- Change the error to a warning when enabling experiments with mismatched
+  analyzer/sdk versions since this will still work for experiments with release
+  versions (such as null safety).
+
 ## 1.4.2
 
 - Fix a bug around assets that appear missing to the analyzer even when they

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -435,14 +435,14 @@ FeatureSet _featureSet({List<String> enableExperiments}) {
   enableExperiments ??= [];
   if (enableExperiments.isNotEmpty &&
       sdkLanguageVersion > ExperimentStatus.currentVersion) {
-    throw StateError('''
+    log.warning('''
 Attempting to enable experiments `$enableExperiments`, but the current SDK
 language version does not match your `analyzer` package language version:
 
 Analyzer language version: ${ExperimentStatus.currentVersion}
 SDK language version: $sdkLanguageVersion
 
-In order to use experiments you will need to upgrade or downgrade your
+In order to use experiments you may need to upgrade or downgrade your
 `analyzer` package dependency such that its language version matches that of
 your current SDK, see https://github.com/dart-lang/build/issues/2685.
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.4.2
+version: 1.4.3
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 


### PR DESCRIPTION
For experiments with release versions this is no longer a requirement, so downgrade to a warning.