### PR TITLE
Adjust usage of `crawlAsync` for non-ignored nulls

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.7-dev
+
 ## 3.0.6
 
 - Update to graphs `1.x`

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -306,7 +306,7 @@ Future<void> _findModuleDeps(
 Future<List<Module>> _resolveTransitiveModules(
     Module root, BuildStep buildStep) async {
   var missing = <AssetId>{};
-  var modules = await crawlAsync<AssetId, Module /*?*/>(
+  var modules = await crawlAsync<AssetId, Module /*?*/ >(
           [root.primarySource],
           (id) => buildStep.fetchResource(moduleCache).then((c) async {
                 var moduleId =

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 3.0.6
+version: 3.0.7-dev
 description: Builders for Dart modules
 repository: https://github.com/dart-lang/build/tree/master/build_modules
 
@@ -22,6 +22,7 @@ dependencies:
   path: ^1.4.2
   pedantic: ^1.0.0
   scratch_space: ">=0.0.4 <2.0.0"
+  stream_transform: ^2.0.0
 
 dev_dependencies:
   # Used inside tests


### PR DESCRIPTION
See https://github.com/dart-lang/graphs/issues/58

Handle a null `module` argument in the `edges` callback, and filter out
nulls with `whereType`. This change is backwards compatible.