### PR TITLE
Report expected outputs for build steps

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.0-dev
+
+- Add an `allowedOutputs` getter to `BuildStep`. It returns assets that may be
+  written in that step.
+
 ## 2.0.3
 
 - Allow analyzer version 2.x.x.

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:analyzer/dart/ast/ast.dart';
@@ -40,7 +41,8 @@ class BuildStepImpl implements BuildStep {
 
   /// The list of all outputs which are expected/allowed to be output from this
   /// step.
-  final Set<AssetId> _expectedOutputs;
+  @override
+  final Set<AssetId> allowedOutputs;
 
   /// The result of any writes which are starting during this step.
   final _writeResults = <Future<Result<void>>>[];
@@ -61,7 +63,7 @@ class BuildStepImpl implements BuildStep {
       this._writer, this._resolvers, this._resourceManager,
       {StageTracker? stageTracker,
       void Function(Iterable<AssetId>)? reportUnusedAssets})
-      : _expectedOutputs = expectedOutputs.toSet(),
+      : allowedOutputs = UnmodifiableSetView(expectedOutputs.toSet()),
         _stageTracker = stageTracker ?? NoOpStageTracker.instance,
         _reportUnusedAssets = reportUnusedAssets;
 
@@ -165,8 +167,8 @@ class BuildStepImpl implements BuildStep {
   /// Checks that [id] is an expected output, and throws an
   /// [InvalidOutputException] or [UnexpectedOutputException] if it's not.
   void _checkOutput(AssetId id) {
-    if (!_expectedOutputs.contains(id)) {
-      throw UnexpectedOutputException(id, expected: _expectedOutputs);
+    if (!allowedOutputs.contains(id)) {
+      throw UnexpectedOutputException(id, expected: allowedOutputs);
     }
   }
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 2.0.3
+version: 2.1.0-dev
 description: A build system for Dart.
 repository: https://github.com/dart-lang/build/tree/master/build
 

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -27,13 +27,15 @@ void main() {
   group('with reader/writer stub', () {
     late AssetId primary;
     late BuildStepImpl buildStep;
+    late List<AssetId> outputs;
 
     setUp(() {
       var reader = StubAssetReader();
       var writer = StubAssetWriter();
       primary = makeAssetId();
-      buildStep = BuildStepImpl(
-          primary, [], reader, writer, AnalyzerResolvers(), resourceManager);
+      outputs = List.generate(5, (index) => makeAssetId());
+      buildStep = BuildStepImpl(primary, outputs, reader, writer,
+          AnalyzerResolvers(), resourceManager);
     });
 
     test('doesnt allow non-expected outputs', () {
@@ -42,6 +44,10 @@ void main() {
           throwsA(TypeMatcher<UnexpectedOutputException>()));
       expect(() => buildStep.writeAsBytes(id, [0]),
           throwsA(TypeMatcher<UnexpectedOutputException>()));
+    });
+
+    test('reports allowed outputs', () {
+      expect(buildStep.allowedOutputs, outputs);
     });
 
     test('fetchResource can fetch resources', () async {

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3-dev
+
+- Use `allowedOutputs` in `TestBuilder` instead of computing them again.
+
 ## 2.1.2
 
 - Allow the latest `package:test_core`.

--- a/build_test/lib/src/builder.dart
+++ b/build_test/lib/src/builder.dart
@@ -11,7 +11,7 @@ typedef BuildBehavior = FutureOr Function(
     BuildStep buildStep, Map<String, List<String>> buildExtensions);
 
 /// Copy the input asset to all possible output assets.
-void _defaultBehavior(
+Future<void> _defaultBehavior(
         BuildStep buildStep, Map<String, List<String>> buildExtensions) =>
     _copyToAll(buildStep, buildExtensions);
 
@@ -21,23 +21,22 @@ Future<String> _readAsset(BuildStep buildStep, AssetId assetId) =>
 
 /// Pass the input assetId through [readFrom] and duplicate the results of
 /// [read] on that asset into every matching output based on [buildExtensions].
-void _copyToAll(BuildStep buildStep, Map<String, List<String>> buildExtensions,
-    {AssetId Function(AssetId assetId) readFrom = _identity,
-    Future<String> Function(BuildStep buildStep, AssetId assetId) read =
-        _readAsset}) {
-  if (!buildExtensions.keys.any((e) => buildStep.inputId.path.endsWith(e))) {
+Future<void> _copyToAll(
+  BuildStep buildStep,
+  Map<String, List<String>> buildExtensions, {
+  AssetId Function(AssetId assetId) readFrom = _identity,
+  Future<String> Function(BuildStep buildStep, AssetId assetId) read =
+      _readAsset,
+}) {
+  final outputs = buildStep.allowedOutputs;
+  if (outputs.isEmpty) {
+    // If there's no output, the builder shouldn't run.
     throw ArgumentError('Only expected inputs with extension in '
         '${buildExtensions.keys.toList()} but got ${buildStep.inputId}');
   }
-  for (final inputExtension in buildExtensions.keys) {
-    if (!buildStep.inputId.path.endsWith(inputExtension)) continue;
-    for (final outputExtension in buildExtensions[inputExtension]!) {
-      final newPath = _replaceSuffix(
-          buildStep.inputId.path, inputExtension, outputExtension);
-      final id = AssetId(buildStep.inputId.package, newPath);
-      buildStep.writeAsString(id, read(buildStep, readFrom(buildStep.inputId)));
-    }
-  }
+
+  return Future.wait(outputs.map((id) => buildStep.writeAsString(
+      id, read(buildStep, readFrom(buildStep.inputId)))));
 }
 
 /// A build behavior which reads [assetId] and copies it's content into every
@@ -107,6 +106,3 @@ class TestBuilder implements Builder {
     _buildsCompletedController.add(buildStep.inputId);
   }
 }
-
-String _replaceSuffix(String path, String old, String replacement) =>
-    path.substring(0, path.length - old.length) + replacement;

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 2.1.2
+version: 2.1.3-dev
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ^2.5.0
-  build: ^2.0.0
+  build: ^2.1.0-dev
   build_config: ^1.0.0
   build_resolvers: ^2.0.0
   crypto: ^3.0.0
@@ -27,3 +27,7 @@ dependencies:
 dev_dependencies:
   analyzer: ">=1.5.0 <3.0.0"
   collection: ^1.15.0
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ^2.5.0
-  build: ^2.1.0-dev
+  build: ^2.1.0
   build_config: ^1.0.0
   build_resolvers: ^2.0.0
   crypto: ^3.0.0


### PR DESCRIPTION
This:

- Adds an `allowedOutputs` getter to `BuildStep`, returning assets that may be written in that step
- Marks `BuildStep` as `@sealed` to indicate that users shouldn't subclass it
- Simplifies the default behavior of `TestBuilder` to use `allowedOutputs` instead of manually matching inputs. If we merge this before capture groups I'll be able to simplify a bunch of test cases in that PR as well :)