### PR TITLE
Update build_web_compiler:entrypoint outputs to support multiple DDC apps on the same page

### DIFF
--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -102,6 +102,7 @@ builders:
     build_extensions:
       .dart:
         - .dart.bootstrap.js
+        - .dart.bootstrap.require.js
         - .dart.js
         - .dart.js.map
         - .dart.js.tar.gz

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -15,6 +15,7 @@ import 'dart2js_bootstrap.dart';
 import 'dev_compiler_bootstrap.dart';
 
 const ddcBootstrapExtension = '.dart.bootstrap.js';
+const ddcBootstrapRequireExtension = '.dart.bootstrap.require.js';
 const jsEntrypointExtension = '.dart.js';
 const jsEntrypointSourceMapExtension = '.dart.js.map';
 const jsEntrypointArchiveExtension = '.dart.js.tar.gz';
@@ -118,6 +119,7 @@ class WebEntrypointBuilder implements Builder {
   final buildExtensions = const {
     '.dart': [
       ddcBootstrapExtension,
+      ddcBootstrapRequireExtension,
       jsEntrypointExtension,
       jsEntrypointSourceMapExtension,
       jsEntrypointArchiveExtension,


### PR DESCRIPTION
## Changes
Currently, serving a page that loads more than one `.dart.js` entrypoint (when they are compiled with DDC) results in only the last one actually executing. This is due to the way the entrypoint JS loads requirejs and queues up the loading of its bootstrap file. Previously, it used the [`data-main` attribute](https://requirejs.org/docs/api.html#data-main) on the require.js `<script>` element, but that only works if there's only one main to call. In the case of multiple entrypoints, each one effectively overwrites the previous `data-main`.

This commit changes the way the bootstrap module is loaded and executed to a way that is compatible with multiple DDC entrypoints on the same page. This is accomplished by generating an additional `.bootstrap.require.js` output from the `build_web_compilers|entrypoint` builder that will be responsible for calling `require([...])` with the bootstrap module name, and then updating the entrypoint JS output to load this new asset after loading `require.js`.

It also changes the logic responsible for populating `window.$dartLoader` so that it appends entrypoint-specific data rather than setting it only once. This allows multiple entrypoints to run and augment that global instead of only the first.

---

Functionally, this accomplishes our goal of being able to at least load and run multiple DDC entrypoints on the same page without any errors. But there may be a better way to do this that maybe doesn't require an extra builder output. I originally tried adding that call to `require(["<module_name>"]);` via an inline script, but because the `require.js` script is deferred loaded, the inline script was running too early. I also tried setting up an onload listener for `require.js`, but that got complicated because each entrypoint adds its own <script> to load it, and if I understood correctly, the onload event wouldn't fire if the script had already been loaded. Ultimately, it seemed that the simplest option for the runtime logic was to load a script that would call `require()` in the same way we were loading the other scripts to ensure that they'd be run in order.

Open to suggestions on any and all of this!

## Testing

For testing purposes, I've been using a very simple app:

```html
<!-- web/index.html -->
<!DOCTYPE html>
<html>
  <head>
    <title>App with multiple DDC entrypoints</title>
  </head>
  <body>
    <h1>App</h1>
    <p id="one">Loading one.dart...</p>
    <p id="two">Loading two.dart...</p>
    <script defer src="one.dart.js"></script>
    <script defer src="two.dart.js"></script>
  </body>
</html>
```

```dart
// web/one.dart
import 'dart:async';
import 'dart:html';

void main() {
  querySelector('#one').innerText = 'one.dart loaded';
  print('one');
}
```

```dart
// web/two.dart
import 'dart:async';
import 'dart:html';

void main() {
  querySelector('#two').innerText = 'two.dart loaded';
  print('two');
}
```

Without these changes, you'd see only the second entrypoint run. With the changes, both run.
_Note: if serving with webdev, you'll also need `--no-injected-client` as the webdev server and injected client code make some similar assumptions about only having one entrypoint on the page. I'm going to put up a similar PR to webdev._