### PR TITLE
Remove overrides, expand build_config constraint

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -21,13 +21,3 @@ dev_dependencies:
   build_test: ^1.0.0
   pedantic: ^1.0.0
   test: ^1.2.0
-
-dependency_overrides:
-  ## Remove each of the following as they are published
-  build_config:
-    path: ../build_config
-  build_resolvers:
-    path: ../build_resolvers
-  build_test:
-    path: ../build_test
-  ## Remove each of the above as they are published

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -20,18 +20,3 @@ dev_dependencies:
   #json_serializable: ^3.0.0
   term_glyph: ^1.0.0
   test: ^1.6.0
-
-dependency_overrides:
-  ## Remove each of the following as they are published
-  build:
-    path: ../build
-  build_daemon:
-    path: ../build_daemon
-  build_resolvers:
-    path: ../build_resolvers
-  ## Remove each of the above as they are published
-  # Required due to the tight dependency on this package from these packages
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -20,3 +20,10 @@ dev_dependencies:
   #json_serializable: ^3.0.0
   term_glyph: ^1.0.0
   test: ^1.6.0
+
+dependency_overrides:
+  # Required due to the tight dependency on this package from these packages
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -28,13 +28,3 @@ dev_dependencies:
   test: ^1.3.3
   test_descriptor: ^1.1.1
   uuid: ^2.0.0
-
-dependency_overrides:
-  ## Remove each of the following as they are published
-  build_config:
-    path: ../build_config
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core
-  ## Remove each of the above as they are published

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -32,23 +32,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  ## Remove each of the below as they are published
-  build:
-    path: ../build
-  build_config:
-    path: ../build_config
-  build_daemon:
-    path: ../build_daemon
-  build_resolvers:
-    path: ../build_resolvers
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core
-  build_test:
-    path: ../build_test
-  scratch_space:
-    path: ../scratch_space
-  ## Remove each of the above as they are published

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -21,13 +21,3 @@ dependencies:
 dev_dependencies:
   test: ^1.0.0
   build_test: ^1.0.0
-
-dependency_overrides:
-  ## Remove each of the below as they are published
-  build:
-    path: ../build
-  build_config:
-    path: ../build_config
-  build_test:
-    path: ../build_test
-  ## Remove each of the above as they are published

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.3
+
+- Allow the latest `build_config`.
+
 ## 1.11.2
 
 - Update to glob `2.x`.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -51,25 +51,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  ## Remove each of the below as they are published
-  build:
-    path: ../build
-  build_config:
-    path: ../build_config
-  build_daemon:
-    path: ../build_daemon
-  build_modules:
-    path: ../build_modules
-  build_resolvers:
-    path: ../build_resolvers
-  build_runner_core:
-    path: ../build_runner_core
-  build_test:
-    path: ../build_test
-  build_web_compilers:
-    path: ../build_web_compilers
-  scratch_space:
-    path: ../scratch_space
-  ## Remove each of the above as they are published

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.11.2
+version: 1.11.3
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 
@@ -10,7 +10,7 @@ dependencies:
   args: ">=1.4.0 <3.0.0"
   async: ">=1.13.3 <3.0.0"
   build: ">=1.5.0 <1.7.0"
-  build_config: '>=0.4.1 <0.4.6'
+  build_config: '>=0.4.1 <0.4.7'
   build_daemon: ^2.1.0
   build_resolvers: ^1.4.0
   build_runner_core: ">=5.2.0 <7.0.0"

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.9
+
+- Allow the latest `build_config`.
+
 ## 6.1.8
 
 - Update glob to `2.x`.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 6.1.8
+version: 6.1.9
 description: Core tools to write binaries that run builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
@@ -9,7 +9,7 @@ environment:
 dependencies:
   async: ">=1.13.3 <3.0.0"
   build: ">=1.5.1 <1.7.0"
-  build_config: ">=0.4.3 <0.4.6"
+  build_config: ">=0.4.3 <0.4.7"
   build_resolvers: ^1.4.0
   collection: ^1.14.0
   convert: ">=2.0.1 <4.0.0"

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -33,15 +33,3 @@ dev_dependencies:
   test_process: ^1.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  ## Remove each of the below as they are published
-  build:
-    path: ../build
-  build_config:
-    path: ../build_config
-  build_resolvers:
-    path: ../build_resolvers
-  build_test:
-    path: ../build_test
-  ## Remove each of the above as they are published

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -27,13 +27,3 @@ dependencies:
 dev_dependencies:
   analyzer: ^1.0.0
   collection: ^1.14.0
-
-dependency_overrides:
-  ## Remove each of the below as they are published
-  build:
-    path: ../build
-  build_config:
-    path: ../build_config
-  build_resolvers:
-    path: ../build_resolvers
-  ## Remove each of the above as they are published

--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.8
+
+- Update to build_modules version `3.0.0`.
+
 ## 1.0.7
 
 - Update to latest analyzer version `1.0.0`.

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_vm_compilers
-version: 1.0.7
+version: 1.0.8
 description: Builder implementations wrapping Dart VM compilers.
 homepage: https://github.com/dart-lang/build/tree/master/build_vm_compilers
 
@@ -10,7 +10,7 @@ dependencies:
   analyzer: ^1.0.0
   build: ^1.0.0
   build_config: ">=0.3.0 <0.5.0"
-  build_modules: ^2.0.0
+  build_modules: ^3.0.0
   path: ^1.6.0
   pool: ^1.3.0
 

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -20,25 +20,3 @@ dev_dependencies:
   test_descriptor: ^1.1.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  ## Remove each of the below as they are published
-  build:
-    path: ../build
-  build_config:
-    path: ../build_config
-  build_daemon:
-    path: ../build_daemon
-  build_modules:
-    path: ../build_modules
-  build_resolvers:
-    path: ../build_resolvers
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core
-  build_test:
-    path: ../build_test
-  scratch_space:
-    path: ../scratch_space
-  ## Remove each of the above as they are published

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -33,25 +33,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  ## Remove each of the below as they are published
-  build:
-    path: ../build
-  build_config:
-    path: ../build_config
-  build_daemon:
-    path: ../build_daemon
-  build_modules:
-    path: ../build_modules
-  build_resolvers:
-    path: ../build_resolvers
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core
-  build_test:
-    path: ../build_test
-  scratch_space:
-    path: ../scratch_space
-  ## Remove each of the above as they are published

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -17,21 +17,3 @@ dev_dependencies:
   build_runner: ^1.0.0
   build_test: ^1.0.0
   test: ^1.0.0
-
-dependency_overrides:
-  ## Remove each of the below as they are published
-  build:
-    path: ../build
-  build_config:
-    path: ../build_config
-  build_daemon:
-    path: ../build_daemon
-  build_resolvers:
-    path: ../build_resolvers
-  build_runner:
-    path: ../build_runner
-  build_runner_core:
-    path: ../build_runner_core
-  build_test:
-    path: ../build_test
-  ## Remove each of the above as they are published


### PR DESCRIPTION
All the packages are published now so this cleans things up and removes the overrides.

I also expanded the build_config constraint in build_runner and build_runner_core which uses a tight constraint and didn't allow the latest version.

Also updates the build_modules dep in build_vm_compilers.