### PR TITLE
release packages

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.4-dev
+## 2.1.4
 
 - Minor fixes to the log message when compiling the build script has some
   output.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.4-dev
+version: 2.1.4
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.2.1-dev
+## 7.2.1
 
 - Drop package:pedantic dependency and replace it with package:lints.
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 7.2.1-dev
+version: 7.2.1
 description: Core tools to write binaries that run builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.4-dev
+## 2.1.4
 
 - Update `pub run` references to `dart run`.
 - Drop package:pedantic dependency and replace it with package:lints.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 2.1.4-dev
+version: 2.1.4
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:


### PR DESCRIPTION
Releases build_runner, build_runner_core, and build_test. These were meant to be released as a part of https://github.com/dart-lang/build/pull/3197 but I missed updating the version.