### PR TITLE
[WIP] Add macro e2e test

### DIFF
--- a/_test/analysis_options.yaml
+++ b/_test/analysis_options.yaml
@@ -1,1 +1,4 @@
 include: ../analysis/analysis_options.yaml
+analyzer:
+  enable-experiment:
+    - macros

--- a/_test/build.dart2js.yaml
+++ b/_test/build.dart2js.yaml
@@ -8,6 +8,7 @@ targets:
           - --enable-asserts
         generate_for:
           - web/main.dart
+          - web/macros/main.dart
           - web/sub/main.dart
           - test/configurable_uri_test.dart
           - test/configurable_uri_test.dart.browser_test.dart

--- a/_test/build.post_process.yaml
+++ b/_test/build.post_process.yaml
@@ -7,6 +7,7 @@ targets:
       build_web_compilers:entrypoint:
         generate_for:
           - web/main.dart
+          - web/macros/main.dart
           - web/sub/main.dart
           - test/hello_world_test.dart
           - test/hello_world_test.dart.browser_test.dart

--- a/_test/build.throws.yaml
+++ b/_test/build.throws.yaml
@@ -7,6 +7,7 @@ targets:
       build_web_compilers:entrypoint:
         generate_for:
           - web/main.dart
+          - web/macros/main.dart
           - web/sub/main.dart
           - test/hello_world_test.dart
           - test/hello_world_test.dart.browser_test.dart

--- a/_test/build.yaml
+++ b/_test/build.yaml
@@ -4,6 +4,7 @@ targets:
       build_web_compilers:entrypoint:
         generate_for:
           - web/main.dart
+          - web/macros/main.dart
           - web/sub/main.dart
           - test/configurable_uri_test.dart.browser_test.dart
           - test/hello_world_test.dart.browser_test.dart

--- a/_test/lib/macros/debug_to_string.dart
+++ b/_test/lib/macros/debug_to_string.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:_fe_analyzer_shared/src/macros/api.dart';

--- a/_test/lib/macros/debug_to_string.dart
+++ b/_test/lib/macros/debug_to_string.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+
+import 'package:_fe_analyzer_shared/src/macros/api.dart';
+
+macro class DebugToString implements ClassDeclarationsMacro {
+  const DebugToString();
+
+  @override
+  Future<void> buildDeclarationsForClass(
+      ClassDeclaration clazz, MemberDeclarationBuilder builder) async {
+    final fields = await builder.fieldsOf(clazz);
+    builder.declareInType(DeclarationCode.fromParts([
+      'String debugToString() => """\n${clazz.identifier.name} {\n',
+      for (var field in fields) ...[
+        '  ${field.identifier.name}: \${',
+        field.identifier,
+        '}\n',
+      ],
+      '}""";',
+    ]));
+  }
+}

