### PR TITLE
Allow null-safe version of json_annotation across packages

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -37,16 +37,16 @@ jobs:
       - name: mono_repo self validate
         run: pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart dev; PKGS: build_web_compilers, scratch_space, build, build_config, build_daemon, build_modules, build_resolvers, build_runner, build_runner_core, build_test, build_vm_compilers, example; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
+    name: "analyze_and_format; linux; Dart dev; PKGS: build_web_compilers, build_vm_compilers, scratch_space, build, build_config, build_daemon, build_modules, build_resolvers, build_runner, build_runner_core, build_test, example; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_web_compilers-scratch_space-build-build_config-build_daemon-build_modules-build_resolvers-build_runner-build_runner_core-build_test-build_vm_compilers-example;commands:dartfmt-dartanalyzer"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_web_compilers-build_vm_compilers-scratch_space-build-build_config-build_daemon-build_modules-build_resolvers-build_runner-build_runner_core-build_test-example;commands:dartfmt-dartanalyzer"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_web_compilers-scratch_space-build-build_config-build_daemon-build_modules-build_resolvers-build_runner-build_runner_core-build_test-build_vm_compilers-example
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_web_compilers-build_vm_compilers-scratch_space-build-build_config-build_daemon-build_modules-build_resolvers-build_runner-build_runner_core-build_test-example
             os:ubuntu-latest;pub-cache-hosted;dart:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -66,6 +66,18 @@ jobs:
       - name: "build_web_compilers; dartanalyzer --fatal-infos --fatal-warnings ."
         if: "steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
         working-directory: build_web_compilers
+        run: dartanalyzer --fatal-infos --fatal-warnings .
+      - id: build_vm_compilers_pub_upgrade
+        name: "build_vm_compilers; pub upgrade --no-precompile"
+        working-directory: build_vm_compilers
+        run: pub upgrade --no-precompile
+      - name: "build_vm_compilers; dartfmt -n --set-exit-if-changed ."
+        if: "steps.build_vm_compilers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_vm_compilers
+        run: dartfmt -n --set-exit-if-changed .
+      - name: "build_vm_compilers; dartanalyzer --fatal-infos --fatal-warnings ."
+        if: "steps.build_vm_compilers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_vm_compilers
         run: dartanalyzer --fatal-infos --fatal-warnings .
       - id: scratch_space_pub_upgrade
         name: "scratch_space; pub upgrade --no-precompile"
@@ -175,18 +187,6 @@ jobs:
         if: "steps.build_test_pub_upgrade.conclusion == 'success'"
         working-directory: build_test
         run: dartanalyzer --fatal-infos --fatal-warnings .
-      - id: build_vm_compilers_pub_upgrade
-        name: "build_vm_compilers; pub upgrade --no-precompile"
-        working-directory: build_vm_compilers
-        run: pub upgrade --no-precompile
-      - name: "build_vm_compilers; dartfmt -n --set-exit-if-changed ."
-        if: "steps.build_vm_compilers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_vm_compilers
-        run: dartfmt -n --set-exit-if-changed .
-      - name: "build_vm_compilers; dartanalyzer --fatal-infos --fatal-warnings ."
-        if: "steps.build_vm_compilers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_vm_compilers
-        run: dartanalyzer --fatal-infos --fatal-warnings .
       - id: example_pub_upgrade
         name: "example; pub upgrade --no-precompile"
         working-directory: example
@@ -260,12 +260,45 @@ jobs:
         working-directory: _test_null_safety
         run: dartanalyzer.bat --fatal-infos --fatal-warnings .
   job_005:
-    name: "unit_test; windows; Dart dev; PKG: build_modules; `pub run test -P presubmit --test-randomize-ordering-seed=random`"
+    name: "analyze_and_format; linux; Dart 2.10.0; PKG: build_modules; `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:build_modules;commands:dartfmt-dartanalyzer"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:build_modules
+            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: stable
+          version: "2.10.0"
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_modules_pub_upgrade
+        name: "build_modules; pub upgrade --no-precompile"
+        working-directory: build_modules
+        run: pub upgrade --no-precompile
+      - name: "build_modules; dartfmt -n --set-exit-if-changed ."
+        if: "steps.build_modules_pub_upgrade.conclusion == 'success'"
+        working-directory: build_modules
+        run: dartfmt -n --set-exit-if-changed .
+      - name: "build_modules; dartanalyzer --fatal-infos --fatal-warnings ."
+        if: "steps.build_modules_pub_upgrade.conclusion == 'success'"
+        working-directory: build_modules
+        run: dartanalyzer --fatal-infos --fatal-warnings .
+  job_006:
+    name: "unit_test; windows; Dart 2.10.0; PKG: build_modules; `pub run test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - uses: cedx/setup-dart@v2
         with:
-          release-channel: dev
+          release-channel: stable
+          version: "2.10.0"
       - run: dart --version
       - uses: actions/checkout@v2
       - id: build_modules_pub_upgrade
@@ -281,471 +314,8 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_006:
-    name: "unit_test; windows; Dart dev; PKG: build_test; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_test_pub_upgrade
-        name: "build_test; pub.bat upgrade --no-precompile"
-        working-directory: build_test
-        run: pub.bat upgrade --no-precompile
-      - name: "build_test; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_test_pub_upgrade.conclusion == 'success'"
-        working-directory: build_test
-        run: "pub.bat run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
+      - job_005
   job_007:
