### PR TITLE
fixes for the latest dev build and latest analyzer

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -29,7 +29,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: stable
       - id: checkout
@@ -54,7 +54,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -84,7 +84,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -157,7 +157,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -196,7 +196,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -226,7 +226,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -351,7 +351,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -381,7 +381,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -441,7 +441,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -480,7 +480,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -519,7 +519,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -558,7 +558,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -597,7 +597,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -636,7 +636,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -675,7 +675,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -714,7 +714,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -753,7 +753,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -792,7 +792,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -831,7 +831,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -870,7 +870,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -909,7 +909,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -948,7 +948,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -987,7 +987,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1026,7 +1026,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -1065,7 +1065,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -1104,7 +1104,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -1143,7 +1143,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -1182,7 +1182,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -1211,7 +1211,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -1240,7 +1240,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -1269,7 +1269,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -1298,7 +1298,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -1327,7 +1327,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -1356,7 +1356,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: "3.4.0"
       - id: checkout
@@ -1385,7 +1385,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1414,7 +1414,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1443,7 +1443,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1472,7 +1472,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1501,7 +1501,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1530,7 +1530,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1559,7 +1559,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1588,7 +1588,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -1617,7 +1617,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -1646,7 +1646,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -1685,7 +1685,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1760,7 +1760,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1835,7 +1835,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1910,7 +1910,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -1985,7 +1985,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: dev
       - id: checkout
@@ -2060,7 +2060,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2135,7 +2135,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2210,7 +2210,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2285,7 +2285,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2360,7 +2360,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2435,7 +2435,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2510,7 +2510,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2585,7 +2585,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2650,7 +2650,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2715,7 +2715,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2780,7 +2780,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2856,7 +2856,7 @@ jobs:
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout
@@ -2938,7 +2938,7 @@ jobs:
     if: "github.event_name == 'schedule'"
     steps:
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
           sdk: main
       - id: checkout

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -40,23 +40,23 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.3.0; PKG: build; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.4.0; PKG: build; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -70,23 +70,23 @@ jobs:
         if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
         working-directory: build
   job_003:
-    name: "analyze_and_format; linux; Dart 3.3.0; PKGS: build_resolvers, build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.4.0; PKGS: build_resolvers, build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_resolvers-build_test-example-scratch_space;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_resolvers-build_test-example-scratch_space;commands:format-analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_resolvers-build_test-example-scratch_space
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_resolvers-build_test-example-scratch_space
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -427,23 +427,23 @@ jobs:
         if: "always() && steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
         working-directory: build_web_compilers
   job_009:
-    name: "unit_test; linux; Dart 3.3.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.4.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -466,23 +466,23 @@ jobs:
       - job_007
       - job_008
   job_010:
-    name: "unit_test; linux; Dart 3.3.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.4.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_daemon;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_daemon;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_daemon
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_daemon
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -505,23 +505,23 @@ jobs:
       - job_007
       - job_008
   job_011:
-    name: "unit_test; linux; Dart 3.3.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.4.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_resolvers;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_resolvers;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_resolvers
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_resolvers
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -544,23 +544,23 @@ jobs:
       - job_007
       - job_008
   job_012:
-    name: "unit_test; linux; Dart 3.3.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.4.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_runner_core;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_runner_core;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_runner_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_runner_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -583,23 +583,23 @@ jobs:
       - job_007
       - job_008
   job_013:
-    name: "unit_test; linux; Dart 3.3.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.4.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_test;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_test;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -622,23 +622,23 @@ jobs:
       - job_007
       - job_008
   job_014:
-    name: "unit_test; linux; Dart 3.3.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.4.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:scratch_space;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:scratch_space;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:scratch_space
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:scratch_space
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1207,13 +1207,13 @@ jobs:
       - job_007
       - job_008
   job_029:
-    name: "unit_test; windows; Dart 3.3.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.4.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1236,13 +1236,13 @@ jobs:
       - job_007
       - job_008
   job_030:
-    name: "unit_test; windows; Dart 3.3.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.4.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1265,13 +1265,13 @@ jobs:
       - job_007
       - job_008
   job_031:
