### PR TITLE
Fix clean and generate commands

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.5
+
+- Fix arg parsing for the `clean` and `generate-build-script` commands.
+
 ## 1.11.4
 
 - Fix snapshot generation hanging on windows if there is anything on stdout.

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -28,9 +28,9 @@ Future<void> main(List<String> args) async {
       BuildCommandRunner([], await PackageGraph.forThisPackage());
   var localCommands = [CleanCommand(), GenerateBuildScript()];
   var localCommandNames = localCommands.map((c) => c.name).toSet();
-  localCommands.forEach(commandRunner.addCommand);
   for (var command in localCommands) {
-    // This flag is added to each command indivudally
+    commandRunner.addCommand(command);
+    // This flag is added to each command individually and not the top level.
     command.argParser.addFlag(verboseOption,
         abbr: 'v',
         defaultsTo: false,

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -13,6 +13,7 @@ import 'package:io/io.dart';
 import 'package:logging/logging.dart';
 
 import 'package:build_runner/src/build_script_generate/bootstrap.dart';
+import 'package:build_runner/src/entrypoint/options.dart';
 import 'package:build_runner/src/entrypoint/runner.dart';
 import 'package:build_runner/src/logging/std_io_logging.dart';
 
@@ -28,8 +29,14 @@ Future<void> main(List<String> args) async {
   var localCommands = [CleanCommand(), GenerateBuildScript()];
   var localCommandNames = localCommands.map((c) => c.name).toSet();
   localCommands.forEach(commandRunner.addCommand);
-  commandRunner.argParser.addFlag('verbose',
-      defaultsTo: false, negatable: false, help: 'Enables verbose logging.');
+  for (var command in localCommands) {
+    // This flag is added to each command indivudally
+    command.argParser.addFlag(verboseOption,
+        abbr: 'v',
+        defaultsTo: false,
+        negatable: false,
+        help: 'Enables verbose logging.');
+  }
 
   ArgResults parsedArgs;
   try {
@@ -81,7 +88,7 @@ Future<void> main(List<String> args) async {
       }
     });
   } else {
-    var verbose = parsedArgs['verbose'] as bool ?? false;
+    var verbose = parsedArgs.command['verbose'] as bool ?? false;
     if (verbose) Logger.root.level = Level.ALL;
     logListener =
         Logger.root.onRecord.listen(stdIOLogListener(verbose: verbose));

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -28,6 +28,8 @@ Future<void> main(List<String> args) async {
   var localCommands = [CleanCommand(), GenerateBuildScript()];
   var localCommandNames = localCommands.map((c) => c.name).toSet();
   localCommands.forEach(commandRunner.addCommand);
+  commandRunner.argParser.addFlag('verbose',
+      defaultsTo: false, negatable: false, help: 'Enables verbose logging.');
 
   ArgResults parsedArgs;
   try {
@@ -79,7 +81,7 @@ Future<void> main(List<String> args) async {
       }
     });
   } else {
-    var verbose = parsedArgs.command['verbose'] as bool ?? false;
+    var verbose = parsedArgs['verbose'] as bool ?? false;
     if (verbose) Logger.root.level = Level.ALL;
     logListener =
         Logger.root.onRecord.listen(stdIOLogListener(verbose: verbose));

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -184,7 +184,7 @@ Future<int> _createSnapshotIfNeeded(Logger logger) async {
     if (hadStdOut) {
       logger.info('There was output on stdout while compiling the build script '
           'snapshot, run with `--verbose` to see it (you will need to run '
-          'a `clean` first to re-snapshot)\n.');
+          'a `clean` first to re-snapshot).\n');
     }
     if (!await snapshotFile.exists()) {
       logger.severe('''

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.11.4
+version: 1.11.5
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/entrypoint/run_test.dart
+++ b/build_runner/test/entrypoint/run_test.dart
@@ -17,7 +17,7 @@ import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 void main() {
-  setUp(() async {
+  setUpAll(() async {
     await d.dir('a', [
       await pubspec(
         'a',
@@ -51,6 +51,11 @@ main() {
     ]).create();
 
     await pubGet('a', offline: false);
+  });
+
+  tearDown(() async {
+    expect((await runPub('a', 'run', args: ['build_runner', 'clean'])).exitCode,
+        0);
   });
 
   void expectOutput(String path, {@required bool exists}) {


### PR DESCRIPTION
This effectively does add some integration test coverage for `clean`, but we should follow up with some explicit integration tests for both of these commands.

Filed https://github.com/dart-lang/build/issues/3016