### PR TITLE
Write SDK summary to a temp file and rename

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Require the latest analyzer, and stop passing the `withNullability`
   parameter which was previously required and is now deprecated.
 - Bump the min sdk to 3.5.0.
+- Fix SDK summary reads when multiple isolates are using build resolvers (not
+  recommended).
 
 ## 2.4.2
 

--- a/build_resolvers/lib/src/sdk_summary.dart
+++ b/build_resolvers/lib/src/sdk_summary.dart
@@ -61,9 +61,10 @@ Future<String> defaultSdkSummaryGenerator() async {
   if (needsRebuild) {
     var watch = Stopwatch()..start();
     _logger.info('Generating SDK summary...');
+    await Directory(cacheDir).create(recursive: true);
     final tempDir = await Directory(cacheDir).createTemp();
     final tempFile = File(p.join(tempDir.path, p.basename(summaryPath)));
-    await tempFile.create(recursive: true);
+    await tempFile.create();
     final embedderYamlPath =
         isFlutter ? p.join(_dartUiPath, '_embedder.yaml') : null;
     await tempFile.writeAsBytes(

--- a/build_resolvers/lib/src/sdk_summary.dart
+++ b/build_resolvers/lib/src/sdk_summary.dart
@@ -62,7 +62,7 @@ Future<String> defaultSdkSummaryGenerator() async {
     var watch = Stopwatch()..start();
     _logger.info('Generating SDK summary...');
     final tempDir = await Directory(cacheDir).createTemp();
-    final tempFile = File(p.join(tempDir.path,p.basename(summaryPath)));
+    final tempFile = File(p.join(tempDir.path, p.basename(summaryPath)));
     await tempFile.create(recursive: true);
     final embedderYamlPath =
         isFlutter ? p.join(_dartUiPath, '_embedder.yaml') : null;


### PR DESCRIPTION
Avoid writing partial output to the file that could be concurrently read
by another isolate in the same process. Create a temp directory to
incrementally write the file, then use `rename` to atomically move it to
the location where other isolates may try to read it.

It's best to still avoid using the SDK summary from and analysis driver
in multiple isolates, but this should reduce flakiness in some cases
where they do run concurrently.