-    name: "unit_test; windows; Dart 3.3.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.4.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1294,13 +1294,13 @@ jobs:
       - job_007
       - job_008
   job_032:
-    name: "unit_test; windows; Dart 3.3.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.4.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1323,13 +1323,13 @@ jobs:
       - job_007
       - job_008
   job_033:
-    name: "unit_test; windows; Dart 3.3.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.4.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1352,13 +1352,13 @@ jobs:
       - job_007
       - job_008
   job_034:
-    name: "unit_test; windows; Dart 3.3.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.4.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.3.0"
+          sdk: "3.4.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -40,23 +40,23 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.0.0; PKG: build; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.3.0; PKG: build; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -70,23 +70,23 @@ jobs:
         if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
         working-directory: build
   job_003:
-    name: "analyze_and_format; linux; Dart 3.0.0; PKGS: build_resolvers, build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.3.0; PKGS: build_resolvers, build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build_resolvers-build_test-example-scratch_space;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_resolvers-build_test-example-scratch_space;commands:format-analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build_resolvers-build_test-example-scratch_space
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_resolvers-build_test-example-scratch_space
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -427,23 +427,23 @@ jobs:
         if: "always() && steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
         working-directory: build_web_compilers
   job_009:
-    name: "unit_test; linux; Dart 3.0.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.3.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -466,23 +466,23 @@ jobs:
       - job_007
       - job_008
   job_010:
-    name: "unit_test; linux; Dart 3.0.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.3.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build_daemon;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_daemon;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build_daemon
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_daemon
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -505,23 +505,23 @@ jobs:
       - job_007
       - job_008
   job_011:
-    name: "unit_test; linux; Dart 3.0.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.3.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build_resolvers;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_resolvers;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build_resolvers
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_resolvers
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -544,23 +544,23 @@ jobs:
       - job_007
       - job_008
   job_012:
-    name: "unit_test; linux; Dart 3.0.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.3.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build_runner_core;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_runner_core;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build_runner_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_runner_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -583,23 +583,23 @@ jobs:
       - job_007
       - job_008
   job_013:
-    name: "unit_test; linux; Dart 3.0.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.3.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build_test;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_test;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:build_test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:build_test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -622,23 +622,23 @@ jobs:
       - job_007
       - job_008
   job_014:
-    name: "unit_test; linux; Dart 3.0.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.3.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:scratch_space;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:scratch_space;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:scratch_space
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0;packages:scratch_space
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.3.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1207,13 +1207,13 @@ jobs:
       - job_007
       - job_008
   job_029:
-    name: "unit_test; windows; Dart 3.0.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.3.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1236,13 +1236,13 @@ jobs:
       - job_007
       - job_008
   job_030:
-    name: "unit_test; windows; Dart 3.0.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.3.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1265,13 +1265,13 @@ jobs:
       - job_007
       - job_008
   job_031:
-    name: "unit_test; windows; Dart 3.0.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.3.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1294,13 +1294,13 @@ jobs:
       - job_007
       - job_008
   job_032:
-    name: "unit_test; windows; Dart 3.0.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.3.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1323,13 +1323,13 @@ jobs:
       - job_007
       - job_008
   job_033:
-    name: "unit_test; windows; Dart 3.0.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.3.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1352,13 +1352,13 @@ jobs:
       - job_007
       - job_008
   job_034:
-    name: "unit_test; windows; Dart 3.0.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.3.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
-          sdk: "3.0.0"
+          sdk: "3.3.0"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/_test/pkgs/provides_builder/pubspec.yaml
+++ b/_test/pkgs/provides_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: provides_builder
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   build:

--- a/_test/pkgs/provides_builder/pubspec.yaml
+++ b/_test/pkgs/provides_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: provides_builder
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   build:

--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: _test
 publish_to: none
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dev_dependencies:
   analyzer: any

--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: _test
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dev_dependencies:
   analyzer: any

--- a/_test_common/pubspec.yaml
+++ b/_test_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: Test infra for writing build tests. Is not published.
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   build: any

