### PR TITLE
update to the latest dart_style

### DIFF
--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -115,8 +115,7 @@ abstract class Resolver {
   /// **NOTE**: In general, its recommended to use [libraryFor] with an absolute
   /// asset id instead of a named identifier that has the possibility of not
   /// being unique.
-  Future<LibraryElement2?> findLibraryByName2(
-      String libraryName);
+  Future<LibraryElement2?> findLibraryByName2(String libraryName);
 
   /// Returns the [AssetId] of the Dart library or part declaring [element].
   ///

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -239,7 +239,8 @@ class _DelayedResolver implements Resolver {
       (await _delegate).astNodeFor(element, resolve: resolve);
 
   @override
-  Future<AstNode?> astNodeFor2(Fragment fragment, {bool resolve = false}) async =>
+  Future<AstNode?> astNodeFor2(Fragment fragment,
+          {bool resolve = false}) async =>
       (await _delegate).astNodeFor2(fragment, resolve: resolve);
 
   @override

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -27,6 +27,10 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.1.0
   test: ^1.16.0
 
+dependency_overrides:
+  build_resolvers:
+    path: ../build_resolvers
+
 topics:
  - build-runner
  - codegen

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.10
+
+- Allow analyzer version 7.x.
+
 ## 5.0.10-beta.0
 
 - Bump the min sdk to 3.5.0.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 5.0.10-beta.0
+version: 5.0.10
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.5.0 <3.7.0-z'
 
 dependencies:
-  analyzer: '>=5.1.0 <7.0.0'
+  analyzer: '>=5.1.0 <8.0.0'
   async: ^2.5.0
   bazel_worker: ^1.0.0
   build: ^2.0.0

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -46,7 +46,7 @@ class PerActionResolver implements ReleasableResolver {
       this._delegate, this._driverPool, this._readAndWritePool, this._step);
 
   Stream<LibraryElement> get _librariesFromEntrypoints {
-    return _librariesFromEntrypoints2.map((e) => e.asElement);
+    return _librariesFromEntrypoints2.map((e) => e.asElement as LibraryElement);
   }
 
   Stream<LibraryElement2> get _librariesFromEntrypoints2 async* {
@@ -101,7 +101,7 @@ class PerActionResolver implements ReleasableResolver {
     if (element == null) {
       return null;
     }
-    return element.asElement;
+    return element.asElement as LibraryElement;
   }
 
   @override
@@ -151,7 +151,7 @@ class PerActionResolver implements ReleasableResolver {
       assetId,
       allowSyntaxErrors: allowSyntaxErrors,
     );
-    return element.asElement;
+    return element.asElement as LibraryElement;
   }
 
   @override
@@ -325,7 +325,7 @@ class AnalyzerResolver implements ReleasableResolver {
       {bool allowSyntaxErrors = false}) async {
     var element =
         await libraryFor2(assetId, allowSyntaxErrors: allowSyntaxErrors);
-    return element.asElement;
+    return element.asElement as LibraryElement;
   }
 
   @override
@@ -415,7 +415,7 @@ class AnalyzerResolver implements ReleasableResolver {
   }
 
   Stream<LibraryElement> get sdkLibraries {
-    return sdkLibraries2.map((e) => e.asElement);
+    return sdkLibraries2.map((e) => e.asElement as LibraryElement);
   }
 
   Stream<LibraryElement2> get sdkLibraries2 {

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -31,5 +31,9 @@ dev_dependencies:
   dart_flutter_team_lints: ^3.1.0
   test: ^1.16.0
 
+dependency_overrides:
+  build:
+    path: ../build
+
 topics:
  - build-runner

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,7 +1,15 @@
-## 2.4.14-wip
+## 2.4.14
 
 - Write generated assets at the end of a build to avoid invalidating other
   tools with a file watcher multiple times.
+- Support the latest dart_style version.
+- Force the generated build script language version to 3.5.0.
+  - **Note**: This is technically breaking, although it is unlikely to actually
+    break anybody. If you are affected please open an issue.
+  - This is expected to periodically increase in the future, in an adhoc
+    fashion. If you would like to use new language features in your builder
+    factory expressions, please open an issue asking for the language version to
+    be increased.
 
 ## 2.4.13
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -10,6 +10,7 @@
     fashion. If you would like to use new language features in your builder
     factory expressions, please open an issue asking for the language version to
     be increased.
+- Allow analyzer version 7.x.
 
 ## 2.4.13
 

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -12,6 +12,7 @@ import 'package:dart_style/dart_style.dart';
 import 'package:graphs/graphs.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
 
 import '../package_graph/build_config_overrides.dart';
 import 'builder_ordering.dart';
@@ -22,6 +23,8 @@ const scriptKernelSuffix = '.dill';
 const scriptKernelCachedLocation =
     '$scriptKernelLocation$scriptKernelCachedSuffix';
 const scriptKernelCachedSuffix = '.cached';
+
+final _buildScriptLanguageVersion = Version(3, 5, 0);
 
 final _log = Logger('Entrypoint');
 
@@ -44,10 +47,13 @@ Future<String> _generateBuildScript() async {
       allocator: Allocator.simplePrefixing(), useNullSafetySyntax: true);
   try {
     final content = StringBuffer()
+      ..writeln('// @dart=${_buildScriptLanguageVersion.major}.'
+          '${_buildScriptLanguageVersion.minor}')
       ..writeln('// ignore_for_file: directives_ordering')
       ..writeln(library.accept(emitter));
 
-    return DartFormatter().format(content.toString());
+    return DartFormatter(languageVersion: _buildScriptLanguageVersion)
+        .format(content.toString());
   } on FormatterException {
     _log.severe('Generated build script could not be parsed.\n'
         'This is likely caused by a misconfigured builder definition.');

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.14-wip
+version: 2.4.14
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 #resolution: workspace
@@ -24,7 +24,7 @@ dependencies:
   code_builder: ^4.2.0
   collection: ^1.15.0
   crypto: ^3.0.0
-  dart_style: ^2.0.0
+  dart_style: '>=2.3.7 <4.0.0'
   frontend_server_client: ">=3.0.0 <5.0.0"
   glob: ^2.0.0
   graphs: ^2.2.0

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -13,7 +13,7 @@ platforms:
   macos:
 
 dependencies:
-  analyzer: '>=4.4.0 <7.0.0'
+  analyzer: '>=4.4.0 <8.0.0'
   args: ^2.0.0
   async: ^2.5.0
   build: ">=2.1.0 <2.5.0"

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   build_config: ">=1.1.0 <1.2.0"
   build_daemon: ^4.0.0
   build_resolvers: ^2.0.0
-  build_runner_core: ^8.0.0-wip
+  build_runner_core: ^8.0.0
   code_builder: ^4.2.0
   collection: ^1.15.0
   crypto: ^3.0.0

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.0.0-wip
+## 8.0.0
 
 - __Breaking__: Add `completeBuild` to `RunnerAssetWriter`, a method expected
   to be called by the build system at the end of a completed build.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 8.0.0-wip
+version: 8.0.0
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 4.1.0-wip
+## 4.1.0
 
 - Support package:archive version 4.x.
+- Allow analyzer version 7.x.
 
 ## 4.1.0-beta.3
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.1.0-wip
+version: 4.1.0
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 # This package can't be part of the workspace because it requires a very recent
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.6.0-165.0.dev <3.7.0-z'
 
 dependencies:
-  analyzer: '>=5.1.0 <7.0.0'
+  analyzer: '>=5.1.0 <8.0.0'
   archive: '>=3.0.0 <5.0.0'
   bazel_worker: ^1.0.0
   build: ^2.0.0


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/3780

- Allow the latest dart_style, and always pass a language version
- Pins the language version in a similar fashion to https://github.com/dart-lang/build/pull/3774
  - Previously this was just based on the current packages language version which was unstable and probably quite variable, so it is probably safer overall to go with the pinning approach.
- Allows latest analyzer across many packages
- Preps many packages for release
- Adds overrides to build/build_resolvers to fix existing dependency resolution issues