### PR TITLE
fix snapshot generation hanging on windows

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.11.2-dev
 
 - Update to glob `2.x`.
+- Fix snapshot generation hanging on windows if there is anything on stdout.
 
 ## 1.11.1
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.4
+
+- Fix snapshot generation hanging on windows if there is anything on stdout.
+
 ## 1.11.3
 
 - Allow the latest `build_config`.
@@ -5,7 +9,6 @@
 ## 1.11.2
 
 - Update to glob `2.x`.
-- Fix snapshot generation hanging on windows if there is anything on stdout.
 
 ## 1.11.1
 

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -79,7 +79,10 @@ Future<void> main(List<String> args) async {
       }
     });
   } else {
-    logListener = Logger.root.onRecord.listen(stdIOLogListener());
+    var verbose = parsedArgs.command['verbose'] as bool ?? false;
+    if (verbose) Logger.root.level = Level.ALL;
+    logListener =
+        Logger.root.onRecord.listen(stdIOLogListener(verbose: verbose));
   }
   if (localCommandNames.contains(commandName)) {
     exitCode = await commandRunner.runCommand(parsedArgs);

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -183,7 +183,7 @@ Future<int> _createSnapshotIfNeeded(Logger logger) async {
     });
     if (hadStdOut) {
       logger.info('There was output on stdout while compiling the build script '
-          'snapshot, run with `--verbose` to see the it (you will need to run '
+          'snapshot, run with `--verbose` to see it (you will need to run '
           'a `clean` first to re-snapshot)\n.');
     }
     if (!await snapshotFile.exists()) {

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -183,7 +183,8 @@ Future<int> _createSnapshotIfNeeded(Logger logger) async {
     });
     if (hadStdOut) {
       logger.info('There was output on stdout while compiling the build script '
-          'snapshot, run with `--verbose` to see the it\n.');
+          'snapshot, run with `--verbose` to see the it (you will need to run '
+          'a `clean` first to re-snapshot)\n.');
     }
     if (!await snapshotFile.exists()) {
       logger.severe('''

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.11.3
+version: 1.11.4
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/integration_tests/wrong_builder_factory_test.dart
+++ b/build_runner/test/integration_tests/wrong_builder_factory_test.dart
@@ -31,9 +31,9 @@ void main() {
     test('warns when builder definition produces invalid build script',
         () async {
       var result = await buildTool.build(expectExitCode: ExitCode.config.code);
+      expect(result, emitsThrough(contains('Getter not found: \'wrongKey\'')));
       expect(
           result, emitsThrough(contains('misconfigured builder definition')));
-      expect(result, emitsThrough(contains('Getter not found: \'wrongKey\'')));
     });
   });
 }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/2998

Logs at `fine` level everything on stdout, and `warning` everything on stderr. Adds an info level message if anything is visible on stdout telling you to run in `--verbose` mode.

This fixes the issue by actually draining the stdout stream. I am unsure why this is only presenting itself as an issue on windows, but seems like a good change anyways.