### PR TITLE
Use WebSocket fakes

### DIFF
--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   stream_transform: ^2.0.0
   timing: ^1.0.0
   watcher: ^1.0.0
-  web_socket_channel: ">=2.0.0 <4.0.0"
+  web_socket_channel: ^3.0.0
   yaml: ^3.0.0
 
 dev_dependencies:
@@ -58,8 +58,6 @@ dev_dependencies:
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
   web_socket: ^0.1.5
-  # unnecessary_dev_dependency false positive.
-  # web_socket_channel: ^3.0.0
 
 topics:
  - build-runner

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -58,7 +58,8 @@ dev_dependencies:
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
   web_socket: ^0.1.5
-  web_socket_channel: ^3.0.0
+  # unnecessary_dev_dependency false positive.
+  # web_socket_channel: ^3.0.0
 
 topics:
  - build-runner

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -57,6 +57,8 @@ dev_dependencies:
   test: ^1.25.5
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
+  web_socket: ^0.1.5
+  web_socket_channel: ^3.0.0
 
 topics:
  - build-runner

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -21,9 +21,9 @@ import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/fake.dart';
 import 'package:test/test.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
-import 'package:web_socket_channel/adapter_web_socket_channel.dart';
 import 'package:web_socket/testing.dart';
+import 'package:web_socket_channel/adapter_web_socket_channel.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() {
   late ServeHandler serveHandler;

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -327,6 +327,7 @@ void main() {
         await createMockConnection(serverChannel1, 'web');
         await createMockConnection(serverChannel2, 'web');
         await handler.emitUpdateMessage(BuildResult(BuildStatus.success, []));
+        await pumpEventQueue();
         await clientChannel1.sink.close();
         await clientChannel2.sink.close();
       });
@@ -337,8 +338,10 @@ void main() {
         await createMockConnection(serverChannel1, 'web');
         await createMockConnection(serverChannel2, 'web');
         await handler.emitUpdateMessage(BuildResult(BuildStatus.success, []));
+        await pumpEventQueue();
         await clientChannel2.sink.close();
         await handler.emitUpdateMessage(BuildResult(BuildStatus.success, []));
+        await pumpEventQueue();
         await clientChannel1.sink.close();
       });
 
@@ -382,6 +385,7 @@ void main() {
           AssetId('a', 'web/index.html'),
           AssetId('a', 'lib/some.dart.js'),
         ]));
+        await pumpEventQueue();
         await clientChannel1.sink.close();
       });
 
@@ -421,6 +425,7 @@ void main() {
           AssetId('a', 'web2/index.html'),
           AssetId('a', 'lib/some.dart.js'),
         ]));
+        await pumpEventQueue();
         await clientChannel1.sink.close();
         await clientChannel2.sink.close();
       });


### PR DESCRIPTION
Refactor serve_handler_test to use the `fakes` utility from the
`web_socket` package instead of reimplement it locally.

Currently this changes the behavior of the tests and they fail.
