### PR TITLE
Fix analysis errors

### DIFF
--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -292,8 +292,7 @@ void main() {
         var clazz = lib.getClass('A');
         expect(clazz, isNotNull);
         expect(clazz!.interfaces, hasLength(1));
-        expect(clazz.interfaces.first.getDisplayString(withNullability: false),
-            'B');
+        expect(clazz.interfaces.first.getDisplayString(), 'B');
       }, resolvers: resolvers);
     });
 
@@ -314,8 +313,7 @@ void main() {
         var clazz = lib.getClass('A');
         expect(clazz, isNotNull);
         expect(clazz!.interfaces, hasLength(1));
-        expect(clazz.interfaces.first.getDisplayString(withNullability: false),
-            'B');
+        expect(clazz.interfaces.first.getDisplayString(), 'B');
       }, resolvers: resolvers);
 
       // `resolveSources` actually completes prior to the build step being

--- a/build_runner_core/test/fixtures/basic_pkg/pubspec.yaml
+++ b/build_runner_core/test/fixtures/basic_pkg/pubspec.yaml
@@ -4,11 +4,11 @@ publish_to: none
 dependencies:
   a: 2.0.0
   b:
-    git: git://github.com/b/b.git
+    git: https://github.com/b/b
   c:
     path: pkg/c
   d:
     version: ^5.0.0
     hosted:
       name: d
-      url: http://your-package-server.com
+      url: https://your-package-server.com

--- a/build_runner_core/test/fixtures/flutter_pkg/pubspec.yaml
+++ b/build_runner_core/test/fixtures/flutter_pkg/pubspec.yaml
@@ -3,22 +3,21 @@
 name: flutter_gallery
 dependencies:
   collection: '>=1.9.1 <2.0.0'
-  intl: '>=0.14.0 <0.15.0'
-  string_scanner: ^1.0.0
-
   flutter:
-    sdk: flutter
-
+    sdk:
+      flutter
   # Also update dev/benchmarks/complex_layout/pubspec.yaml
   flutter_gallery_assets:
     git:
       url: https://flutter.googlesource.com/gallery-assets
       ref: ef928550119411358b8b25e16aecde6ace513526
+  intl: '>=0.14.0 <0.15.0'
+  string_scanner: ^1.0.0
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   flutter_driver:
+    sdk: flutter
+  flutter_test:
     sdk: flutter
 
 flutter:


### PR DESCRIPTION
- Remove usage of deprecated `withNullability` argument from the
  analyzer.
- Use https URLs in fixture package pubspec files.
- Sort dependencies in a fixture package pubspec file.
