### PR TITLE
Experiment with running client tests

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           repository: simolus3/moor
           ref: latest-release
-          path: client_tests
+          path: client_tests/drift
       - run: |-
-          dart run tool/bin/patch_build_dependencies.dart client_tests/drift
-          cd client_tests/drift
+          dart run tool/bin/patch_build_dependencies.dart client_tests/drift/drift
+          cd client_tests/drift/drift
           git add pubspec.yaml
       - run: dart test --preset build_community_tests
         name: Drift community tests
-        working-directory: client_tests/drift
+        working-directory: client_tests/drift/drift

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -18,10 +18,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: simolus3/moor
-          path: /tmp/drift
+          path: client_tests
       - run: |-
-          dart run tool/bin/patch_build_dependencies.dart /tmp/drift/drift
-          cd /tmp/drift/drift
+          dart run tool/bin/patch_build_dependencies.dart client_tests/drift
+          cd client_tests/drift
           git add pubspec.yaml
       - run: dart test --preset build_community_tests
         name: Drift community tests
+        working-directory: client_tests/drift

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -1,0 +1,27 @@
+name: Community tests
+on:
+  pull_request:
+env:
+  PUB_ENVIRONMENT: bot.github
+
+jobs:
+  drift:
+    # Tests maintained by oss@simonbinder.eu
+    name: "Tests for pkg:drift"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1.3
+      - uses: actions/checkout@v2
+      - run: dart pub get
+        working-directory: tool
+
+      - uses: actions/checkout@v2
+        with:
+          repository: simolus3/moor
+          path: /tmp/drift
+      - run: |-
+          dart run tool/bin/patch_build_dependencies.dart /tmp/drift/drift
+          cd /tmp/drift/drift
+          git add pubspec.yaml
+      - run: dart test --preset build_community_tests
+        name: Drift community tests

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: simolus3/moor
+          ref: latest-release
           path: client_tests
       - run: |-
           dart run tool/bin/patch_build_dependencies.dart client_tests/drift

--- a/tool/bin/patch_build_dependencies.dart
+++ b/tool/bin/patch_build_dependencies.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/tool/bin/patch_build_dependencies.dart
+++ b/tool/bin/patch_build_dependencies.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:build_development_tools/patch_build_dependencies.dart';
+
+void main(List<String> args) {
+  if (args.length != 1) {
+    print(
+        'Usage: dart run tool/bin/patch_build_dependencies.dart <target_dir>');
+    exit(1);
+  }
+
+  patchBuildDependencies(args.single);
+}

--- a/tool/lib/patch_build_dependencies.dart
+++ b/tool/lib/patch_build_dependencies.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/tool/lib/patch_build_dependencies.dart
+++ b/tool/lib/patch_build_dependencies.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+const _buildPackages = [
+  'build',
+  'build_config',
+  'build_daemon',
+  'build_modules',
+  'build_resolvers',
+  'build_runner',
+  'build_runner_core',
+  'build_test',
+  'build_vm_compilers',
+  'build_web_compilers',
+  'scratch_space',
+];
+
+/// Adds `dependency_overrides` for to a pubspec.yaml file in [packageDir]
+/// build packages, assuming that the current working directory is the root of
+/// the `build` repository checkout.
+Future<void> patchBuildDependencies(String packageDir) async {
+  final pubspec = File(p.join(packageDir, 'pubspec.yaml'));
+
+  if (!await pubspec.exists()) {
+    throw UnsupportedError('No pubspec.yaml in $packageDir');
+  }
+
+  final editor = YamlEditor(await pubspec.readAsString());
+
+  const targetSection = ['dependency_overrides'];
+  if (editor
+          .parseAt(targetSection, orElse: () => YamlScalar.wrap(null))
+          .value ==
+      null) {
+    // There are no `dependency_overrides` in this pubspec, so create an empty
+    // block first.
+    editor.update(targetSection, {});
+  }
+
+  final buildCheckout = Directory.current.path;
+
+  for (final buildPackage in _buildPackages) {
+    final path = p.join(buildCheckout, buildPackage);
+    editor.update([...targetSection, buildPackage], {'path': path});
+  }
+
+  await pubspec.writeAsString(editor.toString());
+}

