### PR TITLE
Use platform paths for fake watch events

### DIFF
--- a/_test_common/lib/in_memory_writer.dart
+++ b/_test_common/lib/in_memory_writer.dart
@@ -19,7 +19,7 @@ class InMemoryRunnerAssetWriter extends InMemoryAssetWriter
     var type = assets.containsKey(id) ? ChangeType.MODIFY : ChangeType.ADD;
     await super.writeAsBytes(id, bytes);
     FakeWatcher.notifyWatchers(
-        WatchEvent(type, p.absolute(id.package, id.path)));
+        WatchEvent(type, p.absolute(id.package, p.fromUri(id.path))));
   }
 
   @override
@@ -28,14 +28,14 @@ class InMemoryRunnerAssetWriter extends InMemoryAssetWriter
     var type = assets.containsKey(id) ? ChangeType.MODIFY : ChangeType.ADD;
     await super.writeAsString(id, contents, encoding: encoding);
     FakeWatcher.notifyWatchers(
-        WatchEvent(type, p.absolute(id.package, id.path)));
+        WatchEvent(type, p.absolute(id.package, p.fromUri(id.path))));
   }
 
   @override
   Future delete(AssetId id) async {
     onDelete?.call(id);
     assets.remove(id);
-    FakeWatcher.notifyWatchers(
-        WatchEvent(ChangeType.REMOVE, p.absolute(id.package, id.path)));
+    FakeWatcher.notifyWatchers(WatchEvent(
+        ChangeType.REMOVE, p.absolute(id.package, p.fromUri(id.path))));
   }
 }


### PR DESCRIPTION
The Asset ID uses URI format for the paths. Convert to the system style paths when emitting fake file change events for the written files.