### PR TITLE
Migrate uses of followedBy to collection literals

### DIFF
--- a/_test_common/lib/common.dart
+++ b/_test_common/lib/common.dart
@@ -28,8 +28,7 @@ Digest computeDigest(AssetId id, String contents) {
     var package = id.package.substring(2);
     id = AssetId(package, '.dart_tool/build/generated/$package/${id.path}');
   }
-  return md5.convert(
-      utf8.encode(contents).followedBy(id.toString().codeUnits).toList());
+  return md5.convert([...utf8.encode(contents), ...id.toString().codeUnits]);
 }
 
 class PlaceholderBuilder extends Builder {

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.0.1-dev
+
 ## 4.0.0
 
 - Migrate to null safety.

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -149,12 +149,12 @@ List<Module> _mergeModules(Iterable<Module> modules, Set<AssetId> entrypoints) {
     }
   }
 
-  return mergedModules.values
-      .map(Module.merge)
-      .map(_withConsistentPrimarySource)
-      .followedBy(entrypointModuleGroups.values.map(Module.merge))
-      .followedBy(standaloneModules)
-      .toList();
+  return [
+    for (var module in mergedModules.values)
+      _withConsistentPrimarySource(Module.merge(module)),
+    for (var module in entrypointModuleGroups.values) Module.merge(module),
+    ...standaloneModules
+  ];
 }
 
 Module _withConsistentPrimarySource(Module m) => Module(m.sources.reduce(_min),
@@ -252,14 +252,15 @@ MetaModule _coarseModulesForLibraries(
 
 MetaModule _fineModulesForLibraries(
     AssetReader reader, List<ModuleLibrary> libraries, DartPlatform platform) {
-  var modules = libraries
-      .map((library) => Module(
+  var modules = [
+    for (var library in libraries)
+      Module(
           library.id,
-          library.parts.followedBy([library.id]),
+          [...library.parts, library.id],
           library.depsForPlatform(platform),
           platform,
-          library.sdkDeps.every(platform.supportsLibrary)))
-      .toList();
+          library.sdkDeps.every(platform.supportsLibrary))
+  ];
   _sortModules(modules);
   return MetaModule(modules);
 }

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 4.0.0
+version: 4.0.1-dev
 description: Builders for Dart modules
 repository: https://github.com/dart-lang/build/tree/master/build_modules
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.5-dev
+
 ## 2.0.4
 
 - Allow builders defined as relative imports from the root of a package to run

--- a/build_runner/lib/src/server/path_to_asset_id.dart
+++ b/build_runner/lib/src/server/path_to_asset_id.dart
@@ -11,7 +11,7 @@ AssetId pathToAssetId(
   return packagesIndex >= 0
       ? AssetId(pathSegments[packagesIndex + 1],
           p.join('lib', p.joinAll(pathSegments.sublist(packagesIndex + 2))))
-      : AssetId(rootPackage, p.joinAll([rootDir].followedBy(pathSegments)));
+      : AssetId(rootPackage, p.joinAll([rootDir, ...pathSegments]));
 }
 
 /// Returns null for paths that neither a lib nor starts from a rootDir

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -308,11 +308,8 @@ class AssetHandler {
       (request.url.path.endsWith('/') || request.url.path.isEmpty)
           ? _handle(
               request.headers,
-              pathToAssetId(
-                  _rootPackage,
-                  rootDir,
-                  request.url.pathSegments
-                      .followedBy(const ['index.html']).toList()),
+              pathToAssetId(_rootPackage, rootDir,
+                  [...request.url.pathSegments, 'index.html']),
               fallbackToDirectoryList: true)
           : _handle(request.headers,
               pathToAssetId(_rootPackage, rootDir, request.url.pathSegments));

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.0.4
+version: 2.0.5-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/integration_tests/utils/build_descriptor.dart
+++ b/build_runner/test/integration_tests/utils/build_descriptor.dart
@@ -90,23 +90,20 @@ Map _builderDefinition(TestBuilderDefinition builder) => {
 /// Files other than the pubspec should be set up with [packageContents].
 Future<BuildTool> package(Iterable<d.Descriptor> otherPackages,
     {Iterable<d.Descriptor> packageContents = const []}) async {
-  await d
-      .dir(
-          'a',
-          <d.Descriptor>[
-            await _pubspecWithDeps('a', currentIsolateDependencies: [
-              'build',
-              'build_config',
-              'build_daemon',
-              'build_resolvers',
-              'build_runner',
-              'build_runner_core',
-              'code_builder',
-            ], pathDependencies: {
-              for (var o in otherPackages) o.name: p.join(d.sandbox, o.name),
-            }),
-          ].followedBy(packageContents))
-      .create();
+  await d.dir('a', <d.Descriptor>[
+    await _pubspecWithDeps('a', currentIsolateDependencies: [
+      'build',
+      'build_config',
+      'build_daemon',
+      'build_resolvers',
+      'build_runner',
+      'build_runner_core',
+      'code_builder',
+    ], pathDependencies: {
+      for (var o in otherPackages) o.name: p.join(d.sandbox, o.name),
+    }),
+    ...packageContents
+  ]).create();
   await Future.wait(otherPackages.map((d) => d.create()));
   await pubGet('a');
   return BuildTool._('pub', ['run', 'build_runner']);
@@ -128,28 +125,25 @@ Future<BuildTool> packageWithBuildScript(
     Iterable<TestBuilderDefinition> builders,
     {Iterable<d.Descriptor> contents = const []}) async {
   var frameCaller = Frame.caller().uri;
-  await d
-      .dir(
-          'a',
-          [
-            await _pubspecWithDeps('a', currentIsolateDependencies: [
-              'build',
-              'build_config',
-              'build_daemon',
-              'build_resolvers',
-              'build_runner',
-              'build_runner_core',
-              'build_test',
-              'code_builder',
-            ]),
-            d.dir('tool', [
-              d.file(
-                  'build.dart',
-                  _buildToolFile(builders,
-                      (await Isolate.resolvePackageUri(frameCaller))!))
-            ])
-          ].followedBy(contents))
-      .create();
+  await d.dir('a', [
+    await _pubspecWithDeps('a', currentIsolateDependencies: [
+      'build',
+      'build_config',
+      'build_daemon',
+      'build_resolvers',
+      'build_runner',
+      'build_runner_core',
+      'build_test',
+      'code_builder',
+    ]),
+    d.dir('tool', [
+      d.file(
+          'build.dart',
+          _buildToolFile(
+              builders, (await Isolate.resolvePackageUri(frameCaller))!))
+    ]),
+    ...contents
+  ]).create();
   await pubGet('a');
   return BuildTool._('dart', [p.join('tool', 'build.dart')]);
 }
@@ -273,14 +267,14 @@ class BuildTool {
 
   BuildTool._(this._executable, this._baseArgs);
 
-  Future<BuildServer> serve() async => BuildServer(await TestProcess.start(
-      _executable, _baseArgs.followedBy(['serve']),
-      workingDirectory: rootPackageDir));
+  Future<BuildServer> serve() async =>
+      BuildServer(await TestProcess.start(_executable, [..._baseArgs, 'serve'],
+          workingDirectory: rootPackageDir));
 
   Future<StreamQueue<String>> build(
       {List<String> args = const [], int expectExitCode = 0}) async {
     var process = await TestProcess.start(
-        _executable, _baseArgs.followedBy(['build']).followedBy(args).toList(),
+        _executable, [..._baseArgs, 'build', ...args],
         workingDirectory: rootPackageDir);
     await process.shouldExit(expectExitCode);
     return process.stdout;

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 7.0.1-dev
+
 ## 7.0.0
 
 - Migrate to null safety.

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -319,8 +319,7 @@ class AssetGraph {
 
     var newGeneratedOutputs =
         _addOutputsForSources(buildPhases, newIds, rootPackage);
-    var allNewAndDeletedIds =
-        Set.of(newGeneratedOutputs.followedBy(transitiveRemovedIds));
+    var allNewAndDeletedIds = {...newGeneratedOutputs, ...transitiveRemovedIds};
 
     void invalidateNodeAndDeps(AssetId id) {
       var node = get(id);

--- a/build_runner_core/lib/src/logging/failure_reporter.dart
+++ b/build_runner_core/lib/src/logging/failure_reporter.dart
@@ -56,10 +56,10 @@ class FailureReporter {
     if (!_reportedActions.add(_actionKey(output))) return;
     final errorFile =
         await File(_errorPathForOutput(output)).create(recursive: true);
-    await errorFile.writeAsString(jsonEncode(<dynamic>[actionDescription]
-        .followedBy(errors
-            .map((e) => [e.message, e.error, e.stackTrace?.toString() ?? '']))
-        .toList()));
+    await errorFile.writeAsString(jsonEncode(<dynamic>[
+      actionDescription,
+      for (var e in errors) [e.message, e.error, e.stackTrace?.toString() ?? '']
+    ]));
   }
 
   /// Indicate that the build steps which would produce [outputs] are failing

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 7.0.0
+version: 7.0.1-dev
 description: Core tools to write binaries that run builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.1-dev
+
 ## 3.0.0
 
 - Migrate to null safety.

--- a/build_web_compilers/lib/src/common.dart
+++ b/build_web_compilers/lib/src/common.dart
@@ -72,6 +72,6 @@ List<String> fixSourceMapSources(List<String> uris) {
     var newSegments = uri.pathSegments.first == 'packages'
         ? uri.pathSegments
         : uri.pathSegments.skip(1);
-    return Uri(path: p.url.joinAll(['/'].followedBy(newSegments))).toString();
+    return Uri(path: p.url.joinAll(['/', ...newSegments])).toString();
   }).toList();
 }

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 3.0.0
+version: 3.0.1-dev
 description: Builder implementations wrapping Dart compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 

--- a/build_web_compilers/web/stack_trace_mapper.dart
+++ b/build_web_compilers/web/stack_trace_mapper.dart
@@ -47,7 +47,7 @@ List<String> fixSourceMapSources(List<String> uris) {
     var newSegments = uri.pathSegments.first == 'packages'
         ? uri.pathSegments
         : uri.pathSegments.skip(1);
-    return Uri(path: p.url.joinAll(['/'].followedBy(newSegments))).toString();
+    return Uri(path: p.url.joinAll(['/', ...newSegments])).toString();
   }).toList();
 }
 


### PR DESCRIPTION
In the past I've looked for other common patterns that look nicer as
literals and on a hunch I wanted to check which uses of `followedBy` are
more readable as subsequent elements in a collection. In these cases I
think it is an improvement.

Most migrated cases either were immediately gathered into a collection
to `.toList` or `.toSet`. In a few places where I trust that the
collection will be fairly small and always iterated I also switched from
using a lazy iterable into an eager collection.

Some uses of `followedBy` remain. Those cases are either where an eager
collection could be non-performant, or cases where the iterable chains
subsequent `.map` or other calls that would make the collection literal
more noisy.