### PR TITLE
Add `topics` to build_modues `pubspec.yaml`

### DIFF
--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -35,3 +35,6 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.1.0
   json_serializable: ^6.0.0
   test: ^1.16.0
+
+topics:
+ - build-runner


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

topics:

my-topic
some-other-topic
See also: https://dart.dev/tools/pub/pubspec#topics