### PR TITLE
Add `topics` to build_test `pubspec.yaml`

### DIFF
--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -27,3 +27,7 @@ dev_dependencies:
   analyzer: '>=5.2.0 <7.0.0'
   collection: ^1.15.0
   dart_flutter_team_lints: ^2.0.0
+
+topics:
+ - build-runner
+ - testing


### PR DESCRIPTION
Topics help users on pub.dev discover packages and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

topics:

my-topic
some-other-topic
See also: https://dart.dev/tools/pub/pubspec#topics