### PR TITLE
Return empty for findAssets on missing package

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.3
+
+- Return an empty stream instead of throwing from
+  `PackageAssetReader.findAssets` when passed a non-existing package name.
+
 ## 1.3.2
 
 - Fix the `test/index.html` not generating by default.

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -110,9 +110,7 @@ class PackageAssetReader extends AssetReader
           'explicit `package`.');
     }
     var packageLibDir = _packageConfig[package]?.packageUriRoot;
-    if (packageLibDir == null) {
-      throw UnsupportedError('Unable to find package $package');
-    }
+    if (packageLibDir == null) return Stream.empty();
 
     var packageFiles = Directory.fromUri(packageLibDir)
         .list(recursive: true)

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 1.3.2
+version: 1.3.3
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:


### PR DESCRIPTION
We have checks in the real build system to keep packages on the rails.
Those checks don't necessarily need to be included in test code and for
fake environments within the test.

Closes #2923