### PR TITLE
fix deprecation warnings

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -40,23 +40,23 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.4.0; PKG: build; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.5.0-259.0.dev; PKG: build; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -70,23 +70,23 @@ jobs:
         if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
         working-directory: build
   job_003:
-    name: "analyze_and_format; linux; Dart 3.4.0; PKGS: build_resolvers, build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.5.0-259.0.dev; PKGS: build_resolvers, build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_resolvers-build_test-example-scratch_space;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build_resolvers-build_test-example-scratch_space;commands:format-analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_resolvers-build_test-example-scratch_space
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build_resolvers-build_test-example-scratch_space
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -427,23 +427,23 @@ jobs:
         if: "always() && steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
         working-directory: build_web_compilers
   job_009:
-    name: "unit_test; linux; Dart 3.4.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -466,23 +466,23 @@ jobs:
       - job_007
       - job_008
   job_010:
-    name: "unit_test; linux; Dart 3.4.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_daemon;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build_daemon;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_daemon
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build_daemon
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -505,23 +505,23 @@ jobs:
       - job_007
       - job_008
   job_011:
-    name: "unit_test; linux; Dart 3.4.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_resolvers;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build_resolvers;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_resolvers
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build_resolvers
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -544,23 +544,23 @@ jobs:
       - job_007
       - job_008
   job_012:
-    name: "unit_test; linux; Dart 3.4.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_runner_core;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build_runner_core;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_runner_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build_runner_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -583,23 +583,23 @@ jobs:
       - job_007
       - job_008
   job_013:
-    name: "unit_test; linux; Dart 3.4.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_test;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build_test;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:build_test
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:build_test
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -622,23 +622,23 @@ jobs:
       - job_007
       - job_008
   job_014:
-    name: "unit_test; linux; Dart 3.4.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.5.0-259.0.dev; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:scratch_space;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:scratch_space;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0;packages:scratch_space
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.4.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev;packages:scratch_space
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0-259.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1207,13 +1207,13 @@ jobs:
       - job_007
       - job_008
   job_029:
-    name: "unit_test; windows; Dart 3.4.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1236,13 +1236,13 @@ jobs:
       - job_007
       - job_008
   job_030:
-    name: "unit_test; windows; Dart 3.4.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1265,13 +1265,13 @@ jobs:
       - job_007
       - job_008
   job_031:
-    name: "unit_test; windows; Dart 3.4.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1294,13 +1294,13 @@ jobs:
       - job_007
       - job_008
   job_032:
-    name: "unit_test; windows; Dart 3.4.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1323,13 +1323,13 @@ jobs:
       - job_007
       - job_008
   job_033:
-    name: "unit_test; windows; Dart 3.4.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1352,13 +1352,13 @@ jobs:
       - job_007
       - job_008
   job_034:
-    name: "unit_test; windows; Dart 3.4.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.5.0-259.0.dev; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.4.0"
+          sdk: "3.5.0-259.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/_test/pkgs/provides_builder/pubspec.yaml
+++ b/_test/pkgs/provides_builder/pubspec.yaml
@@ -1,7 +1,7 @@
 name: provides_builder
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   build:

--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: _test
 publish_to: none
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dev_dependencies:
   analyzer: any

--- a/_test_common/pubspec.yaml
+++ b/_test_common/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 description: Test infra for writing build tests. Is not published.
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   build: any

--- a/analysis/pubspec.yaml
+++ b/analysis/pubspec.yaml
@@ -3,6 +3,6 @@
 name: _for_analysis_options_only
 publish_to: none
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 dev_dependencies:
   dart_flutter_team_lints: ^3.1.0

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.4.2-wip
 
-- Bump the min sdk to 3.4.0.
+- Bump the min sdk to 3.5.0-259.0.dev.
 - Remove some unnecessary casts and non-null assertions now that we have private
   field promotion.
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -4,7 +4,7 @@ description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   analyzer: ">=1.5.0 <7.0.0"

