### PR TITLE
migrate build_config to null safety

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-dev
+
+- Migrate to null safety.
+
 ## 0.4.7
 
 - Allow the latest `pubspec_parse` and `checked_yaml`.

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -74,7 +74,7 @@ class BuildConfig {
   @JsonKey(name: 'global_options')
   final Map<String, GlobalBuilderConfig> globalOptions;
 
-  @JsonKey(name: 'additional_public_assets')
+  @JsonKey(name: 'additional_public_assets', defaultValue: [])
   final List<String> additionalPublicAssets;
 
   /// The default config if you have no `build.yaml` file.

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:checked_yaml/checked_yaml.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:pubspec_parse/pubspec_parse.dart';
 
@@ -68,6 +67,10 @@ class BuildConfig {
   @JsonKey(name: 'targets', fromJson: _buildTargetsFromJson)
   final Map<String, BuildTarget> buildTargets;
 
+  /// Used to represent no build target supplied, returned from
+  /// [_buildTargetsFromJson].
+  static final _placeholderBuildTarget = <String, BuildTarget>{};
+
   @JsonKey(name: 'global_options')
   final Map<String, GlobalBuilderConfig> globalOptions;
 
@@ -101,7 +104,7 @@ class BuildConfig {
     String packageName,
     Iterable<String> dependencies,
     String configYaml, {
-    String configYamlPath,
+    String? configYamlPath,
   }) {
     try {
       return checkedYamlDecode(
@@ -124,19 +127,21 @@ class BuildConfig {
   }
 
   BuildConfig({
-    String packageName,
-    @required Map<String, BuildTarget> buildTargets,
-    Map<String, GlobalBuilderConfig> globalOptions,
-    Map<String, BuilderDefinition> builderDefinitions,
-    Map<String, PostProcessBuilderDefinition> postProcessBuilderDefinitions =
+    String? packageName,
+    required Map<String, BuildTarget> buildTargets,
+    Map<String, GlobalBuilderConfig>? globalOptions,
+    Map<String, BuilderDefinition>? builderDefinitions,
+    Map<String, PostProcessBuilderDefinition>? postProcessBuilderDefinitions =
         const {},
     this.additionalPublicAssets = const [],
-  })  : buildTargets = buildTargets ??
-            {
-              _defaultTarget(packageName ?? currentPackage): BuildTarget(
-                dependencies: currentPackageDefaultDependencies,
-              )
-            },
+  })  : buildTargets =
+            identical(buildTargets, BuildConfig._placeholderBuildTarget)
+                ? {
+                    _defaultTarget(packageName ?? currentPackage): BuildTarget(
+                      dependencies: currentPackageDefaultDependencies,
+                    )
+                  }
+                : buildTargets,
         globalOptions = (globalOptions ?? const {}).map((key, config) =>
             MapEntry(normalizeBuilderKeyUsage(key, currentPackage), config)),
         builderDefinitions = _normalizeBuilderDefinitions(
@@ -171,9 +176,9 @@ Map<String, T> _normalizeBuilderDefinitions<T>(
     builderDefinitions.map((key, definition) =>
         MapEntry(normalizeBuilderKeyDefinition(key, packageName), definition));
 
-Map<String, BuildTarget> _buildTargetsFromJson(Map json) {
+Map<String, BuildTarget> _buildTargetsFromJson(Map? json) {
   if (json == null) {
-    return null;
+    return BuildConfig._placeholderBuildTarget;
   }
   var targets = json.map((key, target) => MapEntry(
       normalizeTargetKeyDefinition(key as String, currentPackage),

--- a/build_config/lib/src/build_config.g.dart
+++ b/build_config/lib/src/build_config.g.dart
@@ -17,33 +17,30 @@ BuildConfig _$BuildConfigFromJson(Map json) {
     ]);
     final val = BuildConfig(
       buildTargets: $checkedConvert(
-          json, 'targets', (v) => _buildTargetsFromJson(v as Map)),
+          json, 'targets', (v) => _buildTargetsFromJson(v as Map?)),
       globalOptions: $checkedConvert(
           json,
           'global_options',
-          (v) => (v as Map)?.map(
-                (k, e) => MapEntry(k as String,
-                    e == null ? null : GlobalBuilderConfig.fromJson(e as Map)),
+          (v) => (v as Map?)?.map(
+                (k, e) => MapEntry(
+                    k as String, GlobalBuilderConfig.fromJson(e as Map)),
               )),
       builderDefinitions: $checkedConvert(
           json,
           'builders',
-          (v) => (v as Map)?.map(
-                (k, e) => MapEntry(k as String,
-                    e == null ? null : BuilderDefinition.fromJson(e as Map)),
+          (v) => (v as Map?)?.map(
+                (k, e) =>
+                    MapEntry(k as String, BuilderDefinition.fromJson(e as Map)),
               )),
       postProcessBuilderDefinitions: $checkedConvert(
           json,
           'post_process_builders',
-          (v) => (v as Map)?.map(
-                (k, e) => MapEntry(
-                    k as String,
-                    e == null
-                        ? null
-                        : PostProcessBuilderDefinition.fromJson(e as Map)),
+          (v) => (v as Map?)?.map(
+                (k, e) => MapEntry(k as String,
+                    PostProcessBuilderDefinition.fromJson(e as Map)),
               )),
       additionalPublicAssets: $checkedConvert(json, 'additional_public_assets',
-          (v) => (v as List)?.map((e) => e as String)?.toList()),
+          (v) => (v as List<dynamic>).map((e) => e as String).toList()),
     );
     return val;
   }, fieldKeyMap: const {

--- a/build_config/lib/src/build_config.g.dart
+++ b/build_config/lib/src/build_config.g.dart
@@ -40,7 +40,8 @@ BuildConfig _$BuildConfigFromJson(Map json) {
                     PostProcessBuilderDefinition.fromJson(e as Map)),
               )),
       additionalPublicAssets: $checkedConvert(json, 'additional_public_assets',
-          (v) => (v as List<dynamic>).map((e) => e as String).toList()),
+              (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()) ??
+          [],
     );
     return val;
   }, fieldKeyMap: const {

--- a/build_config/lib/src/build_target.dart
+++ b/build_config/lib/src/build_target.dart
@@ -46,7 +46,10 @@ class BuildTarget {
             MapEntry(normalizeBuilderKeyUsage(key, currentPackage), config)),
         sources = sources ?? InputSet.anything;
 
-  factory BuildTarget.fromJson(Map json) => _$BuildTargetFromJson(json);
+  factory BuildTarget.fromJson(Map json) {
+    ArgumentError.checkNotNull(json);
+    return _$BuildTargetFromJson(json);
+  }
 
   @override
   String toString() => {
@@ -110,8 +113,10 @@ class TargetBuilderConfig {
         devOptions = devOptions ?? const {},
         releaseOptions = releaseOptions ?? const {};
 
-  factory TargetBuilderConfig.fromJson(Map json) =>
-      _$TargetBuilderConfigFromJson(json);
+  factory TargetBuilderConfig.fromJson(Map json) {
+    ArgumentError.checkNotNull(json);
+    return _$TargetBuilderConfigFromJson(json);
+  }
 
   @override
   String toString() => {
@@ -151,8 +156,10 @@ class GlobalBuilderConfig {
         devOptions = devOptions ?? const {},
         releaseOptions = releaseOptions ?? const {};
 
-  factory GlobalBuilderConfig.fromJson(Map json) =>
-      _$GlobalBuilderConfigFromJson(json);
+  factory GlobalBuilderConfig.fromJson(Map json) {
+    ArgumentError.checkNotNull(json);
+    return _$GlobalBuilderConfigFromJson(json);
+  }
 
   @override
   String toString() => {

--- a/build_config/lib/src/build_target.dart
+++ b/build_config/lib/src/build_target.dart
@@ -29,15 +29,15 @@ class BuildTarget {
   final InputSet sources;
 
   /// A unique key for this target in `'$package:$target'` format.
-  String get key => builderKeyExpando[this];
+  String get key => builderKeyExpando[this]!;
 
-  String get package => packageExpando[this];
+  String get package => packageExpando[this]!;
 
   BuildTarget({
-    bool autoApplyBuilders,
-    InputSet sources,
-    Iterable<String> dependencies,
-    Map<String, TargetBuilderConfig> builders,
+    bool? autoApplyBuilders,
+    InputSet? sources,
+    Iterable<String>? dependencies,
+    Map<String, TargetBuilderConfig>? builders,
   })  : autoApplyBuilders = autoApplyBuilders ?? true,
         dependencies = (dependencies ?? currentPackageDefaultDependencies)
             .map((d) => normalizeTargetKeyUsage(d, currentPackage))
@@ -80,7 +80,7 @@ class TargetBuilderConfig {
   /// [BuildTarget]. May be `null` in which cases it will be all the sources in
   /// the target.
   @JsonKey(name: 'generate_for')
-  final InputSet generateFor;
+  final InputSet? generateFor;
 
   /// The options to pass to the `BuilderFactory` when constructing this
   /// builder.
@@ -100,11 +100,11 @@ class TargetBuilderConfig {
   final Map<String, dynamic> releaseOptions;
 
   TargetBuilderConfig({
-    bool isEnabled,
+    bool? isEnabled,
     this.generateFor,
-    Map<String, dynamic> options,
-    Map<String, dynamic> devOptions,
-    Map<String, dynamic> releaseOptions,
+    Map<String, dynamic>? options,
+    Map<String, dynamic>? devOptions,
+    Map<String, dynamic>? releaseOptions,
   })  : isEnabled = isEnabled ?? true,
         options = options ?? const {},
         devOptions = devOptions ?? const {},
@@ -144,9 +144,9 @@ class GlobalBuilderConfig {
   final Map<String, dynamic> releaseOptions;
 
   GlobalBuilderConfig({
-    Map<String, dynamic> options,
-    Map<String, dynamic> devOptions,
-    Map<String, dynamic> releaseOptions,
+    Map<String, dynamic>? options,
+    Map<String, dynamic>? devOptions,
+    Map<String, dynamic>? releaseOptions,
   })  : options = options ?? const {},
         devOptions = devOptions ?? const {},
         releaseOptions = releaseOptions ?? const {};

--- a/build_config/lib/src/build_target.g.dart
+++ b/build_config/lib/src/build_target.g.dart
@@ -16,17 +16,17 @@ BuildTarget _$BuildTargetFromJson(Map json) {
     ]);
     final val = BuildTarget(
       autoApplyBuilders:
-          $checkedConvert(json, 'auto_apply_builders', (v) => v as bool),
+          $checkedConvert(json, 'auto_apply_builders', (v) => v as bool?),
       sources: $checkedConvert(
           json, 'sources', (v) => v == null ? null : InputSet.fromJson(v)),
-      dependencies: $checkedConvert(
-          json, 'dependencies', (v) => (v as List)?.map((e) => e as String)),
+      dependencies: $checkedConvert(json, 'dependencies',
+          (v) => (v as List<dynamic>?)?.map((e) => e as String)),
       builders: $checkedConvert(
           json,
           'builders',
-          (v) => (v as Map)?.map(
-                (k, e) => MapEntry(k as String,
-                    e == null ? null : TargetBuilderConfig.fromJson(e as Map)),
+          (v) => (v as Map?)?.map(
+                (k, e) => MapEntry(
+                    k as String, TargetBuilderConfig.fromJson(e as Map)),
               )),
     );
     return val;
@@ -43,25 +43,25 @@ TargetBuilderConfig _$TargetBuilderConfigFromJson(Map json) {
       'release_options'
     ]);
     final val = TargetBuilderConfig(
-      isEnabled: $checkedConvert(json, 'enabled', (v) => v as bool),
+      isEnabled: $checkedConvert(json, 'enabled', (v) => v as bool?),
       generateFor: $checkedConvert(
           json, 'generate_for', (v) => v == null ? null : InputSet.fromJson(v)),
       options: $checkedConvert(
           json,
           'options',
-          (v) => (v as Map)?.map(
+          (v) => (v as Map?)?.map(
                 (k, e) => MapEntry(k as String, e),
               )),
       devOptions: $checkedConvert(
           json,
           'dev_options',
-          (v) => (v as Map)?.map(
+          (v) => (v as Map?)?.map(
                 (k, e) => MapEntry(k as String, e),
               )),
       releaseOptions: $checkedConvert(
           json,
           'release_options',
-          (v) => (v as Map)?.map(
+          (v) => (v as Map?)?.map(
                 (k, e) => MapEntry(k as String, e),
               )),
     );
@@ -82,19 +82,19 @@ GlobalBuilderConfig _$GlobalBuilderConfigFromJson(Map json) {
       options: $checkedConvert(
           json,
           'options',
-          (v) => (v as Map)?.map(
+          (v) => (v as Map?)?.map(
                 (k, e) => MapEntry(k as String, e),
               )),
       devOptions: $checkedConvert(
           json,
           'dev_options',
-          (v) => (v as Map)?.map(
+          (v) => (v as Map?)?.map(
                 (k, e) => MapEntry(k as String, e),
               )),
       releaseOptions: $checkedConvert(
           json,
           'release_options',
-          (v) => (v as Map)?.map(
+          (v) => (v as Map?)?.map(
                 (k, e) => MapEntry(k as String, e),
               )),
     );

--- a/build_config/lib/src/builder_definition.dart
+++ b/build_config/lib/src/builder_definition.dart
@@ -138,8 +138,10 @@ class BuilderDefinition {
     }
   }
 
-  factory BuilderDefinition.fromJson(Map json) =>
-      _$BuilderDefinitionFromJson(json);
+  factory BuilderDefinition.fromJson(Map json) {
+    ArgumentError.checkNotNull(json);
+    return _$BuilderDefinitionFromJson(json);
+  }
 
   @override
   String toString() => {
@@ -197,8 +199,10 @@ class PostProcessBuilderDefinition {
     TargetBuilderConfigDefaults? defaults,
   }) : defaults = defaults ?? const TargetBuilderConfigDefaults();
 
-  factory PostProcessBuilderDefinition.fromJson(Map json) =>
-      _$PostProcessBuilderDefinitionFromJson(json);
+  factory PostProcessBuilderDefinition.fromJson(Map json) {
+    ArgumentError.checkNotNull(json);
+    return _$PostProcessBuilderDefinitionFromJson(json);
+  }
 
   @override
   String toString() => {
@@ -233,6 +237,8 @@ class TargetBuilderConfigDefaults {
         devOptions = devOptions ?? const {},
         releaseOptions = releaseOptions ?? const {};
 
-  factory TargetBuilderConfigDefaults.fromJson(Map json) =>
-      _$TargetBuilderConfigDefaultsFromJson(json);
+  factory TargetBuilderConfigDefaults.fromJson(Map json) {
+    ArgumentError.checkNotNull(json);
+    return _$TargetBuilderConfigDefaultsFromJson(json);
+  }
 }

--- a/build_config/lib/src/builder_definition.dart
+++ b/build_config/lib/src/builder_definition.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:meta/meta.dart';
 
 import 'build_target.dart';
 import 'common.dart';
@@ -35,10 +34,10 @@ enum BuildTo {
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)
 class BuilderDefinition {
   /// The package which provides this Builder.
-  String get package => packageExpando[this];
+  String get package => packageExpando[this]!;
 
   /// A unique key for this Builder in `'$package:$builder'` format.
-  String get key => builderKeyExpando[this];
+  String get key => builderKeyExpando[this]!;
 
   /// The names of the top-level methods in [import] from args -> Builder.
   @JsonKey(name: 'builder_factories', required: true, disallowNullValue: true)
@@ -57,7 +56,7 @@ class BuilderDefinition {
   ///
   /// May be null or unreliable and should not be used.
   @deprecated
-  final String target;
+  final String? target;
 
   /// Which packages should have this builder applied automatically.
   @JsonKey(name: 'auto_apply')
@@ -95,17 +94,17 @@ class BuilderDefinition {
   final TargetBuilderConfigDefaults defaults;
 
   BuilderDefinition({
-    @required this.builderFactories,
-    @required this.buildExtensions,
-    @required this.import,
-    String target,
-    AutoApply autoApply,
-    Iterable<String> requiredInputs,
-    Iterable<String> runsBefore,
-    Iterable<String> appliesBuilders,
-    bool isOptional,
-    BuildTo buildTo,
-    TargetBuilderConfigDefaults defaults,
+    required this.builderFactories,
+    required this.buildExtensions,
+    required this.import,
+    String? target,
+    AutoApply? autoApply,
+    Iterable<String>? requiredInputs,
+    Iterable<String>? runsBefore,
+    Iterable<String>? appliesBuilders,
+    bool? isOptional,
+    BuildTo? buildTo,
+    TargetBuilderConfigDefaults? defaults,
   })  :
         // ignore: deprecated_member_use
         target = target != null
@@ -116,12 +115,12 @@ class BuilderDefinition {
         runsBefore = runsBefore
                 ?.map((builder) =>
                     normalizeBuilderKeyUsage(builder, currentPackage))
-                ?.toList() ??
+                .toList() ??
             const [],
         appliesBuilders = appliesBuilders
                 ?.map((builder) =>
                     normalizeBuilderKeyUsage(builder, currentPackage))
-                ?.toList() ??
+                .toList() ??
             const [],
         isOptional = isOptional ?? false,
         buildTo = buildTo ?? BuildTo.cache,
@@ -161,10 +160,10 @@ class BuilderDefinition {
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)
 class PostProcessBuilderDefinition {
   /// The package which provides this Builder.
-  String get package => packageExpando[this];
+  String get package => packageExpando[this]!;
 
   /// A unique key for this Builder in `'$package:$builder'` format.
-  String get key => builderKeyExpando[this];
+  String get key => builderKeyExpando[this]!;
 
   /// The name of the top-level method in [import] from
   /// Map<String, dynamic> -> Builder.
@@ -180,22 +179,22 @@ class PostProcessBuilderDefinition {
   /// May be null or unreliable and should not be used.
   @deprecated
   @JsonKey(name: 'input_extensions')
-  final Iterable<String> inputExtensions;
+  final Iterable<String>? inputExtensions;
 
   /// The name of the dart_library target that contains `import`.
   ///
   /// May be null or unreliable and should not be used.
   @deprecated
-  final String target;
+  final String? target;
 
   final TargetBuilderConfigDefaults defaults;
 
   PostProcessBuilderDefinition({
-    @required this.builderFactory,
-    @required this.import,
+    required this.builderFactory,
+    required this.import,
     this.inputExtensions,
     this.target,
-    TargetBuilderConfigDefaults defaults,
+    TargetBuilderConfigDefaults? defaults,
   }) : defaults = defaults ?? const TargetBuilderConfigDefaults();
 
   factory PostProcessBuilderDefinition.fromJson(Map json) =>
@@ -225,10 +224,10 @@ class TargetBuilderConfigDefaults {
   final Map<String, dynamic> releaseOptions;
 
   const TargetBuilderConfigDefaults({
-    InputSet generateFor,
-    Map<String, dynamic> options,
-    Map<String, dynamic> devOptions,
-    Map<String, dynamic> releaseOptions,
+    InputSet? generateFor,
+    Map<String, dynamic>? options,
+    Map<String, dynamic>? devOptions,
+    Map<String, dynamic>? releaseOptions,
   })  : generateFor = generateFor ?? InputSet.anything,
         options = options ?? const {},
         devOptions = devOptions ?? const {},

--- a/build_config/lib/src/builder_definition.g.dart
+++ b/build_config/lib/src/builder_definition.g.dart
@@ -31,25 +31,25 @@ BuilderDefinition _$BuilderDefinitionFromJson(Map json) {
     ]);
     final val = BuilderDefinition(
       builderFactories: $checkedConvert(json, 'builder_factories',
-          (v) => (v as List).map((e) => e as String).toList()),
+          (v) => (v as List<dynamic>).map((e) => e as String).toList()),
       buildExtensions: $checkedConvert(
           json,
           'build_extensions',
           (v) => (v as Map).map(
-                (k, e) => MapEntry(
-                    k as String, (e as List).map((e) => e as String).toList()),
+                (k, e) => MapEntry(k as String,
+                    (e as List<dynamic>).map((e) => e as String).toList()),
               )),
       import: $checkedConvert(json, 'import', (v) => v as String),
-      target: $checkedConvert(json, 'target', (v) => v as String),
+      target: $checkedConvert(json, 'target', (v) => v as String?),
       autoApply: $checkedConvert(json, 'auto_apply',
           (v) => _$enumDecodeNullable(_$AutoApplyEnumMap, v)),
-      requiredInputs: $checkedConvert(
-          json, 'required_inputs', (v) => (v as List)?.map((e) => e as String)),
-      runsBefore: $checkedConvert(
-          json, 'runs_before', (v) => (v as List)?.map((e) => e as String)),
+      requiredInputs: $checkedConvert(json, 'required_inputs',
+          (v) => (v as List<dynamic>?)?.map((e) => e as String)),
+      runsBefore: $checkedConvert(json, 'runs_before',
+          (v) => (v as List<dynamic>?)?.map((e) => e as String)),
       appliesBuilders: $checkedConvert(json, 'applies_builders',
-          (v) => (v as List)?.map((e) => e as String)),
-      isOptional: $checkedConvert(json, 'is_optional', (v) => v as bool),
+          (v) => (v as List<dynamic>?)?.map((e) => e as String)),
+      isOptional: $checkedConvert(json, 'is_optional', (v) => v as bool?),
       buildTo: $checkedConvert(
           json, 'build_to', (v) => _$enumDecodeNullable(_$BuildToEnumMap, v)),
       defaults: $checkedConvert(
@@ -72,36 +72,41 @@ BuilderDefinition _$BuilderDefinitionFromJson(Map json) {
   });
 }
 
-T _$enumDecode<T>(
-  Map<T, dynamic> enumValues,
-  dynamic source, {
-  T unknownValue,
+K _$enumDecode<K, V>(
+  Map<K, V> enumValues,
+  Object? source, {
+  K? unknownValue,
 }) {
   if (source == null) {
-    throw ArgumentError('A value must be provided. Supported values: '
-        '${enumValues.values.join(', ')}');
+    throw ArgumentError(
+      'A value must be provided. Supported values: '
+      '${enumValues.values.join(', ')}',
+    );
   }
 
-  final value = enumValues.entries
-      .singleWhere((e) => e.value == source, orElse: () => null)
-      ?.key;
-
-  if (value == null && unknownValue == null) {
-    throw ArgumentError('`$source` is not one of the supported values: '
-        '${enumValues.values.join(', ')}');
-  }
-  return value ?? unknownValue;
+  return enumValues.entries.singleWhere(
+    (e) => e.value == source,
+    orElse: () {
+      if (unknownValue == null) {
+        throw ArgumentError(
+          '`$source` is not one of the supported values: '
+          '${enumValues.values.join(', ')}',
+        );
+      }
+      return MapEntry(unknownValue, enumValues.values.first);
+    },
+  ).key;
 }
 
-T _$enumDecodeNullable<T>(
-  Map<T, dynamic> enumValues,
+K? _$enumDecodeNullable<K, V>(
+  Map<K, V> enumValues,
   dynamic source, {
-  T unknownValue,
+  K? unknownValue,
 }) {
   if (source == null) {
     return null;
   }
-  return _$enumDecode<T>(enumValues, source, unknownValue: unknownValue);
+  return _$enumDecode<K, V>(enumValues, source, unknownValue: unknownValue);
 }
 
 const _$AutoApplyEnumMap = {
@@ -136,8 +141,8 @@ PostProcessBuilderDefinition _$PostProcessBuilderDefinitionFromJson(Map json) {
           $checkedConvert(json, 'builder_factory', (v) => v as String),
       import: $checkedConvert(json, 'import', (v) => v as String),
       inputExtensions: $checkedConvert(json, 'input_extensions',
-          (v) => (v as List)?.map((e) => e as String)),
-      target: $checkedConvert(json, 'target', (v) => v as String),
+          (v) => (v as List<dynamic>?)?.map((e) => e as String)),
+      target: $checkedConvert(json, 'target', (v) => v as String?),
       defaults: $checkedConvert(
           json,
           'defaults',
@@ -166,19 +171,19 @@ TargetBuilderConfigDefaults _$TargetBuilderConfigDefaultsFromJson(Map json) {
       options: $checkedConvert(
           json,
           'options',
-          (v) => (v as Map)?.map(
+          (v) => (v as Map?)?.map(
                 (k, e) => MapEntry(k as String, e),
               )),
       devOptions: $checkedConvert(
           json,
           'dev_options',
-          (v) => (v as Map)?.map(
+          (v) => (v as Map?)?.map(
                 (k, e) => MapEntry(k as String, e),
               )),
       releaseOptions: $checkedConvert(
           json,
           'release_options',
-          (v) => (v as Map)?.map(
+          (v) => (v as Map?)?.map(
                 (k, e) => MapEntry(k as String, e),
               )),
     );

--- a/build_config/lib/src/common.dart
+++ b/build_config/lib/src/common.dart
@@ -15,7 +15,7 @@ T runInBuildConfigZone<T>(
     });
 
 String get currentPackage {
-  var package = Zone.current[_packageZoneKey] as String;
+  var package = Zone.current[_packageZoneKey] as String?;
   if (package == null) {
     throw StateError(
         'Must be running inside a build config zone, which can be done using '
@@ -26,7 +26,7 @@ String get currentPackage {
 
 List<String> get currentPackageDefaultDependencies {
   var defaultDependencies =
-      Zone.current[_defaultDependenciesZoneKey] as List<String>;
+      Zone.current[_defaultDependenciesZoneKey] as List<String>?;
   if (defaultDependencies == null) {
     throw StateError(
         'Must be running inside a build config zone, which can be done using '

--- a/build_config/lib/src/input_set.dart
+++ b/build_config/lib/src/input_set.dart
@@ -28,6 +28,10 @@ class InputSet {
 
   factory InputSet.fromJson(dynamic json) {
     if (json is List) {
+      if (json.any((e) => e == null)) {
+        throw ArgumentError.value(
+            json, 'generate_for', 'Include globs must not be empty');
+      }
       json = <String, List>{'include': json};
     } else if (json is! Map) {
       throw ArgumentError.value(json, 'sources',

--- a/build_config/lib/src/input_set.dart
+++ b/build_config/lib/src/input_set.dart
@@ -17,30 +17,28 @@ class InputSet {
   /// The globs to include in the set.
   ///
   /// May be null or empty which means every possible path (like `'**'`).
-  final List<String> include;
+  final List<String>? include;
 
   /// The globs as a subset of [include] to remove from the set.
   ///
   /// May be null or empty which means every path in [include].
-  final List<String> exclude;
+  final List<String>? exclude;
 
   const InputSet({this.include, this.exclude});
 
   factory InputSet.fromJson(dynamic json) {
     if (json is List) {
-      json = {'include': json};
+      json = <String, List>{'include': json};
     } else if (json is! Map) {
       throw ArgumentError.value(json, 'sources',
           'Expected a Map or a List but got a ${json.runtimeType}');
     }
     final parsed = _$InputSetFromJson(json as Map);
-    if (parsed.include != null &&
-        parsed.include.any((s) => s == null || s.isEmpty)) {
+    if (parsed.include != null && parsed.include!.any((s) => s.isEmpty)) {
       throw ArgumentError.value(
           parsed.include, 'include', 'Include globs must not be empty');
     }
-    if (parsed.exclude != null &&
-        parsed.exclude.any((s) => s == null || s.isEmpty)) {
+    if (parsed.exclude != null && parsed.exclude!.any((s) => s.isEmpty)) {
       throw ArgumentError.value(
           parsed.exclude, 'exclude', 'Exclude globs must not be empty');
     }
@@ -50,12 +48,12 @@ class InputSet {
   @override
   String toString() {
     final result = StringBuffer();
-    if (include == null || include.isEmpty) {
+    if (include == null || include!.isEmpty) {
       result.write('any path');
     } else {
       result.write('paths matching $include');
     }
-    if (exclude != null && exclude.isNotEmpty) {
+    if (exclude != null && exclude!.isNotEmpty) {
       result.write(' except $exclude');
     }
     return '$result';

--- a/build_config/lib/src/input_set.g.dart
+++ b/build_config/lib/src/input_set.g.dart
@@ -11,9 +11,9 @@ InputSet _$InputSetFromJson(Map json) {
     $checkKeys(json, allowedKeys: const ['include', 'exclude']);
     final val = InputSet(
       include: $checkedConvert(json, 'include',
-          (v) => (v as List)?.map((e) => e as String)?.toList()),
+          (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()),
       exclude: $checkedConvert(json, 'exclude',
-          (v) => (v as List)?.map((e) => e as String)?.toList()),
+          (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()),
     );
     return val;
   });

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   checked_yaml: ^2.0.0
   json_annotation: ^4.0.0
-  meta: ^1.3.0
   path: ^1.8.0
   pubspec_parse: ^1.0.0
   yaml: ^3.0.0

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,25 +1,24 @@
 name: build_config
-version: 0.4.7
+version: 1.0.0-dev
 description: Support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config
 
 environment:
-  sdk: '>=2.11.99 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  checked_yaml: '>=1.0.0 <3.0.0'
-  json_annotation: '>=1.0.0 <5.0.0'
-  meta: ^1.1.0
-  path: ^1.4.0
-  pubspec_parse: '>=0.1.5 <2.0.0'
-  yaml: '>=2.1.11 <4.0.0'
+  checked_yaml: ^2.0.0
+  json_annotation: ^4.0.0
+  meta: ^1.3.0
+  path: ^1.8.0
+  pubspec_parse: ^1.0.0
+  yaml: ^3.0.0
 
 dev_dependencies:
   build_runner: ^1.0.0
-  # TODO: Untangle source_gen dependency
-  #json_serializable: ^3.0.0
-  term_glyph: ^1.0.0
-  test: ^1.6.0
+  json_serializable: ^4.0.0
+  term_glyph: ^1.2.0
+  test: ^1.16.0
 
 dependency_overrides:
   # Required due to the tight dependency on this package from these packages

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -20,6 +20,8 @@ dev_dependencies:
   test: ^1.16.0
 
 dependency_overrides:
+  # Required due to cyclic dep
+  json_serializable: ^4.0.0
   # Required due to the tight dependency on this package from these packages
   build_runner:
     path: ../build_runner

--- a/build_config/test/build_config_test.dart
+++ b/build_config/test/build_config_test.dart
@@ -151,9 +151,9 @@ builders:
     applies_builders: ["a|foo_builder"]
 ''');
     expect(buildConfig.builderDefinitions.keys, ['example:example']);
-    expect(buildConfig.builderDefinitions['example:example'].runsBefore,
+    expect(buildConfig.builderDefinitions['example:example']!.runsBefore,
         ['a:foo_builder']);
-    expect(buildConfig.builderDefinitions['example:example'].appliesBuilders,
+    expect(buildConfig.builderDefinitions['example:example']!.appliesBuilders,
         ['a:foo_builder']);
   });
 }
@@ -251,7 +251,7 @@ void expectBuilderDefinitions(Map<String, BuilderDefinition> actual,
     Map<String, BuilderDefinition> expected) {
   expect(actual.keys, unorderedEquals(expected.keys));
   for (var p in actual.keys) {
-    expect(actual[p], _matchesBuilderDefinition(expected[p]));
+    expect(actual[p], _matchesBuilderDefinition(expected[p]!));
   }
 }
 
@@ -260,7 +260,7 @@ void expectPostProcessBuilderDefinitions(
     Map<String, PostProcessBuilderDefinition> expected) {
   expect(actual.keys, unorderedEquals(expected.keys));
   for (var p in actual.keys) {
-    expect(actual[p], _matchesPostProcessBuilderDefinition(expected[p]));
+    expect(actual[p], _matchesPostProcessBuilderDefinition(expected[p]!));
   }
 }
 
@@ -268,7 +268,7 @@ void expectGlobalOptions(Map<String, GlobalBuilderConfig> actual,
     Map<String, GlobalBuilderConfig> expected) {
   expect(actual.keys, unorderedEquals(expected.keys));
   for (var p in actual.keys) {
-    expect(actual[p], _matchesGlobalBuilderConfig(expected[p]));
+    expect(actual[p], _matchesGlobalBuilderConfig(expected[p]!));
   }
 }
 
@@ -325,7 +325,7 @@ void expectBuildTargets(
     Map<String, BuildTarget> actual, Map<String, BuildTarget> expected) {
   expect(actual.keys, unorderedEquals(expected.keys));
   for (var p in actual.keys) {
-    expect(actual[p], _matchesBuildTarget(expected[p]));
+    expect(actual[p], _matchesBuildTarget(expected[p]!));
   }
 }
 
@@ -355,11 +355,11 @@ Matcher _matchesBuilderConfig(TargetBuilderConfig expected) =>
             expected.generateFor?.exclude);
 
 BuildTarget createBuildTarget(String package,
-    {String key,
-    Map<String, TargetBuilderConfig> builders,
-    Iterable<String> dependencies,
-    InputSet sources,
-    bool autoApplyBuilders}) {
+    {String? key,
+    Map<String, TargetBuilderConfig>? builders,
+    Iterable<String>? dependencies,
+    InputSet? sources,
+    bool? autoApplyBuilders}) {
   return runInBuildConfigZone(() {
     var target = BuildTarget(
       autoApplyBuilders: autoApplyBuilders,
@@ -376,17 +376,17 @@ BuildTarget createBuildTarget(String package,
 }
 
 BuilderDefinition createBuilderDefinition(String package,
-    {List<String> builderFactories,
-    AutoApply autoApply,
-    bool isOptional,
-    BuildTo buildTo,
-    String import,
-    Map<String, List<String>> buildExtensions,
-    String key,
-    Iterable<String> requiredInputs,
-    Iterable<String> runsBefore,
-    Iterable<String> appliesBuilders,
-    TargetBuilderConfigDefaults defaults}) {
+    {required List<String> builderFactories,
+    AutoApply? autoApply,
+    bool? isOptional,
+    BuildTo? buildTo,
+    required String import,
+    required Map<String, List<String>> buildExtensions,
+    String? key,
+    Iterable<String>? requiredInputs,
+    Iterable<String>? runsBefore,
+    Iterable<String>? appliesBuilders,
+    TargetBuilderConfigDefaults? defaults}) {
   return runInBuildConfigZone(() {
     var definition = BuilderDefinition(
         builderFactories: builderFactories,
@@ -406,10 +406,10 @@ BuilderDefinition createBuilderDefinition(String package,
 }
 
 PostProcessBuilderDefinition createPostProcessBuilderDefinition(String package,
-    {String builderFactory,
-    String import,
-    String key,
-    TargetBuilderConfigDefaults defaults}) {
+    {required String builderFactory,
+    required String import,
+    String? key,
+    TargetBuilderConfigDefaults? defaults}) {
   return runInBuildConfigZone(() {
     var definition = PostProcessBuilderDefinition(
         builderFactory: builderFactory, import: import, defaults: defaults);

--- a/build_config/test/errors_test.dart
+++ b/build_config/test/errors_test.dart
@@ -117,6 +117,27 @@ line 6, column 11 of build.yaml: Unsupported value for "generate_for". Exclude g
 7 │ └           - ''
   ╵''');
   });
+
+  test('for null builder config', () {
+    var buildYaml = r'''
+targets:
+  $default:
+    builders:
+      not:defined:
+''';
+
+    _expectThrows(
+        buildYaml,
+        allOf(
+          contains(
+              'line 4, column 7 of build.yaml: Unsupported value for "builders".'),
+          contains(r'''
+  ╷
+4 │       not:defined:
+  │       ^^^^^^^^^^^^
+  ╵'''),
+        ));
+  });
 }
 
 void _expectThrows(String buildYaml, Object matcher) => expect(

--- a/build_config/test/errors_test.dart
+++ b/build_config/test/errors_test.dart
@@ -45,7 +45,7 @@ line 4, column 7 of build.yaml: Unsupported value for "build_extensions". May no
   ╵''');
   });
 
-  test('for empty include globs', () {
+  test('for null generate_for globs', () {
     var buildYaml = r'''
 targets:
   $default:
@@ -60,6 +60,61 @@ line 6, column 9 of build.yaml: Unsupported value for "generate_for". Include gl
   ╷
 6 │         -
   │         ^
+  ╵''');
+  });
+  test('for empty generate_for globs', () {
+    var buildYaml = r'''
+targets:
+  $default:
+    builders:
+      some_package:some_builder:
+        generate_for:
+        - ''
+''';
+
+    _expectThrows(buildYaml, r'''
+line 6, column 9 of build.yaml: Unsupported value for "generate_for". Include globs must not be empty
+  ╷
+6 │         - ''
+  │         ^^^^
+  ╵''');
+  });
+
+  test('for null exclude globs', () {
+    var buildYaml = r'''
+targets:
+  $default:
+    builders:
+      some_package:some_builder:
+        generate_for:
+          exclude:
+          -
+''';
+
+    _expectThrows(buildYaml, r'''
+line 7, column 11 of build.yaml: Unsupported value for "exclude". type 'Null' is not a subtype of type 'String' in type cast
+  ╷
+7 │           -
+  │           ^
+  ╵''');
+  });
+
+  test('for empty exclude globs', () {
+    var buildYaml = r'''
+targets:
+  $default:
+    builders:
+      some_package:some_builder:
+        generate_for:
+          exclude:
+          - ''
+''';
+
+    _expectThrows(buildYaml, r'''
+line 6, column 11 of build.yaml: Unsupported value for "generate_for". Exclude globs must not be empty
+  ╷
+6 │ ┌           exclude:
+7 │ └           - ''
   ╵''');
   });
 }

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -523,6 +523,7 @@ targets:
   $default:
     builders:
       bad:builder:
+        enabled: true
 '''),
         d.dir('tool', [d.file('build.dart', buildContent)]),
         d.dir('web', [
@@ -551,6 +552,7 @@ targets:
         d.file('build.yaml', r'''
 global_options:
   bad:builder:
+    options: {}
 '''),
         d.dir('tool', [d.file('build.dart', buildContent)]),
         d.dir('web', [


### PR DESCRIPTION
Note that error handling around null values changes a bit here. We could add more specialized handling to explicitly handle null values in explicit `include` or `exclude` globs (a cast error surfaces today).  However I think it might make the most sense to try and get something added upstream here to improve the message generally. 