### PR TITLE
Fix the build

### DIFF
--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
-  analyzer: ^5.2.0
+  analyzer: ^5.12.0
   async: ^2.5.0
   build: ^2.0.0
   collection: ^1.17.0

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -9,6 +9,7 @@ import 'dart:isolate';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:build/experiments.dart';
 import 'package:build_resolvers/src/analysis_driver.dart';
@@ -733,7 +734,7 @@ int? get x => 1;
                   .toString(),
               equals('dart:ui'));
         } else {
-          expect(color.type.element!.name, equals('dynamic'));
+          expect(color.type, isA<InvalidType>());
         }
       }, resolvers: AnalyzerResolvers());
     });

--- a/build_runner/test/build_script_generate/bootstrap_test.dart
+++ b/build_runner/test/build_script_generate/bootstrap_test.dart
@@ -2,41 +2,34 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 @Timeout.factor(2)
-import 'dart:io';
+library;
 
 import 'package:build_runner/build_script_generate.dart';
 import 'package:test/test.dart';
-
-import '../integration_tests/utils/build_descriptor.dart';
 
 void main() {
   test('invokes custom error function', () async {
     Object? error;
     StackTrace? stackTrace;
 
-    final pkgDir = (await package([])).rootPackageDir;
-
-    await IOOverrides.runZoned(
-      () {
-        return expectLater(
-          generateAndRun(
-            [],
-            generateBuildScript: () async {
-              return '''
+    // TODO: https://github.com/dart-lang/sdk/issues/52469 Use IOOverrides to
+    // run this is a tmp dir, this currently bashes over the actual cache dir.
+    await expectLater(
+      generateAndRun(
+        [],
+        generateBuildScript: () async {
+          return '''
               void main() {
                 throw 'expected error';
               }
               ''';
-            },
-            handleUncaughtError: (err, trace) {
-              error = err;
-              stackTrace = trace;
-            },
-          ),
-          completion(1),
-        );
-      },
-      getCurrentDirectory: () => Directory(pkgDir),
+        },
+        handleUncaughtError: (err, trace) {
+          error = err;
+          stackTrace = trace;
+        },
+      ),
+      completion(1),
     );
 
     expect(error, 'expected error');


### PR DESCRIPTION
- check for InvalidType instead of dynamic, require analyzer 5.12.0
- update tests  using IOOverrides to not any more, see https://github.com/dart-lang/sdk/issues/52469