### PR TITLE
Share Unused Assets between inputs

### DIFF
--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -161,6 +161,8 @@ CheckInvalidInput _checkInvalidInputFactory(
   };
 }
 
+var unusedAssets = <AssetId>{};
+
 /// Performs a single build and manages state that only lives for a single
 /// build.
 class _SingleBuild {
@@ -517,7 +519,6 @@ class _SingleBuild {
             .putIfAbsent(phaseNumber, () => <String>{})
             .add(actionDescription);
 
-        var unusedAssets = <AssetId>{};
         await tracker.trackStage(
             'Build',
             () => runBuilder(


### PR DESCRIPTION
## Goal
As a developer, I would like to decrease the duration for each build time. A way that this can be achieved is by filtering out files that do not need code generation to avoid unintentionally triggering the build_runner.

## Issue
Currently, if an asset gets added to `unusedAssets` the build_runner can still be triggered by said asset.
This happens because the unused asset is not included in `unusedAssets` for every input individually, therefore it's never truly ignored. 

## Proposal
Each time `_runForInput` runs, the variable `unusedAssets` is declared, making it specific only to the input. I propose that we move the variable to the outside of `_runForInput`'s scope, which would allow each asset that is added to `unusedAssets` to be shared across all inputs.

## Pros
- Unused assets can be shared between inputs
- Add unused assets for files that do not require code generation
- The developer can speed up build times by avoiding unintentional build triggers

## Cons
- Requires more dev work to avoid unintentionally adding assets
- Possible code break if an asset is marked as unused for specific files only