### PR TITLE
fix: Issue In abstract class Builder Documentation 

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -50,7 +50,7 @@ class CopyBuilder implements Builder {
   };
 
   @override
-  Future<void> build(BuildStep buildStep) async {
+  FutureOr<void> build(BuildStep buildStep) async {
     // Each `buildStep` has a single input.
     var inputId = buildStep.inputId;
 
@@ -90,7 +90,7 @@ class ResolvingCopyBuilder implements Builder {
   };
 
   @override
-  Future<void> build(BuildStep buildStep) async {
+  FutureOr<void> build(BuildStep buildStep) async {
     // Get the `LibraryElement` for the primary input.
     var entryLib = await buildStep.inputLibrary;
     // Resolves all libraries reachable from the primary input.


### PR DESCRIPTION
Related Issue:
https://github.com/dart-lang/build/issues/2959

**Actual:** 
In Section `Implementing your own Builders`:

![image](https://user-images.githubusercontent.com/67098758/102682665-26445880-41ed-11eb-94a9-f4da0a987eb6.png)
![image](https://user-images.githubusercontent.com/67098758/102682899-c189fd80-41ee-11eb-9b6b-65d54ba15549.png)

**Expected:**
This should be FurtureOr like in the abstract class: 

`FutureOr` in place of `Future`