### PR TITLE
Require analyzer 2.8.0, remove UriResolver.restoreAbsolute() implementation.

### DIFF
--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -191,7 +191,6 @@ class BuildAssetUriResolver extends UriResolver {
   }
 
   @override
-  // ignore: override_on_non_overriding_member
   Uri pathToUri(String path) {
     var pathSegments = p.posix.split(path);
     var packageName = pathSegments[1];
@@ -206,11 +205,6 @@ class BuildAssetUriResolver extends UriResolver {
         pathSegments: [packageName].followedBy(pathSegments.skip(2)),
       );
     }
-  }
-
-  @override
-  Uri restoreAbsolute(Source source) {
-    return pathToUri(source.fullName);
   }
 }
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=2.7.0 <4.0.0"
+  analyzer: ">=2.8.0 <4.0.0"
   async: ^2.5.0
   build: ^2.0.0
   crypto: ^3.0.0


### PR DESCRIPTION
See https://dart-review.googlesource.com/c/sdk/+/235765