### PR TITLE
Add include_defaults for sources in build.yaml to include all default sources

### DIFF
--- a/build_config/lib/src/input_set.dart
+++ b/build_config/lib/src/input_set.dart
@@ -14,6 +14,8 @@ part 'input_set.g.dart';
 class InputSet {
   static const anything = InputSet();
 
+  final bool includeDefaults;
+
   /// The globs to include in the set.
   ///
   /// May be null or empty which means every possible path (like `'**'`).
@@ -24,7 +26,7 @@ class InputSet {
   /// May be null or empty which means every path in [include].
   final List<String>? exclude;
 
-  const InputSet({this.include, this.exclude});
+  const InputSet({this.include, this.exclude, this.includeDefaults = false});
 
   factory InputSet.fromJson(dynamic json) {
     if (json is List) {
@@ -38,7 +40,8 @@ class InputSet {
           'Expected a Map or a List but got a ${json.runtimeType}');
     }
     final parsed = _$InputSetFromJson(json as Map);
-    if (parsed.include != null && parsed.include!.any((s) => s.isEmpty)) {
+    if (parsed.include != null && parsed.include!.any((s) => s.isEmpty) ||
+        parsed.includeDefaults && parsed.include == null) {
       throw ArgumentError.value(
           parsed.include, 'include', 'Include globs must not be empty');
     }
@@ -56,6 +59,9 @@ class InputSet {
       result.write('any path');
     } else {
       result.write('paths matching $include');
+    }
+    if (includeDefaults) {
+      result.write(' with defaults');
     }
     if (exclude != null && exclude!.isNotEmpty) {
       result.write(' except $exclude');

--- a/build_config/lib/src/input_set.g.dart
+++ b/build_config/lib/src/input_set.g.dart
@@ -12,14 +12,17 @@ InputSet _$InputSetFromJson(Map json) => $checkedCreate(
       ($checkedConvert) {
         $checkKeys(
           json,
-          allowedKeys: const ['include', 'exclude'],
+          allowedKeys: const ['include_defaults', 'include', 'exclude'],
         );
         final val = InputSet(
           include: $checkedConvert('include',
               (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()),
           exclude: $checkedConvert('exclude',
               (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()),
+          includeDefaults:
+              $checkedConvert('include_defaults', (v) => v as bool? ?? false),
         );
         return val;
       },
+      fieldKeyMap: const {'includeDefaults': 'include_defaults'},
     );

--- a/build_config/test/errors_test.dart
+++ b/build_config/test/errors_test.dart
@@ -138,6 +138,39 @@ targets:
   ╵'''),
         ));
   });
+
+  test('for null sources include globs if include_defaults is true', () {
+    var buildYaml = r'''
+targets:
+  $default:
+    sources:
+      include_defaults: true
+''';
+
+    _expectThrows(buildYaml, r'''
+line 4, column 7 of build.yaml: Unsupported value for "sources". Include globs must not be empty
+  ╷
+4 │       include_defaults: true
+  │       ^^^^^^^^^^^^^^^^^^^^^^
+  ╵''');
+  });
+
+  test('for null sources include globs if include_defaults is true', () {
+    var buildYaml = r'''
+targets:
+  $default:
+    sources:
+      include_defaults: true
+      include:
+''';
+
+    _expectThrows(buildYaml, r'''
+line 4, column 7 of build.yaml: Unsupported value for "sources". Include globs must not be empty
+  ╷
+4 │ ┌       include_defaults: true
+5 │ └       include:
+  ╵''');
+  });
 }
 
 void _expectThrows(String buildYaml, Object matcher) => expect(

--- a/build_runner_core/lib/src/package_graph/target_graph.dart
+++ b/build_runner_core/lib/src/package_graph/target_graph.dart
@@ -61,7 +61,7 @@ class TargetGraph {
     final modulesByKey = <String, TargetNode>{};
     final publicAssetsByPackage = <String, InputMatcher>{};
     final modulesByPackage = <String, List<TargetNode>>{};
-    final includedSourceDefaults = <InputSet>{};
+    final sourcesWithIncludedDefaults = <InputSet>{};
     late BuildConfig rootPackageConfig;
     for (final package in packageGraph.allPackages.values) {
       final config = overrideBuildConfig[package.name] ??
@@ -85,8 +85,8 @@ class TargetGraph {
       }
       final nodes = config.buildTargets.values.map((target) {
         if (target.sources.includeDefaults &&
-            !includedSourceDefaults.contains(target.sources)) {
-          includedSourceDefaults.add(target.sources);
+            !sourcesWithIncludedDefaults.contains(target.sources)) {
+          sourcesWithIncludedDefaults.add(target.sources);
           target.sources.include!.addAll(defaultInclude);
         }
         return TargetNode(target, package, defaultInclude: defaultInclude);

--- a/build_runner_core/lib/src/package_graph/target_graph.dart
+++ b/build_runner_core/lib/src/package_graph/target_graph.dart
@@ -82,8 +82,14 @@ class TargetGraph {
         publicAssetsByPackage[package.name] =
             InputMatcher(const InputSet(), defaultInclude: defaultInclude);
       }
-      final nodes = config.buildTargets.values.map((target) =>
-          TargetNode(target, package, defaultInclude: defaultInclude));
+      final nodes = config.buildTargets.values.map((target) {
+        if (target.sources.include?.contains(r'$defaults$') == true) {
+          target.sources.include!.removeWhere((s) => s == r'$defaults$');
+          target.sources.include!.addAll(defaultInclude);
+        }
+
+        return TargetNode(target, package, defaultInclude: defaultInclude);
+      });
       if (package.name != r'$sdk') {
         var requiredPackagePaths =
             package.isRoot ? requiredRootSourcePaths : requiredSourcePaths;

--- a/build_runner_core/lib/src/package_graph/target_graph.dart
+++ b/build_runner_core/lib/src/package_graph/target_graph.dart
@@ -61,6 +61,7 @@ class TargetGraph {
     final modulesByKey = <String, TargetNode>{};
     final publicAssetsByPackage = <String, InputMatcher>{};
     final modulesByPackage = <String, List<TargetNode>>{};
+    final includedSourceDefaults = <InputSet>{};
     late BuildConfig rootPackageConfig;
     for (final package in packageGraph.allPackages.values) {
       final config = overrideBuildConfig[package.name] ??
@@ -83,11 +84,11 @@ class TargetGraph {
             InputMatcher(const InputSet(), defaultInclude: defaultInclude);
       }
       final nodes = config.buildTargets.values.map((target) {
-        if (target.sources.include?.contains(r'$defaults$') == true) {
-          target.sources.include!.removeWhere((s) => s == r'$defaults$');
+        if (target.sources.includeDefaults &&
+            !includedSourceDefaults.contains(target.sources)) {
+          includedSourceDefaults.add(target.sources);
           target.sources.include!.addAll(defaultInclude);
         }
-
         return TargetNode(target, package, defaultInclude: defaultInclude);
       });
       if (package.name != r'$sdk') {

--- a/build_runner_core/test/package_graph/target_graph_test.dart
+++ b/build_runner_core/test/package_graph/target_graph_test.dart
@@ -94,9 +94,7 @@ void main() {
       var packageGraph = PackageGraph.fromRoot(packageA);
 
       final defaultSources = ['d', 'f'];
-      final customSource1 = 'a';
-      final customSource2 = 'b';
-      final customSource3 = 'c';
+      final customSources = ['a', 'b'];
 
       final targetGraph = await TargetGraph.forPackageGraph(
         packageGraph,
@@ -105,20 +103,14 @@ void main() {
           'a': BuildConfig.fromMap('a', [], {
             'targets': {
               r'$default': {
-                'sources': [
-                  customSource1,
-                  r'$defaults$',
-                  customSource2,
-                  r'$defaults$',
-                  customSource3,
-                ]
+                'sources': {'include_defaults': true, 'include': customSources}
               }
             }
           }),
           'b': BuildConfig.fromMap('b', [], {
             'targets': {
               r'$default': {
-                'sources': [r'$defaults$', customSource1]
+                'sources': {'include_defaults': true, 'include': customSources}
               }
             }
           })
@@ -126,10 +118,10 @@ void main() {
       );
 
       expect(targetGraph.rootPackageConfig.buildTargets['a:a']?.sources.include,
-          [customSource1, customSource2, customSource3, ...defaultSources]);
+          [...customSources, ...defaultSources]);
 
       expect(targetGraph.allModules['b:b']?.target.sources.include,
-          [customSource1, ...defaultNonRootVisibleAssets]);
+          [...customSources, ...defaultNonRootVisibleAssets]);
     });
   });
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -188,14 +188,15 @@ targets:
       - $package$
 ```
 
-If you just would like to include your additional files with files which are included by default you will need to add the `$defaults$` source:
+If you just would like to include your additional files with files which are included by default you will need to enable the `include_defaults` in `sources`:
 
 ```yaml
 targets:
   $default:
     sources:
-      - $defaults$
-      - my_custom_sources/**
+      include_defaults: true
+      include:
+        - my_custom_sources/**
 ```
 
 ## Why do Builders need unique outputs?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -188,6 +188,16 @@ targets:
       - $package$
 ```
 
+If you just would like to include your additional files with files which are included by default you will need to add the `$defaults$` source:
+
+```yaml
+targets:
+  $default:
+    sources:
+      - $defaults$
+      - my_custom_sources/**
+```
+
 ## Why do Builders need unique outputs?
 
 `build_runner` relies on determining a static build graph before starting a


### PR DESCRIPTION
Every time when we would like to include custom sources to `build.yaml` file, we also have to add all items from [defaultNonRootVisibleAssets](https://github.com/dart-lang/build/blob/995fc94d34c8a6c144002cf9e04a485c4348b878/build_runner_core/lib/src/generate/options.dart#L24) or [defaultRootPackageSources](https://github.com/dart-lang/build/blob/995fc94d34c8a6c144002cf9e04a485c4348b878/build_runner_core/lib/src/generate/options.dart#L37) manually. 

It's ok if we develop our own project but if we develop a package for public usage, we need to ask everyone who uses our package to create `build.yaml` file and define both their sources and all these items in the `sources`.

For me, it's not good approach because the list of these items can be extended in over time.

So, I suggest to add the `include_defaults` parameter to `sources` which includes all sources from [defaultNonRootVisibleAssets](https://github.com/dart-lang/build/blob/995fc94d34c8a6c144002cf9e04a485c4348b878/build_runner_core/lib/src/generate/options.dart#L24) or [defaultRootPackageSources](https://github.com/dart-lang/build/blob/995fc94d34c8a6c144002cf9e04a485c4348b878/build_runner_core/lib/src/generate/options.dart#L37) by default.

As result, we can keep our `build.yaml` clean and event if default sources will be changed in future we will be able easily update them in `build_runner_core` and provide them for all developer by new publishing.

Example:
```yaml
targets:
  $default:
    sources:
      include_defaults: true
      include:
        - my_custom_sources/**
```