### PR TITLE
Fix 500 response for cached failure nodes in serve mode

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Require the latest build version (1.5.1).
 - Support the `additional_public_assets` option in build configurations.
+- Fix a bug where the server would respond with a 500 instead of a 404 for
+  files that don't match any build filters but had previously failed.
 
 ## 6.0.3
 

--- a/build_runner_core/lib/src/asset/finalized_reader.dart
+++ b/build_runner_core/lib/src/asset/finalized_reader.dart
@@ -35,7 +35,8 @@ class FinalizedReader implements AssetReader {
   Future<UnreadableReason> unreadableReason(AssetId id) async {
     if (!_assetGraph.contains(id)) return UnreadableReason.notFound;
     var node = _assetGraph.get(id);
-    if (!_optionalOutputTracker.isRequired(node.id)) {
+    if (_optionalOutputTracker != null &&
+        !_optionalOutputTracker.isRequired(node.id)) {
       return UnreadableReason.notOutput;
     }
     if (node.isDeleted) return UnreadableReason.deleted;

--- a/build_runner_core/lib/src/asset/finalized_reader.dart
+++ b/build_runner_core/lib/src/asset/finalized_reader.dart
@@ -35,13 +35,14 @@ class FinalizedReader implements AssetReader {
   Future<UnreadableReason> unreadableReason(AssetId id) async {
     if (!_assetGraph.contains(id)) return UnreadableReason.notFound;
     var node = _assetGraph.get(id);
+    if (!_optionalOutputTracker.isRequired(node.id)) {
+      return UnreadableReason.notOutput;
+    }
     if (node.isDeleted) return UnreadableReason.deleted;
     if (!node.isReadable) return UnreadableReason.assetType;
     if (node is GeneratedAssetNode) {
       if (node.isFailure) return UnreadableReason.failed;
-      if (!(node.wasOutput && (_optionalOutputTracker.isRequired(node.id)))) {
-        return UnreadableReason.notOutput;
-      }
+      if (!node.wasOutput) return UnreadableReason.notOutput;
     }
     if (await _delegate.canRead(id)) return null;
     return UnreadableReason.unknown;

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -3,10 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 @TestOn('vm')
 import 'package:build/build.dart';
+import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset/finalized_reader.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/generate/phase.dart';
 import 'package:build_test/build_test.dart';
+import 'package:glob/glob.dart';
 import 'package:test/test.dart';
 
 import 'package:_test_common/common.dart';
@@ -14,16 +17,17 @@ import 'package:_test_common/common.dart';
 void main() {
   group('FinalizedReader', () {
     FinalizedReader reader;
-    AssetNode notDeleted;
-    AssetNode deleted;
+    AssetGraph graph;
 
     setUp(() async {
-      var graph = await AssetGraph.build([], <AssetId>{}, <AssetId>{},
+      graph = await AssetGraph.build([], <AssetId>{}, <AssetId>{},
           buildPackageGraph({rootPackage('foo'): []}), null);
+    });
 
-      notDeleted = makeAssetNode(
+    test('can not read deleted files', () async {
+      var notDeleted = makeAssetNode(
           'a|web/a.txt', [], computeDigest(AssetId('a', 'web/a.txt'), 'a'));
-      deleted = makeAssetNode(
+      var deleted = makeAssetNode(
           'a|lib/b.txt', [], computeDigest(AssetId('a', 'lib/b.txt'), 'b'));
       deleted.deletedBy.add(deleted.id.addExtension('.post_anchor.1'));
 
@@ -33,11 +37,33 @@ void main() {
       delegate.assets.addAll({notDeleted.id: [], deleted.id: []});
 
       reader = FinalizedReader(delegate, graph, [], 'a');
-    });
-
-    test('can not read deleted files', () async {
       expect(await reader.canRead(notDeleted.id), true);
       expect(await reader.canRead(deleted.id), false);
+    });
+
+    test('Failure nodes interact well with build filters ', () async {
+      var id = AssetId('a', 'web/a.txt');
+      var node = GeneratedAssetNode(id,
+          state: NodeState.upToDate,
+          phaseNumber: 0,
+          wasOutput: true,
+          isFailure: true,
+          primaryInput: AssetId('a', 'web/a.dart'),
+          isHidden: true,
+          builderOptionsId: AssetId('a', 'builder_options'));
+      graph.add(node);
+      var delegate = InMemoryAssetReader();
+      delegate.assets.addAll({id: []});
+      reader = FinalizedReader(delegate, graph,
+          [InBuildPhase(TestBuilder(), 'a', isOptional: false)], 'a')
+        ..reset({'web'}, {});
+      expect(await reader.unreadableReason(id), UnreadableReason.failed,
+          reason: 'Should report a failure if no build filters apply');
+
+      reader.reset({'web'}, {BuildFilter(Glob('b'), Glob('foo'))});
+      expect(await reader.unreadableReason(id), UnreadableReason.notOutput,
+          reason:
+              'Should report as not output if it doesn\'t match requested build filters');
     });
   });
 }


### PR DESCRIPTION
Respond with UnreadableReason.notOutput for failure nodes that don't match any build filters, which makes the server respond with a 404 instead of 500.