--- a/_test_common/pubspec.yaml
+++ b/_test_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: Test infra for writing build tests. Is not published.
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   build: any

--- a/analysis/pubspec.yaml
+++ b/analysis/pubspec.yaml
@@ -3,6 +3,6 @@
 name: _for_analysis_options_only
 publish_to: none
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0

--- a/analysis/pubspec.yaml
+++ b/analysis/pubspec.yaml
@@ -3,6 +3,6 @@
 name: _for_analysis_options_only
 publish_to: none
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.4.2-wip
 
-- Bump the min sdk to 3.3.0.
+- Bump the min sdk to 3.4.0.
 
 ## 2.4.1
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.4.2-wip
 
 - Bump the min sdk to 3.4.0.
+- Remove some unnecessary casts now that we have private field promotion.
 
 ## 2.4.1
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.4.2-wip
 
-- Bump the min sdk to 3.0.0.
+- Bump the min sdk to 3.3.0.
 
 ## 2.4.1
 

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 2.4.2-wip
 
 - Bump the min sdk to 3.4.0.
-- Remove some unnecessary casts now that we have private field promotion.
+- Remove some unnecessary casts and non-null assertions now that we have private
+  field promotion.
 
 ## 2.4.1
 

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -127,8 +127,7 @@ class BuildStepImpl implements BuildStep {
   Stream<AssetId> findAssets(Glob glob) {
     if (_isComplete) throw BuildStepCompletedException();
     if (_reader is MultiPackageAssetReader) {
-      return (_reader as MultiPackageAssetReader)
-          .findAssets(glob, package: inputId.package);
+      return _reader.findAssets(glob, package: inputId.package);
     } else {
       return _reader.findAssets(glob);
     }

--- a/build/lib/src/resource/resource.dart
+++ b/build/lib/src/resource/resource.dart
@@ -115,7 +115,7 @@ class Resource<T> {
     assert(_instanceByManager.containsKey(manager));
     var oldInstance = _instanceByManager[manager]!;
     if (_userDispose != null) {
-      return oldInstance.then(_userDispose!);
+      return oldInstance.then(_userDispose);
     } else {
       _instanceByManager.remove(manager);
       return Future.value(null);

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -4,7 +4,7 @@ description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   analyzer: ">=1.5.0 <7.0.0"

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -4,7 +4,7 @@ description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   analyzer: ">=1.5.0 <7.0.0"

--- a/build/test/generate/run_builder_test.dart
+++ b/build/test/generate/run_builder_test.dart
@@ -80,7 +80,7 @@ void main() {
             config.packages.singleWhere((p) => p.name == 'build');
         expect(buildPackage.root, Uri.parse('asset:build/'));
         expect(buildPackage.packageUriRoot, Uri.parse('asset:build/lib/'));
-        expect(buildPackage.languageVersion, LanguageVersion(3, 0));
+        expect(buildPackage.languageVersion, LanguageVersion(3, 4));
 
         final resolvedBuildUri =
             config.resolve(Uri.parse('package:build/foo.txt'))!;
@@ -104,7 +104,7 @@ void main() {
           Package(
             'build',
             Uri.file('/foo/bar/'),
-            languageVersion: LanguageVersion(3, 0),
+            languageVersion: LanguageVersion(3, 4),
           ),
         ]),
       );

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.1.2-wip
 
 - Stop using deprecated `JsonKey.ignore`.
-- Bump the min sdk to 3.0.0.
+- Bump the min sdk to 3.3.0.
 
 ## 1.1.1
 

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.1.2-wip
 
 - Stop using deprecated `JsonKey.ignore`.
-- Bump the min sdk to 3.3.0.
+- Bump the min sdk to 3.4.0.
 
 ## 1.1.1
 

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 repository: https://github.com/dart-lang/build/tree/master/build_config
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   checked_yaml: ^2.0.0

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 repository: https://github.com/dart-lang/build/tree/master/build_config
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   checked_yaml: ^2.0.0

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.2-wip
 
-- Bump the min sdk to 3.3.0.
+- Bump the min sdk to 3.4.0.
 
 ## 4.0.1
 

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2-wip
+
+- Bump the min sdk to 3.3.0.
+
 ## 4.0.1
 
 - Use a hash of the working dir to create the unique workspace dir. This

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -4,7 +4,7 @@ description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_daemon
-version:  4.0.1
+version:  4.0.2-wip
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.9-wip
+
+- Bump the min sdk to 3.3.0.
+
 ## 5.0.8
 
 - Allow version 3.5.x of the Dart SDK.

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.0.9-wip
 
-- Bump the min sdk to 3.3.0.
+- Bump the min sdk to 3.4.0.
 
 ## 5.0.8
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 5.0.8
+version: 5.0.9-wip
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.

--- a/build_modules/test/fixtures/a/lib/a_dep_on_non_sdk.dart
+++ b/build_modules/test/fixtures/a/lib/a_dep_on_non_sdk.dart
@@ -1,2 +1,2 @@
 // ignore_for_file: unused_import
-import 'package:a/a_non_sdk.dart';
+import 'a_non_sdk.dart';

--- a/build_modules/test/fixtures/a/pubspec.yaml
+++ b/build_modules/test/fixtures/a/pubspec.yaml
@@ -1,7 +1,7 @@
 name: a
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   b:

--- a/build_modules/test/fixtures/a/pubspec.yaml
+++ b/build_modules/test/fixtures/a/pubspec.yaml
@@ -1,7 +1,7 @@
 name: a
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   b:

--- a/build_modules/test/fixtures/b/pubspec.yaml
+++ b/build_modules/test/fixtures/b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: b
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   a:

--- a/build_modules/test/fixtures/b/pubspec.yaml
+++ b/build_modules/test/fixtures/b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: b
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   a:

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Require the latest analyzer, and stop passing the `withNullability`
   parameter which was previously required and is now deprecated.
-- Bump the min sdk to 3.3.0.
+- Bump the min sdk to 3.4.0.
 
 ## 2.4.2
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Require the latest analyzer, and stop passing the `withNullability`
   parameter which was previously required and is now deprecated.
+- Bump the min sdk to 3.3.0.
 
 ## 2.4.2
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.4.3-wip
 
+- Require the latest analyzer, and stop passing the `withNullability`
+  parameter which was previously required and is now deprecated.
+
 ## 2.4.2
 
 - Add a builder to clean up transitive digest files from the build output.

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  analyzer: '>=5.12.0 <7.0.0'
+  analyzer: '>=6.5.0 <7.0.0'
   async: ^2.5.0
   build: ^2.0.0
   collection: ^1.17.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -4,7 +4,7 @@ description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   analyzer: '>=6.5.0 <7.0.0'

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -4,7 +4,7 @@ description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   analyzer: '>=6.5.0 <7.0.0'

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -292,8 +292,7 @@ void main() {
         var clazz = lib.getClass('A');
         expect(clazz, isNotNull);
         expect(clazz!.interfaces, hasLength(1));
-        expect(clazz.interfaces.first.getDisplayString(withNullability: false),
-            'B');
+        expect(clazz.interfaces.first.getDisplayString(), 'B');
       }, resolvers: resolvers);
     });
 
