### PR TITLE
Expose a new api to get the AstNode for an Element

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.6.0
 
-- Adds the `Future<AstNode> astNodeFor(Element element)` api to
+- Adds the `Future<AstNode> astNodeFor(Element, {bool resolve})` api to
   `Resolver` which provides a safe way of getting ast nodes (avoiding
   `InconsistentAnalysisException`s).
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.6.0
 
-- Adds the `Future<AstNode> astNodeFor(Element, {bool resolve})` api to
+- Adds the `Future<AstNode> astNodeFor(Element element)` api to
   `Resolver` which provides a safe way of getting ast nodes (avoiding
   `InconsistentAnalysisException`s).
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.0
+
+- Adds the `Future<AstNode> astNodeFor(Element, {bool resolve})` api to
+  `Resolver` which provides a safe way of getting ast nodes (avoiding
+  `InconsistentAnalysisException`s).
+
 ## 1.5.2
 
 - Allow the latest analyzer verion `0.41.x`.

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -29,13 +29,10 @@ abstract class Resolver {
   /// This should always be preferred over using the [AnalysisSession]
   /// directly, because it avoids [InconsistentAnalysisException] issues.
   ///
-  /// If [resolve] is `true` then you will get a resolved ast node, otherwise
-  /// it will only be a parsed ast node.
-  ///
   /// Returns `null` if the ast node can not be found. This can happen if an
   /// element is coming from a summary, or is unavailable for some other
   /// reason.
-  Future<AstNode> astNodeFor(Element element, {bool resolve = false});
+  Future<AstNode> astNodeFor(Element element);
 
   /// Returns a parsed AST structor representing the file defined in [assetId].
   ///

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -29,10 +29,13 @@ abstract class Resolver {
   /// This should always be preferred over using the [AnalysisSession]
   /// directly, because it avoids [InconsistentAnalysisException] issues.
   ///
+  /// If [resolve] is `true` then you will get a resolved ast node, otherwise
+  /// it will only be a parsed ast node.
+  ///
   /// Returns `null` if the ast node can not be found. This can happen if an
   /// element is coming from a summary, or is unavailable for some other
   /// reason.
-  Future<AstNode> astNodeFor(Element element);
+  Future<AstNode> astNodeFor(Element element, {bool resolve = false});
 
   /// Returns a parsed AST structor representing the file defined in [assetId].
   ///

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/analysis/session.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/error/error.dart';
@@ -22,6 +23,15 @@ abstract class Resolver {
   ///
   /// **NOTE**: This includes all Dart SDK libraries as well.
   Stream<LibraryElement> get libraries;
+
+  /// Returns the parsed [AstNode] for [Element].
+  ///
+  /// This should always be preferred over using the [AnalysisSession]
+  /// directly, because it avoids [InconsistentAnalysisException] issues.
+  ///
+  /// If [resolve] is `true` then you will get a resolved ast node, otherwise
+  /// it will only be a parsed ast node.
+  Future<AstNode> astNodeFor(Element element, {bool resolve = false});
 
   /// Returns a parsed AST structor representing the file defined in [assetId].
   ///

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -31,6 +31,10 @@ abstract class Resolver {
   ///
   /// If [resolve] is `true` then you will get a resolved ast node, otherwise
   /// it will only be a parsed ast node.
+  ///
+  /// Returns `null` if the ast node can not be found. This can happen if an
+  /// element is coming from a summary, or is unavailable for some other
+  /// reason.
   Future<AstNode> astNodeFor(Element element, {bool resolve = false});
 
   /// Returns a parsed AST structor representing the file defined in [assetId].

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -186,6 +186,10 @@ class _DelayedResolver implements Resolver {
   }
 
   @override
+  Future<AstNode> astNodeFor(Element element, {bool resolve = false}) async =>
+      (await _delegate).astNodeFor(element, resolve: resolve);
+
+  @override
   Future<CompilationUnit> compilationUnitFor(AssetId assetId,
           {bool allowSyntaxErrors = false}) async =>
       (await _delegate)

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -186,8 +186,8 @@ class _DelayedResolver implements Resolver {
   }
 
   @override
-  Future<AstNode> astNodeFor(Element element, {bool resolve = false}) async =>
-      (await _delegate).astNodeFor(element, resolve: resolve);
+  Future<AstNode> astNodeFor(Element element) async =>
+      (await _delegate).astNodeFor(element);
 
   @override
   Future<CompilationUnit> compilationUnitFor(AssetId assetId,

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -186,8 +186,8 @@ class _DelayedResolver implements Resolver {
   }
 
   @override
-  Future<AstNode> astNodeFor(Element element) async =>
-      (await _delegate).astNodeFor(element);
+  Future<AstNode> astNodeFor(Element element, {bool resolve = false}) async =>
+      (await _delegate).astNodeFor(element, resolve: resolve);
 
   @override
   Future<CompilationUnit> compilationUnitFor(AssetId assetId,

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 1.5.2
+version: 1.6.0
 description: A build system for Dart.
 homepage: https://github.com/dart-lang/build/tree/master/build
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -21,3 +21,7 @@ dev_dependencies:
   build_test: ^1.0.0
   pedantic: ^1.0.0
   test: ^1.2.0
+
+dependency_overrides:
+  build_resolvers:
+    path: ../build_resolvers

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.0
+
+- Support the latest `build` package (`1.6.x`).
+  - Implements the new `Future<AstNode> astNodeFor(Element, {bool resolve})`
+    method.
+
 ## 1.4.4
 
 - Allow the latest analyzer verion `0.41.x`.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -92,6 +92,10 @@ class PerActionResolver implements ReleasableResolver {
   }
 
   @override
+  Future<AstNode> astNodeFor(Element element, {bool resolve = false}) =>
+      _delegate.astNodeFor(element, resolve: resolve);
+
+  @override
   Future<CompilationUnit> compilationUnitFor(AssetId assetId,
       {bool allowSyntaxErrors = false}) async {
     if (!await _step.canRead(assetId)) throw AssetNotFoundException(assetId);
@@ -149,6 +153,23 @@ class AnalyzerResolver implements ReleasableResolver {
     return source != null &&
         source.exists() &&
         (await _driver.getSourceKind(assetPath(assetId))) == SourceKind.LIBRARY;
+  }
+
+  @override
+  Future<AstNode> astNodeFor(Element element, {bool resolve = false}) async {
+    var session = _driver.currentSession;
+    var library = element.library;
+
+    if (resolve) {
+      return (await session.getResolvedLibraryByElement(library))
+          .getElementDeclaration(element)
+          .node;
+    } else {
+      return session
+          .getParsedLibraryByElement(library)
+          .getElementDeclaration(element)
+          .node;
+    }
   }
 
   @override

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -161,12 +161,12 @@ class AnalyzerResolver implements ReleasableResolver {
     var library = element.library;
 
     if (resolve) {
-      return (await session.getResolvedLibraryByElement(library))
+      return (await session.getResolvedLibrary(library.source.fullName))
           .getElementDeclaration(element)
           .node;
     } else {
       return session
-          .getParsedLibraryByElement(library)
+          .getParsedLibrary(library.source.fullName)
           .getElementDeclaration(element)
           .node;
     }

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -158,17 +158,14 @@ class AnalyzerResolver implements ReleasableResolver {
   @override
   Future<AstNode> astNodeFor(Element element, {bool resolve = false}) async {
     var session = _driver.currentSession;
-    var library = element.library;
+    var path = element.library.source.fullName;
 
     if (resolve) {
-      return (await session.getResolvedLibrary(library.source.fullName))
+      return (await session.getResolvedLibrary(path))
           .getElementDeclaration(element)
           .node;
     } else {
-      return session
-          .getParsedLibrary(library.source.fullName)
-          .getElementDeclaration(element)
-          .node;
+      return session.getParsedLibrary(path).getElementDeclaration(element).node;
     }
   }
 

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -92,7 +92,8 @@ class PerActionResolver implements ReleasableResolver {
   }
 
   @override
-  Future<AstNode> astNodeFor(Element element) => _delegate.astNodeFor(element);
+  Future<AstNode> astNodeFor(Element element, {bool resolve = false}) =>
+      _delegate.astNodeFor(element, resolve: resolve);
 
   @override
   Future<CompilationUnit> compilationUnitFor(AssetId assetId,
@@ -155,10 +156,18 @@ class AnalyzerResolver implements ReleasableResolver {
   }
 
   @override
-  Future<AstNode> astNodeFor(Element element) async => _driver.currentSession
-      .getParsedLibrary(element.library.source.fullName)
-      .getElementDeclaration(element)
-      .node;
+  Future<AstNode> astNodeFor(Element element, {bool resolve = false}) async {
+    var session = _driver.currentSession;
+    var path = element.library.source.fullName;
+
+    if (resolve) {
+      return (await session.getResolvedLibrary(path))
+          .getElementDeclaration(element)
+          .node;
+    } else {
+      return session.getParsedLibrary(path).getElementDeclaration(element).node;
+    }
+  }
 
   @override
   Future<CompilationUnit> compilationUnitFor(AssetId assetId,

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -92,8 +92,7 @@ class PerActionResolver implements ReleasableResolver {
   }
 
   @override
-  Future<AstNode> astNodeFor(Element element, {bool resolve = false}) =>
-      _delegate.astNodeFor(element, resolve: resolve);
+  Future<AstNode> astNodeFor(Element element) => _delegate.astNodeFor(element);
 
   @override
   Future<CompilationUnit> compilationUnitFor(AssetId assetId,
@@ -156,18 +155,10 @@ class AnalyzerResolver implements ReleasableResolver {
   }
 
   @override
-  Future<AstNode> astNodeFor(Element element, {bool resolve = false}) async {
-    var session = _driver.currentSession;
-    var path = element.library.source.fullName;
-
-    if (resolve) {
-      return (await session.getResolvedLibrary(path))
-          .getElementDeclaration(element)
-          .node;
-    } else {
-      return session.getParsedLibrary(path).getElementDeclaration(element).node;
-    }
-  }
+  Future<AstNode> astNodeFor(Element element) async => _driver.currentSession
+      .getParsedLibrary(element.library.source.fullName)
+      .getElementDeclaration(element)
+      .node;
 
   @override
   Future<CompilationUnit> compilationUnitFor(AssetId assetId,

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 1.4.4
+version: 1.5.0
 description: Resolve Dart code in a Builder
 homepage: https://github.com/dart-lang/build/tree/master/build_resolvers
 
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   analyzer: ">=0.40.1 <0.42.0"
-  build: ">=1.5.0 <1.6.0"
+  build: ">=1.6.0 <1.7.0"
   crypto: ^2.0.0
   graphs: ^0.2.0
   logging: ^0.11.2
@@ -21,3 +21,7 @@ dependencies:
 dev_dependencies:
   test: ^1.0.0
   build_test: ^1.0.0
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -695,6 +695,19 @@ int? get x => 1;
       }, resolvers: AnalyzerResolvers());
     });
 
+    test('can return an resolved ast', () {
+      return resolveSources({
+        'a|web/main.dart': 'main() {}',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var unit = await resolver.astNodeFor(lib.topLevelElements.first,
+            resolve: true);
+        expect(unit, isA<FunctionDeclaration>());
+        expect(unit.toSource(), 'main() {}');
+        expect((unit as FunctionDeclaration).declaredElement, isNotNull);
+      }, resolvers: AnalyzerResolvers());
+    });
+
     test(
         'can get an unresolved AstNode for an old Element after resolving '
         'additional assets', () async {
@@ -716,6 +729,55 @@ int? get x => 1;
         expect(astNode, isA<VariableDeclaration>());
         expect((astNode as VariableDeclaration).name.name, 'x');
         expect((astNode as VariableDeclaration).declaredElement, isNull);
+      }, resolvers: resolvers);
+    });
+
+    test(
+        'can get a resolved AstNode for an old Element after resolving '
+        'additional assets', () async {
+      var resolvers = AnalyzerResolvers();
+      await resolveSources({
+        'a|web/main.dart': 'int x;',
+        'a|web/other.dart': '',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var x = lib.topLevelElements.firstWhere((x) => !x.isSynthetic);
+        expect(x.name, 'x');
+        expect(await resolver.isLibrary(AssetId('a', 'web/other.dart')), true);
+
+        // Validate that direct session usage would throw
+        expect(() => lib.session.getParsedLibraryByElement(x.library),
+            throwsA(isA<InconsistentAnalysisException>()));
+
+        var astNode = await resolver.astNodeFor(x, resolve: true);
+        expect(astNode, isA<VariableDeclaration>());
+        expect((astNode as VariableDeclaration).name.name, 'x');
+        expect((astNode as VariableDeclaration).declaredElement, isNotNull);
+      }, resolvers: resolvers);
+    });
+
+    test('library results can be used even if the session is invalidated',
+        () async {
+      var resolvers = AnalyzerResolvers();
+      await resolveSources({
+        'a|web/main.dart': 'int x;',
+        'a|web/other.dart': '',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var x = lib.topLevelElements.firstWhere((x) => !x.isSynthetic);
+        expect(x.name, 'x');
+        var originalResult =
+            await lib.session.getResolvedLibrary(lib.source.fullName);
+        expect(await resolver.isLibrary(AssetId('a', 'web/other.dart')), true);
+
+        // Validate that direct session usage would throw
+        expect(() => lib.session.getResolvedLibrary(lib.source.fullName),
+            throwsA(isA<InconsistentAnalysisException>()));
+
+        var astNode = originalResult.getElementDeclaration(x).node;
+        expect(astNode, isA<VariableDeclaration>());
+        expect((astNode as VariableDeclaration).name.name, 'x');
+        expect((astNode as VariableDeclaration).declaredElement, isNotNull);
       }, resolvers: resolvers);
     });
   });

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -695,19 +695,6 @@ int? get x => 1;
       }, resolvers: AnalyzerResolvers());
     });
 
-    test('can return an resolved ast', () {
-      return resolveSources({
-        'a|web/main.dart': 'main() {}',
-      }, (resolver) async {
-        var lib = await resolver.libraryFor(entryPoint);
-        var unit = await resolver.astNodeFor(lib.topLevelElements.first,
-            resolve: true);
-        expect(unit, isA<FunctionDeclaration>());
-        expect(unit.toSource(), 'main() {}');
-        expect((unit as FunctionDeclaration).declaredElement, isNotNull);
-      }, resolvers: AnalyzerResolvers());
-    });
-
     test(
         'can get an unresolved AstNode for an old Element after resolving '
         'additional assets', () async {
@@ -729,55 +716,6 @@ int? get x => 1;
         expect(astNode, isA<VariableDeclaration>());
         expect((astNode as VariableDeclaration).name.name, 'x');
         expect((astNode as VariableDeclaration).declaredElement, isNull);
-      }, resolvers: resolvers);
-    });
-
-    test(
-        'can get a resolved AstNode for an old Element after resolving '
-        'additional assets', () async {
-      var resolvers = AnalyzerResolvers();
-      await resolveSources({
-        'a|web/main.dart': 'int x;',
-        'a|web/other.dart': '',
-      }, (resolver) async {
-        var lib = await resolver.libraryFor(entryPoint);
-        var x = lib.topLevelElements.firstWhere((x) => !x.isSynthetic);
-        expect(x.name, 'x');
-        expect(await resolver.isLibrary(AssetId('a', 'web/other.dart')), true);
-
-        // Validate that direct session usage would throw
-        expect(() => lib.session.getParsedLibraryByElement(x.library),
-            throwsA(isA<InconsistentAnalysisException>()));
-
-        var astNode = await resolver.astNodeFor(x, resolve: true);
-        expect(astNode, isA<VariableDeclaration>());
-        expect((astNode as VariableDeclaration).name.name, 'x');
-        expect((astNode as VariableDeclaration).declaredElement, isNotNull);
-      }, resolvers: resolvers);
-    });
-
-    test('library results can be used even if the session is invalidated',
-        () async {
-      var resolvers = AnalyzerResolvers();
-      await resolveSources({
-        'a|web/main.dart': 'int x;',
-        'a|web/other.dart': '',
-      }, (resolver) async {
-        var lib = await resolver.libraryFor(entryPoint);
-        var x = lib.topLevelElements.firstWhere((x) => !x.isSynthetic);
-        expect(x.name, 'x');
-        var originalResult =
-            await lib.session.getResolvedLibrary(lib.source.fullName);
-        expect(await resolver.isLibrary(AssetId('a', 'web/other.dart')), true);
-
-        // Validate that direct session usage would throw
-        expect(() => lib.session.getResolvedLibrary(lib.source.fullName),
-            throwsA(isA<InconsistentAnalysisException>()));
-
-        var astNode = originalResult.getElementDeclaration(x).node;
-        expect(astNode, isA<VariableDeclaration>());
-        expect((astNode as VariableDeclaration).name.name, 'x');
-        expect((astNode as VariableDeclaration).declaredElement, isNotNull);
       }, resolvers: resolvers);
     });
   });

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -689,8 +689,9 @@ int? get x => 1;
       }, (resolver) async {
         var lib = await resolver.libraryFor(entryPoint);
         var unit = await resolver.astNodeFor(lib.topLevelElements.first);
-        expect(unit, isA<AstNode>());
+        expect(unit, isA<FunctionDeclaration>());
         expect(unit.toSource(), 'main() {}');
+        expect((unit as FunctionDeclaration).declaredElement, isNull);
       }, resolvers: AnalyzerResolvers());
     });
 
