### PR TITLE
Fix Dart 3 dev CI builds

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -2081,14 +2081,14 @@ jobs:
       - job_047
       - job_048
   job_052:
-    name: "e2e_test; linux; Dart dev; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+    name: "e2e_test; linux; Dart dev; PKG: _test_null_safety; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test_null_safety;commands:command_2-command_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test_null_safety;commands:command_0-command_2"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test_null_safety
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
@@ -2106,8 +2106,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: _test_null_safety
-      - name: "_test_null_safety; dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
-        run: "dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
+      - name: "_test_null_safety; dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
+        run: "dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
         if: "always() && steps._test_null_safety_pub_upgrade.conclusion == 'success'"
         working-directory: _test_null_safety
       - name: "_test_null_safety; dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
@@ -2164,6 +2164,85 @@ jobs:
       - job_047
       - job_048
   job_053:
+    name: "e2e_test; linux; Dart dev; PKG: _test_null_safety; `dart run build_runner test -- -p vm --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test_null_safety;commands:command_3"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test_null_safety
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: _test_null_safety_pub_upgrade
+        name: _test_null_safety; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: _test_null_safety
+      - name: "_test_null_safety; dart run build_runner test -- -p vm --test-randomize-ordering-seed=random"
+        run: "dart run build_runner test -- -p vm --test-randomize-ordering-seed=random"
+        if: "always() && steps._test_null_safety_pub_upgrade.conclusion == 'success'"
+        working-directory: _test_null_safety
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+      - job_033
+      - job_034
+      - job_035
+      - job_036
+      - job_037
+      - job_038
+      - job_039
+      - job_040
+      - job_041
+      - job_042
+      - job_043
+      - job_044
+      - job_045
+      - job_046
+      - job_047
+      - job_048
+  job_054:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2242,7 +2321,7 @@ jobs:
       - job_046
       - job_047
       - job_048
-  job_054:
+  job_055:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2321,7 +2400,7 @@ jobs:
       - job_046
       - job_047
       - job_048
-  job_055:
+  job_056:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2400,7 +2479,7 @@ jobs:
       - job_046
       - job_047
       - job_048
-  job_056:
+  job_057:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2479,7 +2558,7 @@ jobs:
       - job_046
       - job_047
       - job_048
-  job_057:
+  job_058:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2558,7 +2637,7 @@ jobs:
       - job_046
       - job_047
       - job_048
-  job_058:
+  job_059:
     name: "e2e_test; windows; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2627,7 +2706,7 @@ jobs:
       - job_046
       - job_047
       - job_048
-  job_059:
+  job_060:
     name: "e2e_test; windows; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2696,7 +2775,7 @@ jobs:
       - job_046
       - job_047
       - job_048
-  job_060:
+  job_061:
     name: "e2e_test; windows; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2765,8 +2844,8 @@ jobs:
       - job_046
       - job_047
       - job_048
-  job_061:
-    name: "e2e_test; windows; Dart dev; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+  job_062:
+    name: "e2e_test; windows; Dart dev; PKG: _test_null_safety; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
@@ -2781,8 +2860,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: _test_null_safety
-      - name: "_test_null_safety; dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
-        run: "dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
+      - name: "_test_null_safety; dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
+        run: "dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
         if: "always() && steps._test_null_safety_pub_upgrade.conclusion == 'success'"
         working-directory: _test_null_safety
       - name: "_test_null_safety; dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
@@ -2838,7 +2917,101 @@ jobs:
       - job_046
       - job_047
       - job_048
