### PR TITLE
Add `topics` to  build_daemon `pubspec.yaml`

### DIFF
--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -34,3 +34,6 @@ dev_dependencies:
 dependency_overrides:
   build_runner:
     path: ../build_runner
+
+topics:
+ - build-runner


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

topics:

my-topic
some-other-topic
See also: https://dart.dev/tools/pub/pubspec#topics