### PR TITLE
dont rethrow file watcher errors, just log them at severe level

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.1-dev
+
+- Don't rethrow file watcher errors - instead log at severe level and continue
+  going. The file watcher implementation should restart automatically as of
+  package:watcher version `0.9.7+13`.
+
 ## 2.1.0
 
 - Add `--log-requests` flag to build daemon.

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -59,9 +59,9 @@ class PackageGraphWatcher {
                   'Error from directory watcher for package:${w.node.name}\n\n'
                   'If you see this consistently then it is recommended that '
                   'you enable the polling file watcher with '
-                  '--use-polling-watcher.');
-              // ignore: only_throw_errors
-              throw e;
+                  '--use-polling-watcher.',
+                  e,
+                  s);
             }))
         .toList();
     // Asynchronously complete the `_readyCompleter` once all the watchers

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.0
+version: 2.1.1-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/3150

Can you confirm if this fixes the issue? You should be able to test it by adding this to your pubspec:

```yaml
dependency_overrides:
  build_runner:
    git:
      url: https://github.com/dart-lang/build.git
      ref: ignore-watcher-errors
      path: build_runner
```