### PR TITLE
Backport: don't rethrow file watcher errors, just log them at severe level (#3165)

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.12.3
+
+- Backport of 2.1.1:
+  - Don't rethrow file watcher errors - instead log at severe level and continue
+    going. The file watcher implementation should restart automatically as of
+    package:watcher version `0.9.7+13`.
+
 ## 1.12.2
 
 - Allow the latest `dart_style`.

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -59,8 +59,9 @@ class PackageGraphWatcher {
                   'Error from directory watcher for package:${w.node.name}\n\n'
                   'If you see this consistently then it is recommended that '
                   'you enable the polling file watcher with '
-                  '--use-polling-watcher.');
-              throw e;
+                  '--use-polling-watcher.',
+                  e,
+                  s);
             }))
         .toList();
     // Asynchronously complete the `_readyCompleter` once all the watchers

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 1.12.2
+version: 1.12.3
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
@insinfo can you get a version solve with this PR, and does it fix the issue?

```yaml
dependency_overrides:
  build_runner:
    git:
      url: https://github.com/dart-lang/build.git
      ref: backport-watcher-fix
      path: build_runner
```