### PR TITLE
don't complete the buildScriptCompleter twice

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.7-dev
+
+- Fix a daemon mode issue where we might try to complete a completer twice
+  during build script updates.
+
 ## 1.10.6
 
 - Allow build_config version 0.4.3.

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -76,7 +76,9 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
     if (!_buildOptions.skipBuildScriptCheck &&
         _builder.buildScriptUpdates.hasBeenUpdated(
             changes.map<AssetId>((change) => change.id).toSet())) {
-      _buildScriptUpdateCompleter.complete();
+      if (!_buildScriptUpdateCompleter.isCompleted) {
+        _buildScriptUpdateCompleter.complete();
+      }
       return;
     }
     var targetNames = targets.map((t) => t.target).toSet();

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.10.6
+version: 1.10.7-dev
 description: A build system for Dart code generation and modular compilation.
 homepage: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/2898.

In the case where multiple builds are scheduled we can hit this code path more than once.