### PR TITLE
Fix presubmit warning about ignored checked-in files.

### DIFF
--- a/build_runner_core/test/fixtures/.gitignore
+++ b/build_runner_core/test/fixtures/.gitignore
@@ -8,3 +8,9 @@
 /*/.dart_tool/*
 # Re-include the package config file.
 !/*/.dart_tool/package_config.json
+
+# Handwritten pubspec.lock files.
+!basic_pkg/pubspec.lock
+!flutter_pkg/pubspec.lock
+!with_dev_deps/pubspec.lock
+!workspace/pubspec.lock


### PR DESCRIPTION
Example failure https://github.com/dart-lang/build/actions/runs/13054962412/job/36423631149?pr=3802