### PR TITLE
Use raw string literals in more places when generating the build script

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -109,14 +109,14 @@ final _builders = <_i1.BuilderApplication>[
         r'test/**.node_test.dart',
         r'test/**.vm_test.dart'
       ]),
-      defaultOptions: _i8.BuilderOptions(const {
+      defaultOptions: const _i8.BuilderOptions({
         r'dart2js_args': [r'--minify']
       }),
-      defaultDevOptions: _i8.BuilderOptions(const {
+      defaultDevOptions: const _i8.BuilderOptions({
         r'dart2js_args': [r'--enable-asserts']
       }),
       defaultReleaseOptions:
-          _i8.BuilderOptions(const {r'compiler': r'dart2js'}),
+          const _i8.BuilderOptions({r'compiler': r'dart2js'}),
       appliesBuilders: const [
         r'build_web_compilers:dart2js_archive_extractor'
       ]),
@@ -127,10 +127,10 @@ final _builders = <_i1.BuilderApplication>[
   _i1.applyPostProcess(r'build_web_compilers:dart2js_archive_extractor',
       _i7.dart2jsArchiveExtractor,
       defaultReleaseOptions:
-          _i8.BuilderOptions(const {r'filter_outputs': true})),
+          const _i8.BuilderOptions({r'filter_outputs': true})),
   _i1.applyPostProcess(
       r'build_web_compilers:dart_source_cleanup', _i7.dartSourceCleanup,
-      defaultReleaseOptions: _i8.BuilderOptions(const {r'enabled': true})),
+      defaultReleaseOptions: const _i8.BuilderOptions({r'enabled': true})),
   _i1.applyPostProcess(
       r'provides_builder:some_post_process_builder', _i4.somePostProcessBuilder)
 ];

--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -109,13 +109,14 @@ final _builders = <_i1.BuilderApplication>[
         r'test/**.node_test.dart',
         r'test/**.vm_test.dart'
       ]),
-      defaultOptions: _i8.BuilderOptions({
-        'dart2js_args': ['--minify']
+      defaultOptions: _i8.BuilderOptions(const {
+        r'dart2js_args': [r'--minify']
       }),
-      defaultDevOptions: _i8.BuilderOptions({
-        'dart2js_args': ['--enable-asserts']
+      defaultDevOptions: _i8.BuilderOptions(const {
+        r'dart2js_args': [r'--enable-asserts']
       }),
-      defaultReleaseOptions: _i8.BuilderOptions({'compiler': 'dart2js'}),
+      defaultReleaseOptions:
+          _i8.BuilderOptions(const {r'compiler': r'dart2js'}),
       appliesBuilders: const [
         r'build_web_compilers:dart2js_archive_extractor'
       ]),
@@ -125,10 +126,11 @@ final _builders = <_i1.BuilderApplication>[
   _i1.applyPostProcess(r'build_modules:module_cleanup', _i5.moduleCleanup),
   _i1.applyPostProcess(r'build_web_compilers:dart2js_archive_extractor',
       _i7.dart2jsArchiveExtractor,
-      defaultReleaseOptions: _i8.BuilderOptions({'filter_outputs': true})),
+      defaultReleaseOptions:
+          _i8.BuilderOptions(const {r'filter_outputs': true})),
   _i1.applyPostProcess(
       r'build_web_compilers:dart_source_cleanup', _i7.dartSourceCleanup,
-      defaultReleaseOptions: _i8.BuilderOptions({'enabled': true})),
+      defaultReleaseOptions: _i8.BuilderOptions(const {r'enabled': true})),
   _i1.applyPostProcess(
       r'provides_builder:some_post_process_builder', _i4.somePostProcessBuilder)
 ];

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.5-dev
+## 2.1.5
 
 - Use raw string literals for builder options when generating build scripts.
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.5-dev
+
+- Use raw string literals for builder options when generating build scripts.
+
 ## 2.1.4
 
 - Minor fixes to the log message when compiling the build script has some

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -310,8 +310,8 @@ Expression _applyPostProcessBuilder(PostProcessBuilderDefinition definition) {
   ], namedArgs);
 }
 
-Expression _rawStringList(List<String> strings) => literalConstList(
-    [for (var string in strings) literalString(string, raw: true)]);
+Expression _rawStringList(List<String> strings) =>
+    strings.toExpression(constant: true);
 
 /// Returns the actual import to put in the generated script based on an import
 /// found in the build.yaml.
@@ -351,8 +351,34 @@ Expression _findToExpression(BuilderDefinition definition) {
 /// An expression creating a [BuilderOptions] from a json string.
 Expression _constructBuilderOptions(Map<String, dynamic> options) =>
     refer('BuilderOptions', 'package:build/build.dart')
-        .newInstance([literalMap(options)]);
+        .newInstance([options.toExpression(constant: true)]);
 
 extension on LanguageVersion {
   Version get asVersion => Version(major, minor, 0);
+}
+
+/// Converts a Dart object to a source code representation.
+///
+/// This is similar to [literal] from `package:code_builder`, except that it
+/// always writes raw string literals.
+extension ConvertToExpression on Object? {
+  Expression toExpression({bool constant = false}) {
+    final $this = this;
+
+    if ($this is Map) {
+      final create = constant ? literalConstMap : literalMap;
+      return create({
+        for (final entry in $this.cast<Object?, Object?>().entries)
+          entry.key.toExpression(): entry.value.toExpression()
+      });
+    } else if ($this is List) {
+      final create = constant ? literalConstList : literalList;
+      return create(
+          [for (final entry in $this.cast<Object?>()) entry.toExpression()]);
+    } else if ($this is String) {
+      return literalString($this, raw: true);
+    } else {
+      return literal(this);
+    }
+  }
 }

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -351,7 +351,7 @@ Expression _findToExpression(BuilderDefinition definition) {
 /// An expression creating a [BuilderOptions] from a json string.
 Expression _constructBuilderOptions(Map<String, dynamic> options) =>
     refer('BuilderOptions', 'package:build/build.dart')
-        .newInstance([options.toExpression(constant: true)]);
+        .constInstance([options.toExpression()]);
 
 extension on LanguageVersion {
   Version get asVersion => Version(major, minor, 0);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.5-dev
+version: 2.1.5
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.4
+version: 2.1.5-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
When generating the build script, some string literals like the builder's name are generated as raw strings already. However, strings that might be part of a builder's options are not escaped.

For example, a build script generated for the following builder options would fail to run:

```yaml
options:
  args: "-shared -o $output $input"
```

With this PR, we use raw string literals in more places. I have updated the golden file as a test, let me know if we need more tests for this.