### PR TITLE
Make package configuration loading use the correct function.

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.1.6-dev
 
+- Fix bug in package config file loading.
+
 ## 2.1.5
 
 - Allow the latest analyzer.

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -76,8 +76,7 @@ class PackageAssetReader extends AssetReader
       {String? rootPackage}) async {
     final packageConfigUri = await Isolate.packageConfig ??
         (throw UnsupportedError('No package config found'));
-    final packageConfig = await findPackageConfigUri(packageConfigUri) ??
-        (throw UnsupportedError('Package configuration file not found'));
+    final packageConfig = await loadPackageConfigUri(packageConfigUri);
 
     return PackageAssetReader(packageConfig, rootPackage);
   }


### PR DESCRIPTION
When you have the URI of a package configuration file, you should load it directly.
It's not safe to use discovery, which assumes you start with a Dart script file.

Fixes https://github.com/dart-lang/build/issues/3354