### PR TITLE
Add `topics` to build_config `pubspec.yaml`

### DIFF
--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -20,3 +20,6 @@ dev_dependencies:
   json_serializable: ^6.0.0
   term_glyph: ^1.2.0
   test: ^1.16.0
+
+topics:
+ - build-runner


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

topics:

my-topic
some-other-topic
See also: https://dart.dev/tools/pub/pubspec#topics