-  job_062:
+  job_063:
+    name: "e2e_test_cron; linux; Dart dev; PKG: _test_null_safety; `dart run build_runner test -- -p vm --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    if: "github.event_name == 'schedule'"
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test_null_safety;commands:command_3"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test_null_safety
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: _test_null_safety_pub_upgrade
+        name: _test_null_safety; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: _test_null_safety
+      - name: "_test_null_safety; dart run build_runner test -- -p vm --test-randomize-ordering-seed=random"
+        run: "dart run build_runner test -- -p vm --test-randomize-ordering-seed=random"
+        if: "always() && steps._test_null_safety_pub_upgrade.conclusion == 'success'"
+        working-directory: _test_null_safety
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+      - job_010
+      - job_011
+      - job_012
+      - job_013
+      - job_014
+      - job_015
+      - job_016
+      - job_017
+      - job_018
+      - job_019
+      - job_020
+      - job_021
+      - job_022
+      - job_023
+      - job_024
+      - job_025
+      - job_026
+      - job_027
+      - job_028
+      - job_029
+      - job_030
+      - job_031
+      - job_032
+      - job_033
+      - job_034
+      - job_035
+      - job_036
+      - job_037
+      - job_038
+      - job_039
+      - job_040
+      - job_041
+      - job_042
+      - job_043
+      - job_044
+      - job_045
+      - job_046
+      - job_047
+      - job_048
+      - job_049
+      - job_050
+      - job_051
+      - job_052
+      - job_053
+      - job_054
+      - job_055
+      - job_056
+      - job_057
+      - job_058
+      - job_059
+      - job_060
+      - job_061
+      - job_062
+  job_064:
     name: "e2e_test_cron; linux; Dart main; PKG: _test; `dart test`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -2931,8 +3104,9 @@ jobs:
       - job_059
       - job_060
       - job_061
-  job_063:
-    name: "e2e_test_cron; linux; Dart main; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      - job_062
+  job_065:
+    name: "e2e_test_cron; linux; Dart main; PKG: _test_null_safety; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
     steps:
@@ -2940,7 +3114,7 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:_test_null_safety;commands:command_2-command_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:_test_null_safety;commands:command_0-command_2"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:main;packages:_test_null_safety
             os:ubuntu-latest;pub-cache-hosted;sdk:main
@@ -2958,8 +3132,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: _test_null_safety
-      - name: "_test_null_safety; dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
-        run: "dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
+      - name: "_test_null_safety; dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
+        run: "dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
         if: "always() && steps._test_null_safety_pub_upgrade.conclusion == 'success'"
         working-directory: _test_null_safety
       - name: "_test_null_safety; dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
@@ -3028,7 +3202,8 @@ jobs:
       - job_059
       - job_060
       - job_061
-  job_064:
+      - job_062
+  job_066:
     name: "e2e_test_cron; windows; Dart main; PKG: _test; `dart test`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
@@ -3111,8 +3286,9 @@ jobs:
       - job_059
       - job_060
       - job_061
-  job_065:
-    name: "e2e_test_cron; windows; Dart main; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
+      - job_062
+  job_067:
+    name: "e2e_test_cron; windows; Dart main; PKG: _test_null_safety; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
     steps:
@@ -3128,8 +3304,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: _test_null_safety
-      - name: "_test_null_safety; dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
-        run: "dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random"
+      - name: "_test_null_safety; dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
+        run: "dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
         if: "always() && steps._test_null_safety_pub_upgrade.conclusion == 'success'"
         working-directory: _test_null_safety
       - name: "_test_null_safety; dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random"
@@ -3198,7 +3374,8 @@ jobs:
       - job_059
       - job_060
       - job_061
-  job_066:
+      - job_062
+  job_068:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -3275,3 +3452,5 @@ jobs:
       - job_063
       - job_064
       - job_065
+      - job_066
+      - job_067

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -786,14 +786,14 @@ jobs:
       - job_007
       - job_008
   job_017:
-    name: "unit_test; linux; Dart dev; PKG: _test; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart dev; PKG: _test; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test;commands:command_0-command_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test;commands:command_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
@@ -815,6 +815,41 @@ jobs:
         run: "dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
         if: "always() && steps._test_pub_upgrade.conclusion == 'success'"
         working-directory: _test
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+  job_018:
+    name: "unit_test; linux; Dart dev; PKG: _test; `dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test;commands:command_1"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:_test
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: _test_pub_upgrade
+        name: _test; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: _test
       - name: "_test; dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random"
         run: "dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random"
         if: "always() && steps._test_pub_upgrade.conclusion == 'success'"
@@ -828,7 +863,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_018:
+  job_019:
     name: "unit_test; linux; Dart dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -867,7 +902,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_019:
+  job_020:
     name: "unit_test; linux; Dart dev; PKG: build_config; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -906,7 +941,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_020:
+  job_021:
     name: "unit_test; linux; Dart dev; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -945,7 +980,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_021:
+  job_022:
     name: "unit_test; linux; Dart dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -984,7 +1019,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_022:
+  job_023:
     name: "unit_test; linux; Dart dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1023,7 +1058,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_023:
+  job_024:
     name: "unit_test; linux; Dart dev; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1062,7 +1097,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_024:
+  job_025:
     name: "unit_test; linux; Dart dev; PKG: build_web_compilers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1101,7 +1136,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_025:
+  job_026:
     name: "unit_test; linux; Dart dev; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1140,7 +1175,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_026:
+  job_027:
     name: "unit_test; linux; Dart dev; PKG: build_modules; `dart test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1179,7 +1214,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_027:
+  job_028:
     name: "unit_test; linux; Dart dev; PKG: build_runner; `dart test -x integration --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1218,7 +1253,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_028:
+  job_029:
     name: "unit_test; linux; Dart dev; PKG: build_vm_compilers; `dart test`"
     runs-on: ubuntu-latest
     steps:
@@ -1257,7 +1292,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_029:
+  job_030:
     name: "unit_test; windows; Dart 2.18.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1286,7 +1321,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_030:
+  job_031:
     name: "unit_test; windows; Dart 2.18.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1315,7 +1350,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_031:
+  job_032:
     name: "unit_test; windows; Dart 2.18.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1344,7 +1379,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_032:
+  job_033:
     name: "unit_test; windows; Dart 2.18.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1373,7 +1408,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_033:
+  job_034:
     name: "unit_test; windows; Dart 2.18.0; PKG: build_web_compilers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1402,7 +1437,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_034:
+  job_035:
     name: "unit_test; windows; Dart 2.18.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1431,7 +1466,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_035:
+  job_036:
     name: "unit_test; windows; Dart 2.18.0; PKG: build_modules; `dart test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1460,7 +1495,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_036:
+  job_037:
     name: "unit_test; windows; Dart 2.18.0; PKG: build_vm_compilers; `dart test`"
     runs-on: windows-latest
     steps:
@@ -1489,8 +1524,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_037:
-    name: "unit_test; windows; Dart dev; PKG: _test; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`, `dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`"
+  job_038:
+    name: "unit_test; windows; Dart dev; PKG: _test; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
@@ -1509,10 +1544,6 @@ jobs:
         run: "dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random"
         if: "always() && steps._test_pub_upgrade.conclusion == 'success'"
         working-directory: _test
-      - name: "_test; dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random"
-        run: "dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random"
-        if: "always() && steps._test_pub_upgrade.conclusion == 'success'"
-        working-directory: _test
     needs:
       - job_001
       - job_002
@@ -1522,7 +1553,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_038:
+  job_039:
     name: "unit_test; windows; Dart dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1551,7 +1582,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_039:
+  job_040:
     name: "unit_test; windows; Dart dev; PKG: build_config; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1580,7 +1611,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_040:
+  job_041:
     name: "unit_test; windows; Dart dev; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1609,7 +1640,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_041:
+  job_042:
     name: "unit_test; windows; Dart dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1638,7 +1669,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_042:
+  job_043:
     name: "unit_test; windows; Dart dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1667,7 +1698,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_043:
+  job_044:
     name: "unit_test; windows; Dart dev; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1696,7 +1727,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_044:
+  job_045:
     name: "unit_test; windows; Dart dev; PKG: build_web_compilers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1725,7 +1756,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_045:
+  job_046:
     name: "unit_test; windows; Dart dev; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1754,7 +1785,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_046:
+  job_047:
     name: "unit_test; windows; Dart dev; PKG: build_modules; `dart test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1783,7 +1814,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_047:
+  job_048:
     name: "unit_test; windows; Dart dev; PKG: build_vm_compilers; `dart test`"
     runs-on: windows-latest
     steps:
@@ -1812,7 +1843,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_048:
+  job_049:
     name: "e2e_test; linux; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1890,7 +1921,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_049:
+      - job_048
+  job_050:
     name: "e2e_test; linux; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1968,7 +2000,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_050:
+      - job_048
+  job_051:
     name: "e2e_test; linux; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -2046,7 +2079,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_051:
+      - job_048
+  job_052:
     name: "e2e_test; linux; Dart dev; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -2128,7 +2162,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_052:
+      - job_048
+  job_053:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2206,7 +2241,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_053:
+      - job_048
+  job_054:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2284,7 +2320,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_054:
+      - job_048
+  job_055:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2362,7 +2399,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_055:
+      - job_048
+  job_056:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2440,7 +2478,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_056:
+      - job_048
+  job_057:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces`"
     runs-on: ubuntu-latest
     steps:
@@ -2518,7 +2557,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_057:
+      - job_048
+  job_058:
     name: "e2e_test; windows; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2586,7 +2626,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_058:
+      - job_048
+  job_059:
     name: "e2e_test; windows; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2654,7 +2695,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_059:
+      - job_048
+  job_060:
     name: "e2e_test; windows; Dart dev; PKG: _test; `dart test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2722,7 +2764,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_060:
+      - job_048
+  job_061:
     name: "e2e_test; windows; Dart dev; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2794,7 +2837,8 @@ jobs:
       - job_045
       - job_046
       - job_047
-  job_061:
+      - job_048
+  job_062:
     name: "e2e_test_cron; linux; Dart main; PKG: _test; `dart test`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -2886,7 +2930,8 @@ jobs:
       - job_058
       - job_059
       - job_060
-  job_062:
+      - job_061
+  job_063:
     name: "e2e_test_cron; linux; Dart main; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -2982,7 +3027,8 @@ jobs:
       - job_058
       - job_059
       - job_060
-  job_063:
+      - job_061
+  job_064:
     name: "e2e_test_cron; windows; Dart main; PKG: _test; `dart test`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
@@ -3064,7 +3110,8 @@ jobs:
       - job_058
       - job_059
       - job_060
-  job_064:
+      - job_061
+  job_065:
     name: "e2e_test_cron; windows; Dart main; PKG: _test_null_safety; `dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random`, `dart run build_runner test --define=\"build_web_compilers:entrypoint=compiler=dart2js\" -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
@@ -3150,7 +3197,8 @@ jobs:
       - job_058
       - job_059
       - job_060
-  job_065:
+      - job_061
+  job_066:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -3226,3 +3274,4 @@ jobs:
       - job_062
       - job_063
       - job_064
+      - job_065

--- a/_test/mono_pkg.yaml
+++ b/_test/mono_pkg.yaml
@@ -10,9 +10,10 @@ stages:
   - analyze: --fatal-infos .
     os: linux
 - unit_test:
-  - group:
-    - command: dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random
-    - command: dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random
+  - command: dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random
+  # TODO(https://github.com/dart-lang/build/issues/3423): restore this on windows 
+  - command: dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random
+    os: linux
 - e2e_test:
   - test: --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random
     os: linux

--- a/_test_common/lib/sdk.dart
+++ b/_test_common/lib/sdk.dart
@@ -8,10 +8,14 @@ import 'dart:io';
 // ignore: implementation_imports
 import 'package:build_runner_core/src/util/constants.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 String _dartBinary = p.join(sdkBin, 'dart');
+
+final bool supportsUnsoundNullSafety =
+    Version.parse(Platform.version.split(' ').first).major == 2;
 
 /// Runs `pub get` on [package] (which is assumed to be in a directory with
 /// that name under the [d.sandbox] directory).

--- a/_test_common/pubspec.yaml
+++ b/_test_common/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   logging: ^1.0.0
   package_config: ^2.0.0
   path: ^1.8.0
+  pub_semver: ^2.0.0
   test: ^1.16.0
   test_descriptor: ^2.0.0
   watcher: ^1.0.0

--- a/_test_null_safety/mono_pkg.yaml
+++ b/_test_null_safety/mono_pkg.yaml
@@ -12,12 +12,18 @@ stages:
     sdk: dev
 - e2e_test:
   - group:
-    - command: dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random
+    - command: dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random
     - command: dart run build_runner test --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
