### PR TITLE
Fix CI jobs

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -70,16 +70,16 @@ jobs:
         if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
         working-directory: build
   job_003:
-    name: "analyze_and_format; linux; Dart 3.5.0; PKGS: build_resolvers, build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.5.0; PKGS: build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build_resolvers-build_test-example-scratch_space;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build_test-example-scratch_space;commands:format-analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build_resolvers-build_test-example-scratch_space
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build_test-example-scratch_space
             os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -90,19 +90,6 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_resolvers_pub_upgrade
-        name: build_resolvers; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build_resolvers
-      - name: "build_resolvers; dart format --output=none --set-exit-if-changed ."
-        run: "dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_resolvers
-      - name: "build_resolvers; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_resolvers
       - id: build_test_pub_upgrade
         name: build_test; dart pub upgrade
         run: dart pub upgrade
@@ -143,6 +130,40 @@ jobs:
         if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
         working-directory: scratch_space
   job_004:
+    name: "analyze_and_format; linux; Dart 3.6.0-165.0.dev; PKG: build_resolvers; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_resolvers;commands:format-analyze"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_resolvers
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.6.0-165.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_resolvers_pub_upgrade
+        name: build_resolvers; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_resolvers
+      - name: "build_resolvers; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_resolvers
+      - name: "build_resolvers; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_resolvers
+  job_005:
     name: "analyze_and_format; linux; Dart dev; PKGS: _test_common, build; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -181,7 +202,7 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
         working-directory: build
-  job_005:
+  job_006:
     name: "analyze_and_format; linux; Dart dev; PKG: build; `dart format --output=none --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
@@ -211,7 +232,7 @@ jobs:
         run: "dart format --output=none --set-exit-if-changed ."
         if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
         working-directory: build
-  job_006:
+  job_007:
     name: "analyze_and_format; linux; Dart dev; PKGS: build_config, build_daemon, build_resolvers, build_runner, build_runner_core, build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -336,7 +357,7 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
         working-directory: scratch_space
-  job_007:
+  job_008:
     name: "analyze_and_format; linux; Dart main; PKG: _test; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -366,7 +387,7 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps._test_pub_upgrade.conclusion == 'success'"
         working-directory: _test
-  job_008:
+  job_009:
     name: "analyze_and_format; linux; Dart main; PKGS: build_modules, build_runner, build_web_compilers; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -426,7 +447,7 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
         working-directory: build_web_compilers
-  job_009:
+  job_010:
     name: "unit_test; linux; Dart 3.5.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -465,7 +486,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_010:
+      - job_009
+  job_011:
     name: "unit_test; linux; Dart 3.5.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -504,45 +526,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_011:
-    name: "unit_test; linux; Dart 3.5.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build_resolvers;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build_resolvers
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
-        with:
-          sdk: "3.5.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_resolvers_pub_upgrade
-        name: build_resolvers; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build_resolvers
-      - name: "build_resolvers; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_resolvers
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
+      - job_009
   job_012:
     name: "unit_test; linux; Dart 3.5.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -582,6 +566,7 @@ jobs:
       - job_006
       - job_007
       - job_008
+      - job_009
   job_013:
     name: "unit_test; linux; Dart 3.5.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -621,6 +606,7 @@ jobs:
       - job_006
       - job_007
       - job_008
+      - job_009
   job_014:
     name: "unit_test; linux; Dart 3.5.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -660,7 +646,48 @@ jobs:
       - job_006
       - job_007
       - job_008
+      - job_009
   job_015:
+    name: "unit_test; linux; Dart 3.6.0-165.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_resolvers;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_resolvers
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.6.0-165.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_resolvers_pub_upgrade
+        name: build_resolvers; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_resolvers
+      - name: "build_resolvers; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_resolvers
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+  job_016:
     name: "unit_test; linux; Dart dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -699,7 +726,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_016:
+      - job_009
+  job_017:
     name: "unit_test; linux; Dart dev; PKG: build_config; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -738,7 +766,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_017:
+      - job_009
+  job_018:
     name: "unit_test; linux; Dart dev; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -777,7 +806,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_018:
+      - job_009
+  job_019:
     name: "unit_test; linux; Dart dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -816,7 +846,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_019:
+      - job_009
+  job_020:
     name: "unit_test; linux; Dart dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -855,7 +886,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_020:
+      - job_009
+  job_021:
     name: "unit_test; linux; Dart dev; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -894,7 +926,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_021:
+      - job_009
+  job_022:
     name: "unit_test; linux; Dart dev; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -933,7 +966,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_022:
+      - job_009
+  job_023:
     name: "unit_test; linux; Dart dev; PKG: build_runner; `dart test -P experiments --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -972,7 +1006,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_023:
+      - job_009
+  job_024:
     name: "unit_test; linux; Dart dev; PKG: build_runner; `dart test -x integration --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1011,7 +1046,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_024:
+      - job_009
+  job_025:
     name: "unit_test; linux; Dart main; PKG: _test; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1050,7 +1086,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_025:
