### PR TITLE
Use declareVar and declareFinal from code_builder

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -14,130 +14,187 @@ import 'dart:io' as _i11;
 
 final _builders = <_i1.BuilderApplication>[
   _i1.apply(
-      r'build_test:test_bootstrap',
-      [_i2.debugIndexBuilder, _i2.debugTestBuilder, _i2.testBootstrapBuilder],
-      _i1.toRoot(),
-      hideOutput: true,
-      defaultGenerateFor:
-          const _i3.InputSet(include: [r'$package$', r'test/**'])),
-  _i1.apply(r'provides_builder:some_builder', [_i4.someBuilder],
-      _i1.toDependentsOf(r'provides_builder'),
-      hideOutput: true,
-      appliesBuilders: const [r'provides_builder:some_post_process_builder']),
-  _i1.apply(r'provides_builder:some_not_applied_builder', [_i4.notApplied],
-      _i1.toNoneByDefault(),
-      hideOutput: true),
-  _i1.apply(r'build_modules:module_library', [_i5.moduleLibraryBuilder],
-      _i1.toAllPackages(),
-      isOptional: true,
-      hideOutput: true,
-      appliesBuilders: const [r'build_modules:module_cleanup']),
+    r'build_test:test_bootstrap',
+    [
+      _i2.debugIndexBuilder,
+      _i2.debugTestBuilder,
+      _i2.testBootstrapBuilder,
+    ],
+    _i1.toRoot(),
+    hideOutput: true,
+    defaultGenerateFor: const _i3.InputSet(include: [
+      r'$package$',
+      r'test/**',
+    ]),
+  ),
   _i1.apply(
-      r'build_vm_compilers:modules',
-      [_i6.metaModuleBuilder, _i6.metaModuleCleanBuilder, _i6.moduleBuilder],
-      _i1.toNoneByDefault(),
-      isOptional: true,
-      hideOutput: true,
-      appliesBuilders: const [r'build_modules:module_cleanup']),
-  _i1.apply(r'build_vm_compilers:vm', [_i6.vmKernelModuleBuilder],
-      _i1.toAllPackages(),
-      isOptional: true,
-      hideOutput: true,
-      appliesBuilders: const [r'build_vm_compilers:modules']),
-  _i1.apply(r'build_vm_compilers:entrypoint', [_i6.vmKernelEntrypointBuilder],
-      _i1.toRoot(),
-      hideOutput: true,
-      defaultGenerateFor: const _i3.InputSet(include: [
-        r'bin/**',
-        r'tool/**',
-        r'test/**.dart.vm_test.dart',
-        r'example/**',
-        r'benchmark/**'
-      ])),
+    r'provides_builder:some_builder',
+    [_i4.someBuilder],
+    _i1.toDependentsOf(r'provides_builder'),
+    hideOutput: true,
+    appliesBuilders: const [r'provides_builder:some_post_process_builder'],
+  ),
   _i1.apply(
-      r'build_web_compilers:dart2js_modules',
-      [
-        _i7.dart2jsMetaModuleBuilder,
-        _i7.dart2jsMetaModuleCleanBuilder,
-        _i7.dart2jsModuleBuilder
-      ],
-      _i1.toNoneByDefault(),
-      isOptional: true,
-      hideOutput: true,
-      appliesBuilders: const [r'build_modules:module_cleanup']),
+    r'provides_builder:some_not_applied_builder',
+    [_i4.notApplied],
+    _i1.toNoneByDefault(),
+    hideOutput: true,
+  ),
   _i1.apply(
+    r'build_modules:module_library',
+    [_i5.moduleLibraryBuilder],
+    _i1.toAllPackages(),
+    isOptional: true,
+    hideOutput: true,
+    appliesBuilders: const [r'build_modules:module_cleanup'],
+  ),
+  _i1.apply(
+    r'build_vm_compilers:modules',
+    [
+      _i6.metaModuleBuilder,
+      _i6.metaModuleCleanBuilder,
+      _i6.moduleBuilder,
+    ],
+    _i1.toNoneByDefault(),
+    isOptional: true,
+    hideOutput: true,
+    appliesBuilders: const [r'build_modules:module_cleanup'],
+  ),
+  _i1.apply(
+    r'build_vm_compilers:vm',
+    [_i6.vmKernelModuleBuilder],
+    _i1.toAllPackages(),
+    isOptional: true,
+    hideOutput: true,
+    appliesBuilders: const [r'build_vm_compilers:modules'],
+  ),
+  _i1.apply(
+    r'build_vm_compilers:entrypoint',
+    [_i6.vmKernelEntrypointBuilder],
+    _i1.toRoot(),
+    hideOutput: true,
+    defaultGenerateFor: const _i3.InputSet(include: [
+      r'bin/**',
+      r'tool/**',
+      r'test/**.dart.vm_test.dart',
+      r'example/**',
+      r'benchmark/**',
+    ]),
+  ),
+  _i1.apply(
+    r'build_web_compilers:dart2js_modules',
+    [
+      _i7.dart2jsMetaModuleBuilder,
+      _i7.dart2jsMetaModuleCleanBuilder,
+      _i7.dart2jsModuleBuilder,
+    ],
+    _i1.toNoneByDefault(),
+    isOptional: true,
+    hideOutput: true,
+    appliesBuilders: const [r'build_modules:module_cleanup'],
+  ),
+  _i1.apply(
+    r'build_web_compilers:ddc_modules',
+    [
+      _i7.ddcMetaModuleBuilder,
+      _i7.ddcMetaModuleCleanBuilder,
+      _i7.ddcModuleBuilder,
+    ],
+    _i1.toNoneByDefault(),
+    isOptional: true,
+    hideOutput: true,
+    appliesBuilders: const [r'build_modules:module_cleanup'],
+  ),
+  _i1.apply(
+    r'build_web_compilers:ddc',
+    [
+      _i7.ddcKernelBuilderUnsound,
+      _i7.ddcBuilderUnsound,
+      _i7.ddcKernelBuilderSound,
+      _i7.ddcBuilderSound,
+    ],
+    _i1.toAllPackages(),
+    isOptional: true,
+    hideOutput: true,
+    appliesBuilders: const [
       r'build_web_compilers:ddc_modules',
-      [
-        _i7.ddcMetaModuleBuilder,
-        _i7.ddcMetaModuleCleanBuilder,
-        _i7.ddcModuleBuilder
-      ],
-      _i1.toNoneByDefault(),
-      isOptional: true,
-      hideOutput: true,
-      appliesBuilders: const [r'build_modules:module_cleanup']),
+      r'build_web_compilers:dart2js_modules',
+      r'build_web_compilers:dart_source_cleanup',
+    ],
+  ),
   _i1.apply(
-      r'build_web_compilers:ddc',
-      [
-        _i7.ddcKernelBuilderUnsound,
-        _i7.ddcBuilderUnsound,
-        _i7.ddcKernelBuilderSound,
-        _i7.ddcBuilderSound
-      ],
-      _i1.toAllPackages(),
-      isOptional: true,
-      hideOutput: true,
-      appliesBuilders: const [
-        r'build_web_compilers:ddc_modules',
-        r'build_web_compilers:dart2js_modules',
-        r'build_web_compilers:dart_source_cleanup'
-      ]),
+    r'build_web_compilers:sdk_js',
+    [
+      _i7.sdkJsCompileUnsound,
+      _i7.sdkJsCompileSound,
+      _i7.sdkJsCopyRequirejs,
+    ],
+    _i1.toNoneByDefault(),
+    isOptional: true,
+    hideOutput: true,
+  ),
   _i1.apply(
-      r'build_web_compilers:sdk_js',
-      [_i7.sdkJsCompileUnsound, _i7.sdkJsCompileSound, _i7.sdkJsCopyRequirejs],
-      _i1.toNoneByDefault(),
-      isOptional: true,
-      hideOutput: true),
-  _i1.apply(r'build_web_compilers:entrypoint', [_i7.webEntrypointBuilder],
-      _i1.toRoot(),
-      hideOutput: true,
-      defaultGenerateFor: const _i3.InputSet(include: [
+    r'build_web_compilers:entrypoint',
+    [_i7.webEntrypointBuilder],
+    _i1.toRoot(),
+    hideOutput: true,
+    defaultGenerateFor: const _i3.InputSet(
+      include: [
         r'web/**',
         r'test/**.dart.browser_test.dart',
         r'example/**',
-        r'benchmark/**'
-      ], exclude: [
+        r'benchmark/**',
+      ],
+      exclude: [
         r'test/**.node_test.dart',
-        r'test/**.vm_test.dart'
-      ]),
-      defaultOptions: const _i8.BuilderOptions(<String, dynamic>{
-        r'dart2js_args': <dynamic>[r'--minify']
-      }),
-      defaultDevOptions: const _i8.BuilderOptions(<String, dynamic>{
-        r'dart2js_args': <dynamic>[r'--enable-asserts']
-      }),
-      defaultReleaseOptions:
-          const _i8.BuilderOptions(<String, dynamic>{r'compiler': r'dart2js'}),
-      appliesBuilders: const [
-        r'build_web_compilers:dart2js_archive_extractor'
-      ]),
-  _i1.apply(r'provides_builder:throwing_builder', [_i4.throwingBuilder],
-      _i1.toDependentsOf(r'provides_builder'),
-      hideOutput: true),
-  _i1.applyPostProcess(r'build_modules:module_cleanup', _i5.moduleCleanup),
-  _i1.applyPostProcess(r'build_web_compilers:dart2js_archive_extractor',
-      _i7.dart2jsArchiveExtractor,
-      defaultReleaseOptions:
-          const _i8.BuilderOptions(<String, dynamic>{r'filter_outputs': true})),
+        r'test/**.vm_test.dart',
+      ],
+    ),
+    defaultOptions: const _i8.BuilderOptions(<String, dynamic>{
+      r'dart2js_args': <dynamic>[r'--minify']
+    }),
+    defaultDevOptions: const _i8.BuilderOptions(<String, dynamic>{
+      r'dart2js_args': <dynamic>[r'--enable-asserts']
+    }),
+    defaultReleaseOptions:
+        const _i8.BuilderOptions(<String, dynamic>{r'compiler': r'dart2js'}),
+    appliesBuilders: const [r'build_web_compilers:dart2js_archive_extractor'],
+  ),
+  _i1.apply(
+    r'provides_builder:throwing_builder',
+    [_i4.throwingBuilder],
+    _i1.toDependentsOf(r'provides_builder'),
+    hideOutput: true,
+  ),
   _i1.applyPostProcess(
-      r'build_web_compilers:dart_source_cleanup', _i7.dartSourceCleanup,
-      defaultReleaseOptions:
-          const _i8.BuilderOptions(<String, dynamic>{r'enabled': true})),
+    r'build_modules:module_cleanup',
+    _i5.moduleCleanup,
+  ),
   _i1.applyPostProcess(
-      r'provides_builder:some_post_process_builder', _i4.somePostProcessBuilder)
+    r'build_web_compilers:dart2js_archive_extractor',
+    _i7.dart2jsArchiveExtractor,
+    defaultReleaseOptions:
+        const _i8.BuilderOptions(<String, dynamic>{r'filter_outputs': true}),
+  ),
+  _i1.applyPostProcess(
+    r'build_web_compilers:dart_source_cleanup',
+    _i7.dartSourceCleanup,
+    defaultReleaseOptions:
+        const _i8.BuilderOptions(<String, dynamic>{r'enabled': true}),
+  ),
+  _i1.applyPostProcess(
+    r'provides_builder:some_post_process_builder',
+    _i4.somePostProcessBuilder,
+  ),
 ];
