### PR TITLE
add better error message when the package config is out of date

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 7.2.11-dev
 
+- Add better error messages for incomplete package configs when creating a
+  package graph.
+
 ## 7.2.10
 
 - Fix build script invalidation check for custom build scripts from other


### PR DESCRIPTION
See https://github.com/dart-lang/build/issues/3550 - previously we would just assert that all dependencies of all packages were in the package config. This will give a better error, indicating which dependency (and of which package) is missing, as well as suggesting that you fetch dependencies.