### PR TITLE
fix broken link in readme

### DIFF
--- a/build_runner/README.md
+++ b/build_runner/README.md
@@ -226,7 +226,7 @@ $ dart run test
 
 [Bazel]: https://bazel.build/
 [`package:build`]: https://pub.dev/packages/build
-[analysis_options]: https://github.com/dart-lang/build/blob/master/analysis_options.yaml
+[analysis_options]: https://github.com/dart-lang/build/blob/master/analysis/analysis_options.yaml
 
 [builder]: https://pub.dev/documentation/build/latest/build/Builder-class.html
 [run_fn]: https://pub.dev/documentation/build_runner/latest/build_runner/run.html

--- a/docs/transforming_code.md
+++ b/docs/transforming_code.md
@@ -1,11 +1,9 @@
 # Transforming code with `build` and `build_runner`
 
-Unlike the [old `barback` and `pub`][pub] asset systems, it's not permitted to
+Unlike the old `barback` and `pub` asset systems, it's not permitted to
 overwrite or otherwise transform existing on-disk files as part of the build
 process, and our newer build tools and packages will throw exceptions if this is
 attempted.
-
-[pub]: https://dart.dev/tools/pub/obsolete
 
 ## Examples
 


### PR DESCRIPTION
I am trying to see if we can re-enable the markdown checker as well (I just re-enabled the workflow).

Fixes https://github.com/dart-lang/build/issues/3343