### PR TITLE
Warn about configuring builders with --config

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.12-dev
+
+- Add a warning if a `builders` section is found in when parsing an overriden
+  build.yaml file via the `--config` flag.
+
 ## 1.10.11
 
 - Fix handling of `build.yaml` `generateFor` default config for values including

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -66,8 +66,8 @@ Future<Iterable<Expression>> _findBuilderApplications() async {
     equals: (a, b) => a.name == b.name,
     hashCode: (n) => n.name.hashCode,
   ).expand((c) => c);
-  final buildConfigOverrides =
-      await findBuildConfigOverrides(packageGraph, null);
+  final buildConfigOverrides = await findBuildConfigOverrides(
+      packageGraph, null, FileBasedAssetReader(packageGraph));
   Future<BuildConfig> _packageBuildConfig(PackageNode package) async {
     if (buildConfigOverrides.containsKey(package.name)) {
       return buildConfigOverrides[package.name];

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -191,8 +191,8 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
     var logSubscription =
         LogSubscription(environment, verbose: daemonOptions.verbose);
 
-    var overrideBuildConfig =
-        await findBuildConfigOverrides(packageGraph, daemonOptions.configKey);
+    var overrideBuildConfig = await findBuildConfigOverrides(
+        packageGraph, daemonOptions.configKey, daemonEnvironment.reader);
 
     var buildOptions = await BuildOptions.create(
       logSubscription,

--- a/build_runner/lib/src/entrypoint/doctor.dart
+++ b/build_runner/lib/src/entrypoint/doctor.dart
@@ -51,8 +51,8 @@ class DoctorCommand extends BuildRunnerCommand {
 
   Future<Map<String, BuilderDefinition>> _loadBuilderDefinitions() async {
     final packageGraph = await PackageGraph.forThisPackage();
-    final buildConfigOverrides =
-        await findBuildConfigOverrides(packageGraph, null);
+    final buildConfigOverrides = await findBuildConfigOverrides(
+        packageGraph, null, FileBasedAssetReader(packageGraph));
     Future<BuildConfig> _packageBuildConfig(PackageNode package) async {
       if (buildConfigOverrides.containsKey(package.name)) {
         return buildConfigOverrides[package.name];

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -87,8 +87,8 @@ Future<BuildResult> build(List<BuilderApplication> builders,
     deleteFilesByDefault: deleteFilesByDefault,
     packageGraph: packageGraph,
     skipBuildScriptCheck: skipBuildScriptCheck,
-    overrideBuildConfig:
-        await findBuildConfigOverrides(packageGraph, configKey),
+    overrideBuildConfig: await findBuildConfigOverrides(
+        packageGraph, configKey, environment.reader),
     enableLowResourcesMode: enableLowResourcesMode,
     trackPerformance: trackPerformance,
     logPerformanceDir: logPerformanceDir,

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -66,8 +66,8 @@ Future<ServeHandler> watch(
       onLog: onLog ?? stdIOLogListener(assumeTty: assumeTty, verbose: verbose));
   var logSubscription =
       LogSubscription(environment, verbose: verbose, logLevel: logLevel);
-  overrideBuildConfig ??=
-      await findBuildConfigOverrides(packageGraph, configKey);
+  overrideBuildConfig ??= await findBuildConfigOverrides(
+      packageGraph, configKey, environment.reader);
   var options = await BuildOptions.create(
     logSubscription,
     deleteFilesByDefault: deleteFilesByDefault,

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.10.11
+version: 1.10.12-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -16,7 +16,7 @@ import 'package:_test_common/common.dart';
 import 'package:_test_common/package_graphs.dart';
 
 void main() {
-  /// Basic phases/phase groups which get used in many tests
+  // Basic phases/phase groups which get used in many tests
   final copyABuildApplication = applyToRoot(
       TestBuilder(buildExtensions: appendExtension('.copy', from: '.txt')));
   final packageConfigId = makeAssetId('a|.dart_tool/package_config.json');

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -32,7 +32,7 @@ a:file://fake/pkg/path
   });
 
   group('--config', () {
-    test('warns if you atempt to configure builders', () async {
+    test('warns override config defines builders', () async {
       var logs = <LogRecord>[];
       final packageGraph = buildPackageGraph({
         rootPackage('a', path: path.absolute('a')): [],

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -1,6 +1,7 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:convert';
 
@@ -37,7 +38,7 @@ a:file://fake/pkg/path
       final packageGraph = buildPackageGraph({
         rootPackage('a', path: path.absolute('a')): [],
       });
-      var result = await doBuild([
+      var result = await _doBuild([
         copyABuildApplication
       ], {
         'a|build.yaml': '',
@@ -62,7 +63,7 @@ builders:
   });
 }
 
-Future<BuildResult> doBuild(List<BuilderApplication> builders,
+Future<BuildResult> _doBuild(List<BuilderApplication> builders,
     Map<String, String> inputs, InMemoryRunnerAssetWriter writer,
     {PackageGraph packageGraph,
     void Function(LogRecord) onLog,

--- a/build_runner/test/generate/build_test.dart
+++ b/build_runner/test/generate/build_test.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import 'package:build_runner_core/build_runner_core.dart';
+import 'package:build_runner/src/generate/build.dart' as build_impl;
+import 'package:build_test/build_test.dart';
+
+import 'package:_test_common/common.dart';
+import 'package:_test_common/package_graphs.dart';
+
+void main() {
+  /// Basic phases/phase groups which get used in many tests
+  final copyABuildApplication = applyToRoot(
+      TestBuilder(buildExtensions: appendExtension('.copy', from: '.txt')));
+  final packageConfigId = makeAssetId('a|.dart_tool/package_config.json');
+  InMemoryRunnerAssetWriter writer;
+
+  setUp(() async {
+    writer = InMemoryRunnerAssetWriter();
+    await writer.writeAsString(makeAssetId('a|.packages'), '''
+# Fake packages file
+a:file://fake/pkg/path
+''');
+    await writer.writeAsString(packageConfigId, jsonEncode(_packageConfig));
+  });
+
+  group('--config', () {
+    test('warns if you atempt to configure builders', () async {
+      var logs = <LogRecord>[];
+      final packageGraph = buildPackageGraph({
+        rootPackage('a', path: path.absolute('a')): [],
+      });
+      var result = await doBuild([
+        copyABuildApplication
+      ], {
+        'a|build.yaml': '',
+        'a|build.cool.yaml': '''
+builders:
+  fake:
+    import: "a.dart"
+    builder_factories: ["myFactory"]
+    build_extensions: {"a": ["b"]}
+'''
+      }, writer,
+          configKey: 'cool',
+          logLevel: Level.WARNING,
+          onLog: logs.add,
+          packageGraph: packageGraph);
+      expect(result.status, BuildStatus.success);
+      expect(
+          logs.first.message,
+          contains('Ignoring `builders` configuration in `build.cool.yaml` - '
+              'overriding builder configuration is not supported.'));
+    });
+  });
+}
+
+Future<BuildResult> doBuild(List<BuilderApplication> builders,
+    Map<String, String> inputs, InMemoryRunnerAssetWriter writer,
+    {PackageGraph packageGraph,
+    void Function(LogRecord) onLog,
+    Level logLevel,
+    String configKey}) async {
+  onLog ??= (_) {};
+  inputs.forEach((serializedId, contents) {
+    writer.writeAsString(makeAssetId(serializedId), contents);
+  });
+  packageGraph ??=
+      buildPackageGraph({rootPackage('a', path: path.absolute('a')): []});
+  final reader = InMemoryRunnerAssetReader.shareAssetCache(writer.assets,
+      rootPackage: packageGraph.root.name);
+
+  return await build_impl.build(builders,
+      configKey: configKey,
+      deleteFilesByDefault: true,
+      reader: reader,
+      writer: writer,
+      packageGraph: packageGraph,
+      logLevel: logLevel,
+      onLog: onLog,
+      skipBuildScriptCheck: true);
+}
+
+const _packageConfig = {
+  'configVersion': 2,
+  'packages': [
+    {'name': 'a', 'rootUri': 'file://fake/pkg/path', 'packageUri': 'lib/'},
+  ],
+};


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/2942

This also cleans up some `dart:io` imports to use the asset reader interface instead, which was a requirement for unit testing this but is a good general cleanup.