### PR TITLE
update to the latest analyzer across all packages

### DIFF
--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -23,7 +23,6 @@ dev_dependencies:
   test_process: ^2.0.0
 
 dependency_overrides:
-  analyzer: ^3.0.0
   build:
     path: ../build
   build_config:

--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
-  analyzer: ">=1.0.0 <3.0.0"
+  analyzer: ">=1.0.0 <4.0.0"
   build: any
   build_config: any
   build_modules: any
@@ -23,6 +23,7 @@ dev_dependencies:
   test_process: ^2.0.0
 
 dependency_overrides:
+  analyzer: ^3.0.0
   build:
     path: ../build
   build_config:

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 2.2.0-dev
+## 2.2.0
 
 - Allow reusing the values held by `Resource`s when the resource has a `dispose`
   method. Previously the instances were discarded and recreated for every build
   even if they had tried to clean up their own state.
+- Allow the latest analyzer.
 
 ## 2.1.1
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -21,6 +21,3 @@ dev_dependencies:
   build_test: ^2.0.0
   lints: ^1.0.0
   test: ^1.16.0
-
-dependency_overrides:
-  analyzer: ^3.0.0

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 2.2.0-dev
+version: 2.2.0
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=1.5.0 <3.0.0"
+  analyzer: ">=1.5.0 <4.0.0"
   async: ^2.5.0
   convert: ^3.0.0
   crypto: ^3.0.0
@@ -21,3 +21,6 @@ dev_dependencies:
   build_test: ^2.0.0
   lints: ^1.0.0
   test: ^1.16.0
+
+dependency_overrides:
+  analyzer: ^3.0.0

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 4.0.4-dev
 
+- Allow the latest analyzer.
+
 ## 4.0.3
 
 - Drop package:pedantic dependency and replace it with package:lints.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=1.0.0 <3.0.0"
+  analyzer: ">=1.0.0 <4.0.0"
   async: ^2.5.0
   bazel_worker: ^1.0.0
   build: ^2.0.0
@@ -33,3 +33,6 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  analyzer: ^3.0.0

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -33,6 +33,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  analyzer: ^3.0.0

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.6
+
+- Allow the latest analyzer.
+
 ## 2.0.5
 
 - Consider files without a `.dart` extension as not Dart libraries. Previously

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.0.5
+version: 2.0.6
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  analyzer: ^2.7.0
+  analyzer: ">=2.7.0 <4.0.0"
   async: ^2.5.0
   build: ^2.0.0
   crypto: ^3.0.0
@@ -24,3 +24,6 @@ dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0
   build_test: ^2.0.0
+
+dependency_overrides:
+  analyzer: ^3.0.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -24,6 +24,3 @@ dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0
   build_test: ^2.0.0
-
-dependency_overrides:
-  analyzer: ^3.0.0

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.6
+
+- Allow the latest analyzer.
+
 ## 2.1.5
 
 - Use raw string literals for builder options when generating build scripts.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.5
+version: 2.1.6
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 
@@ -9,9 +9,9 @@ environment:
 dependencies:
   args: ^2.0.0
   async: ^2.5.0
-  analyzer: ">=1.4.0 <3.0.0"
+  analyzer: ">=1.4.0 <4.0.0"
   build: ">=2.1.0 <2.2.0"
-  build_config: '>=1.0.0 <1.1.0'
+  build_config: ">=1.0.0 <1.1.0"
   build_daemon: ^3.0.0
   build_resolvers: ^2.0.0
   build_runner_core: ^7.2.0
@@ -52,3 +52,6 @@ dev_dependencies:
   test_process: ^2.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  analyzer: ^3.0.0

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -52,6 +52,3 @@ dev_dependencies:
   test_process: ^2.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  analyzer: ^3.0.0

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 7.2.3-dev
+## 7.2.3
+
+- Allow the latest analyzer.
 
 ## 7.2.2
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -37,6 +37,3 @@ dev_dependencies:
   test_process: ^2.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  analyzer: ^3.0.0

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 7.2.3-dev
+version: 7.2.3
 description: Core tools to write binaries that run builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
