### PR TITLE
Fix determining null-safety for relative imports

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.4
+
+- Allow builders defined as relative imports from the root of a package to run
+  with sound null safety.
+
 ## 2.0.3
 
 - Fix a serve mode bug which causes an unhandled exception if the build fails

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -168,7 +168,8 @@ Future<bool> _allMigratedToNullSafety(PackageGraph packageGraph,
   }
 
   for (final import in imports.toSet()) {
-    final id = AssetId.resolve(Uri.parse(import), from: baseForRelative);
+    final id = AssetId.resolve(Uri.parse(_buildScriptImport(import)),
+        from: baseForRelative);
     String content;
     try {
       content = await reader.readAsString(id);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.0.3
+version: 2.0.4
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/build_script_generate/build_script_generate_test.dart
+++ b/build_runner/test/build_script_generate/build_script_generate_test.dart
@@ -200,5 +200,29 @@ builders:
           packageGraph: await PackageGraph.forPath('${d.sandbox}/a'));
       expect(options.canRunWithSoundNullSafety, isFalse);
     });
+
+    test('when a builder-defining library uses a top-level relative path',
+        () async {
+      await d.dir('a', [
+        d.file('pubspec.yaml', '''
+name: a
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+      '''),
+        d.file('build.yaml', '''
+builders:
+  a:
+    import: 'tool/builder.dart'
+    build_extensions: {'.foo': ['.bar']}
+    builder_factories: ['builder']
+    '''),
+        d.dir('tool', [d.file('builder.dart', '')]),
+      ]).create();
+      await runPub('a', 'get');
+
+      final options = await findBuildScriptOptions(
+          packageGraph: await PackageGraph.forPath('${d.sandbox}/a'));
+      expect(options.canRunWithSoundNullSafety, isTrue);
+    });
   });
 }


### PR DESCRIPTION
There's a bug in the code that determines whether a build can run with sound null safety when a package uses builders with relative imports from its pubspec (e.g. without the `../` prefix).
Currently, it tried to read the asset by resolving it relative to the generated build script which is not correct in that case. For instance, consider a `tool/my_builder.dart` import in a `build.yaml`. We'd then try to read `.dart_tool/build/entrypoint/tool/my_builder.dart` to determine that file's language version. As that fails, we bail out and run the build without null safety. We now use the existing logic to determine the proper import.