### PR TITLE
Replace implicit-casts with strict-casts

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 include: package:lints/recommended.yaml
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
   errors:
     unused_import: error
     unused_local_variable: error

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -61,7 +61,7 @@ class _AssetGraphDeserializer {
     // Read in all the nodes and their outputs.
     //
     // Note that this does not read in the inputs of generated nodes.
-    for (var serializedItem in _serializedGraph['nodes']) {
+    for (var serializedItem in _serializedGraph['nodes'] as Iterable) {
       graph._add(_deserializeAssetNode(serializedItem as List));
     }
 

--- a/build_runner_core/lib/src/package_graph/package_graph.dart
+++ b/build_runner_core/lib/src/package_graph/package_graph.dart
@@ -176,7 +176,7 @@ Map<String, DependencyType> _parseDependencyTypes(String rootPackagePath) {
   }
   final dependencyTypes = <String, DependencyType>{};
   final dependencies = loadYaml(pubspecLock.readAsStringSync()) as YamlMap;
-  for (final packageName in dependencies['packages'].keys) {
+  for (final packageName in dependencies['packages'].keys as Iterable) {
     final source = dependencies['packages'][packageName]['source'];
     dependencyTypes[packageName as String] =
         _dependencyTypeFromSource(source as String);


### PR DESCRIPTION
`stict-casts` is the replacement for `implicit-casts` with additional
checking around for-in loops.

Add some explicit casts to `Iterable` for for-in loops.