### PR TITLE
Add `topics` to build_runner `pubspec.yaml`

### DIFF
--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -57,3 +57,6 @@ dev_dependencies:
   test: ^1.16.0
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
+
+topics:
+ - build-runner


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

topics:
 - my-topic
 - some-other-topic
See also: https://dart.dev/tools/pub/pubspec#topics