### PR TITLE
Always log stack traces for Error objects

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.4.7-wip
 
+- Print stack traces for `Error` subtype exceptions in non-verbose mode.
 - Fix broken link in README.md.
 - Bump the min sdk to 3.0.0.
 

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -33,7 +33,7 @@ StringBuffer colorLog(LogRecord record, {required bool verbose}) {
     lines.add(record.error!);
   }
 
-  if (record.stackTrace != null && verbose) {
+  if (record.stackTrace != null && (verbose || record.error is Error)) {
     var trace = Trace.from(record.stackTrace!);
     const buildSystem = {'build_runner', 'build_runner_core', 'build'};
     if (trace.frames.isNotEmpty &&


### PR DESCRIPTION
Closes #3585

The default logging omits stack traces by default and prints them only
in verbose mode. This is intended to allow builder implementations to
cease execution and log a user friendly message by throwing a single
`Exception` with a custom `toString()`. When a builder or utility
library has an implementation bug leading to an `Error` the stack trace
is much more likely to be useful information for debugging, and worth
including by default.
