### PR TITLE
Fix compatibility with package:logger

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 7.2.9-wip
+## 7.2.9
+
+- Fix compatibility with `package:logging` version `1.2.0`.
 
 ## 7.2.8
 

--- a/build_runner_core/lib/src/logging/build_for_input_logger.dart
+++ b/build_runner_core/lib/src/logging/build_for_input_logger.dart
@@ -88,4 +88,7 @@ class BuildForInputLogger implements Logger {
   @override
   void warning(Object? message, [Object? error, StackTrace? stackTrace]) =>
       _delegate.warning(message, error, stackTrace);
+
+  @override
+  Stream<Level?> get onLevelChanged => _delegate.onLevelChanged;
 }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_runner_core
-version: 7.2.9-wip
+version: 7.2.9
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=2.19.0 <4.0.0"
 
 platforms:
   linux:
@@ -22,7 +22,7 @@ dependencies:
   glob: ^2.0.0
   graphs: ^2.0.0
   json_annotation: ^4.8.1
-  logging: ^1.0.0
+  logging: ^1.2.0
   meta: ^1.3.0
   package_config: ^2.0.0
   path: ^1.8.0
@@ -42,7 +42,3 @@ dev_dependencies:
   test: ^1.16.0
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
-
-dependency_overrides:
-  build:
-    path: ../build


### PR DESCRIPTION
Fixes #3514

Add a forwarding implementation of `onLevelChanged` which was added in
the `Logger` class.

Update upper bound SDK constraint to avoid pub publish warning.

Remove `dependency_overrides` section in `pubspec.yaml` since there is a
separate overrides file.
