### PR TITLE
Prep to release null safe packages

### DIFF
--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -6,8 +6,8 @@ environment:
 
 dev_dependencies:
   analyzer: ^1.0.0
-  path: ^1.4.2
-  test: ^1.6.2
+  path: ^1.8.0
+  test: ^1.16.0
   test_process: ^2.0.0
   provides_builder:
     path: pkgs/provides_builder/

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1
+
+- Require package:async version 2.5.0 (previous null safety release should
+  have as well).
+
 ## 2.0.0
 
 - Migrate to null-safety

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.0.1
 
-- Require package:async version 2.5.0 (previous null safety release should
-  have as well).
+- Require package:async version 2.5.0 and package:collection version 1.15.0.
 
 ## 2.0.0
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -27,5 +27,7 @@ dependency_overrides:
     path: ../build_resolvers
   build_test:
     path: ../build_test
+  build_config:
+    path: ../build_config
   # Remove each of the above as they are published.
   # They're only used for testing.

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 2.0.0
+version: 2.0.1
 description: A build system for Dart.
 repository: https://github.com/dart-lang/build/tree/master/build
 
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   analyzer: ^1.0.0
-  async: ^2.0.0
+  async: ^2.5.0
   convert: ^3.0.0
   crypto: ^3.0.0
   glob: ^2.0.0

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-dev
+## 1.0.0
 
 - Migrate to null safety.
 

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   yaml: ^3.0.0
 
 dev_dependencies:
-  build_runner: ^1.0.0
+  build_runner: ^2.0.0
   json_serializable: ^4.0.0
   term_glyph: ^1.2.0
   test: ^1.16.0

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 1.0.0-dev
+version: 1.0.0
 description: Support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config
 
@@ -29,8 +29,6 @@ dependency_overrides:
     path: ../build_runner
   build_runner_core:
     path: ../build_runner_core
-  # Temporarily required until build version 2.0.0 is released
-  build:
-    path: ../build
+  # Required until latest build_resolvers is published
   build_resolvers:
     path: ../build_resolvers

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.0-dev
+## 3.0.0
 
 - Migrate to null safety.
 

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 3.0.0-dev
+version: 3.0.0
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 
@@ -31,8 +31,6 @@ dev_dependencies:
 
 dependency_overrides:
   ## Remove each of the following as they are published
-  build:
-    path: ../build
   build_config:
     path: ../build_config
   build_resolvers:

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   web_socket_channel: ^2.0.0
 
 dev_dependencies:
-  build_runner: ^1.0.0
+  build_runner: ^2.0.0
   # TODO: untangle analyzer dependency
   built_value_generator: ^8.0.0
   mockito: ^5.0.0

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.0-dev
+## 4.0.0
 
 - Migrate to null safety.
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 4.0.0-dev
+version: 4.0.0
 description: Builders for Dart modules
 repository: https://github.com/dart-lang/build/tree/master/build_modules
 
@@ -36,16 +36,12 @@ dev_dependencies:
 
 dependency_overrides:
   # Remove these when they're published
-  build:
-    path: ../build
   build_config:
     path: ../build_config
   build_daemon:
     path: ../build_daemon
   build_resolvers:
     path: ../build_resolvers
-  build_test:
-    path: ../build_test
   build_runner_core:
     path: ../build_runner_core
   build_runner:

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   bazel_worker: ^1.0.0
   build: ^2.0.0
   build_config: ^1.0.0
-  collection: ^1.0.0
+  collection: ^1.15.0
   crypto: ^3.0.0
   glob: ^2.0.0
   graphs: ^2.0.0

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   analyzer: ^1.0.0
-  async: ^2.0.0
+  async: ^2.5.0
   bazel_worker: ^1.0.0
   build: ^2.0.0
   build_config: ^1.0.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -21,10 +21,3 @@ dependencies:
 dev_dependencies:
   test: ^1.16.0
   build_test: ^2.0.0
