### PR TITLE
Change AssetId.resolve argument from String to Uri

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Migrate to null-safety
 - __Breaking__: Remove the deprecated `rootPackage` argument to `runBuilder`
+- __Breaking__: Change the first argument to `AssetId.resolve` from a `String`
+  (which previously was required to be a valid URI) to a `Uri` instance. Call
+  sites which have static errors can wrap the argument with `Uri.parse()`.
 
 ## 1.6.3
 

--- a/build/README.md
+++ b/build/README.md
@@ -95,7 +95,8 @@ class ResolvingCopyBuilder implements Builder {
     var resolver = buildStep.resolver;
     // Get a `LibraryElement` for another asset.
     var libFromAsset = await resolver.libraryFor(
-        AssetId.resolve('some_import.dart', from: buildStep.inputId));
+        AssetId.resolve(Uri.parse('some_import.dart'),
+        from: buildStep.inputId));
     // Or get a `LibraryElement` by name.
     var libByName = await resolver.findLibraryByName('my.library');
   }

--- a/build/lib/src/asset/id.dart
+++ b/build/lib/src/asset/id.dart
@@ -55,31 +55,22 @@ class AssetId implements Comparable<AssetId> {
   ///
   /// `asset:` uris have the format '$package/$path', including the top level
   /// directory.
-  factory AssetId.resolve(String uri, {AssetId? from}) {
-    final parsedUri = Uri.parse(uri);
-    if (parsedUri.hasScheme) {
-      if (parsedUri.scheme == 'package') {
-        return AssetId(parsedUri.pathSegments.first,
-            p.url.join('lib', p.url.joinAll(parsedUri.pathSegments.skip(1))));
-      } else if (parsedUri.scheme == 'asset') {
-        return AssetId(parsedUri.pathSegments.first,
-            p.url.joinAll(parsedUri.pathSegments.skip(1)));
-      }
-      throw UnsupportedError(
-          'Cannot resolve $uri; only "package" and "asset" schemes supported');
+  factory AssetId.resolve(Uri uri, {AssetId? from}) {
+    var resolved = uri.hasScheme
+        ? uri
+        : from != null
+            ? from.uri.resolveUri(uri)
+            : (throw ArgumentError.value(from, 'from',
+                'An AssetId "from" must be specified to resolve a relative URI'));
+    if (resolved.scheme == 'package') {
+      return AssetId(resolved.pathSegments.first,
+          p.url.join('lib', p.url.joinAll(resolved.pathSegments.skip(1))));
+    } else if (resolved.scheme == 'asset') {
+      return AssetId(resolved.pathSegments.first,
+          p.url.joinAll(resolved.pathSegments.skip(1)));
     }
-    if (from == null) {
-      throw ArgumentError.value(from, 'from',
-          'An AssetId "from" must be specified to resolve a relative URI');
-    }
-
-    // Empty urls resolve to the base
-    if (uri.isEmpty) {
-      return from;
-    }
-
-    return AssetId(p.url.normalize(from.package),
-        p.url.join(p.url.dirname(from.path), uri));
+    throw UnsupportedError(
+        'Cannot resolve $uri; only "package" and "asset" schemes supported');
   }
 
   /// Parses an [AssetId] string of the form "package|path/to/asset.txt".

--- a/build/test/asset/id_test.dart
+++ b/build/test/asset/id_test.dart
@@ -51,60 +51,61 @@ void main() {
 
   group('resolve', () {
     test('should parse a package: URI', () {
-      var id = AssetId.resolve(r'package:app/app.dart');
+      var id = AssetId.resolve(Uri.parse(r'package:app/app.dart'));
       expect(id, AssetId('app', 'lib/app.dart'));
     });
 
     test('should parse a package: URI with a long path', () {
-      var id = AssetId.resolve(r'package:app/src/some/path.dart');
+      var id = AssetId.resolve(Uri.parse(r'package:app/src/some/path.dart'));
       expect(id, AssetId('app', 'lib/src/some/path.dart'));
     });
 
     test('should parse an asset: URI', () {
-      var id = AssetId.resolve(r'asset:app/test/foo_test.dart');
+      var id = AssetId.resolve(Uri.parse(r'asset:app/test/foo_test.dart'));
       expect(id, AssetId('app', 'test/foo_test.dart'));
     });
 
     test('should throw for a file: URI', () {
-      expect(() => AssetId.resolve(r'file://localhost/etc/fstab1'),
+      expect(() => AssetId.resolve(Uri.parse(r'file://localhost/etc/fstab1')),
           throwsUnsupportedError);
     });
 
     test('should throw for a dart: URI', () {
-      expect(() => AssetId.resolve(r'dart:collection'), throwsUnsupportedError);
+      expect(() => AssetId.resolve(Uri.parse(r'dart:collection')),
+          throwsUnsupportedError);
     });
 
     test('should throw parsing a relative package URI without an origin', () {
-      expect(() => AssetId.resolve('some/relative/path.dart'),
+      expect(() => AssetId.resolve(Uri.parse('some/relative/path.dart')),
           throwsArgumentError);
     });
 
     test('should parse a relative URI within the test/ folder', () {
-      var id = AssetId.resolve('common.dart',
+      var id = AssetId.resolve(Uri.parse('common.dart'),
           from: AssetId('app', 'test/some_test.dart'));
       expect(id, AssetId('app', 'test/common.dart'));
     });
 
     test('should parse a relative package URI', () {
-      var id = AssetId.resolve('some/relative/path.dart',
+      var id = AssetId.resolve(Uri.parse('some/relative/path.dart'),
           from: AssetId('app', 'lib/app.dart'));
       expect(id, AssetId('app', 'lib/some/relative/path.dart'));
     });
 
     test('should parse a relative package URI pointing back', () {
-      var id = AssetId.resolve('../src/some/path.dart',
+      var id = AssetId.resolve(Uri.parse('../src/some/path.dart'),
           from: AssetId('app', 'folder/folder.dart'));
       expect(id, AssetId('app', 'src/some/path.dart'));
     });
 
     test('should parse an empty url in lib/', () {
       var source = AssetId('foo', 'lib/src/bar.dart');
-      expect(AssetId.resolve('', from: source), source);
+      expect(AssetId.resolve(Uri.parse(''), from: source), source);
     });
 
     test('should parse an empty url in test/', () {
       var source = AssetId('foo', 'test/bar.dart');
-      expect(AssetId.resolve('', from: source), source);
+      expect(AssetId.resolve(Uri.parse(''), from: source), source);
     });
   });
 

--- a/build_modules/lib/src/errors.dart
+++ b/build_modules/lib/src/errors.dart
@@ -97,7 +97,7 @@ Future<String> _missingImportMessage(
       parsed.directives.whereType<UriBasedDirective>().firstWhere((directive) {
     var uriString = directive.uri.stringValue;
     if (uriString.startsWith('dart:')) return false;
-    var id = AssetId.resolve(uriString, from: sourceId);
+    var id = AssetId.resolve(Uri.parse(uriString), from: sourceId);
     return id == missingId;
   }, orElse: () => null);
   if (import == null) return null;

--- a/build_modules/lib/src/module_library.dart
+++ b/build_modules/lib/src/module_library.dart
@@ -91,7 +91,7 @@ class ModuleLibrary {
         sdkDeps.add(uri.path);
         continue;
       }
-      var linkedId = AssetId.resolve(path, from: id);
+      var linkedId = AssetId.resolve(uri, from: id);
       if (linkedId == null) continue;
       if (directive is PartDirective) {
         parts.add(linkedId);
@@ -114,7 +114,7 @@ class ModuleLibrary {
                 '`${condition.uri.stringValue}` found in $id.');
           }
           conditions[condition.name.toSource()] =
-              AssetId.resolve(condition.uri.stringValue, from: id);
+              AssetId.resolve(Uri.parse(condition.uri.stringValue), from: id);
         }
         conditionalDeps.add(conditions);
       } else {

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -144,7 +144,7 @@ class BuildAssetUriResolver extends UriResolver {
   AssetId? parseAsset(Uri uri) {
     if (_ignoredSchemes.any(uri.isScheme)) return null;
     if (uri.isScheme('package') || uri.isScheme('asset')) {
-      return AssetId.resolve('$uri');
+      return AssetId.resolve(uri);
     }
     if (uri.isScheme('file')) {
       final parts = p.split(uri.path);
@@ -211,7 +211,7 @@ Set<AssetId> _parseDirectives(String content, AssetId from) => HashSet.of(
           .whereType<String>()
           .where((uriContent) =>
               !_ignoredSchemes.any(Uri.parse(uriContent).isScheme))
-          .map((content) => AssetId.resolve(content, from: from)),
+          .map((content) => AssetId.resolve(Uri.parse(content), from: from)),
     );
 
 class _AssetState {

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -282,7 +282,7 @@ class AnalyzerResolver implements ReleasableResolver {
     if (!uri.isScheme('package') && !uri.isScheme('asset')) {
       throw UnresolvableAssetException('${element.name} in ${source.uri}');
     }
-    return AssetId.resolve('${source.uri}');
+    return AssetId.resolve(source.uri);
   }
 }
 


### PR DESCRIPTION
This prevents some situations from needing to convert a Uri to a String,
just to immediately re-parse it as a Uri. It also makes the argument
have a more clear intention and eliminates the possibility of passing a
String that is not a valid URI.