### PR TITLE
add a warning if a build.yml file is found in the doctor command

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 2.4.7-wip
+## 2.4.7
 
 - Fix broken link in README.md.
 - Bump the min sdk to 3.0.0.
+- Add a warning to the `doctor` command if a `build.yml` file is found (instead
+  of a `build.yaml` file).
 
 ## 2.4.6
 

--- a/build_runner/lib/src/entrypoint/doctor.dart
+++ b/build_runner/lib/src/entrypoint/doctor.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
@@ -11,6 +12,7 @@ import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/generate/phase.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 
 import '../logging/std_io_logging.dart';
 import '../package_graph/build_config_overrides.dart';
@@ -38,6 +40,14 @@ class DoctorCommand extends BuildRunnerCommand {
     for (final builderApplication in builderApplications) {
       final builderOk = _checkBuildExtensions(builderApplication, config);
       isOk = isOk && builderOk;
+    }
+
+    if (File(p.join(p.current, 'build.yml')).existsSync() &&
+        !File(p.join(p.current, 'build.yaml')).existsSync()) {
+      logger.warning(
+          'Found a `build.yml` file but no `build.yaml` file, rename it with '
+          'the `.yaml` extension for it to take effect.');
+      isOk = false;
     }
 
     if (isOk) {

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.7-wip
+version: 2.4.7
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/build/issues/3615

Note that this would only give the warning if running the `doctor` command, which people may not be in the habit of running, but is typically where we put these kinds of diagnostics.

@schaipipat out of curiosity were you aware of the doctor command? Would this have helped you or not?