### PR TITLE
Fix crash on assets ending in a dot

### DIFF
--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.1-dev
+
+- Fix crash when running on assets ending in a dot.
+
 ## 8.0.0
 
 - __Breaking__: Add `completeBuild` to `RunnerAssetWriter`, a method expected

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -941,7 +941,14 @@ String _actionLoggerName(
     InBuildPhase phase, AssetId primaryInput, String rootPackageName) {
   var asset = primaryInput.package == rootPackageName
       ? primaryInput.path
-      : primaryInput.uri;
+      : primaryInput.uri.toString();
+
+  // In the rare case that the assets ends with a dot, remove it to ensure that
+  // the logger name is valid.
+  while (asset.endsWith('.')) {
+    asset = asset.substring(0, asset.length - 1);
+  }
+
   return '${phase.builderLabel} on $asset';
 }
 

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 8.0.0
+version: 8.0.1-dev
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1906,6 +1906,26 @@ void main() {
       // A build does not crash in `_cleanUpStaleOutputs`
       await testBuilders(builders, {'a|lib/a.txt': 'a'});
     });
+
+    test('can have assets ending in a dot', () async {
+      var builders = [
+        applyToRoot(
+          TestBuilder(
+            buildExtensions: {
+              '': ['copy']
+            },
+            build: (step, __) async {
+              await step.writeAsString(step.allowedOutputs.single, 'out');
+            },
+          ),
+        ),
+      ];
+      await testBuilders(builders, {
+        'a|lib/a.': 'a',
+      }, outputs: {
+        'a|lib/a.copy': 'out',
+      });
+    });
   });
 }
 


### PR DESCRIPTION
We create a logger for each builder containing the asset id it's running on. Loggers aren't allowed to end with a dot because that character is used to build hierarchies.

In the somewhat absurd case where users have files ending with a dot in their project and also somehow managed to end up with builders actually matching an empty extension, `build_runner` would crash. I think this might be causing https://github.com/simolus3/drift/issues/3435.