### PR TITLE
Add top level argument type in generated file

### DIFF
--- a/build_runner/test/integration_tests/utils/build_descriptor.dart
+++ b/build_runner/test/integration_tests/utils/build_descriptor.dart
@@ -161,7 +161,7 @@ ${builders.map(_builderFactory).join('\n')}
 ''';
 
 String _builderFactory(TestBuilderDefinition builder) =>
-    'Builder ${builder.key}Factory(_) => ${builder.key};';
+    'Builder ${builder.key}Factory(BuilderOptions _) => ${builder.key};';
 
 String _buildToolFile(
         Iterable<TestBuilderDefinition> builders, Uri callingScript) =>


### PR DESCRIPTION
Clean up the last instance of `^Builder.*(_)` after the same pattern was
changed everywhere else to adhere to the strict top level inference
lint.

Add the `BuilderOptions` annotation in a string being written as a
top level function in a generated file.

There do not appear to be instances of this pattern in documentation.
