### PR TITLE
Migrate build_test, tests of migrated packages, example

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -29,7 +29,3 @@ dependency_overrides:
     path: ../build_test
   # Remove each of the above as they are published.
   # They're only used for testing.
-  graphs:
-    git:
-      url: https://github.com/hovadur/graphs.git
-      ref: a19da5b30388752a62d0eb96d38f371311c0cebf

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -27,4 +27,9 @@ dependency_overrides:
     path: ../build_resolvers
   build_test:
     path: ../build_test
-  ## Remove each of the above as they are published
+  # Remove each of the above as they are published.
+  # They're only used for testing.
+  graphs:
+    git:
+      url: https://github.com/hovadur/graphs.git
+      ref: a19da5b30388752a62d0eb96d38f371311c0cebf

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -17,8 +17,8 @@ dependencies:
   path: ^1.8.0
 
 dev_dependencies:
-  build_resolvers: ^1.0.0
-  build_test: ^1.4.0
+  build_resolvers: ^2.0.0
+  build_test: ^2.0.0
   pedantic: ^1.0.0
   test: ^1.16.0
 

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-//@dart=2.9
 @TestOn('vm')
 import 'dart:async';
 import 'dart:convert';
@@ -16,7 +15,7 @@ import 'package:build/build.dart';
 import 'package:build/src/builder/build_step_impl.dart';
 
 void main() {
-  ResourceManager resourceManager;
+  late ResourceManager resourceManager;
 
   setUp(() {
     resourceManager = ResourceManager();
@@ -27,8 +26,8 @@ void main() {
   });
 
   group('with reader/writer stub', () {
-    AssetId primary;
-    BuildStepImpl buildStep;
+    late AssetId primary;
+    late BuildStepImpl buildStep;
 
     setUp(() {
       var reader = StubAssetReader();
@@ -55,8 +54,8 @@ void main() {
   });
 
   group('with in memory file system', () {
-    InMemoryAssetWriter writer;
-    InMemoryAssetReader reader;
+    late InMemoryAssetWriter writer;
+    late InMemoryAssetReader reader;
 
     setUp(() {
       writer = InMemoryAssetWriter();
@@ -107,7 +106,7 @@ void main() {
             isTrue);
 
         var bLib = await resolver.findLibraryByName('b');
-        expect(bLib.name, 'b');
+        expect(bLib!.name, 'b');
         expect(bLib.importedLibraries.length, 1);
 
         await buildStep.complete();
@@ -116,10 +115,10 @@ void main() {
   });
 
   group('With slow writes', () {
-    BuildStepImpl buildStep;
-    SlowAssetWriter assetWriter;
-    AssetId outputId;
-    String outputContent;
+    late BuildStepImpl buildStep;
+    late SlowAssetWriter assetWriter;
+    late AssetId outputId;
+    late String outputContent;
 
     setUp(() async {
       var primary = makeAssetId();
@@ -165,9 +164,9 @@ void main() {
   });
 
   group('With erroring writes', () {
-    AssetId primary;
-    BuildStepImpl buildStep;
-    AssetId output;
+    late AssetId primary;
+    late BuildStepImpl buildStep;
+    late AssetId output;
 
     setUp(() {
       var reader = StubAssetReader();

--- a/build/test/builder/multiplexing_builder_test.dart
+++ b/build/test/builder/multiplexing_builder_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';

--- a/build/test/generate/run_builder_test.dart
+++ b/build/test/generate/run_builder_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 @TestOn('vm')
 import 'dart:async';
 
@@ -12,15 +11,15 @@ import 'package:build/build.dart';
 import 'package:build/src/generate/run_builder.dart';
 
 void main() {
-  InMemoryAssetWriter writer;
-  InMemoryAssetReader reader;
+  late InMemoryAssetWriter writer;
+  late InMemoryAssetReader reader;
   final primary = makeAssetId('a|web/primary.txt');
   final inputs = {
     primary: 'foo',
   };
-  Resource resource;
-  bool resourceDisposed;
-  Builder builder;
+  late Resource resource;
+  late bool resourceDisposed;
+  late Builder builder;
 
   setUp(() async {
     resourceDisposed = false;
@@ -35,7 +34,7 @@ void main() {
   });
 
   group('Given a ResourceManager', () {
-    TrackingResourceManager resourceManager;
+    late TrackingResourceManager resourceManager;
 
     setUp(() async {
       resourceManager = TrackingResourceManager();

--- a/build/test/generate/run_post_process_builder_test.dart
+++ b/build/test/generate/run_post_process_builder_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
@@ -12,8 +11,8 @@ import '../common/builders.dart';
 
 void main() {
   group('runPostProcessBuilder', () {
-    InMemoryAssetReader reader;
-    InMemoryAssetWriter writer;
+    late InMemoryAssetReader reader;
+    late InMemoryAssetWriter writer;
     final copyBuilder = CopyingPostProcessBuilder();
     final deleteBuilder = DeletePostProcessBuilder();
     final aTxt = makeAssetId('a|lib/a.txt');

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 
 dev_dependencies:
   test: ^1.16.0
-  build_test: ^1.0.0
+  build_test: ^1.4.0-dev
 
 dependency_overrides:
   # Temporarily required until build version 2.0.0 is released

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 
 dev_dependencies:
   test: ^1.16.0
-  build_test: ^1.4.0-dev
+  build_test: ^2.0.0
 
 dependency_overrides:
   # Temporarily required until build version 2.0.0 is released

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -62,4 +62,3 @@ dependency_overrides:
     path: ../build_resolvers
   build_runner_core:
     path: ../build_runner_core
-

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.4.0-dev
 
-- Migrate to null safety
+- Migrate `package:build_test/build_test.dart` to null safety.
 
 ## 1.3.7
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.4.0-dev
+## 2.0.0
 
 - Migrate `package:build_test/build_test.dart` to null safety.
 

--- a/build_test/lib/build_test.dart
+++ b/build_test/lib/build_test.dart
@@ -1,8 +1,6 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-//
-// @dart=2.9
 
 export 'package:build/src/builder/logging.dart' show scopeLogAsync;
 

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -175,8 +175,9 @@ Future<T> _resolveAssets<T>(
   Future<Null>? tearDown,
   Resolvers? resolvers,
 }) async {
-  packageConfig ??= await loadPackageConfigUri((await Isolate.packageConfig)!);
-  final assetReader = PackageAssetReader(packageConfig, rootPackage);
+  final resolvedConfig = packageConfig ??
+      await loadPackageConfigUri((await Isolate.packageConfig)!);
+  final assetReader = PackageAssetReader(resolvedConfig, rootPackage);
   final resolveBuilder = _ResolveSourceBuilder(
     action,
     resolverFor,
@@ -198,9 +199,9 @@ Future<T> _resolveAssets<T>(
 
   // Use the default resolver if no experiments are enabled. This is much
   // faster.
-  resolvers ??= enabledExperiments.isEmpty
+  resolvers ??= packageConfig == null && enabledExperiments.isEmpty
       ? defaultResolvers
-      : AnalyzerResolvers(null, null, packageConfig);
+      : AnalyzerResolvers(null, null, resolvedConfig);
 
   // We don't care about the results of this build, but we also can't await
   // it because that would block on the `tearDown` of the `resolveBuilder`.

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-//@dart=2.9
 
 import 'dart:async';
 import 'dart:isolate';
@@ -30,10 +29,10 @@ const useAssetReader = '__useAssetReader__';
 Future<T> resolveSource<T>(
   String inputSource,
   FutureOr<T> Function(Resolver resolver) action, {
-  AssetId inputId,
-  PackageConfig packageConfig,
-  Future<Null> tearDown,
-  Resolvers resolvers,
+  AssetId? inputId,
+  PackageConfig? packageConfig,
+  Future<Null>? tearDown,
+  Resolvers? resolvers,
 }) {
   inputId ??= AssetId('_resolve_source', 'lib/_resolve_source.dart');
   return _resolveAssets(
@@ -121,13 +120,13 @@ Future<T> resolveSource<T>(
 Future<T> resolveSources<T>(
   Map<String, String> inputs,
   FutureOr<T> Function(Resolver resolver) action, {
-  PackageConfig packageConfig,
-  String resolverFor,
-  String rootPackage,
-  Future<Null> tearDown,
-  Resolvers resolvers,
+  PackageConfig? packageConfig,
+  String? resolverFor,
+  String? rootPackage,
+  Future<Null>? tearDown,
+  Resolvers? resolvers,
 }) {
-  if (inputs == null || inputs.isEmpty) {
+  if (inputs.isEmpty) {
     throw ArgumentError.value(inputs, 'inputs', 'Must be a non-empty Map');
   }
   return _resolveAssets(
@@ -145,9 +144,9 @@ Future<T> resolveSources<T>(
 Future<T> resolveAsset<T>(
   AssetId inputId,
   FutureOr<T> Function(Resolver resolver) action, {
-  PackageConfig packageConfig,
-  Future<Null> tearDown,
-  Resolvers resolvers,
+  PackageConfig? packageConfig,
+  Future<Null>? tearDown,
+  Resolvers? resolvers,
 }) {
   return _resolveAssets(
     {
@@ -171,12 +170,12 @@ Future<T> _resolveAssets<T>(
   Map<String, String> inputs,
   String rootPackage,
   FutureOr<T> Function(Resolver resolver) action, {
-  PackageConfig packageConfig,
-  AssetId resolverFor,
-  Future<Null> tearDown,
-  Resolvers resolvers,
+  PackageConfig? packageConfig,
+  AssetId? resolverFor,
+  Future<Null>? tearDown,
+  Resolvers? resolvers,
 }) async {
-  packageConfig ??= await loadPackageConfigUri(await Isolate.packageConfig);
+  packageConfig ??= await loadPackageConfigUri((await Isolate.packageConfig)!);
   final assetReader = PackageAssetReader(packageConfig, rootPackage);
   final resolveBuilder = _ResolveSourceBuilder(
     action,
@@ -186,7 +185,7 @@ Future<T> _resolveAssets<T>(
   final inputAssets = <AssetId, String>{};
   await Future.wait(inputs.keys.map((String rawAssetId) async {
     final assetId = AssetId.parse(rawAssetId);
-    var assetValue = inputs[rawAssetId];
+    var assetValue = inputs[rawAssetId]!;
     if (assetValue == useAssetReader) {
       assetValue = await assetReader.readAsString(assetId);
     }
@@ -197,9 +196,9 @@ Future<T> _resolveAssets<T>(
     rootPackage: rootPackage,
   );
 
-  // Use the default resolver if not provided a package config and no
-  // experiments are enabled. This is much faster.
-  resolvers ??= packageConfig == null && enabledExperiments.isEmpty
+  // Use the default resolver if no experiments are enabled. This is much
+  // faster.
+  resolvers ??= enabledExperiments.isEmpty
       ? defaultResolvers
       : AnalyzerResolvers(null, null, packageConfig);
 
@@ -227,8 +226,8 @@ Future<T> _resolveAssets<T>(
 /// input given a set of dependencies to also use. See `resolveSource`.
 class _ResolveSourceBuilder<T> implements Builder {
   final FutureOr<T> Function(Resolver) _action;
-  final Future _tearDown;
-  final AssetId _resolverFor;
+  final Future? _tearDown;
+  final AssetId? _resolverFor;
 
   final onDone = Completer<T>();
 

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -38,7 +38,7 @@ AssetId _passThrough(AssetId id) => id;
 /// association to a package pass [mapAssetIds] to translate from the logical
 /// location to the actual written location.
 void checkOutputs(
-    Map<String, /*List<int>|String|Matcher<List<int>>*/ dynamic>? outputs,
+    Map<String, /*List<int>|String|Matcher<List<int>>*/ Object>? outputs,
     Iterable<AssetId> actualAssets,
     RecordingAssetWriter writer,
     {AssetId Function(AssetId id) mapAssetIds = _passThrough}) {
@@ -125,13 +125,13 @@ void checkOutputs(
 /// Enabling of language experiments is supported through the
 /// `withEnabledExperiments` method from package:build.
 Future testBuilder(
-    Builder builder, Map<String, /*String|List<int>*/ dynamic> sourceAssets,
+    Builder builder, Map<String, /*String|List<int>*/ Object> sourceAssets,
     {Set<String>? generateFor,
     bool Function(String assetId)? isInput,
     String? rootPackage,
     MultiPackageAssetReader? reader,
     RecordingAssetWriter? writer,
-    Map<String, /*String|List<int>|Matcher<List<int>>*/ dynamic>? outputs,
+    Map<String, /*String|List<int>|Matcher<List<int>>*/ Object>? outputs,
     void Function(LogRecord log)? onLog,
     void Function(AssetId, Iterable<AssetId>)? reportUnusedAssetsForInput,
     PackageConfig? packageConfig}) async {

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 import 'dart:convert';
 
 import 'package:build/build.dart';
@@ -39,7 +38,7 @@ AssetId _passThrough(AssetId id) => id;
 /// association to a package pass [mapAssetIds] to translate from the logical
 /// location to the actual written location.
 void checkOutputs(
-    Map<String, /*List<int>|String|Matcher<List<int>>*/ dynamic> outputs,
+    Map<String, /*List<int>|String|Matcher<List<int>>*/ dynamic>? outputs,
     Iterable<AssetId> actualAssets,
     RecordingAssetWriter writer,
     {AssetId Function(AssetId id) mapAssetIds = _passThrough}) {
@@ -56,7 +55,7 @@ void checkOutputs(
       expect(modifiableActualAssets, contains(assetId),
           reason: 'Builder failed to write asset $assetId');
       modifiableActualAssets.remove(assetId);
-      var actual = writer.assets[mapAssetIds(assetId)];
+      var actual = writer.assets[mapAssetIds(assetId)]!;
       Object expected;
       if (contentsMatcher is String) {
         expected = utf8.decode(actual);
@@ -127,15 +126,15 @@ void checkOutputs(
 /// `withEnabledExperiments` method from package:build.
 Future testBuilder(
     Builder builder, Map<String, /*String|List<int>*/ dynamic> sourceAssets,
-    {Set<String> generateFor,
-    bool Function(String assetId) isInput,
-    String rootPackage,
-    MultiPackageAssetReader reader,
-    RecordingAssetWriter writer,
-    Map<String, /*String|List<int>|Matcher<List<int>>*/ dynamic> outputs,
-    void Function(LogRecord log) onLog,
-    void Function(AssetId, Iterable<AssetId>) reportUnusedAssetsForInput,
-    PackageConfig packageConfig}) async {
+    {Set<String>? generateFor,
+    bool Function(String assetId)? isInput,
+    String? rootPackage,
+    MultiPackageAssetReader? reader,
+    RecordingAssetWriter? writer,
+    Map<String, /*String|List<int>|Matcher<List<int>>*/ dynamic>? outputs,
+    void Function(LogRecord log)? onLog,
+    void Function(AssetId, Iterable<AssetId>)? reportUnusedAssetsForInput,
+    PackageConfig? packageConfig}) async {
   writer ??= InMemoryAssetWriter();
 
   var inputIds = {
@@ -164,8 +163,8 @@ Future testBuilder(
     }
   });
 
-  isInput ??= generateFor?.contains ?? (_) => true;
-  inputIds.retainWhere((id) => isInput('$id'));
+  final inputFilter = isInput ?? generateFor?.contains ?? (_) => true;
+  inputIds.retainWhere((id) => inputFilter('$id'));
 
   var writerSpy = AssetWriterSpy(writer);
   var logger = Logger('testBuilder');

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 1.4.0-dev
+version: 2.0.0-dev
 homepage: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -29,7 +29,12 @@ dev_dependencies:
   collection: ^1.14.0
 
 dependency_overrides:
+  # Remove this once the respective packages are published
   build:
     path: ../build
   build_resolvers:
     path: ../build_resolvers
+  graphs:
+    git:
+      url: https://github.com/hovadur/graphs.git
+      ref: a19da5b30388752a62d0eb96d38f371311c0cebf

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -34,7 +34,3 @@ dependency_overrides:
     path: ../build
   build_resolvers:
     path: ../build_resolvers
-  graphs:
-    git:
-      url: https://github.com/hovadur/graphs.git
-      ref: a19da5b30388752a62d0eb96d38f371311c0cebf

--- a/build_test/test/check_outputs_test.dart
+++ b/build_test/test/check_outputs_test.dart
@@ -1,4 +1,3 @@
-//@dart=2.9
 import 'package:test/test.dart';
 
 import 'package:build_test/build_test.dart';

--- a/build_test/test/debug_test_builder_test.dart
+++ b/build_test/test/debug_test_builder_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 
 import 'package:test/test.dart';
 

--- a/build_test/test/debug_test_builder_test.dart
+++ b/build_test/test/debug_test_builder_test.dart
@@ -97,7 +97,7 @@ class _IgnoringNewlinesAndWhitespaceMatcher extends Matcher {
   @override
   bool matches(item, Map matchState) {
     if (item is! String) return false;
-    return _stripWhitespaceAndNewlines(item as String) == _expected;
+    return _stripWhitespaceAndNewlines(item) == _expected;
   }
 }
 

--- a/build_test/test/in_memory_reader_test.dart
+++ b/build_test/test/in_memory_reader_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
@@ -14,7 +13,7 @@ void main() {
     final libAsset = AssetId(packageName, 'lib/some_pkg.dart');
     final testAsset = AssetId(packageName, 'test/some_test.dart');
 
-    InMemoryAssetReader assetReader;
+    late InMemoryAssetReader assetReader;
 
     setUp(() {
       var allAssets = {

--- a/build_test/test/multi_asset_reader_test.dart
+++ b/build_test/test/multi_asset_reader_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';

--- a/build_test/test/package_reader_test.dart
+++ b/build_test/test/package_reader_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
@@ -10,7 +9,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('$PackageAssetReader', () {
-    PackageAssetReader reader;
+    late PackageAssetReader reader;
 
     final buildAsset = AssetId('build', 'lib/build.dart');
     final buildTest = AssetId('build_test', 'lib/build_test.dart');

--- a/build_test/test/record_logs_test.dart
+++ b/build_test/test/record_logs_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 
 import 'dart:async';
 

--- a/build_test/test/test_builder_test.dart
+++ b/build_test/test/test_builder_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 
 import 'dart:async';
 

--- a/build_test/test/written_asset_reader_test.dart
+++ b/build_test/test/written_asset_reader_test.dart
@@ -1,13 +1,11 @@
-// @dart=2.9
-
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:glob/glob.dart';
 import 'package:test/test.dart';
 
 void main() {
-  WrittenAssetReader reader;
-  InMemoryAssetWriter writer;
+  late WrittenAssetReader reader;
+  late InMemoryAssetWriter writer;
 
   setUp(() async {
     writer = InMemoryAssetWriter();

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,10 +1,10 @@
 name: example
 
 environment:
-  sdk: ">=2.10.0-93.0.dev <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
-  build: ^1.0.0
+  build: ^2.0.0
   # Not imported in code, but used to constrain `build.yaml` requirements
   build_config: ">=0.3.0 <0.5.0"
 

--- a/example/web/index.dart
+++ b/example/web/index.dart
@@ -5,5 +5,5 @@
 import 'dart:html';
 
 void main() {
-  querySelector('#content').appendText('Script running!');
+  querySelector('#content')!.appendText('Script running!');
 }

--- a/example/web/index.dart.info
+++ b/example/web/index.dart.info
@@ -1,3 +1,3 @@
          Input ID: example|web/index.dart
      Member count: 1
-Visible libraries: 22
+Visible libraries: 25

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -26,7 +26,3 @@ dependency_overrides:
     path: ../build_resolvers
   build_test:
     path: ../build_test
-  graphs: # todo: Remove before merging
-    git:
-      url: https://github.com/hovadur/graphs.git
-      ref: a19da5b30388752a62d0eb96d38f371311c0cebf

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.0.0
-  build_test: ^1.0.0
-  test: ^1.0.0
+  build_test: ^1.4.0-dev
+  test: ^1.16.0
 
 dependency_overrides:
   # Temporarily required until build version 2.0.0 is released

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.0.0
-  build_test: ^1.4.0-dev
+  build_test: ^2.0.0
   test: ^1.16.0
 
 dependency_overrides:

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -26,3 +26,7 @@ dependency_overrides:
     path: ../build_resolvers
   build_test:
     path: ../build_test
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -22,3 +22,11 @@ dependency_overrides:
   # Temporarily required until build version 2.0.0 is released
   build:
     path: ../build
+  build_resolvers:
+    path: ../build_resolvers
+  build_test:
+    path: ../build_test
+  graphs: # todo: Remove before merging
+    git:
+      url: https://github.com/hovadur/graphs.git
+      ref: a19da5b30388752a62d0eb96d38f371311c0cebf

--- a/scratch_space/test/scratch_space_test.dart
+++ b/scratch_space/test/scratch_space_test.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// @dart=2.9
 
 import 'dart:async';
 import 'dart:convert';
@@ -19,8 +18,8 @@ import 'package:scratch_space/src/util.dart';
 
 void main() {
   group('ScratchSpace', () {
-    ScratchSpace scratchSpace;
-    InMemoryAssetReader assetReader;
+    late ScratchSpace scratchSpace;
+    late InMemoryAssetReader assetReader;
 
     var allAssets = [
       'dep|lib/dep.dart',


### PR DESCRIPTION
This migrates:

- `package:build_test`
- the tests of `package:build`, `package:build_resolvers` and `package:scratch_space`
- the example in this repo

With this, builder authors will be able to write and test their builders with sound null safety :tada: 