### PR TITLE
Fix unintended_html_in_doc_comment lints

### DIFF
--- a/build_config/lib/src/builder_definition.dart
+++ b/build_config/lib/src/builder_definition.dart
@@ -155,8 +155,8 @@ class PostProcessBuilderDefinition {
   /// A unique key for this Builder in `'$package:$builder'` format.
   String get key => builderKeyExpando[this]!;
 
-  /// The name of the top-level method in [import] from
-  /// Map<String, dynamic> -> Builder.
+  /// The name of the top-level method in [import] which takes a
+  /// `Map<String, dynamic>` and returns a `Builder`.
   @JsonKey(required: true, disallowNullValue: true)
   final String builderFactory;
 

--- a/build_daemon/lib/data/build_target.dart
+++ b/build_daemon/lib/data/build_target.dart
@@ -75,8 +75,11 @@ abstract class OutputLocation
   /// path.
   ///
   /// For example hoisting the build target web:
-  ///   <web>/<web-contents>
+  ///
+  ///     <web>/<web-contents>
+  ///
   /// Should result in:
-  ///   <output-folder>/<web-contents>
+  ///
+  ///     <output-folder>/<web-contents>
   bool get hoist;
 }

--- a/build_modules/lib/src/kernel_builder.dart
+++ b/build_modules/lib/src/kernel_builder.dart
@@ -67,7 +67,8 @@ class KernelBuilder implements Builder {
   /// Optional. When omitted the [platform] name is used.
   final String kernelTargetName;
 
-  /// Experiments to pass to kernel (as --enable-experiment=<experiment> args).
+  /// Experiments to pass to kernel (as `--enable-experiment=<experiment>`
+  /// args).
   final Iterable<String> experiments;
 
   KernelBuilder({

--- a/build_runner_core/lib/src/asset/file_based.dart
+++ b/build_runner_core/lib/src/asset/file_based.dart
@@ -123,7 +123,7 @@ File _fileFor(AssetId id, PackageGraph packageGraph) {
   return File(_filePathFor(id, packageGraph));
 }
 
-/// Returns a [Future<File>] for [id] given [packageGraph].
+/// Returns a `File` for the asset reference by [id] given [packageGraph].
 ///
 /// Throws an `AssetNotFoundException` if it doesn't exist.
 Future<File> _fileForOrThrow(AssetId id, PackageGraph packageGraph) {

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -175,9 +175,9 @@ class AssetGraph {
   /// Removes the node representing [id] from the graph, and all of its
   /// `primaryOutput`s.
   ///
-  /// Also removes all edges between all removed nodes and other nodes.
+  /// Also removes all edges between all removed nodes and remaining nodes.
   ///
-  /// Returns a [Set<AssetId>] of all removed nodes.
+  /// Returns the IDs of removed asset nodes.
   Set<AssetId> _removeRecursive(AssetId id, {Set<AssetId>? removedIds}) {
     removedIds ??= <AssetId>{};
     var node = get(id);

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -331,8 +331,8 @@ class _SingleBuild {
   String _buildProgress() =>
       '$actionsCompletedCount/$actionsStartedCount actions completed.';
 
-  /// Runs the actions in [_buildPhases] and returns a [Future<BuildResult>]
-  /// which completes once all [BuildPhase]s are done.
+  /// Runs the actions in [_buildPhases] and returns a future which completes
+  /// to the [BuildResult] once all [BuildPhase]s are done.
   Future<BuildResult> _runPhases() {
     return _performanceTracker.track(() async {
       final outputs = <AssetId>[];

--- a/build_test/lib/src/in_memory_reader.dart
+++ b/build_test/lib/src/in_memory_reader.dart
@@ -22,8 +22,8 @@ class InMemoryAssetReader extends AssetReader
 
   /// Create a new asset reader that contains [sourceAssets].
   ///
-  /// Any items in [sourceAssets] which are [String]s will be converted into
-  /// a [List<int>] of bytes.
+  /// Any strings in [sourceAssets] will be converted into a `List<int>` of
+  /// bytes.
   ///
   /// May optionally define a [rootPackage], which is required for some APIs.
   InMemoryAssetReader({Map<AssetId, dynamic>? sourceAssets, this.rootPackage})


### PR DESCRIPTION
There are a few that are false positives, collection types with
specified generics in square braces (`[List<int>]`) work in dartdoc, but
it's slightly better style for these cases to not over-link to core
types. Refer to collection types in prose, and use backticks where
describing but not linking to a type is appropriate.

Reformat a code block to use 4 space indent and a blank following the
prose block to use the intended markdown syntax.

Rephrase a few updated docs for readability.
