### PR TITLE
Check packageGraph when validating build definition

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.4-dev
+
+- Warn if a `package:` builder import cannot be resolved and skip it,
+  instead of creating an invalid build script or failing in other obscure ways.
+
 ## 2.3.3
 
 - Remove references to `NullThrownError`.

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -127,7 +127,8 @@ Future<BuildScriptInfo> findBuildScriptOptions({
       if (packageGraph?.allPackages.containsKey(pkg) ?? true) {
         return true;
       }
-      _log.warning('Could not load imported package "$pkg" for definition "${definition.key}".');
+      _log.warning(
+          'Could not load imported package "$pkg" for definition "${definition.key}".');
       return false;
     }
     return definition.package == packageGraph!.root.name;

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -120,7 +120,16 @@ Future<BuildScriptInfo> findBuildScriptOptions({
   bool _isValidDefinition(dynamic definition) {
     // Filter out builderDefinitions with relative imports that aren't
     // from the root package, because they will never work.
-    if (definition.import.startsWith('package:') as bool) return true;
+    if (definition.import.startsWith('package:') as bool) {
+      // Make sure package is known in packageGraph (when present),
+      // otherwise PackageNotFoundException will be thrown down the road
+      final pkg = AssetId.resolve(Uri.parse('${definition.import}')).package;
+      if (packageGraph?.allPackages.containsKey(pkg) ?? true) {
+        return true;
+      }
+      _log.warning('Could not load imported package "$pkg" for definition "${definition.key}".');
+      return false;
+    }
     return definition.package == packageGraph!.root.name;
   }
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.3.3
+version: 2.3.4-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/build_script_generate/build_script_generate_test.dart
+++ b/build_runner/test/build_script_generate/build_script_generate_test.dart
@@ -109,8 +109,7 @@ builders:
             skip: 'https://github.com/dart-lang/sdk/issues/50592');
         expect(
             result.stdout,
-            contains(
-                'Could not load imported package "unknown_package" '
+            contains('Could not load imported package "unknown_package" '
                 'for definition "a:fake".'));
       });
     });

--- a/build_runner/test/build_script_generate/build_script_generate_test.dart
+++ b/build_runner/test/build_script_generate/build_script_generate_test.dart
@@ -93,6 +93,26 @@ builders:
             skip: 'https://github.com/dart-lang/sdk/issues/50592');
         expect(result.stdout, contains('could not be parsed'));
       });
+
+      test('warn when import not present in packageGraph', () async {
+        await d.dir('a', [
+          d.file('build.yaml', '''
+builders:
+  fake:
+    import: "package:unknown_package/import.dart"
+    builder_factories: ["myFactory"]
+    build_extensions: {"foo": ["bar"]}
+''')
+        ]).create();
+        var result = await runPub('a', 'run', args: ['build_runner', 'build']);
+        expect(result.stderr, isEmpty,
+            skip: 'https://github.com/dart-lang/sdk/issues/50592');
+        expect(
+            result.stdout,
+            contains(
+                'Could not load imported package "unknown_package" '
+                'for definition "a:fake".'));
+      });
     });
 
     test('checks builder keys in global_options', () async {


### PR DESCRIPTION
In my setup, I've got something like this:

- `my_codegen` package
  - contains generator classes
- `my_core` package
  - `build.yaml` containing builders from `my_codegen` package, used for generating core code
  - `pubspec.yaml` 
    - has a "dev_dependency" on `my_codegen`
- `my_other_package`
  - `pubspec.yaml` 
    - has a dependency on `my_core`
    - has a dependency on `isar_generator`

Now the problem is that when I run `dart run build_runner build` in `my_other_package` (for generating `isar` code), I get the following logs:
```console
Building package executable...
Built build_runner:build_runner.
[INFO] Entrypoint:Generating build script...
Unhandled exception:
PackageNotFoundException: my_codegen
``` 

Debugging the `_generateBuildScript()` method, I couldn't figure out why the `my_codegen` build configuration is being included. I also tried to add a `build.yaml` file in `my_other_package` containing `enabled: false` for all previously defined builders, but to no avail.

At first I added `on PackageNotFoundException` to `_allMigratedToNullSafety()`, but it still gave issues down the road.
So eventually, the solution to my problem was to "invalidate" the build definition, because the imported package wasn't present in the `packageGraph`. I'm not totally satisfied with this solution, but right now it does the trick for me. And it might just be a nice extra validation step anyway.

Still, if there is some obvious configuration thing I'm missing out on, I'm more than happy to hear this.