### PR TITLE
Use frontend_server for snapshots

### DIFF
--- a/_test/test/build_integration_test.dart
+++ b/_test/test/build_integration_test.dart
@@ -113,8 +113,8 @@ void main() {
           nextBuild.stdout.split('\n'),
           containsAllInOrder([
             contains('Generating build script'),
-            contains('Deleted previous build script Kernel due to missing '
-                'asset graph.'),
+            contains(
+                'Deleted precompiled build script due to missing asset graph.'),
             contains('Precompiling build script'),
             contains('Building new asset graph.'),
             contains('Succeeded after'),

--- a/_test/test/build_integration_test.dart
+++ b/_test/test/build_integration_test.dart
@@ -6,6 +6,7 @@
 import 'dart:io';
 
 import 'package:build_runner_core/src/util/constants.dart';
+import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -104,8 +105,7 @@ void main() {
     });
 
     test('Re-snapshots if there is no asset graph', () async {
-      var assetGraph = assetGraphPathFor(p.url
-          .join('.dart_tool', 'build', 'entrypoint', 'build.dart.snapshot'));
+      var assetGraph = assetGraphPathFor(scriptKernelLocation);
       await File(assetGraph).delete();
 
       var nextBuild = await runBuild();
@@ -114,7 +114,7 @@ void main() {
           containsAllInOrder([
             contains('Generating build script'),
             contains(
-                'Deleted precompiled build script due to missing asset graph.'),
+                'Invalidated precompiled build script due to missing asset graph.'),
             contains('Precompiling build script'),
             contains('Building new asset graph.'),
             contains('Succeeded after'),

--- a/_test/test/build_integration_test.dart
+++ b/_test/test/build_integration_test.dart
@@ -113,8 +113,9 @@ void main() {
           nextBuild.stdout.split('\n'),
           containsAllInOrder([
             contains('Generating build script'),
-            contains('Deleted previous snapshot due to missing asset graph.'),
-            contains('Creating build script snapshot'),
+            contains('Deleted previous build script Kernel due to missing '
+                'asset graph.'),
+            contains('Precompiling build script'),
             contains('Building new asset graph.'),
             contains('Succeeded after'),
           ]));

--- a/_test/test/build_integration_test.dart
+++ b/_test/test/build_integration_test.dart
@@ -5,8 +5,8 @@
 @TestOn('vm')
 import 'dart:io';
 
-import 'package:build_runner_core/src/util/constants.dart';
 import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
+import 'package:build_runner_core/src/util/constants.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.2-dev
+
+- Use the frontend server to improve the performance of generating build script
+  snapshots.
+
 ## 2.0.1
 
 - Fix bad cast in build_runner while parsing options for daemon mode.

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -169,7 +169,7 @@ Future<int> _createKernelIfNeeded(Logger logger) async {
         // Note: We're logging all output with a single log call to keep
         // annotated source spans intact.
         final logOutput = result?.compilerOutputLines.join('\n');
-        if (logOutput != null) {
+        if (logOutput != null && logOutput.isNotEmpty) {
           hadOutput = true;
           if (hadErrors) {
             // Always show compiler output if there were errors

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -16,7 +16,7 @@ import 'package:stack_trace/stack_trace.dart';
 
 final _logger = Logger('Bootstrap');
 
-/// Generates the build script, snapshots it if needed, and runs it.
+/// Generates the build script, precompiles it if needed, and runs it.
 ///
 /// The [handleUncaughtError] function will be invoked when the build script
 /// terminates with an uncaught error.
@@ -66,7 +66,7 @@ Future<int> generateAndRun(
       return ExitCode.config.code;
     }
 
-    scriptExitCode = await _createSnapshotIfNeeded(logger);
+    scriptExitCode = await _createKernelIfNeeded(logger);
     if (scriptExitCode != 0) return scriptExitCode!;
 
     exitPort = ReceivePort();
@@ -80,7 +80,7 @@ Future<int> generateAndRun(
       if (scriptExitCode == 0) scriptExitCode = 1;
     });
     try {
-      await Isolate.spawnUri(Uri.file(p.absolute(scriptSnapshotLocation)), args,
+      await Isolate.spawnUri(Uri.file(p.absolute(scriptKernelLocation)), args,
           messagePort.sendPort,
           errorsAreFatal: true,
           onExit: exitPort.sendPort,
@@ -98,9 +98,9 @@ Future<int> generateAndRun(
       } else {
         logger.warning(
             'Error spawning build script isolate, this is likely due to a Dart '
-            'SDK update. Deleting snapshot and retrying...');
+            'SDK update. Deleting precompiled script and retrying...');
       }
-      await File(scriptSnapshotLocation).delete();
+      await File(scriptKernelLocation).delete();
     }
   }
 
@@ -123,7 +123,7 @@ Future<int> generateAndRun(
   return scriptExitCode ?? 1;
 }
 
-/// Creates a script snapshot for the build script in necessary.
+/// Creates a precompiled Kernel snapshot for the build script if necessary.
 ///
 /// A snapshot is generated if:
 ///
@@ -133,48 +133,50 @@ Future<int> generateAndRun(
 ///
 /// Returns zero for success or a number for failure which should be set to the
 /// exit code.
-Future<int> _createSnapshotIfNeeded(Logger logger) async {
-  var assetGraphFile = File(assetGraphPathFor(scriptSnapshotLocation));
-  var snapshotFile = File(scriptSnapshotLocation);
+Future<int> _createKernelIfNeeded(Logger logger) async {
+  var assetGraphFile = File(assetGraphPathFor(scriptKernelLocation));
+  var kernelFile = File(scriptKernelLocation);
 
-  if (await snapshotFile.exists()) {
+  if (await kernelFile.exists()) {
     // If we failed to serialize an asset graph for the snapshot, then we don't
     // want to re-use it because we can't check if it is up to date.
     if (!await assetGraphFile.exists()) {
-      await snapshotFile.delete();
-      logger.warning('Deleted previous snapshot due to missing asset graph.');
+      await kernelFile.delete();
+      logger.warning(
+          'Deleted previous build script Kernel due to missing asset graph.');
     } else if (!await _checkImportantPackageDeps()) {
-      await snapshotFile.delete();
-      logger.warning('Deleted previous snapshot due to core package update');
+      await kernelFile.delete();
+      logger.warning(
+          'Deleted previous build script Kernel due to core package update');
     }
   }
 
-  if (!await snapshotFile.exists()) {
+  if (!await kernelFile.exists()) {
     final client = await FrontendServerClient.start(
       scriptLocation,
-      scriptSnapshotLocation,
+      scriptKernelLocation,
       'lib/_internal/vm_platform_strong.dill',
       printIncrementalDependencies: false,
     );
 
     var hadOutput = false;
-    await logTimedAsync(logger, 'Creating build script snapshot...', () async {
+    await logTimedAsync(logger, 'Precompiling build script...', () async {
       try {
         final result = await client.compile();
         result?.compilerOutputLines.forEach(logger.fine);
-        hadOutput = result == null || result.errorCount > 0;
+        hadOutput = result == null || result.compilerOutputLines.isNotEmpty;
       } finally {
         client.kill();
       }
     });
     if (hadOutput) {
-      logger.info('There was output on stdout while compiling the build script '
-          'snapshot, run with `--verbose` to see it (you will need to run '
-          'a `clean` first to re-snapshot).\n');
+      logger.info('There was output on stdout while precompiling the build  '
+          'script, run with `--verbose` to see it (you will need to run '
+          'a `clean` first to re-generate it).\n');
     }
-    if (!await snapshotFile.exists()) {
+    if (!await kernelFile.exists()) {
       logger.severe('''
-Failed to snapshot build script $scriptLocation.
+Failed to precompile build script $scriptLocation.
 This is likely caused by a misconfigured builder definition.
 ''');
       return ExitCode.config.code;
@@ -189,8 +191,8 @@ const _importantPackages = [
   'build_daemon',
   'build_runner',
 ];
-final _previousLocationsFile = File(
-    p.url.join(p.url.dirname(scriptSnapshotLocation), '.packageLocations'));
+final _previousLocationsFile =
+    File(p.url.join(p.url.dirname(scriptKernelLocation), '.packageLocations'));
 
 /// Returns whether the [_importantPackages] are all pointing at same locations
 /// from the previous run.
@@ -198,7 +200,7 @@ final _previousLocationsFile = File(
 /// Also updates the [_previousLocationsFile] with the new locations if not.
 ///
 /// This is used to detect potential changes to the user facing api and
-/// pre-emptively resolve them by resnapshotting, see
+/// pre-emptively resolve them by precompiling the build script again, see
 /// https://github.com/dart-lang/build/issues/1929.
 Future<bool> _checkImportantPackageDeps() async {
   var currentLocations = await Future.wait(_importantPackages.map((pkg) =>

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -143,11 +143,11 @@ Future<int> _createKernelIfNeeded(Logger logger) async {
     if (!await assetGraphFile.exists()) {
       await kernelFile.delete();
       logger.warning(
-          'Deleted previous build script Kernel due to missing asset graph.');
+          'Deleted precompiled build script due to missing asset graph.');
     } else if (!await _checkImportantPackageDeps()) {
       await kernelFile.delete();
       logger.warning(
-          'Deleted previous build script Kernel due to core package update');
+          'Deleted precompiled build script due to core package update');
     }
   }
 

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -22,7 +22,7 @@ import '../package_graph/build_config_overrides.dart';
 import 'builder_ordering.dart';
 
 const scriptLocation = '$entryPointDir/build.dart';
-const scriptSnapshotLocation = '$scriptLocation.snapshot';
+const scriptKernelLocation = '$scriptLocation.snapshot';
 
 final _log = Logger('Entrypoint');
 

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -22,7 +22,11 @@ import '../package_graph/build_config_overrides.dart';
 import 'builder_ordering.dart';
 
 const scriptLocation = '$entryPointDir/build.dart';
-const scriptKernelLocation = '$scriptLocation.snapshot';
+const scriptKernelLocation = '$scriptLocation$scriptKernelSuffix';
+const scriptKernelSuffix = '.dill';
+const scriptKernelCachedLocation =
+    '$scriptKernelLocation$scriptKernelCachedSuffix';
+const scriptKernelCachedSuffix = '.cached';
 
 final _log = Logger('Entrypoint');
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.0.1
+version: 2.0.2-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   collection: ^1.15.0
   crypto: ^3.0.0
   dart_style: ^2.0.0
+  frontend_server_client: ^2.1.0
   glob: ^2.0.0
   graphs: ^2.0.0
   http_multi_server: ^3.0.0

--- a/build_runner/test/integration_tests/build_invalidation_test.dart
+++ b/build_runner/test/integration_tests/build_invalidation_test.dart
@@ -87,7 +87,7 @@ void main() {
 
       await expectOutput(secondBuild, [
         'Invalidating asset graph due to build script update',
-        'Creating build script snapshot',
+        'Precompiling build script',
         'Building new asset graph',
       ]);
     });
@@ -124,7 +124,7 @@ void main() {
 
       await expectOutput(server.stdout, [
         'Terminating builds due to build script update',
-        'Creating build script snapshot',
+        'Precompiling build script',
         'Building new asset graph',
       ]);
 
@@ -158,8 +158,8 @@ void main() {
     final secondBuild = await buildTool.build();
 
     await expectOutput(secondBuild, [
-      'Deleted previous snapshot due to core package update',
-      'Creating build script snapshot',
+      'Deleted previous build script Kernel due to core package update',
+      'Precompiling build script',
     ]);
   });
 

--- a/build_runner/test/integration_tests/build_invalidation_test.dart
+++ b/build_runner/test/integration_tests/build_invalidation_test.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
 import 'package:build_runner_core/src/util/constants.dart';
 import 'package:build_test/build_test.dart';
 import 'package:path/path.dart' as p;
@@ -93,11 +94,8 @@ void main() {
     });
 
     test('for invalid asset graph version', () async {
-      final assetGraph = File(p.join(
-          d.sandbox,
-          'a',
-          assetGraphPathFor(p.url.join(
-              '.dart_tool', 'build', 'entrypoint', 'build.dart.snapshot'))));
+      final assetGraph =
+          File(p.join(d.sandbox, 'a', assetGraphPathFor(scriptKernelLocation)));
       // Prepend a 1 to the version number
       await assetGraph.writeAsString((await assetGraph.readAsString())
           .replaceFirst('"version":', '"version":1'));
@@ -158,7 +156,7 @@ void main() {
     final secondBuild = await buildTool.build();
 
     await expectOutput(secondBuild, [
-      'Deleted precompiled build script due to core package update',
+      'Invalidated precompiled build script due to core package update',
       'Precompiling build script',
     ]);
   });

--- a/build_runner/test/integration_tests/build_invalidation_test.dart
+++ b/build_runner/test/integration_tests/build_invalidation_test.dart
@@ -158,7 +158,7 @@ void main() {
     final secondBuild = await buildTool.build();
 
     await expectOutput(secondBuild, [
-      'Deleted previous build script Kernel due to core package update',
+      'Deleted precompiled build script due to core package update',
       'Precompiling build script',
     ]);
   });


### PR DESCRIPTION
Generate build script snapshots by spawning a frontend server instead of invoking a non-incremental compiler. This makes creating snapshots much faster.