--- a/build/test/generate/run_builder_test.dart
+++ b/build/test/generate/run_builder_test.dart
@@ -82,7 +82,7 @@ void main() {
             config.packages.singleWhere((p) => p.name == 'build');
         expect(buildPackage.root, Uri.parse('asset:build/'));
         expect(buildPackage.packageUriRoot, Uri.parse('asset:build/lib/'));
-        expect(buildPackage.languageVersion, LanguageVersion(3, 4));
+        expect(buildPackage.languageVersion, LanguageVersion(3, 5));
 
         final resolvedBuildUri =
             config.resolve(Uri.parse('package:build/foo.txt'))!;
@@ -106,7 +106,7 @@ void main() {
           Package(
             'build',
             Uri.file('/foo/bar/'),
-            languageVersion: LanguageVersion(3, 4),
+            languageVersion: LanguageVersion(3, 5),
           ),
         ]),
       );

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.1.2-wip
 
 - Stop using deprecated `JsonKey.ignore`.
-- Bump the min sdk to 3.4.0.
+- Bump the min sdk to 3.5.0-259.0.dev.
 
 ## 1.1.1
 

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 repository: https://github.com/dart-lang/build/tree/master/build_config
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   checked_yaml: ^2.0.0

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.3-wip
+
+- Bump the min sdk to 3.5.0-259.0.dev.
+
 ## 4.0.2
 
 - Support version `1.x` and `2.x` of `shelf_web_socket` and `2.x` and `3.x`

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_daemon
-version:  4.0.2
+version:  4.0.3-wip
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   built_collection: ^5.0.0

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.0.9-wip
 
-- Bump the min sdk to 3.4.0.
+- Bump the min sdk to 3.5.0-259.0.dev.
 
 ## 5.0.8
 

--- a/build_modules/test/fixtures/a/pubspec.yaml
+++ b/build_modules/test/fixtures/a/pubspec.yaml
@@ -1,7 +1,7 @@
 name: a
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   b:

--- a/build_modules/test/fixtures/b/pubspec.yaml
+++ b/build_modules/test/fixtures/b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: b
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   a:

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Require the latest analyzer, and stop passing the `withNullability`
   parameter which was previously required and is now deprecated.
-- Bump the min sdk to 3.4.0.
+- Bump the min sdk to 3.5.0-259.0.dev.
 
 ## 2.4.2
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -4,7 +4,7 @@ description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   analyzer: '>=6.7.0 <7.0.0'

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.12-wip
+
+- Bump the min sdk to 3.5.0-259.0.dev.
+
 ## 2.4.11
 
 - Explicitly pass the current isolates package config instead of assuming the

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,10 +1,10 @@
 name: build_runner
-version: 2.4.11
+version: 2.4.12-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 platforms:
   linux:

