### PR TITLE
dont set the content length or body when responding to HEAD requests

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 2.0.5-dev
+## 2.0.5
+
+- Don't set the content length header or body when responding to HEAD requests.
 
 ## 2.0.4
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.0.5-dev
+version: 2.0.5
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -118,6 +118,15 @@ void main() {
         rootDir: 'web');
     expect(response.statusCode, HttpStatus.internalServerError);
   });
+
+  test('Supports HEAD requests', () async {
+    _addAsset('a|web/index.html', 'content');
+    var response = await handler.handle(
+        Request('HEAD', Uri.parse('http://server.com/index.html')),
+        rootDir: 'web');
+    expect(response.contentLength, 0);
+    expect(await response.readAsString(), '');
+  });
 }
 
 class FakeAssetReader with Fake implements AssetReader {}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/3129

Note that in the test I am getting out `0` and `''` for the content length/body (instead of null), but I am not setting those. I assume that shelf itself is plugging in some empty values here for convenience? cc @kevmoo not sure if you know.