--- a/_test/lib/macros/debug_to_string.dart
+++ b/_test/lib/macros/debug_to_string.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+// ignore: implementation_imports
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
 macro class DebugToString implements ClassDeclarationsMacro {

--- a/_test/pkgs/provides_builder/build.yaml
+++ b/_test/pkgs/provides_builder/build.yaml
@@ -1,4 +1,9 @@
 builders:
+  has_debug_to_string_builder:
+    import: "package:provides_builder/builders.dart"
+    builder_factories: ["hasDebugToStringBuilder"]
+    build_extensions: {".fail": [".hasDebugToString"]}
+    auto_apply: dependents
   some_builder:
     import: "package:provides_builder/builders.dart"
     builder_factories: ["someBuilder"]

--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -2,9 +2,10 @@ name: _test
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0-0
 
 dev_dependencies:
+  _fe_analyzer_shared: any
   analyzer: any
   build: any
   build_config: any
@@ -23,6 +24,14 @@ dev_dependencies:
   test_process: ^2.0.0
 
 dependency_overrides:
+  _fe_analyzer_shared:
+    path: ../../dart-lang-sdk/sdk/pkg/_fe_analyzer_shared
+  _js_interop_checks:
+    path: ../../dart-lang-sdk/sdk/pkg/_js_interop_checks
+  analyzer:
+    path: ../../dart-lang-sdk/sdk/pkg/analyzer
+  build_integration:
+    path: ../../dart-lang-sdk/sdk/pkg/build_integration
   build:
     path: ../build
   build_config:
@@ -41,5 +50,35 @@ dependency_overrides:
     path: ../build_test
   build_web_compilers:
     path: ../build_web_compilers
+  compiler:
+    path: ../../dart-lang-sdk/sdk/pkg/compiler
+  dart2js_info:
+    path: ../../dart-lang-sdk/sdk/pkg/dart2js_info
+  dart2wasm:
+    path: ../../dart-lang-sdk/sdk/pkg/dart2wasm
+  dev_compiler:
+    path: ../../dart-lang-sdk/sdk/pkg/dev_compiler
+  dart_style:
+    path: ../../dart-lang-sdk/sdk/third_party/pkg/dart_style
+  front_end:
+    path: ../../dart-lang-sdk/sdk/pkg/front_end
+  frontend_server:
+    path: ../../dart-lang-sdk/sdk/pkg/frontend_server
+  js_ast:
+    path: ../../dart-lang-sdk/sdk/pkg/js_ast
+  js_runtime:
+    path: ../../dart-lang-sdk/sdk/pkg/js_runtime
+  js_shared:
+    path: ../../dart-lang-sdk/sdk/pkg/js_shared
+  kernel:
+    path: ../../dart-lang-sdk/sdk/pkg/kernel
+  meta:
+    path: ../../dart-lang-sdk/sdk/pkg/meta
+  mmap:
+    path: ../../dart-lang-sdk/sdk/pkg/mmap
   scratch_space:
     path: ../scratch_space
+  vm:
+    path: ../../dart-lang-sdk/sdk/pkg/vm
+  wasm_builder:
+    path: ../../dart-lang-sdk/sdk/pkg/wasm_builder

--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -4,8 +4,10 @@ publish_to: none
 environment:
   sdk: ^3.3.0-0
 
-dev_dependencies:
+dependencies:
   _fe_analyzer_shared: any
+
+dev_dependencies:
   analyzer: any
   build: any
   build_config: any
@@ -30,14 +32,14 @@ dependency_overrides:
     path: ../../dart-lang-sdk/sdk/pkg/_js_interop_checks
   analyzer:
     path: ../../dart-lang-sdk/sdk/pkg/analyzer
-  build_integration:
-    path: ../../dart-lang-sdk/sdk/pkg/build_integration
   build:
     path: ../build
   build_config:
     path: ../build_config
   build_daemon:
     path: ../build_daemon
+  build_integration:
+    path: ../../dart-lang-sdk/sdk/pkg/build_integration
   build_modules:
     path: ../build_modules
   build_resolvers:
@@ -56,10 +58,10 @@ dependency_overrides:
     path: ../../dart-lang-sdk/sdk/pkg/dart2js_info
   dart2wasm:
     path: ../../dart-lang-sdk/sdk/pkg/dart2wasm
-  dev_compiler:
-    path: ../../dart-lang-sdk/sdk/pkg/dev_compiler
   dart_style:
     path: ../../dart-lang-sdk/sdk/third_party/pkg/dart_style
+  dev_compiler:
+    path: ../../dart-lang-sdk/sdk/pkg/dev_compiler
   front_end:
     path: ../../dart-lang-sdk/sdk/pkg/front_end
   frontend_server:

--- a/_test/test/macro_test.dart
+++ b/_test/test/macro_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:_test/macros/debug_to_string.dart';
+
+void main() {
+  test('macro stuff is generated', () {
+    expect(User('Jill', 25).debugToString(), equals('''
+User {
+  name: Jill
+  age: 25
+}'''));
+  });
+}
+
+@DebugToString()
+class User {
+  final String name;
+  final int age;
+
+  User(this.name, this.age);
+}

--- a/_test/test/macro_test.dart
+++ b/_test/test/macro_test.dart
@@ -2,9 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:_test/macros/debug_to_string.dart';
+
 import 'package:test/test.dart';
 
-import 'package:_test/macros/debug_to_string.dart';
 
 void main() {
   test('macro stuff is generated', () {

--- a/_test/web/macros/index.html
+++ b/_test/web/macros/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>build integration tests - macros</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script defer src="main.dart.js" type="application/javascript"></script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/_test/web/macros/main.dart
+++ b/_test/web/macros/main.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:html';
+
+import 'package:_test/macros/debug_to_string.dart';
+
+void main() {
+  document.body!.text = User('Jill', 25).debugToString();
+}
+
+@DebugToString()
+class User {
+  final String name;
+  final int age;
+
+  User(this.name, this.age);
+}

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -261,7 +261,20 @@ Set<AssetId> _parseDependencies(String content, AssetId from) => HashSet.of(
           .whereType<String>()
           .where((uriContent) =>
               !_ignoredSchemes.any(Uri.parse(uriContent).isScheme))
-          .map((content) => AssetId.resolve(Uri.parse(content), from: from)),
+          .map((content) => AssetId.resolve(Uri.parse(content), from: from))
+          // TODO: Something better here? We assume anything depending on the
+          // macro APIs is a macro, and the bootstrap program we create for
+          // those libraries will require the macro implementations, but there
+          // is no transitive dependency exposed.
+          .followedBy(
+              from == AssetId('_fe_analyzer_shared', 'lib/src/macros/api.dart')
+                  ? [
+                      AssetId('_fe_analyzer_shared',
+                          'lib/src/macros/executor/client.dart'),
+                      AssetId('_fe_analyzer_shared',
+                          'lib/src/macros/executor/serialization.dart'),
+                    ]
+                  : const []),
     );
 
 /// Read the (potentially) cached dependencies of [id] based on parsing the


### PR DESCRIPTION
I am starting to test out macros in build_runner, compiler integrations are known to need work but I am confused by the analyzer stuff in particular here. I did expect it to work correctly (but inefficiently) and be able to run the macros, however they never seem to be applied.

Specifically in this branch, if you run:

- `cd _test`
- `dart pub upgrade`
- `dart run build_runner build --enable-experiment=macros --build-filter=web/macros/main.hasDebugToString`

And then open up `.dart_tool/build/generated/_test/web/macros.hasDebugToString` I would expect to see `true`, indicating the macro had ran. But I get `false`, indicating it never ran. I am not sure the best way to start debugging that?

@scheglov do I need to toggle anything special to enable macros in the analysis context?

cc @davidmorgan 