### PR TITLE
Optimize gh actions

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,136 +1,146 @@
-# Created with package:mono_repo v3.1.0-beta.1
+# Created with package:mono_repo v3.1.0-beta.2
 name: Dart CI
-
 on:
   push:
-    branches: [ master ]
+    branches:
+      - $default-branch
   pull_request:
-
 defaults:
   run:
     shell: bash
+env:
+  PUB_ENVIRONMENT: bot.github
 
 jobs:
   job_001:
+    name: mono_repo self validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: stable
+          version: latest
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - run: pub global activate mono_repo 3.1.0-beta.2
+      - run: pub global run mono_repo generate --validate
+  job_002:
     name: "OS: linux; SDK: dev; PKGS: _test, _test_common; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test _test_common
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartanalyzer_0
-  job_002:
+  job_003:
     name: "OS: linux; SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh command_0 command_1
-  job_003:
+  job_004:
     name: "OS: windows; SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh command_0 command_1
-  job_004:
-    name: "OS: linux; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 0 --test-randomize-ordering-seed=random`"
+  job_005:
+    name: "OS: linux; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_00
-  job_005:
-    name: "OS: linux; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 1 --test-randomize-ordering-seed=random`"
+  job_006:
+    name: "OS: linux; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_01
-  job_006:
+  job_007:
+    name: "OS: linux; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test
+          TRAVIS_OS_NAME: linux
+        run: tool/ci.sh test_02
+  job_008:
     name: "OS: windows; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_02
-  job_007:
+        run: tool/ci.sh test_00
+  job_009:
     name: "OS: windows; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_03
-  job_008:
+        run: tool/ci.sh test_01
+  job_010:
     name: "OS: windows; SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_04
-  job_009:
-    name: "OS: linux; SDK: dev; PKG: _test; TASKS: `pub run test`"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - uses: actions/checkout@v2
-      - env:
-          PKGS: _test
-          TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_05
-  job_010:
-    name: "OS: windows; SDK: dev; PKG: _test; TASKS: `pub run test`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - uses: actions/checkout@v2
-      - env:
-          PKGS: _test
-          TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_05
+        run: tool/ci.sh test_02
   job_011:
     name: "OS: linux; SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
     runs-on: ubuntu-latest
@@ -138,48 +148,65 @@ jobs:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test_null_safety
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartanalyzer_1
   job_012:
+    name: "OS: windows; SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test_null_safety
+          TRAVIS_OS_NAME: windows
+        run: tool/ci.sh dartanalyzer_1
+  job_013:
     name: "OS: linux; SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test_null_safety
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh command_2 command_3
-  job_013:
+  job_014:
     name: "OS: windows; SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: _test_null_safety
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh command_2 command_3
-  job_014:
+  job_015:
     name: "OS: linux; SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_resolvers, build_runner, build_runner_core, build_test, build_vm_compilers, build_web_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartfmt dartanalyzer_0
-  job_015:
+  job_016:
     name: "OS: linux; SDK: 2.9.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
     runs-on: ubuntu-latest
     steps:
@@ -187,300 +214,325 @@ jobs:
         with:
           release-channel: stable
           version: "2.9.0"
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartanalyzer_2
-  job_016:
+  job_017:
     name: "OS: linux; SDK: dev; PKG: build; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_06
-  job_017:
+        run: tool/ci.sh test_04
+  job_018:
     name: "OS: linux; SDK: dev; PKG: build_config; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_config
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_06
-  job_018:
+        run: tool/ci.sh test_04
+  job_019:
     name: "OS: linux; SDK: dev; PKG: build_daemon; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_daemon
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_06
-  job_019:
+        run: tool/ci.sh test_04
+  job_020:
     name: "OS: linux; SDK: dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_resolvers
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_06
-  job_020:
+        run: tool/ci.sh test_04
+  job_021:
     name: "OS: linux; SDK: dev; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_runner_core
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_06
-  job_021:
+        run: tool/ci.sh test_04
+  job_022:
     name: "OS: linux; SDK: dev; PKG: build_test; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_test
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_06
-  job_022:
+        run: tool/ci.sh test_04
+  job_023:
     name: "OS: linux; SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_web_compilers
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_06
-  job_023:
+        run: tool/ci.sh test_04
+  job_024:
     name: "OS: linux; SDK: dev; PKG: scratch_space; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: scratch_space
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_06
-  job_024:
+        run: tool/ci.sh test_04
+  job_025:
     name: "OS: windows; SDK: dev; PKG: build; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_06
