### PR TITLE
Await and skip a missed broken expectation

### DIFF
--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -215,7 +215,7 @@ void main() {
 
           await expectLater(
               resolver.libraries.map((l) => l.name), emits('other'),
-              skip: 'Currently failing');
+              skip: 'https://github.com/dart-lang/build/issues/3256');
         });
       });
 

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -208,11 +208,14 @@ void main() {
 
       test('are included in library stream', () {
         return _runWith((resolver) async {
-          expect(resolver.libraries.map((l) => l.name), neverEmits('other'));
+          await expectLater(
+              resolver.libraries.map((l) => l.name), neverEmits('other'));
 
           await resolver.libraryFor(entryPoint);
 
-          expect(resolver.libraries.map((l) => l.name), emits('other'));
+          await expectLater(
+              resolver.libraries.map((l) => l.name), emits('other'),
+              skip: 'Currently failing');
         });
       });
 


### PR DESCRIPTION
These expectations can fail as an unhandled async error and the
exception lost because of the error handling zone running the `Builder`.
The test should have been failing, add a `skip` for now instead of
silently missing the failure.