### PR TITLE
Add a default onLog behavior with printOnFailure

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0-wip
+
+- Forward logs from `testBuilder` to `printOnFailure` by default.
+
 ## 2.1.7
 
 - Allow the latest test_core (version 5.x).

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -135,6 +135,7 @@ Future testBuilder(
     void Function(LogRecord log)? onLog,
     void Function(AssetId, Iterable<AssetId>)? reportUnusedAssetsForInput,
     PackageConfig? packageConfig}) async {
+  onLog ??= (log) => printOnFailure('$log');
   writer ??= InMemoryAssetWriter();
 
   var inputIds = {

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 2.1.7
+version: 2.2.0-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:


### PR DESCRIPTION
In `testBuilder`, if there was no `onLog` passed, use `printOnFailure`
by default. This is the most useful behavior, and all use cases that
aren't otherwise testing the logs specifically would benefit from seeing
the output on test failure.