-  job_025:
+        run: tool/ci.sh test_04
+  job_026:
     name: "OS: windows; SDK: dev; PKG: build_config; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_config
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_06
-  job_026:
+        run: tool/ci.sh test_04
+  job_027:
     name: "OS: windows; SDK: dev; PKG: build_daemon; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_daemon
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_06
-  job_027:
+        run: tool/ci.sh test_04
+  job_028:
     name: "OS: windows; SDK: dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_resolvers
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_06
-  job_028:
+        run: tool/ci.sh test_04
+  job_029:
     name: "OS: windows; SDK: dev; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_runner_core
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_06
-  job_029:
+        run: tool/ci.sh test_04
+  job_030:
     name: "OS: windows; SDK: dev; PKG: build_test; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_test
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_06
-  job_030:
+        run: tool/ci.sh test_04
+  job_031:
     name: "OS: windows; SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_web_compilers
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_06
-  job_031:
+        run: tool/ci.sh test_04
+  job_032:
     name: "OS: windows; SDK: dev; PKG: scratch_space; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: scratch_space
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_06
-  job_032:
+        run: tool/ci.sh test_04
+  job_033:
     name: "OS: linux; SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_modules
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_07
-  job_033:
+        run: tool/ci.sh test_05
+  job_034:
     name: "OS: windows; SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_modules
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_07
-  job_034:
+        run: tool/ci.sh test_05
+  job_035:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -x integration --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_08
-  job_035:
+        run: tool/ci.sh test_06
+  job_036:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_09
-  job_036:
+        run: tool/ci.sh test_07
+  job_037:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_10
-  job_037:
+        run: tool/ci.sh test_08
+  job_038:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_11
-  job_038:
+        run: tool/ci.sh test_09
+  job_039:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_12
-  job_039:
+        run: tool/ci.sh test_10
+  job_040:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_13
-  job_040:
+        run: tool/ci.sh test_11
+  job_041:
     name: "OS: linux; SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -488,12 +540,13 @@ jobs:
         with:
           release-channel: stable
           version: "2.9.0"
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_runner_core
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_06
-  job_041:
+        run: tool/ci.sh test_04
+  job_042:
     name: "OS: windows; SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -501,32 +554,35 @@ jobs:
         with:
           release-channel: stable
           version: "2.9.0"
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_runner_core
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_06
-  job_042:
+        run: tool/ci.sh test_04
+  job_043:
     name: "OS: linux; SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_vm_compilers
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh test_05
-  job_043:
+        run: tool/ci.sh test_03
+  job_044:
     name: "OS: windows; SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
           release-channel: dev
+      - run: dart --version
       - uses: actions/checkout@v2
       - env:
           PKGS: build_vm_compilers
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh test_05
+        run: tool/ci.sh test_03

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -25,7 +25,7 @@ jobs:
       - run: pub global activate mono_repo 3.1.0-beta.2
       - run: pub global run mono_repo generate --validate
   job_002:
-    name: "OS: linux; SDK: dev; PKGS: _test, _test_common; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
+    name: "OS: linux; SDK: dev; PKGS: _test, _test_common, _test_null_safety; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
@@ -34,7 +34,7 @@ jobs:
       - run: dart --version
       - uses: actions/checkout@v2
       - env:
-          PKGS: _test _test_common
+          PKGS: _test _test_common _test_null_safety
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartanalyzer_0
   job_003:
@@ -142,20 +142,7 @@ jobs:
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_02
   job_011:
-    name: "OS: linux; SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - env:
-          PKGS: _test_null_safety
-          TRAVIS_OS_NAME: linux
-        run: tool/ci.sh dartanalyzer_1
-  job_012:
-    name: "OS: windows; SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
+    name: "OS: windows; SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
@@ -166,9 +153,9 @@ jobs:
       - env:
           PKGS: _test_null_safety
           TRAVIS_OS_NAME: windows