+  # TODO(https://github.com/dart-lang/build/issues/3423): restore this on windows 
+  - command: dart run build_runner test -- -p vm --test-randomize-ordering-seed=random
+    os: linux
 # This stage is configured to only run for scheduled builds (see mono_repo.yaml)
 - e2e_test_cron:
   - group:
-    - command: dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random
+    - command: dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random
     - command: dart run build_runner test --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random
     sdk:
       - be/raw/latest
+  # TODO(https://github.com/dart-lang/build/issues/3423): restore this on windows 
+  - command: dart run build_runner test -- -p vm --test-randomize-ordering-seed=random
+    os: linux

--- a/build_runner/test/build_script_generate/build_script_generate_test.dart
+++ b/build_runner/test/build_script_generate/build_script_generate_test.dart
@@ -140,32 +140,39 @@ environment:
         buildYaml,
         d.dir('lib', [d.file('builder.dart', '')]),
       ]).create();
-      await runPub('a', 'get');
+      var pubGetResult = await runPub('a', 'get');
+      expect(pubGetResult.exitCode, 0,
+          reason: 'stdout: ${pubGetResult.stdout}\n\n'
+              'stderr: ${pubGetResult.stderr}');
 
       final options = await findBuildScriptOptions(
           packageGraph: await PackageGraph.forPath('${d.sandbox}/a'));
       expect(options.canRunWithSoundNullSafety, isTrue);
     });
 
