### PR TITLE
Fix extra space and comma in stdout info text

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.4-dev
+
+- Minor fixes to the log message when compiling the build script has some
+  output.
+
 ## 2.1.3
 
 - Use `dart` top level command instead of `pub` when running pub executables.

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -195,9 +195,11 @@ Future<int> _createKernelIfNeeded(Logger logger) async {
     if (!hadErrors) {
       await kernelCacheFile.rename(scriptKernelLocation);
       if (hadOutput) {
-        logger.info('There was output on stdout while precompiling the build  '
-            'script, run with `--verbose` to see it (you will need to run '
-            'a `clean` first to re-generate it).\n');
+        logger.info(
+          'There was output on stdout while precompiling the build script; run '
+          'with `--verbose` to see it (you will need to run a `clean` first to '
+          're-generate it).\n',
+        );
       }
     }
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.3
+version: 2.1.4-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
* There was an extra space after 'build'
* The sentence, 'run with ...' should be preceded by a semicolon, not a comma.