### PR TITLE
Log requests and request failures in build daemon asset server

### DIFF
--- a/_test/test/serve_integration_test.dart
+++ b/_test/test/serve_integration_test.dart
@@ -25,7 +25,10 @@ void main() {
   group('basic serve', () {
     setUpAll(() async {
       // These tests depend on running `test` while a `serve` is ongoing.
-      await startServer(ensureCleanBuild: true);
+      await startServer(
+        ensureCleanBuild: true,
+        buildArgs: ['--verbose', '--log-requests'],
+      );
     });
 
     tearDownAll(() async {
@@ -135,6 +138,8 @@ void main() {
       'web',
       '--build-filter',
       'web/sub/main.dart.js',
+      '--verbose',
+      '--log-requests',
       '--define',
       'build_web_compilers|ddc=environment={"message": "goodbye"}',
     ]);

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.0.7-dev
 
+- Add `--log-requests` flag to build daemon.
+- Log failed asset requests in build_runner server.
+
 ## 2.0.6
 
 - Allow analyzer version 2.x.x.

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.7-dev
+## 2.1.0-dev
 
 - Add `--log-requests` flag to build daemon.
 - Log failed asset requests in build_runner server.

--- a/build_runner/lib/src/entrypoint/daemon.dart
+++ b/build_runner/lib/src/entrypoint/daemon.dart
@@ -31,9 +31,14 @@ class DaemonCommand extends WatchCommand {
   String get name => 'daemon';
 
   DaemonCommand() {
-    argParser.addOption(buildModeFlag,
-        help: 'Specify the build mode of the daemon, e.g. auto or manual.',
-        defaultsTo: 'BuildMode.Auto');
+    argParser
+      ..addOption(buildModeFlag,
+          help: 'Specify the build mode of the daemon, e.g. auto or manual.',
+          defaultsTo: 'BuildMode.Auto')
+      ..addFlag(logRequestsOption,
+          defaultsTo: false,
+          negatable: false,
+          help: 'Enables logging for each request to the server.');
   }
 
   @override
@@ -98,7 +103,8 @@ $logEndMarker'''));
           stdout.writeln(log.message);
         }
       });
-      var server = await AssetServer.run(builder, packageGraph.root.name);
+      var server =
+          await AssetServer.run(options, builder, packageGraph.root.name);
       File(assetServerPortFilePath(workingDirectory))
           .writeAsStringSync('${server.port}');
       unawaited(builder.buildScriptUpdated.then((_) async {

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -128,10 +128,12 @@ class SharedOptions {
 /// Options specific to the `daemon` command.
 class DaemonOptions extends WatchOptions {
   BuildMode buildMode;
+  bool logRequests;
 
   DaemonOptions._({
     required Set<BuildFilter> buildFilters,
     required this.buildMode,
+    required this.logRequests,
     required bool deleteFilesByDefault,
     required bool enableLowResourcesMode,
     required String? configKey,
@@ -185,6 +187,7 @@ class DaemonOptions extends WatchOptions {
     return DaemonOptions._(
       buildFilters: buildFilters,
       buildMode: buildMode,
+      logRequests: argResults[logRequestsOption] as bool,
       deleteFilesByDefault: argResults[deleteFilesByDefaultOption] as bool,
       enableLowResourcesMode: argResults[lowResourcesModeOption] as bool,
       configKey: argResults[configOption] as String?,

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -367,8 +367,8 @@ class AssetHandler {
       }
       return shelf.Response.ok(body, headers: headers);
     } catch (e, s) {
-      _logger.finest('Error on request '
-          '${request.method} ${request.requestedUri}: $e:$s');
+      _logger.finest(
+          'Error on request ${request.method} ${request.requestedUri}', e, s);
       rethrow;
     }
   }

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -317,53 +317,60 @@ class AssetHandler {
   Future<shelf.Response> _handle(shelf.Request request, AssetId assetId,
       {bool fallbackToDirectoryList = false}) async {
     try {
-      if (!await _reader.canRead(assetId)) {
-        var reason = await _reader.unreadableReason(assetId);
-        switch (reason) {
-          case UnreadableReason.failed:
-            return shelf.Response.internalServerError(
-                body: 'Build failed for $assetId');
-          case UnreadableReason.notOutput:
-            return shelf.Response.notFound('$assetId was not output');
-          case UnreadableReason.notFound:
-            if (fallbackToDirectoryList) {
-              return shelf.Response.notFound(await _findDirectoryList(assetId));
-            }
-            return shelf.Response.notFound('Not Found');
-          default:
-            return shelf.Response.notFound('Not Found');
+      try {
+        if (!await _reader.canRead(assetId)) {
+          var reason = await _reader.unreadableReason(assetId);
+          switch (reason) {
+            case UnreadableReason.failed:
+              return shelf.Response.internalServerError(
+                  body: 'Build failed for $assetId');
+            case UnreadableReason.notOutput:
+              return shelf.Response.notFound('$assetId was not output');
+            case UnreadableReason.notFound:
+              if (fallbackToDirectoryList) {
+                return shelf.Response.notFound(
+                    await _findDirectoryList(assetId));
+              }
+              return shelf.Response.notFound('Not Found');
+            default:
+              return shelf.Response.notFound('Not Found');
+          }
         }
+      } on ArgumentError catch (_) {
+        return shelf.Response.notFound('Not Found');
       }
-    } on ArgumentError catch (_) {
-      return shelf.Response.notFound('Not Found');
-    }
 
-    var etag = base64.encode((await _reader.digest(assetId)).bytes);
-    var contentType = _typeResolver.lookup(assetId.path);
-    if (contentType == 'text/x-dart') {
-      contentType = '$contentType; charset=utf-8';
-    }
-    var headers = <String, Object>{
-      if (contentType != null) HttpHeaders.contentTypeHeader: contentType,
-      HttpHeaders.etagHeader: etag,
-      // We always want this revalidated, which requires specifying both
-      // max-age=0 and must-revalidate.
-      //
-      // See spec https://goo.gl/Lhvttg for more info about this header.
-      HttpHeaders.cacheControlHeader: 'max-age=0, must-revalidate',
-    };
+      var etag = base64.encode((await _reader.digest(assetId)).bytes);
+      var contentType = _typeResolver.lookup(assetId.path);
+      if (contentType == 'text/x-dart') {
+        contentType = '$contentType; charset=utf-8';
+      }
+      var headers = <String, Object>{
+        if (contentType != null) HttpHeaders.contentTypeHeader: contentType,
+        HttpHeaders.etagHeader: etag,
+        // We always want this revalidated, which requires specifying both
+        // max-age=0 and must-revalidate.
+        //
+        // See spec https://goo.gl/Lhvttg for more info about this header.
+        HttpHeaders.cacheControlHeader: 'max-age=0, must-revalidate',
+      };
 
-    if (request.headers[HttpHeaders.ifNoneMatchHeader] == etag) {
-      // This behavior is still useful for cases where a file is hit
-      // without a cache-busting query string.
-      return shelf.Response.notModified(headers: headers);
+      if (request.headers[HttpHeaders.ifNoneMatchHeader] == etag) {
+        // This behavior is still useful for cases where a file is hit
+        // without a cache-busting query string.
+        return shelf.Response.notModified(headers: headers);
+      }
+      List<int>? body;
+      if (request.method != 'HEAD') {
+        body = await _reader.readAsBytes(assetId);
+        headers[HttpHeaders.contentLengthHeader] = '${body.length}';
+      }
+      return shelf.Response.ok(body, headers: headers);
+    } catch (e, s) {
+      _logger.finest('Error on request '
+          '${request.method} ${request.requestedUri}: $e:$s');
+      rethrow;
     }
-    List<int>? body;
-    if (request.method != 'HEAD') {
-      body = await _reader.readAsBytes(assetId);
-      headers[HttpHeaders.contentLengthHeader] = '${body.length}';
-    }
-    return shelf.Response.ok(body, headers: headers);
   }
 
   Future<String> _findDirectoryList(AssetId from) async {

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -55,13 +55,11 @@ class PackageGraphWatcher {
                 .watch()
                 .where(_nestedPathFilter(w.node))
                 .handleError((Object e, StackTrace s) {
-              _logger
-                ..severe('Error in watcher for package: ${w.node.name}: $e:$s')
-                ..severe(
-                    'Error from directory watcher for package:${w.node.name}\n\n'
-                    'If you see this consistently then it is recommended that '
-                    'you enable the polling file watcher with '
-                    '--use-polling-watcher.');
+              _logger.severe(
+                  'Error from directory watcher for package:${w.node.name}\n\n'
+                  'If you see this consistently then it is recommended that '
+                  'you enable the polling file watcher with '
+                  '--use-polling-watcher.');
               // ignore: only_throw_errors
               throw e;
             }))

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -55,11 +55,13 @@ class PackageGraphWatcher {
                 .watch()
                 .where(_nestedPathFilter(w.node))
                 .handleError((Object e, StackTrace s) {
-              _logger.severe(
-                  'Error from directory watcher for package:${w.node.name}\n\n'
-                  'If you see this consistently then it is recommended that '
-                  'you enable the polling file watcher with '
-                  '--use-polling-watcher.');
+              _logger
+                ..severe('Error in watcher for package: ${w.node.name}: $e:$s')
+                ..severe(
+                    'Error from directory watcher for package:${w.node.name}\n\n'
+                    'If you see this consistently then it is recommended that '
+                    'you enable the polling file watcher with '
+                    '--use-polling-watcher.');
               // ignore: only_throw_errors
               throw e;
             }))

--- a/build_runner/test/server/serve_integration_test.dart
+++ b/build_runner/test/server/serve_integration_test.dart
@@ -56,12 +56,14 @@ void main() {
       packageGraph: graph,
       reader: reader,
       writer: writer,
-      logLevel: Level.OFF,
+      logLevel: Level.ALL,
+      onLog: (record) => printOnFailure('[${record.level}] '
+          '${record.loggerName}: ${record.message}'),
       directoryWatcherFactory: (path) => FakeWatcher(path),
       terminateEventStream: terminateController.stream,
       skipBuildScriptCheck: true,
     );
-    handler = server.handlerFor('web');
+    handler = server.handlerFor('web', logRequests: true);
 
     nextBuild = Completer<BuildResult>();
     subscription = server.buildResults.listen((result) {


### PR DESCRIPTION
- Add `--log-requests` flag to build runner daemon command.
- Log request failures in asset server.
- Configure http client in tests to limit max connections per host,
  to prevent CI from failing with reset connection errors.

Extra logging will help diagnose CI flakes in build:

https://github.com/dart-lang/build/runs/3062926301

and webdev:

Related: https://github.com/dart-lang/webdev/issues/1345