### PR TITLE
Notify the analyzer of deleted files

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.1-wip
+
+- Fix an issue where deleted files were not removed from the analysis engine,
+  and were still accessible via the analyzer apis.
+
 ## 2.4.0
 
 - Deprecate the unnamed `AnalyzerResolvers` constructor, an replace it with the

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -137,6 +137,7 @@ class BuildAssetUriResolver extends UriResolver {
       _cachedAssetDigests.remove(id);
       if (resourceProvider.getFile(path).exists) {
         resourceProvider.deleteFile(path);
+        _needsChangeFile.add(path);
       }
       return _AssetState(path, const {});
     }

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.4.0
+version: 2.4.1-wip
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -297,6 +297,52 @@ void main() {
       }, resolvers: resolvers);
     });
 
+    test('handles removing deleted missing parts', () async {
+      var resolvers = AnalyzerResolvers();
+      await resolveSources({
+        'a|web/main.dart': '''
+              part 'main.g.dart';
+
+              class A implements B {}
+              ''',
+        'a|web/main.g.dart': '''
+              part of 'main.dart';
+              class B {}
+              ''',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var clazz = lib.getClass('A');
+        expect(clazz, isNotNull);
+        expect(clazz!.interfaces, hasLength(1));
+        expect(clazz.interfaces.first.getDisplayString(withNullability: false),
+            'B');
+      }, resolvers: resolvers);
+
+      // `resolveSources` actually completes prior to the build step being
+      // done, which causes this `reset` call to fail. After a few microtasks
+      // it succeeds though.
+      var tries = 0;
+      while (tries++ < 5) {
+        await Future.value(null);
+        try {
+          resolvers.reset();
+        } catch (_) {}
+      }
+
+      await resolveSources({
+        'a|web/main.dart': '''
+              part 'main.g.dart';
+
+              class A implements B {}
+              ''',
+      }, (resolver) async {
+        var lib = await resolver.libraryFor(entryPoint);
+        var clazz = lib.getClass('A');
+        expect(clazz, isNotNull);
+        expect(clazz!.interfaces, isEmpty);
+      }, resolvers: resolvers);
+    });
+
     test('should list all libraries', () {
       return resolveSources({
         'a|web/main.dart': '''


### PR DESCRIPTION
Related to https://github.com/dart-lang/source_gen/issues/682.

Deleted files were never getting a `changeFile` call and so they were still available in the analyzer. This exposed in particular old generated part files to subsequent builds which could cause weird errors.