### PR TITLE
Question: how to configure `build.yaml` to "disable" provided/inherited builder?

### DIFF
--- a/_test/build.yaml
+++ b/_test/build.yaml
@@ -11,3 +11,9 @@ targets:
           - test/hello_world_custom_html_test.dart.browser_test.dart
           - test/other_test.dart.browser_test.dart
           - test/sub-dir/subdir_test.dart.browser_test.dart
+      # HELP: the settings below won't have any effect on the builders applied in `build.dart`
+      provides_builder|not_enabled_builder:
+        enabled: false
+      # HELP: Only when adding (even an empty) `other_builder.build.yaml` file, the builder won't show up in `build.dart`
+      other_builder|other_builder:
+        enabled: false

--- a/_test/other_builder.build.yaml
+++ b/_test/other_builder.build.yaml
@@ -1,0 +1,5 @@
+#---
+## disable all inherited "provides_builder" builders...
+#targets:
+#  $default:
+#    auto_apply_builders: false

--- a/_test/pkgs/other_builder/build.yaml
+++ b/_test/pkgs/other_builder/build.yaml
@@ -1,0 +1,5 @@
+builders:
+  other_builder:
+    import: "package:provides_builder/builders.dart"
+    builder_factories: ["someBuilder"]
+    build_extensions: {".dart": [".something.dart"]}

--- a/_test/pkgs/other_builder/lib/builders.dart
+++ b/_test/pkgs/other_builder/lib/builders.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+
+class _SomeBuilder implements Builder {
+  const _SomeBuilder();
+
+  factory _SomeBuilder.fromOptions(BuilderOptions options) {
+    if (options.config['throw_in_constructor'] == true) {
+      throw StateError('Throwing on purpose cause you asked for it!');
+    }
+    return const _SomeBuilder();
+  }
+
+  @override
+  final buildExtensions = const {
+    '.dart': ['.something.dart']
+  };
+
+  @override
+  Future build(BuildStep buildStep) async {
+    if (!await buildStep.canRead(buildStep.inputId)) return;
+
+    await buildStep.writeAsBytes(
+        buildStep.inputId.changeExtension('.something.dart'),
+        buildStep.readAsBytes(buildStep.inputId));
+  }
+}
+
+
+Builder otherBuilder(BuilderOptions options) =>
+    _SomeBuilder.fromOptions(options);

--- a/_test/pkgs/other_builder/pubspec.yaml
+++ b/_test/pkgs/other_builder/pubspec.yaml
@@ -1,0 +1,10 @@
+name: other_builder
+
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  build:
+    path: ../../../build
+  provides_builder:
+    path: ../provides_builder

--- a/_test/pkgs/provides_builder/build.yaml
+++ b/_test/pkgs/provides_builder/build.yaml
@@ -15,6 +15,10 @@ builders:
     builder_factories: ["throwingBuilder"]
     build_extensions: {".fail": [".fail.message"]}
     auto_apply: dependents
+  not_enabled_builder:
+    import: "package:provides_builder/builders.dart"
+    builder_factories: [ "notEnabledBuilder" ]
+    build_extensions: { ".not.enabled": [ ".not.enabled.message" ] }
 post_process_builders:
   some_post_process_builder:
     target: "provides_builder"

--- a/_test/pkgs/provides_builder/lib/builders.dart
+++ b/_test/pkgs/provides_builder/lib/builders.dart
@@ -66,3 +66,5 @@ Builder notApplied(BuilderOptions options) => _SomeBuilder.fromOptions(options);
 PostProcessBuilder somePostProcessBuilder(BuilderOptions options) =>
     _SomePostProcessBuilder.fromOptions(options);
 Builder throwingBuilder(_) => _ThrowingBuilder();
+Builder notEnabledBuilder(BuilderOptions options) =>
+    _SomeBuilder.fromOptions(options);

--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -16,6 +16,8 @@ dev_dependencies:
   build_web_compilers: any
   dart_flutter_team_lints: ^2.0.0
   io: ^1.0.0
+  other_builder:
+    path: pkgs/other_builder/
   path: ^1.8.0
   provides_builder:
     path: pkgs/provides_builder/

--- a/_test/test/generated_script_integration_test.dart
+++ b/_test/test/generated_script_integration_test.dart
@@ -14,6 +14,7 @@ void main() {
     await runCommand(['generate-build-script']);
   });
 
+  // TODO: this test fails, because the "not_enabled_builder" still shows up...
   test('Generates a build script matching the golden', () {
     var generatedScript =
         File('.dart_tool/build/entrypoint/build.dart').readAsStringSync();
@@ -22,4 +23,17 @@ void main() {
         .replaceAll('\r', '');
     expect(generatedScript, expected);
   });
+
+
+  /// Nog een ander probleem:
+  ///  of zo lijkt toch:
+  ///   - er worden té veel builders binnengepakt obv dependencies...
+  ///   - maar nu: both scorekeeper_codege:serializer_generator and scorekeeper_codege:serializer_generator may output lib/proto.config.json
+  ///
+  /// ik DENK dat het probleem als volgt is:
+  ///  - scorekeeper_example_domain wordt in tests / dev_dependencies van scorekeeper_codegen binnengetrokken
+  ///  - scorekeeper_example_domain is ook een dependency van ????
+  ///   -> kan ik dependency tree opzoeken van een dart project?
+
+
 }


### PR DESCRIPTION
I'm using this PR as a way to ask a question, but it might result in some extra addition to the golden test to show this functionality (if it actually exists).

So, my question is this: given the extra `not_enabled_builder`, is there a way to have it **not** show up in the resulting `build.dart` file?

The test that's failing now, is `generated_script_integration_test.dart`.

I've been trying various things to keep this builder from ending in the `build.dart` file, but to no avail so far.

One thing that helps a little, is the addition of `provides_builder.build.yaml` with the following contents:

```yaml
---
# disable all inherited builders...
targets:
  $default:
    auto_apply_builders: false
```

The only problem is that it will omit all builders from the `provides_builder` package.

Is there a way to disable a builder in such a granulary way?