### PR TITLE
Remove language version marker in daemon_test.dart test fixture

### DIFF
--- a/build_daemon/test/daemon_test.dart
+++ b/build_daemon/test/daemon_test.dart
@@ -181,7 +181,6 @@ Future<Process> _runDaemon(String workspace,
     int closeChangeProviderAfterNSeconds = -1}) async {
   timeout = timeout > 0 ? timeout : defaultIdleTimeoutSec;
   await d.file('test.dart', '''
-    // @dart=2.9
     import 'package:build_daemon/daemon.dart';
     import 'package:build_daemon/daemon_builder.dart';
     import 'package:build_daemon/client.dart';


### PR DESCRIPTION
This was removed in https://github.com/dart-lang/build/pull/3395 but reverted in https://github.com/dart-lang/build/pull/3411 (likely a bad merge). This just removes it again.