@@ -701,14 +702,15 @@ int? get x => 1;
         var lib = await resolver.libraryFor(entryPoint);
         var unit = await resolver.astNodeFor(lib.topLevelElements.first,
             resolve: true);
-        expect(unit, isA<AstNode>());
+        expect(unit, isA<FunctionDeclaration>());
         expect(unit.toSource(), 'main() {}');
+        expect((unit as FunctionDeclaration).declaredElement, isNotNull);
       }, resolvers: AnalyzerResolvers());
     });
 
     test(
-        'can get an AstNode for an old Element after resolving additional assets',
-        () async {
+        'can get an unresolved AstNode for an old Element after resolving '
+        'additional assets', () async {
       var resolvers = AnalyzerResolvers();
       await resolveSources({
         'a|web/main.dart': 'int x;',
@@ -726,6 +728,56 @@ int? get x => 1;
         var astNode = await resolver.astNodeFor(x);
         expect(astNode, isA<VariableDeclaration>());
         expect((astNode as VariableDeclaration).name.name, 'x');
+        expect((astNode as VariableDeclaration).declaredElement, isNull);
+      }, resolvers: resolvers);
+    });
+
+    test(
+        'can get a resolved AstNode for an old Element after resolving '
+        'additional assets', () async {
+      var resolvers = AnalyzerResolvers();
+      await resolveSources({
+        'a|web/main.dart': 'int x;',
+        'a|web/other.dart': '',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var x = lib.topLevelElements.firstWhere((x) => !x.isSynthetic);
+        expect(x.name, 'x');
+        expect(await resolver.isLibrary(AssetId('a', 'web/other.dart')), true);
+
+        // Validate that direct session usage would throw
+        expect(() => lib.session.getParsedLibraryByElement(x.library),
+            throwsA(isA<InconsistentAnalysisException>()));
+
+        var astNode = await resolver.astNodeFor(x, resolve: true);
+        expect(astNode, isA<VariableDeclaration>());
+        expect((astNode as VariableDeclaration).name.name, 'x');
+        expect((astNode as VariableDeclaration).declaredElement, isNotNull);
+      }, resolvers: resolvers);
+    });
+
+    test('library results can be used even if the session is invalidated',
+        () async {
+      var resolvers = AnalyzerResolvers();
+      await resolveSources({
+        'a|web/main.dart': 'int x;',
+        'a|web/other.dart': '',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var x = lib.topLevelElements.firstWhere((x) => !x.isSynthetic);
+        expect(x.name, 'x');
+        var originalResult =
+            await lib.session.getResolvedLibrary(lib.source.fullName);
+        expect(await resolver.isLibrary(AssetId('a', 'web/other.dart')), true);
+
+        // Validate that direct session usage would throw
+        expect(() => lib.session.getResolvedLibrary(lib.source.fullName),
+            throwsA(isA<InconsistentAnalysisException>()));
+
+        var astNode = originalResult.getElementDeclaration(x).node;
+        expect(astNode, isA<VariableDeclaration>());
+        expect((astNode as VariableDeclaration).name.name, 'x');
+        expect((astNode as VariableDeclaration).declaredElement, isNotNull);
       }, resolvers: resolvers);
     });
   });

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:isolate';
 
