### PR TITLE
Account for the snapshot of dartdevc in the Dart SDK changing from a JIT snapshot to an AOT snapshot

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.0.12-wip
 
 - Bump the min sdk to 3.5.0.
+- Account for dartdevc snapshot in the Dart SDK changing to an AOT snapshot.
 
 ## 4.0.11
 

--- a/build_web_compilers/lib/src/sdk_js_compile_builder.dart
+++ b/build_web_compilers/lib/src/sdk_js_compile_builder.dart
@@ -86,8 +86,17 @@ Future<void> _createDevCompilerModule(
   try {
     // Use standalone process instead of the worker due to
     // https://github.com/dart-lang/sdk/issues/49441
-    result = await Process.run(p.join(sdkDir, 'bin', 'dart'), [
-      p.join(sdkDir, 'bin', 'snapshots', 'dartdevc.dart.snapshot'),
+    var snapshotPath = p.join(
+        sdkDir, 'bin', 'snapshots', 'dartdevc_aot.dart.snapshot');
+    var execSuffix = Platform.isWindows ? '.exe' : '';
+    var dartPath = p.join(sdkDir, 'bin', 'dartaotruntime$execSuffix');
+    if (!File(snapshotPath).existsSync()) {
+      snapshotPath = p.join(
+          sdkDir, 'bin', 'snapshots', 'dartdevc.dart.snapshot');
+      dartPath = p.join(sdkDir, 'bin', 'dart$execSuffix');
+    }
+    result = await Process.run(dartPath, [
+      snapshotPath,
       '--multi-root-scheme=org-dartlang-sdk',
       '--modules=amd',
       if (canaryFeatures) '--canary',

--- a/build_web_compilers/lib/src/sdk_js_compile_builder.dart
+++ b/build_web_compilers/lib/src/sdk_js_compile_builder.dart
@@ -86,13 +86,13 @@ Future<void> _createDevCompilerModule(
   try {
     // Use standalone process instead of the worker due to
     // https://github.com/dart-lang/sdk/issues/49441
-    var snapshotPath = p.join(
-        sdkDir, 'bin', 'snapshots', 'dartdevc_aot.dart.snapshot');
+    var snapshotPath =
+        p.join(sdkDir, 'bin', 'snapshots', 'dartdevc_aot.dart.snapshot');
     var execSuffix = Platform.isWindows ? '.exe' : '';
     var dartPath = p.join(sdkDir, 'bin', 'dartaotruntime$execSuffix');
     if (!File(snapshotPath).existsSync()) {
-      snapshotPath = p.join(
-          sdkDir, 'bin', 'snapshots', 'dartdevc.dart.snapshot');
+      snapshotPath =
+          p.join(sdkDir, 'bin', 'snapshots', 'dartdevc.dart.snapshot');
       dartPath = p.join(sdkDir, 'bin', 'dart$execSuffix');
     }
     result = await Process.run(dartPath, [


### PR DESCRIPTION
Dart SDK is in the process of changing snapshots in the SDK from JIT snapshots to AOT snapshots.
This change ensures that the package will continue to work when that change happens.

Note: Having the package reaching into the snapshot using the Dart SDK layout makes it brittle as things will break if the Dart SDK changes the SDK layout, instead we need to add a Dart CLI command that will invoke the dartdevc compiler and have this package use the Dart CLI for invoking dartdevc.
