### PR TITLE
Avoid folding frames for build system bugs

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.7-dev
+
 ## 2.0.6
 
 - Allow analyzer version 2.x.x.

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -36,8 +36,8 @@ StringBuffer colorLog(LogRecord record, {required bool verbose}) {
   if (record.stackTrace != null && verbose) {
     var trace = Trace.from(record.stackTrace!);
     const buildSystem = {'build_runner', 'build_runner_core', 'build'};
-    var exceptionRoot = trace.frames.first.package;
-    if (!buildSystem.contains(exceptionRoot)) {
+    if (trace.frames.isNotEmpty &&
+        !buildSystem.contains(trace.frames.first.package)) {
       trace =
           trace.foldFrames((f) => buildSystem.contains(f.package), terse: true);
     }

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -34,10 +34,13 @@ StringBuffer colorLog(LogRecord record, {required bool verbose}) {
   }
 
   if (record.stackTrace != null && verbose) {
-    var trace = Trace.from(record.stackTrace!).foldFrames((f) {
-      return f.package == 'build_runner' || f.package == 'build';
-    }, terse: true);
-
+    var trace = Trace.from(record.stackTrace!);
+    const buildSystem = {'build_runner', 'build_runner_core', 'build'};
+    var exceptionRoot = trace.frames.first.package;
+    if (!buildSystem.contains(exceptionRoot)) {
+      trace =
+          trace.foldFrames((f) => buildSystem.contains(f.package), terse: true);
+    }
     lines.add(trace);
   }
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.0.6
+version: 2.0.7-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
The intent of the `.foldFrames` call is to reduce the noise for stack
traces when an exception is thrown inside a builder implementation. The
folding makes internal bugs harder to diagnose though, because it can
mask the source of exceptions that are thrown within `build_runner`
code.

Check if the lowest frame of the trace is within one of the build
system implementation packages, and if it is do no folding.

Add `build_runner_core` to the list of packages treated as
implementation of the build system.