### PR TITLE
Unskip kernel integration test

### DIFF
--- a/build_vm_compilers/test/vm_kernel_integration_test.dart
+++ b/build_vm_compilers/test/vm_kernel_integration_test.dart
@@ -1,4 +1,3 @@
-@OnPlatform({'windows': Skip('https://github.com/dart-lang/build/issues/3001')})
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.


### PR DESCRIPTION
Closes #3001

Whatever failure existed previously is no longer present - potentially
as a result of further null safety migrations.