### PR TITLE
Skip delete for SDK summary and deps file

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.3.2
+
+- Skip file delete for SDK summary and deps file. This will only impact behavior
+  for usage in `build_test` where there may be multiple resolvers used
+  concurrently.
+
 ## 2.3.1
 
 - Fix a bug in the transitive digest builder, ensure we check if assets are

--- a/build_resolvers/lib/src/sdk_summary.dart
+++ b/build_resolvers/lib/src/sdk_summary.dart
@@ -53,19 +53,12 @@ Future<String> defaultSdkSummaryGenerator() async {
       package: await packagePath(package),
   };
 
-  // Invalidate existing summary/version/analyzer files if present.
-  if (await depsFile.exists()) {
-    if (!await _checkDeps(depsFile, currentDeps)) {
-      await depsFile.delete();
-      if (await summaryFile.exists()) await summaryFile.delete();
-    }
-  } else if (await summaryFile.exists()) {
-    // Fallback for cases where we could not do a proper version check.
-    await summaryFile.delete();
-  }
+  final needsRebuild = !await summaryFile.exists() ||
+      !await depsFile.exists() ||
+      !await _checkDeps(depsFile, currentDeps);
 
   // Generate the summary and version files if necessary.
-  if (!await summaryFile.exists()) {
+  if (needsRebuild) {
     var watch = Stopwatch()..start();
     _logger.info('Generating SDK summary...');
     await summaryFile.create(recursive: true);

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.3.1
+version: 2.3.2
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 


### PR DESCRIPTION
Fixes #2995

When the summary file is determined to be invalid, regenerate it and
overwrite it without deleting. This resolves a race condition where
multiple resolvers could try to delete the same file. The invalid
content will not be read, because we will regenerate the file before
moving on to the rest of the build.
