### PR TITLE
Fix failing builder ordering tests

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -1,11 +1,11 @@
 // ignore_for_file: directives_ordering
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:build_runner_core/build_runner_core.dart' as _i1;
-import 'package:build_test/builder.dart' as _i2;
-import 'package:build_config/build_config.dart' as _i3;
-import 'package:provides_builder/builders.dart' as _i4;
-import 'package:build_modules/builders.dart' as _i5;
-import 'package:build_web_compilers/builders.dart' as _i6;
+import 'package:provides_builder/builders.dart' as _i2;
+import 'package:build_web_compilers/builders.dart' as _i3;
+import 'package:build_test/builder.dart' as _i4;
+import 'package:build_config/build_config.dart' as _i5;
+import 'package:build_modules/builders.dart' as _i6;
 import 'package:build/build.dart' as _i7;
 import 'dart:isolate' as _i8;
 import 'package:build_runner/build_runner.dart' as _i9;
@@ -13,35 +13,51 @@ import 'dart:io' as _i10;
 
 final _builders = <_i1.BuilderApplication>[
   _i1.apply(
-    r'build_test:test_bootstrap',
-    [
-      _i2.debugIndexBuilder,
-      _i2.debugTestBuilder,
-      _i2.testBootstrapBuilder,
-    ],
-    _i1.toRoot(),
+    r'provides_builder:throwing_builder',
+    [_i2.throwingBuilder],
+    _i1.toDependentsOf(r'provides_builder'),
     hideOutput: true,
-    defaultGenerateFor: const _i3.InputSet(include: [
-      r'$package$',
-      r'test/**',
-    ]),
+  ),
+  _i1.apply(
+    r'provides_builder:some_not_applied_builder',
+    [_i2.notApplied],
+    _i1.toNoneByDefault(),
+    hideOutput: true,
   ),
   _i1.apply(
     r'provides_builder:some_builder',
-    [_i4.someBuilder],
+    [_i2.someBuilder],
     _i1.toDependentsOf(r'provides_builder'),
     hideOutput: true,
     appliesBuilders: const [r'provides_builder:some_post_process_builder'],
   ),
   _i1.apply(
-    r'provides_builder:some_not_applied_builder',
-    [_i4.notApplied],
+    r'build_web_compilers:sdk_js',
+    [
+      _i3.sdkJsCompile,
+      _i3.sdkJsCopyRequirejs,
+    ],
     _i1.toNoneByDefault(),
+    isOptional: true,
     hideOutput: true,
   ),
   _i1.apply(
+    r'build_test:test_bootstrap',
+    [
+      _i4.debugIndexBuilder,
+      _i4.debugTestBuilder,
+      _i4.testBootstrapBuilder,
+    ],
+    _i1.toRoot(),
+    hideOutput: true,
+    defaultGenerateFor: const _i5.InputSet(include: [
+      r'$package$',
+      r'test/**',
+    ]),
+  ),
+  _i1.apply(
     r'build_modules:module_library',
-    [_i5.moduleLibraryBuilder],
+    [_i6.moduleLibraryBuilder],
     _i1.toAllPackages(),
     isOptional: true,
     hideOutput: true,
@@ -50,9 +66,9 @@ final _builders = <_i1.BuilderApplication>[
   _i1.apply(
     r'build_web_compilers:dart2js_modules',
     [
-      _i6.dart2jsMetaModuleBuilder,
-      _i6.dart2jsMetaModuleCleanBuilder,
-      _i6.dart2jsModuleBuilder,
+      _i3.dart2jsMetaModuleBuilder,
+      _i3.dart2jsMetaModuleCleanBuilder,
+      _i3.dart2jsModuleBuilder,
     ],
     _i1.toNoneByDefault(),
     isOptional: true,
@@ -62,9 +78,9 @@ final _builders = <_i1.BuilderApplication>[
   _i1.apply(
     r'build_web_compilers:ddc_modules',
     [
-      _i6.ddcMetaModuleBuilder,
-      _i6.ddcMetaModuleCleanBuilder,
-      _i6.ddcModuleBuilder,
+      _i3.ddcMetaModuleBuilder,
+      _i3.ddcMetaModuleCleanBuilder,
+      _i3.ddcModuleBuilder,
     ],
     _i1.toNoneByDefault(),
     isOptional: true,
@@ -74,8 +90,8 @@ final _builders = <_i1.BuilderApplication>[
   _i1.apply(
     r'build_web_compilers:ddc',
     [
-      _i6.ddcKernelBuilder,
-      _i6.ddcBuilder,
+      _i3.ddcKernelBuilder,
+      _i3.ddcBuilder,
     ],
     _i1.toAllPackages(),
     isOptional: true,
@@ -87,21 +103,11 @@ final _builders = <_i1.BuilderApplication>[
     ],
   ),
   _i1.apply(
-    r'build_web_compilers:sdk_js',
-    [
-      _i6.sdkJsCompile,
-      _i6.sdkJsCopyRequirejs,
-    ],
-    _i1.toNoneByDefault(),
-    isOptional: true,
-    hideOutput: true,
-  ),
-  _i1.apply(
     r'build_web_compilers:entrypoint',
-    [_i6.webEntrypointBuilder],
+    [_i3.webEntrypointBuilder],
     _i1.toRoot(),
     hideOutput: true,
-    defaultGenerateFor: const _i3.InputSet(
+    defaultGenerateFor: const _i5.InputSet(
       include: [
         r'web/**',
         r'test/**.dart.browser_test.dart',
@@ -123,31 +129,25 @@ final _builders = <_i1.BuilderApplication>[
         const _i7.BuilderOptions(<String, dynamic>{r'compiler': r'dart2js'}),
     appliesBuilders: const [r'build_web_compilers:dart2js_archive_extractor'],
   ),
-  _i1.apply(
-    r'provides_builder:throwing_builder',
-    [_i4.throwingBuilder],
-    _i1.toDependentsOf(r'provides_builder'),
-    hideOutput: true,
-  ),
   _i1.applyPostProcess(
     r'build_modules:module_cleanup',
-    _i5.moduleCleanup,
+    _i6.moduleCleanup,
   ),
   _i1.applyPostProcess(
     r'build_web_compilers:dart2js_archive_extractor',
-    _i6.dart2jsArchiveExtractor,
+    _i3.dart2jsArchiveExtractor,
     defaultReleaseOptions:
         const _i7.BuilderOptions(<String, dynamic>{r'filter_outputs': true}),
   ),
   _i1.applyPostProcess(
     r'build_web_compilers:dart_source_cleanup',
-    _i6.dartSourceCleanup,
+    _i3.dartSourceCleanup,
     defaultReleaseOptions:
         const _i7.BuilderOptions(<String, dynamic>{r'enabled': true}),
   ),
   _i1.applyPostProcess(
     r'provides_builder:some_post_process_builder',
-    _i4.somePostProcessBuilder,
+    _i2.somePostProcessBuilder,
   ),
 ];
 void main(

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.4.3-wip
+
 ## 2.4.2
 
 - Support package:build version 2.4.x.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.2
+version: 2.4.3-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/build_script_generate/builder_ordering_test.dart
+++ b/build_runner/test/build_script_generate/builder_ordering_test.dart
@@ -18,6 +18,7 @@ void main() {
               'build_extensions': <String, List<String>>{},
               'target': '',
               'import': '',
+              'runs_before': [':c'],
             },
             'b': {
               'builder_factories': ['createBuilder'],
@@ -57,7 +58,6 @@ void main() {
                 'build_extensions': {},
                 'target': '',
                 'import': '',
-                'runs_before': [':a'],
               },
               'c': {
                 'builder_factories': ['createBuilder'],
@@ -70,15 +70,18 @@ void main() {
         });
         final orderedBuilders = findBuilderOrder(
             buildConfigs.values.expand((v) => v.builderDefinitions.values), {
-          'a:c': GlobalBuilderConfig.fromJson({
+          'a:b': GlobalBuilderConfig.fromJson({
             'runs_before': ['a:a'],
+          }),
+          'a:a': GlobalBuilderConfig.fromJson({
+            'runs_before': ['a:c'],
           }),
         });
         final orderedKeys = orderedBuilders.map((b) => b.key);
         expect(orderedKeys, [
           'a:b',
-          'a:c',
           'a:a',
+          'a:c',
         ]);
       }, 'a', []);
     });
@@ -99,6 +102,7 @@ void main() {
                 'build_extensions': {},
                 'target': '',
                 'import': '',
+                'runs_before': [':a'],
               },
               'c': {
                 'builder_factories': ['createBuilder'],
@@ -111,8 +115,8 @@ void main() {
         });
         final orderedBuilders = findBuilderOrder(
             buildConfigs.values.expand((v) => v.builderDefinitions.values), {
-          'a:b': GlobalBuilderConfig.fromJson({
-            'runs_before': ['a:a'],
+          'a:a': GlobalBuilderConfig.fromJson({
+            'runs_before': ['a:c'],
           }),
         });
         final orderedKeys = orderedBuilders.map((b) => b.key);


### PR DESCRIPTION
These were broken by the latest package:graphs, I made them also be more stable so that they weren't relying on undefined behavior.