### PR TITLE
run dart2js through 'dart compile js' instead of its snapshot

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 3.2.4-dev
+## 3.2.4
+
+- Use `dart compile js` instead of running dart2js from its sdk snapshot.
 
 ## 3.2.3
 

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -99,12 +99,13 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
       ]);
   }
 
-  log.info('Running dart2js with ${args.join(' ')}\n');
+  log.info('Running `dart compile js` with ${args.join(' ')}\n');
   var result = await Process.run(
       p.join(sdkDir, 'bin', 'dart'),
       [
         ..._dart2jsVmArgs,
-        p.join(sdkDir, 'bin', 'snapshots', 'dart2js.dart.snapshot'),
+        'compile',
+        'js',
         ...args,
       ],
       workingDirectory: scratchSpace.tempDir.path);

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_web_compilers
-version: 3.2.4-dev
+version: 3.2.4
 description: Builder implementations wrapping Dart compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   analyzer: ">=1.0.0 <5.0.0"


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/3337