### PR TITLE
Move test skips before the test body

### DIFF
--- a/_test/test/hello_world_test.dart
+++ b/_test/test/hello_world_test.dart
@@ -23,7 +23,7 @@ void main() {
     expect(document.body!.text, contains(message));
   });
 
-  test('failing test', () {
+  test('failing test', skip: 'Expected failure', () {
     expect(true, isFalse);
-  }, skip: 'Expected failure');
+  });
 }

--- a/_test/test/serve_integration_test.dart
+++ b/_test/test/serve_integration_test.dart
@@ -49,9 +49,11 @@ void main() {
           isNot(contains('Hello World!')));
     });
 
-    test('Can run passing tests with --pub-serve', () async {
+    test('Can run passing tests with --pub-serve',
+        skip: 'TODO: Get non-custom html tests passing with pub serve',
+        () async {
       await expectTestsPass(usePrecompiled: false);
-    }, skip: 'TODO: Get non-custom html tests passing with pub serve');
+    });
 
     test('Serves a directory list when it fails to fallback on index.html',
         () async {

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.4.3-wip
+
 ## 2.4.2
 
 - Add a builder to clean up transitive digest files from the build output.

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.4.2
+version: 2.4.3-wip
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -182,7 +182,7 @@ void main() {
       });
 
       test('allows a version of analyzer compatibile with the current sdk',
-          () async {
+          skip: _skipOnPreRelease, () async {
         var originalLevel = Logger.root.level;
         Logger.root.level = Level.WARNING;
         var listener = Logger.root.onRecord.listen((record) {
@@ -197,7 +197,7 @@ void main() {
         }, (resolver) async {
           await resolver.libraryFor(entryPoint);
         }, resolvers: AnalyzerResolvers());
-      }, skip: _skipOnPreRelease);
+      });
     });
 
     group('assets that aren\'t a transitive import of input', () {
@@ -491,7 +491,7 @@ void main() {
       }, resolvers: AnalyzerResolvers());
     });
 
-    test('Respects withEnabledExperiments', () async {
+    test('Respects withEnabledExperiments', skip: _skipOnPreRelease, () async {
       Logger.root.level = Level.ALL;
       Logger.root.onRecord.listen(print);
       await withEnabledExperiments(
@@ -511,7 +511,7 @@ int? get x => 1;
                 expect(errors.errors, isEmpty);
               }, resolvers: AnalyzerResolvers()),
           ['non-nullable']);
-    }, skip: _skipOnPreRelease);
+    });
 
     test('can get a new analysis session after resolving additional assets',
         () async {

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.4.9-wip
+
 ## 2.4.8
 
 - Update README.md to point to the FAQ and other docs.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.8
+version: 2.4.9-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 

--- a/build_runner/test/daemon/daemon_test.dart
+++ b/build_runner/test/daemon/daemon_test.dart
@@ -139,7 +139,8 @@ main() {
       await startDaemon();
     });
 
-    test('shuts down on build script change', () async {
+    test('shuts down on build script change',
+        skip: 'https://github.com/dart-lang/build/issues/3438', () async {
       await startDaemon();
       var client = await startClient()
         ..registerBuildTarget(webTarget)
@@ -154,7 +155,7 @@ main() {
           ])
         ])
       ]).create();
-    }, skip: 'https://github.com/dart-lang/build/issues/3438');
+    });
 
     test('supports --enable-experiment option', () async {
       // TODO: Check for specific message about a bad experiment

--- a/build_runner/test/integration_tests/symlinks_test.dart
+++ b/build_runner/test/integration_tests/symlinks_test.dart
@@ -72,7 +72,9 @@ void main() {
   });
 
   group('serve', () {
-    test('watches a linked file', () async {
+    test('watches a linked file',
+        skip: 'Watcher package does not support watching symlink targets',
+        () async {
       var server = await buildTool.serve();
       await server.nextSuccessfulBuild;
       await expectGeneratedContent('linked');
@@ -80,6 +82,6 @@ void main() {
       await updateLinkContent('new content');
       await server.nextSuccessfulBuild;
       await expectGeneratedContent('new content');
-    }, skip: 'Watcher package does not support watching symlink targets');
+    });
   });
 }


### PR DESCRIPTION
Style improves in many cases when the block structured argument is last.
The skip also is likely to get lost visually when it follows a long test
body, it is metadata that makes sense to put early in the test
definition.
