### PR TITLE
Require analyzer 3.4.0, prepare for future breaking changes.

### DIFF
--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -80,6 +80,7 @@ class BuildAssetUriResolver extends UriResolver {
         driver.changeFile(state.path);
       }
     }
+    await driver.applyPendingFileChanges();
   }
 
   /// Updates the internal state for [id], if it has changed.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -402,10 +402,13 @@ Future<String> _defaultSdkSummaryGenerator() async {
     await summaryFile.create(recursive: true);
     final embedderYamlPath =
         isFlutter ? p.join(_dartUiPath, '_embedder.yaml') : null;
-    await summaryFile.writeAsBytes(buildSdkSummary(
+    await summaryFile.writeAsBytes(
+      await buildSdkSummary2(
         sdkPath: _runningDartSdkPath,
         resourceProvider: PhysicalResourceProvider.INSTANCE,
-        embedderYamlPath: embedderYamlPath));
+        embedderYamlPath: embedderYamlPath,
+      ),
+    );
 
     await _createDepsFile(depsFile, currentDeps);
     watch.stop();

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=2.8.0 <4.0.0"
+  analyzer: ">=3.4.0 <4.0.0"
   async: ^2.5.0
   build: ^2.0.0
   crypto: ^3.0.0


### PR DESCRIPTION
In `analyzer 4.0.0` we will stop processing `changeFile()` immediately, and instead will do it between other async  requests. But this will invalidate the session, so `applyPendingFileChanges()` is required before invoking any `AnalysisSession` API.

Also, linking elements will become an async operation to support future work on macros (which require async talking to the macro running isolates).

The internal presubmit [looks](https://fusion2.corp.google.com/presubmit/tap/432593346/OCL:432593346:BASE:436659250:1648052090843:e0a2b5cd/targets) green.