### PR TITLE
Stop depending on analyzer support for Dart <2.12.

### DIFF
--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -125,10 +125,10 @@ void main() {
     group('language versioning', () {
       test('gives a correct languageVersion based on comments', () async {
         await resolveSources({
-          'a|web/main.dart': '// @dart=2.1\n\nmain() {}',
+          'a|web/main.dart': '// @dart=3.1\n\nmain() {}',
         }, (resolver) async {
           var lib = await resolver.libraryFor(entryPoint);
-          expect(lib.languageVersion.effective.major, 2);
+          expect(lib.languageVersion.effective.major, 3);
           expect(lib.languageVersion.effective.minor, 1);
         }, resolvers: AnalyzerResolvers());
       });


### PR DESCRIPTION
It doesn't matter which Dart language version is used by the test `gives a correct languageVersion based on comments`, since all the test is doing is confirming that the language version is properly reflected in the return value of `resolver.libraryFor`. Previously the test used language version 2.1; it now uses language version 3.1.

This helps unblock removal of legacy (pre-null-safety) support from the Dart analyzer.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
