### PR TITLE
Use ??= over contains and `!` for map defaulting

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.0.5-dev
+
 ## 4.0.4
 
 - Allow the latest analyzer.

--- a/build_modules/lib/src/meta_module.dart
+++ b/build_modules/lib/src/meta_module.dart
@@ -238,14 +238,13 @@ MetaModule _coarseModulesForLibraries(
   var librariesByDirectory = <String, Map<AssetId, ModuleLibrary>>{};
   for (var library in libraries) {
     final dir = _topLevelDir(library.id.path);
-    if (!librariesByDirectory.containsKey(dir)) {
-      librariesByDirectory[dir] = <AssetId, ModuleLibrary>{};
-    }
-    librariesByDirectory[dir]![library.id] = library;
+    (librariesByDirectory[dir] ??= {})[library.id] = library;
   }
-  final modules = librariesByDirectory.values
-      .expand((libs) => _computeModules(libs, platform))
-      .toList();
+
+  final modules = [
+    for (var libraries in librariesByDirectory.values)
+      ..._computeModules(libraries, platform)
+  ];
   _sortModules(modules);
   return MetaModule(modules);
 }

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 4.0.4
+version: 4.0.5-dev
 description: Builders for Dart modules
 repository: https://github.com/dart-lang/build/tree/master/build_modules
 


### PR DESCRIPTION
Avoid a non-null assertion by chaining access from a null conditional
assignment instead of separately inserting to the map, then reading it
back out for further operations.

Also refactor an iterable `.toList()` to a List literal.