-    name: "unit_test; windows; Dart dev; PKG: build_config; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_config_pub_upgrade
-        name: "build_config; pub.bat upgrade --no-precompile"
-        working-directory: build_config
-        run: pub.bat upgrade --no-precompile
-      - name: "build_config; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_config_pub_upgrade.conclusion == 'success'"
-        working-directory: build_config
-        run: "pub.bat run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_008:
-    name: "unit_test; windows; Dart dev; PKG: build_daemon; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_daemon_pub_upgrade
-        name: "build_daemon; pub.bat upgrade --no-precompile"
-        working-directory: build_daemon
-        run: pub.bat upgrade --no-precompile
-      - name: "build_daemon; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_daemon_pub_upgrade.conclusion == 'success'"
-        working-directory: build_daemon
-        run: "pub.bat run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_009:
-    name: "unit_test; windows; Dart dev; PKG: build; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_pub_upgrade
-        name: "build; pub.bat upgrade --no-precompile"
-        working-directory: build
-        run: pub.bat upgrade --no-precompile
-      - name: "build; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_pub_upgrade.conclusion == 'success'"
-        working-directory: build
-        run: "pub.bat run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_010:
-    name: "unit_test; windows; Dart dev; PKG: scratch_space; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: scratch_space_pub_upgrade
-        name: "scratch_space; pub.bat upgrade --no-precompile"
-        working-directory: scratch_space
-        run: pub.bat upgrade --no-precompile
-      - name: "scratch_space; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.scratch_space_pub_upgrade.conclusion == 'success'"
-        working-directory: scratch_space
-        run: "pub.bat run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_011:
-    name: "unit_test; windows; Dart dev; PKG: build_resolvers; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_resolvers_pub_upgrade
-        name: "build_resolvers; pub.bat upgrade --no-precompile"
-        working-directory: build_resolvers
-        run: pub.bat upgrade --no-precompile
-      - name: "build_resolvers; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_resolvers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_resolvers
-        run: "pub.bat run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_012:
-    name: "unit_test; windows; Dart dev; PKG: build_web_compilers; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_web_compilers_pub_upgrade
-        name: "build_web_compilers; pub.bat upgrade --no-precompile"
-        working-directory: build_web_compilers
-        run: pub.bat upgrade --no-precompile
-      - name: "build_web_compilers; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_web_compilers
-        run: "pub.bat run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_013:
-    name: "unit_test; windows; Dart dev; PKG: build_runner_core; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_runner_core_pub_upgrade
-        name: "build_runner_core; pub.bat upgrade --no-precompile"
-        working-directory: build_runner_core
-        run: pub.bat upgrade --no-precompile
-      - name: "build_runner_core; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_runner_core_pub_upgrade.conclusion == 'success'"
-        working-directory: build_runner_core
-        run: "pub.bat run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_014:
-    name: "unit_test; linux; Dart dev; PKG: build; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_pub_upgrade
-        name: "build; pub upgrade --no-precompile"
-        working-directory: build
-        run: pub upgrade --no-precompile
-      - name: "build; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_pub_upgrade.conclusion == 'success'"
-        working-directory: build
-        run: "pub run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_015:
-    name: "unit_test; linux; Dart dev; PKG: build_config; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_config;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_config
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_config_pub_upgrade
-        name: "build_config; pub upgrade --no-precompile"
-        working-directory: build_config
-        run: pub upgrade --no-precompile
-      - name: "build_config; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_config_pub_upgrade.conclusion == 'success'"
-        working-directory: build_config
-        run: "pub run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_016:
-    name: "unit_test; linux; Dart dev; PKG: build_daemon; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_daemon;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_daemon
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_daemon_pub_upgrade
-        name: "build_daemon; pub upgrade --no-precompile"
-        working-directory: build_daemon
-        run: pub upgrade --no-precompile
-      - name: "build_daemon; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_daemon_pub_upgrade.conclusion == 'success'"
-        working-directory: build_daemon
-        run: "pub run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_017:
-    name: "unit_test; linux; Dart dev; PKG: build_resolvers; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_resolvers;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_resolvers
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_resolvers_pub_upgrade
-        name: "build_resolvers; pub upgrade --no-precompile"
-        working-directory: build_resolvers
-        run: pub upgrade --no-precompile
-      - name: "build_resolvers; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_resolvers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_resolvers
-        run: "pub run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_018:
-    name: "unit_test; linux; Dart dev; PKG: scratch_space; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:scratch_space;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:scratch_space
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: scratch_space_pub_upgrade
-        name: "scratch_space; pub upgrade --no-precompile"
-        working-directory: scratch_space
-        run: pub upgrade --no-precompile
-      - name: "scratch_space; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.scratch_space_pub_upgrade.conclusion == 'success'"
-        working-directory: scratch_space
-        run: "pub run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_019:
-    name: "unit_test; linux; Dart dev; PKG: build_test; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_test;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_test
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_test_pub_upgrade
-        name: "build_test; pub upgrade --no-precompile"
-        working-directory: build_test
-        run: pub upgrade --no-precompile
-      - name: "build_test; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_test_pub_upgrade.conclusion == 'success'"
-        working-directory: build_test
-        run: "pub run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_020:
-    name: "unit_test; linux; Dart dev; PKG: build_runner_core; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner_core;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner_core
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_runner_core_pub_upgrade
-        name: "build_runner_core; pub upgrade --no-precompile"
-        working-directory: build_runner_core
-        run: pub upgrade --no-precompile
-      - name: "build_runner_core; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_runner_core_pub_upgrade.conclusion == 'success'"
-        working-directory: build_runner_core
-        run: "pub run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_021:
-    name: "unit_test; linux; Dart dev; PKG: build_web_compilers; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_web_compilers;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_web_compilers
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_web_compilers_pub_upgrade
-        name: "build_web_compilers; pub upgrade --no-precompile"
-        working-directory: build_web_compilers
-        run: pub upgrade --no-precompile
-      - name: "build_web_compilers; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_web_compilers
-        run: "pub run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_022:
-    name: "unit_test; linux; Dart dev; PKG: build_vm_compilers; `pub run test`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_vm_compilers;commands:test_03"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_vm_compilers
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_vm_compilers_pub_upgrade
-        name: "build_vm_compilers; pub upgrade --no-precompile"
-        working-directory: build_vm_compilers
-        run: pub upgrade --no-precompile
-      - name: build_vm_compilers; pub run test
-        if: "steps.build_vm_compilers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_vm_compilers
-        run: pub run test
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_023:
     name: "unit_test; linux; Dart dev; PKG: build_modules; `pub run test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -777,7 +347,479 @@ jobs:
       - job_002
       - job_003
       - job_004
