### PR TITLE
Use explicit dynamic collections in build script

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -110,14 +110,14 @@ final _builders = <_i1.BuilderApplication>[
         r'test/**.node_test.dart',
         r'test/**.vm_test.dart'
       ]),
-      defaultOptions: const _i8.BuilderOptions({
-        r'dart2js_args': [r'--minify']
+      defaultOptions: const _i8.BuilderOptions(<dynamic, dynamic>{
+        r'dart2js_args': <dynamic>[r'--minify']
       }),
-      defaultDevOptions: const _i8.BuilderOptions({
-        r'dart2js_args': [r'--enable-asserts']
+      defaultDevOptions: const _i8.BuilderOptions(<dynamic, dynamic>{
+        r'dart2js_args': <dynamic>[r'--enable-asserts']
       }),
       defaultReleaseOptions:
-          const _i8.BuilderOptions({r'compiler': r'dart2js'}),
+          const _i8.BuilderOptions(<dynamic, dynamic>{r'compiler': r'dart2js'}),
       appliesBuilders: const [
         r'build_web_compilers:dart2js_archive_extractor'
       ]),
@@ -127,11 +127,12 @@ final _builders = <_i1.BuilderApplication>[
   _i1.applyPostProcess(r'build_modules:module_cleanup', _i5.moduleCleanup),
   _i1.applyPostProcess(r'build_web_compilers:dart2js_archive_extractor',
       _i7.dart2jsArchiveExtractor,
-      defaultReleaseOptions:
-          const _i8.BuilderOptions({r'filter_outputs': true})),
+      defaultReleaseOptions: const _i8.BuilderOptions(
+          <dynamic, dynamic>{r'filter_outputs': true})),
   _i1.applyPostProcess(
       r'build_web_compilers:dart_source_cleanup', _i7.dartSourceCleanup,
-      defaultReleaseOptions: const _i8.BuilderOptions({r'enabled': true})),
+      defaultReleaseOptions:
+          const _i8.BuilderOptions(<dynamic, dynamic>{r'enabled': true})),
   _i1.applyPostProcess(
       r'provides_builder:some_post_process_builder', _i4.somePostProcessBuilder)
 ];

--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -110,14 +110,14 @@ final _builders = <_i1.BuilderApplication>[
         r'test/**.node_test.dart',
         r'test/**.vm_test.dart'
       ]),
-      defaultOptions: const _i8.BuilderOptions(<dynamic, dynamic>{
+      defaultOptions: const _i8.BuilderOptions(<String, dynamic>{
         r'dart2js_args': <dynamic>[r'--minify']
       }),
-      defaultDevOptions: const _i8.BuilderOptions(<dynamic, dynamic>{
+      defaultDevOptions: const _i8.BuilderOptions(<String, dynamic>{
         r'dart2js_args': <dynamic>[r'--enable-asserts']
       }),
       defaultReleaseOptions:
-          const _i8.BuilderOptions(<dynamic, dynamic>{r'compiler': r'dart2js'}),
+          const _i8.BuilderOptions(<String, dynamic>{r'compiler': r'dart2js'}),
       appliesBuilders: const [
         r'build_web_compilers:dart2js_archive_extractor'
       ]),
@@ -127,12 +127,12 @@ final _builders = <_i1.BuilderApplication>[
   _i1.applyPostProcess(r'build_modules:module_cleanup', _i5.moduleCleanup),
   _i1.applyPostProcess(r'build_web_compilers:dart2js_archive_extractor',
       _i7.dart2jsArchiveExtractor,
-      defaultReleaseOptions: const _i8.BuilderOptions(
-          <dynamic, dynamic>{r'filter_outputs': true})),
+      defaultReleaseOptions:
+          const _i8.BuilderOptions(<String, dynamic>{r'filter_outputs': true})),
   _i1.applyPostProcess(
       r'build_web_compilers:dart_source_cleanup', _i7.dartSourceCleanup,
       defaultReleaseOptions:
-          const _i8.BuilderOptions(<dynamic, dynamic>{r'enabled': true})),
+          const _i8.BuilderOptions(<String, dynamic>{r'enabled': true})),
   _i1.applyPostProcess(
       r'provides_builder:some_post_process_builder', _i4.somePostProcessBuilder)
 ];

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.11-dev
+
+- Use an explicit `dynamic` generic type for collections in default builder
+  options to reduce behavior differences between reading default options and
+  user provided options.
+
 ## 2.1.10
 
 - Allow build version 2.3.x.

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -312,7 +312,7 @@ Expression _applyPostProcessBuilder(PostProcessBuilderDefinition definition) {
 }
 
 Expression _rawStringList(List<String> strings) =>
-    strings.toExpression(constant: true);
+    literalConstList([for (var s in strings) literalString(s, raw: true)]);
 
 /// Returns the actual import to put in the generated script based on an import
 /// found in the build.yaml.
@@ -363,19 +363,18 @@ extension on LanguageVersion {
 /// This is similar to [literal] from `package:code_builder`, except that it
 /// always writes raw string literals.
 extension ConvertToExpression on Object? {
-  Expression toExpression({bool constant = false}) {
+  Expression toExpression() {
     final $this = this;
 
     if ($this is Map) {
-      final create = constant ? literalConstMap : literalMap;
-      return create({
+      return literalMap({
         for (final entry in $this.cast<Object?, Object?>().entries)
           entry.key.toExpression(): entry.value.toExpression()
-      });
+      }, refer('dynamic'), refer('dynamic'));
     } else if ($this is List) {
-      final create = constant ? literalConstList : literalList;
-      return create(
-          [for (final entry in $this.cast<Object?>()) entry.toExpression()]);
+      return literalList(
+          [for (final entry in $this.cast<Object?>()) entry.toExpression()],
+          refer('dynamic'));
     } else if ($this is String) {
       return literalString($this, raw: true);
     } else {

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -370,7 +370,7 @@ extension ConvertToExpression on Object? {
       return literalMap({
         for (final entry in $this.cast<Object?, Object?>().entries)
           entry.key.toExpression(): entry.value.toExpression()
-      }, refer('dynamic'), refer('dynamic'));
+      }, refer('String'), refer('dynamic'));
     } else if ($this is List) {
       return literalList(
           [for (final entry in $this.cast<Object?>()) entry.toExpression()],

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.10
+version: 2.1.11-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
Towards #3300

Avoid inference to improve consistency between getting configuration in
from default options or from user provided options which are a
`YamlList` or `YamlMap` and never have a generic other than `dynamic`.
The generic is the most user visible difference, the type of the
concrete collection is not as likely to cause problems.

Avoid `toExpression` for the `appliesBuilders` key to keep using
inference for that list. Now `toExpression` is only for the default
options. Remove now unused support for const in `toExpression`.