### PR TITLE
fix bad cast while parsing options in daemon mode

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Fix bad cast in build_runner while parsing options for daemon mode.
+
 ## 2.0.0
 
 - Migrate to null safety.

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -187,7 +187,7 @@ class DaemonOptions extends WatchOptions {
       buildMode: buildMode,
       deleteFilesByDefault: argResults[deleteFilesByDefaultOption] as bool,
       enableLowResourcesMode: argResults[lowResourcesModeOption] as bool,
-      configKey: argResults[configOption] as String,
+      configKey: argResults[configOption] as String?,
       buildDirs: buildDirs,
       outputSymlinksOnly: argResults[symlinkOption] as bool,
       trackPerformance: argResults[trackPerformanceOption] as bool,

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.0.0
+version: 2.0.1
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
I don't understand how this wasn't caught before, but it was causing some failures on my previous PR.