+import 'package:analyzer/dart/analysis/session.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:build/build.dart';
 import 'package:build/experiments.dart';
@@ -678,6 +679,54 @@ int? get x => 1;
             isA<FunctionDeclaration>()
                 .having((d) => d.name.name, 'main', 'main'));
       }, resolvers: AnalyzerResolvers());
+    });
+  });
+
+  group('astNodeFor', () {
+    test('can return an unresolved ast', () {
+      return resolveSources({
+        'a|web/main.dart': ' main() {}',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var unit = await resolver.astNodeFor(lib.topLevelElements.first);
+        expect(unit, isA<AstNode>());
+        expect(unit.toSource(), 'main() {}');
+      }, resolvers: AnalyzerResolvers());
+    });
+
+    test('can return an resolved ast', () {
+      return resolveSources({
+        'a|web/main.dart': 'main() {}',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var unit = await resolver.astNodeFor(lib.topLevelElements.first,
+            resolve: true);
+        expect(unit, isA<AstNode>());
+        expect(unit.toSource(), 'main() {}');
+      }, resolvers: AnalyzerResolvers());
+    });
+
+    test(
+        'can get an AstNode for an old Element after resolving additional assets',
+        () async {
+      var resolvers = AnalyzerResolvers();
+      await resolveSources({
+        'a|web/main.dart': 'int x;',
+        'a|web/other.dart': '',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var x = lib.topLevelElements.firstWhere((x) => !x.isSynthetic);
+        expect(x.name, 'x');
+        expect(await resolver.isLibrary(AssetId('a', 'web/other.dart')), true);
+
+        // Validate that direct session usage would throw
+        expect(() => lib.session.getParsedLibraryByElement(x.library),
+            throwsA(isA<InconsistentAnalysisException>()));
+
+        var astNode = await resolver.astNodeFor(x);
+        expect(astNode, isA<VariableDeclaration>());
+        expect((astNode as VariableDeclaration).name.name, 'x');
+      }, resolvers: resolvers);
     });
   });
 }

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.10
+
+- Allow build version `1.6.x`.
+
 ## 1.10.9
 
 - Allow build_config version `'>=0.4.1 <0.4.6'`.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.10.9
