### PR TITLE
allow the 3.2.x SDK in build_web_compilers

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.4
+
+- Allow version 3.2.x of the Dart SDK.
+
 ## 5.0.3
 
 - Allow the latest analyzer (6.x.x).

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,12 +1,12 @@
 name: build_modules
-version: 5.0.3
+version: 5.0.4
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.
 repository: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: '>=3.0.0 <3.2.0'
+  sdk: '>=3.0.0 <3.3.0'
 
 dependencies:
   analyzer: '>=5.1.0 <7.0.0'

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.5
+
+- Allow version 3.2.x of the Dart SDK.
+
 ## 4.0.4
 
 - Allow the latest analyzer (6.x.x).

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_web_compilers
-version: 4.0.4
+version: 4.0.5
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: '>=3.0.0 <3.2.0'
+  sdk: '>=3.0.0 <3.3.0'
 
 dependencies:
   analyzer: '>=5.1.0 <7.0.0'


### PR DESCRIPTION
This will fix the webdev tests in the SDK