### PR TITLE
fix strict top level inference lints

### DIFF
--- a/_test/pkgs/provides_builder/lib/builders.dart
+++ b/_test/pkgs/provides_builder/lib/builders.dart
@@ -65,4 +65,4 @@ Builder someBuilder(BuilderOptions options) =>
 Builder notApplied(BuilderOptions options) => _SomeBuilder.fromOptions(options);
 PostProcessBuilder somePostProcessBuilder(BuilderOptions options) =>
     _SomePostProcessBuilder.fromOptions(options);
-Builder throwingBuilder(_) => _ThrowingBuilder();
+Builder throwingBuilder(BuilderOptions _) => _ThrowingBuilder();

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.0.11-wip
+
 ## 5.0.10
 
 - Bump the min sdk to 3.6.0.

--- a/build_modules/lib/builders.dart
+++ b/build_modules/lib/builders.dart
@@ -7,6 +7,6 @@ import 'build_modules.dart';
 import 'src/module_cleanup.dart';
 import 'src/module_library_builder.dart';
 
-Builder moduleLibraryBuilder(_) => const ModuleLibraryBuilder();
+Builder moduleLibraryBuilder(BuilderOptions _) => const ModuleLibraryBuilder();
 
-PostProcessBuilder moduleCleanup(_) => const ModuleCleanup();
+PostProcessBuilder moduleCleanup(BuilderOptions _) => const ModuleCleanup();

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 5.0.10
+version: 5.0.11-wip
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.4.4-wip
+
 ## 2.4.3
 
 - Require the latest analyzer, and stop passing the `withNullability`

--- a/build_resolvers/lib/builder.dart
+++ b/build_resolvers/lib/builder.dart
@@ -10,7 +10,8 @@ import 'package:crypto/crypto.dart';
 
 import 'src/build_asset_uri_resolver.dart';
 
