### PR TITLE
publish build_modules, build_web_compilers, and build_runner

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.0-dev
+## 5.0.0
 
 - Require Dart 3.0.
   - Drop support for unsound null safety.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 5.0.0-dev
+version: 5.0.0
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.4.0-dev
+## 2.4.0
 
 - Warn if a `package:` builder import cannot be resolved and skip it,
   instead of creating an invalid build script or failing in other obscure ways.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.0-dev
+version: 2.4.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.0-dev
+## 4.0.0
 
 - Require Dart 3.0.
   - Drop support for unsound null safety.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.0.0-dev
+version: 4.0.0
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 


### PR DESCRIPTION
These work with the upcoming dev sdk release which moves around some files, and also they drop support for unsound null safety.