### PR TITLE
Allow more null safe packages from build_test

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Return an empty stream instead of throwing from
   `PackageAssetReader.findAssets` when passed a non-existing package name.
+- Allow the null safe migration package versions for `crypto`, `glob`,
+  `logging`, and `package_config`.
 
 ## 1.3.2
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -11,12 +11,12 @@ dependencies:
   build: ">=1.6.0 <1.7.0"
   build_config: ">=0.2.0 <0.5.0"
   build_resolvers: ^1.3.5
-  crypto: ">=0.9.2 <3.0.0"
-  glob: ^1.1.0
+  crypto: ">=0.9.2 <4.0.0"
+  glob: ">=1.1.0 <2.0.0"
   html: ">=0.9.0 <0.15.0"
-  logging: ^0.11.2
+  logging: ">=0.11.2 <2.0.0"
   matcher: ^0.12.0
-  package_config: ^1.9.0
+  package_config: ">=1.9.0 <3.0.0"
   path: ^1.4.1
   pedantic: ^1.0.0
   stream_transform: ">=0.0.20 <2.0.0"


### PR DESCRIPTION
These won't be picked up due to transitive constraints. Tested locally.