### PR TITLE
Build runner core backport

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.7+1
+
+- Backport the fix for package:logging version 1.2.0.
+
 ## 7.2.7
 
 - Handle generation of hidden assets in a way consistent with the definition of

--- a/build_runner_core/lib/src/logging/build_for_input_logger.dart
+++ b/build_runner_core/lib/src/logging/build_for_input_logger.dart
@@ -88,4 +88,7 @@ class BuildForInputLogger implements Logger {
   @override
   void warning(Object? message, [Object? error, StackTrace? stackTrace]) =>
       _delegate.warning(message, error, stackTrace);
+
+  @override
+  Stream<Level?> get onLevelChanged => _delegate.onLevelChanged;
 }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   glob: ^2.0.0
   graphs: ^2.0.0
   json_annotation: ^4.3.0
-  logging: ^1.0.0
+  logging: ^1.2.0
   meta: ^1.3.0
   path: ^1.8.0
   package_config: ^2.0.0

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 7.2.7
+version: 7.2.7+1
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/3519

Currently, users on the previous flutter SDK (3.7, <6 months old), can't get the latest package:build_runner_core but can get the latest package:logging. This causes compile errors due to a member not being implemented.

This backports the fix to build_runner_core 7.2.7+1, which should be resolvable with build_runner version 2.3.3, which was the last version to allow a Dart version <3.0.0 (it supports 2.14 and later).

Once this is approved, I will tag and release, and then resolve merge conflicts with master so there is a changelog entry.