### PR TITLE
dont throw in canRead for unknown package names

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.1.1
+
+- Fix a bug where `canRead` would throw if the `package` was unknown, instead
+  of returning `false`.
+
 ## 6.1.0
 
 - Require the latest build version (1.5.1).

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -89,9 +89,10 @@ class SingleStepReader implements AssetReader {
     try {
       _checkInvalidInput(id);
     } on InvalidInputException {
-      if (catchInvalidInputs) {
-        return false;
-      }
+      if (catchInvalidInputs) return false;
+      rethrow;
+    } on PackageNotFoundException {
+      if (catchInvalidInputs) return false;
       rethrow;
     }
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 6.1.0
+version: 6.1.1
 description: Core tools to write binaries that run builders.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -517,6 +517,37 @@ void main() {
           outputs: {},
         );
       });
+
+      test('canRead doesn\'t throw for invalid inputs or missing packages', () {
+        final packageGraph = buildPackageGraph({
+          rootPackage('a', path: 'a/'): ['b'],
+          package('b', path: 'a/b'): []
+        });
+
+        final builder = TestBuilder(
+          buildExtensions: const {
+            '.txt': ['.copy']
+          },
+          build: (step, _) {
+            final invalidInput = AssetId.parse('b|test/my_test.dart');
+
+            expect(step.canRead(invalidInput), completion(isFalse));
+            expect(step.canRead(AssetId('invalid', 'foo.dart')),
+                completion(isFalse));
+          },
+        );
+
+        return testBuilders(
+          [
+            apply('', [(_) => builder], toPackage('a'))
+          ],
+          {
+            'a|lib/foo.txt': "doesn't matter",
+          },
+          packageGraph: packageGraph,
+          outputs: {},
+        );
+      });
     });
 
     test('skips builders which would output files in non-root packages',

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -529,9 +529,8 @@ void main() {
             '.txt': ['.copy']
           },
           build: (step, _) {
-            final invalidInput = AssetId.parse('b|test/my_test.dart');
-
-            expect(step.canRead(invalidInput), completion(isFalse));
+            expect(step.canRead(AssetId('b', 'test/my_test.dart')),
+                completion(isFalse));
             expect(step.canRead(AssetId('invalid', 'foo.dart')),
                 completion(isFalse));
           },


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/2916

Also adds tests for this for invalid inputs as well as unknown package names