-        run: tool/ci.sh dartanalyzer_1
-  job_013:
-    name: "OS: linux; SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
+        run: tool/ci.sh dartanalyzer_0
+  job_012:
+    name: "OS: linux; SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
     runs-on: ubuntu-latest
     steps:
       - uses: cedx/setup-dart@v2
@@ -179,21 +166,21 @@ jobs:
       - env:
           PKGS: _test_null_safety
           TRAVIS_OS_NAME: linux
+        run: tool/ci.sh command_2 command_3
+  job_013:
+    name: "OS: windows; SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - env:
+          PKGS: _test_null_safety
+          TRAVIS_OS_NAME: windows
         run: tool/ci.sh command_2 command_3
   job_014:
-    name: "OS: windows; SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - env:
-          PKGS: _test_null_safety
-          TRAVIS_OS_NAME: windows
-        run: tool/ci.sh command_2 command_3
-  job_015:
     name: "OS: linux; SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_resolvers, build_runner, build_runner_core, build_test, build_vm_compilers, build_web_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
     runs-on: ubuntu-latest
     steps:
@@ -206,7 +193,7 @@ jobs:
           PKGS: build build_config build_daemon build_modules build_resolvers build_runner build_runner_core build_test build_vm_compilers build_web_compilers example scratch_space
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh dartfmt dartanalyzer_0
-  job_016:
+  job_015:
     name: "OS: linux; SDK: 2.9.0; PKGS: build, build_config, build_daemon, build_resolvers, build_runner_core, build_test, build_vm_compilers, scratch_space; TASKS: `dartanalyzer --fatal-warnings .`"
     runs-on: ubuntu-latest
     steps:
@@ -219,8 +206,8 @@ jobs:
       - env:
           PKGS: build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space
           TRAVIS_OS_NAME: linux
-        run: tool/ci.sh dartanalyzer_2
-  job_017:
+        run: tool/ci.sh dartanalyzer_1
+  job_016:
     name: "OS: linux; SDK: dev; PKG: build; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -233,7 +220,7 @@ jobs:
           PKGS: build
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_04
-  job_018:
+  job_017:
     name: "OS: linux; SDK: dev; PKG: build_config; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -246,7 +233,7 @@ jobs:
           PKGS: build_config
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_04
-  job_019:
+  job_018:
     name: "OS: linux; SDK: dev; PKG: build_daemon; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -259,7 +246,7 @@ jobs:
           PKGS: build_daemon
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_04
-  job_020:
+  job_019:
     name: "OS: linux; SDK: dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -272,7 +259,7 @@ jobs:
           PKGS: build_resolvers
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_04
-  job_021:
+  job_020:
     name: "OS: linux; SDK: dev; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -285,7 +272,7 @@ jobs:
           PKGS: build_runner_core
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_04
-  job_022:
+  job_021:
     name: "OS: linux; SDK: dev; PKG: build_test; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -298,7 +285,7 @@ jobs:
           PKGS: build_test
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_04
-  job_023:
+  job_022:
     name: "OS: linux; SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -311,7 +298,7 @@ jobs:
           PKGS: build_web_compilers
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_04
-  job_024:
+  job_023:
     name: "OS: linux; SDK: dev; PKG: scratch_space; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -324,7 +311,7 @@ jobs:
           PKGS: scratch_space
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_04
-  job_025:
+  job_024:
     name: "OS: windows; SDK: dev; PKG: build; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -337,7 +324,7 @@ jobs:
           PKGS: build
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_04
-  job_026:
+  job_025:
     name: "OS: windows; SDK: dev; PKG: build_config; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -350,7 +337,7 @@ jobs:
           PKGS: build_config
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_04
-  job_027:
+  job_026:
     name: "OS: windows; SDK: dev; PKG: build_daemon; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -363,7 +350,7 @@ jobs:
           PKGS: build_daemon
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_04
-  job_028:
+  job_027:
     name: "OS: windows; SDK: dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -376,7 +363,7 @@ jobs:
           PKGS: build_resolvers
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_04
-  job_029:
+  job_028:
     name: "OS: windows; SDK: dev; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -389,7 +376,7 @@ jobs:
           PKGS: build_runner_core
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_04
-  job_030:
+  job_029:
     name: "OS: windows; SDK: dev; PKG: build_test; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -402,7 +389,7 @@ jobs:
           PKGS: build_test
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_04
-  job_031:
+  job_030:
     name: "OS: windows; SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -415,7 +402,7 @@ jobs:
           PKGS: build_web_compilers
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_04
-  job_032:
+  job_031:
     name: "OS: windows; SDK: dev; PKG: scratch_space; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -428,7 +415,7 @@ jobs:
           PKGS: scratch_space
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_04
-  job_033:
+  job_032:
     name: "OS: linux; SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -441,7 +428,7 @@ jobs:
           PKGS: build_modules
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_05
-  job_034:
+  job_033:
     name: "OS: windows; SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -454,7 +441,7 @@ jobs:
           PKGS: build_modules
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_05
-  job_035:
+  job_034:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -x integration --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -467,7 +454,7 @@ jobs:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_06
-  job_036:
+  job_035:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -480,7 +467,7 @@ jobs:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_07
-  job_037:
+  job_036:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -493,7 +480,7 @@ jobs:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_08
-  job_038:
+  job_037:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -506,7 +493,7 @@ jobs:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_09
-  job_039:
+  job_038:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -519,7 +506,7 @@ jobs:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_10
-  job_040:
+  job_039:
     name: "OS: linux; SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -532,7 +519,7 @@ jobs:
           PKGS: build_runner
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_11
-  job_041:
+  job_040:
     name: "OS: linux; SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -546,7 +533,7 @@ jobs:
           PKGS: build_runner_core
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_04
-  job_042:
+  job_041:
     name: "OS: windows; SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -560,7 +547,7 @@ jobs:
           PKGS: build_runner_core
           TRAVIS_OS_NAME: windows
         run: tool/ci.sh test_04
