### PR TITLE
Fix stuck in LruCache after updating items

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.2.4-dev
 
 - Fix some new lints.
+- Fix a bug in the LRU cache.
 
 ## 7.2.3
 

--- a/build_runner_core/lib/src/asset/lru_cache.dart
+++ b/build_runner_core/lib/src/asset/lru_cache.dart
@@ -32,7 +32,7 @@ class LruCache<K, V> {
     if (entry.weight > _individualWeightMax) {
       return;
     }
-    
+
     if (_entries.containsKey(key)) {
       remove(key);
     }

--- a/build_runner_core/lib/src/asset/lru_cache.dart
+++ b/build_runner_core/lib/src/asset/lru_cache.dart
@@ -27,14 +27,11 @@ class LruCache<K, V> {
   }
 
   void operator []=(K key, V value) {
+    remove(key);
     var entry = _Link(key, value, _computeWeight(value));
     // Don't cache at all if above the individual weight max.
     if (entry.weight > _individualWeightMax) {
       return;
-    }
-
-    if (_entries.containsKey(key)) {
-      remove(key);
     }
 
     _entries[key] = entry;

--- a/build_runner_core/lib/src/asset/lru_cache.dart
+++ b/build_runner_core/lib/src/asset/lru_cache.dart
@@ -32,6 +32,10 @@ class LruCache<K, V> {
     if (entry.weight > _individualWeightMax) {
       return;
     }
+    
+    if (_entries.containsKey(key)) {
+      remove(key);
+    }
 
     _entries[key] = entry;
     _currentWeightTotal += entry.weight;

--- a/build_runner_core/test/asset/lru_cache_test.dart
+++ b/build_runner_core/test/asset/lru_cache_test.dart
@@ -97,13 +97,14 @@ void main() {
     // Update the first item, then the second is now the least recently used.
     cache['0'] = maxIndividualWeight;
     // Add another item, the second item should now be removed.
-    cache['${n+1}'] = maxIndividualWeight;
+    cache['${n + 1}'] = maxIndividualWeight;
     expect(cache['1'], null);
 
-    // Read the first n-1 items, then the latest added item is now the least recently used.
+    // Read the first n-1 items, then the latest added item is now the least
+    // recently used.
     for (var i = 0; i < n; i++) {
       if (i != 1) {
-       expect(cache['$i'], maxIndividualWeight);
+        expect(cache['$i'], maxIndividualWeight);
       }
     }
 
@@ -111,7 +112,7 @@ void main() {
     for (var i = 0; i < n; i++) {
       cache['$i'] = maxIndividualWeight;
     }
-    expect(cache['${n}'], null);
+    expect(cache['$n'], null);
 
     // Check the first n entries shouldn't be removed
     for (var i = 0; i < n; i++) {


### PR DESCRIPTION
Inside the [LruCache](build_runner_core/lib/src/asset/lru_cache.dart#L29), it always create a new link node when doing the `[]=` operator, what if we're doing the "updating" operation? 

The `_entries` will replace the new value to the same key entry, but the link list will have two nodes with a same key, once the capacity is exhausted, the application will stuck in removing item as the second removing with the same key changes nothing.

You can reproduce this case by executing the test cases provided by this PR.