### PR TITLE
Support latest web socket packages

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.9-dev
+
+- Support version `1.x` of `shelf_web_socket` and `2.x` of `web_socket_channel`
+
 ## 2.1.8
 
 - Begin conversion to use analyzer 1.0.0.

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 2.1.8
+version: 2.1.9-dev
 description: A daemon for running Dart builds.
 homepage: https://github.com/dart-lang/build/tree/master/build_daemon
 
@@ -15,10 +15,10 @@ dependencies:
   path: ^1.6.2
   pool: ^1.3.6
   shelf: '>=0.7.4 <2.0.0'
-  shelf_web_socket: ^0.2.2+4
+  shelf_web_socket: '>=0.2.2+4 <2.0.0'
   stream_transform: ">=0.0.20 <3.0.0"
   watcher: '>=0.9.7 <2.0.0'
-  web_socket_channel: ^1.0.9
+  web_socket_channel: '>=1.0.9 <3.0.0'
 
 dev_dependencies:
   build_runner: ^1.0.0

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -3,6 +3,7 @@
 - __Breaking__: Remove support for hot-reloads. Use `package:webdev` instead.
 - Support version 2.0.x of the `build` package
 - Update to graphs `1.x`
+- Support version `1.x` of `shelf_web_socket` and `2.x` of `web_socket_channel`
 
 ## 1.11.5
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -32,12 +32,12 @@ dependencies:
   pub_semver: ">=1.4.0 <3.0.0"
   pubspec_parse: ^1.0.0
   shelf: ">=0.6.5 <2.0.0"
-  shelf_web_socket: ^0.2.2+4
+  shelf_web_socket: ">=0.2.2+4 <2.0.0"
   stack_trace: ^1.9.0
   stream_transform: ">=0.0.20 <3.0.0"
   timing: ^0.1.1
   watcher: '>=0.9.7 <2.0.0'
-  web_socket_channel: ^1.0.9
+  web_socket_channel: '>=1.0.9 <3.0.0'
   yaml: ">=2.1.11 <4.0.0"
 
 dev_dependencies:
@@ -64,3 +64,7 @@ dependency_overrides:
     path: ../build_resolvers
   build_runner_core:
     path: ../build_runner_core
+  # We're overriding build_daemon so that the CI runs tests with the latest
+  # versions of web_socket_channel. This can be removed safely.
+  build_daemon:
+    path: ../build_daemon


### PR DESCRIPTION
Support the latest version of `web_socket_channel` and `shelf_web_socket` in `build_runner` and `build_daemon`.

Closes #3024. Closes #3025.