### PR TITLE
fix test for reading from the sdk

### DIFF
--- a/build_runner_core/test/asset/file_based_test.dart
+++ b/build_runner_core/test/asset/file_based_test.dart
@@ -99,10 +99,7 @@ void main() async {
     });
 
     test('can read from the SDK', () async {
-      expect(
-          await reader.canRead(
-              makeAssetId(r'$sdk|lib/dev_compiler/kernel/amd/dart_sdk.js')),
-          true);
+      expect(await reader.canRead(makeAssetId(r'$sdk|bin/dart')), true);
     });
   });
 

--- a/build_runner_core/test/asset/file_based_test.dart
+++ b/build_runner_core/test/asset/file_based_test.dart
@@ -99,7 +99,8 @@ void main() async {
     });
 
     test('can read from the SDK', () async {
-      expect(await reader.canRead(makeAssetId(r'$sdk|bin/dart')), true);
+      expect(
+          await reader.canRead(makeAssetId(r'$sdk|lib/libraries.json')), true);
     });
   });
 


### PR DESCRIPTION
This now checks if it can read `bin/dart` which is far less likely to move in the future :)