### PR TITLE
add pubspec_overrides.yaml files, drop dependency overrides

### DIFF
--- a/build/pubspec_overrides.yaml
+++ b/build/pubspec_overrides.yaml
@@ -1,0 +1,7 @@
+dependency_overrides:
+  build_config:
+    path: ../build_config
+  build_resolvers:
+    path: ../build_resolvers
+  build_test:
+    path: ../build_test

--- a/build_config/pubspec_overrides.yaml
+++ b/build_config/pubspec_overrides.yaml
@@ -1,0 +1,15 @@
+dependency_overrides:
+  build:
+    path: ../build
+  build_daemon:
+    path: ../build_daemon
+  build_modules:
+    path: ../build_modules
+  build_resolvers:
+    path: ../build_resolvers
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core
+  scratch_space:
+    path: ../scratch_space

--- a/build_daemon/pubspec_overrides.yaml
+++ b/build_daemon/pubspec_overrides.yaml
@@ -1,0 +1,17 @@
+dependency_overrides:
+  build:
+    path: ../build
+  build_config:
+    path: ../build_config
+  build_modules:
+    path: ../build_modules
+  build_resolvers:
+    path: ../build_resolvers
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core
+  build_test:
+    path: ../build_test
+  scratch_space:
+    path: ../scratch_space

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -35,7 +35,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  build_runner:
-    path: ../build_runner

--- a/build_modules/pubspec_overrides.yaml
+++ b/build_modules/pubspec_overrides.yaml
@@ -1,0 +1,17 @@
+dependency_overrides:
+  build:
+    path: ../build
+  build_config:
+    path: ../build_config
+  build_daemon:
+    path: ../build_daemon
+  build_resolvers:
+    path: ../build_resolvers
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core
+  build_test:
+    path: ../build_test
+  scratch_space:
+    path: ../scratch_space

--- a/build_resolvers/pubspec_overrides.yaml
+++ b/build_resolvers/pubspec_overrides.yaml
@@ -1,0 +1,7 @@
+dependency_overrides:
+  build:
+    path: ../build
+  build_config:
+    path: ../build_config
+  build_test:
+    path: ../build_test

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -57,9 +57,3 @@ dev_dependencies:
   test_process: ^2.0.0
   _test_common:
     path: ../_test_common
-
-dependency_overrides:
-  build_modules:
-    path: ../build_modules
-  build_web_compilers:
-    path: ../build_web_compilers

--- a/build_runner/pubspec_overrides.yaml
+++ b/build_runner/pubspec_overrides.yaml
@@ -1,0 +1,19 @@
+dependency_overrides:
+  build:
+    path: ../build
+  build_config:
+    path: ../build_config
+  build_daemon:
+    path: ../build_daemon
+  build_modules:
+    path: ../build_modules
+  build_resolvers:
+    path: ../build_resolvers
+  build_runner_core:
+    path: ../build_runner_core
+  build_test:
+    path: ../build_test
+  build_web_compilers:
+    path: ../build_web_compilers
+  scratch_space:
+    path: ../scratch_space

--- a/build_runner_core/pubspec_overrides.yaml
+++ b/build_runner_core/pubspec_overrides.yaml
@@ -1,0 +1,17 @@
+dependency_overrides:
+  build:
+    path: ../build
+  build_config:
+    path: ../build_config
+  build_daemon:
+    path: ../build_daemon
+  build_modules:
+    path: ../build_modules
+  build_resolvers:
+    path: ../build_resolvers
+  build_runner:
+    path: ../build_runner
+  build_test:
+    path: ../build_test
+  scratch_space:
+    path: ../scratch_space

--- a/build_test/pubspec_overrides.yaml
+++ b/build_test/pubspec_overrides.yaml
@@ -1,0 +1,7 @@
+dependency_overrides:
+  build:
+    path: ../build
+  build_config:
+    path: ../build_config
+  build_resolvers:
+    path: ../build_resolvers

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -33,7 +33,3 @@ dev_dependencies:
     path: test/fixtures/a
   b:
     path: test/fixtures/b
-
-dependency_overrides:
-  build_modules:
-    path: ../build_modules

--- a/build_web_compilers/pubspec_overrides.yaml
+++ b/build_web_compilers/pubspec_overrides.yaml
@@ -1,0 +1,19 @@
+dependency_overrides:
+  build:
+    path: ../build
+  build_config:
+    path: ../build_config
+  build_daemon:
+    path: ../build_daemon
+  build_modules:
+    path: ../build_modules
+  build_resolvers:
+    path: ../build_resolvers
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core
+  build_test:
+    path: ../build_test
+  scratch_space:
+    path: ../scratch_space

--- a/scratch_space/pubspec_overrides.yaml
+++ b/scratch_space/pubspec_overrides.yaml
@@ -1,0 +1,17 @@
+dependency_overrides:
+  build:
+    path: ../build
+  build_config:
+    path: ../build_config
+  build_daemon:
+    path: ../build_daemon
+  build_modules:
+    path: ../build_modules
+  build_resolvers:
+    path: ../build_resolvers
+  build_runner:
+    path: ../build_runner
+  build_runner_core:
+    path: ../build_runner_core
+  build_test:
+    path: ../build_test


### PR DESCRIPTION
This will ensure all packages are running against the latest versions of each other package in the repo, but without triggering pub warnings on publish.