-Builder transitiveDigestsBuilder(_) => _TransitiveDigestsBuilder();
+Builder transitiveDigestsBuilder(BuilderOptions _) =>
+    _TransitiveDigestsBuilder();
 
 PostProcessBuilder transitiveDigestCleanup(BuilderOptions options) =>
     FileDeletingBuilder([transitiveDigestExtension],

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.4.3
+version: 2.4.4-wip
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 resolution: workspace

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -249,7 +249,7 @@
  `package:build_runner/build_script_generate.dart`:
   - Export `generateAndRun` to snapshot and run build scripts.
   - Export `findBuilderApplications` to find builder applications from a
-    package grah.
+    package graph.
 
 ## 1.10.13
 
@@ -258,7 +258,7 @@
 ## 1.10.12
 
 - Allow the null safe pre-releases of all migrated deps.
-- Add a warning if a `builders` section is found in when parsing an overriden
+- Add a warning if a `builders` section is found in when parsing an overridden
   build.yaml file via the `--config` flag.
 
 ## 1.10.11
@@ -318,7 +318,7 @@ Pin `analyzer` to `0.39.14` to work around Issue #2763.
 
 ## 1.9.0
 
-- Add a warning if a package is missing some required placholder files,
+- Add a warning if a package is missing some required placeholder files,
   including `$package$` and `lib/$lib$`.
 - Reduce chances for changing apparent build phases across machines with a
   different order of packages from `package_config.json`.
@@ -772,7 +772,7 @@ also work when you create an output directory.
 ## 0.8.7
 
 - Improve error handling on the `/$graph` page.
-- Support the latest `package:builde`
+- Support the latest `package:build`
 
 ## 0.8.6
 
@@ -818,7 +818,7 @@ also work when you create an output directory.
 
 - Allow passing multiple `--output` options. Each option will be split on
   `:`. The first value will be the root input directory, the second value will
-  be the output directory. If no delimeter is provided, all resources
+  be the output directory. If no delimiter is provided, all resources
   will be copied to the output directory.
 - Allow deleting files in the post process build step.
 - Bug Fix: Correctly include the default allow list when multiple targets
@@ -857,7 +857,7 @@ also work when you create an output directory.
   - They can not be optional themselves, and can only output to cache.
   - Because they all run in a single phase, after other builders, none of their
     outputs can be used as inputs to any actions.
-- Added `applyPostProccess` method which takes `PostProcessBuilderFactory`s
+- Added `applyPostProcess` method which takes `PostProcessBuilderFactory`s
   instead of `BuilderFactory`s.
 
 ### Breaking Changes
@@ -1112,7 +1112,7 @@ clients:
 ### Internal Improvements
 
 - Outputs will no longer be rebuilt unless their inputs actually changed,
-  previously if any transtive dependency changed they would be invalidated.
+  previously if any transitive dependency changed they would be invalidated.
 - Switched to using semantic analyzer summaries, this combined with the better
   input validation means that, ddc/summary builds are much faster on non-api
   affecting edits (dependent modules will no longer be rebuilt).

--- a/build_runner/web/graph_viz_main.dart
+++ b/build_runner/web/graph_viz_main.dart
@@ -4,7 +4,9 @@
 
 import 'dart:async';
 import 'dart:convert';
+// ignore: deprecated_member_use
 import 'dart:html';
+// ignore: deprecated_member_use
 import 'dart:js' as js;
 
 final _graphReference = js.context[r'$build']! as js.JsObject;

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.2.4-wip
+
 ## 2.2.3
 
 - Bump the min sdk to 3.6.0.

--- a/build_test/lib/builder.dart
+++ b/build_test/lib/builder.dart
@@ -2,12 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:build/build.dart';
+
 import 'src/debug_test_builder.dart';
 import 'src/test_bootstrap_builder.dart';
 
 export 'src/debug_test_builder.dart' show DebugTestBuilder;
 export 'src/test_bootstrap_builder.dart' show TestBootstrapBuilder;
 
-DebugTestBuilder debugTestBuilder(_) => const DebugTestBuilder();
-DebugIndexBuilder debugIndexBuilder(_) => const DebugIndexBuilder();
-TestBootstrapBuilder testBootstrapBuilder(_) => TestBootstrapBuilder();
+DebugTestBuilder debugTestBuilder(BuilderOptions _) => const DebugTestBuilder();
+DebugIndexBuilder debugIndexBuilder(BuilderOptions _) =>
+    const DebugIndexBuilder();
+TestBootstrapBuilder testBootstrapBuilder(BuilderOptions _) =>
+    TestBootstrapBuilder();

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 2.2.3
+version: 2.2.4-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.1.1-wip
+
 ## 4.1.0
 
 - Support package:archive version 4.x.

--- a/build_web_compilers/lib/builders.dart
+++ b/build_web_compilers/lib/builders.dart
@@ -18,8 +18,9 @@ Builder webEntrypointBuilder(BuilderOptions options) =>
 // Ddc related builders
 Builder ddcMetaModuleBuilder(BuilderOptions options) =>
     MetaModuleBuilder.forOptions(ddcPlatform, options);
-Builder ddcMetaModuleCleanBuilder(_) => MetaModuleCleanBuilder(ddcPlatform);
-Builder ddcModuleBuilder([_]) => ModuleBuilder(ddcPlatform);
+Builder ddcMetaModuleCleanBuilder(BuilderOptions _) =>
+    MetaModuleCleanBuilder(ddcPlatform);
+Builder ddcModuleBuilder(BuilderOptions _) => ModuleBuilder(ddcPlatform);
 
 Builder ddcBuilder(BuilderOptions options) {
   validateOptions(options.config, _supportedOptions, 'build_web_compilers:ddc');
@@ -52,7 +53,7 @@ Builder ddcKernelBuilder(BuilderOptions options) {
       trackUnusedInputs: _readTrackInputsCompilerOption(options));
 }
 
-Builder sdkJsCopyRequirejs(_) => SdkJsCopyBuilder();
+Builder sdkJsCopyRequirejs(BuilderOptions _) => SdkJsCopyBuilder();
 Builder sdkJsCompile(BuilderOptions options) => SdkJsCompileBuilder(
       sdkKernelPath: 'lib/_internal/ddc_platform.dill',
       outputPath: 'lib/src/dev_compiler/dart_sdk.js',
@@ -62,18 +63,20 @@ Builder sdkJsCompile(BuilderOptions options) => SdkJsCompileBuilder(
 // Dart2js related builders
 Builder dart2jsMetaModuleBuilder(BuilderOptions options) =>
     MetaModuleBuilder.forOptions(dart2jsPlatform, options);
-Builder dart2jsMetaModuleCleanBuilder(_) =>
+Builder dart2jsMetaModuleCleanBuilder(BuilderOptions _) =>
     MetaModuleCleanBuilder(dart2jsPlatform);
-Builder dart2jsModuleBuilder([_]) => ModuleBuilder(dart2jsPlatform);
+Builder dart2jsModuleBuilder(BuilderOptions _) =>
+    ModuleBuilder(dart2jsPlatform);
 PostProcessBuilder dart2jsArchiveExtractor(BuilderOptions options) =>
     Dart2JsArchiveExtractor.fromOptions(options);
 
 // Dart2wasm related builders
 Builder dart2wasmMetaModuleBuilder(BuilderOptions options) =>
     MetaModuleBuilder.forOptions(dart2wasmPlatform, options);
-Builder dart2wasmMetaModuleCleanBuilder(_) =>
+Builder dart2wasmMetaModuleCleanBuilder(BuilderOptions _) =>
     MetaModuleCleanBuilder(dart2wasmPlatform);
-Builder dart2wasmModuleBuilder([_]) => ModuleBuilder(dart2wasmPlatform);
+Builder dart2wasmModuleBuilder(BuilderOptions _) =>
+    ModuleBuilder(dart2wasmPlatform);
 
 // General purpose builders
 PostProcessBuilder dartSourceCleanup(BuilderOptions options) =>

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,9 +1,7 @@
 name: build_web_compilers
-version: 4.1.0
+version: 4.1.1-wip
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
-# This package can't be part of the workspace because it requires a very recent
-# Dart SDK - see the top-level pubspec for details.
 resolution: workspace
 
 environment:

--- a/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -165,7 +165,8 @@ Future<void> runPrerequisites(Map<String, Object> assets) async {
   // It is necessary to add a fake asset so that the build_web_compilers
   // package exists.
   var sdkAssets = <String, Object>{'build_web_compilers|fake.txt': ''};
-  await testBuilderAndCollectAssets(sdkJsCopyRequirejs(null), sdkAssets);
+  await testBuilderAndCollectAssets(
+      sdkJsCopyRequirejs(const BuilderOptions({})), sdkAssets);
   await testBuilderAndCollectAssets(
       sdkJsCompile(const BuilderOptions({})), sdkAssets);
   assets.addAll(sdkAssets);

--- a/build_web_compilers/tool/copy_builder.dart
+++ b/build_web_compilers/tool/copy_builder.dart
@@ -5,7 +5,7 @@
 import 'package:build/build.dart';
 
 /// Factory for the build script.
-Builder copyBuilder(_) => _CopyBuilder();
+Builder copyBuilder(BuilderOptions _) => _CopyBuilder();
 
 /// Copies the [_stackTraceMapperJs] file to [_stackTraceMapperCopyJs].
 class _CopyBuilder extends Builder {


### PR DESCRIPTION
These are all just `_` params that were falling back on dynamic.

Technically these are all breaking changes but none should be in practice.