+      - job_009
+  job_026:
     name: "unit_test; linux; Dart main; PKG: _test; `dart run build_runner test -- -p vm test/configurable_uri_test.dart --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1089,7 +1126,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_026:
+      - job_009
+  job_027:
     name: "unit_test; linux; Dart main; PKG: build_modules; `dart test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1128,7 +1166,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_027:
+      - job_009
+  job_028:
     name: "unit_test; linux; Dart main; PKG: build_runner; `dart test -x integration --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1167,7 +1206,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_028:
+      - job_009
+  job_029:
     name: "unit_test; linux; Dart main; PKG: build_web_compilers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1206,7 +1246,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_029:
+      - job_009
+  job_030:
     name: "unit_test; windows; Dart 3.5.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1235,7 +1276,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_030:
+      - job_009
+  job_031:
     name: "unit_test; windows; Dart 3.5.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1264,35 +1306,7 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_031:
-    name: "unit_test; windows; Dart 3.5.0; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
-        with:
-          sdk: "3.5.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_resolvers_pub_upgrade
-        name: build_resolvers; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build_resolvers
-      - name: "build_resolvers; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
-        working-directory: build_resolvers
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
+      - job_009
   job_032:
     name: "unit_test; windows; Dart 3.5.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
@@ -1322,6 +1336,7 @@ jobs:
       - job_006
       - job_007
       - job_008
+      - job_009
   job_033:
     name: "unit_test; windows; Dart 3.5.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
@@ -1351,6 +1366,7 @@ jobs:
       - job_006
       - job_007
       - job_008
+      - job_009
   job_034:
     name: "unit_test; windows; Dart 3.5.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
@@ -1380,7 +1396,38 @@ jobs:
       - job_006
       - job_007
       - job_008
+      - job_009
   job_035:
+    name: "unit_test; windows; Dart 3.6.0-165.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.6.0-165.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_resolvers_pub_upgrade
+        name: build_resolvers; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_resolvers
+      - name: "build_resolvers; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
+        working-directory: build_resolvers
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+  job_036:
     name: "unit_test; windows; Dart dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1409,7 +1456,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_036:
+      - job_009
+  job_037:
     name: "unit_test; windows; Dart dev; PKG: build_config; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1438,7 +1486,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_037:
+      - job_009
+  job_038:
     name: "unit_test; windows; Dart dev; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1467,7 +1516,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_038:
+      - job_009
+  job_039:
     name: "unit_test; windows; Dart dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1496,7 +1546,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_039:
+      - job_009
+  job_040:
     name: "unit_test; windows; Dart dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1525,7 +1576,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_040:
+      - job_009
+  job_041:
     name: "unit_test; windows; Dart dev; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1554,7 +1606,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_041:
+      - job_009
+  job_042:
     name: "unit_test; windows; Dart dev; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1583,7 +1636,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_042:
+      - job_009
+  job_043:
     name: "unit_test; windows; Dart main; PKG: _test; `dart run build_runner test -- -p chrome --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1612,7 +1666,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_043:
+      - job_009
+  job_044:
     name: "unit_test; windows; Dart main; PKG: build_modules; `dart test -P presubmit --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1641,7 +1696,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_044:
+      - job_009
+  job_045:
     name: "unit_test; windows; Dart main; PKG: build_web_compilers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1670,7 +1726,8 @@ jobs:
       - job_006
       - job_007
       - job_008
-  job_045:
+      - job_009
+  job_046:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -1745,7 +1802,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_046:
+      - job_045
+  job_047:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -1820,7 +1878,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_047:
+      - job_045
+  job_048:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -1895,7 +1954,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_048:
+      - job_045
+  job_049:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -1970,7 +2030,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_049:
+      - job_045
+  job_050:
     name: "e2e_test; linux; Dart dev; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -2045,7 +2106,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_050:
+      - job_045
+  job_051:
     name: "e2e_test; linux; Dart main; PKG: _test; `dart test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -2120,7 +2182,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_051:
+      - job_045
+  job_052:
     name: "e2e_test; linux; Dart main; PKG: _test; `dart test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -2195,7 +2258,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_052:
+      - job_045
+  job_053:
     name: "e2e_test; linux; Dart main; PKG: _test; `dart test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -2270,7 +2334,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_053:
+      - job_045
+  job_054:
     name: "e2e_test; linux; Dart main; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 0 --test-randomize-ordering-seed=random --no-chain-stack-traces -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -2345,7 +2410,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_054:
+      - job_045
+  job_055:
     name: "e2e_test; linux; Dart main; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 1 --test-randomize-ordering-seed=random --no-chain-stack-traces -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -2420,7 +2486,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_055:
+      - job_045
+  job_056:
     name: "e2e_test; linux; Dart main; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 2 --test-randomize-ordering-seed=random --no-chain-stack-traces -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -2495,7 +2562,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_056:
+      - job_045
+  job_057:
     name: "e2e_test; linux; Dart main; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 3 --test-randomize-ordering-seed=random --no-chain-stack-traces -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -2570,7 +2638,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_057:
