### PR TITLE
Bump SDK in old release of build_modules

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.6+1
+
+- Update language version to `2.19` to avoid inference error, while maintaining
+  compatibility with older versions of `package:analyzer`.
+
 ## 4.0.6
 
 - Allow the latest `package:analyzer`.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_modules
-version: 4.0.6
+version: 4.0.6+1
 description: Builders for Dart modules
 repository: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   analyzer: '>=4.4.0 <6.0.0'


### PR DESCRIPTION
Closes https://github.com/dart-lang/sdk/issues/51128

SDK version `2.19.0` introduces a static error that was missing from earlier SDK versions. Upgrading to language version `2.18` or greater brings a language change with improved inference which resolves the issue. Upgrade to `2.19.0` so that the backported change impacts the fewest users possible.