+      - job_005
+  job_008:
+    name: "unit_test; linux; Dart dev; PKG: build_web_compilers; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_web_compilers;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_web_compilers
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_web_compilers_pub_upgrade
+        name: "build_web_compilers; pub upgrade --no-precompile"
+        working-directory: build_web_compilers
+        run: pub upgrade --no-precompile
+      - name: "build_web_compilers; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_web_compilers
+        run: "pub run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_009:
+    name: "unit_test; linux; Dart dev; PKG: build_config; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_config;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_config
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_config_pub_upgrade
+        name: "build_config; pub upgrade --no-precompile"
+        working-directory: build_config
+        run: pub upgrade --no-precompile
+      - name: "build_config; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_config_pub_upgrade.conclusion == 'success'"
+        working-directory: build_config
+        run: "pub run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_010:
+    name: "unit_test; linux; Dart dev; PKG: build_daemon; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_daemon;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_daemon
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_daemon_pub_upgrade
+        name: "build_daemon; pub upgrade --no-precompile"
+        working-directory: build_daemon
+        run: pub upgrade --no-precompile
+      - name: "build_daemon; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_daemon_pub_upgrade.conclusion == 'success'"
+        working-directory: build_daemon
+        run: "pub run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_011:
+    name: "unit_test; linux; Dart dev; PKG: build; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_pub_upgrade
+        name: "build; pub upgrade --no-precompile"
+        working-directory: build
+        run: pub upgrade --no-precompile
+      - name: "build; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_pub_upgrade.conclusion == 'success'"
+        working-directory: build
+        run: "pub run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_012:
+    name: "unit_test; linux; Dart dev; PKG: build_resolvers; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_resolvers;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_resolvers
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_resolvers_pub_upgrade
+        name: "build_resolvers; pub upgrade --no-precompile"
+        working-directory: build_resolvers
+        run: pub upgrade --no-precompile
+      - name: "build_resolvers; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_resolvers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_resolvers
+        run: "pub run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_013:
+    name: "unit_test; linux; Dart dev; PKG: build_test; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_test;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_test
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_test_pub_upgrade
+        name: "build_test; pub upgrade --no-precompile"
+        working-directory: build_test
+        run: pub upgrade --no-precompile
+      - name: "build_test; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_test_pub_upgrade.conclusion == 'success'"
+        working-directory: build_test
+        run: "pub run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_014:
+    name: "unit_test; linux; Dart dev; PKG: scratch_space; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:scratch_space;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:scratch_space
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: scratch_space_pub_upgrade
+        name: "scratch_space; pub upgrade --no-precompile"
+        working-directory: scratch_space
+        run: pub upgrade --no-precompile
+      - name: "scratch_space; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.scratch_space_pub_upgrade.conclusion == 'success'"
+        working-directory: scratch_space
+        run: "pub run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_015:
+    name: "unit_test; linux; Dart dev; PKG: build_runner_core; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner_core;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner_core
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_runner_core_pub_upgrade
+        name: "build_runner_core; pub upgrade --no-precompile"
+        working-directory: build_runner_core
+        run: pub upgrade --no-precompile
+      - name: "build_runner_core; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_runner_core_pub_upgrade.conclusion == 'success'"
+        working-directory: build_runner_core
+        run: "pub run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_016:
+    name: "unit_test; windows; Dart dev; PKG: build_vm_compilers; `pub run test`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_vm_compilers_pub_upgrade
+        name: "build_vm_compilers; pub.bat upgrade --no-precompile"
+        working-directory: build_vm_compilers
+        run: pub.bat upgrade --no-precompile
+      - name: build_vm_compilers; pub run test
+        if: "steps.build_vm_compilers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_vm_compilers
+        run: pub.bat run test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_017:
+    name: "unit_test; windows; Dart dev; PKG: build_config; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_config_pub_upgrade
+        name: "build_config; pub.bat upgrade --no-precompile"
+        working-directory: build_config
+        run: pub.bat upgrade --no-precompile
+      - name: "build_config; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_config_pub_upgrade.conclusion == 'success'"
+        working-directory: build_config
+        run: "pub.bat run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_018:
+    name: "unit_test; windows; Dart dev; PKG: scratch_space; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: scratch_space_pub_upgrade
+        name: "scratch_space; pub.bat upgrade --no-precompile"
+        working-directory: scratch_space
+        run: pub.bat upgrade --no-precompile
+      - name: "scratch_space; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.scratch_space_pub_upgrade.conclusion == 'success'"
+        working-directory: scratch_space
+        run: "pub.bat run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_019:
+    name: "unit_test; windows; Dart dev; PKG: build_daemon; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_daemon_pub_upgrade
+        name: "build_daemon; pub.bat upgrade --no-precompile"
+        working-directory: build_daemon
+        run: pub.bat upgrade --no-precompile
+      - name: "build_daemon; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_daemon_pub_upgrade.conclusion == 'success'"
+        working-directory: build_daemon
+        run: "pub.bat run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_020:
+    name: "unit_test; windows; Dart dev; PKG: build; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_pub_upgrade
+        name: "build; pub.bat upgrade --no-precompile"
+        working-directory: build
+        run: pub.bat upgrade --no-precompile
+      - name: "build; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_pub_upgrade.conclusion == 'success'"
+        working-directory: build
+        run: "pub.bat run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_021:
+    name: "unit_test; windows; Dart dev; PKG: build_resolvers; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_resolvers_pub_upgrade
+        name: "build_resolvers; pub.bat upgrade --no-precompile"
+        working-directory: build_resolvers
+        run: pub.bat upgrade --no-precompile
+      - name: "build_resolvers; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_resolvers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_resolvers
+        run: "pub.bat run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_022:
+    name: "unit_test; windows; Dart dev; PKG: build_runner_core; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_runner_core_pub_upgrade
+        name: "build_runner_core; pub.bat upgrade --no-precompile"
+        working-directory: build_runner_core
+        run: pub.bat upgrade --no-precompile
+      - name: "build_runner_core; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_runner_core_pub_upgrade.conclusion == 'success'"
+        working-directory: build_runner_core
+        run: "pub.bat run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_023:
+    name: "unit_test; windows; Dart dev; PKG: build_web_compilers; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_web_compilers_pub_upgrade
+        name: "build_web_compilers; pub.bat upgrade --no-precompile"
+        working-directory: build_web_compilers
+        run: pub.bat upgrade --no-precompile
+      - name: "build_web_compilers; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_web_compilers
+        run: "pub.bat run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
   job_024:
