### PR TITLE
Scrub unnecessary term from changelogs

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -72,7 +72,7 @@
 
 - Keep cached deserialized module instances in more cases. This may improve
   performance of incremental builds in watch mode.
-- **Deprecated**: The package specific unsupported module whitelist option
+- **Deprecated**: The package specific unsupported module allow list option
   provided by `computeTransitiveDependencies`. The only known uses are being
   removed.
 - Allow analyzer version `0.39.x`.

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -577,7 +577,7 @@ also work when you create an output directory.
   be the output directory. If no delimeter is provided, all resources
   will be copied to the output directory.
 - Allow deleting files in the post process build step.
-- Bug Fix: Correctly include the default whitelist when multiple targets
+- Bug Fix: Correctly include the default allow list when multiple targets
   without include are provided.
 - Allow logging from within a build factory.
 - Allow serving assets from successful build steps if the overall build fails.
@@ -768,13 +768,13 @@ also work when you create an output directory.
   - Disables stack trace folding and terse stack traces.
   - Disables the overwriting of previous info logs.
   - Sets the default log level to `Level.ALL`.
-- Added `pubspec.yaml` and `pubspec.lock` to the whitelist for the root package
+- Added `pubspec.yaml` and `pubspec.lock` to the allow list for the root package
   sources.
 
 ## 0.7.4
 
 - Allows using files in any build targets in the root package as sources if they
-  fall outside the hardcoded whitelist.
+  fall outside the hardcoded allow list.
 - Changes to the root `.packages` file during watch mode will now cause the
   build script to exit and prompt the user to restart the build.
 
@@ -827,7 +827,7 @@ also work when you create an output directory.
   `package:build_config` rather than a separate package and builder name.
 - Changed the default value of `hideOutput` from `false` to `true` for `apply`.
   With `applyToRoot` the value remains `false`.
-- There is now a whitelist of top level directories that will be used as a part
+- There is now a allow list of top level directories that will be used as a part
   of the build, and other files will be ignored. For now those directories
   include 'benchmark', 'bin', 'example', 'lib', 'test', 'tool', and 'web'.
   - If this breaks your workflow please file an issue and we can look at either

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -47,10 +47,7 @@
 
 ## 6.0.0
 
--   Remove some constants and utilities which are implementation details:
-    `defaultRootPackageWhitelist`, `errorCachePath`, `generatedOutputDirectory`,
-    `lockGeneratedOutputDirectory`, `overrideGeneratedOutputDirectory`,
-    `sdkPath`, `buildPhasePoolSize`.
+-   Remove some constants and utilities which are implementation details.
 
 ## 5.2.0
 
@@ -113,7 +110,7 @@
 - Add the `$package$` synthetic placeholder file and update the docs to prefer
   using only that or `lib/$lib$`.
 - Add the `assets` directory and `$package$` placeholders to the default
-  sources whitelist.
+  sources allow list.
 
 ## 4.2.1
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -145,7 +145,7 @@ of what it claimed.
 ## 2.6.0
 
 Add an option to globally skip the platform checks instead of only skipping
-them for a set of whitelisted packages.
+them for a set of allowed packages.
 
 ## 2.5.2
 


### PR DESCRIPTION
The code was already updated with the changelog left as is. While it's
not entirely clear that these removals are critical - it's easier to
just update it than to try to make the detection tools less sensitive.

Removes some specific references to code members that were removed in a
changelog entry that is old enough that the value of keeping the
specifics in the changelog is low. Rewrites other uses in prose since it
doesn't matter that they don't specifically match the names used in the
code at the time the changelog was written.