### PR TITLE
allow customized builder ordering by users

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0-dev
+## 1.1.0
 
 - Require Dart 2.14
 - Support `runsBefore` global configuration for builders. This allows users to

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 1.0.1-dev
+## 1.1.0-dev
 
 - Require Dart 2.14
+- Support `runsBefore` global configuration for builders. This allows users to
+  have some control over builder ordering.
 
 ## 1.0.0
 

--- a/build_config/lib/src/build_target.dart
+++ b/build_config/lib/src/build_target.dart
@@ -142,13 +142,29 @@ class GlobalBuilderConfig {
   /// Overrides for [options] in release mode.
   final Map<String, dynamic> releaseOptions;
 
+  /// Builder keys in `$package:$builder` format which should only be run after
+  /// this Builder.
+  ///
+  /// This allows the user to configure the ordering of particular builders as
+  /// necessary, but it is a global option.
+  ///
+  /// This config is merged with the `runsBefore` configuration of the builder
+  /// definition, and does not overwrite it.
+  final List<String> runsBefore;
+
   GlobalBuilderConfig({
     Map<String, dynamic>? options,
     Map<String, dynamic>? devOptions,
     Map<String, dynamic>? releaseOptions,
+    List<String>? runsBefore,
   })  : options = options ?? const {},
         devOptions = devOptions ?? const {},
-        releaseOptions = releaseOptions ?? const {};
+        releaseOptions = releaseOptions ?? const {},
+        runsBefore = runsBefore
+                ?.map((builder) =>
+                    normalizeBuilderKeyUsage(builder, currentPackage))
+                .toList() ??
+            const [];
 
   factory GlobalBuilderConfig.fromJson(Map json) {
     ArgumentError.checkNotNull(json);

--- a/build_config/lib/src/build_target.dart
+++ b/build_config/lib/src/build_target.dart
@@ -176,5 +176,6 @@ class GlobalBuilderConfig {
         'options': options,
         'devOptions': devOptions,
         'releaseOptions': releaseOptions,
+        'runsBefore': runsBefore,
       }.toString();
 }

--- a/build_config/lib/src/build_target.g.dart
+++ b/build_config/lib/src/build_target.g.dart
@@ -88,7 +88,12 @@ GlobalBuilderConfig _$GlobalBuilderConfigFromJson(Map json) => $checkedCreate(
       ($checkedConvert) {
         $checkKeys(
           json,
-          allowedKeys: const ['options', 'dev_options', 'release_options'],
+          allowedKeys: const [
+            'options',
+            'dev_options',
+            'release_options',
+            'runs_before'
+          ],
         );
         final val = GlobalBuilderConfig(
           options: $checkedConvert(
@@ -106,11 +111,14 @@ GlobalBuilderConfig _$GlobalBuilderConfigFromJson(Map json) => $checkedCreate(
               (v) => (v as Map?)?.map(
                     (k, e) => MapEntry(k as String, e),
                   )),
+          runsBefore: $checkedConvert('runs_before',
+              (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()),
         );
         return val;
       },
       fieldKeyMap: const {
         'devOptions': 'dev_options',
-        'releaseOptions': 'release_options'
+        'releaseOptions': 'release_options',
+        'runsBefore': 'runs_before'
       },
     );

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 1.0.1-dev
+version: 1.1.0-dev
 description: Support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config
 
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   checked_yaml: ^2.0.0
-  json_annotation: ^4.3.0
+  json_annotation: ^4.5.0
   path: ^1.8.0
   pubspec_parse: ^1.0.0
   yaml: ^3.0.0

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 1.1.0-dev
+version: 1.1.0
 description: Support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config
 

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -19,3 +19,7 @@ dev_dependencies:
   json_serializable: ^6.0.0
   term_glyph: ^1.2.0
   test: ^1.16.0
+
+dependency_overrides:
+  build_runner:
+    path: ../build_runner

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.2.0-dev
 
 - Support global 'runs_before' configuration for builders. This allows users
-  to specify the ordering of builders in their build.
+  to influence the ordering of builders in their build.
 
 ## 2.1.11
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0-dev
+## 2.2.0
 
 - Support global 'runs_before' configuration for builders. This allows users
   to influence the ordering of builders in their build.

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0-dev
+
+- Support global 'runs_before' configuration for builders. This allows users
+  to specify the ordering of builders in their build.
+
 ## 2.1.11
 
 - Stop reading or requiring `.packages` files.

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -132,7 +132,10 @@ Future<BuildScriptInfo> findBuildScriptOptions({
       .expand((c) => c.builderDefinitions.values)
       .where(_isValidDefinition);
 
-  final orderedBuilders = findBuilderOrder(builderDefinitions).toList();
+  final rootBuildConfig = orderedConfigs.last;
+  final orderedBuilders =
+      findBuilderOrder(builderDefinitions, rootBuildConfig.globalOptions)
+          .toList();
 
   final postProcessBuilderDefinitions = orderedConfigs
       .expand((c) => c.postProcessBuilderDefinitions.values)

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -141,6 +141,21 @@ Future<BuildScriptInfo> findBuildScriptOptions({
       .expand((c) => c.postProcessBuilderDefinitions.values)
       .where(_isValidDefinition);
 
+  // Validate the builder keys in the global builder config, these should always
+  // refer to actual builders.
+  var allBuilderKeys = {for (var definition in orderedBuilders) definition.key};
+  for (var globalBuilderConfig in rootBuildConfig.globalOptions.entries) {
+    void _checkBuilderKey(String builderKey) {
+      if (allBuilderKeys.contains(builderKey)) return;
+      _log.warning(
+          'Invalid builder key `$builderKey` found in global_options config of '
+          'build.yaml. This configuration will have no effect.');
+    }
+
+    _checkBuilderKey(globalBuilderConfig.key);
+    globalBuilderConfig.value.runsBefore.forEach(_checkBuilderKey);
+  }
+
   final applications = [
     for (var builder in orderedBuilders) _applyBuilder(builder),
     for (var builder in postProcessBuilderDefinitions)

--- a/build_runner/lib/src/build_script_generate/builder_ordering.dart
+++ b/build_runner/lib/src/build_script_generate/builder_ordering.dart
@@ -12,12 +12,14 @@ import 'package:graphs/graphs.dart';
 /// Builders will be ordered such that their `required_inputs` and `runs_before`
 /// constraints are met, but the rest of the ordering is arbitrary.
 Iterable<BuilderDefinition> findBuilderOrder(
-    Iterable<BuilderDefinition> builders) {
+    Iterable<BuilderDefinition> builders,
+    Map<String, GlobalBuilderConfig> globalBuilderConfigs) {
   final consistentOrderBuilders = builders.toList()
     ..sort((a, b) => a.key.compareTo(b.key));
   Iterable<BuilderDefinition> dependencies(BuilderDefinition parent) =>
       consistentOrderBuilders.where((child) =>
-          _hasInputDependency(parent, child) || _mustRunBefore(parent, child));
+          _hasInputDependency(parent, child) ||
+          _mustRunBefore(parent, child, globalBuilderConfigs));
   var components = stronglyConnectedComponents<BuilderDefinition>(
     consistentOrderBuilders,
     dependencies,
@@ -41,5 +43,7 @@ bool _hasInputDependency(BuilderDefinition parent, BuilderDefinition child) {
 }
 
 /// Whether [child] specifies that it wants to run before [parent].
-bool _mustRunBefore(BuilderDefinition parent, BuilderDefinition child) =>
-    child.runsBefore.contains(parent.key);
+bool _mustRunBefore(BuilderDefinition parent, BuilderDefinition child,
+        Map<String, GlobalBuilderConfig?> globalBuilderConfigs) =>
+    child.runsBefore.contains(parent.key) ||
+    (globalBuilderConfigs[child.key]?.runsBefore.contains(parent.key) ?? false);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.1.11
+version: 2.2.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   async: ^2.5.0
   analyzer: ">=1.4.0 <5.0.0"
   build: ">=2.1.0 <2.4.0"
-  build_config: ">=1.0.0 <1.1.0"
+  build_config: ">=1.1.0 <1.2.0"
   build_daemon: ^3.1.0
   build_resolvers: ^2.0.0
   build_runner_core: ^7.2.0
@@ -52,3 +52,7 @@ dev_dependencies:
   test_process: ^2.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_config:
+    path: ../build_config

--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -85,6 +85,7 @@ key             | value                             | default
 options         | [BuilderOptions](#builderoptions) | none
 dev_options     | [BuilderOptions](#builderoptions) | none
 release_options | [BuilderOptions](#builderoptions) | none
+runs_before     | List<[BuilderKey](#builderkey)>   | none
 
 ## BuilderOptions
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -361,3 +361,15 @@ a schema URL. The configuration should look similar to this:
 ![Schema configuration for IDEA based IDEs](images/idea_schema_config.png)
 
 [YAML extension]: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
+
+## How can I adjust builder ordering?
+
+You can configure certain builders to run before other builders globally, using the
+`global_options` configuration in your `build.yaml` file:
+
+```yaml
+global_options:
+  some_package:some_builder:
+    runs_before:
+      - some_other_package:some_other_builder
+```


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/3328

@[explodus](https://github.com/explodus) did you want to try this out?

You should be able to add a dependency override like this to try it (in your pubspec.yaml):

```yaml
dependency_overrides:
  build_config:
    git:
      url: https://github.com/dart-lang/build.git
      ref: allow-customizing-builder-ordering
      path: build_config
  build_runner:
    git:
      url: https://github.com/dart-lang/build.git
      ref: allow-customizing-builder-ordering
      path: build_runner
```

And then configure it like this in your build.yaml:

```yaml
global_options:
  source_gen:combining_builder:
    runs_before:
      - reflectable
```