### PR TITLE
_test_null_safety: no longer need analysis options

### DIFF
--- a/_test_null_safety/analysis_options.yaml
+++ b/_test_null_safety/analysis_options.yaml
@@ -1,4 +1,1 @@
 include: ../analysis_options.yaml
-analyzer:
-  enable-experiment:
-    - non-nullable


### PR DESCRIPTION
For null safety – it's on by default with 2.12.0