### PR TITLE
fix a failing build_daemon test

### DIFF
--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -257,7 +257,7 @@ main() {
       var succeededResult = await client.buildResults.first;
       expect(succeededResult.results.first.status, BuildStatus.succeeded);
       var ddcContent = await File(p.join(d.sandbox, 'a', '.dart_tool', 'build',
-              'generated', 'a', 'web', 'main.unsound.ddc.js'))
+              'generated', 'a', 'web', 'main.sound.ddc.js'))
           .readAsString();
       expect(ddcContent, contains('goodbye world'));
     });


### PR DESCRIPTION
Not sure why this was expecting unsound output files previously, but it should be outputting sound files.