+    name: "unit_test; windows; Dart dev; PKG: build_test; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_test_pub_upgrade
+        name: "build_test; pub.bat upgrade --no-precompile"
+        working-directory: build_test
+        run: pub.bat upgrade --no-precompile
+      - name: "build_test; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_test_pub_upgrade.conclusion == 'success'"
+        working-directory: build_test
+        run: "pub.bat run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_025:
     name: "unit_test; linux; Dart dev; PKG: _test; `pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -813,7 +855,125 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_025:
+      - job_005
+  job_026:
+    name: "unit_test; windows; Dart dev; PKG: _test; `pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: _test_pub_upgrade
+        name: "_test; pub.bat upgrade --no-precompile"
+        working-directory: _test
+        run: pub.bat upgrade --no-precompile
+      - name: "_test; pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
+        if: "steps._test_pub_upgrade.conclusion == 'success'"
+        working-directory: _test
+        run: "pub.bat run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
+      - name: "_test; pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random"
+        if: "steps._test_pub_upgrade.conclusion == 'success'"
+        working-directory: _test
+        run: "pub.bat run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_027:
+    name: "unit_test; linux; Dart 2.10.0; PKG: build_modules; `pub run test -P presubmit --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:build_modules;commands:test_05"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:build_modules
+            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: stable
+          version: "2.10.0"
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_modules_pub_upgrade
+        name: "build_modules; pub upgrade --no-precompile"
+        working-directory: build_modules
+        run: pub upgrade --no-precompile
+      - name: "build_modules; pub run test -P presubmit --test-randomize-ordering-seed=random"
+        if: "steps.build_modules_pub_upgrade.conclusion == 'success'"
+        working-directory: build_modules
+        run: "pub run test -P presubmit --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_028:
+    name: "unit_test; windows; Dart dev; PKG: build_modules; `pub run test -P presubmit --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_modules_pub_upgrade
+        name: "build_modules; pub.bat upgrade --no-precompile"
+        working-directory: build_modules
+        run: pub.bat upgrade --no-precompile
+      - name: "build_modules; pub run test -P presubmit --test-randomize-ordering-seed=random"
+        if: "steps.build_modules_pub_upgrade.conclusion == 'success'"
+        working-directory: build_modules
+        run: "pub.bat run test -P presubmit --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_029:
+    name: "unit_test; linux; Dart dev; PKG: build_vm_compilers; `pub run test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_vm_compilers;commands:test_03"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_vm_compilers
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_vm_compilers_pub_upgrade
+        name: "build_vm_compilers; pub upgrade --no-precompile"
+        working-directory: build_vm_compilers
+        run: pub upgrade --no-precompile
+      - name: build_vm_compilers; pub run test
+        if: "steps.build_vm_compilers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_vm_compilers
+        run: pub run test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_030:
     name: "unit_test; linux; Dart dev; PKG: build_runner; `pub run test -x integration --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -845,7 +1005,32 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_026:
+      - job_005
+  job_031:
+    name: "unit_test; windows; Dart 2.9.0; PKG: build_runner_core; `pub run test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: stable
+          version: "2.9.0"
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_runner_core_pub_upgrade
+        name: "build_runner_core; pub.bat upgrade --no-precompile"
+        working-directory: build_runner_core
+        run: pub.bat upgrade --no-precompile
+      - name: "build_runner_core; pub run test --test-randomize-ordering-seed=random"
+        if: "steps.build_runner_core_pub_upgrade.conclusion == 'success'"
+        working-directory: build_runner_core
+        run: "pub.bat run test --test-randomize-ordering-seed=random"
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+  job_032:
     name: "unit_test; linux; Dart 2.9.0; PKG: build_runner_core; `pub run test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -878,237 +1063,63 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_027:
-    name: "unit_test; windows; Dart dev; PKG: _test; `pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: _test_pub_upgrade
-        name: "_test; pub.bat upgrade --no-precompile"
-        working-directory: _test
-        run: pub.bat upgrade --no-precompile
-      - name: "_test; pub run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
-        if: "steps._test_pub_upgrade.conclusion == 'success'"
-        working-directory: _test
-        run: "pub.bat run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
-      - name: "_test; pub run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random"
-        if: "steps._test_pub_upgrade.conclusion == 'success'"
-        working-directory: _test
-        run: "pub.bat run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_028:
-    name: "unit_test; windows; Dart dev; PKG: build_vm_compilers; `pub run test`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_vm_compilers_pub_upgrade
-        name: "build_vm_compilers; pub.bat upgrade --no-precompile"
-        working-directory: build_vm_compilers
-        run: pub.bat upgrade --no-precompile
-      - name: build_vm_compilers; pub run test
-        if: "steps.build_vm_compilers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_vm_compilers
-        run: pub.bat run test
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_029:
-    name: "unit_test; windows; Dart 2.9.0; PKG: build_runner_core; `pub run test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: stable
-          version: "2.9.0"
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_runner_core_pub_upgrade
-        name: "build_runner_core; pub.bat upgrade --no-precompile"
-        working-directory: build_runner_core
-        run: pub.bat upgrade --no-precompile
-      - name: "build_runner_core; pub run test --test-randomize-ordering-seed=random"
-        if: "steps.build_runner_core_pub_upgrade.conclusion == 'success'"
-        working-directory: build_runner_core
-        run: "pub.bat run test --test-randomize-ordering-seed=random"
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_030:
-    name: "e2e_test; linux; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test;commands:test_00"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: _test_pub_upgrade
-        name: "_test; pub upgrade --no-precompile"
-        working-directory: _test
-        run: pub upgrade --no-precompile
-      - name: "_test; pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random"
-        if: "steps._test_pub_upgrade.conclusion == 'success'"
-        working-directory: _test
-        run: "pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random"
-    needs:
       - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-      - job_010
-      - job_011
-      - job_012
-      - job_013
-      - job_014
-      - job_015
-      - job_016
-      - job_017
-      - job_018
-      - job_019
-      - job_020
-      - job_021
-      - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-  job_031:
-    name: "e2e_test; linux; Dart dev; PKG: build_runner; `pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner;commands:test_11"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_runner_pub_upgrade
-        name: "build_runner; pub upgrade --no-precompile"
-        working-directory: build_runner
-        run: pub upgrade --no-precompile
-      - name: "build_runner; pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces"
-        if: "steps.build_runner_pub_upgrade.conclusion == 'success'"
-        working-directory: build_runner
-        run: "pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces"
-    needs:
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-      - job_010
-      - job_011
-      - job_012
-      - job_013
-      - job_014
-      - job_015
-      - job_016
-      - job_017
-      - job_018
-      - job_019
-      - job_020
-      - job_021
-      - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-  job_032:
-    name: "e2e_test; linux; Dart dev; PKG: build_runner; `pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner;commands:test_09"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: build_runner_pub_upgrade
-        name: "build_runner; pub upgrade --no-precompile"
-        working-directory: build_runner
-        run: pub upgrade --no-precompile
-      - name: "build_runner; pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces"
-        if: "steps.build_runner_pub_upgrade.conclusion == 'success'"
-        working-directory: build_runner
-        run: "pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces"
-    needs:
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-      - job_010
-      - job_011
-      - job_012
-      - job_013
-      - job_014
-      - job_015
-      - job_016
-      - job_017
-      - job_018
-      - job_019
-      - job_020
-      - job_021
-      - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
   job_033:
+    name: "e2e_test; linux; Dart dev; PKG: build_runner; `pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner;commands:test_10"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_runner_pub_upgrade
+        name: "build_runner; pub upgrade --no-precompile"
+        working-directory: build_runner
+        run: pub upgrade --no-precompile
+      - name: "build_runner; pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces"
+        if: "steps.build_runner_pub_upgrade.conclusion == 'success'"
+        working-directory: build_runner
+        run: "pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces"
+    needs:
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+  job_034:
     name: "e2e_test; linux; Dart dev; PKG: _test_null_safety; `pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1140,7 +1151,6 @@ jobs:
         working-directory: _test_null_safety
         run: "pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
     needs:
-      - job_005
       - job_006
       - job_007
       - job_008
@@ -1165,7 +1175,10 @@ jobs:
       - job_027
       - job_028
       - job_029
