### PR TITLE
dont pass an explicit --native-null-assertion option if none was provided

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.1
+
+- Allow the compiler to choose the default for the native null assertions
+  option when one is not explicitly provided.
+
 ## 4.0.0
 
 - Require Dart 3.0.

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -24,7 +24,7 @@ import 'web_entrypoint_builder.dart';
 Future<void> bootstrapDart2Js(
   BuildStep buildStep,
   List<String> dart2JsArgs, {
-  required bool nativeNullAssertions,
+  required bool? nativeNullAssertions,
 }) =>
     _resourcePool.withResource(() => _bootstrapDart2Js(buildStep, dart2JsArgs,
         nativeNullAssertions: nativeNullAssertions));
@@ -32,7 +32,7 @@ Future<void> bootstrapDart2Js(
 Future<void> _bootstrapDart2Js(
   BuildStep buildStep,
   List<String> dart2JsArgs, {
-  required bool nativeNullAssertions,
+  required bool? nativeNullAssertions,
 }) async {
   var dartEntrypointId = buildStep.inputId;
   var moduleId =
@@ -85,7 +85,8 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
         '--multi-root=${scratchSpace.tempDir.uri.toFilePath()}',
         for (var experiment in enabledExperiments)
           '--enable-experiment=$experiment',
-        '--${nativeNullAssertions ? '' : 'no-'}native-null-assertions',
+        if (nativeNullAssertions != null)
+          '--${nativeNullAssertions ? '' : 'no-'}native-null-assertions',
         '-o$jsOutputPath',
         '$dartUri',
       ]);

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -31,7 +31,7 @@ Future<void> bootstrapDdc(
   BuildStep buildStep, {
   DartPlatform? platform,
   Iterable<AssetId> requiredAssets = const [],
-  required bool nativeNullAssertions,
+  required bool? nativeNullAssertions,
 }) async {
   platform = ddcPlatform;
   // Ensures that the sdk resources are built and available.
@@ -193,12 +193,15 @@ String _appBootstrap({
   required String moduleScope,
   required String entrypointLibraryName,
   required String oldModuleScope,
-  required bool nativeNullAssertions,
-}) =>
-    '''
+  required bool? nativeNullAssertions,
+}) {
+  var nativeAssertsCode = nativeNullAssertions == null
+      ? ''
+      : 'dart_sdk.dart.nativeNonNullAsserts($nativeNullAssertions);';
+  return '''
 define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_sdk) {
   dart_sdk.dart.setStartAsyncSynchronously(true);
-  dart_sdk.dart.nativeNonNullAsserts($nativeNullAssertions);
+  $nativeAssertsCode
   dart_sdk._isolate_helper.startRootIsolate(() => {}, []);
   $_initializeTools
   $_mainExtensionMarker
@@ -231,6 +234,7 @@ define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_s
 });
 })();
 ''';
+}
 
 /// The actual entrypoint JS file which injects all the necessary scripts to
 /// run the app.

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -55,7 +55,10 @@ class WebEntrypointBuilder implements Builder {
 
   /// Whether or not to enable runtime non-null assertions for values returned
   /// from browser apis.
-  final bool nativeNullAssertions;
+  ///
+  /// If `null` then no flag will be provided to the compiler, and the default
+  /// will be used.
+  final bool? nativeNullAssertions;
 
   const WebEntrypointBuilder(
     this.webCompiler, {
@@ -97,7 +100,7 @@ class WebEntrypointBuilder implements Builder {
     return WebEntrypointBuilder(compiler,
         dart2JsArgs: dart2JsArgs,
         nativeNullAssertions:
-            options.config[_nativeNullAssertionsOption] as bool? ?? true);
+            options.config[_nativeNullAssertionsOption] as bool?);
   }
 
   @override

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.0.0
+version: 4.0.1
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 


### PR DESCRIPTION
Related to https://github.com/dart-lang/sdk/issues/50710, this will allow the optimization level in dart2js to control the default setting for this flag. It can still be overridden with explicit config. 