### PR TITLE
Fix CI failures

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.1-dev
+
+- Stop ignoring the no_leading_underscores_for_library_prefixes lint in
+  generated build scripts, code_builder now does this for you.
+
 ## 2.2.0
 
 - Support global 'runs_before' configuration for builders. This allows users

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -60,8 +60,6 @@ Future<String> _generateBuildScript() async {
     }
     content
       ..writeln('// ignore_for_file: directives_ordering')
-      ..writeln(
-          '// ignore_for_file: no_leading_underscores_for_library_prefixes')
       ..writeln(library.accept(emitter));
 
     return DartFormatter().format(content.toString());

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.2.0
+version: 2.2.1-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
- Stop ignoring the no_leading_underscores_for_library_prefixes in build scripts, code_builder does it and we end up with duplicate lines.