### PR TITLE
Prepare beta release for build_web_compilers

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.1.0-wip
+## 4.1.0-beta.0
 
 - Support compiling to WebAssembly by using `dart2wasm` as a value for the
   compiler option.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.1.0-wip
+version: 4.1.0-beta.0
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 # This package can't be part of the workspace because it requires a very recent


### PR DESCRIPTION
Having a published pre-release of `build_web_compilers` with dart2wasm support makes it much easier for package authors to test that everything works before the stable 3.6 release.

If coordinating these releases is too much effort I can also just close this, but I think there's a pretty low risk of breaking anyone since we depend on a pretty recent SDK in `build_web_compilers`.