### PR TITLE
Add missing implementation for Logger.onLevelChanged

### DIFF
--- a/build_runner_core/lib/src/logging/build_for_input_logger.dart
+++ b/build_runner_core/lib/src/logging/build_for_input_logger.dart
@@ -88,4 +88,7 @@ class BuildForInputLogger implements Logger {
   @override
   void warning(Object? message, [Object? error, StackTrace? stackTrace]) =>
       _delegate.warning(message, error, stackTrace);
+
+  @override
+  Stream<Level?> get onLevelChanged => _delegate.onLevelChanged;
 }


### PR DESCRIPTION
Add implementation for Logger.onLevelChanged to fix the error with the latest update in `logging` package [[ref](https://pub.dev/packages/logging/changelog#120)]

fixed error:
```
pub.dev/build_runner_core-7.2.7/lib/src/logging/build_for_input_logger.dart:13:7: Error: The non-abstract class 'BuildForInputLogger' is missing implementations for these members:
 - Logger.onLevelChanged
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

(note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback)
