### PR TITLE
add more context to the outdated analyzer version warning

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 2.0.2-dev
+## 2.0.2
+
+- Add more context to the outdated analyzer version message. It now provides
+  different suggestions depending on if you are on the latest analyzer.
 
 ## 2.0.1
 

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -446,7 +446,7 @@ void _warnOnLanguageVersionMismatch() async {
   try {
     var client = HttpClient();
     var request = await client
-        .getUrl(Uri.parse('https://pub.dartlang.org/api/packages/analyzer'));
+        .getUrl(Uri.https('pub.dartlang.org', 'api/packages/analyzer'));
     var response = await request.close();
     var content = StringBuffer();
     await response.transform(utf8.decoder).listen(content.write).asFuture();

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.0.2-dev
+version: 2.0.2
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 
@@ -17,6 +17,7 @@ dependencies:
   pool: ^1.5.0
   pub_semver: ^2.0.0
   stream_transform: ^2.0.0
+  yaml: ^3.0.0
 
 dev_dependencies:
   test: ^1.16.0


### PR DESCRIPTION
Related to https://github.com/dart-lang/sdk/issues/46041.

We now reach out to pub to find the latest analyzer version, and compare that against the current version. We will only suggest filing an issue if you are on the latest. Otherwise we suggest upgrading.

This does require making an http get request to pub to know the latest version, as well as reading the pubspec from the current analyzer, which requires a dep on `yaml`. As a result the error will be asynchronously logged some time after the resolver is created.