### PR TITLE
Include all SDK libraries in resolver

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -40,66 +40,6 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 2.17.0; PKGS: build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:build_test-example-scratch_space;commands:format-analyze_0"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:build_test-example-scratch_space
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
-        with:
-          sdk: "2.17.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_test_pub_upgrade
-        name: build_test; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build_test
-      - name: "build_test; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.build_test_pub_upgrade.conclusion == 'success'"
-        working-directory: build_test
-      - name: "build_test; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.build_test_pub_upgrade.conclusion == 'success'"
-        working-directory: build_test
-      - id: example_pub_upgrade
-        name: example; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: example
-      - name: "example; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.example_pub_upgrade.conclusion == 'success'"
-        working-directory: example
-      - name: "example; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.example_pub_upgrade.conclusion == 'success'"
-        working-directory: example
-      - id: scratch_space_pub_upgrade
-        name: scratch_space; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: scratch_space
-      - name: "scratch_space; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
-        working-directory: scratch_space
-      - name: "scratch_space; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
-        working-directory: scratch_space
-  job_003:
     name: "analyze_and_format; linux; Dart 2.18.0; PKG: build; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -129,17 +69,17 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
         working-directory: build
-  job_004:
-    name: "analyze_and_format; linux; Dart 2.18.0; PKGS: build_modules, build_resolvers, build_vm_compilers, build_web_compilers; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+  job_003:
+    name: "analyze_and_format; linux; Dart 2.18.0; PKGS: build_modules, build_resolvers, build_test, build_vm_compilers, build_web_compilers, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:build_modules-build_resolvers-build_vm_compilers-build_web_compilers;commands:format-analyze_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:build_modules-build_resolvers-build_test-build_vm_compilers-build_web_compilers-example-scratch_space;commands:format-analyze_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:build_modules-build_resolvers-build_vm_compilers-build_web_compilers
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:build_modules-build_resolvers-build_test-build_vm_compilers-build_web_compilers-example-scratch_space
             os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -176,6 +116,19 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
         working-directory: build_resolvers
+      - id: build_test_pub_upgrade
+        name: build_test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_test
+      - name: "build_test; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.build_test_pub_upgrade.conclusion == 'success'"
+        working-directory: build_test
+      - name: "build_test; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.build_test_pub_upgrade.conclusion == 'success'"
+        working-directory: build_test
       - id: build_vm_compilers_pub_upgrade
         name: build_vm_compilers; dart pub upgrade
         run: dart pub upgrade
@@ -202,7 +155,33 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
         working-directory: build_web_compilers
-  job_005:
+      - id: example_pub_upgrade
+        name: example; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: example
+      - name: "example; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.example_pub_upgrade.conclusion == 'success'"
+        working-directory: example
+      - name: "example; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.example_pub_upgrade.conclusion == 'success'"
+        working-directory: example
+      - id: scratch_space_pub_upgrade
+        name: scratch_space; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: scratch_space
+      - name: "scratch_space; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
+        working-directory: scratch_space
+      - name: "scratch_space; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
+        working-directory: scratch_space
+  job_004:
     name: "analyze_and_format; linux; Dart dev; PKGS: _test, _test_common, build; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -250,7 +229,7 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
         working-directory: build
-  job_006:
+  job_005:
     name: "analyze_and_format; linux; Dart dev; PKG: _test_null_safety; `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
@@ -280,7 +259,7 @@ jobs:
         run: dart analyze --fatal-infos
         if: "always() && steps._test_null_safety_pub_upgrade.conclusion == 'success'"
         working-directory: _test_null_safety
-  job_007:
+  job_006:
     name: "analyze_and_format; linux; Dart dev; PKG: build; `dart format --output=none --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
@@ -310,7 +289,7 @@ jobs:
         run: "dart format --output=none --set-exit-if-changed ."
         if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
         working-directory: build
-  job_008:
+  job_007:
     name: "analyze_and_format; linux; Dart dev; PKGS: build_config, build_daemon, build_modules, build_resolvers, build_runner, build_runner_core, build_test, build_vm_compilers, build_web_compilers, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -474,7 +453,7 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
         working-directory: scratch_space
