### PR TITLE
release build and build_runner_core

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 2.1.0-dev
+## 2.1.0
 
 - Expand the expressiveness of `buildExtensions` include capture groups,
   enabling directory moves. For more information on this feature, see
-  https://github.com/dart-lang/build/blob/master/docs/writing_a_builder.md#capture-groups
+  [capture groups](https://github.com/dart-lang/build/blob/master/docs/writing_a_builder.md#capture-groups)
 - Add an `allowedOutputs` getter to `BuildStep`. It returns assets that may be
   written in that step.
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 2.1.0-dev
+version: 2.1.0
 description: A build system for Dart.
 repository: https://github.com/dart-lang/build/tree/master/build
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.1.0-dev
+## 7.1.0
 
 - Support capture groups, a feature introduced in `build`: `2.1.0`.
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 7.1.0-dev
+version: 7.1.0
 description: Core tools to write binaries that run builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 


### PR DESCRIPTION
This releases the "capture groups" feature for build extensions.