### PR TITLE
Don't mixin non-mixins.

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.1.1-dev
 
 - Report file watching errors and stop the daemon.
-
+- Change `Level` to implement `Comparable` instead of using it as a mixin.
 
 ## 3.1.0
 
@@ -9,7 +9,6 @@
   build.
 - Updated the example to use `dart pub` instead of `pub`.
 - Run `serveRequests` in an error zone and forward errors to the clients.
-
 
 ## 3.0.1
 

--- a/build_daemon/lib/data/server_log.dart
+++ b/build_daemon/lib/data/server_log.dart
@@ -11,7 +11,7 @@ part 'server_log.g.dart';
 
 /// Logging levels, these have a 1:1 mapping with the levels from
 /// `package:logging`.
-class Level extends EnumClass with Comparable<Level> {
+class Level extends EnumClass implements Comparable<Level> {
   static Serializer<Level> get serializer => _$levelSerializer;
 
   // ignore: constant_identifier_names


### PR DESCRIPTION
The comparable interface is not a mixin and is not intended as a mixin. It has no implementation to inherit.

Also, it won't work in Dart 3.0.

Broke when we enabled class modifiers in platform libraries.