### PR TITLE
fix an issue where the build process would hang if the resolver fails to initialize

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+- Handle failed resolvers in `buildStep.complete`.
+
 ## 2.0.1
 
 - Require package:async version 2.5.0 and package:collection version 1.15.0.

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -157,7 +157,9 @@ class BuildStepImpl implements BuildStep {
   Future<void> complete() async {
     _isComplete = true;
     await Future.wait(_writeResults.map(Result.release));
-    (await _resolver)?.release();
+    try {
+      (await _resolver)?.release();
+    } catch (_) {}
   }
 
   /// Checks that [id] is an expected output, and throws an

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 2.0.1
+version: 2.0.2
 description: A build system for Dart.
 repository: https://github.com/dart-lang/build/tree/master/build
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.3
+
+- Fix an issue where the build process would hang if the resolver fails to
+  properly initialize.
+
 ## 2.0.2
 
 - Add more context to the outdated analyzer version message. It now provides

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -18,6 +18,7 @@ import 'package:analyzer/src/dart/analysis/driver.dart' show AnalysisDriver;
 import 'package:analyzer/src/dart/analysis/experiments.dart';
 import 'package:analyzer/src/generated/engine.dart'
     show AnalysisOptions, AnalysisOptionsImpl;
+import 'package:async/async.dart';
 import 'package:build/build.dart';
 import 'package:build/experiments.dart';
 import 'package:logging/logging.dart';
@@ -302,7 +303,7 @@ class AnalyzerResolvers implements Resolvers {
   BuildAssetUriResolver? _uriResolver;
 
   /// Nullable, should not be accessed outside of [_ensureInitialized].
-  Future<void>? _initialized;
+  Future<Result<void>>? _initialized;
 
   PackageConfig? _packageConfig;
 
@@ -334,7 +335,7 @@ class AnalyzerResolvers implements Resolvers {
   /// Create a Resolvers backed by an `AnalysisContext` using options
   /// [_analysisOptions].
   Future<void> _ensureInitialized() {
-    return _initialized ??= () async {
+    return Result.release(_initialized ??= Result.capture(() async {
       _warnOnLanguageVersionMismatch();
       final uriResolver = _uriResolver = BuildAssetUriResolver();
       final loadedConfig = _packageConfig ??=
@@ -342,7 +343,7 @@ class AnalyzerResolvers implements Resolvers {
       var driver = await analysisDriver(uriResolver, _analysisOptions,
           await _sdkSummaryGenerator(), loadedConfig);
       _resolver = AnalyzerResolver(driver, uriResolver);
-    }();
+    }()));
   }
 
   @override

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.0.2
+version: 2.0.3
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   analyzer: ^1.5.0
+  async: ^2.5.0
   build: ^2.0.0
   crypto: ^3.0.0
   graphs: ">=1.0.0 <3.0.0"


### PR DESCRIPTION
This future completes with an error in the zone of the builder that first triggers it - and then never completes when accessed from other builders since errors can't cross error handling zones.

Now we use Result.capture and Result.release to ensure each invocation of Resolver.get gets a future from its own zone, and thus gets the error instead of hanging.