+      - job_045
+  job_058:
     name: "e2e_test; linux; Dart main; PKG: build_runner; `dart test -t integration --total-shards 5 --shard-index 4 --test-randomize-ordering-seed=random --no-chain-stack-traces -j 1`"
     runs-on: ubuntu-latest
     steps:
@@ -2645,7 +2714,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_058:
+      - job_045
+  job_059:
     name: "e2e_test; windows; Dart main; PKG: _test; `dart test --total-shards 3 --shard-index 0 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2710,7 +2780,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_059:
+      - job_045
+  job_060:
     name: "e2e_test; windows; Dart main; PKG: _test; `dart test --total-shards 3 --shard-index 1 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2775,7 +2846,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_060:
+      - job_045
+  job_061:
     name: "e2e_test; windows; Dart main; PKG: _test; `dart test --total-shards 3 --shard-index 2 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -2840,7 +2912,8 @@ jobs:
       - job_042
       - job_043
       - job_044
-  job_061:
+      - job_045
+  job_062:
     name: "e2e_test_cron; linux; Dart main; PKG: _test; `dart test`"
     runs-on: ubuntu-latest
     if: "github.event_name == 'schedule'"
@@ -2932,7 +3005,8 @@ jobs:
       - job_058
       - job_059
       - job_060
-  job_062:
+      - job_061
+  job_063:
     name: "e2e_test_cron; windows; Dart main; PKG: _test; `dart test`"
     runs-on: windows-latest
     if: "github.event_name == 'schedule'"
@@ -3014,7 +3088,8 @@ jobs:
       - job_058
       - job_059
       - job_060
-  job_063:
+      - job_061
+  job_064:
     name: Notify failure
     runs-on: ubuntu-latest
     if: "(github.event_name == 'push' || github.event_name == 'schedule') && failure()"
@@ -3088,3 +3163,4 @@ jobs:
       - job_060
       - job_061
       - job_062
+      - job_063

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -528,46 +528,6 @@ jobs:
       - job_008
       - job_009
   job_012:
-    name: "unit_test; linux; Dart 3.5.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build_runner_core;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build_runner_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
-        with:
-          sdk: "3.5.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_runner_core_pub_upgrade
-        name: build_runner_core; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build_runner_core
-      - name: "build_runner_core; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.build_runner_core_pub_upgrade.conclusion == 'success'"
-        working-directory: build_runner_core
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-  job_013:
     name: "unit_test; linux; Dart 3.5.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -607,7 +567,7 @@ jobs:
       - job_007
       - job_008
       - job_009
-  job_014:
+  job_013:
     name: "unit_test; linux; Dart 3.5.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -647,7 +607,7 @@ jobs:
       - job_007
       - job_008
       - job_009
-  job_015:
+  job_014:
     name: "unit_test; linux; Dart 3.6.0-165.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -677,6 +637,46 @@ jobs:
         run: "dart test --test-randomize-ordering-seed=random"
         if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
         working-directory: build_resolvers
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+  job_015:
+    name: "unit_test; linux; Dart 3.6.0-165.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_runner_core;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_runner_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.6.0-165.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_runner_core_pub_upgrade
+        name: build_runner_core; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_runner_core
+      - name: "build_runner_core; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_runner_core_pub_upgrade.conclusion == 'success'"
+        working-directory: build_runner_core
     needs:
       - job_001
       - job_002
@@ -1308,36 +1308,6 @@ jobs:
       - job_008
       - job_009
   job_032:
-    name: "unit_test; windows; Dart 3.5.0; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
-        with:
-          sdk: "3.5.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_runner_core_pub_upgrade
-        name: build_runner_core; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build_runner_core
-      - name: "build_runner_core; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.build_runner_core_pub_upgrade.conclusion == 'success'"
-        working-directory: build_runner_core
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-  job_033:
     name: "unit_test; windows; Dart 3.5.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1367,7 +1337,7 @@ jobs:
       - job_007
       - job_008
       - job_009
-  job_034:
+  job_033:
     name: "unit_test; windows; Dart 3.5.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1397,7 +1367,7 @@ jobs:
       - job_007
       - job_008
       - job_009
-  job_035:
+  job_034:
     name: "unit_test; windows; Dart 3.6.0-165.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1417,6 +1387,36 @@ jobs:
         run: "dart test --test-randomize-ordering-seed=random"
         if: "always() && steps.build_resolvers_pub_upgrade.conclusion == 'success'"
         working-directory: build_resolvers
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+  job_035:
+    name: "unit_test; windows; Dart 3.6.0-165.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.6.0-165.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_runner_core_pub_upgrade
+        name: build_runner_core; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_runner_core
+      - name: "build_runner_core; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_runner_core_pub_upgrade.conclusion == 'success'"
+        working-directory: build_runner_core
     needs:
       - job_001
       - job_002

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -130,23 +130,23 @@ jobs:
         if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
         working-directory: scratch_space
   job_004:
-    name: "analyze_and_format; linux; Dart 3.6.0-165.0.dev; PKG: build_resolvers; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.6.0-217.0.dev; PKG: build_resolvers; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_resolvers;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_resolvers;commands:format-analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_resolvers
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_resolvers
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-165.0.dev"
+          sdk: "3.6.0-217.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -608,23 +608,23 @@ jobs:
       - job_008
       - job_009
   job_014:
