### PR TITLE
allow the 3.5.x Dart SDK

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.8
+
+- Allow version 3.5.x of the Dart SDK.
+
 ## 5.0.7
 
 - Fixes to support package:js version 0.7.0.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,12 +1,12 @@
 name: build_modules
-version: 5.0.7
+version: 5.0.8
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.
 repository: https://github.com/dart-lang/build/tree/master/build_modules
 
 environment:
-  sdk: '>=3.0.0 <3.5.0'
+  sdk: '>=3.0.0 <3.6.0'
 
 dependencies:
   analyzer: '>=5.1.0 <7.0.0'

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.10
+
+- Allow version 3.5.x of the Dart SDK.
+
 ## 4.0.9
 
 - Support latest version of `package:js`.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_web_compilers
-version: 4.0.9
+version: 4.0.10
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 
 environment:
-  sdk: '>=3.1.0 <3.5.0'
+  sdk: '>=3.1.0 <3.6.0'
 
 dependencies:
   analyzer: '>=5.1.0 <7.0.0'

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -2,6 +2,9 @@
     "ignorePatterns": [
         {
             "pattern": "^https://stackoverflow.com"
+        },
+        {
+            "pattern": "^https://bazel.build"
         }
     ]
 }


### PR DESCRIPTION
- also ignore https://bazel.build links in the markdown checker as it seems to be failing on those now too

cc @sortie 