### PR TITLE
Add required github deployment environment for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,3 +19,4 @@ jobs:
       sdk: dev
     permissions:
       id-token: write # Required for authentication using OIDC
+      pull-requests: write # Enables the validate job to comment on PRs.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,8 +10,17 @@ on:
     tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
-  publish:
-    if: ${{ github.repository_owner == 'dart-lang' }}
+  validate:
+    if: ${{ github.repository_owner == 'dart-lang' && github.event_name == 'pull_request' }}
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
     with:
       sdk: dev
+  publish:
+    if: ${{ github.repository_owner == 'dart-lang' && github.event_name == 'push' }}
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    with:
+      # Protected github deployment environment, requires approval to run.
+      environment: pub.dev
+      sdk: dev
+    permissions:
+      id-token: write # Required for authentication using OIDC

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,6 +17,3 @@ jobs:
       # Protected github deployment environment, requires approval to publish.
       environment: pub.dev
       sdk: dev
-    permissions:
-      id-token: write # Required for authentication using OIDC
-      pull-requests: write # Enables the validate job to comment on PRs.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,16 +10,11 @@ on:
     tags: [ '[A-z]+-v[0-9]+.[0-9]+.[0-9]+*' ]
 
 jobs:
-  validate:
-    if: ${{ github.repository_owner == 'dart-lang' && github.event_name == 'pull_request' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
-    with:
-      sdk: dev
   publish:
-    if: ${{ github.repository_owner == 'dart-lang' && github.event_name == 'push' }}
+    if: ${{ github.repository_owner == 'dart-lang' }}
     uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
     with:
-      # Protected github deployment environment, requires approval to run.
+      # Protected github deployment environment, requires approval to publish.
       environment: pub.dev
       sdk: dev
     permissions:


### PR DESCRIPTION
Pass environment config to the publish action to harden our releases.

Upon approval I will also update the publish settings on pub to require this environment.

(see https://dart.dev/tools/pub/automated-publishing#hardening-security-with-github-deployment-environments)