@@ -314,8 +313,7 @@ void main() {
         var clazz = lib.getClass('A');
         expect(clazz, isNotNull);
         expect(clazz!.interfaces, hasLength(1));
-        expect(clazz.interfaces.first.getDisplayString(withNullability: false),
-            'B');
+        expect(clazz.interfaces.first.getDisplayString(), 'B');
       }, resolvers: resolvers);
 
       // `resolveSources` actually completes prior to the build step being

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.4.10-wip
 
-- Bump the min sdk to 3.3.0.
+- Bump the min sdk to 3.4.0.
 
 ## 2.4.9
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.10-wip
+
+- Bump the min sdk to 3.3.0.
+
 ## 2.4.9
 
 - Update the `package:frontend_server_client` constraint to `>=3.0.0 <5.0.0`.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -4,7 +4,7 @@ description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 platforms:
   linux:

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_runner
-version: 2.4.9
+version: 2.4.10-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 platforms:
   linux:

--- a/build_runner/test/integration_tests/utils/build_descriptor.dart
+++ b/build_runner/test/integration_tests/utils/build_descriptor.dart
@@ -234,7 +234,7 @@ d.FileDescriptor _pubspec(String name,
   var buffer = StringBuffer()
     ..writeln('name: $name')
     ..writeln('environment:')
-    ..writeln('  sdk: ^3.3.0');
+    ..writeln('  sdk: ^3.4.0');
 
   void writeDeps(String group) {
     buffer.writeln(group);

--- a/build_runner/test/integration_tests/utils/build_descriptor.dart
+++ b/build_runner/test/integration_tests/utils/build_descriptor.dart
@@ -234,7 +234,7 @@ d.FileDescriptor _pubspec(String name,
   var buffer = StringBuffer()
     ..writeln('name: $name')
     ..writeln('environment:')
-    ..writeln('  sdk: ^3.0.0');
+    ..writeln('  sdk: ^3.3.0');
 
   void writeDeps(String group) {
     buffer.writeln(group);

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 7.3.1-wip
 
 - Bump the min sdk to 3.4.0.
+- Remove some unnecessary casts and non-null assertions now that we have private
+  field promotion.
 
 ## 7.3.0
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 7.3.1-wip
 
-- Bump the min sdk to 3.3.0.
+- Bump the min sdk to 3.4.0.
 
 ## 7.3.0
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.3.1-wip
+
+- Bump the min sdk to 3.3.0.
+
 ## 7.3.0
 
 - Bump the min sdk to 3.0.0.

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -173,7 +173,7 @@ class SingleStepReader implements AssetReader {
     }
     var streamCompleter = StreamCompleter<AssetId>();
 
-    doAfter(_getGlobNode!(glob, _primaryPackage, _phaseNumber),
+    doAfter(_getGlobNode(glob, _primaryPackage, _phaseNumber),
         (GlobAssetNode globNode) {
       assetsRead.add(globNode.id);
       streamCompleter.setSourceStream(Stream.fromIterable(globNode.results!));

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -266,7 +266,7 @@ class _SingleBuild {
       var invalidated = await _assetGraph.updateAndInvalidate(
           _buildPhases, updates, _packageGraph.root.name, _delete, _reader);
       if (_reader is CachingAssetReader) {
-        (_reader as CachingAssetReader).invalidate(invalidated);
+        _reader.invalidate(invalidated);
       }
     });
   }
@@ -306,7 +306,7 @@ class _SingleBuild {
         assert(result.performance != null);
         var now = DateTime.now();
         var logPath = p.join(
-            _logPerformanceDir!,
+            _logPerformanceDir,
             '${now.year}-${_twoDigits(now.month)}-${_twoDigits(now.day)}'
             '_${_twoDigits(now.hour)}-${_twoDigits(now.minute)}-'
             '${_twoDigits(now.second)}');

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_runner_core
-version: 7.3.0
+version: 7.3.1-wip
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 platforms:
   linux:

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -4,7 +4,7 @@ description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 platforms:
   linux:

--- a/build_runner_core/test/fixtures/basic_pkg/pubspec.yaml
+++ b/build_runner_core/test/fixtures/basic_pkg/pubspec.yaml
@@ -4,11 +4,11 @@ publish_to: none
 dependencies:
   a: 2.0.0
   b:
-    git: git://github.com/b/b.git
+    git: https://github.com/b/b.git
   c:
     path: pkg/c
   d:
     version: ^5.0.0
     hosted:
       name: d
-      url: http://your-package-server.com
+      url: https://your-package-server.com

--- a/build_runner_core/test/fixtures/flutter_pkg/pubspec.yaml
+++ b/build_runner_core/test/fixtures/flutter_pkg/pubspec.yaml
@@ -1,24 +1,23 @@
 # Copied from flutter/flutter/master/examples/flutter_gallery/pubspec.yaml
 # Commit: 1bdf351.
 name: flutter_gallery
+environment:
+  sdk: ^3.4.0
 dependencies:
   collection: '>=1.9.1 <2.0.0'
-  intl: '>=0.14.0 <0.15.0'
-  string_scanner: ^1.0.0
-
   flutter:
     sdk: flutter
-
-  # Also update dev/benchmarks/complex_layout/pubspec.yaml
   flutter_gallery_assets:
     git:
       url: https://flutter.googlesource.com/gallery-assets
       ref: ef928550119411358b8b25e16aecde6ace513526
+  intl: '>=0.14.0 <0.15.0'
+  string_scanner: ^1.0.0
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   flutter_driver:
+    sdk: flutter
+  flutter_test:
     sdk: flutter
 
 flutter:

--- a/build_runner_core/test/package_graph/package_graph_test.dart
+++ b/build_runner_core/test/package_graph/package_graph_test.dart
@@ -25,7 +25,7 @@ void main() {
         final buildRunner =
             config.packages.singleWhere((p) => p.name == 'build_runner_core');
 
-        expect(buildRunner.languageVersion, LanguageVersion(3, 0));
+        expect(buildRunner.languageVersion, LanguageVersion(3, 4));
       });
     });
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.3-wip
+
+- Bump the min sdk to 3.3.0.
+
 ## 2.2.2
 
 - Bump the min sdk to 3.0.0.

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.3-wip
 
-- Bump the min sdk to 3.3.0.
+- Bump the min sdk to 3.4.0.
 
 ## 2.2.2
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.2.3-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   async: ^2.5.0

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 2.2.2
+version: 2.2.3-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   async: ^2.5.0

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.11-wip
+
+- Bump the min sdk to 3.3.0.
+
 ## 4.0.10
 
 - Allow version 3.5.x of the Dart SDK.

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.11-wip
 
-- Bump the min sdk to 3.3.0.
+- Bump the min sdk to 3.4.0.
 
 ## 4.0.10
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.0.10
+version: 4.0.11-wip
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 

--- a/build_web_compilers/test/fixtures/a/pubspec.yaml
+++ b/build_web_compilers/test/fixtures/a/pubspec.yaml
@@ -1,7 +1,7 @@
 name: a
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   b:

--- a/build_web_compilers/test/fixtures/a/pubspec.yaml
+++ b/build_web_compilers/test/fixtures/a/pubspec.yaml
@@ -1,7 +1,7 @@
 name: a
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   b:

--- a/build_web_compilers/test/fixtures/b/pubspec.yaml
+++ b/build_web_compilers/test/fixtures/b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: b
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   a:

--- a/build_web_compilers/test/fixtures/b/pubspec.yaml
+++ b/build_web_compilers/test/fixtures/b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: b
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   a:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 publish_to: none
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   analyzer: ">=5.0.0 <7.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 publish_to: none
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   analyzer: ">=5.0.0 <7.0.0"

--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.3-wip
 
-- Bump the min sdk to 3.3.0.
+- Bump the min sdk to 3.4.0.
 
 ## 1.0.2
 

--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.3-wip
 
-- Bump the min sdk to 3.0.0.
+- Bump the min sdk to 3.3.0.
 
 ## 1.0.2
 

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - codegen
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   build: ^2.0.0

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - codegen
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   build: ^2.0.0

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -3,7 +3,7 @@ name: build_development_tools
 description: Collection of scripts used during development of build packages.
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.3.0
 
 dependencies:
   path: ^1.8.0

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -3,7 +3,7 @@ name: build_development_tools
 description: Collection of scripts used during development of build packages.
 
 environment:
-  sdk: ^3.3.0
+  sdk: ^3.4.0
 
 dependencies:
   path: ^1.8.0


### PR DESCRIPTION
We do now require the latest analyzer since the `withNullability` parameter was previously required, we can't cleanly remove it without also increasing the dependency.

We also seem to be getting a few more lints triggered on the latest dev, which this should fix.

Also updates the min SDK to ~3.3.0~ 3.4.0 across the board (analyzer 6.5.0 requires this).