### PR TITLE
Pass error and stack trace for request failure log

### DIFF
--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -641,28 +641,27 @@ final _enablePerformanceTracking = '''
 
 /// [shelf.Middleware] that logs all requests, inspired by [shelf.logRequests].
 shelf.Handler _logRequests(shelf.Handler innerHandler) {
-  return (shelf.Request request) {
+  return (shelf.Request request) async {
     var startTime = DateTime.now();
     var watch = Stopwatch()..start();
-
-    return Future.sync(() => innerHandler(request)).then((response) {
+    try {
+      var response = await innerHandler(request);
       var logFn = response.statusCode >= 500 ? _logger.warning : _logger.info;
-      var msg = _getMessage(startTime, response.statusCode,
+      var msg = _requestLabel(startTime, response.statusCode,
           request.requestedUri, request.method, watch.elapsed);
       logFn(msg);
       return response;
-    }, onError: (Object error, StackTrace stackTrace) {
-      if (error is shelf.HijackException) throw error;
-      var msg = _getMessage(
+    } catch(error, stackTrace) {
+      if (error is shelf.HijackException) rethrow;
+      var msg = _requestLabel(
           startTime, 500, request.requestedUri, request.method, watch.elapsed);
-      _logger.severe('$msg\r\n$error\r\n$stackTrace', true);
-      // ignore: only_throw_errors
-      throw error;
-    });
+      _logger.severe(msg, error, stackTrace);
+      rethrow;
+    }
   };
 }
 
-String _getMessage(DateTime requestTime, int statusCode, Uri requestedUri,
+String _requestLabel(DateTime requestTime, int statusCode, Uri requestedUri,
     String method, Duration elapsedTime) {
   return '${requestTime.toIso8601String()} '
       '${humanReadable(elapsedTime)} '

--- a/build_runner/lib/src/server/server.dart
+++ b/build_runner/lib/src/server/server.dart
@@ -651,7 +651,7 @@ shelf.Handler _logRequests(shelf.Handler innerHandler) {
           request.requestedUri, request.method, watch.elapsed);
       logFn(msg);
       return response;
-    } catch(error, stackTrace) {
+    } catch (error, stackTrace) {
       if (error is shelf.HijackException) rethrow;
       var msg = _requestLabel(
           startTime, 500, request.requestedUri, request.method, watch.elapsed);


### PR DESCRIPTION
Correct the `_logger.severe` call to pass the error (instead of a
hardcode `true`) and stack trace to the log record instead of manually
formatting a full message.

Refactor the logging middleware to async/await for better readability,
and to allow using `rethrow` which does not to ignore a lint about only
throwing subtypes of Error or Exception.

Rename `_getMessage` to `_requestLabel` to be more descriptive about the
message it creates.