### PR TITLE
fix an analyzer hint in build_runner_core

### DIFF
--- a/build_runner_core/test/fixtures/basic_pkg/pubspec.yaml
+++ b/build_runner_core/test/fixtures/basic_pkg/pubspec.yaml
@@ -1,5 +1,6 @@
 name: basic_pkg
 version: 1.0.0
+publish_to: none
 dependencies:
   a: 2.0.0
   b:


### PR DESCRIPTION
adds `publish_to: none` to a testing only package pubspec 