### PR TITLE
Use : as builder key separator in docs

### DIFF
--- a/_test/pkgs/provides_builder/build.yaml
+++ b/_test/pkgs/provides_builder/build.yaml
@@ -5,7 +5,7 @@ builders:
     build_extensions: {".dart": [".something.dart"]}
     auto_apply: dependents
     applies_builders:
-      - provides_builder|some_post_process_builder
+      - provides_builder:some_post_process_builder
   some_not_applied_builder:
     import: "package:provides_builder/builders.dart"
     builder_factories: ["notApplied"]

--- a/_test/test/build_integration_test.dart
+++ b/_test/test/build_integration_test.dart
@@ -94,7 +94,7 @@ void main() {
       final dartSource =
           File(p.join('build', 'web', 'packages', '_test', 'app.dart'));
       await runBuild(trailingArgs: [
-        '--define=build_web_compilers|dart_source_cleanup=enabled=true',
+        '--define=build_web_compilers:dart_source_cleanup=enabled=true',
         '--output',
         'build'
       ]);

--- a/_test/test/serve_integration_test.dart
+++ b/_test/test/serve_integration_test.dart
@@ -148,7 +148,7 @@ void main() {
       '--build-filter',
       'web/sub/main.dart.js',
       '--define',
-      'build_web_compilers|ddc=environment={"message": "goodbye"}',
+      'build_web_compilers:ddc=environment={"message": "goodbye"}',
     ]);
 
     addTearDown(() async {
@@ -177,7 +177,7 @@ void main() {
       'web/sub/main.dart.js',
       '--verbose',
       '--define',
-      'build_web_compilers|ddc=generate-full-dill=true',
+      'build_web_compilers:ddc=generate-full-dill=true',
     ]);
 
     addTearDown(() async {

--- a/build_runner_core/lib/src/generate/phase.dart
+++ b/build_runner_core/lib/src/generate/phase.dart
@@ -197,10 +197,10 @@ String _builderLabel(Object builder) {
   return label;
 }
 
-/// Change "angular|angular" to "angular".
+/// Change "angular:angular" to "angular".
 String _simpleBuilderKey(String builderKey) {
-  if (!builderKey.contains('|')) return builderKey;
-  var parts = builderKey.split('|');
+  if (!builderKey.contains(':')) return builderKey;
+  var parts = builderKey.split(':');
   if (parts[0] == parts[1]) return parts[0];
   return builderKey;
 }

--- a/build_vm_compilers/CHANGELOG.md
+++ b/build_vm_compilers/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.0.12-dev
+
 ## 1.0.11
 
 - Allow the latest analyzer

--- a/build_vm_compilers/README.md
+++ b/build_vm_compilers/README.md
@@ -54,7 +54,7 @@ builder applications to what you already have, sometime after the
 `build_modules` builder applications:
 
 ```dart
-    apply('build_vm_compilers|entrypoint',
+    apply('build_vm_compilers:entrypoint',
         [vmKernelEntrypointBuilder], toRoot(),
         hideOutput: true,
         // These globs should match your entrypoints only.

--- a/build_vm_compilers/build.yaml
+++ b/build_vm_compilers/build.yaml
@@ -14,7 +14,7 @@ builders:
     is_optional: True
     auto_apply: none
     required_inputs: [".dart", ".module.library"]
-    applies_builders: ["build_modules|module_cleanup"]
+    applies_builders: ["build_modules:module_cleanup"]
   vm:
     import: "package:build_vm_compilers/builders.dart"
     builder_factories:
@@ -28,7 +28,7 @@ builders:
       - .dart
       - .vm.module
     applies_builders:
-      - build_vm_compilers|modules
+      - build_vm_compilers:modules
   entrypoint:
     import: "package:build_vm_compilers/builders.dart"
     builder_factories:

--- a/build_vm_compilers/pubspec.yaml
+++ b/build_vm_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_vm_compilers
-version: 1.0.11
+version: 1.0.12-dev
 description: Builder implementations wrapping Dart VM compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_vm_compilers
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.2.4-dev
+
 ## 3.2.3
 
 - Allow analyzer 4.x.

--- a/build_web_compilers/build.yaml
+++ b/build_web_compilers/build.yaml
@@ -45,7 +45,7 @@ builders:
     is_optional: True
     auto_apply: none
     required_inputs: [".dart", ".module.library"]
-    applies_builders: ["build_modules|module_cleanup"]
+    applies_builders: ["build_modules:module_cleanup"]
   ddc_modules:
     import: "package:build_web_compilers/builders.dart"
     builder_factories:
@@ -61,7 +61,7 @@ builders:
     is_optional: True
     auto_apply: none
     required_inputs: [".dart", ".module.library"]
-    applies_builders: ["build_modules|module_cleanup"]
+    applies_builders: ["build_modules:module_cleanup"]
   ddc:
     import: "package:build_web_compilers/builders.dart"
     builder_factories:
@@ -90,11 +90,11 @@ builders:
     required_inputs:
       - .ddc.module
     applies_builders:
-      - build_web_compilers|ddc_modules
+      - build_web_compilers:ddc_modules
       # This isn't really the best place to apply these, but it is the only
       # place we can (its the only builder which runs on all packages).
-      - build_web_compilers|dart2js_modules
-      - build_web_compilers|dart_source_cleanup
+      - build_web_compilers:dart2js_modules
+      - build_web_compilers:dart_source_cleanup
   entrypoint:
     import: "package:build_web_compilers/builders.dart"
     builder_factories:
@@ -134,7 +134,7 @@ builders:
       release_options:
         compiler: dart2js
     applies_builders:
-      - build_web_compilers|dart2js_archive_extractor
+      - build_web_compilers:dart2js_archive_extractor
   _stack_trace_mapper_copy:
     import: "tool/copy_builder.dart"
     builder_factories:

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 3.2.3
+version: 3.2.4-dev
 description: Builder implementations wrapping Dart compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 

--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -126,5 +126,5 @@ default target in the current package (which has the same name as the package).
 An identifier for a `builder`. A builder has two parts, a `package` and a
 `name`.
 
-To construct a key, you join the package and name with a `|`, so for instance
-the `bar` builder in the `foo` package would be referenced like this `foo|bar`.
+To construct a key, you join the package and name with a `:`, so for instance
+the `bar` builder in the `foo` package would be referenced like this `foo:bar`.


### PR DESCRIPTION
Closes #3239

The character was originally `|` but was changed to `:` because the
former is a special character in windows terminals. Some docs where
updated with that change, but some were missed.

Use `:` over `|` consistently in docs, `build.yaml`, and command line
arguments in tests.

Fix a utility which shortens redundant builder names to use the new
separator. This utility had not been working.