### PR TITLE
use base64 encoded md5 hash of working dir to build the unique workspace dir

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 4.0.1-wip
+## 4.0.1
 
+- Use a hash of the working dir to create the unique workspace dir. This
+  resolves an issue when file names become too long.
 - Bump the min sdk to 3.0.0.
 
 ## 4.0.0

--- a/build_daemon/lib/constants.dart
+++ b/build_daemon/lib/constants.dart
@@ -2,8 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
 
 const readyToConnectLog = 'READY TO CONNECT';
@@ -42,10 +44,9 @@ var _username = Platform.environment['USER'] ?? '';
 String daemonWorkspace(String workingDirectory) {
   var segments = [Directory.systemTemp.path];
   if (_username.isNotEmpty) segments.add(_username);
-  segments.add(workingDirectory
-      .replaceAll('/', '_')
-      .replaceAll(':', '_')
-      .replaceAll('\\', '_'));
+  final workingDirHash =
+      base64Encode(md5.convert(workingDirectory.codeUnits).bytes);
+  segments.add(workingDirHash);
   return p.joinAll(segments);
 }
 

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version:  4.0.1-wip
+version:  4.0.1
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   built_collection: ^5.0.0
   built_value: ^8.1.0
+  crypto: ^3.0.3
   http_multi_server: ^3.0.0
   logging: ^1.0.0
   path: ^1.8.0


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/3607

@Parsaloi you could try this out if you would like by adding the following to your pubspec.yaml:

```yaml
dependency_overrides:
  build_daemon:
    git:
      url: https://github.com/dart-lang/build.git
      ref: shorter-file-names
      path: build_daemon
```