### PR TITLE
add github actions CI

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v3.1.0-beta
+# Created with package:mono_repo v3.1.0-beta.1
 name: Dart CI
 
 on:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,532 @@
+# Created with package:mono_repo v3.1.0-beta
+name: Dart CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  job_001:
+    name: "OS: linux; SDK: dev; PKGS: _test, _test_common; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test _test_common
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh dartanalyzer_0
+  job_002:
+    name: "OS: linux; SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh command_0 command_1
+  job_003:
+    name: "OS: windows; SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh command_0 command_1
+  job_004:
+    name: "OS: linux; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 0 --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_00
+  job_005:
+    name: "OS: linux; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 1 --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_01
+  job_006:
+    name: "OS: windows; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_02
+  job_007:
+    name: "OS: windows; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_03
+  job_008:
+    name: "OS: windows; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_04
+  job_009:
+    name: "OS: linux; SDK: dev; PKG: _test; TASKS: `pub run test`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_05
+  job_010:
+    name: "OS: windows; SDK: dev; PKG: _test; TASKS: `pub run test`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_05
+  job_011:
+    name: "OS: linux; SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test_null_safety
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh dartanalyzer_1
+  job_012:
+    name: "OS: linux; SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test_null_safety
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh command_2 command_3
+  job_013:
+    name: "OS: windows; SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test_null_safety
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh command_2 command_3
+  job_014:
+    name: "OS: linux; SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_resolvers, build_runner, build_runner_core, build_test, build_vm_compilers, build_web_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh dartfmt dartanalyzer_0
+  job_015:
+    name: "OS: linux; SDK: 2.9.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: stable
+          version: "2.9.0"
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh dartanalyzer_2
+  job_016:
+    name: "OS: linux; SDK: dev; PKG: build; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_06
+  job_017:
+    name: "OS: linux; SDK: dev; PKG: build_config; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_config
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_06
+  job_018:
+    name: "OS: linux; SDK: dev; PKG: build_daemon; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_daemon
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_06
+  job_019:
+    name: "OS: linux; SDK: dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_resolvers
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_06
+  job_020:
+    name: "OS: linux; SDK: dev; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_runner_core
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_06
+  job_021:
+    name: "OS: linux; SDK: dev; PKG: build_test; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_test
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_06
+  job_022:
+    name: "OS: linux; SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_web_compilers
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_06
+  job_023:
+    name: "OS: linux; SDK: dev; PKG: scratch_space; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: scratch_space
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_06
+  job_024:
+    name: "OS: windows; SDK: dev; PKG: build; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_06
+  job_025:
+    name: "OS: windows; SDK: dev; PKG: build_config; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_config
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_06
+  job_026:
+    name: "OS: windows; SDK: dev; PKG: build_daemon; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_daemon
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_06
+  job_027:
+    name: "OS: windows; SDK: dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_resolvers
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_06
+  job_028:
+    name: "OS: windows; SDK: dev; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_runner_core
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_06
+  job_029:
+    name: "OS: windows; SDK: dev; PKG: build_test; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_test
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_06
+  job_030:
+    name: "OS: windows; SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_web_compilers
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_06
+  job_031:
+    name: "OS: windows; SDK: dev; PKG: scratch_space; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: scratch_space
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_06
+  job_032:
+    name: "OS: linux; SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_modules
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_07
+  job_033:
+    name: "OS: windows; SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_modules
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_07
+  job_034:
+    name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -x integration --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_runner
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_08
+  job_035:
+    name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_runner
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_09
+  job_036:
+    name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_runner
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_10
+  job_037:
+    name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_runner
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_11
+  job_038:
+    name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_runner
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_12
+  job_039:
+    name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_runner
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_13
+  job_040:
+    name: "OS: linux; SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: stable
+          version: "2.9.0"
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_runner_core
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_06
+  job_041:
+    name: "OS: windows; SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: stable
+          version: "2.9.0"
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_runner_core
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_06
+  job_042:
+    name: "OS: linux; SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_vm_compilers
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_05
+  job_043:
+    name: "OS: windows; SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: build_vm_compilers
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh test_05

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v3.1.0-beta
+# Created with package:mono_repo v3.1.0-beta.1
 language: dart
 
 # Custom configuration
