### PR TITLE
Allow latest build_config in build_runner, remove various dep overrides

### DIFF
--- a/_test_null_safety/mono_pkg.yaml
+++ b/_test_null_safety/mono_pkg.yaml
@@ -7,17 +7,17 @@ os:
 
 stages:
 - analyze_and_format:
-  - dartanalyzer: --enable-experiment=non-nullable --fatal-infos --fatal-warnings .
+  - dartanalyzer: --fatal-infos --fatal-warnings .
     os: linux
 - e2e_test:
   - group:
-    - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
-    - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
+    - command: pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random
+    - command: pub run build_runner test --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
     os: linux
 - e2e_test_cron:
   - group:
-    - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
-    - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
+    - command: pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random
+    - command: pub run build_runner test --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
     dart:
       - be/raw/latest
       - dev

--- a/_test_null_safety/pubspec.yaml
+++ b/_test_null_safety/pubspec.yaml
@@ -2,10 +2,10 @@ name: _test_null_safety
 publish_to: none
 
 environment:
-  sdk: ">=2.10.0-0.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dev_dependencies:
-  js: ^0.6.0
+  js: ^0.6.3-nullsafety
   test: ^1.16.0-nullsafety
 
 dependency_overrides:

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.4-dev
+
 ## 0.4.3
 
 - Added the `additional_public_assets` option, which describes the assets

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.4.3-dev
+version: 0.4.3
 description: Support for parsing `build.yaml` configuration.
 homepage: https://github.com/dart-lang/build/tree/master/build_config
 

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.4.3
+version: 0.4.3-dev
 description: Support for parsing `build.yaml` configuration.
 homepage: https://github.com/dart-lang/build/tree/master/build_config
 
@@ -26,7 +26,3 @@ dependency_overrides:
     path: ../build_runner
   build_runner_core:
     path: ../build_runner_core
-  analyzer: ^0.40.0
-  # Temporarily required until build version 1.5.1 is released
-  build:
-    path: ../build

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.4.3
+version: 0.4.4-dev
 description: Support for parsing `build.yaml` configuration.
 homepage: https://github.com/dart-lang/build/tree/master/build_config
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.6
+
+- Allow build_config version 0.4.3.
+
 ## 1.10.5
 
 - Better handle the case where the package config file is deleted while

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.10.5
+version: 1.10.6
 description: A build system for Dart code generation and modular compilation.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 
@@ -10,7 +10,7 @@ dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
   build: ">=1.5.0 <1.6.0"
-  build_config: ">=0.4.1 <0.4.3"
+  build_config: ">=0.4.1 <0.4.4"
   build_daemon: ^2.1.0
   build_resolvers: ^1.4.0
   build_runner_core: ">=5.2.0 <7.0.0"

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -34,11 +34,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build:
-    path: ../build
-  build_config:
-    path: ../build_config
-  build_resolvers:
-    path: ../build_resolvers

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,4 +31,3 @@ dependency_overrides:
     path: ../build_config
   scratch_space:
     path: ../scratch_space
-  analyzer: ^0.39.0


### PR DESCRIPTION
General post publish cleanup CL, removes overrides and prep to publish a build_runner version that allows the latest build_config so people can actually get it :).

Also opts in the `_test_null_safety` e2e package to null safety without the experiment.

Will land as a rebase/merge with separate commits.