-  job_034:
+      - job_030
+      - job_031
+      - job_032
+  job_035:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `pub run test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -1193,7 +1206,6 @@ jobs:
         working-directory: build_runner
         run: "pub run test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces"
     needs:
-      - job_005
       - job_006
       - job_007
       - job_008
@@ -1218,289 +1230,10 @@ jobs:
       - job_027
       - job_028
       - job_029
-  job_035:
-    name: "e2e_test; windows; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: _test_pub_upgrade
-        name: "_test; pub.bat upgrade --no-precompile"
-        working-directory: _test
-        run: pub.bat upgrade --no-precompile
-      - name: "_test; pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random"
-        if: "steps._test_pub_upgrade.conclusion == 'success'"
-        working-directory: _test
-        run: "pub.bat run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random"
-    needs:
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-      - job_010
-      - job_011
-      - job_012
-      - job_013
-      - job_014
-      - job_015
-      - job_016
-      - job_017
-      - job_018
-      - job_019
-      - job_020
-      - job_021
-      - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
+      - job_030
+      - job_031
+      - job_032
   job_036:
-    name: "e2e_test; windows; Dart dev; PKG: _test_null_safety; `pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: _test_null_safety_pub_upgrade
-        name: "_test_null_safety; pub.bat upgrade --no-precompile"
-        working-directory: _test_null_safety
-        run: pub.bat upgrade --no-precompile
-      - name: "_test_null_safety; pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
-        if: "steps._test_null_safety_pub_upgrade.conclusion == 'success'"
-        working-directory: _test_null_safety
-        run: "pub.bat run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
-      - name: "_test_null_safety; pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
-        if: "steps._test_null_safety_pub_upgrade.conclusion == 'success'"
-        working-directory: _test_null_safety
-        run: "pub.bat run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
-    needs:
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-      - job_010
-      - job_011
-      - job_012
-      - job_013
-      - job_014
-      - job_015
-      - job_016
-      - job_017
-      - job_018
-      - job_019
-      - job_020
-      - job_021
-      - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-  job_037:
-    name: "e2e_test; linux; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test;commands:test_02"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: _test_pub_upgrade
-        name: "_test; pub upgrade --no-precompile"
-        working-directory: _test
-        run: pub upgrade --no-precompile
-      - name: "_test; pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random"
-        if: "steps._test_pub_upgrade.conclusion == 'success'"
-        working-directory: _test
-        run: "pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random"
-    needs:
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-      - job_010
-      - job_011
-      - job_012
-      - job_013
-      - job_014
-      - job_015
-      - job_016
-      - job_017
-      - job_018
-      - job_019
-      - job_020
-      - job_021
-      - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-  job_038:
-    name: "e2e_test; windows; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: _test_pub_upgrade
-        name: "_test; pub.bat upgrade --no-precompile"
-        working-directory: _test
-        run: pub.bat upgrade --no-precompile
-      - name: "_test; pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random"
-        if: "steps._test_pub_upgrade.conclusion == 'success'"
-        working-directory: _test
-        run: "pub.bat run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random"
-    needs:
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-      - job_010
-      - job_011
-      - job_012
-      - job_013
-      - job_014
-      - job_015
-      - job_016
-      - job_017
-      - job_018
-      - job_019
-      - job_020
-      - job_021
-      - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-  job_039:
-    name: "e2e_test; linux; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test;commands:test_01"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: _test_pub_upgrade
-        name: "_test; pub upgrade --no-precompile"
-        working-directory: _test
-        run: pub upgrade --no-precompile
-      - name: "_test; pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random"
-        if: "steps._test_pub_upgrade.conclusion == 'success'"
-        working-directory: _test
-        run: "pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random"
-    needs:
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-      - job_010
-      - job_011
-      - job_012
-      - job_013
-      - job_014
-      - job_015
-      - job_016
-      - job_017
-      - job_018
-      - job_019
-      - job_020
-      - job_021
-      - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-  job_040:
-    name: "e2e_test; windows; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: dev
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: _test_pub_upgrade
-        name: "_test; pub.bat upgrade --no-precompile"
-        working-directory: _test
-        run: pub.bat upgrade --no-precompile
-      - name: "_test; pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random"
-        if: "steps._test_pub_upgrade.conclusion == 'success'"
-        working-directory: _test
-        run: "pub.bat run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random"
-    needs:
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-      - job_010
-      - job_011
-      - job_012
-      - job_013
-      - job_014
-      - job_015
-      - job_016
-      - job_017
-      - job_018
-      - job_019
-      - job_020
-      - job_021
-      - job_022
-      - job_023
-      - job_024
-      - job_025
-      - job_026
-      - job_027
-      - job_028
-      - job_029
-  job_041:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `pub run test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -1528,7 +1261,6 @@ jobs:
         working-directory: build_runner
         run: "pub run test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces"
     needs:
-      - job_005
       - job_006
       - job_007
       - job_008
@@ -1553,15 +1285,367 @@ jobs:
       - job_027
       - job_028
       - job_029
-  job_042:
-    name: "e2e_test; linux; Dart dev; PKG: build_runner; `pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
+      - job_030
+      - job_031
+      - job_032
+  job_037:
+    name: "e2e_test; linux; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner;commands:test_10"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test;commands:test_01"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: _test_pub_upgrade
+        name: "_test; pub upgrade --no-precompile"
+        working-directory: _test
+        run: pub upgrade --no-precompile
+      - name: "_test; pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random"
+        if: "steps._test_pub_upgrade.conclusion == 'success'"
+        working-directory: _test
+        run: "pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random"
+    needs:
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+  job_038:
+    name: "e2e_test; windows; Dart dev; PKG: _test_null_safety; `pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: _test_null_safety_pub_upgrade
+        name: "_test_null_safety; pub.bat upgrade --no-precompile"
+        working-directory: _test_null_safety
+        run: pub.bat upgrade --no-precompile
+      - name: "_test_null_safety; pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
+        if: "steps._test_null_safety_pub_upgrade.conclusion == 'success'"
+        working-directory: _test_null_safety
+        run: "pub.bat run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
+      - name: "_test_null_safety; pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
+        if: "steps._test_null_safety_pub_upgrade.conclusion == 'success'"
+        working-directory: _test_null_safety
+        run: "pub.bat run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
+    needs:
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+  job_039:
+    name: "e2e_test; linux; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test;commands:test_02"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: _test_pub_upgrade
+        name: "_test; pub upgrade --no-precompile"
+        working-directory: _test
+        run: pub upgrade --no-precompile
+      - name: "_test; pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random"
+        if: "steps._test_pub_upgrade.conclusion == 'success'"
+        working-directory: _test
+        run: "pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random"
+    needs:
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+  job_040:
+    name: "e2e_test; linux; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test;commands:test_00"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:_test
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: _test_pub_upgrade
+        name: "_test; pub upgrade --no-precompile"
+        working-directory: _test
+        run: pub upgrade --no-precompile
+      - name: "_test; pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random"
+        if: "steps._test_pub_upgrade.conclusion == 'success'"
+        working-directory: _test
+        run: "pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random"
+    needs:
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+  job_041:
+    name: "e2e_test; windows; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: _test_pub_upgrade
+        name: "_test; pub.bat upgrade --no-precompile"
+        working-directory: _test
+        run: pub.bat upgrade --no-precompile
+      - name: "_test; pub run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random"
+        if: "steps._test_pub_upgrade.conclusion == 'success'"
+        working-directory: _test
+        run: "pub.bat run test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random"
+    needs:
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+  job_042:
+    name: "e2e_test; windows; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: _test_pub_upgrade
+        name: "_test; pub.bat upgrade --no-precompile"
+        working-directory: _test
+        run: pub.bat upgrade --no-precompile
+      - name: "_test; pub run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random"
+        if: "steps._test_pub_upgrade.conclusion == 'success'"
+        working-directory: _test
+        run: "pub.bat run test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random"
+    needs:
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+  job_043:
+    name: "e2e_test; windows; Dart dev; PKG: _test; `pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: _test_pub_upgrade
+        name: "_test; pub.bat upgrade --no-precompile"
+        working-directory: _test
+        run: pub.bat upgrade --no-precompile
+      - name: "_test; pub run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random"
+        if: "steps._test_pub_upgrade.conclusion == 'success'"
+        working-directory: _test
+        run: "pub.bat run test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random"
+    needs:
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+  job_044:
+    name: "e2e_test; linux; Dart dev; PKG: build_runner; `pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner;commands:test_11"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner
             os:ubuntu-latest;pub-cache-hosted;dart:dev
