### PR TITLE
Use `dart` instead of `pub`

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.3-dev
+
+- Updated the example to use `dart pub` instead of `pub`.
+
 ## 3.0.2
 
 - Run `serveRequests` in an error zone and forward errors to the clients.

--- a/build_daemon/example/example.dart
+++ b/build_daemon/example/example.dart
@@ -20,7 +20,7 @@ void main(List<String> args) async {
     client = await BuildDaemonClient.connect(
         workingDirectory,
         [
-          'pub',
+          'dart',
           'run',
           'build_runner',
           'daemon',

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version:  3.0.2
+version:  3.0.3-dev
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 

--- a/build_modules/test/build_test.dart
+++ b/build_modules/test/build_test.dart
@@ -33,7 +33,7 @@ void main() {
     expect(_changedGeneratedFiles(), isEmpty);
 
     // 2 - run build - should be no output, since nothing should change
-    var result = _runProc('pub${Platform.isWindows ? '.bat' : ''}',
+    var result = _runProc('dart',
         ['run', 'build_runner', 'build', '--delete-conflicting-outputs']);
     expect(result,
         contains(RegExp(r'Succeeded after \S+( \S+)? with \d+ outputs')));

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.0.7-dev
 
+- Updated error messages to use `dart pub` instead of `pub`.
+
 ## 2.0.6
 
 - Allow the latest analyzer.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -472,7 +472,7 @@ https://github.com/dart-lang/sdk/issues/new with the title
     ''');
     } else {
       var upgradeCommand =
-          isFlutter ? 'flutter packages upgrade' : 'pub upgrade';
+          isFlutter ? 'flutter packages upgrade' : 'dart pub upgrade';
       log.warning('''
 Your current `analyzer` version may not fully support your current SDK version.
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.1.8-dev
+
 ## 2.1.7
 
 - Allow the latest `pkg:build`.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.7
+version: 2.1.8-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/integration_tests/utils/build_descriptor.dart
+++ b/build_runner/test/integration_tests/utils/build_descriptor.dart
@@ -106,7 +106,7 @@ Future<BuildTool> package(Iterable<d.Descriptor> otherPackages,
   ]).create();
   await Future.wait(otherPackages.map((d) => d.create()));
   await pubGet('a');
-  return BuildTool._('pub', ['run', 'build_runner']);
+  return BuildTool._('dart', ['run', 'build_runner']);
 }
 
 /// Create a package in [d.sandbox] with a `tool/build.dart` script using


### PR DESCRIPTION
We still have the deprecated `pubBinary` constant in `build_runner_core`, but it probably isn't worth dropping yet. 