### PR TITLE
Migrate to runZonedGuarded

### DIFF
--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -23,7 +23,7 @@ Logger get log => Zone.current[logKey] as Logger ?? _default;
 /// Completes with the first error or result of `fn`, whichever comes first.
 Future<T> scopeLogAsync<T>(Future<T> Function() fn, Logger log) {
   var done = Completer<T>();
-  runZoned(fn, (e, st) {
+  runZonedGuarded(fn, (e, st) {
     log.severe('', e, st);
     if (done.isCompleted) return;
     done.completeError(e, st);

--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -23,15 +23,15 @@ Logger get log => Zone.current[logKey] as Logger ?? _default;
 /// Completes with the first error or result of `fn`, whichever comes first.
 Future<T> scopeLogAsync<T>(Future<T> Function() fn, Logger log) {
   var done = Completer<T>();
-  runZonedGuarded(fn, (e, st) {
-    log.severe('', e, s);
+  runZoned(fn, (e, st) {
+    log.severe('', e, st);
     if (done.isCompleted) return;
-    done.completeError(e, s);
-  }).then((result) {
-    if (done.isCompleted) return;
-    done.complete(result);
+    done.completeError(e, st);
   }, zoneSpecification: ZoneSpecification(print: (self, parent, zone, message) {
     log.warning(message);
-  }), zoneValues: {logKey: log});
+  }), zoneValues: {logKey: log}).then((result) {
+    if (done.isCompleted) return;
+    done.complete(result);
+  });
   return done.future;
 }

--- a/build/lib/src/builder/logging.dart
+++ b/build/lib/src/builder/logging.dart
@@ -23,19 +23,15 @@ Logger get log => Zone.current[logKey] as Logger ?? _default;
 /// Completes with the first error or result of `fn`, whichever comes first.
 Future<T> scopeLogAsync<T>(Future<T> Function() fn, Logger log) {
   var done = Completer<T>();
-  runZoned(fn,
-      zoneSpecification:
-          ZoneSpecification(print: (self, parent, zone, message) {
-        log.warning(message);
-      }),
-      zoneValues: {logKey: log},
-      onError: (Object e, StackTrace s) {
-        log.severe('', e, s);
-        if (done.isCompleted) return;
-        done.completeError(e, s);
-      }).then((result) {
+  runZonedGuarded(fn, (e, st) {
+    log.severe('', e, s);
+    if (done.isCompleted) return;
+    done.completeError(e, s);
+  }).then((result) {
     if (done.isCompleted) return;
     done.complete(result);
-  });
+  }, zoneSpecification: ZoneSpecification(print: (self, parent, zone, message) {
+    log.warning(message);
+  }), zoneValues: {logKey: log});
   return done.future;
 }

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -286,7 +286,7 @@ class _SingleBuild {
       hungActionsHeartbeat.stop();
     });
 
-    runZoned(() async {
+    runZonedGuarded(() async {
       if (updates.isNotEmpty) {
         await _updateAssetGraph(updates);
       }
@@ -318,7 +318,7 @@ class _SingleBuild {
       }
 
       if (!done.isCompleted) done.complete(result);
-    }, onError: (Object e, StackTrace st) {
+    }, (e, st) {
       if (!done.isCompleted) {
         _logger.severe('Unhandled build failure!', e, st);
         done.complete(BuildResult(BuildStatus.failure, []));

--- a/build_runner_core/lib/src/package_graph/apply_builders.dart
+++ b/build_runner_core/lib/src/package_graph/apply_builders.dart
@@ -392,15 +392,11 @@ Map<String, List<BuilderApplication>> _applyWith(
 /// Any calls to [print] will be logged with `log.info`, and any errors will be
 /// logged with `log.severe`.
 T _scopeLogSync<T>(T Function() fn, Logger log) {
-  return runZoned(fn,
-      zoneSpecification:
-          ZoneSpecification(print: (self, parent, zone, message) {
-        log.info(message);
-      }),
-      zoneValues: {logKey: log},
-      onError: (Object e, StackTrace s) {
-        log.severe('', e, s);
-      });
+  return runZonedGuarded(fn, (e, st) {
+    log.severe('', e, st);
+  }, zoneSpecification: ZoneSpecification(print: (self, parent, zone, message) {
+    log.info(message);
+  }), zoneValues: {logKey: log});
 }
 
 String _factoryFailure(String packageName, BuilderOptions options) =>


### PR DESCRIPTION
The `onError` argument to `runZoned` is deprecated. Switch to the
supported `runZonedGuarded`.

Remove argument types on the function literal since thy can now be
inferred. `runZonedGuarded` has a specific function type argument,
whereas `onError` was typed as `Function` which did not allow inference
on argument types.