--- a/build_runner/test/integration_tests/utils/build_descriptor.dart
+++ b/build_runner/test/integration_tests/utils/build_descriptor.dart
@@ -234,7 +234,7 @@ d.FileDescriptor _pubspec(String name,
   var buffer = StringBuffer()
     ..writeln('name: $name')
     ..writeln('environment:')
-    ..writeln('  sdk: ^3.4.0');
+    ..writeln('  sdk: ^3.5.0-259.0.dev');
 
   void writeDeps(String group) {
     buffer.writeln(group);

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.3.2-dev
+## 7.3.2-wip
 
 - Migrate deprecates uses of `whereNotNull()` to `nonNulls`.
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.3.2-dev
+
+- Migrate deprecates uses of `whereNotNull()` to `nonNulls`.
+
 ## 7.3.1
 
 - Support the upcoming pub workspaces feature.

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.3.2-wip
 
 - Migrate deprecates uses of `whereNotNull()` to `nonNulls`.
+- Bump the min sdk to 3.5.0-259.0.dev.
 
 ## 7.3.1
 

--- a/build_runner_core/lib/src/changes/build_script_updates.dart
+++ b/build_runner_core/lib/src/changes/build_script_updates.dart
@@ -51,7 +51,7 @@ class _MirrorBuildScriptUpdates implements BuildScriptUpdates {
     try {
       allSources = _urisForThisScript
           .map((id) => idForUri(id, packageGraph))
-          .whereNotNull()
+          .nonNulls
           .toSet();
       var missing = allSources.firstWhereOrNull((id) => !graph.contains(id));
       if (missing != null) {

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';
-import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
@@ -74,8 +73,7 @@ Future<bool> createMergedOutputDirectories(
 Set<String> _conflicts(Set<BuildDirectory> buildDirs) {
   final seen = <String>{};
   final conflicts = <String>{};
-  var outputLocations =
-      buildDirs.map((d) => d.outputLocation?.path).whereNotNull();
+  var outputLocations = buildDirs.map((d) => d.outputLocation?.path).nonNulls;
   for (var location in outputLocations) {
     if (!seen.add(location)) conflicts.add(location);
   }

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -4,7 +4,7 @@ description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 platforms:
   linux:

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 7.3.1
+version: 7.3.2-wip
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/fixtures/flutter_pkg/pubspec.yaml
+++ b/build_runner_core/test/fixtures/flutter_pkg/pubspec.yaml
@@ -2,7 +2,7 @@
 # Commit: 1bdf351.
 name: flutter_gallery
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 dependencies:
   collection: '>=1.9.1 <2.0.0'
   flutter:

--- a/build_runner_core/test/package_graph/package_graph_test.dart
+++ b/build_runner_core/test/package_graph/package_graph_test.dart
@@ -27,7 +27,7 @@ void main() {
         final buildRunner =
             config.packages.singleWhere((p) => p.name == 'build_runner_core');
 
-        expect(buildRunner.languageVersion, LanguageVersion(3, 4));
+        expect(buildRunner.languageVersion, LanguageVersion(3, 5));
       });
     });
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.3-wip
 
-- Bump the min sdk to 3.4.0.
+- Bump the min sdk to 3.5.0-259.0.dev.
 
 ## 2.2.2
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.2.3-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   async: ^2.5.0

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.11-wip
 
-- Bump the min sdk to 3.4.0.
+- Bump the min sdk to 3.5.0-259.0.dev.
 
 ## 4.0.10
 

--- a/build_web_compilers/test/fixtures/a/pubspec.yaml
+++ b/build_web_compilers/test/fixtures/a/pubspec.yaml
@@ -1,7 +1,7 @@
 name: a
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   b:

--- a/build_web_compilers/test/fixtures/b/pubspec.yaml
+++ b/build_web_compilers/test/fixtures/b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: b
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   a:

--- a/build_web_compilers/web/source_map_stack_trace.dart
+++ b/build_web_compilers/web/source_map_stack_trace.dart
@@ -8,7 +8,6 @@
 // This is forked from the equivalent file that ships with the SDK which is
 // intended for use within bazel only.
 
-import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:stack_trace/stack_trace.dart';
@@ -71,7 +70,7 @@ StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
 
     return Frame(Uri.parse(sourceUrl), span.start.line + 1,
         span.start.column + 1, _prettifyMember(frame.member!));
-  }).whereNotNull())
+  }).nonNulls)
       .foldFrames((Frame frame) => frame.uri.scheme.contains('dart'));
 }
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 publish_to: none
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   analyzer: ">=5.0.0 <7.0.0"

--- a/scratch_space/CHANGELOG.md
+++ b/scratch_space/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.3-wip
 
-- Bump the min sdk to 3.4.0.
+- Bump the min sdk to 3.5.0-259.0.dev.
 
 ## 1.0.2
 

--- a/scratch_space/pubspec.yaml
+++ b/scratch_space/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - codegen
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   build: ^2.0.0

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -3,7 +3,7 @@ name: build_development_tools
 description: Collection of scripts used during development of build packages.
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.5.0-259.0.dev
 
 dependencies:
   path: ^1.8.0


### PR DESCRIPTION
Migration from `whereNotNull()` to `nonNulls`.

Should fix the analysis failures at HEAD.