### PR TITLE
add a top level pubspec to silence the analysis_options.yaml diagnostic

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,8 @@
+# This file only exists to enable the top level shared analysis_options.yaml
+# file to import package:lints.
+name: _for_analysis_options_only
+publish_to: none
+environment:
+  sdk: ">=2.12.0 <4.0.0"
+dev_dependencies:
+  lints: ^2.0.0


### PR DESCRIPTION
Up for discussion, it isn't super ideal but I don't know of a simpler/better option. Getting quite tired of having the persistent diagnostic that `package:lints` can't be resolved.

One alternative is creating a whole subdirectory instead and moving the file there, but then it wouldn't apply automatically to all packages, we would have to manually add an analysis_options.yaml to each and import that one, and may forget to do so when adding new packages.

One advantage of the alternative approach though would be that we would get a warning if forgetting to include `package:lints` from any given package (they do each have to add it or else the import doesn't resolve correctly). 