### PR TITLE
Add package config to build step

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 2.3.2-dev
+## 2.4.0-dev
+
+- Add `BuildStep.packageConfig` getter to resolve a package config of all
+  packages involved in the current build.
 
 ## 2.3.1
 

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:meta/meta.dart';
+import 'package:package_config/package_config_types.dart';
 
 import '../analyzer/resolver.dart';
 import '../asset/id.dart';
@@ -118,6 +119,17 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   /// `InvalidOutputException` when attempting to write an asset not part of
   /// the [allowedOutputs].
   Iterable<AssetId> get allowedOutputs;
+
+  /// Returns a [PackageConfig] resolvable from this build step.
+  ///
+  /// The package config contains all packages involved in the build. Typically,
+  /// this is the package config taken from the current isolate.
+  ///
+  /// The returned package config does not use `file:/`-based URIs and can't be
+  /// used to access package contents with `dart:io`. Instead, packages resolve
+  /// to `asset:/` URIs that can be parsed with [AssetId.resolve] and read with
+  /// [readAsBytes] or [readAsString].
+  Future<PackageConfig> get packageConfig;
 }
 
 abstract class StageTracker {

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -80,8 +80,8 @@ class BuildStepImpl implements BuildStep {
 
   @override
   Future<PackageConfig> get packageConfig async {
-    final resolved = _resolvedPackageConfig ??=
-        Result.capture(Future.sync(_resolvePackageConfig));
+    final resolved =
+        _resolvedPackageConfig ??= Result.capture(_resolvePackageConfig());
 
     return (await resolved).asFuture;
   }

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:async/async.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
+import 'package:package_config/package_config_types.dart';
 
 import '../analyzer/resolver.dart';
 import '../asset/exceptions.dart';
@@ -60,13 +61,30 @@ class BuildStepImpl implements BuildStep {
 
   final void Function(Iterable<AssetId>)? _reportUnusedAssets;
 
-  BuildStepImpl(this.inputId, Iterable<AssetId> expectedOutputs, this._reader,
-      this._writer, this._resolvers, this._resourceManager,
+  final Future<PackageConfig> Function() _resolvePackageConfig;
+  Future<Result<PackageConfig>>? _resolvedPackageConfig;
+
+  BuildStepImpl(
+      this.inputId,
+      Iterable<AssetId> expectedOutputs,
+      this._reader,
+      this._writer,
+      this._resolvers,
+      this._resourceManager,
+      this._resolvePackageConfig,
       {StageTracker? stageTracker,
       void Function(Iterable<AssetId>)? reportUnusedAssets})
       : allowedOutputs = UnmodifiableSetView(expectedOutputs.toSet()),
         _stageTracker = stageTracker ?? NoOpStageTracker.instance,
         _reportUnusedAssets = reportUnusedAssets;
+
+  @override
+  Future<PackageConfig> get packageConfig async {
+    final resolved = _resolvedPackageConfig ??=
+        Result.capture(Future.sync(_resolvePackageConfig));
+
+    return (await resolved).asFuture;
+  }
 
   @override
   Resolver get resolver {

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -1,7 +1,10 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:isolate';
+
 import 'package:logging/logging.dart';
+import 'package:package_config/package_config.dart';
 
 import '../analyzer/resolver.dart';
 import '../asset/id.dart';
@@ -28,22 +31,50 @@ import 'expected_outputs.dart';
 /// If [reportUnusedAssetsForInput] is provided then all calls to
 /// `BuildStep.reportUnusedAssets` in [builder] will be forwarded to this
 /// function with the associated primary input.
-Future<void> runBuilder(Builder builder, Iterable<AssetId> inputs,
-    AssetReader reader, AssetWriter writer, Resolvers? resolvers,
-    {Logger? logger,
-    ResourceManager? resourceManager,
-    StageTracker stageTracker = NoOpStageTracker.instance,
-    void Function(AssetId input, Iterable<AssetId> assets)?
-        reportUnusedAssetsForInput}) async {
+Future<void> runBuilder(
+  Builder builder,
+  Iterable<AssetId> inputs,
+  AssetReader reader,
+  AssetWriter writer,
+  Resolvers? resolvers, {
+  Logger? logger,
+  ResourceManager? resourceManager,
+  StageTracker stageTracker = NoOpStageTracker.instance,
+  void Function(AssetId input, Iterable<AssetId> assets)?
+      reportUnusedAssetsForInput,
+  PackageConfig? packageConfig,
+}) async {
   var shouldDisposeResourceManager = resourceManager == null;
   final resources = resourceManager ?? ResourceManager();
   logger ??= Logger('runBuilder');
+
+  PackageConfig? transformedConfig;
+
+  Future<PackageConfig> loadPackageConfig() async {
+    if (transformedConfig != null) return transformedConfig!;
+
+    var config = packageConfig;
+    if (config == null) {
+      final uri = await Isolate.packageConfig;
+
+      if (uri == null) {
+        throw UnsupportedError(
+            'Isolate running the build does not have a package config and no '
+            'fallback has been provided');
+      }
+
+      config = await loadPackageConfigUri(uri);
+    }
+
+    return transformedConfig = config.transformToAssetUris();
+  }
+
   //TODO(nbosch) check overlapping outputs?
   Future<void> buildForInput(AssetId input) async {
     var outputs = expectedOutputs(builder, input);
     if (outputs.isEmpty) return;
     var buildStep = BuildStepImpl(
-        input, outputs, reader, writer, resolvers, resources,
+        input, outputs, reader, writer, resolvers, resources, loadPackageConfig,
         stageTracker: stageTracker,
         reportUnusedAssets: reportUnusedAssetsForInput == null
             ? null
@@ -60,5 +91,28 @@ Future<void> runBuilder(Builder builder, Iterable<AssetId> inputs,
   if (shouldDisposeResourceManager) {
     await resources.disposeAll();
     await resources.beforeExit();
+  }
+}
+
+extension on Package {
+  Package transformToAssetUris() {
+    return Package(
+      name,
+      Uri(scheme: 'asset', pathSegments: [name, '']),
+      packageUriRoot: Uri(scheme: 'asset', pathSegments: [name, 'lib', '']),
+      relativeRoot: false,
+      extraData: extraData,
+    );
+  }
+}
+
+extension on PackageConfig {
+  PackageConfig transformToAssetUris() {
+    return PackageConfig(
+      [
+        for (final package in packages) package.transformToAssetUris(),
+      ],
+      extraData: extraData,
+    );
   }
 }

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -95,13 +95,15 @@ Future<void> runBuilder(
 }
 
 extension on Package {
+  static final _lib = Uri.parse('lib/');
+
   Package transformToAssetUris() {
     return Package(
       name,
       Uri(scheme: 'asset', pathSegments: [name, '']),
-      packageUriRoot: Uri(scheme: 'asset', pathSegments: [name, 'lib', '']),
-      relativeRoot: false,
+      packageUriRoot: _lib,
       extraData: extraData,
+      languageVersion: languageVersion,
     );
   }
 }

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 2.3.2-dev
+version: 2.4.0-dev
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 
@@ -14,6 +14,7 @@ dependencies:
   glob: ^2.0.0
   logging: ^1.0.0
   meta: ^1.3.0
+  package_config: ^2.1.0
   path: ^1.8.0
 
 dev_dependencies:

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -10,6 +10,7 @@ import 'package:build/src/builder/build_step.dart';
 import 'package:build/src/builder/build_step_impl.dart';
 import 'package:build_resolvers/build_resolvers.dart';
 import 'package:build_test/build_test.dart';
+import 'package:package_config/package_config.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -34,7 +35,7 @@ void main() {
       primary = makeAssetId();
       outputs = List.generate(5, (index) => makeAssetId());
       buildStep = BuildStepImpl(primary, outputs, reader, writer,
-          AnalyzerResolvers(), resourceManager);
+          AnalyzerResolvers(), resourceManager, _unsupported);
     });
 
     test('doesnt allow non-expected outputs', () {
@@ -87,8 +88,15 @@ void main() {
       };
       addAssets(inputs, writer);
       var outputId = AssetId.parse('$primary.copy');
-      var buildStep = BuildStepImpl(primary, [outputId], reader, writer,
-          AnalyzerResolvers(), resourceManager);
+      var buildStep = BuildStepImpl(
+        primary,
+        [outputId],
+        reader,
+        writer,
+        AnalyzerResolvers(),
+        resourceManager,
+        _unsupported,
+      );
 
       await builder.build(buildStep);
       await buildStep.complete();
@@ -112,8 +120,8 @@ void main() {
         addAssets(inputs, writer);
 
         var primary = makeAssetId('a|web/a.dart');
-        var buildStep = BuildStepImpl(
-            primary, [], reader, writer, AnalyzerResolvers(), resourceManager);
+        var buildStep = BuildStepImpl(primary, [], reader, writer,
+            AnalyzerResolvers(), resourceManager, _unsupported);
         var resolver = buildStep.resolver;
 
         var aLib = await resolver.libraryFor(primary);
@@ -143,7 +151,7 @@ void main() {
       outputId = makeAssetId('a|test.txt');
       outputContent = '$outputId';
       buildStep = BuildStepImpl(primary, [outputId], StubAssetReader(),
-          assetWriter, AnalyzerResolvers(), resourceManager);
+          assetWriter, AnalyzerResolvers(), resourceManager, _unsupported);
     });
 
     test('Completes only after writes finish', () async {
@@ -191,7 +199,7 @@ void main() {
       primary = makeAssetId();
       output = makeAssetId();
       buildStep = BuildStepImpl(primary, [output], reader, writer,
-          AnalyzerResolvers(), resourceManager,
+          AnalyzerResolvers(), resourceManager, _unsupported,
           stageTracker: NoOpStageTracker.instance);
     });
 
@@ -205,8 +213,8 @@ void main() {
     var reader = StubAssetReader();
     var writer = StubAssetWriter();
     var unused = <AssetId>{};
-    var buildStep = BuildStepImpl(
-        makeAssetId(), [], reader, writer, AnalyzerResolvers(), resourceManager,
+    var buildStep = BuildStepImpl(makeAssetId(), [], reader, writer,
+        AnalyzerResolvers(), resourceManager, _unsupported,
         reportUnusedAssets: unused.addAll);
     var reported = [
       makeAssetId(),
@@ -233,4 +241,8 @@ class SlowAssetWriter implements AssetWriter {
   Future<void> writeAsString(AssetId id, FutureOr<String> contents,
           {Encoding encoding = utf8}) =>
       _writeCompleter.future;
+}
+
+Future<PackageConfig> _unsupported() {
+  return Future.error(UnsupportedError('stub'));
 }

--- a/build/test/generate/run_builder_test.dart
+++ b/build/test/generate/run_builder_test.dart
@@ -80,6 +80,7 @@ void main() {
             config.packages.singleWhere((p) => p.name == 'build');
         expect(buildPackage.root, Uri.parse('asset:build/'));
         expect(buildPackage.packageUriRoot, Uri.parse('asset:build/lib/'));
+        expect(buildPackage.languageVersion, LanguageVersion(2, 18));
 
         final resolvedBuildUri =
             config.resolve(Uri.parse('package:build/foo.txt'))!;
@@ -99,7 +100,13 @@ void main() {
         reader,
         writer,
         null,
-        packageConfig: PackageConfig([Package('build', Uri.file('/foo/bar/'))]),
+        packageConfig: PackageConfig([
+          Package(
+            'build',
+            Uri.file('/foo/bar/'),
+            languageVersion: LanguageVersion(2, 18),
+          ),
+        ]),
       );
     });
   });

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   analyzer: ^5.2.0
   async: ^2.5.0
-  build: ^2.0.0
+  build: ^2.4.0
   collection: ^1.17.0
   crypto: ^3.0.0
   graphs: '>=1.0.0 <3.0.0'
@@ -25,3 +25,6 @@ dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
   test: ^1.16.0
   build_test: ^2.0.0
+
+dependency_overrides:
+  build:

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   analyzer: ^5.2.0
   async: ^2.5.0
-  build: ^2.4.0
+  build: ^2.0.0
   collection: ^1.17.0
   crypto: ^3.0.0
   graphs: '>=1.0.0 <3.0.0'
@@ -25,6 +25,3 @@ dev_dependencies:
   lints: '>=1.0.0 <3.0.0'
   test: ^1.16.0
   build_test: ^2.0.0
-
-dependency_overrides:
-  build:

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.2.8-dev
 
 - Raise the minimum SDK constraint to 2.18.
+- Optimize `BuildStep.packageConfig`
 
 ## 7.2.7
 

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -536,6 +536,7 @@ class _SingleBuild {
                   stageTracker: tracker,
                   reportUnusedAssetsForInput: (_, assets) =>
                       unusedAssets.addAll(assets),
+                  packageConfig: _packageGraph.asPackageConfig,
                 ).catchError((void _) {
                   // Errors tracked through the logger
                 }));

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -13,7 +13,7 @@ platforms:
 
 dependencies:
   async: ^2.5.0
-  build: ^2.1.0
+  build: ^2.4.0
   build_config: ^1.0.0
   build_resolvers: ^2.0.0
   collection: ^1.15.0
@@ -42,3 +42,7 @@ dev_dependencies:
   test_process: ^2.0.0
   _test_common:
     path: ../_test_common
+
+dependency_overrides:
+  build:
+    path: ../build

--- a/build_runner_core/test/package_graph/package_graph_test.dart
+++ b/build_runner_core/test/package_graph/package_graph_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 @TestOn('vm')
 import 'package:build_runner_core/build_runner_core.dart';
+import 'package:package_config/package_config_types.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -17,6 +18,14 @@ void main() {
 
       test('root', () {
         expectPkg(graph.root, 'build_runner_core', '', DependencyType.path);
+      });
+
+      test('asPackageConfig', () {
+        final config = graph.asPackageConfig;
+        final buildRunner =
+            config.packages.singleWhere((p) => p.name == 'build_runner_core');
+
+        expect(buildRunner.languageVersion, LanguageVersion(2, 18));
       });
     });
 
@@ -48,6 +57,14 @@ void main() {
       test('dependency', () {
         expectPkg(graph['a']!, 'a', '$basicPkgPath/pkg/a',
             DependencyType.hosted, [graph['b']!, graph['c']!]);
+      });
+
+      test('asPackageConfig', () {
+        final config = graph.asPackageConfig;
+        final names = config.packages.map((e) => e.name);
+
+        expect(names, isNot(contains(r'$sdk')));
+        expect(names, containsAll(['a', 'b', 'c', 'd', 'basic_pkg']));
       });
     });
 


### PR DESCRIPTION
This adds a `packageConfig` getter to `BuildStep`, which can be used to read the language version of packages involved in the build. The package config exposed in the build step hides the actual files of packages on the file system. Instead, 

By default, the package config will be resolved from the current isolate in `runBuilder`. However, `build_runner_core` also constructs a config based on the `PackageGraph` which avoids loading the raw package config multiple times.

Closes #3492.