@@ -27,7 +27,7 @@ dependencies:
   yaml: ^3.0.0
 
 dev_dependencies:
-  analyzer: ^2.0.0
+  analyzer: ">=2.0.0 <4.0.0"
   build_runner: ^2.0.0
   build_test: ^2.0.0
   lints: ^1.0.0
@@ -38,3 +38,5 @@ dev_dependencies:
   _test_common:
     path: ../_test_common
 
+dependency_overrides:
+  analyzer: ^3.0.0

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.5
+
+- Allow the latest analyzer.
+
 ## 2.1.4
 
 - Update `pub run` references to `dart run`.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -27,6 +27,3 @@ dev_dependencies:
   analyzer: ">=2.1.0 <4.0.0"
   collection: ^1.15.0
   lints: ^1.0.0
-
-dependency_overrides:
-  analyzer: ^3.0.0

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 2.1.4
+version: 2.1.5
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
@@ -20,10 +20,13 @@ dependencies:
   path: ^1.8.0
   stream_transform: ^2.0.0
   test: ^1.16.0
-  test_core: '>=0.3.19 <0.5.0'
+  test_core: ">=0.3.19 <0.5.0"
   watcher: ^1.0.0
 
 dev_dependencies:
-  analyzer: ^2.1.0
+  analyzer: ">=2.1.0 <4.0.0"
   collection: ^1.15.0
   lints: ^1.0.0
+
+dependency_overrides:
+  analyzer: ^3.0.0

--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.0.10-dev
+## 1.0.10
 
 - Update `pub run` references to `dart run`.
+- Allow the latest analyzer.
 
 ## 1.0.9
 

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -23,6 +23,5 @@ dev_dependencies:
     path: ../_test_common
 
 dependency_overrides:
-  analyzer: ^3.0.0
   build_runner_core:
     path: ../build_runner_core

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -1,13 +1,13 @@
 name: build_vm_compilers
-version: 1.0.10-dev
+version: 1.0.10
 description: Builder implementations wrapping Dart VM compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_vm_compilers
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=1.0.0 <3.0.0"
+  analyzer: ">=1.0.0 <4.0.0"
   build: ^2.0.0
   build_config: ^1.0.0
   build_modules: ^4.0.0
@@ -23,5 +23,6 @@ dev_dependencies:
     path: ../_test_common
 
 dependency_overrides:
+  analyzer: ^3.0.0
   build_runner_core:
     path: ../build_runner_core

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.2
+
+- Allow the latest analyzer.
+
 ## 3.2.1
 
 - Fix enable-experiment flag support for dartdevc to also pass experiment flags

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 3.2.1
+version: 3.2.2
 description: Builder implementations wrapping Dart compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.14.0-216.0.dev <3.0.0"
 
 dependencies:
-  analyzer: ">=1.0.0 <3.0.0"
+  analyzer: ">=1.0.0 <4.0.0"
   archive: ^3.0.0
   bazel_worker: ^1.0.0
   build: ^2.0.0
@@ -33,3 +33,6 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
+
+dependency_overrides:
+  analyzer: ^3.0.0

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -33,6 +33,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  analyzer: ^3.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,8 +15,6 @@ dev_dependencies:
   lints: ^1.0.0
 
 dependency_overrides:
-  # Needed until the world rolls forward
-  analyzer: ^3.0.0
   build:
     path: ../build
   build_runner_core:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ^2.0.0
+  analyzer: ">=2.0.0 <4.0.0"
   build: ^2.0.0
   # Not imported in code, but used to constrain `build.yaml` requirements
   build_config: ^1.0.0
@@ -16,7 +16,7 @@ dev_dependencies:
 
 dependency_overrides:
   # Needed until the world rolls forward
-  analyzer: ^2.0.0
+  analyzer: ^3.0.0
   build:
     path: ../build
   build_runner_core:


### PR DESCRIPTION
If we are green I will just remove the overrides and publish with the expanded range, won't need to wait on dependencies to update first.