-  job_043:
+  job_042:
     name: "OS: linux; SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
     runs-on: ubuntu-latest
     steps:
@@ -573,7 +560,7 @@ jobs:
           PKGS: build_vm_compilers
           TRAVIS_OS_NAME: linux
         run: tool/ci.sh test_03
-  job_044:
+  job_043:
     name: "OS: windows; SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
     runs-on: windows-latest
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,23 +19,17 @@ jobs:
       os: linux
       script: "pub global activate mono_repo 3.1.0-beta.2 && pub global run mono_repo generate --validate"
     - stage: analyze_and_format
-      name: "SDK: dev; PKGS: _test, _test_common; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
+      name: "SDK: dev; PKGS: _test, _test_common, _test_null_safety; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
       dart: dev
       os: linux
-      env: PKGS="_test _test_common"
+      env: PKGS="_test _test_common _test_null_safety"
       script: tool/ci.sh dartanalyzer_0
     - stage: analyze_and_format
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
-      dart: dev
-      os: linux
-      env: PKGS="_test_null_safety"
-      script: tool/ci.sh dartanalyzer_1
-    - stage: analyze_and_format
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
       dart: dev
       os: windows
       env: PKGS="_test_null_safety"
-      script: tool/ci.sh dartanalyzer_1
+      script: tool/ci.sh dartanalyzer_0
     - stage: analyze_and_format
       name: "SDK: dev; PKGS: build, build_config, build_daemon, build_modules, build_resolvers, build_runner, build_runner_core, build_test, build_vm_compilers, build_web_compilers, example, scratch_space; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: dev
@@ -47,7 +41,7 @@ jobs:
       dart: "2.9.0"
       os: linux
       env: PKGS="build build_config build_daemon build_resolvers build_runner_core build_test build_vm_compilers scratch_space"
-      script: tool/ci.sh dartanalyzer_2
+      script: tool/ci.sh dartanalyzer_1
     - stage: unit_test
       name: "SDK: dev; PKG: _test; TASKS: [`pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`]"
       dart: dev
@@ -235,13 +229,13 @@ jobs:
       env: PKGS="_test"
       script: tool/ci.sh test_02
     - stage: e2e_test
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: dev
       os: linux
       env: PKGS="_test_null_safety"
       script: tool/ci.sh command_2 command_3
     - stage: e2e_test
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: dev
       os: windows
       env: PKGS="_test_null_safety"
