### PR TITLE
Avoid passing a nullable value to Future<nn-type>.value

### DIFF
--- a/build_test/lib/src/written_asset_reader.dart
+++ b/build_test/lib/src/written_asset_reader.dart
@@ -51,7 +51,7 @@ class WrittenAssetReader extends MultiPackageAssetReader {
     if (!source.assets.containsKey(id)) {
       throw AssetNotFoundException(id);
     }
-    return Future.value(source.assets[id]);
+    return Future.value(source.assets[id]!);
   }
 
   @override


### PR DESCRIPTION
This is cleanup work required to start enforcing this with static analysis, as per https://github.com/dart-lang/sdk/issues/53253.

Real quick this issue is that this code is unsafe:

```dart
void f(Completer<int> c, int? i) {
  Future<int>.value(i); // Ouch!
  c.complete(i);        // Ouch!
}
```

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
