### PR TITLE
Ignore stack overflow URLs in link checker

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,12 +1,7 @@
 {
-    "httpHeaders": [
+    "ignorePatterns": [
         {
-            "urls": [
-                "https://stackoverflow.com"
-            ],
-            "headers": {
-                "User-Agent": "dart-lang/build Link Checker"
-            }
+            "pattern": "^https://stackoverflow.com"
         }
     ]
 }

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,12 @@
+{
+    "httpHeaders": [
+        {
+            "urls": [
+                "https://stackoverflow.com"
+            ],
+            "headers": {
+                "User-Agent": "dart-lang/build Link Checker"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
We get a 403 (forbidden) for these currently. Just ignore them.

I also tried adding a user agent but that didn't seem to help.