### PR TITLE
Build runner release

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.10
+
+- Allow build version 2.3.x.
+
 ## 2.1.9
 
 - Fix up the formatting a bit for the error message that is logged when we get

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.9
+version: 2.1.10
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 
@@ -10,7 +10,7 @@ dependencies:
   args: ^2.0.0
   async: ^2.5.0
   analyzer: ">=1.4.0 <5.0.0"
-  build: ">=2.1.0 <2.3.0"
+  build: ">=2.1.0 <2.4.0"
   build_config: ">=1.0.0 <1.1.0"
   build_daemon: ^3.1.0
   build_resolvers: ^2.0.0

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -52,7 +52,3 @@ dev_dependencies:
   test_process: ^2.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build_daemon:
-    path: ../build_daemon


### PR DESCRIPTION
allow latest build (2.3.x) and remove overrides on now published build_daemon.