### PR TITLE
Fix json serializable annotation for ignored field

### DIFF
--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -52,7 +52,7 @@ class BuildConfig {
     }
   }
 
-  @JsonKey(includeFromJson: true, includeToJson: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   final String packageName;
 
   /// All the `builders` defined in a `build.yaml` file.


### PR DESCRIPTION
The annotation was last changed in
https://github.com/dart-lang/build/pull/3445

The intention of the change was to retain behavior of passing the
deprecated option `ignore: true`. The replacement is to use two fields
`includeToJson` and `includeFromJson` which allow more fine-grained
configuration, but also invert the condition. The boolean must be
`false` to retain old behavior.

Before this change rerunning code generation would result in a change to
`build_config.g.gdart`. After this change the build is a no-op.
