### PR TITLE
Fix bug with manual deletions of files from build steps with multiple outputs

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 7.2.4-dev
+## 7.2.4
 
 - Fix some new lints.
 - Fix a bug in the LRU cache.
+- Fix a bug when manually deleting outputs of multiple output builders.
 
 ## 7.2.3
 

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -295,8 +295,9 @@ class AssetGraph {
     // `primaryOutputs`.
     var transitiveRemovedIds = <AssetId>{};
     void addTransitivePrimaryOutputs(AssetId id) {
-      transitiveRemovedIds.add(id);
-      get(id)!.primaryOutputs.forEach(addTransitivePrimaryOutputs);
+      if (transitiveRemovedIds.add(id)) {
+        get(id)!.primaryOutputs.forEach(addTransitivePrimaryOutputs);
+      }
     }
 
     removeIds

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -680,28 +680,36 @@ class _SingleBuild {
         '${outputs.where((o) => !_assetGraph.contains(o)).toList()}');
     assert(outputs.isNotEmpty, 'Can\'t run a build with no outputs');
 
-    // We only check the first output, because all outputs share the same inputs
-    // and invalidation state.
-    var firstOutput = outputs.first;
-    var node = _assetGraph.get(firstOutput) as GeneratedAssetNode;
+    // We check if any output definitely needs an update - its possible during
+    // manual deletions that only one of the outputs would be marked.
+    for (var output in outputs.skip(1)) {
+      if ((_assetGraph.get(output) as GeneratedAssetNode).state ==
+          NodeState.definitelyNeedsUpdate) {
+        return true;
+      }
+    }
+
+    // Otherwise, we only check the first output, because all outputs share the
+    // same inputs and invalidation state.
+    var firstNode = _assetGraph.get(outputs.first) as GeneratedAssetNode;
     assert(
         outputs.skip(1).every((output) =>
             (_assetGraph.get(output) as GeneratedAssetNode)
                 .inputs
-                .difference(node.inputs)
+                .difference(firstNode.inputs)
                 .isEmpty),
         'All outputs of a build action should share the same inputs.');
 
     // No need to build an up to date output
-    if (node.state == NodeState.upToDate) return false;
+    if (firstNode.state == NodeState.upToDate) return false;
     // Early bail out condition, this is a forced update.
-    if (node.state == NodeState.definitelyNeedsUpdate) return true;
+    if (firstNode.state == NodeState.definitelyNeedsUpdate) return true;
     // This is a fresh build or the first time we've seen this output.
-    if (node.previousInputsDigest == null) return true;
+    if (firstNode.previousInputsDigest == null) return true;
 
     var digest = await _computeCombinedDigest(
-        node.inputs, node.builderOptionsId, reader);
-    if (digest != node.previousInputsDigest) {
+        firstNode.inputs, firstNode.builderOptionsId, reader);
+    if (digest != firstNode.previousInputsDigest) {
       return true;
     } else {
       // Make sure to update the `state` field for all outputs.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 7.2.4-dev
+version: 7.2.4
 description: Core tools to write binaries that run builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1277,6 +1277,44 @@ void main() {
           writer: writer);
     });
 
+    test('deleting only the second output of a builder causes it to rerun',
+        () async {
+      var builders = [
+        applyToRoot(TestBuilder(buildExtensions: {
+          '.txt': ['.txt.1', '.txt.2']
+        }))
+      ];
+
+      // Initial build.
+      var writer = InMemoryRunnerAssetWriter();
+      await testBuilders(
+          builders,
+          {
+            'a|lib/a.txt': 'a',
+          },
+          outputs: {
+            'a|lib/a.txt.1': 'a',
+            'a|lib/a.txt.2': 'a',
+          },
+          writer: writer);
+
+      // Followup build with the 2nd output missing.
+      var serializedGraph = writer.assets[makeAssetId('a|$assetGraphPath')]!;
+      writer.assets.clear();
+      await testBuilders(
+          builders,
+          {
+            'a|lib/a.txt': 'a',
+            'a|lib/a.txt.1': 'a',
+            'a|$assetGraphPath': serializedGraph,
+          },
+          outputs: {
+            'a|lib/a.txt.1': 'a',
+            'a|lib/a.txt.2': 'a',
+          },
+          writer: writer);
+    });
+
     group('reportUnusedAssets', () {
       test('removes input dependencies', () async {
         final builder = TestBuilder(


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/3364

When a manual delete happens, we mark just that output as `definitelyNeedsUpdate`, but when checking if a given build step needs to run, we were only checking the state of the first output, based on an assumption that all outputs got invalidated together. That is true for all cases except this one.

This changes it to check if any of the output nodes definitely need an update, to cover this particular case.