### PR TITLE
Support --enable-experiment option in build daemon command

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 2.1.2-dev
+## 2.1.2
+
+- Support `--enable-experiment` option in build daemon.
 
 ## 2.1.1
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.2-dev
+version: 2.1.2
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -143,6 +143,19 @@ main() {
       ]).create();
     });
 
+    test('supports --enable-experiment option', () async {
+      await _startDaemon(options: ['--enable-experiment=fake-experiment']);
+      var client =
+          await _startClient(options: ['--enable-experiment=fake-experiment'])
+            ..registerBuildTarget(webTarget)
+            ..startBuild();
+      clients.add(client);
+      await expectLater(
+          client.buildResults,
+          emitsThrough((BuildResults b) =>
+              b.results.first.status == BuildStatus.succeeded));
+    });
+
     test('does not shut down down on build script change when configured',
         () async {
       await _startDaemon(options: ['--skip-build-script-check']);

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -54,10 +54,17 @@ main() {
   print('hello');
 }'''),
       ]),
+      d.dir('lib', [
+        d.file('message.dart', '''
+const message = 'hello world';
+      '''),
+      ]),
       d.dir('web', [
         d.file('main.dart', '''
+import 'package:a/message.dart';
+
 main() {
-  print('hello world');
+  print(message);
 }'''),
       ]),
     ]).create();
@@ -152,8 +159,9 @@ main() {
       clients.add(client);
       await expectLater(
           client.buildResults,
+          // TODO: Check for specific message about a bad experiment
           emitsThrough((BuildResults b) =>
-              b.results.first.status == BuildStatus.succeeded));
+              b.results.first.status == BuildStatus.failed));
     });
 
     test('does not shut down down on build script change when configured',


### PR DESCRIPTION
Add --enable-experiment option to build daemon so webdev can pass it to the daemon. 
This is needed to verify that debugger works with new language features.