@@ -1576,12 +1660,11 @@ jobs:
         name: "build_runner; pub upgrade --no-precompile"
         working-directory: build_runner
         run: pub upgrade --no-precompile
-      - name: "build_runner; pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces"
+      - name: "build_runner; pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces"
         if: "steps.build_runner_pub_upgrade.conclusion == 'success'"
         working-directory: build_runner
-        run: "pub run test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces"
+        run: "pub run test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces"
     needs:
-      - job_005
       - job_006
       - job_007
       - job_008
@@ -1606,7 +1689,65 @@ jobs:
       - job_027
       - job_028
       - job_029
-  job_043:
+      - job_030
+      - job_031
+      - job_032
+  job_045:
+    name: "e2e_test; linux; Dart dev; PKG: build_runner; `pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner;commands:test_09"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_runner
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: dev
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: build_runner_pub_upgrade
+        name: "build_runner; pub upgrade --no-precompile"
+        working-directory: build_runner
+        run: pub upgrade --no-precompile
+      - name: "build_runner; pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces"
+        if: "steps.build_runner_pub_upgrade.conclusion == 'success'"
+        working-directory: build_runner
+        run: "pub run test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces"
+    needs:
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+  job_046:
     name: "e2e_test_cron; windows; Dart edge; PKG: _test_null_safety; `pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1629,9 +1770,6 @@ jobs:
         run: "pub.bat run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
     if: "github.event_name == 'schedule'"
     needs:
-      - job_030
-      - job_031
-      - job_032
       - job_033
       - job_034
       - job_035
@@ -1642,7 +1780,10 @@ jobs:
       - job_040
       - job_041
       - job_042
-  job_044:
+      - job_043
+      - job_044
+      - job_045
+  job_047:
     name: "e2e_test_cron; linux; Dart edge; PKG: _test_null_safety; `pub run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1675,9 +1816,6 @@ jobs:
         run: "pub run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
     if: "github.event_name == 'schedule'"
     needs:
-      - job_030
-      - job_031
-      - job_032
       - job_033
       - job_034
       - job_035
@@ -1688,39 +1826,10 @@ jobs:
       - job_040
       - job_041
       - job_042
