### PR TITLE
release build_runner and build_runner_core

### DIFF
--- a/_test/pkgs/provides_builder/pubspec.yaml
+++ b/_test/pkgs/provides_builder/pubspec.yaml
@@ -2,6 +2,7 @@ name: provides_builder
 resolution: workspace
 environment:
   sdk: ^3.5.0-259.0.dev
+publish_to: none
 
 dependencies:
   build:

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.4.12-wip
+## 2.4.12
 
 - Bump the min sdk to 3.5.0-259.0.dev.
+- Fix watch mode for workspace repos.
 
 ## 2.4.11
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.12-wip
+version: 2.4.12
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Additional fixes for pub workspace repos
 - Migrate deprecates uses of `whereNotNull()` to `nonNulls`.
-- Bump the min sdk to 3.5.0-259.0.dev..
+- Bump the min sdk to 3.5.0-259.0.dev.
 
 ## 7.3.1
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 7.3.2-wip
+## 7.3.2
 
+- Additional fixes for pub workspace repos
 - Migrate deprecates uses of `whereNotNull()` to `nonNulls`.
-- Bump the min sdk to 3.5.0-259.0.dev.
+- Bump the min sdk to 3.5.0-259.0.dev..
 
 ## 7.3.1
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 7.3.2-wip
+version: 7.3.2
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 resolution: workspace


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/3726

These have some additional fixes that are needed for workspace repos to function.