### PR TITLE
Add integration test for changing build extensions

### DIFF
--- a/build/lib/src/builder/builder.dart
+++ b/build/lib/src/builder/builder.dart
@@ -17,10 +17,13 @@ abstract class Builder {
   /// from the values in this map are expected as outputs.
   ///
   /// - If an empty key exists, all inputs are considered matching.
-  /// - A builder must always return the same configuration. Typically this will
-  /// be `const` but may vary based on build arguments.
+  /// - An instance of a builder must always return the same configuration.
+  ///   Typically, a builder will return a `const` map. Builders may also choose
+  ///   extensions based on [BuilderOptions].
   /// - Most builders will use a single input extension and one or more output
-  /// extensions.
+  ///   extensions.
+  /// - For more information on build extensions, see
+  ///   https://github.com/dart-lang/build/blob/master/docs/writing_a_builder.md#configuring-outputs
   Map<String, List<String>> get buildExtensions;
 }
 
@@ -52,10 +55,7 @@ class BuilderOptions {
   /// The `isRoot` value will also be overridden to value from [other].
   BuilderOptions overrideWith(BuilderOptions? other) {
     if (other == null) return this;
-    return BuilderOptions(
-        {}
-          ..addAll(config)
-          ..addAll(other.config),
+    return BuilderOptions({}..addAll(config)..addAll(other.config),
         isRoot: other.isRoot);
   }
 }

--- a/build/lib/src/builder/builder.dart
+++ b/build/lib/src/builder/builder.dart
@@ -55,7 +55,10 @@ class BuilderOptions {
   /// The `isRoot` value will also be overridden to value from [other].
   BuilderOptions overrideWith(BuilderOptions? other) {
     if (other == null) return this;
-    return BuilderOptions({}..addAll(config)..addAll(other.config),
+    return BuilderOptions(
+        {}
+          ..addAll(config)
+          ..addAll(other.config),
         isRoot: other.isRoot);
   }
 }

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -74,18 +74,9 @@ main(List<String> args) async {
 
       test('updates can change extensions', () async {
         // Update the extension from .copy to .copy2
-        var changedBuildScript = '''
-import 'dart:io';
-import 'package:build_runner/build_runner.dart';
-import 'package:build_runner_core/build_runner_core.dart';
-import 'package:build_test/build_test.dart';
-
-main(List<String> args) async {
-  exitCode = await run(args,
-      [applyToRoot(TestBuilder(buildExtensions: appendExtension('.copy2')))]);
-}
-''';
-
+        var changedBuildScript = originalBuildContent.replaceFirst(
+            'TestBuilder()',
+            "TestBuilder(buildExtensions: appendExtension('.copy2'))");
         await d.dir('a', [
           d.dir('tool', [d.file('build.dart', changedBuildScript)])
         ]).create();

--- a/build_runner/test/generate/build_integration_test.dart
+++ b/build_runner/test/generate/build_integration_test.dart
@@ -72,6 +72,40 @@ main(List<String> args) async {
         ]).validate();
       });
 
+      test('updates can change extensions', () async {
+        // Update the extension from .copy to .copy2
+        var changedBuildScript = '''
+import 'dart:io';
+import 'package:build_runner/build_runner.dart';
+import 'package:build_runner_core/build_runner_core.dart';
+import 'package:build_test/build_test.dart';
+
+main(List<String> args) async {
+  exitCode = await run(args,
+      [applyToRoot(TestBuilder(buildExtensions: appendExtension('.copy2')))]);
+}
+''';
+
+        await d.dir('a', [
+          d.dir('tool', [d.file('build.dart', changedBuildScript)])
+        ]).create();
+
+        var result = await runDart('a', 'tool/build.dart',
+            args: ['build', '--delete-conflicting-outputs']);
+        expect(result.exitCode, 0, reason: result.stderr as String);
+        expect(
+            result.stdout,
+            contains(
+                'Throwing away cached asset graph because the build phases '
+                'have changed.'));
+
+        // Running a new builder should delete the old generated asset and add
+        // the new copy.
+        await d.dir('a', [
+          d.dir('web', [d.file('a.txt.copy2', 'a'), d.nothing('a.txt.copy')])
+        ]).validate();
+      });
+
       test('--output creates a merged directory', () async {
         // Run a build and validate the full rebuild output.
         var result = await runDart('a', 'tool/build.dart',


### PR DESCRIPTION
Adds a test for a builder changing its extensions after re-running a build script. I also clarified the dart docs on `buildExtensions` to point out that extensions may be chosen based on builder options and linked to the detailed documentation for outputs.

I guess this closes #683?