-  job_045:
-    name: "e2e_test_cron; windows; Dart edge; PKG: _test; `pub run test`"
-    runs-on: windows-latest
-    steps:
-      - uses: cedx/setup-dart@v2
-        with:
-          release-channel: edge
-      - run: dart --version
-      - uses: actions/checkout@v2
-      - id: _test_pub_upgrade
-        name: "_test; pub.bat upgrade --no-precompile"
-        working-directory: _test
-        run: pub.bat upgrade --no-precompile
-      - name: _test; pub run test
-        if: "steps._test_pub_upgrade.conclusion == 'success'"
-        working-directory: _test
-        run: pub.bat run test
-    if: "github.event_name == 'schedule'"
-    needs:
-      - job_030
-      - job_031
-      - job_032
-      - job_033
-      - job_034
-      - job_035
-      - job_036
-      - job_037
-      - job_038
-      - job_039
-      - job_040
-      - job_041
-      - job_042
-  job_046:
+      - job_043
+      - job_044
+      - job_045
+  job_048:
     name: "e2e_test_cron; linux; Dart edge; PKG: _test; `pub run test`"
     runs-on: ubuntu-latest
     steps:
@@ -1749,9 +1858,6 @@ jobs:
         run: pub run test
     if: "github.event_name == 'schedule'"
     needs:
-      - job_030
-      - job_031
-      - job_032
       - job_033
       - job_034
       - job_035
@@ -1762,7 +1868,42 @@ jobs:
       - job_040
       - job_041
       - job_042
-  job_047:
+      - job_043
+      - job_044
+      - job_045
+  job_049:
+    name: "e2e_test_cron; windows; Dart edge; PKG: _test; `pub run test`"
+    runs-on: windows-latest
+    steps:
+      - uses: cedx/setup-dart@v2
+        with:
+          release-channel: edge
+      - run: dart --version
+      - uses: actions/checkout@v2
+      - id: _test_pub_upgrade
+        name: "_test; pub.bat upgrade --no-precompile"
+        working-directory: _test
+        run: pub.bat upgrade --no-precompile
+      - name: _test; pub run test
+        if: "steps._test_pub_upgrade.conclusion == 'success'"
+        working-directory: _test
+        run: pub.bat run test
+    if: "github.event_name == 'schedule'"
+    needs:
+      - job_033
+      - job_034
+      - job_035
+      - job_036
+      - job_037
+      - job_038
+      - job_039
+      - job_040
+      - job_041
+      - job_042
+      - job_043
+      - job_044
+      - job_045
+  job_050:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -1774,7 +1915,7 @@ jobs:
         env:
           CHAT_WEBHOOK_URL: "${{ secrets.BUILD_AND_TEST_TEAM_CHAT_WEBHOOK_URL }}"
     needs:
-      - job_043
-      - job_044
-      - job_045
       - job_046
+      - job_047
+      - job_048
+      - job_049

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5
+
+- Allow `package:json_annotation` `v4.x`.
+
 ## 0.4.4
 
 - Support the latest `pkg:yaml`.

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 0.4.4
+version: 0.4.5
 description: Support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config
 
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   checked_yaml: ^1.0.0
-  json_annotation: '>=1.0.0 <4.0.0'
+  json_annotation: '>=1.0.0 <5.0.0'
   meta: ^1.1.0
   path: ^1.4.0
   pubspec_parse: ^0.1.5

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 3.0.2
+
+- Allow `package:json_annotation` `v4.x`.
+
 ## 3.0.1
 
-- Allow the latest analyzer verion `0.41.x`.
+- Allow the latest analyzer version `0.41.x`.
 
 ## 3.0.0
 

--- a/build_modules/mono_pkg.yaml
+++ b/build_modules/mono_pkg.yaml
@@ -1,4 +1,5 @@
 dart:
+- 2.10.0
 - dev
 
 stages:

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_modules
-version: 3.0.1
+version: 3.0.2
 description: Builders for Dart modules
-homepage: https://github.com/dart-lang/build/tree/master/build_modules
+repository: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: ">=2.10.0-93.0.dev <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
   analyzer: ">0.36.4 <0.42.0"
@@ -16,7 +16,7 @@ dependencies:
   crypto: ^2.0.0
   glob: ^1.0.0
   graphs: ^0.2.0
-  json_annotation: ">=1.2.0 <4.0.0"
+  json_annotation: ">=1.2.0 <5.0.0"
   logging: ^0.11.2
   meta: ^1.1.0
   path: ^1.4.2

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.3
+
+- Allow `package:json_annotation` `v4.x`.
+
 ## 6.1.2
 
 - Support the latest `package:build_config`.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: build_runner_core
-version: 6.1.2
+version: 6.1.3
 description: Core tools to write binaries that run builders.
-homepage: https://github.com/dart-lang/build/tree/master/build_runner_core
+repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
 environment:
   sdk: ">=2.9.0 <3.0.0"
@@ -16,7 +16,7 @@ dependencies:
   crypto: ">=0.9.2 <3.0.0"
   glob: ^1.1.0
   graphs: ^0.2.0
-  json_annotation: '>=1.0.0 <4.0.0'
+  json_annotation: '>=1.0.0 <5.0.0'
   logging: ^0.11.2
   meta: ^1.1.0
   path: ^1.1.0


### PR DESCRIPTION
build_config, build_modules, build_runner_core

Also added back testing for build_modules on Dart v2.10
