### PR TITLE
Build hidden outputs if they're public

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.2.7-dev
+
+- Handle generation of hidden assets in a way consistent with the definition of
+  public assets used in other parts of the build system.
+
 ## 7.2.6
 
 - Add supported platforms to pubspec.

--- a/build_runner_core/lib/src/asset/finalized_reader.dart
+++ b/build_runner_core/lib/src/asset/finalized_reader.dart
@@ -14,22 +14,24 @@ import 'package:glob/glob.dart';
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../asset_graph/optional_output_tracker.dart';
+import '../package_graph/target_graph.dart';
 
 /// An [AssetReader] which ignores deleted files.
 class FinalizedReader implements AssetReader {
   final AssetReader _delegate;
   final AssetGraph _assetGraph;
+  final TargetGraph _targetGraph;
   OptionalOutputTracker? _optionalOutputTracker;
   final String _rootPackage;
   final List<BuildPhase> _buildPhases;
 
   void reset(Set<String> buildDirs, Set<BuildFilter> buildFilters) {
     _optionalOutputTracker = OptionalOutputTracker(
-        _assetGraph, buildDirs, buildFilters, _buildPhases);
+        _assetGraph, _targetGraph, buildDirs, buildFilters, _buildPhases);
   }
 
-  FinalizedReader(
-      this._delegate, this._assetGraph, this._buildPhases, this._rootPackage);
+  FinalizedReader(this._delegate, this._assetGraph, this._targetGraph,
+      this._buildPhases, this._rootPackage);
 
   /// Returns a reason why [id] is not readable, or null if it is readable.
   Future<UnreadableReason?> unreadableReason(AssetId id) async {

--- a/build_runner_core/lib/src/asset_graph/optional_output_tracker.dart
+++ b/build_runner_core/lib/src/asset_graph/optional_output_tracker.dart
@@ -6,6 +6,7 @@ import 'package:build/build.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 
 import '../generate/phase.dart';
+import '../package_graph/target_graph.dart';
 import '../util/build_dirs.dart';
 import 'graph.dart';
 import 'node.dart';
@@ -31,12 +32,13 @@ import 'node.dart';
 class OptionalOutputTracker {
   final _checkedOutputs = <AssetId, bool>{};
   final AssetGraph _assetGraph;
+  final TargetGraph _targetGraph;
   final Set<String> _buildDirs;
   final Set<BuildFilter> _buildFilters;
   final List<BuildPhase> _buildPhases;
 
-  OptionalOutputTracker(
-      this._assetGraph, this._buildDirs, this._buildFilters, this._buildPhases);
+  OptionalOutputTracker(this._assetGraph, this._targetGraph, this._buildDirs,
+      this._buildFilters, this._buildPhases);
 
   /// Returns whether [output] is required.
   ///
@@ -53,7 +55,11 @@ class OptionalOutputTracker {
     if (node is! GeneratedAssetNode) return true;
     final phase = _buildPhases[node.phaseNumber];
     if (!phase.isOptional &&
-        shouldBuildForDirs(output, _buildDirs, _buildFilters, phase)) {
+        shouldBuildForDirs(output,
+            buildDirs: _buildDirs,
+            buildFilters: _buildFilters,
+            phase: phase,
+            targetGraph: _targetGraph)) {
       return true;
     }
     return _checkedOutputs.putIfAbsent(

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -124,6 +124,7 @@ class BuildImpl {
     var finalizedReader = FinalizedReader(
         singleStepReader,
         buildDefinition.assetGraph,
+        buildDefinition.targetGraph,
         buildPhases,
         options.packageGraph.root.name);
     var build =
@@ -233,8 +234,8 @@ class _SingleBuild {
   Future<BuildResult> run(Map<AssetId, ChangeType> updates) async {
     var watch = Stopwatch()..start();
     var result = await _safeBuild(updates);
-    var optionalOutputTracker = OptionalOutputTracker(
-        _assetGraph, _buildPaths(_buildDirs), _buildFilters, _buildPhases);
+    var optionalOutputTracker = OptionalOutputTracker(_assetGraph, _targetGraph,
+        _buildPaths(_buildDirs), _buildFilters, _buildPhases);
     if (result.status == BuildStatus.success) {
       final failures = _assetGraph.failedOutputs
           .where((n) => optionalOutputTracker.isRequired(n.id));
@@ -374,8 +375,11 @@ class _SingleBuild {
 
     await Future.wait(
         _assetGraph.outputsForPhase(package, phaseNumber).map((node) async {
-      if (!shouldBuildForDirs(
-          node.id, _buildPaths(_buildDirs), _buildFilters, phase)) {
+      if (!shouldBuildForDirs(node.id,
+          buildDirs: _buildPaths(_buildDirs),
+          buildFilters: _buildFilters,
+          phase: phase,
+          targetGraph: _targetGraph)) {
         return;
       }
 

--- a/build_runner_core/lib/src/util/build_dirs.dart
+++ b/build_runner_core/lib/src/util/build_dirs.dart
@@ -6,33 +6,39 @@ import 'package:build/build.dart';
 
 import '../generate/options.dart';
 import '../generate/phase.dart';
+import '../package_graph/target_graph.dart';
 
 /// Returns whether or not [id] should be built based upon [buildDirs],
-/// [phase], and optional [buildFilters].
+/// [phase], [targetGraph], and optional [buildFilters].
 ///
 /// The logic for this is as follows:
 ///
 /// - If any [buildFilters] are supplied, then this only returns `true` if [id]
 ///   explicitly matches one of the filters.
 /// - If no [buildFilters] are supplied, then the old behavior applies - all
-///   build to source builders and all files under `lib` of all packages are
-///   always built.
+///   build to source builders and all public assets (according to
+///   [TargetGraph.isPublicAsset]) are always built.
 /// - Regardless of the [buildFilters] setting, if [buildDirs] is supplied then
 ///   `id.path` must start with one of the specified directory names.
-bool shouldBuildForDirs(AssetId id, Set<String> buildDirs,
-    Set<BuildFilter>? buildFilters, BuildPhase phase) {
-  buildFilters ??= {};
+bool shouldBuildForDirs(
+  AssetId id, {
+  required Set<String> buildDirs,
+  required BuildPhase phase,
+  required TargetGraph targetGraph,
+  Set<BuildFilter> buildFilters = const {},
+}) {
   if (buildFilters.isEmpty) {
+    // Build non-hidden and public assets
     if (!phase.hideOutput) return true;
 
-    if (id.path.startsWith('lib/')) return true;
+    if (targetGraph.isPublicAsset(id)) return true;
   } else {
     if (!buildFilters.any((f) => f.matches(id))) {
       return false;
     }
   }
 
-  if (buildDirs.isEmpty) return true;
-
-  return id.path.startsWith('lib/') || buildDirs.any(id.path.startsWith);
+  return buildDirs.isEmpty ||
+      targetGraph.isPublicAsset(id) ||
+      buildDirs.any(id.path.startsWith);
 }

--- a/build_runner_core/lib/src/util/build_dirs.dart
+++ b/build_runner_core/lib/src/util/build_dirs.dart
@@ -28,17 +28,22 @@ bool shouldBuildForDirs(
   Set<BuildFilter> buildFilters = const {},
 }) {
   if (buildFilters.isEmpty) {
-    // Build non-hidden and public assets
-    if (!phase.hideOutput) return true;
-
-    if (targetGraph.isPublicAsset(id)) return true;
+    // Build asset if: It's built to source, it's public or if it's matched by
+    // a build directory.
+    return !phase.hideOutput ||
+        buildDirs.isEmpty ||
+        buildDirs.any(id.path.startsWith) ||
+        targetGraph.isPublicAsset(id);
   } else {
+    // Don't build assets not matched by build filters
     if (!buildFilters.any((f) => f.matches(id))) {
       return false;
     }
-  }
 
-  return buildDirs.isEmpty ||
-      targetGraph.isPublicAsset(id) ||
-      buildDirs.any(id.path.startsWith);
+    // In filtered assets, build the public ones or those inside a build
+    // directory.
+    return buildDirs.isEmpty ||
+        buildDirs.any(id.path.startsWith) ||
+        targetGraph.isPublicAsset(id);
+  }
 }

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -23,12 +23,12 @@ void main() {
     late TargetGraph targetGraph;
 
     setUp(() async {
-      final packageGraph = buildPackageGraph({rootPackage('foo'): []});
+      final packageGraph = buildPackageGraph({rootPackage('a'): []});
       targetGraph = await TargetGraph.forPackageGraph(packageGraph,
           defaultRootPackageSources: defaultNonRootVisibleAssets);
 
       graph = await AssetGraph.build([], <AssetId>{}, <AssetId>{},
-          buildPackageGraph({rootPackage('foo'): []}), _FakeAssetReader());
+          buildPackageGraph({rootPackage('a'): []}), _FakeAssetReader());
     });
 
     test('can not read deleted files', () async {

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -27,8 +27,8 @@ void main() {
       targetGraph = await TargetGraph.forPackageGraph(packageGraph,
           defaultRootPackageSources: defaultNonRootVisibleAssets);
 
-      graph = await AssetGraph.build([], <AssetId>{}, <AssetId>{},
-          buildPackageGraph({rootPackage('a'): []}), _FakeAssetReader());
+      graph = await AssetGraph.build(
+          [], <AssetId>{}, <AssetId>{}, packageGraph, _FakeAssetReader());
     });
 
     test('can not read deleted files', () async {


### PR DESCRIPTION
Some directories, like `lib/`, are special-cased by the build system in the sense that

1. Their assets are readable for non-root packages
2. Hidden assets are generated for them even if they're not part of any build filter or directory.

Some time ago, I've added the `additional_public_assets` configuration to expand this behavior to non-standard directories. As a motivation, consider building a C library with the build system and some builder generating a hidden file in `include/`. Similar to hidden outputs in `lib/`, we definitely want this builder to run for this asset since `include/` has a meaning somewhat comparable to `lib/` in Dart. The `additional_public_assets` build configuration hence makes it easier to integrate non-Dart components in the Dart package ecosystem and build them with Dart's standard build tools.

I am also running into this issue with a static site generator that I'm writing. It generates a (hidden) asset for markdown files in `pages/` containing HTML and a list of target URLs. A post-process builder later generates `.html` assets in `web/` based on these intermediate assets. This builder breaks when a build directory is present, since hidden assets in `pages/` are no longer built (see https://github.com/dart-lang/webdev/issues/1200, https://github.com/dart-lang/webdev/issues/1733).

Having public assets handled in a consistent way would really help with my static site generator. I also believe that it is generally the right thing to do in the implementation as it could avoid confusion for advanced users interested in building not-only-Dart modules or packages.
So, this PR makes the output check consistent with the notion of a public asset used in other parts of the build implementation. 