### PR TITLE
Add $package$ to default generate_for

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -23,7 +23,8 @@ final _builders = <_i1.BuilderApplication>[
       [_i2.debugIndexBuilder, _i2.debugTestBuilder, _i2.testBootstrapBuilder],
       _i1.toRoot(),
       hideOutput: true,
-      defaultGenerateFor: const _i3.InputSet(include: [r'test/**'])),
+      defaultGenerateFor:
+          const _i3.InputSet(include: [r'$package$', r'test/**'])),
   _i1.apply(r'provides_builder:some_builder', [_i4.someBuilder],
       _i1.toDependentsOf(r'provides_builder'),
       hideOutput: true,

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+- Fix the `test/index.html` not generating by default.
+
 ## 1.3.1
 
 - Allow build version `1.6.x`.

--- a/build_test/build.yaml
+++ b/build_test/build.yaml
@@ -19,4 +19,4 @@ builders:
     build_to: cache
     auto_apply: root_package
     defaults:
-      generate_for: ["test/**"]
+      generate_for: ["$package$", "test/**"]

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 1.3.1
+version: 1.3.2
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ">=1.2.0 <3.0.0"
-  build: ">=1.3.0 <1.7.0"
+  build: ">=1.6.0 <1.7.0"
   build_config: ">=0.2.0 <0.5.0"
   build_resolvers: ^1.3.5
   crypto: ">=0.9.2 <3.0.0"


### PR DESCRIPTION
This was missed in #2944

After changing the input extension from `$test$` to `$package$` it is
critical to also include it in the default `generate_for`, otherwise the
builder will not run.