### PR TITLE
Revert "Bump archive from 3.6.1 to 4.0.1 in /build_web_compilers (#3776)"

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 4.1.0-wip
-
-- Support package:archive version 4.x.
-
 ## 4.1.0-beta.3
 
 - Support 3.7.0 pre-release sdks.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.1.0-wip
+version: 4.1.0-beta.3
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 # This package can't be part of the workspace because it requires a very recent
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   analyzer: '>=5.1.0 <7.0.0'
-  archive: '>=3.0.0 <5.0.0'
+  archive: ^3.0.0
   bazel_worker: ^1.0.0
   build: ^2.0.0
   build_config: ^1.0.0


### PR DESCRIPTION
This reverts commit fbdfb677c0f0dd188b38a9119be06a15c4043b1b.

I have forked the repo prior to this revert here https://github.com/dart-lang/build/tree/resolver-2-methods.

The plan is to use that fork internally until all builders are updated to the new APIs. Then we will do a breaking change in this repo to migrate to all the new APIs. We do not plan to publish ever the *2 APIs on pub.

In the short term, we will update our analyzer upper constraints across all packages but not add these new methods or expose the new APIs. Those versions will be published (soon ish) to unblock other work (such as updating to the latest dart_style).