### PR TITLE
Add `topics` to `pubspec.yaml`

### DIFF
--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -22,3 +22,6 @@ dev_dependencies:
   build_test: ^2.0.0
   dart_flutter_team_lints: ^3.1.0
   test: ^1.16.0
+
+topics:
+ - build-runner


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

topics:

my-topic
some-other-topic
See also: https://dart.dev/tools/pub/pubspec#topics