### PR TITLE
make the doctor command visible

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.3
+
+- Make the `doctor` command visible.
+
 ## 2.4.2
 
 - Support package:build version 2.4.x.

--- a/build_runner/lib/src/entrypoint/doctor.dart
+++ b/build_runner/lib/src/entrypoint/doctor.dart
@@ -22,9 +22,6 @@ class DoctorCommand extends BuildRunnerCommand {
   String get name => 'doctor';
 
   @override
-  bool get hidden => true;
-
-  @override
   String get description => 'Check for misconfiguration of the build.';
 
   @override

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.2
+version: 2.4.3
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
We had this hidden originally because I think we thought we might add more things to it and wanted to wait to push it more broadly, but that obviously didn't happen :).

I don't think it does any harm to make it visible at this point and it will help with issues like https://github.com/dart-lang/build/issues/3503 and https://github.com/dart-lang/graphs/issues/86.