### PR TITLE
prep to release all packages with build 2.0 support

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-dev
+## 2.0.0
 
 - Migrate to null-safety
 - __Breaking__: Remove the deprecated `rootPackage` argument to `runBuilder`

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 2.0.0-dev
+version: 2.0.0
 description: A build system for Dart.
 repository: https://github.com/dart-lang/build/tree/master/build
 

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 3.0.6-dev
+## 3.0.6
 
 - Update to graphs `1.x`
+- Update to build `2.x`
+- Update to scratch_space `1.x`
 
 ## 3.0.5
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 3.0.6-dev
+version: 3.0.6
 description: Builders for Dart modules
 repository: https://github.com/dart-lang/build/tree/master/build_modules
 
@@ -10,7 +10,7 @@ dependencies:
   analyzer: ^1.0.0
   async: ^2.0.0
   bazel_worker: ">=0.1.20 <2.0.0"
-  build: "^2.0.0"
+  build: ^2.0.0
   build_config: ">=0.3.0 <0.5.0"
   collection: ^1.0.0
   crypto: ">=2.0.0 <4.0.0"
@@ -21,7 +21,7 @@ dependencies:
   meta: ^1.1.0
   path: ^1.4.2
   pedantic: ^1.0.0
-  scratch_space: ^0.0.4
+  scratch_space: ^1.0.0
 
 dev_dependencies:
   # Used inside tests

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   meta: ^1.1.0
   path: ^1.4.2
   pedantic: ^1.0.0
-  scratch_space: ^1.0.0
+  scratch_space: ">=0.0.4 <2.0.0"
 
 dev_dependencies:
   # Used inside tests

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.0.0-dev
+## 2.0.0
 
 - Migrate to null-safety
+- Update to build `2.x`.
 
 ## 1.5.4
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.0.0-dev
+version: 2.0.0
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.12.0-dev
+## 1.12.0
 
 - Remove support for hot-reloads. Use `package:webdev` instead.
 - Support version 2.0.x of the `build` package

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   shelf_web_socket: ">=0.2.2+4 <2.0.0"
   stack_trace: ^1.9.0
   stream_transform: ">=0.0.20 <3.0.0"
-  timing: ^0.1.1
+  timing: '>=0.1.1 <2.0.0'
   watcher: '>=0.9.7 <2.0.0'
   web_socket_channel: '>=1.0.9 <3.0.0'
   yaml: ">=2.1.11 <4.0.0"

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.12.0-dev
+version: 1.12.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 
@@ -13,7 +13,7 @@ dependencies:
   build_config: '>=0.4.1 <0.4.6'
   build_daemon: ^2.1.0
   build_resolvers: ^2.0.0
-  build_runner_core: ">=5.2.0 <7.0.0"
+  build_runner_core: ^6.1.11
   code_builder: ">2.3.0 <4.0.0"
   collection: ^1.14.0
   crypto: ">=0.9.2 <4.0.0"

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 6.1.11-dev
+## 6.1.11
 
 - Update to graphs `1.x`
+- Update to build `2.x`.
+- Update to build_resolvers `2.x`.
 
 ## 6.1.10
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 6.1.11-dev
+version: 6.1.11
 description: Core tools to write binaries that run builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   package_config: '>=1.9.0 <3.0.0'
   pedantic: ^1.0.0
   pool: ^1.0.0
-  timing: ^0.1.1
+  timing: '>=0.1.1 <2.0.0'
   watcher: '>=0.9.7 <2.0.0'
   yaml: ">=2.1.11 <4.0.0"
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.0.0
 
 - Migrate `package:build_test/build_test.dart` to null safety.
+- Update to build `2.x`.
+- Update to build_resolvers `2.x`.
 
 ## 1.3.7
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 2.0.0-dev
+version: 2.0.0
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: "^2.5.0"
-  build: "^2.0.0-dev"
+  build: "^2.0.0"
   build_config: ">=0.2.0 <0.5.0"
   build_resolvers: ^2.0.0
   crypto: "^3.0.0"

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 2.16.5-dev
+## 2.16.5
+
+- Update to build `2.x`.
+- Update to scratch_space `1.x`.
 
 ## 2.16.4
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 2.16.5-dev
+version: 2.16.5
 description: Builder implementations wrapping Dart compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
@@ -20,7 +20,7 @@ dependencies:
   meta: ^1.1.0
   path: ^1.4.2
   pool: ^1.3.0
-  scratch_space: ^0.0.2
+  scratch_space: ^1.0.0
   source_maps: ^0.10.4
   source_span: ^1.4.0
   stack_trace: ^1.9.2

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   meta: ^1.1.0
   path: ^1.4.2
   pool: ^1.3.0
-  scratch_space: ^1.0.0
+  scratch_space: ">=0.0.2 <2.0.0"
   source_maps: ^0.10.4
   source_span: ^1.4.0
   stack_trace: ^1.9.2

--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.0.5
 
 - Migrate to null-safety
+- Update to build `2.x`.
 
 ## 0.0.4+3
 

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scratch_space
-version: 0.0.5-dev
+version: 1.0.0
 description: A tool to manage running external executables within package:build
 respository: https://github.com/dart-lang/build/tree/master/scratch_space
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  build: "^2.0.0-dev"
+  build: "^2.0.0"
   crypto: "^3.0.0"
   path: ^1.8.0
   pedantic: ^1.10.0


### PR DESCRIPTION
cc @simolus3

With this all user facing packages should be migrated to null safety (build, build_resolvers, and package:build_test/build_test.dart).

And then it also bumps the deps in other packages to allow the new versions where there were breaking releases.

I also bumped `scratch_space` to 1.0.0