-  job_009:
+  job_008:
     name: "analyze_and_format; windows; Dart dev; PKG: _test_null_safety; `dart analyze --fatal-infos`"
     runs-on: windows-latest
     steps:
@@ -494,127 +473,7 @@ jobs:
         run: dart analyze --fatal-infos
         if: "always() && steps._test_null_safety_pub_upgrade.conclusion == 'success'"
         working-directory: _test_null_safety
-  job_010:
-    name: "unit_test; linux; Dart 2.17.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:build_runner_core;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:build_runner_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
-        with:
-          sdk: "2.17.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_runner_core_pub_upgrade
-        name: build_runner_core; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build_runner_core
-      - name: "build_runner_core; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.build_runner_core_pub_upgrade.conclusion == 'success'"
-        working-directory: build_runner_core
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-  job_011:
-    name: "unit_test; linux; Dart 2.17.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:build_test;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:build_test
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
-        with:
-          sdk: "2.17.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_test_pub_upgrade
-        name: build_test; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build_test
-      - name: "build_test; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.build_test_pub_upgrade.conclusion == 'success'"
-        working-directory: build_test
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-  job_012:
-    name: "unit_test; linux; Dart 2.17.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:scratch_space;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0;packages:scratch_space
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.17.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
-        with:
-          sdk: "2.17.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: scratch_space_pub_upgrade
-        name: scratch_space; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: scratch_space
-      - name: "scratch_space; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
-        working-directory: scratch_space
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-  job_013:
+  job_009:
     name: "unit_test; linux; Dart 2.18.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -653,8 +512,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_014:
+  job_010:
     name: "unit_test; linux; Dart 2.18.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -693,8 +551,85 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_015:
+  job_011:
+    name: "unit_test; linux; Dart 2.18.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:build_runner_core;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:build_runner_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.18.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_runner_core_pub_upgrade
+        name: build_runner_core; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_runner_core
+      - name: "build_runner_core; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_runner_core_pub_upgrade.conclusion == 'success'"
+        working-directory: build_runner_core
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+  job_012:
+    name: "unit_test; linux; Dart 2.18.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:build_test;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:build_test
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.18.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_test_pub_upgrade
+        name: build_test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_test
+      - name: "build_test; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_test_pub_upgrade.conclusion == 'success'"
+        working-directory: build_test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+  job_013:
     name: "unit_test; linux; Dart 2.18.0; PKG: build_web_compilers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -733,8 +668,46 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_016:
+  job_014:
+    name: "unit_test; linux; Dart 2.18.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:scratch_space;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0;packages:scratch_space
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.18.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.18.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: scratch_space_pub_upgrade
+        name: scratch_space; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: scratch_space
+      - name: "scratch_space; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
+        working-directory: scratch_space
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+  job_015:
     name: "unit_test; linux; Dart 2.18.0; PKG: build_modules; `dart test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -773,8 +746,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_017:
+  job_016:
     name: "unit_test; linux; Dart 2.18.0; PKG: build_vm_compilers; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -813,8 +785,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_018:
+  job_017:
     name: "unit_test; linux; Dart dev; PKG: _test; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -857,8 +828,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_019:
+  job_018:
     name: "unit_test; linux; Dart dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -897,8 +867,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_020:
+  job_019:
     name: "unit_test; linux; Dart dev; PKG: build_config; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -937,8 +906,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_021:
+  job_020:
     name: "unit_test; linux; Dart dev; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -977,8 +945,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_022:
+  job_021:
     name: "unit_test; linux; Dart dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1017,8 +984,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_023:
+  job_022:
     name: "unit_test; linux; Dart dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1057,8 +1023,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_024:
+  job_023:
     name: "unit_test; linux; Dart dev; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1097,8 +1062,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_025:
+  job_024:
     name: "unit_test; linux; Dart dev; PKG: build_web_compilers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1137,8 +1101,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_026:
+  job_025:
     name: "unit_test; linux; Dart dev; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1177,8 +1140,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_027:
+  job_026:
     name: "unit_test; linux; Dart dev; PKG: build_modules; `dart test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1217,8 +1179,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_028:
+  job_027:
     name: "unit_test; linux; Dart dev; PKG: build_runner; `dart test -x integration --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1257,8 +1218,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_029:
+  job_028:
     name: "unit_test; linux; Dart dev; PKG: build_vm_compilers; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -1297,98 +1257,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_030:
-    name: "unit_test; windows; Dart 2.17.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
-        with:
-          sdk: "2.17.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_runner_core_pub_upgrade
-        name: build_runner_core; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build_runner_core
-      - name: "build_runner_core; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.build_runner_core_pub_upgrade.conclusion == 'success'"
-        working-directory: build_runner_core
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-  job_031:
-    name: "unit_test; windows; Dart 2.17.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
-        with:
-          sdk: "2.17.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_test_pub_upgrade
-        name: build_test; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build_test
-      - name: "build_test; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.build_test_pub_upgrade.conclusion == 'success'"
-        working-directory: build_test
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-  job_032:
-    name: "unit_test; windows; Dart 2.17.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
-        with:
-          sdk: "2.17.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: scratch_space_pub_upgrade
-        name: scratch_space; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: scratch_space
-      - name: "scratch_space; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
-        working-directory: scratch_space
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-  job_033:
+  job_029:
     name: "unit_test; windows; Dart 2.18.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1417,8 +1286,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_034:
+  job_030:
     name: "unit_test; windows; Dart 2.18.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1447,8 +1315,65 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_035:
+  job_031:
+    name: "unit_test; windows; Dart 2.18.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.18.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_runner_core_pub_upgrade
+        name: build_runner_core; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_runner_core
+      - name: "build_runner_core; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_runner_core_pub_upgrade.conclusion == 'success'"
+        working-directory: build_runner_core
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+  job_032:
+    name: "unit_test; windows; Dart 2.18.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.18.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_test_pub_upgrade
+        name: build_test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_test
+      - name: "build_test; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_test_pub_upgrade.conclusion == 'success'"
+        working-directory: build_test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+  job_033:
     name: "unit_test; windows; Dart 2.18.0; PKG: build_web_compilers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1477,8 +1402,36 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_036:
+  job_034:
+    name: "unit_test; windows; Dart 2.18.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: "2.18.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: scratch_space_pub_upgrade
+        name: scratch_space; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: scratch_space
+      - name: "scratch_space; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
+        working-directory: scratch_space
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+  job_035:
     name: "unit_test; windows; Dart 2.18.0; PKG: build_modules; `dart test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1507,8 +1460,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_037:
+  job_036:
     name: "unit_test; windows; Dart 2.18.0; PKG: build_vm_compilers; `dart test`"
     runs-on: windows-latest
     steps:
@@ -1537,8 +1489,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_038:
+  job_037:
     name: "unit_test; windows; Dart dev; PKG: _test; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1571,8 +1522,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_039:
+  job_038:
     name: "unit_test; windows; Dart dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1601,8 +1551,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_040:
+  job_039:
     name: "unit_test; windows; Dart dev; PKG: build_config; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1631,8 +1580,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_041:
+  job_040:
     name: "unit_test; windows; Dart dev; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1661,8 +1609,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_042:
+  job_041:
     name: "unit_test; windows; Dart dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1691,8 +1638,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_043:
+  job_042:
     name: "unit_test; windows; Dart dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1721,8 +1667,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_044:
+  job_043:
     name: "unit_test; windows; Dart dev; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1751,8 +1696,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_045:
+  job_044:
     name: "unit_test; windows; Dart dev; PKG: build_web_compilers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1781,8 +1725,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_046:
+  job_045:
     name: "unit_test; windows; Dart dev; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1811,8 +1754,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_047:
+  job_046:
     name: "unit_test; windows; Dart dev; PKG: build_modules; `dart test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1841,8 +1783,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_048:
+  job_047:
     name: "unit_test; windows; Dart dev; PKG: build_vm_compilers; `dart test`"
     runs-on: windows-latest
     steps:
@@ -1871,8 +1812,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-      - job_009
-  job_049:
+  job_048:
     name: "e2e_test; linux; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1950,8 +1890,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_050:
+  job_049:
     name: "e2e_test; linux; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -2029,8 +1968,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_051:
+  job_050:
     name: "e2e_test; linux; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -2108,8 +2046,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_052:
+  job_051:
     name: "e2e_test; linux; Dart dev; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -2191,8 +2128,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_053:
+  job_052:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2270,8 +2206,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_054:
+  job_053:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2349,8 +2284,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_055:
+  job_054:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2428,8 +2362,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_056:
+  job_055:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2507,8 +2440,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_057:
+  job_056:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2586,8 +2518,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_058:
+  job_057:
     name: "e2e_test; windows; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2655,8 +2586,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_059:
+  job_058:
     name: "e2e_test; windows; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2724,8 +2654,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_060:
+  job_059:
     name: "e2e_test; windows; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2793,8 +2722,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_061:
+  job_060:
     name: "e2e_test; windows; Dart dev; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2866,8 +2794,7 @@ jobs:
       - job_045
       - job_046
       - job_047
-      - job_048
-  job_062:
+  job_061:
     name: "e2e_test_cron; linux; Dart main; PKG: _test; `dart test`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -2959,8 +2886,7 @@ jobs:
       - job_058
       - job_059
       - job_060
-      - job_061
-  job_063:
+  job_062:
     name: "e2e_test_cron; linux; Dart main; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -3056,8 +2982,7 @@ jobs:
       - job_058
       - job_059
       - job_060
-      - job_061
-  job_064:
+  job_063:
     name: "e2e_test_cron; windows; Dart main; PKG: _test; `dart test`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
@@ -3139,8 +3064,7 @@ jobs:
       - job_058
       - job_059
       - job_060
-      - job_061
-  job_065:
+  job_064:
     name: "e2e_test_cron; windows; Dart main; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
@@ -3226,8 +3150,7 @@ jobs:
       - job_058
       - job_059
       - job_060
-      - job_061
-  job_066:
+  job_065:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -3303,4 +3226,3 @@ jobs:
       - job_062
       - job_063
       - job_064
-      - job_065

