### PR TITLE
use base64UrlEncode instead of base64Encode

### DIFF
--- a/build_daemon/lib/constants.dart
+++ b/build_daemon/lib/constants.dart
@@ -45,7 +45,7 @@ String daemonWorkspace(String workingDirectory) {
   var segments = [Directory.systemTemp.path];
   if (_username.isNotEmpty) segments.add(_username);
   final workingDirHash =
-      base64Encode(md5.convert(workingDirectory.codeUnits).bytes);
+      base64UrlEncode(md5.convert(workingDirectory.codeUnits).bytes);
   segments.add(workingDirHash);
   return p.joinAll(segments);
 }


### PR DESCRIPTION
Otherwise we can get invalid directory names (see https://github.com/dart-lang/build/actions/runs/6804218228/job/18501303266)