### PR TITLE
fix broken link in build_runner readme

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.7-dev
+
+- Fix broken link in README.md.
+
 ## 2.4.6
 
 - Allow the latest analyzer (6.x.x).

--- a/build_runner/README.md
+++ b/build_runner/README.md
@@ -86,7 +86,7 @@ All the above commands support the following arguments:
   logged. By default this is false.
 - `--build-filter`: Build filters allow you to choose explicitly which files to
   build instead of building entire directories. See further documentation on
-  this feature [here](#partial_builds).
+  this feature [here][partial_builds].
 
 Some commands also have additional options:
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.6
+version: 2.4.7-dev
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
Pointed out in https://github.com/dart-lang/build/commit/c88db16df8eab435a0ee74ecba65c39beda0a9e1#r122710065