@@ -17,7 +17,7 @@ jobs:
     - stage: analyze_and_format
       name: mono_repo self validate
       os: linux
-      script: "pub global activate mono_repo 3.1.0-beta && pub global run mono_repo travis --validate"
+      script: "pub global activate mono_repo 3.1.0-beta.1 && pub global run mono_repo generate --validate"
     - stage: analyze_and_format
       name: "SDK: dev; PKGS: _test, _test_common; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
       dart: dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v3.0.0
+# Created with package:mono_repo v3.1.0-beta
 language: dart
 
 # Custom configuration
@@ -17,295 +17,295 @@ jobs:
     - stage: analyze_and_format
       name: mono_repo self validate
       os: linux
-      script: "pub global activate mono_repo 3.0.0 && pub global run mono_repo travis --validate"
+      script: "pub global activate mono_repo 3.1.0-beta && pub global run mono_repo travis --validate"
     - stage: analyze_and_format
       name: "SDK: dev; PKGS: _test, _test_common; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
       dart: dev
       os: linux
       env: PKGS="_test _test_common"
-      script: tool/travis.sh dartanalyzer_0
+      script: tool/ci.sh dartanalyzer_0
     - stage: analyze_and_format
       name: "SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
       dart: dev
       os: linux
       env: PKGS="_test_null_safety"
-      script: tool/travis.sh dartanalyzer_1
+      script: tool/ci.sh dartanalyzer_1
     - stage: analyze_and_format
       name: "SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_resolvers, build_runner, build_runner_core, build_test, build_vm_compilers, build_web_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: dev
       os: linux
       env: PKGS="build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space"
-      script: tool/travis.sh dartfmt dartanalyzer_0
+      script: tool/ci.sh dartfmt dartanalyzer_0
     - stage: analyze_and_format
       name: "SDK: 2.9.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
       dart: "2.9.0"
       os: linux
       env: PKGS="build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
-      script: tool/travis.sh dartanalyzer_2
+      script: tool/ci.sh dartanalyzer_2
     - stage: unit_test
       name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"
       dart: dev
       os: linux
       env: PKGS="_test"
-      script: tool/travis.sh command_0 command_1
+      script: tool/ci.sh command_0 command_1
     - stage: unit_test
       name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"
       dart: dev
       os: windows
       env: PKGS="_test"
-      script: tool/travis.sh command_0 command_1
+      script: tool/ci.sh command_0 command_1
     - stage: unit_test
       name: "SDK: dev; PKG: build; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_config; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_config"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_config; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_config"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_daemon; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_daemon"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_daemon; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_daemon"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_modules"
-      script: tool/travis.sh test_07
+      script: tool/ci.sh test_07
     - stage: unit_test
       name: "SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_modules"
-      script: tool/travis.sh test_07
+      script: tool/ci.sh test_07
     - stage: unit_test
       name: "SDK: dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_resolvers"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_resolvers"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -x integration --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/travis.sh test_08
+      script: tool/ci.sh test_08
     - stage: unit_test
       name: "SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: "2.9.0"
       os: linux
       env: PKGS="build_runner_core"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: "2.9.0"
       os: windows
       env: PKGS="build_runner_core"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_runner_core"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_runner_core"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_test; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_test"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_test; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_test"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
       dart: dev
       os: linux
       env: PKGS="build_vm_compilers"
-      script: tool/travis.sh test_05
+      script: tool/ci.sh test_05
     - stage: unit_test
       name: "SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
       dart: dev
       os: windows
       env: PKGS="build_vm_compilers"
-      script: tool/travis.sh test_05
+      script: tool/ci.sh test_05
     - stage: unit_test
       name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_web_compilers"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_web_compilers"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: scratch_space; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="scratch_space"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: dev; PKG: scratch_space; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="scratch_space"
