### PR TITLE
release build_runner and build_test that support build 2.1.0

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add `--log-requests` flag to build daemon.
 - Log failed asset requests in build_runner server.
-- Support the latest build_runner
+- Support the latest build (`2.1.0`).
 
 ## 2.0.6
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 2.1.0-dev
+## 2.1.0
 
 - Add `--log-requests` flag to build daemon.
 - Log failed asset requests in build_runner server.
+- Support the latest build_runner
 
 ## 2.0.6
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.0.7
+version: 2.1.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.0.7-dev
+version: 2.0.7
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 
@@ -10,11 +10,11 @@ dependencies:
   args: ^2.0.0
   async: ^2.5.0
   analyzer: ">=1.4.0 <3.0.0"
-  build: ">=2.0.0 <2.1.0"
+  build: ">=2.1.0 <2.2.0"
   build_config: '>=1.0.0 <1.1.0'
   build_daemon: ^3.0.0
   build_resolvers: ^2.0.0
-  build_runner_core: ^7.0.0
+  build_runner_core: ^7.1.0
   code_builder: ^4.0.0
   collection: ^1.15.0
   crypto: ^3.0.0

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -39,9 +39,5 @@ dev_dependencies:
     path: ../_test_common
 
 dependency_overrides:
-  # Needed for testing until the world rolls forward
-  analyzer: ^2.0.0
-  build:
-    path: ../build
-  build_test:
-    path: ../build_test
+  build_runner:
+    path: ../build_runner

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -39,5 +39,7 @@ dev_dependencies:
     path: ../_test_common
 
 dependency_overrides:
+  build:
+    path: ../build
   build_runner:
     path: ../build_runner

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -43,3 +43,5 @@ dependency_overrides:
     path: ../build
   build_runner:
     path: ../build_runner
+  build_test:
+    path: ../build_test

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.3-dev
+## 2.1.3
 
 - Use `allowedOutputs` in `TestBuilder` instead of computing them again.
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 2.1.3-dev
+version: 2.1.3
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:


### PR DESCRIPTION
This also bumps to require build_runner_core 7.1.0, which solves the potential weird issue around an getting a newer package:build with an older package:build_runner_core 🥳 