-    name: "unit_test; linux; Dart 3.6.0-165.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-217.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_resolvers;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_resolvers;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_resolvers
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_resolvers
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-165.0.dev"
+          sdk: "3.6.0-217.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -648,23 +648,23 @@ jobs:
       - job_008
       - job_009
   job_015:
-    name: "unit_test; linux; Dart 3.6.0-165.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-217.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_runner_core;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_runner_core;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev;packages:build_runner_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-165.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_runner_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-165.0.dev"
+          sdk: "3.6.0-217.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1368,13 +1368,13 @@ jobs:
       - job_008
       - job_009
   job_034:
-    name: "unit_test; windows; Dart 3.6.0-165.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-217.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-165.0.dev"
+          sdk: "3.6.0-217.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1398,13 +1398,13 @@ jobs:
       - job_008
       - job_009
   job_035:
-    name: "unit_test; windows; Dart 3.6.0-165.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-217.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-165.0.dev"
+          sdk: "3.6.0-217.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -40,36 +40,6 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; Dart 3.5.0; PKG: build; `dart analyze --fatal-infos .`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build;commands:analyze"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
-        with:
-          sdk: "3.5.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_pub_upgrade
-        name: build; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build
-      - name: "build; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
-        working-directory: build
-  job_003:
     name: "analyze_and_format; linux; Dart 3.5.0; PKGS: build_test, example, scratch_space; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
@@ -129,6 +99,36 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
         working-directory: scratch_space
+  job_003:
+    name: "analyze_and_format; linux; Dart 3.6.0-217.0.dev; PKG: build; `dart analyze --fatal-infos .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build;commands:analyze"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.6.0-217.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_pub_upgrade
+        name: build; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build
+      - name: "build; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
+        working-directory: build
   job_004:
     name: "analyze_and_format; linux; Dart 3.6.0-217.0.dev; PKG: build_resolvers; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
@@ -448,46 +448,6 @@ jobs:
         if: "always() && steps.build_web_compilers_pub_upgrade.conclusion == 'success'"
         working-directory: build_web_compilers
   job_010:
-    name: "unit_test; linux; Dart 3.5.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build;commands:test_04"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0;packages:build
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.5.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
-        with:
-          sdk: "3.5.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_pub_upgrade
-        name: build; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build
-      - name: "build; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
-        working-directory: build
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-  job_011:
     name: "unit_test; linux; Dart 3.5.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -527,7 +487,7 @@ jobs:
       - job_007
       - job_008
       - job_009
-  job_012:
+  job_011:
     name: "unit_test; linux; Dart 3.5.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -567,7 +527,7 @@ jobs:
       - job_007
       - job_008
       - job_009
-  job_013:
+  job_012:
     name: "unit_test; linux; Dart 3.5.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -597,6 +557,46 @@ jobs:
         run: "dart test --test-randomize-ordering-seed=random"
         if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
         working-directory: scratch_space
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+  job_013:
+    name: "unit_test; linux; Dart 3.6.0-217.0.dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build;commands:test_04"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.6.0-217.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_pub_upgrade
+        name: build; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build
+      - name: "build; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
+        working-directory: build
     needs:
       - job_001
       - job_002
@@ -1248,36 +1248,6 @@ jobs:
       - job_008
       - job_009
   job_030:
-    name: "unit_test; windows; Dart 3.5.0; PKG: build; `dart test --test-randomize-ordering-seed=random`"
-    runs-on: windows-latest
-    steps:
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
-        with:
-          sdk: "3.5.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - id: build_pub_upgrade
-        name: build; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: build
-      - name: "build; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
-        working-directory: build
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-      - job_005
-      - job_006
-      - job_007
-      - job_008
-      - job_009
-  job_031:
     name: "unit_test; windows; Dart 3.5.0; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1307,7 +1277,7 @@ jobs:
       - job_007
       - job_008
       - job_009
-  job_032:
+  job_031:
     name: "unit_test; windows; Dart 3.5.0; PKG: build_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1337,7 +1307,7 @@ jobs:
       - job_007
       - job_008
       - job_009
-  job_033:
+  job_032:
     name: "unit_test; windows; Dart 3.5.0; PKG: scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1357,6 +1327,36 @@ jobs:
         run: "dart test --test-randomize-ordering-seed=random"
         if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
         working-directory: scratch_space
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+      - job_009
+  job_033:
+    name: "unit_test; windows; Dart 3.6.0-217.0.dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: windows-latest
+    steps:
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
+        with:
+          sdk: "3.6.0-217.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - id: build_pub_upgrade
+        name: build; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build
+      - name: "build; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
+        working-directory: build
     needs:
       - job_001
       - job_002

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -100,23 +100,23 @@ jobs:
         if: "always() && steps.scratch_space_pub_upgrade.conclusion == 'success'"
         working-directory: scratch_space
   job_003:
-    name: "analyze_and_format; linux; Dart 3.6.0-217.0.dev; PKG: build; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.6.0-228.0.dev; PKG: build; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev;packages:build;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev;packages:build
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-217.0.dev"
+          sdk: "3.6.0-228.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -130,23 +130,23 @@ jobs:
         if: "always() && steps.build_pub_upgrade.conclusion == 'success'"
         working-directory: build
   job_004:
-    name: "analyze_and_format; linux; Dart 3.6.0-217.0.dev; PKG: build_resolvers; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; Dart 3.6.0-228.0.dev; PKG: build_resolvers; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_resolvers;commands:format-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev;packages:build_resolvers;commands:format-analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_resolvers
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev;packages:build_resolvers
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-217.0.dev"
+          sdk: "3.6.0-228.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -568,23 +568,23 @@ jobs:
       - job_008
       - job_009
   job_013:
-    name: "unit_test; linux; Dart 3.6.0-217.0.dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-228.0.dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev;packages:build;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev;packages:build
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-217.0.dev"
+          sdk: "3.6.0-228.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -608,23 +608,23 @@ jobs:
       - job_008
       - job_009
   job_014:
-    name: "unit_test; linux; Dart 3.6.0-217.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-228.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_resolvers;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev;packages:build_resolvers;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_resolvers
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev;packages:build_resolvers
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-217.0.dev"
+          sdk: "3.6.0-228.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -648,23 +648,23 @@ jobs:
       - job_008
       - job_009
   job_015:
-    name: "unit_test; linux; Dart 3.6.0-217.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; linux; Dart 3.6.0-228.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_runner_core;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev;packages:build_runner_core;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev;packages:build_runner_core
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-217.0.dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev;packages:build_runner_core
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.6.0-228.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-217.0.dev"
+          sdk: "3.6.0-228.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1338,13 +1338,13 @@ jobs:
       - job_008
       - job_009
   job_033:
-    name: "unit_test; windows; Dart 3.6.0-217.0.dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-228.0.dev; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-217.0.dev"
+          sdk: "3.6.0-228.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1368,13 +1368,13 @@ jobs:
       - job_008
       - job_009
   job_034:
-    name: "unit_test; windows; Dart 3.6.0-217.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-228.0.dev; PKG: build_resolvers; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-217.0.dev"
+          sdk: "3.6.0-228.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -1398,13 +1398,13 @@ jobs:
       - job_008
       - job_009
   job_035:
-    name: "unit_test; windows; Dart 3.6.0-217.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
+    name: "unit_test; windows; Dart 3.6.0-228.0.dev; PKG: build_runner_core; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30
         with:
-          sdk: "3.6.0-217.0.dev"
+          sdk: "3.6.0-228.0.dev"
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: none
 #resolution: workspace
 
 environment:
-  sdk: ^3.6.0-217.0.dev
+  sdk: ^3.6.0-228.0.dev
 
 dependencies:
   web: ^1.0.0

--- a/_test/pubspec.yaml
+++ b/_test/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: none
 #resolution: workspace
 
 environment:
-  sdk: ^3.6.0-165.0.dev
+  sdk: ^3.6.0-217.0.dev
 
 dependencies:
   web: ^1.0.0

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.4.2-wip
 
-- Bump the min sdk to 3.6.0-217.0.dev.
+- Bump the min sdk to 3.6.0-228.0.dev.
 - Remove some unnecessary casts and non-null assertions now that we have private
   field promotion.
 - Require analyzer ^6.9.0.

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## 2.4.2-wip
 
-- Bump the min sdk to 3.5.0.
+- Bump the min sdk to 3.6.0-217.0.dev.
 - Remove some unnecessary casts and non-null assertions now that we have private
   field promotion.
+- Require analyzer ^6.9.0.
+- Fix analyzer deprecations.
 
 ## 2.4.1
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -9,7 +9,7 @@ resolution: workspace
 #resolution: workspace
 
 environment:
-  sdk: ^3.6.0-217.0.dev
+  sdk: ^3.6.0-228.0.dev
 
 dependencies:
   analyzer: ^6.9.0

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -2,7 +2,6 @@ name: build
 version: 2.4.2-wip
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
-resolution: workspace
 
 # This package can't be part of the workspace because it requires a very recent
 # Dart SDK - see the top-level pubspec for details.

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
 dev_dependencies:
   build_resolvers: ^2.4.0
   build_test: ^2.0.0
+  dart_flutter_team_lints: ^3.1.0
   test: ^1.16.0
 
 topics:

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -4,11 +4,15 @@ description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace
 
+# This package can't be part of the workspace because it requires a very recent
+# Dart SDK - see the top-level pubspec for details.
+#resolution: workspace
+
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0-217.0.dev
 
 dependencies:
-  analyzer: ">=1.5.0 <7.0.0"
+  analyzer: ^6.9.0
   async: ^2.5.0
   convert: ^3.0.0
   crypto: ^3.0.0

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -131,7 +131,7 @@ void main() {
         expect(aLib.definingCompilationUnit.libraryImports.length, 2);
         expect(
             aLib.definingCompilationUnit.libraryImports
-                .any((import) => import.library.name == 'b'),
+                .any((import) => import.importedLibrary!.name == 'b'),
             isTrue);
 
         var bLib = await resolver.findLibraryByName('b');

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -128,13 +128,15 @@ void main() {
 
         var aLib = await resolver.libraryFor(primary);
         expect(aLib.name, 'a');
-        expect(aLib.importedLibraries.length, 2);
-        expect(aLib.importedLibraries.any((library) => library.name == 'b'),
+        expect(aLib.definingCompilationUnit.libraryImports.length, 2);
+        expect(
+            aLib.definingCompilationUnit.libraryImports
+                .any((import) => import.library.name == 'b'),
             isTrue);
 
         var bLib = await resolver.findLibraryByName('b');
         expect(bLib!.name, 'b');
-        expect(bLib.importedLibraries.length, 1);
+        expect(bLib.definingCompilationUnit.libraryImports.length, 1);
 
         await buildStep.complete();
       });

--- a/build/test/generate/run_builder_test.dart
+++ b/build/test/generate/run_builder_test.dart
@@ -82,7 +82,7 @@ void main() {
             config.packages.singleWhere((p) => p.name == 'build');
         expect(buildPackage.root, Uri.parse('asset:build/'));
         expect(buildPackage.packageUriRoot, Uri.parse('asset:build/lib/'));
-        expect(buildPackage.languageVersion, LanguageVersion(3, 5));
+        expect(buildPackage.languageVersion, LanguageVersion(3, 6));
 
         final resolvedBuildUri =
             config.resolve(Uri.parse('package:build/foo.txt'))!;
@@ -106,7 +106,7 @@ void main() {
           Package(
             'build',
             Uri.file('/foo/bar/'),
-            languageVersion: LanguageVersion(3, 5),
+            languageVersion: LanguageVersion(3, 6),
           ),
         ]),
       );

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.0.10-wip
 
 - Bump the min sdk to 3.5.0.
+- Support 3.7.0 pre-release sdks.
 
 ## 5.0.9
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/dart-lang/build/tree/master/build_modules
 resolution: workspace
 
 environment:
-  sdk: '>=3.5.0 <3.7.0'
+  sdk: '>=3.5.0 <3.7.0-z'
 
 dependencies:
   analyzer: '>=5.1.0 <7.0.0'

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bump the min sdk to 3.5.0.
 - Fix SDK summary reads when multiple isolates are using build resolvers (not
   recommended).
+- Fix analyzer deprecations.
 
 ## 2.4.2
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Require the latest analyzer, and stop passing the `withNullability`
   parameter which was previously required and is now deprecated.
