### PR TITLE
Add support for `CompilationUnitElement` to `AnalysisResolver.astNodeFor()`

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+- Add support for `CompilationUnitElement` to `AnalysisResolver.astNodeFor()`.
+
 ## 2.1.0
 
 - Migrate off deprecated analyzer apis.

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   analyzer: ^5.2.0
   async: ^2.5.0
   build: ^2.0.0
+  collection: ^1.17.0
   crypto: ^3.0.0
   graphs: '>=1.0.0 <3.0.0'
   logging: ^1.0.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.1.0
+version: 2.2.0
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -856,6 +856,27 @@ int? get x => 1;
         );
       }, resolvers: AnalyzerResolvers());
     });
+
+    test('can return a resolved compilation unit', () {
+      return resolveSources({
+        'a|web/main.dart': 'main() {}',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var unit = await resolver.astNodeFor(lib.definingCompilationUnit,
+            resolve: true);
+        expect(
+          unit,
+          isA<CompilationUnit>().having(
+              (unit) => unit.declarations, 'declarations', hasLength(1)),
+        );
+        expect(
+          (unit as CompilationUnit).declarations.single,
+          isA<FunctionDeclaration>()
+              .having((fd) => fd.toSource(), 'toSource()', 'main() {}')
+              .having((fd) => fd.declaredElement, 'declaredElement', isNotNull),
+        );
+      });
+    });
   });
 }
 


### PR DESCRIPTION
The `AnalysisResolver` defers to `ResolvedLibraryResult.getElementDeclaration()` or `ParsedLibraryResult.getElementDeclaration()` to find the associated AST node. Neither method supports `CompilationUnitElement` and previously would return null.

Since the `AnalysisResolver` already has a direct reference to the `ResolvedLibraryResult` or `ParsedLibraryResult`, it's trivial to obtain the associated `CompilationUnit` AST node if requested.