### PR TITLE
publish build_modules 5.0.1

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.1-dev
+## 5.0.1
 
 - Delete the long deprecated `dart2JsWorkerResource` api and associated code.
   - This should have landed in 5.0.0 but in practice doesn't work in Dart 3 any

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 5.0.1-dev
+version: 5.0.1
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.


### PR DESCRIPTION
I figured we should get this released asap due to the removal of the deprecated API.