-    test('when the root package opts out', () async {
-      await d.dir('a', [
-        d.file('pubspec.yaml', '''
+    if (supportsUnsoundNullSafety) {
+      test('when the root package opts out', () async {
+        await d.dir('a', [
+          d.file('pubspec.yaml', '''
 name: a
 environment:
   sdk: '>=2.9.0 <3.0.0'
       '''),
-        d.dir('lib', [d.file('builder.dart', '')]),
-      ]).create();
-      await runPub('a', 'get');
+          d.dir('lib', [d.file('builder.dart', '')]),
+        ]).create();
+        var pubGetResult = await runPub('a', 'get');
+        expect(pubGetResult.exitCode, 0,
+            reason: 'stdout: ${pubGetResult.stdout}\n\n'
+                'stderr: ${pubGetResult.stderr}');
 
-      final options = await findBuildScriptOptions(
-          packageGraph: await PackageGraph.forPath('${d.sandbox}/a'));
-      expect(options.canRunWithSoundNullSafety, isFalse);
-    });
+        final options = await findBuildScriptOptions(
+            packageGraph: await PackageGraph.forPath('${d.sandbox}/a'));
+        expect(options.canRunWithSoundNullSafety, isFalse);
+      });
 
-    test('when a builder-defining package opts out', () async {
-      await d.dir('a', [
-        d.file('pubspec.yaml', '''
+      test('when a builder-defining package opts out', () async {
+        await d.dir('a', [
+          d.file('pubspec.yaml', '''
 name: a
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -173,24 +180,29 @@ dependencies:
   b:
     path: ../b/
       '''),
-      ]).create();
-      await d.dir('b', [
-        d.file('pubspec.yaml', '''
+        ]).create();
+        await d.dir('b', [
+          d.file('pubspec.yaml', '''
 name: b
 environment:
   sdk: '>=2.9.0 <3.0.0'
       '''),
-        buildYaml,
-        d.dir('lib', [
-          d.file('builder.dart', ''),
-        ]),
-      ]).create();
-      await runPub('a', 'get');
+          buildYaml,
+          d.dir('lib', [
+            d.file('builder.dart', ''),
+          ]),
+        ]).create();
+        await runPub('a', 'get');
+        var pubGetResult = await runPub('a', 'get');
+        expect(pubGetResult.exitCode, 0,
+            reason: 'stdout: ${pubGetResult.stdout}\n\n'
+                'stderr: ${pubGetResult.stderr}');
 
-      final options = await findBuildScriptOptions(
-          packageGraph: await PackageGraph.forPath('${d.sandbox}/a'));
-      expect(options.canRunWithSoundNullSafety, isFalse);
-    });
+        final options = await findBuildScriptOptions(
+            packageGraph: await PackageGraph.forPath('${d.sandbox}/a'));
+        expect(options.canRunWithSoundNullSafety, isFalse);
+      });
+    }
 
     test('when a builder-defining library ops out', () async {
       await d.dir('a', [
@@ -203,6 +215,10 @@ environment:
         d.dir('lib', [d.file('builder.dart', '// @dart=2.9')]),
       ]).create();
       await runPub('a', 'get');
+      var pubGetResult = await runPub('a', 'get');
+      expect(pubGetResult.exitCode, 0,
+          reason: 'stdout: ${pubGetResult.stdout}\n\n'
+              'stderr: ${pubGetResult.stderr}');
 
       final options = await findBuildScriptOptions(
           packageGraph: await PackageGraph.forPath('${d.sandbox}/a'));
@@ -227,6 +243,10 @@ builders:
         d.dir('tool', [d.file('builder.dart', '//@dart=2.9')]),
       ]).create();
       await runPub('a', 'get');
+      var pubGetResult = await runPub('a', 'get');
+      expect(pubGetResult.exitCode, 0,
+          reason: 'stdout: ${pubGetResult.stdout}\n\n'
+              'stderr: ${pubGetResult.stderr}');
 
       final options = await findBuildScriptOptions(
           packageGraph: await PackageGraph.forPath('${d.sandbox}/a'));
@@ -251,6 +271,10 @@ builders:
         d.dir('tool', [d.file('builder.dart', '')]),
       ]).create();
       await runPub('a', 'get');
+      var pubGetResult = await runPub('a', 'get');
+      expect(pubGetResult.exitCode, 0,
+          reason: 'stdout: ${pubGetResult.stdout}\n\n'
+              'stderr: ${pubGetResult.stderr}');
 
       final options = await findBuildScriptOptions(
           packageGraph: await PackageGraph.forPath('${d.sandbox}/a'));

--- a/build_vm_compilers/test/vm_kernel_integration_test.dart
+++ b/build_vm_compilers/test/vm_kernel_integration_test.dart
@@ -9,7 +9,9 @@ import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 
 void main() {
-  group('without null safety', () => _runTests(false));
+  if (supportsUnsoundNullSafety) {
+    group('without null safety', () => _runTests(false));
+  }
   group('with null safety', () => _runTests(true));
 }
 

--- a/build_web_compilers/test/fixtures/a/pubspec.yaml
+++ b/build_web_compilers/test/fixtures/a/pubspec.yaml
@@ -1,7 +1,7 @@
 name: a
 
 environment:
-  sdk: ">=1.0.0 <3.0.0"
+  sdk: ">=1.0.0 <4.0.0"
 
 dependencies:
   b:

--- a/build_web_compilers/test/fixtures/b/pubspec.yaml
+++ b/build_web_compilers/test/fixtures/b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: b
 
 environment:
-  sdk: ">=1.0.0 <3.0.0"
+  sdk: ">=1.0.0 <4.0.0"
 
 dependencies:
   a:

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -84,12 +84,12 @@ for PKG in ${PKGS}; do
         dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
       command_2)
-        echo 'dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random'
-        dart run build_runner test -- -p chrome,vm --test-randomize-ordering-seed=random || EXIT_CODE=$?
-        ;;
-      command_3)
         echo 'dart run build_runner test --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random'
         dart run build_runner test --define="build_web_compilers:entrypoint=compiler=dart2js" -- -p chrome --test-randomize-ordering-seed=random || EXIT_CODE=$?
+        ;;
+      command_3)
+        echo 'dart run build_runner test -- -p vm --test-randomize-ordering-seed=random'
+        dart run build_runner test -- -p vm --test-randomize-ordering-seed=random || EXIT_CODE=$?
         ;;
       format)
         echo 'dart format --output=none --set-exit-if-changed .'


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/3421

- Fix build_web_compilers test fixture sdk constraints to allow dart 3.x.
- Add a test utility to check if unsound null safety is supported (sdk version is 2.x).
  - Use this utility to omit tests for unsound null safety features.
- skip build_vm_compilers related tests on windows CI, there is some sort of issue related to crossing between drives