### PR TITLE
Prepare to publish build_daemon

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.0-dev
+## 3.1.0
 
 - Add `BuildResults.changedAssets` containing asset URIs changed during a
   build.

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version:  3.1.0-dev
+version:  3.1.0
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 


### PR DESCRIPTION
This was not setup for publishing because the `analyzer` is a
`dev_dependency`, but `build_runner` depends on the latest
`build_daemon` already and needs to be published to unblock the analyzer
dependency.