@@ -289,13 +283,13 @@ jobs:
       env: PKGS="_test"
       script: tool/ci.sh test_03
     - stage: e2e_test_cron
-      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
+      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: [`pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: be/raw/latest
       os: linux
       env: PKGS="_test_null_safety"
       script: tool/ci.sh command_2 command_3
     - stage: e2e_test_cron
-      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
+      name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: [`pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: be/raw/latest
       os: windows
       env: PKGS="_test_null_safety"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v3.1.0-beta.1
+# Created with package:mono_repo v3.1.0-beta.2
 language: dart
 
 # Custom configuration
@@ -17,7 +17,7 @@ jobs:
     - stage: analyze_and_format
       name: mono_repo self validate
       os: linux
-      script: "pub global activate mono_repo 3.1.0-beta.1 && pub global run mono_repo generate --validate"
+      script: "pub global activate mono_repo 3.1.0-beta.2 && pub global run mono_repo generate --validate"
     - stage: analyze_and_format
       name: "SDK: dev; PKGS: _test, _test_common; TASKS: `dartanalyzer --fatal-infos --fatal-warnings .`"
       dart: dev
@@ -28,6 +28,12 @@ jobs:
       name: "SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
       dart: dev
       os: linux
+      env: PKGS="_test_null_safety"
+      script: tool/ci.sh dartanalyzer_1
+    - stage: analyze_and_format
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: `dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .`"
+      dart: dev
+      os: windows
       env: PKGS="_test_null_safety"
       script: tool/ci.sh dartanalyzer_1
     - stage: analyze_and_format
@@ -59,173 +65,185 @@ jobs:
       dart: dev
       os: linux
       env: PKGS="build"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_config; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_config"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_config; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_config"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_daemon; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_daemon"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_daemon; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_daemon"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_modules"
-      script: tool/ci.sh test_07
+      script: tool/ci.sh test_05
     - stage: unit_test
       name: "SDK: dev; PKG: build_modules; TASKS: `pub run test -P presubmit --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_modules"
-      script: tool/ci.sh test_07
+      script: tool/ci.sh test_05
     - stage: unit_test
       name: "SDK: dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_resolvers"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_resolvers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_resolvers"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -x integration --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/ci.sh test_08
+      script: tool/ci.sh test_06
     - stage: unit_test
       name: "SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: "2.9.0"
       os: linux
       env: PKGS="build_runner_core"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: 2.9.0; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: "2.9.0"
       os: windows
       env: PKGS="build_runner_core"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_runner_core"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_runner_core; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_runner_core"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_test; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_test"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_test; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_test"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
       dart: dev
       os: linux
       env: PKGS="build_vm_compilers"
-      script: tool/ci.sh test_05
+      script: tool/ci.sh test_03
     - stage: unit_test
       name: "SDK: dev; PKG: build_vm_compilers; TASKS: `pub run test`"
       dart: dev
       os: windows
       env: PKGS="build_vm_compilers"
-      script: tool/ci.sh test_05
+      script: tool/ci.sh test_03
     - stage: unit_test
       name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="build_web_compilers"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: build_web_compilers; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="build_web_compilers"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: scratch_space; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="scratch_space"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: unit_test
       name: "SDK: dev; PKG: scratch_space; TASKS: `pub run test --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="scratch_space"
-      script: tool/ci.sh test_06
+      script: tool/ci.sh test_04
     - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 0 --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="_test"
       script: tool/ci.sh test_00
     - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 2 --shard-index 1 --test-randomize-ordering-seed=random`"
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
+      dart: dev
+      os: windows
+      env: PKGS="_test"
+      script: tool/ci.sh test_00
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
       dart: dev
       os: linux
       env: PKGS="_test"
       script: tool/ci.sh test_01
     - stage: e2e_test
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
-      dart: dev
-      os: windows
-      env: PKGS="_test"
-      script: tool/ci.sh test_02
-    - stage: e2e_test
       name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="_test"
-      script: tool/ci.sh test_03
+      script: tool/ci.sh test_01
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
+      dart: dev
+      os: linux
+      env: PKGS="_test"
+      script: tool/ci.sh test_02
     - stage: e2e_test
       name: "SDK: dev; PKG: _test; TASKS: `pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
       dart: dev
       os: windows
       env: PKGS="_test"
-      script: tool/ci.sh test_04
+      script: tool/ci.sh test_02
     - stage: e2e_test
       name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: dev
       os: linux
+      env: PKGS="_test_null_safety"
+      script: tool/ci.sh command_2 command_3
+    - stage: e2e_test
+      name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
+      dart: dev
+      os: windows
       env: PKGS="_test_null_safety"
       script: tool/ci.sh command_2 command_3
     - stage: e2e_test
@@ -233,55 +251,43 @@ jobs:
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/ci.sh test_09
+      script: tool/ci.sh test_07
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/ci.sh test_10
+      script: tool/ci.sh test_08
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/ci.sh test_11
+      script: tool/ci.sh test_09
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/ci.sh test_12
+      script: tool/ci.sh test_10
     - stage: e2e_test
       name: "SDK: dev; PKG: build_runner; TASKS: `pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
       dart: dev
       os: linux
       env: PKGS="build_runner"
-      script: tool/ci.sh test_13
+      script: tool/ci.sh test_11
     - stage: e2e_test_cron
       name: "SDK: be/raw/latest; PKG: _test; TASKS: `pub run test`"
       dart: be/raw/latest
       os: linux
       env: PKGS="_test"
-      script: tool/ci.sh test_05
+      script: tool/ci.sh test_03
     - stage: e2e_test_cron
       name: "SDK: be/raw/latest; PKG: _test; TASKS: `pub run test`"
       dart: be/raw/latest
       os: windows
       env: PKGS="_test"
-      script: tool/ci.sh test_05
-    - stage: e2e_test_cron
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test`"
-      dart: dev
-      os: linux
-      env: PKGS="_test"
-      script: tool/ci.sh test_05
-    - stage: e2e_test_cron
-      name: "SDK: dev; PKG: _test; TASKS: `pub run test`"
-      dart: dev
-      os: windows
-      env: PKGS="_test"
-      script: tool/ci.sh test_05
+      script: tool/ci.sh test_03
     - stage: e2e_test_cron
       name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: be/raw/latest
@@ -291,18 +297,6 @@ jobs:
     - stage: e2e_test_cron
       name: "SDK: be/raw/latest; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
       dart: be/raw/latest
-      os: windows
-      env: PKGS="_test_null_safety"
-      script: tool/ci.sh command_2 command_3
-    - stage: e2e_test_cron
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
-      dart: dev
-      os: linux
-      env: PKGS="_test_null_safety"
-      script: tool/ci.sh command_2 command_3
-    - stage: e2e_test_cron
-      name: "SDK: dev; PKG: _test_null_safety; TASKS: [`pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --enable-experiment=non-nullable --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`]"
-      dart: dev
       os: windows
       env: PKGS="_test_null_safety"
       script: tool/ci.sh command_2 command_3
@@ -316,7 +310,7 @@ stages:
 
 cache:
   directories:
-    - "$HOME/.pub-cache"
+    - $HOME/.pub-cache
     - build/.dart_tool/build
     - build_config/.dart_tool/build
     - build_modules/.dart_tool/build

--- a/_test/mono_pkg.yaml
+++ b/_test/mono_pkg.yaml
@@ -14,9 +14,11 @@ stages:
     - command: pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random
     - command: pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random
 - e2e_test:
-  - test: --total-shards 2 --shard-index 0 --test-randomize-ordering-seed=random
+  - test: --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random
     os: linux
-  - test: --total-shards 2 --shard-index 1 --test-randomize-ordering-seed=random
+  - test: --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random
+    os: linux
+  - test: --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random
     os: linux
   - test: --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random
     os: windows
@@ -24,8 +26,8 @@ stages:
     os: windows
   - test: --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random
     os: windows
+# This only runs on travis, github actions currently doesn't support be/raw/latest
 - e2e_test_cron:
   - test:
     dart:
     - be/raw/latest
-    - dev

--- a/_test_null_safety/mono_pkg.yaml
+++ b/_test_null_safety/mono_pkg.yaml
@@ -8,16 +8,13 @@ os:
 stages:
 - analyze_and_format:
   - dartanalyzer: --enable-experiment=non-nullable --fatal-infos --fatal-warnings .
-    os: linux
 - e2e_test:
   - group:
     - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
     - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
-    os: linux
 - e2e_test_cron:
   - group:
     - command: pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random
     - command: pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
     dart:
       - be/raw/latest
-      - dev

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -1,9 +1,7 @@
 # See https://github.com/google/mono_repo.dart for details on this file
 self_validate: analyze_and_format
 
-ci:
-  - github
-  - travis
+github:
 
 travis:
   addons:

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -67,22 +67,18 @@ for PKG in ${PKGS}; do
         pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
       command_2)
-        echo 'pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random'
-        pub run build_runner test --enable-experiment=non-nullable -- -p chrome,vm --test-randomize-ordering-seed=random || EXIT_CODE=$?
+        echo 'pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random'
+        pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
       command_3)
-        echo 'pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random'
-        pub run build_runner test --enable-experiment=non-nullable --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random || EXIT_CODE=$?
+        echo 'pub run build_runner test --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random'
+        pub run build_runner test --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
       dartanalyzer_0)
         echo 'dartanalyzer --fatal-infos --fatal-warnings .'
         dartanalyzer --fatal-infos --fatal-warnings . || EXIT_CODE=$?
         ;;
       dartanalyzer_1)
-        echo 'dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings .'
-        dartanalyzer --enable-experiment=non-nullable --fatal-infos --fatal-warnings . || EXIT_CODE=$?
-        ;;
-      dartanalyzer_2)
         echo 'dartanalyzer --fatal-warnings .'
         dartanalyzer --fatal-warnings . || EXIT_CODE=$?
         ;;

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v3.1.0-beta.1
+# Created with package:mono_repo v3.1.0-beta.2
 
 # Support built in commands on windows out of the box.
 function pub() {
@@ -91,58 +91,50 @@ for PKG in ${PKGS}; do
         dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
         ;;
       test_00)
-        echo 'pub run test --total-shards 2 --shard-index 0 --test-randomize-ordering-seed=random'
-        pub run test --total-shards 2 --shard-index 0 --test-randomize-ordering-seed=random || EXIT_CODE=$?
-        ;;
-      test_01)
-        echo 'pub run test --total-shards 2 --shard-index 1 --test-randomize-ordering-seed=random'
-        pub run test --total-shards 2 --shard-index 1 --test-randomize-ordering-seed=random || EXIT_CODE=$?
-        ;;
-      test_02)
         echo 'pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random'
         pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
-      test_03)
+      test_01)
         echo 'pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random'
         pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
-      test_04)
+      test_02)
         echo 'pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random'
         pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
-      test_05)
+      test_03)
         echo 'pub run test'
         pub run test || EXIT_CODE=$?
         ;;
-      test_06)
+      test_04)
         echo 'pub run test --test-randomize-ordering-seed=random'
         pub run test --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
-      test_07)
+      test_05)
         echo 'pub run test -P presubmit --test-randomize-ordering-seed=random'
         pub run test -P presubmit --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
-      test_08)
+      test_06)
         echo 'pub run test -x integration --test-randomize-ordering-seed=random'
         pub run test -x integration --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
-      test_09)
+      test_07)
         echo 'pub run test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces'
         pub run test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces || EXIT_CODE=$?
         ;;
-      test_10)
+      test_08)
         echo 'pub run test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces'
         pub run test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces || EXIT_CODE=$?
         ;;
-      test_11)
+      test_09)
         echo 'pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces'
         pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces || EXIT_CODE=$?
         ;;
-      test_12)
+      test_10)
         echo 'pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces'
         pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces || EXIT_CODE=$?
         ;;
-      test_13)
+      test_11)
         echo 'pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces'
         pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces || EXIT_CODE=$?
         ;;


### PR DESCRIPTION
- Stop cron shards from running on PRs (for now this is done by just selecting an OS that gh actions doesn't support)
  - These are the primary slowdown right now, nearly doubling overall workflow time
- Adds an extra shard to linux tests for the `_test` package (now matches windows with 3).
- Adds windows tests for the `_test_null_safety` package unconditionally (used to be only for cron)
- Update to the latest mono_repo beta