-
-dependency_overrides:
-  # Temporarily required until build version 2.0.0 is released
-  build:
-    path: ../build
-  build_test:
-    path: ../build_test

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-dev
+## 2.0.0
 
 - Migrate to null safety.
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   args: ^2.0.0
-  async: ^2.0.0
+  async: ^2.5.0
   analyzer: ^1.4.0
   build: ">=2.0.0 <2.1.0"
   build_config: '>=1.0.0 <1.1.0'

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.0.0-dev
+version: 2.0.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 
@@ -53,9 +53,7 @@ dev_dependencies:
     path: ../_test_common
 
 dependency_overrides:
-  # Temporarily required until build version 2.0.0 is released
-  build:
-    path: ../build
+  # Temporarily required until new versions are released
   build_config:
     path: ../build_config
   build_modules:

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
 
 dev_dependencies:
   build_test: ^2.0.0
-  build_web_compilers: ^2.0.0
+  build_web_compilers: ^3.0.0
   package_config: ^2.0.0
   stream_channel: ^2.0.0
   test: ^1.16.0

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.0.0-dev
+## 7.0.0
 
 - Migrate to null safety.
 - Add an early error if any output extensions overlap with any input

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 7.0.0-dev
+version: 7.0.0
 description: Core tools to write binaries that run builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
@@ -27,7 +27,7 @@ dependencies:
   yaml: ^3.0.0
 
 dev_dependencies:
-  build_runner: ^1.0.0
+  build_runner: ^2.0.0
   build_test: ^2.0.0
   json_serializable: ^4.0.0
   test: ^1.16.0
@@ -38,8 +38,6 @@ dev_dependencies:
 
 dependency_overrides:
   ## Remove each of the below as they are published
-  build:
-    path: ../build
   build_config:
     path: ../build_config
   build_daemon:
@@ -48,6 +46,4 @@ dependency_overrides:
     path: ../build_resolvers
   build_runner:
     path: ../build_runner
-  build_test:
-    path: ../build_test
   ## Remove each of the above as they are published

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  async: ^2.0.0
+  async: ^2.5.0
   build: ^2.0.0
   build_config: ^1.0.0
   build_resolvers: ^2.0.0

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.1.0-dev
+## 2.1.0
 
 - Migrate internal builders of this package to null safety
+- Require build_config version 1.0.0.
 
 ## 2.0.0
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
 
 dev_dependencies:
   analyzer: ^1.0.0
-  collection: ^1.14.0
+  collection: ^1.15.0
 
 dependency_overrides:
   # Remove this once the respective packages are published

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,28 +1,28 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 2.1.0-dev
+version: 2.1.0
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  async: "^2.5.0"
-  build: "^2.0.0"
-  build_config: ">=0.2.0 <0.5.0"
+  async: ^2.5.0
+  build: ^2.0.0
+  build_config: ^1.0.0
   build_resolvers: ^2.0.0
-  crypto: "^3.0.0"
-  glob: "^2.0.0"
-  html: "^0.15.0"
-  logging: "^1.0.0"
+  crypto: ^3.0.0
+  glob: ^2.0.0
+  html: ^0.15.0
+  logging: ^1.0.0
   matcher: ^0.12.0
-  package_config: '^2.0.0'
+  package_config: ^2.0.0
   path: ^1.8.0
   pedantic: ^1.10.0
-  stream_transform: "^2.0.0"
-  test: '^1.16.0'
+  stream_transform: ^2.0.0
+  test: ^1.16.0
   test_core: '>=0.3.19 <0.4.0'
-  watcher: '^1.0.0'
+  watcher: ^1.0.0
 
 dev_dependencies:
   analyzer: ^1.0.0
@@ -30,7 +30,7 @@ dev_dependencies:
 
 dependency_overrides:
   # Remove this once the respective packages are published
-  build:
-    path: ../build
+  build_config:
+    path: ../build_config
   build_resolvers:
     path: ../build_resolvers

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -9,14 +9,14 @@ environment:
 dependencies:
   analyzer: ^1.0.0
   build: ^2.0.0
-  build_config: ">=0.3.0 <0.5.0"
-  build_modules: ^3.0.0
+  build_config: ^1.0.0
+  build_modules: ^4.0.0
   path: ^1.6.0
   pool: ^1.3.0
 
 dev_dependencies:
