### PR TITLE
Mark mono_repo outputs as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Exclude compiled file from github statistics
 **/*.dart.js linguist-generated=true
+.github/workflows/dart.yml linguist-generated=true
+tool/ci.sh linguist-generated=true


### PR DESCRIPTION
Add a mono_repo outputs to the .gitattributes as generated which allows
GitHub diff views to leave them collapsed by default.