### PR TITLE
Allow nullsafety version(s) of bazel_worker

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.4
+
+- Allow the null safe pre-releases of `bazel_worker`.
+
 ## 3.0.3
 
 - Allow the null safe pre-releases of all migrated deps.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 3.0.3
+version: 3.0.4
 description: Builders for Dart modules
 repository: https://github.com/dart-lang/build/tree/master/build_modules
 
@@ -9,7 +9,7 @@ environment:
 dependencies:
   analyzer: ">0.36.4 <0.42.0"
   async: ^2.0.0
-  bazel_worker: ^0.1.20
+  bazel_worker: ">=0.1.18 <2.0.0"
   build: ">=1.3.0 <2.0.0"
   build_config: ">=0.3.0 <0.5.0"
   collection: ^1.0.0

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   analyzer: ">0.36.4 <0.42.0"
   async: ^2.0.0
-  bazel_worker: ">=0.1.18 <2.0.0"
+  bazel_worker: ">=0.1.20 <2.0.0"
   build: ">=1.3.0 <2.0.0"
   build_config: ">=0.3.0 <0.5.0"
   collection: ^1.0.0

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.16.3
+
+- Allow the null safety pre-release of `bazel_worker`.
+
 ## 2.16.2
 
 - Allow the null safety pre-release of `logging`.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.16.2
+version: 2.16.3
 description: Builder implementations wrapping Dart compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
@@ -9,7 +9,7 @@ environment:
 dependencies:
   analyzer: ">=0.36.4 <0.42.0"
   archive: '>=2.0.0 <4.0.0'
-  bazel_worker: ^0.1.18
+  bazel_worker: ">=0.1.18 <2.0.0"
   build: ">=1.5.0 <2.0.0"
   build_config: ">=0.3.0 <0.5.0"
   build_modules: ^3.0.0


### PR DESCRIPTION
@jakemac53 my apologies if I'm jumping the gun here, but we're working through some `2.12.x` dev readiness items at Workiva, and we've run into an issue where we can't upgrade past `analyzer 0.39.x` on the `2.12.x` dev build of the SDK unless `build_modules`, and subsequently `build_web_compilers` are updated to support the nullsafety release(s) of `bazel_worker`.

When using these version constraints locally - `pub get` resolves successfully.

If there are other work items that are needed besides version range changes - please feel free to close this PR without explanation :)