### PR TITLE
Persistent byte store for analysis driver

### DIFF
--- a/build_resolvers/lib/src/analysis_driver.dart
+++ b/build_resolvers/lib/src/analysis_driver.dart
@@ -22,6 +22,7 @@ Future<AnalysisDriverForPackageBuild> analysisDriver(
   AnalysisOptions analysisOptions,
   String sdkSummaryPath,
   PackageConfig packageConfig,
+  ByteStore? byteStore,
 ) async {
   final cachePath = p.join('.dart_tool', 'build_resolvers', 'cache');
   await Directory(cachePath).create(recursive: true);
@@ -34,11 +35,7 @@ Future<AnalysisDriverForPackageBuild> analysisDriver(
     ),
     resourceProvider: buildAssetUriResolver.resourceProvider,
     sdkSummaryBytes: File(sdkSummaryPath).readAsBytesSync(),
-    byteStore: createByteStore(
-      directory: cachePath,
-      maxFileSize: 1024 * 1024 * 1024, // 1 GiB
-      memoryCacheSize: 1024 * 1024 * 128, // 128 MiB
-    ),
+    byteStore: byteStore,
     uriResolvers: [
       buildAssetUriResolver,
     ],

--- a/build_resolvers/lib/src/analysis_driver.dart
+++ b/build_resolvers/lib/src/analysis_driver.dart
@@ -17,16 +17,13 @@ import 'build_asset_uri_resolver.dart';
 /// Builds an [AnalysisDriverForPackageBuild] backed by a summary SDK.
 ///
 /// Any code must be resolvable through [buildAssetUriResolver].
-Future<AnalysisDriverForPackageBuild> analysisDriver(
+AnalysisDriverForPackageBuild analysisDriver(
   BuildAssetUriResolver buildAssetUriResolver,
   AnalysisOptions analysisOptions,
   String sdkSummaryPath,
   PackageConfig packageConfig,
   ByteStore? byteStore,
-) async {
-  final cachePath = p.join('.dart_tool', 'build_resolvers', 'cache');
-  await Directory(cachePath).create(recursive: true);
-
+) {
   return createAnalysisDriver(
     analysisOptions: analysisOptions,
     packages: _buildAnalyzerPackages(

--- a/build_resolvers/lib/src/analysis_driver.dart
+++ b/build_resolvers/lib/src/analysis_driver.dart
@@ -23,6 +23,9 @@ Future<AnalysisDriverForPackageBuild> analysisDriver(
   String sdkSummaryPath,
   PackageConfig packageConfig,
 ) async {
+  final cachePath = p.join('.dart_tool', 'build_resolvers', 'cache');
+  await Directory(cachePath).create(recursive: true);
+
   return createAnalysisDriver(
     analysisOptions: analysisOptions,
     packages: _buildAnalyzerPackages(
@@ -31,6 +34,11 @@ Future<AnalysisDriverForPackageBuild> analysisDriver(
     ),
     resourceProvider: buildAssetUriResolver.resourceProvider,
     sdkSummaryBytes: File(sdkSummaryPath).readAsBytesSync(),
+    byteStore: createByteStore(
+      directory: cachePath,
+      maxFileSize: 1024 * 1024 * 1024, // 1 GiB
+      memoryCacheSize: 1024 * 1024 * 128, // 128 MiB
+    ),
     uriResolvers: [
       buildAssetUriResolver,
     ],

--- a/build_resolvers/lib/src/byte_store.dart
+++ b/build_resolvers/lib/src/byte_store.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+// ignore: implementation_imports
+import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
+import 'package:tar/tar.dart';
+
+class BuildResolversByteStore implements ByteStore {
+  final Map<String, _ByteStoreEntry> _loadedEntries = {};
+
+  /// Reads previously written entries from a [file].
+  Future<void> readFromFile(File file) async {
+    final archiveStream = file.openRead().transform(gzip.decoder);
+    await TarReader.forEach(archiveStream, (entry) async {
+      final builder = BytesBuilder();
+      await entry.contents.forEach(builder.add);
+
+      _loadedEntries[entry.name] = _ByteStoreEntry(builder.takeBytes());
+    });
+  }
+
+  /// Serializes the in-memory entries of this byte store into a tar archive.
+  Future<void> writeToFile(File file) {
+    return Stream.fromIterable(_loadedEntries.entries)
+        .map<TarEntry>(
+            (e) => TarEntry.data(TarHeader(name: e.key), e.value.data))
+        .transform(tarWriter)
+        .transform(gzip.encoder)
+        .pipe(file.openWrite());
+  }
+
+  @override
+  Uint8List? get(String key) {
+    return _loadedEntries[key]?.data;
+  }
+
+  @override
+  Uint8List putGet(String key, Uint8List bytes) {
+    _loadedEntries[key] = _ByteStoreEntry(bytes);
+    return bytes;
+  }
+
+  @override
+  void release(Iterable<String> keys) {
+    for (final key in keys) {
+      final entry = _loadedEntries[key];
+      if (entry == null) continue;
+
+      if (--entry.refCount == 0) {
+        _loadedEntries.remove(key);
+      }
+    }
+  }
+}
+
+class _ByteStoreEntry {
+  int refCount = 1;
+  final Uint8List data;
+
+  _ByteStoreEntry(this.data);
+}

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -424,7 +424,7 @@ class AnalyzerResolvers implements Resolvers {
         log.warning('Could not restore analyzer cache', e, s);
       }
 
-      var driver = await analysisDriver(uriResolver, _analysisOptions,
+      var driver = analysisDriver(uriResolver, _analysisOptions,
           await _sdkSummaryGenerator(), loadedConfig, _byteStore);
 
       _resolver = AnalyzerResolver(driver, _driverPool, uriResolver);

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -33,7 +33,7 @@ import 'human_readable_duration.dart';
 
 final _logger = Logger('build_resolvers');
 final _cacheFile =
-    File(p.join('.dart_tool', 'build_resolvers', 'cache.tar.gz'));
+    File(p.join('.dart_tool', 'build_resolvers', 'analyzer_cache.tar.gz'));
 
 Future<String> _packagePath(String package) async {
   var libRoot = await Isolate.resolvePackageUri(Uri.parse('package:$package/'));

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -416,11 +416,12 @@ class AnalyzerResolvers implements Resolvers {
           await loadPackageConfigUri((await Isolate.packageConfig)!);
 
       try {
+        log.fine('Restoring analyzer cache from previous builds');
         if (await _cacheFile.exists()) {
           await _byteStore.readFromFile(_cacheFile);
         }
       } catch (e, s) {
-        log.fine('Could not restore analyzer cache', e, s);
+        log.warning('Could not restore analyzer cache', e, s);
       }
 
       var driver = await analysisDriver(uriResolver, _analysisOptions,
@@ -443,6 +444,8 @@ class AnalyzerResolvers implements Resolvers {
   }
 
   Future<void> _persistState() async {
+    log.fine('Storing analyzer cache');
+
     final parent = _cacheFile.parent;
     if (!await parent.exists()) {
       await parent.create(recursive: true);

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
-  analyzer: ^5.2.0
+  analyzer: ^5.3.0
   async: ^2.5.0
   build: ^2.0.0
   crypto: ^3.0.0
@@ -26,9 +26,3 @@ dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
   test: ^1.16.0
   build_test: ^2.0.0
-
-dependency_overrides:
-  analyzer:
-    path: /home/simon/programming/dart-sdk/sdk/pkg/analyzer
-  _fe_analyzer_shared:
-    path: /home/simon/programming/dart-sdk/sdk/pkg/_fe_analyzer_shared

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -19,8 +19,16 @@ dependencies:
   pub_semver: ^2.0.0
   stream_transform: ^2.0.0
   yaml: ^3.0.0
+  tar: ^0.5.6
+  collection: ^1.17.0
 
 dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
   test: ^1.16.0
   build_test: ^2.0.0
+
+dependency_overrides:
+  analyzer:
+    path: /home/simon/programming/dart-sdk/sdk/pkg/analyzer
+  _fe_analyzer_shared:
+    path: /home/simon/programming/dart-sdk/sdk/pkg/_fe_analyzer_shared

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -291,7 +291,7 @@ class _Loader {
         _wrapWriter(_environment.writer, assetGraph!),
         _options.packageGraph,
         _options.deleteFilesByDefault,
-        ResourceManager(),
+        _options.resourceManager,
         buildScriptUpdates,
         _options.enableLowResourcesMode,
         _environment);

--- a/build_runner_core/lib/src/generate/options.dart
+++ b/build_runner_core/lib/src/generate/options.dart
@@ -142,6 +142,7 @@ class BuildOptions {
 
   final PackageGraph packageGraph;
   final Resolvers resolvers;
+  final ResourceManager resourceManager;
   final TargetGraph targetGraph;
   final bool trackPerformance;
 
@@ -157,6 +158,7 @@ class BuildOptions {
     required this.enableLowResourcesMode,
     required this.logListener,
     required this.packageGraph,
+    required this.resourceManager,
     required this.skipBuildScriptCheck,
     required this.trackPerformance,
     required this.targetGraph,
@@ -208,7 +210,8 @@ feature, you may need to run `dart run build_runner clean` and then rebuild.
       }
       trackPerformance = true;
     }
-    resolvers ??= AnalyzerResolvers();
+    final resourceManager = ResourceManager();
+    resolvers ??= AnalyzerResolvers(null, null, null, resourceManager);
 
     return BuildOptions._(
       debounceDelay: debounceDelay,
@@ -221,6 +224,7 @@ feature, you may need to run `dart run build_runner clean` and then rebuild.
       targetGraph: targetGraph,
       logPerformanceDir: logPerformanceDir,
       resolvers: resolvers,
+      resourceManager: resourceManager,
     );
   }
 }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -42,3 +42,7 @@ dev_dependencies:
   test_process: ^2.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build_resolvers:
+    path: ../build_resolvers


### PR DESCRIPTION
In a single build (e.g. not using `watch`), the resolver can take up the majority of the build time. When users are complaining about slow builds, the slowdown is virtually always caused by the analyzer having to analyze hundreds or thousands of files, with lots of transitive imports and a huge package graph being common for Flutter apps.

The analyzer can persist computed resolve results on disk to speed up subsequent resolves. At the moment, we're not benefiting from this as we're always using a memory byte store. So for each `build_runner build`, the analyzer needs to re-analyze all sources being resolved. If we can look up computation results from a previous run, my intuition is that build performance would increase.

I've done a (completely non-vigorous) benchmark on some of the projects I maintain and I've seen build times drop by around 20%. If you know of other large, public project I could try this out on, I will report the numbers for them as well or try to tune the cache behavior.

## Trying this out

In third-party projects, these optimizations can be tried by adding this to the pubspec:

```yaml
dependency_overrides:
  build_resolvers:
    git:
      url: https://github.com/simolus3/build.git
      path: build_resolvers
      ref: persistent-analyzer-byte-store
  build_runner_core:
    git:
      url: https://github.com/simolus3/build.git
      path: build_runner_core
      ref: persistent-analyzer-byte-store
```

This effect is most visible when running a full build with the analyzer cache:

1. Apply these changes to your pubspec
2. Run `rm -r .dart_tool/`
3. Run `dart run build_runner build --delete-conflicting-outputs`
4. Run `rm -r .dart_tool/build/`. This deletes the build cache but keeps the analyzer cache alive.
5. Re-run `dart run build_runner build --delete-conflicting-outputs`. The time spent in the build (shown at the end as "succeeded after x seconds") should ideally be lower now.