--- a/tool/mono_repo.yaml
+++ b/tool/mono_repo.yaml
@@ -1,0 +1,12 @@
+sdk:
+- dev
+
+stages:
+- analyze_and_format:
+  - group:
+    - format
+    - analyze: --fatal-infos .
+- unit_test:
+  - test: --test-randomize-ordering-seed=random
+    os:
+    - linux

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -1,0 +1,16 @@
+publish_to: none
+name: build_development_tools
+description: Collection of scripts used during development of build packages.
+
+environment:
+  sdk: '>=2.15.0 <3.0.0'
+
+dependencies:
+  path: ^1.8.0
+  yaml_edit: ^2.0.1
+  yaml: ^3.1.0
+
+dev_dependencies:
+  lints: ^1.0.0
+  test_descriptor: ^2.0.0
+  test: ^1.20.1

--- a/tool/test/patch_build_dependencies_test.dart
+++ b/tool/test/patch_build_dependencies_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:build_development_tools/patch_build_dependencies.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+void main() {
+  test('without previous overrides', () {
+    return _testTransformation(
+      '''
+name: test
+environment:
+  sdk: ^2.12.0
+
+dependencies:
+  foo: ^1.0.0
+
+dev_dependencies:
+  bar: ^1.2.3
+''',
+      '''
+name: test
+environment:
+  sdk: ^2.12.0
+
+dependencies:
+  foo: ^1.0.0
+
+dev_dependencies:
+  bar: ^1.2.3
+dependency_overrides: {build: {path: ${_packagePath('build')}}, build_config: {path: ${_packagePath('build_config')}}, build_daemon: {path: ${_packagePath('build_daemon')}}, build_modules: {path: ${_packagePath('build_modules')}}, build_resolvers: {path: ${_packagePath('build_resolvers')}}, build_runner: {path: ${_packagePath('build_runner')}}, build_runner_core: {path: ${_packagePath('build_runner_core')}}, build_test: {path: ${_packagePath('build_test')}}, build_vm_compilers: {path: ${_packagePath('build_vm_compilers')}}, build_web_compilers: {path: ${_packagePath('build_web_compilers')}}, scratch_space: {path: ${_packagePath('scratch_space')}}}
+''',
+    );
+  });
+
+  test('with existing overrides', () {
+    return _testTransformation(
+      '''
+name: test
+environment:
+  sdk: ^2.12.0
+
+dependencies:
+  foo: ^1.0.0
+
+dev_dependencies:
+  bar: ^1.2.3
+
+dependency_overrides:
+  unrelated: ^1.0.0
+  build_runner: ^1.2.3
+''',
+      '''
+name: test
+environment:
+  sdk: ^2.12.0
+
+dependencies:
+  foo: ^1.0.0
+
+dev_dependencies:
+  bar: ^1.2.3
+
+dependency_overrides:
+  unrelated: ^1.0.0
+  build_runner: 
+    path: ${_packagePath('build_runner')}
+  build: 
+    path: ${_packagePath('build')}
+  build_config: 
+    path: ${_packagePath('build_config')}
+  build_daemon: 
+    path: ${_packagePath('build_daemon')}
+  build_modules: 
+    path: ${_packagePath('build_modules')}
+  build_resolvers: 
+    path: ${_packagePath('build_resolvers')}
+  build_runner_core: 
+    path: ${_packagePath('build_runner_core')}
+  build_test: 
+    path: ${_packagePath('build_test')}
+  build_vm_compilers: 
+    path: ${_packagePath('build_vm_compilers')}
+  build_web_compilers: 
+    path: ${_packagePath('build_web_compilers')}
+  scratch_space: 
+    path: ${_packagePath('scratch_space')}
+''',
+    );
+  });
+}
+
+String _packagePath(String package) {
+  return p.join(Directory.current.path, package);
+}
+
+Future<void> _testTransformation(String old, String updated) async {
+  await d.dir('package', [d.file('pubspec.yaml', old)]).create();
+  await patchBuildDependencies(p.join(d.sandbox, 'package'));
+  await d.dir('package', [d.file('pubspec.yaml', updated)]).validate();
+}

--- a/tool/test/patch_build_dependencies_test.dart
+++ b/tool/test/patch_build_dependencies_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:build_development_tools/patch_build_dependencies.dart';


### PR DESCRIPTION
For testing purposes, I've added a tool adding necessary `dependency_overrides` to an external package. Based on that, I added a simple test run for my most popular builder as a GitHub Actions workflow.