-      script: tool/travis.sh test_06
+      script: tool/ci.sh test_06
     - stage: e2e_test
       name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 0 --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="_test"
-      script: tool/travis.sh test_00
+      script: tool/ci.sh test_00
     - stage: e2e_test
       name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 1 --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="_test"
-      script: tool/travis.sh test_01
+      script: tool/ci.sh test_01
     - stage: e2e_test
       name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="_test"
-      script: tool/travis.sh test_02
+      script: tool/ci.sh test_02
     - stage: e2e_test
       name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="_test"
-      script: tool/travis.sh test_03
+      script: tool/ci.sh test_03
     - stage: e2e_test
       name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="_test"
-      script: tool/travis.sh test_04
+      script: tool/ci.sh test_04
     - stage: e2e_test
       name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: dev
       os: linux
       env: PKGS="_test_null_safety"
-      script: tool/travis.sh command_2 command_3
+      script: tool/ci.sh command_2 command_3
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/travis.sh test_09
+      script: tool/ci.sh test_09
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/travis.sh test_10
+      script: tool/ci.sh test_10
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/travis.sh test_11
+      script: tool/ci.sh test_11
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/travis.sh test_12
+      script: tool/ci.sh test_12
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/travis.sh test_13
+      script: tool/ci.sh test_13
     - stage: e2e_test_cron
       name: "SDK: be/raw/latest; PKG: _test; TASKS: `pub run test`"
       dart: be/raw/latest
       os: linux
       env: PKGS="_test"
-      script: tool/travis.sh test_05
+      script: tool/ci.sh test_05
     - stage: e2e_test_cron
       name: "SDK: be/raw/latest; PKG: _test; TASKS: `pub run test`"
       dart: be/raw/latest
       os: windows
       env: PKGS="_test"
-      script: tool/travis.sh test_05
+      script: tool/ci.sh test_05
     - stage: e2e_test_cron
       name: "SDK: dev; PKG: _test; TASKS: `pub run test`"
       dart: dev
       os: linux
       env: PKGS="_test"
-      script: tool/travis.sh test_05
+      script: tool/ci.sh test_05
     - stage: e2e_test_cron
       name: "SDK: dev; PKG: _test; TASKS: `pub run test`"
       dart: dev
       os: windows
       env: PKGS="_test"
-      script: tool/travis.sh test_05
+      script: tool/ci.sh test_05
     - stage: e2e_test_cron
       name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: be/raw/latest
       os: linux
       env: PKGS="_test_null_safety"
-      script: tool/travis.sh command_2 command_3
+      script: tool/ci.sh command_2 command_3
     - stage: e2e_test_cron
       name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: be/raw/latest
       os: windows
       env: PKGS="_test_null_safety"
-      script: tool/travis.sh command_2 command_3
+      script: tool/ci.sh command_2 command_3
     - stage: e2e_test_cron
       name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: dev
       os: linux
       env: PKGS="_test_null_safety"
-      script: tool/travis.sh command_2 command_3
+      script: tool/ci.sh command_2 command_3
     - stage: e2e_test_cron
       name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: dev
       os: windows
       env: PKGS="_test_null_safety"
-      script: tool/travis.sh command_2 command_3
+      script: tool/ci.sh command_2 command_3
 
 stages:
   - analyze_and_format

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -1,6 +1,10 @@
 # See https://github.com/google/mono_repo.dart for details on this file
 self_validate: analyze_and_format
 
+ci:
+  - github
+  - travis
+
 travis:
   addons:
     chrome: stable

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v3.1.0-beta
+# Created with package:mono_repo v3.1.0-beta.1
 
 # Support built in commands on windows out of the box.
 function pub() {

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v3.0.0
+# Created with package:mono_repo v3.1.0-beta
 
 # Support built in commands on windows out of the box.
 function pub() {


### PR DESCRIPTION
Use the latest beta release of mono_repo to set up github actions CI.

Leaves travis in place for now for the edge testing of the sdk until we get that worked out, as well as the webhook alerting for failed builds.