### PR TITLE
Update formatting in build_yaml_format.md

### DIFF
--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -95,14 +95,12 @@ for guidance.
 
 ## AutoApply
 
-| value        | meaning                                                     |
-| ------------ | ----------------------------------------------------------- |
-| none         | Doesn't apply by default to any package, must be explicitly |
-:              : enabled.                                                    :
-| dependents   | Applies to all packages with a direct dependency on this    |
-:              : package.                                                    :
-| all_packages | Applies to all packages in the graph.                       |
-| root_package | Applies to only the root (application) package.             |
+value        | meaning                                                               |
+------------ | --------------------------------------------------------------------- |
+none         | Doesn't apply by default to any package, must be explicitly enabled.  |
+dependents   | Applies to all packages with a direct dependency on this package.     |
+all_packages | Applies to all packages in the graph.                                 |
+root_package | Applies to only the root (application) package.                       |
 
 ## BuildTo
 


### PR DESCRIPTION
The table formatting was broken before, not sure how line wrapping is supposed to work in these tables but we just used long lines above so it is at least consistent with the other style.