--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -18,10 +18,15 @@ abstract class Resolver {
   /// or is a `part of` file (not a standalone Dart library).
   Future<bool> isLibrary(AssetId assetId);
 
-  /// All libraries recursively accessible from the entry point or subsequent
-  /// calls to [libraryFor] and [isLibrary].
+  /// All libraries resolved by this resolver.
   ///
-  /// **NOTE**: This includes all Dart SDK libraries as well.
+  /// This includes the following libraries:
+  ///  - The primary input of this resolver (in other words, the
+  ///   [BuildStep.inputId] of a build step).
+  ///  - Libraries resolved with a direct [libraryFor] call.
+  ///  - Every public `dart:` library part of the SDK.
+  ///  - All libraries recursively accessible from the mentioned sources, for
+  ///    instance because due to imports or exports.
   Stream<LibraryElement> get libraries;
 
   /// Returns the parsed [AstNode] for [Element].
@@ -58,8 +63,9 @@ abstract class Resolver {
   /// Returns the first resolved library identified by [libraryName].
   ///
   /// A library is resolved if it's recursively accessible from the entry point
-  /// or subsequent calls to [libraryFor] and [isLibrary]. If no library can be
-  /// found, returns `null`.
+  /// or subsequent calls to [libraryFor]. In other words, this searches for
+  /// libraries in [libraries].
+  /// If no library can be found, returns `null`.
   ///
   /// **NOTE**: In general, its recommended to use [libraryFor] with an absolute
   /// asset id instead of a named identifier that has the possibility of not

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Migrate off deprecated analyzer apis.
 - Update min sdk constraint to 2.18.0.
+- Return all SDK libraries in `Resolver.libraries`, making the implementation
+  consistent with the documentation.
 
 ## 2.0.10
 

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -261,7 +261,7 @@ class AnalyzerResolver implements ReleasableResolver {
   Future<List<ErrorsResult>> _syntacticErrorsFor(LibraryElement element) async {
     final existingSources = [element.source];
 
-    for (final part in element.parts2) {
+    for (final part in element.parts) {
       var uri = part.uri;
       // There may be no source if the part doesn't exist. That's not important
       // for us since we only care about existing file syntax.
@@ -460,7 +460,7 @@ Future<String> _defaultSdkSummaryGenerator() async {
     final embedderYamlPath =
         isFlutter ? p.join(_dartUiPath, '_embedder.yaml') : null;
     await summaryFile.writeAsBytes(
-      await buildSdkSummary2(
+      await buildSdkSummary(
         sdkPath: _runningDartSdkPath,
         resourceProvider: PhysicalResourceProvider.INSTANCE,
         embedderYamlPath: embedderYamlPath,

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=5.1.0 <6.0.0'
+  analyzer: ^5.2.0
   async: ^2.5.0
   build: ^2.0.0
   crypto: ^3.0.0

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -85,6 +85,23 @@ void main() {
       }, resolvers: AnalyzerResolvers());
     });
 
+    test(
+        'calling isLibrary does not include that library in the libraries stream',
+        () {
+      return resolveSources({
+        'a|web/main.dart': '',
+        'b|lib/b.dart': '''
+              library b;
+              ''',
+      }, (resolver) async {
+        await resolver.isLibrary(AssetId('b', 'lib/b.dart'));
+        await expectLater(
+          resolver.libraries,
+          neverEmits(isA<LibraryElement>().having((e) => e.name, 'name', 'b')),
+        );
+      }, resolvers: AnalyzerResolvers());
+    });
+
     test('should still crawl transitively after a call to compilationUnitFor',
         () {
       return resolveSources({
@@ -635,6 +652,8 @@ int? get x => 1;
             'dart:core',
             'dart:math',
             'dart:typed_data',
+            'dart:io',
+            'dart:html',
             if (isFlutter) 'dart:ui',
           ]));
     }, resolvers: AnalyzerResolvers());

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -255,8 +255,8 @@ void main() {
               } ''',
       }, (resolver) async {
         var lib = await resolver.libraryFor(entryPoint);
-        expect(lib.parts2.length, 1);
-        expect(lib.parts2.whereType<DirectiveUriWithSource>(), isEmpty);
+        expect(lib.parts.length, 1);
+        expect(lib.parts.whereType<DirectiveUriWithSource>(), isEmpty);
       }, resolvers: AnalyzerResolvers());
     });
 
@@ -371,7 +371,7 @@ void main() {
               class Bar {}''',
       }, (resolver) async {
         var main = (await resolver.findLibraryByName('web.main'))!;
-        var meta = main.getClass('Foo')!.supertype!.element2.metadata[0];
+        var meta = main.getClass('Foo')!.supertype!.element.metadata[0];
         expect(meta, isNotNull);
         expect(meta.computeConstantValue()?.toIntValue(), 0);
       }, resolvers: AnalyzerResolvers());
@@ -698,14 +698,14 @@ int? get x => 1;
         var color = classDefinition.getField('color')!;
 
         if (isFlutter) {
-          expect(color.type.element2!.name, equals('Color'));
-          expect(color.type.element2!.library!.name, equals('dart.ui'));
+          expect(color.type.element!.name, equals('Color'));
+          expect(color.type.element!.library!.name, equals('dart.ui'));
           expect(
-              color.type.element2!.library!.definingCompilationUnit.source.uri
+              color.type.element!.library!.definingCompilationUnit.source.uri
                   .toString(),
               equals('dart:ui'));
         } else {
-          expect(color.type.element2!.name, equals('dynamic'));
+          expect(color.type.element!.name, equals('dynamic'));
         }
       }, resolvers: AnalyzerResolvers());
     });

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -659,6 +659,21 @@ int? get x => 1;
     }, resolvers: AnalyzerResolvers());
   });
 