-void main(List<String> args, [_i9.SendPort? sendPort]) async {
-  var result = await _i10.run(args, _builders);
+void main(
+  List<String> args, [
+  _i9.SendPort? sendPort,
+]) async {
+  var result = await _i10.run(
+    args,
+    _builders,
+  );
   sendPort?.send(result);
   _i11.exitCode = result;
 }

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -37,11 +37,11 @@ Future<String> _generateBuildScript() async {
   final info = await findBuildScriptOptions();
   final builders = info.builderApplications;
   final library = Library((b) => b.body.addAll([
-        literalList(
+        declareFinal('_builders')
+            .assign(literalList(
                 builders,
                 refer('BuilderApplication',
-                    'package:build_runner_core/build_runner_core.dart'))
-            .assignFinal('_builders')
+                    'package:build_runner_core/build_runner_core.dart')))
             .statement,
         _main()
       ]));
@@ -248,10 +248,9 @@ Method _main() => Method((b) => b
       ..url = 'dart:isolate'
       ..isNullable = true)))
   ..body = Block.of([
-    refer('run', 'package:build_runner/build_runner.dart')
-        .call([refer('args'), refer('_builders')])
-        .awaited
-        .assignVar('result')
+    declareVar('result')
+        .assign(refer('run', 'package:build_runner/build_runner.dart')
+            .call([refer('args'), refer('_builders')]).awaited)
         .statement,
     refer('sendPort')
         .nullSafeProperty('send')

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   build_daemon: ^3.1.0
   build_resolvers: ^2.0.0
   build_runner_core: ^7.2.0
-  code_builder: ^4.0.0
+  code_builder: ^4.2.0
   collection: ^1.15.0
   crypto: ^3.0.0
   dart_style: ^2.0.0


### PR DESCRIPTION
Stop using the deprecated `assignVar` and `assignFinal`. Bump the minimum dep on `code_builder` to `4.2.0` which introduced `declareVar` and `declareFinal`.

Update the generated golden file to reflect the new trailing commas emitted by `code_builder`.