### PR TITLE
Replace use of deprecated AnalysisSession methods

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2-dev
+
 ## 2.0.1
 
 - Update to package:graphs 2.0.0.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -169,12 +169,11 @@ class AnalyzerResolver implements ReleasableResolver {
     var path = library.source.fullName;
 
     if (resolve) {
-      return (await session.getResolvedLibrary(path))
+      return (await session.getResolvedLibrary2(path) as ResolvedLibraryResult)
           .getElementDeclaration(element)
           ?.node;
     } else {
-      return session
-          .getParsedLibrary(path)
+      return (session.getParsedLibrary2(path) as ParsedLibraryResult)
           .getElementDeclaration(element)
           ?.node;
     }

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.0.1
+version: 2.0.2-dev
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ^1.2.0
+  analyzer: ^1.5.0
   build: ^2.0.0
   crypto: ^3.0.0
   graphs: ">=1.0.0 <3.0.0"


### PR DESCRIPTION
The goal of the changes to AnalysisSession is to make it easier to
understand when the result is valid, and when it is not. Previously
sometimes we throw an exception, sometimes return a result that returns
nulls, sometimes return a result that is not valid, so its getters
throw.

Since the result was previously assumed to be valid, continue making the
same assumption explicitly by immediately casting the result.