### PR TITLE
Experimental: Compute and cache transitive digests as files in build_resolvers

### DIFF
--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -9,6 +9,7 @@ dev_dependencies:
   build: any
   build_config: any
   build_modules: any
+  build_resolvers: any
   build_runner: any
   build_runner_core: any
   build_test: any

--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -7,9 +7,10 @@ import 'package:build_test/builder.dart' as _i4;
 import 'package:build_config/build_config.dart' as _i5;
 import 'package:build_modules/builders.dart' as _i6;
 import 'package:build/build.dart' as _i7;
-import 'dart:isolate' as _i8;
-import 'package:build_runner/build_runner.dart' as _i9;
-import 'dart:io' as _i10;
+import 'package:build_resolvers/builder.dart' as _i8;
+import 'dart:isolate' as _i9;
+import 'package:build_runner/build_runner.dart' as _i10;
+import 'dart:io' as _i11;
 
 final _builders = <_i1.BuilderApplication>[
   _i1.apply(
@@ -129,6 +130,13 @@ final _builders = <_i1.BuilderApplication>[
         const _i7.BuilderOptions(<String, dynamic>{r'compiler': r'dart2js'}),
     appliesBuilders: const [r'build_web_compilers:dart2js_archive_extractor'],
   ),
+  _i1.apply(
+    r'build_resolvers:transitive_digests',
+    [_i8.transitiveDigestsBuilder],
+    _i1.toAllPackages(),
+    isOptional: true,
+    hideOutput: true,
+  ),
   _i1.applyPostProcess(
     r'build_modules:module_cleanup',
     _i6.moduleCleanup,
@@ -152,12 +160,12 @@ final _builders = <_i1.BuilderApplication>[
 ];
 void main(
   List<String> args, [
-  _i8.SendPort? sendPort,
+  _i9.SendPort? sendPort,
 ]) async {
-  var result = await _i9.run(
+  var result = await _i10.run(
     args,
     _builders,
   );
   sendPort?.send(result);
-  _i10.exitCode = result;
+  _i11.exitCode = result;
 }

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.0
+
+- Improve performance for resolves by adding a builder which serializes
+  transitive digests to disk.
+
 ## 2.2.1
 
 - Allow the latest analyzer (6.x.x).

--- a/build_resolvers/build.yaml
+++ b/build_resolvers/build.yaml
@@ -1,0 +1,12 @@
+builders:
+  transitive_digests:
+    import: "package:build_resolvers/builder.dart"
+    builder_factories:
+      - transitiveDigestsBuilder
+    build_extensions:
+      .dart:
+        - .dart.transitive_digests
+    auto_apply: all_packages
+    is_optional: True
+    required_inputs: [".dart"]
+    build_to: cache

--- a/build_resolvers/build.yaml
+++ b/build_resolvers/build.yaml
@@ -5,7 +5,7 @@ builders:
       - transitiveDigestsBuilder
     build_extensions:
       .dart:
-        - .dart.transitive_digests
+        - .dart.transitive_digest
     auto_apply: all_packages
     is_optional: True
     required_inputs: [".dart"]

--- a/build_resolvers/lib/builder.dart
+++ b/build_resolvers/lib/builder.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:build/build.dart';
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'src/build_asset_uri_resolver.dart';
+
+Builder transitiveDigestsBuilder(_) => _TransitiveDigestsBuilder();
+
+class _TransitiveDigestsBuilder extends Builder {
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    final seen = <AssetId>{buildStep.inputId};
+    final queue = Queue<AssetId>.from(seen);
+    final digestSink = AccumulatorSink<Digest>();
+    final byteSink = md5.startChunkedConversion(digestSink);
+    while (queue.isNotEmpty) {
+      final next = queue.removeLast();
+      final transitiveDigestId = next.addExtension(transitiveDigestExtension);
+      if (await buildStep.canRead(transitiveDigestId)) {
+        byteSink.add(await buildStep.readAsBytes(transitiveDigestId));
+        continue;
+      }
+      byteSink.add(await buildStep.readAsBytes(next));
+      final deps = parseDependencies(await buildStep.readAsString(next), next);
+      for (final dep in deps) {
+        if (!seen.add(dep)) continue;
+        queue.add(dep);
+      }
+    }
+    byteSink.close();
+    final digest = digestSink.events.single;
+    await buildStep.writeAsBytes(
+        buildStep.inputId.addExtension(transitiveDigestExtension),
+        digest.bytes);
+  }
+
+  @override
+  Map<String, List<String>> get buildExtensions => const {
+        '.dart': ['.dart$transitiveDigestExtension'],
+      };
+}
+
+const transitiveDigestExtension = '.transitive_digest';

--- a/build_resolvers/lib/builder.dart
+++ b/build_resolvers/lib/builder.dart
@@ -1,12 +1,23 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:build/build.dart';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
+
 import 'src/build_asset_uri_resolver.dart';
 
 Builder transitiveDigestsBuilder(_) => _TransitiveDigestsBuilder();
 
+/// Computes a digest comprised of the current libraries digest as well as its
+/// transitive dependency digests, and writes it to a file next to the library.
+///
+/// For any dependency that has a transitive digest already written, we just use
+/// that and don't crawl its transitive deps, as the transitive digest includes
+/// all the information we need.
 class _TransitiveDigestsBuilder extends Builder {
   @override
   Future<void> build(BuildStep buildStep) async {
@@ -14,26 +25,33 @@ class _TransitiveDigestsBuilder extends Builder {
     final queue = [...seen];
     final digestSink = AccumulatorSink<Digest>();
     final byteSink = md5.startChunkedConversion(digestSink);
+
+    /// This gives us access to the resolvers cache of library dependencies,
+    /// which helps us to avoid duplicate parsing of libraries.
     final dependenciesOf = await buildStep.fetchResource(dependenciesResource);
 
     while (queue.isNotEmpty) {
       final next = queue.removeLast();
 
-      // If we have a transitive digest ID available, just add that digest.
+      // If we have a transitive digest ID available, just add that digest and
+      // continue.
       final transitiveDigestId = next.addExtension(transitiveDigestExtension);
       if (await buildStep.canRead(transitiveDigestId)) {
         byteSink.add(await buildStep.readAsBytes(transitiveDigestId));
         continue;
       }
+
+      // Otherwise, add its digest and queue all its dependencies to crawl.
       byteSink.add((await buildStep.digest(next)).bytes);
       final deps = await dependenciesOf(next, buildStep);
       if (deps == null) {
         throw StateError(
-            'Unable to read asset: $next, could not compute transitive deps');
+            'Unable to read asset, could not compute transitive deps: $next');
       }
+
+      // Add all previously unseen deps to the queue.
       for (final dep in deps) {
-        if (!seen.add(dep)) continue;
-        queue.add(dep);
+        if (seen.add(dep)) queue.add(dep);
       }
     }
     byteSink.close();
@@ -47,5 +65,3 @@ class _TransitiveDigestsBuilder extends Builder {
         '.dart': ['.dart$transitiveDigestExtension'],
       };
 }
-
-const transitiveDigestExtension = '.transitive_digest';

--- a/build_resolvers/lib/builder.dart
+++ b/build_resolvers/lib/builder.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
 
 import 'package:build/build.dart';
 import 'package:convert/convert.dart';
@@ -12,31 +11,35 @@ class _TransitiveDigestsBuilder extends Builder {
   @override
   Future<void> build(BuildStep buildStep) async {
     final seen = <AssetId>{buildStep.inputId};
-    final queue = Queue<AssetId>.from(seen);
+    final queue = [...seen];
     final digestSink = AccumulatorSink<Digest>();
     final byteSink = md5.startChunkedConversion(digestSink);
+    final dependenciesOf = await buildStep.fetchResource(dependenciesResource);
+
     while (queue.isNotEmpty) {
       final next = queue.removeLast();
 
       // If we have a transitive digest ID available, just add that digest.
       final transitiveDigestId = next.addExtension(transitiveDigestExtension);
       if (await buildStep.canRead(transitiveDigestId)) {
-        byteSink.add((await buildStep.digest(transitiveDigestId)).bytes);
+        byteSink.add(await buildStep.readAsBytes(transitiveDigestId));
         continue;
       }
       byteSink.add((await buildStep.digest(next)).bytes);
-      final deps = await (await buildStep.fetchResource(depsResource))
-          .readDeps(buildStep, next);
+      final deps = await dependenciesOf(next, buildStep);
+      if (deps == null) {
+        throw StateError(
+            'Unable to read asset: $next, could not compute transitive deps');
+      }
       for (final dep in deps) {
         if (!seen.add(dep)) continue;
         queue.add(dep);
       }
     }
     byteSink.close();
-    final digest = digestSink.events.single;
     await buildStep.writeAsBytes(
         buildStep.inputId.addExtension(transitiveDigestExtension),
-        digest.bytes);
+        digestSink.events.single.bytes);
   }
 
   @override
@@ -46,15 +49,3 @@ class _TransitiveDigestsBuilder extends Builder {
 }
 
 const transitiveDigestExtension = '.transitive_digest';
-
-final depsResource = Resource<_ParsedDepsCache>(_ParsedDepsCache.new,
-    dispose: (cache) => cache._cachedDeps.clear());
-
-class _ParsedDepsCache {
-  final _cachedDeps = <AssetId, Set<AssetId>>{};
-
-  Future<Set<AssetId>> readDeps(BuildStep buildStep, AssetId id) async {
-    return _cachedDeps[id] ??=
-        parseDependencies(await buildStep.readAsString(id), id);
-  }
-}

--- a/build_resolvers/lib/builder.dart
+++ b/build_resolvers/lib/builder.dart
@@ -45,8 +45,13 @@ class _TransitiveDigestsBuilder extends Builder {
       byteSink.add((await buildStep.digest(next)).bytes);
       final deps = await dependenciesOf(next, buildStep);
       if (deps == null) {
-        throw StateError(
-            'Unable to read asset, could not compute transitive deps: $next');
+        // We warn here but do not fail, the downside is slower builds.
+        log.warning('''
+Unable to read asset, could not compute transitive deps: $next
+
+This may cause less efficient builds, see the following doc for help:
+https://github.com/dart-lang/build/blob/master/docs/faq.md#unable-to-read-asset-could-not-compute-transitive-deps''');
+        return;
       }
 
       // Add all previously unseen deps to the queue.

--- a/build_resolvers/lib/builder.dart
+++ b/build_resolvers/lib/builder.dart
@@ -26,10 +26,6 @@ class _TransitiveDigestsBuilder extends Builder {
     final digestSink = AccumulatorSink<Digest>();
     final byteSink = md5.startChunkedConversion(digestSink);
 
-    /// This gives us access to the resolvers cache of library dependencies,
-    /// which helps us to avoid duplicate parsing of libraries.
-    final dependenciesOf = await buildStep.fetchResource(dependenciesResource);
-
     while (queue.isNotEmpty) {
       final next = queue.removeLast();
 

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -147,7 +147,6 @@ class PerActionResolver implements ReleasableResolver {
 
   @override
   void release() {
-    _delegate._uriResolver.notifyComplete(_step);
     _delegate.release();
   }
 
@@ -397,7 +396,7 @@ class AnalyzerResolvers implements Resolvers {
   Future<void> _ensureInitialized() {
     return Result.release(_initialized ??= Result.capture(() async {
       _warnOnLanguageVersionMismatch();
-      final uriResolver = _uriResolver = BuildAssetUriResolver();
+      final uriResolver = _uriResolver = BuildAssetUriResolver.instance;
       final loadedConfig = _packageConfig ??=
           await loadPackageConfigUri((await Isolate.packageConfig)!);
       var driver = await analysisDriver(uriResolver, _analysisOptions,

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -147,6 +147,7 @@ class PerActionResolver implements ReleasableResolver {
 
   @override
   void release() {
+    _delegate._uriResolver.notifyComplete(_step);
     _delegate.release();
   }
 

--- a/build_resolvers/lib/src/shared_resource_pool.dart
+++ b/build_resolvers/lib/src/shared_resource_pool.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'package:pool/pool.dart';
+
+/// A single resource pool which supports an extra [withSharedResource]
+/// method for concurrent shared access to the resource.
+///
+/// Useful for read/write operations.
+class SharedResourcePool extends Pool {
+  Future<PoolResource>? __sharedResource;
+  Future<PoolResource>? get _sharedResource => __sharedResource;
+  set _sharedResource(Future<PoolResource>? resource) {
+    if (resource == null && _sharedResourceCount != 0) {
+      throw StateError('Shared resource was released but still has references');
+    } else if (resource != null && _sharedResourceCount != 1) {
+      throw StateError(
+          'Attempted to create a new shared resource but there are already '
+          '${_sharedResourceCount - 1} references (expected 0).');
+    }
+    __sharedResource = resource;
+  }
+
+  int _sharedResourceCount = 0;
+
+  SharedResourcePool() : super(1);
+
+  /// Any number of entities can access the same shared resource.
+  ///
+  /// Note that this can starve calls to `withResource` as the shared resource
+  /// will not be released until there are no more references to it, and there
+  /// is no limit on the number of concurrent or total references.
+  Future<T> withSharedResource<T>(FutureOr<T> Function() callback) async {
+    if (isClosed) {
+      throw StateError(
+          'withSharedResource() may not be called on a closed Pool.');
+    }
+    _sharedResourceCount++;
+    _sharedResource ??= request();
+    var resource = await _sharedResource!;
+
+    try {
+      return await callback();
+    } finally {
+      _sharedResourceCount--;
+      if (_sharedResourceCount == 0) {
+        resource.release();
+        _sharedResource = null;
+      }
+    }
+  }
+}

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   async: ^2.5.0
   build: ^2.0.0
   collection: ^1.17.0
+  convert: ^3.1.1
   crypto: ^3.0.0
   graphs: '>=1.0.0 <3.0.0'
   logging: ^1.0.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.2.1
+version: 2.3.0
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -368,3 +368,30 @@ global_options:
     runs_before:
       - some_other_package:some_other_builder
 ```
+
+## Unable to read asset, could not compute transitive deps
+
+If you see this error, it means that we tried to compute the transitive
+dependencies of a library, but some of those dependencies did not (yet) exist.
+
+Typically this would be caused by having multiple `target` definitions in your
+`build.yaml` file, but not setting up the proper `dependencies` between them.
+
+For example, lets say you have 2 targets "a" and "b". Target "b" does some code
+generation, and target "a" imports some of those generate files. You will need
+to add a dependency on the "b" target from the "a" target like so:
+
+```yaml
+targets:
+  a:
+    sources:
+      - lib/a.dart
+    dependencies:
+      - :b
+  b:
+    sources:
+      - lib/b.dart // Assume some builder generates lib/b.g.dart in this target.
+```
+
+If you are still having problems, you can file an issue on this repo and ask for
+help.


### PR DESCRIPTION
Spawned from discussion [here](https://github.com/dart-lang/build/issues/3555#issuecomment-1671572726).

- Adds a builder in build_resolvers which emits a file containing the transitive digest of the library and all its imports.
  - When computing the transitive digest, we always first look for transitive digest files next to all of our immediate library deps, if they exist we merge that file into our digest and don't crawl any deeper.
    - If we can't read any transitive dependency for some reason we emit a warning and just give up in the builder, which means we will never emit a transitive digest file for that library (which is fine, just not optimal).
- The resolver reads these files to establish dependencies - for each library dependency we first check for a transitive digest file, if it exists we just read that and don't crawl that libraries deps. If it doesn't exist then we do the old behavior.
  - There is actually an additional step here that will continue the recursive crawl for libraries that have not yet been seen in order to load them into the resource provider for the analyzer.
- I also exposed a shared resource to avoid duplicate parsing of libraries between the resolver itself and the transitive digest builder. We might eventually want to migrate this to a builder as well, and serialize that information to disk instead, which would avoid some unnecessary re-parsing of libraries on rebuilds.