### PR TITLE
Check that the result of getErrors() is ErrorsResult.

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.9-dev
+
 ## 2.0.8
 
 - Allow analyzer version 4.x.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -255,10 +255,10 @@ class AnalyzerResolver implements ReleasableResolver {
     final relevantResults = <ErrorsResult>[];
 
     for (final path in paths) {
-      final result =
-          await _driver.currentSession.getErrors(path) as ErrorsResult;
-      if (result.errors
-          .any((error) => error.errorCode.type == ErrorType.SYNTACTIC_ERROR)) {
+      final result = await _driver.currentSession.getErrors(path);
+      if (result is ErrorsResult &&
+          result.errors.any(
+              (error) => error.errorCode.type == ErrorType.SYNTACTIC_ERROR)) {
         relevantResults.add(result);
       }
     }

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.0.8
+version: 2.0.9-dev
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 


### PR DESCRIPTION
It [will be](https://dart-review.googlesource.com/c/sdk/+/245680) `PartWithoutLibraryResult` if the file at which `part` directive points does not have the corresponding `part of`.