+version: 1.10.10
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 
@@ -9,7 +9,7 @@ environment:
 dependencies:
   args: ">=1.4.0 <2.0.0"
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.5.0 <1.6.0"
+  build: ">=1.5.0 <1.7.0"
   build_config: '>=0.4.1 <0.4.6'
   build_daemon: ^2.1.0
   build_resolvers: ^1.4.0

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.5
+
+- Allow build version `1.6.x`.
+
 ## 6.1.4
 
 - Allow build_config version `'>=0.4.1 <0.4.6'`.

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -198,7 +198,9 @@ class _SingleBuild {
       : _assetGraph = buildImpl.assetGraph,
         _buildFilters = buildFilters,
         _buildPhases = buildImpl._buildPhases,
-        _buildPhasePool = List(buildImpl._buildPhases.length),
+        _buildPhasePool = List.generate(
+            buildImpl._buildPhases.length, (_) => Pool(buildPhasePoolSize),
+            growable: false),
         _environment = buildImpl._environment,
         _packageGraph = buildImpl._packageGraph,
         _targetGraph = buildImpl._targetGraph,
@@ -467,8 +469,7 @@ class _SingleBuild {
 
   Future<Iterable<AssetId>> _runForInput(
       int phaseNumber, InBuildPhase phase, AssetId input) {
-    var pool = _buildPhasePool[phaseNumber] ??= Pool(buildPhasePoolSize);
-    return pool.withResource(() {
+    return _buildPhasePool[phaseNumber].withResource(() {
       final builder = phase.builder;
       var tracker =
           _performanceTracker.addBuilderAction(input, phase.builderLabel);

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 6.1.4
+version: 6.1.5
 description: Core tools to write binaries that run builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ">=1.13.3 <3.0.0"
-  build: ">=1.5.1 <1.6.0"
+  build: ">=1.5.1 <1.7.0"
   build_config: '>=0.4.3 <0.4.6'
   build_resolvers: ^1.4.0
   collection: ^1.14.0

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.3.1-dev
+## 1.3.1
+
+- Allow build version `1.6.x`.
 
 ## 1.3.0
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 1.3.1-dev
+version: 1.3.1
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ">=1.2.0 <3.0.0"
-  build: ">=1.3.0 <1.6.0"
+  build: ">=1.3.0 <1.7.0"
   build_config: ">=0.2.0 <0.5.0"
   build_resolvers: ^1.3.5
   crypto: ">=0.9.2 <3.0.0"


### PR DESCRIPTION
The api is `Future<AstNode> astNodeFor(Element element, {bool resolve: false})`, and is exposed on `Resolver`.

This api can be used avoid using the AnalysisSession directly, which is unsafe to do in Builder code and results in `InconsistentAnalysisException`s. Internally we can avoid this issue due to having synchronous access to the current analysis session.

Fixes https://github.com/dart-lang/build/issues/2946.

cc @rrousselGit @davidmorgan @eernstg I know  you had builders hitting this issue, can try verifying this fix? Does it fully solve all use cases you had for using the `session`? Does it resolve the issue with that?

You can test it out with these dependency overrides:

```
dependency_overrides:
  build:
    git:
      url: https://github.com/dart-lang/build.git
      path: build
      ref: safe-ast
  build_resolvers:
    git:
      url: https://github.com/dart-lang/build.git
      path: build_resolvers
      ref: safe-ast
```

You may also need to override build_runner_core, build_runner, and build_test (if you depend on that) in a similar manner but I don't _think_ so.