### PR TITLE
Bump the _test SDK dep

### DIFF
--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: _test
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dev_dependencies:
   analyzer: ">=1.0.0 <6.0.0"


### PR DESCRIPTION
The SDK is not reporting API use from newer SDKs than the lower bound. We don't test on an SDK that old anymore, so there is no problem bumping the minimum bound.