-  build_runner: ^1.0.0
-  test: ^1.0.0
+  build_runner: ^2.0.0
+  test: ^1.16.0
   test_descriptor: ^2.0.0
   _test_common:
     path: ../_test_common

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
   build: ^2.0.0
   build_config: ^1.0.0
   build_modules: ^4.0.0
-  path: ^1.6.0
-  pool: ^1.3.0
+  path: ^1.8.0
+  pool: ^1.5.0
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.0-dev
+## 3.0.0
 
 - Migrate to null safety.
 - Update to the latest `build_modules`.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 3.0.0-dev
+version: 3.0.0
 description: Builder implementations wrapping Dart compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   build: ^2.0.0
   build_config: ^1.0.0
   build_modules: ^4.0.0
-  collection: ^1.0.0
+  collection: ^1.15.0
   glob: ^2.0.0
   js: ^0.6.3
   logging: ^1.0.0

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,13 +8,15 @@ To use `build_runner`, you need a 2.x version of the Dart SDK.
 If you have issues using `build_runner`, see the
 [Troubleshooting section](#troubleshooting), below.
 
-*   [Using `build_runner` as a development server](#using-build_runner-as-a-development-server)
-*   [Creating an output directory](#creating-an-output-directory)
-*   [Using other `build_runner` commands](#using-other-build_runner-commands)
-*   [Switching to Dart2JS](#switching-to-dart2js)
-*   [Troubleshooting](#troubleshooting)
-    *   [`build_runner` has no versions that match...](#build_runner-has-no-versions-that-match)
-    *   [Too many open files](#too-many-open-files)
+- [Getting started with `build_runner`](#getting-started-with-build_runner)
+  - [Using `build_runner` as a development server](#using-build_runner-as-a-development-server)
+  - [Creating an output directory](#creating-an-output-directory)
+  - [Using other `build_runner` commands](#using-other-build_runner-commands)
+  - [Switching to dart2js](#switching-to-dart2js)
+  - [Troubleshooting](#troubleshooting)
+    - [Diagnosing build times](#diagnosing-build-times)
+    - [build_runner has no versions that match...](#build_runner-has-no-versions-that-match)
+    - [Too many open files](#too-many-open-files)
 
 ## Using `build_runner` as a development server
 
@@ -22,13 +24,9 @@ If you have issues using `build_runner`, see the
     **build_runner** and **build_web_compilers**:
 
     ```yaml
-    ...
-    environment:
-      sdk: '>=2.0.0 <3.0.0'
-    ...
     dev_dependencies:
-      build_runner: ^1.0.0
-      build_web_compilers: ^0.4.0
+      build_runner: ^2.0.0
+      build_web_compilers: ^3.0.0
     ```
 
 2.  Get package dependencies:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
 dependencies:
   build: ^2.0.0
   # Not imported in code, but used to constrain `build.yaml` requirements
-  build_config: ">=0.3.0 <0.5.0"
+  build_config: ^1.0.0
 
 dev_dependencies:
-  build_runner: ^1.0.0
-  build_web_compilers: ^2.0.0
+  build_runner: ^2.0.0
+  build_web_compilers: ^3.0.0
 
 dependency_overrides:
   build:

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -7,21 +7,19 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  build: "^2.0.0"
-  crypto: "^3.0.0"
+  build: ^2.0.0
+  crypto: ^3.0.0
   path: ^1.8.0
   pedantic: ^1.10.0
   pool: ^1.5.0
 
 dev_dependencies:
-  build_runner: ^1.0.0
+  build_runner: ^2.0.0
   build_test: ^2.0.0
   test: ^1.16.0
 
 dependency_overrides:
   # Temporarily required until build version 2.0.0 is released
-  build:
-    path: ../build
   build_config:
     path: ../build_config
   build_daemon:


### PR DESCRIPTION
This releases all packages except for build_vm_compilers which does not actually support null safety fully at this time (and may never, the package status is in flux).