### PR TITLE
support null stack traces coming from the build_runner script isolate

### DIFF
--- a/build_daemon/lib/constants.dart
+++ b/build_daemon/lib/constants.dart
@@ -11,6 +11,7 @@ const versionSkew = 'DIFFERENT RUNNING VERSION';
 const optionsSkew = 'DIFFERENT OPTIONS';
 
 const buildModeFlag = 'build-mode';
+
 enum BuildMode {
   // ignore: constant_identifier_names
   Manual,

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 2.1.8-dev
+## 2.1.8
+
+- Support null stack traces coming from the build runner script isolate.
 
 ## 2.1.7
 

--- a/build_runner/lib/src/build_script_generate/bootstrap.dart
+++ b/build_runner/lib/src/build_script_generate/bootstrap.dart
@@ -74,7 +74,7 @@ Future<int> generateAndRun(
     messagePort = ReceivePort();
     errorListener = errorPort.listen((e) {
       final error = e[0] as Object? ?? NullThrownError();
-      final trace = Trace.parse(e[1] as String).terse;
+      final trace = Trace.parse(e[1] as String? ?? '').terse;
 
       handleUncaughtError(error, trace);
       if (scriptExitCode == 0) scriptExitCode = 1;

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.8-dev
+version: 2.1.8
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/3259

cc @mqus