### PR TITLE
Limit which health checks run

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -8,6 +8,7 @@ jobs:
   health:
     uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
     with:
+      checks: "version,changelog,do-not-submit"
       ignore_license: "**.g.dart"
       sdk: dev
     permissions:


### PR DESCRIPTION
The `breaking` and `leaking` health checks are not currently compatible
with repos using pub workspaces.

Keep `coverage` for now since it's not obvious it's a problem. We may
want to revisit duplicate testing between coverage and the other test
configurations.

Run `version`, `changelog`, and `do-not-submit` checks which are
sensible for every package.
