### PR TITLE
Allow single builder cycles

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.5
+
+- Fix a bug handling a builder which has a `required_input` that matches it's
+  own output.
+
 ## 2.4.4
 
 - Use a stable order for builders without an order defined by dependencies.

--- a/build_runner/lib/src/build_script_generate/builder_ordering.dart
+++ b/build_runner/lib/src/build_script_generate/builder_ordering.dart
@@ -18,8 +18,9 @@ Iterable<BuilderDefinition> findBuilderOrder(
     ..sort((a, b) => a.key.compareTo(b.key));
   Iterable<BuilderDefinition> dependencies(BuilderDefinition parent) =>
       consistentOrderBuilders.where((child) =>
-          _hasInputDependency(parent, child) ||
-          _mustRunBefore(parent, child, globalBuilderConfigs));
+          parent != child &&
+          (_hasInputDependency(parent, child) ||
+              _mustRunBefore(parent, child, globalBuilderConfigs)));
   try {
     return topologicalSort<BuilderDefinition>(
       consistentOrderBuilders,

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.4
+version: 2.4.5
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/build_script_generate/builder_ordering_test.dart
+++ b/build_runner/test/build_script_generate/builder_ordering_test.dart
@@ -192,7 +192,10 @@ void main() {
           'builders': {
             'self_cycle': {
               'builder_factories': ['createBuilder'],
-              'build_extensions': {'.in': ['.out'], '.out': ['.another']},
+              'build_extensions': {
+                '.in': ['.out'],
+                '.out': ['.another']
+              },
               'target': '',
               'import': '',
               'required_inputs': ['.out'],

--- a/build_runner/test/build_script_generate/builder_ordering_test.dart
+++ b/build_runner/test/build_script_generate/builder_ordering_test.dart
@@ -185,5 +185,25 @@ void main() {
               {}),
           throwsA(anything));
     });
+
+    test('allows self cycles with `required_inputs`', () async {
+      final buildConfigs = parseBuildConfigs({
+        'a': {
+          'builders': {
+            'self_cycle': {
+              'builder_factories': ['createBuilder'],
+              'build_extensions': {'.in': ['.out'], '.out': ['.another']},
+              'target': '',
+              'import': '',
+              'required_inputs': ['.out'],
+            },
+          }
+        }
+      });
+      final orderedBuilders = findBuilderOrder(
+          buildConfigs.values.expand((v) => v.builderDefinitions.values), {});
+      final orderedKeys = orderedBuilders.map((b) => b.key);
+      expect(orderedKeys, ['a:self_cycle']);
+    });
   });
 }


### PR DESCRIPTION
Fixes #3531

When a builder outputs a file with the same extension as a
`required_input` it will be in a cycle with itself. When builders were
ordered with `stronglyConnectedComponents` cycles were detected by
looking for a component (cycle) with more than one builder. With the
move to `topologicalSort` the single builder cycle causes an exception
during the sort. Exclude the builder itself from the list of
dependencies for the graph algorithm call.
