### PR TITLE
Update pub.dev README to include Build-Filters

### DIFF
--- a/build_runner/README.md
+++ b/build_runner/README.md
@@ -124,7 +124,7 @@ Glob syntax is allowed in both package names and paths.
 *Example*: The following would build and serve the JS output for an application, as well as copy over the required SDK resources for that app:
 
 ```bash
-pub run build_runner serve \
+dart run build_runner serve \
   --build-filter="web/main.dart.js" \
   --build-filter="package:build_web_compilers/**/*.js"
 ```


### PR DESCRIPTION
This feature was not displayed in the official README featured on pub.dev. It was hidden in the CHANGELOG. I essentially copied the CHANGELOG info and moved it to the README.

By including this information on the main README it will allow other package users to understand how to configure this package further.