### PR TITLE
Update publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,3 +12,5 @@ jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    with:
+      sdk: beta


### PR DESCRIPTION
- try out the new feature to run package validation and publishing from a specific version of an SDK (here, many of the build packages need a pre-release sdk for `pub get` to work)
