### PR TITLE
Enable drift community test again

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -24,11 +24,11 @@ jobs:
           path: client_tests/drift
       - run: |-
           cat << DRIFTDEPS >> client_tests/drift/drift/pubspec.yaml
-            dependency_overrides:
-              drift_dev:
-                path: ../drift_dev
-              sqlparser:
-                path: ../sqlparser
+          dependency_overrides:
+            drift_dev:
+              path: ../drift_dev
+            sqlparser:
+              path: ../sqlparser
           DRIFTDEPS
           dart run tool/bin/patch_build_dependencies.dart client_tests/drift/drift
           cd client_tests/drift/drift

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -1,31 +1,38 @@
-# name: Community tests
-# on:
-#   pull_request:
-# env:
-#   PUB_ENVIRONMENT: bot.github
+name: Community tests
+on:
+  pull_request:
+env:
+  PUB_ENVIRONMENT: bot.github
 
-# jobs:
-#   drift:
-#     # Tests maintained by oss@simonbinder.eu
-#     name: "Tests for pkg:drift"
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
-#         with:
-#           sdk: dev
-#       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-#       - run: dart pub get
-#         working-directory: tool
+jobs:
+  drift:
+    # Tests maintained by oss@simonbinder.eu
+    name: "Tests for pkg:drift"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        with:
+          sdk: dev
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - run: dart pub get
+        working-directory: tool
 
-#       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-#         with:
-#           repository: simolus3/moor
-#           ref: latest-release
-#           path: client_tests/drift
-#       - run: |-
-#           dart run tool/bin/patch_build_dependencies.dart client_tests/drift/drift
-#           cd client_tests/drift/drift
-#           git add pubspec.yaml
-#       - run: dart test --preset build_community_tests
-#         name: Drift community tests
-#         working-directory: client_tests/drift/drift
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        with:
+          repository: simolus3/drift
+          ref: develop
+          path: client_tests/drift
+      - run: |-
+          cat << DRIFTDEPS >> client_tests/drift/drift/pubspec.yaml
+            dependency_overrides:
+              drift_dev:
+                path: ../drift_dev
+              sqlparser:
+                path: ../sqlparser
+          DRIFTDEPS
+          dart run tool/bin/patch_build_dependencies.dart client_tests/drift/drift
+          cd client_tests/drift/drift
+          git add pubspec.yaml
+      - run: dart test --preset build_community_tests
+        name: Drift community tests
+        working-directory: client_tests/drift/drift

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2-dev
+
+- Stop using deprecated `JsonKey.ignore`.
+
 ## 1.1.1
 
 - Expand pubspec description to improve pub score.

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -52,7 +52,7 @@ class BuildConfig {
     }
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: true, includeToJson: true)
   final String packageName;
 
   /// All the `builders` defined in a `build.yaml` file.

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 1.1.1
+version: 1.1.2-dev
 description: >-
   Format definition and support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   checked_yaml: ^2.0.0
-  json_annotation: ^4.5.0
+  json_annotation: ^4.8.0
   path: ^1.8.0
   pubspec_parse: ^1.0.0
   yaml: ^3.0.0


### PR DESCRIPTION
With the additional dependency overrides, tests in drift should hopefully pass with Dart 3 and the latest `build` packages.