+  test('can resolve sdk libraries without seeing anything else', () async {
+    await resolveSources({
+      'a|lib/not_dart.txt': '',
+    }, (resolver) async {
+      var allLibraries = await resolver.libraries.toList();
+
+      expect(allLibraries.map((e) => e.source.uri.toString()),
+          containsAll(['dart:io', 'dart:core', 'dart:html']));
+      expect(
+          allLibraries,
+          everyElement(isA<LibraryElement>()
+              .having((e) => e.isInSdk, 'isInSdk', isTrue)));
+    }, resolvers: AnalyzerResolvers());
+  });
+
   group('The ${isFlutter ? 'flutter' : 'dart'} sdk', () {
     test('can${isFlutter ? '' : ' not'} resolve types from dart:ui', () async {
       return resolveSources({

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -656,6 +656,21 @@ int? get x => 1;
             'dart:html',
             if (isFlutter) 'dart:ui',
           ]));
+
+      // Only public libraries should be reported
+      expect(
+        allLibraries,
+        everyElement(isA<LibraryElement>()
+            .having((e) => e.isPrivate, 'isPrivate', isFalse)),
+      );
+      expect(
+        allLibraries,
+        everyElement(isA<LibraryElement>().having(
+          (e) => e.source.uri.path,
+          'source.uri.path',
+          isNot(startsWith('_')),
+        )),
+      );
     }, resolvers: AnalyzerResolvers());
   });
 

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -663,14 +663,6 @@ int? get x => 1;
         everyElement(isA<LibraryElement>()
             .having((e) => e.isPrivate, 'isPrivate', isFalse)),
       );
-      expect(
-        allLibraries,
-        everyElement(isA<LibraryElement>().having(
-          (e) => e.source.uri.path,
-          'source.uri.path',
-          isNot(startsWith('_')),
-        )),
-      );
     }, resolvers: AnalyzerResolvers());
   });
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.8-dev
+
+- Raise the minimum SDK constraint to 2.18.
+
 ## 7.2.7
 
 - Handle generation of hidden assets in a way consistent with the definition of

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   yaml: ^3.0.0
 
 dev_dependencies:
-  analyzer: '>=4.6.0 <6.0.0'
+  analyzer: ^5.2.0
   build_runner: ^2.0.0
   build_test: ^2.0.0
   lints: '>=1.0.0 <3.0.0'

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -4,7 +4,7 @@ description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 platforms:
   linux:

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 7.2.7
+version: 7.2.8-dev
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/generate/resolution_test.dart
+++ b/build_runner_core/test/generate/resolution_test.dart
@@ -49,7 +49,7 @@ class ListClassesAndHierarchyBuilder implements Builder {
     for (final type in types) {
       output
         ..write('${type.name}: [')
-        ..writeAll(type.allSupertypes.map((t) => t.element2.name), ', ')
+        ..writeAll(type.allSupertypes.map((t) => t.element.name), ', ')
         ..writeln(']');
     }
     await buildStep.writeAsString(outputId, output.toString());

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.6-dev
 
 - Fix bug in package config file loading.
+- Raise the minimum SDK constraint to 2.18.
 
 ## 2.1.5
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -24,6 +24,6 @@ dependencies:
   watcher: ^1.0.0
 
 dev_dependencies:
-  analyzer: '>=4.6.0 <6.0.0'
+  analyzer: ^5.2.0
   collection: ^1.15.0
   lints: '>=1.0.0 <3.0.0'

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.1.6-dev
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   async: ^2.5.0

--- a/build_test/test/resolve_source_test.dart
+++ b/build_test/test/resolve_source_test.dart
@@ -74,7 +74,7 @@ void main() {
       );
       final type = library.getClass('ExamplePrime');
       expect(type, isNotNull);
-      expect(type!.supertype!.element2.name, 'Example');
+      expect(type!.supertype!.element.name, 'Example');
     });
 
     test('waits for tearDown', () async {
@@ -158,7 +158,7 @@ void main() {
 }
 
 String _toStringId(InterfaceType t) =>
-    '${t.element2.source.uri.toString().split('/').first}#${t.element2.name}';
+    '${t.element.source.uri.toString().split('/').first}#${t.element.name}';
 
 extension on Resolver {
   Future<LibraryElement> findLibraryNotNull(String name) async {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 publish_to: none
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   analyzer: ">=2.0.0 <6.0.0"

--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.2-dev
 
-- Require Dart >=2.17.0
+- Require Dart >=2.18.0
 
 ## 1.0.1
 

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -4,7 +4,7 @@ description: A tool to manage running external executables within package:build
 repository: https://github.com/dart-lang/build/tree/master/scratch_space
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   build: ^2.0.0


### PR DESCRIPTION
This PR makes the following changes to the resolvers interface and the default implementation in this repository:

- I've updated the documentation of `libraries` to explicitly state which libraries are included.
- I've adapted the default implementation to always include everything from the Dart SDK.

https://github.com/dart-lang/build/issues/3387