-- Bump the min sdk to 3.5.0.
+- Bump the min sdk to 3.6.0-228.0.dev.
 - Fix SDK summary reads when multiple isolates are using build resolvers (not
   recommended).
 - Fix analyzer deprecations.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -64,9 +64,11 @@ class PerActionResolver implements ReleasableResolver {
       // `BuildStep.canRead`. They'd still be reachable by crawling the element
       // model manually.
       yield current;
-      final toCrawl = current.importedLibraries
-          .followedBy(current.exportedLibraries)
-          .where((l) => !seen.contains(l))
+      final toCrawl = current.definingCompilationUnit.libraryImports
+          .map((import) => import.library)
+          .followedBy(current.definingCompilationUnit.libraryExports
+              .map((export) => export.library))
+          .where((library) => !seen.contains(library))
           .toSet();
       toVisit.addAll(toCrawl);
       seen.addAll(toCrawl);
@@ -279,7 +281,7 @@ class AnalyzerResolver implements ReleasableResolver {
   Future<List<ErrorsResult>> _syntacticErrorsFor(LibraryElement element) async {
     final existingSources = [element.source];
 
-    for (final part in element.parts) {
+    for (final part in element.definingCompilationUnit.parts) {
       var uri = part.uri;
       // There may be no source if the part doesn't exist. That's not important
       // for us since we only care about existing file syntax.

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -65,9 +65,10 @@ class PerActionResolver implements ReleasableResolver {
       // model manually.
       yield current;
       final toCrawl = current.definingCompilationUnit.libraryImports
-          .map((import) => import.library)
+          .map((import) => import.importedLibrary)
           .followedBy(current.definingCompilationUnit.libraryExports
-              .map((export) => export.library))
+              .map((export) => export.exportedLibrary))
+          .nonNulls
           .where((library) => !seen.contains(library))
           .toSet();
       toVisit.addAll(toCrawl);

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 #resolution: workspace
 
 environment:
-  sdk: ^3.6.0-165.0.dev
+  sdk: ^3.6.0-217.0.dev
 
 dependencies:
   analyzer: ^6.9.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  analyzer: '>=6.7.0 <7.0.0'
+  analyzer: ^6.9.0
   async: ^2.5.0
   build: ^2.0.0
   collection: ^1.17.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 #resolution: workspace
 
 environment:
-  sdk: ^3.6.0-217.0.dev
+  sdk: ^3.6.0-228.0.dev
 
 dependencies:
   analyzer: ^6.9.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -2,10 +2,13 @@ name: build_resolvers
 version: 2.4.3-wip
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
-resolution: workspace
+
+# This package can't be part of the workspace because it requires a very recent
+# Dart SDK - see the top-level pubspec for details.
+#resolution: workspace
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0-165.0.dev
 
 dependencies:
   analyzer: ^6.9.0

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
 
 dev_dependencies:
   build_test: ^2.0.0
+  dart_flutter_team_lints: ^3.1.0
   test: ^1.16.0
 
 topics:

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -50,7 +50,7 @@ void main() {
         var libA = lib
           ..definingCompilationUnit
               .libraryImports
-              .where((l) => l.library.name == 'a')
+              .where((l) => l.importedLibrary!.name == 'a')
               .single;
         expect(libA.getClass('Foo'), isNull);
       }, resolvers: AnalyzerResolvers());
@@ -72,7 +72,7 @@ void main() {
         var libB = lib
           ..definingCompilationUnit
               .libraryImports
-              .where((l) => l.library.name == 'b')
+              .where((l) => l.importedLibrary!.name == 'b')
               .single;
         expect(libB.getClass('Foo'), isNull);
       }, resolvers: AnalyzerResolvers());
@@ -466,7 +466,7 @@ void main() {
       }, (resolver) async {
         var entry = await resolver.libraryFor(AssetId('a', 'lib/a.dart'));
         var classDefinition = entry.definingCompilationUnit.libraryImports
-            .map((l) => l.library.getClass('SomeClass'))
+            .map((l) => l.importedLibrary!.getClass('SomeClass'))
             .singleWhere((c) => c != null)!;
         expect(await resolver.assetIdForElement(classDefinition),
             AssetId('a', 'lib/b.dart'));

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -46,8 +46,12 @@ void main() {
               ''',
       }, (resolver) async {
         var lib = await resolver.libraryFor(entryPoint);
-        expect(lib.importedLibraries.length, 2);
-        var libA = lib.importedLibraries.where((l) => l.name == 'a').single;
+        expect(lib.definingCompilationUnit.libraryImports.length, 2);
+        var libA = lib
+          ..definingCompilationUnit
+              .libraryImports
+              .where((l) => l.library.name == 'a')
+              .single;
         expect(libA.getClass('Foo'), isNull);
       }, resolvers: AnalyzerResolvers());
     });
@@ -64,8 +68,12 @@ void main() {
               ''',
       }, (resolver) async {
         var lib = await resolver.libraryFor(entryPoint);
-        expect(lib.importedLibraries.length, 2);
-        var libB = lib.importedLibraries.where((l) => l.name == 'b').single;
+        expect(lib.definingCompilationUnit.libraryImports.length, 2);
+        var libB = lib
+          ..definingCompilationUnit
+              .libraryImports
+              .where((l) => l.library.name == 'b')
+              .single;
         expect(libB.getClass('Foo'), isNull);
       }, resolvers: AnalyzerResolvers());
     });
@@ -257,8 +265,11 @@ void main() {
               } ''',
       }, (resolver) async {
         var lib = await resolver.libraryFor(entryPoint);
-        expect(lib.parts.length, 1);
-        expect(lib.parts.whereType<DirectiveUriWithSource>(), isEmpty);
+        expect(lib.definingCompilationUnit.parts.length, 1);
+        expect(
+            lib.definingCompilationUnit.parts
+                .whereType<DirectiveUriWithSource>(),
+            isEmpty);
       }, resolvers: AnalyzerResolvers());
     });
 
@@ -454,8 +465,8 @@ void main() {
               ''',
       }, (resolver) async {
         var entry = await resolver.libraryFor(AssetId('a', 'lib/a.dart'));
-        var classDefinition = entry.importedLibraries
-            .map((l) => l.getClass('SomeClass'))
+        var classDefinition = entry.definingCompilationUnit.libraryImports
+            .map((l) => l.library.getClass('SomeClass'))
             .singleWhere((c) => c != null)!;
         expect(await resolver.assetIdForElement(classDefinition),
             AssetId('a', 'lib/b.dart'));

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 7.3.3-wip
 
-- Bump the min sdk to 3.5.0.
+- Bump the min sdk to 3.6.0-dev.228.
 - Require analyzer ^6.9.0.
 - Fix analyzer deprecations.
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 7.3.3-wip
 
 - Bump the min sdk to 3.5.0.
+- Require analyzer ^6.9.0.
+- Fix analyzer deprecations.
 
 ## 7.3.2
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -41,6 +41,7 @@ dev_dependencies:
   analyzer: ^6.9.0
   build_runner: ^2.0.0
   build_test: ^2.0.0
+  dart_flutter_team_lints: ^3.1.0
   json_serializable: ^6.0.0
   test: ^1.16.0
   test_descriptor: ^2.0.0

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 #resolution: workspace
 
 environment:
-  sdk: ^3.6.0-165.0.dev
+  sdk: ^3.6.0-217.0.dev
 
 platforms:
   linux:

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -2,10 +2,13 @@ name: build_runner_core
 version: 7.3.3-wip
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
-resolution: workspace
+
+# This package can't be part of the workspace because it requires a very recent
+# Dart SDK - see the top-level pubspec for details.
+#resolution: workspace
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.6.0-165.0.dev
 
 platforms:
   linux:

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 dev_dependencies:
   _test_common:
     path: ../_test_common
-  analyzer: '>=5.2.0 <7.0.0'
+  analyzer: ^6.9.0
   build_runner: ^2.0.0
   build_test: ^2.0.0
   json_serializable: ^6.0.0

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 #resolution: workspace
 
 environment:
-  sdk: ^3.6.0-217.0.dev
+  sdk: ^3.6.0-228.0.dev
 
 platforms:
   linux:

--- a/build_runner_core/test/generate/resolver_reuse_test.dart
+++ b/build_runner_core/test/generate/resolver_reuse_test.dart
@@ -40,10 +40,13 @@ void main() {
             await buildStep.canRead(buildStep.inputId.addExtension('.foo'));
             // Check that the `.imported.dart` library is still reachable
             // through the resolver.
-            var importedLibrary =
-                inputLibrary.definingCompilationUnit.libraryImports.firstWhere(
-                    (l) => l.librarySource.uri.path.endsWith('.imported.dart'));
-            var classNames = importedLibrary.enclosingElement3.classes
+            var importedLibrary = inputLibrary
+                .definingCompilationUnit.libraryImports
+                .firstWhere((l) => l
+                    .importedLibrary!.definingCompilationUnit.source.uri.path
+                    .endsWith('.imported.dart'))
+                .importedLibrary!;
+            var classNames = importedLibrary.definingCompilationUnit.classes
                 .map((c) => c.name)
                 .toList();
             return buildStep.writeAsString(

--- a/build_runner_core/test/generate/resolver_reuse_test.dart
+++ b/build_runner_core/test/generate/resolver_reuse_test.dart
@@ -40,9 +40,10 @@ void main() {
             await buildStep.canRead(buildStep.inputId.addExtension('.foo'));
             // Check that the `.imported.dart` library is still reachable
             // through the resolver.
-            var importedLibrary = inputLibrary.importedLibraries.firstWhere(
-                (l) => l.source.uri.path.endsWith('.imported.dart'));
-            var classNames = importedLibrary.definingCompilationUnit.classes
+            var importedLibrary =
+                inputLibrary.definingCompilationUnit.libraryImports.firstWhere(
+                    (l) => l.librarySource.uri.path.endsWith('.imported.dart'));
+            var classNames = importedLibrary.enclosingElement3.classes
                 .map((c) => c.name)
                 .toList();
             return buildStep.writeAsString(

--- a/build_runner_core/test/package_graph/package_graph_test.dart
+++ b/build_runner_core/test/package_graph/package_graph_test.dart
@@ -27,7 +27,7 @@ void main() {
         final buildRunner =
             config.packages.singleWhere((p) => p.name == 'build_runner_core');
 
-        expect(buildRunner.languageVersion, LanguageVersion(3, 5));
+        expect(buildRunner.languageVersion, LanguageVersion(3, 6));
       });
     });
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.0-wip
+
+- Support 3.7.0 pre-release sdks.
+
 ## 4.1.0-beta.2
 
 - Add source maps for dart2wasm builds.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.1.0-beta.2
+version: 4.1.0-wip
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 # This package can't be part of the workspace because it requires a very recent
@@ -7,7 +7,7 @@ repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 #resolution: workspace
 
 environment:
-  sdk: ^3.6.0-165.0.dev
+  sdk: '>=3.6.0-165.0.dev <3.7.0-z'
 
 dependencies:
   analyzer: '>=5.1.0 <7.0.0'

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -42,5 +42,10 @@ dev_dependencies:
   test: ^1.16.0
   yaml: ^3.1.0
 
+# TODO: remove once this package is back in the workspace
+dependency_overrides:
+  build_modules:
+    path: ../build_modules
+
 topics:
  - build-runner

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ workspace:
 - build_config
 - build_daemon
 - build_modules
-- build_resolvers
+# - build_resolvers
 - build_runner
 - build_runner_core
 - build_test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ workspace:
 - build_modules
 # - build_resolvers
 - build_runner
-- build_runner_core
+# - build_runner_core
 - build_test
 #- build_web_compilers
 - example

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ workspace:
 #- _test
 #- _test/pkgs/provides_builder
 - _test_common
-- build
+# - build
 - build_config
 - build_daemon
 - build_modules


### PR DESCRIPTION
This is an absolute mess now, our workspace is super fragmented at this point, but in general this:

- Fixes new analyzer deprecations
- Requires the new analyzer
  -  Which requires a new SDK
    -  Which requires moving more packages out of the workspace
- Fixes the jobs that run against `main` by allowing 3.7.0 dev SDKs. These versions will be broken at some point because the DDC binary is going to move, so we are not allowing 3.7.0 stable. 