### PR TITLE
Add to `resolver_test`, add to `AnalysisDriverModel` as needed to satisfy the tests.

### DIFF
--- a/build_resolvers/lib/src/analysis_driver_model.dart
+++ b/build_resolvers/lib/src/analysis_driver_model.dart
@@ -34,16 +34,24 @@ class AnalysisDriverModel {
   final MemoryResourceProvider resourceProvider =
       MemoryResourceProvider(context: p.posix);
 
+  /// The import graph of all sources needed for analysis.
+  final _graph = _Graph();
+
+  /// Assets that have been synced into the in-memory filesystem
+  /// [resourceProvider].
+  final _syncedOntoResourceProvider = <AssetId>{};
+
   /// Notifies that [step] has completed.
   ///
   /// All build steps must complete before [reset] is called.
   void notifyComplete(BuildStep step) {
-    // TODO(davidmorgan): add test coverage, fix implementation.
+    // This implementation doesn't keep state per `BuildStep`, nothing to do.
   }
 
   /// Clear cached information specific to an individual build.
   void reset() {
-    // TODO(davidmorgan): add test coverage, fix implementation.
+    _graph.clear();
+    _syncedOntoResourceProvider.clear();
   }
 
   /// Attempts to parse [uri] into an [AssetId] and returns it if it is cached.
@@ -82,66 +90,84 @@ class AnalysisDriverModel {
               FutureOr<void> Function(AnalysisDriverForPackageBuild))
           withDriverResource,
       {required bool transitive}) async {
-    /// TODO(davidmorgan): add test coverage for whether transitive
-    /// sources are read when [transitive] is false, fix the implementation
-    /// here.
-    /// TODO(davidmorgan): add test coverage for whether
-    /// `.transitive_deps` files cut off the reporting of deps to the
-    /// [buildStep], fix the implementation here.
-
-    // Find transitive deps, this also informs [buildStep] of all inputs).
-    final ids = await _expandToTransitive(buildStep, entryPoints);
-
-    // Apply changes to in-memory filesystem.
-    for (final id in ids) {
-      if (await buildStep.canRead(id)) {
-        final content = await buildStep.readAsString(id);
-
-        /// TODO(davidmorgan): add test coverage for when a file is
-        /// modified rather than added, fix the implementation here.
-        resourceProvider.newFile(id.asPath, content);
-      } else {
-        if (resourceProvider.getFile(id.asPath).exists) {
-          resourceProvider.deleteFile(id.asPath);
-        }
-      }
-    }
-
-    // Notify the analyzer of changes.
+    // Immediately take the lock on `driver` so that the whole class state,
+    // `_graph` and `_readForAnalyzir`, is only mutated by one build step at a
+    // time. Otherwise, interleaved access complicates processing significantly.
     await withDriverResource((driver) async {
-      for (final id in ids) {
-        // TODO(davidmorgan): add test coverage for over-notification of
-        // changes, fix the implementaion here.
-        driver.changeFile(id.asPath);
-      }
-      await driver.applyPendingFileChanges();
+      return _performResolve(driver, buildStep, entryPoints, withDriverResource,
+          transitive: transitive);
     });
   }
 
-  /// Walks the import graph from [ids], returns full transitive deps.
-  Future<Set<AssetId>> _expandToTransitive(
-      AssetReader reader, Iterable<AssetId> ids) async {
-    final result = ids.toSet();
-    final nextIds = Queue.of(ids);
-    while (nextIds.isNotEmpty) {
-      final nextId = nextIds.removeFirst();
+  Future<void> _performResolve(
+      AnalysisDriverForPackageBuild driver,
+      BuildStep buildStep,
+      List<AssetId> entryPoints,
+      Future<void> Function(
+              FutureOr<void> Function(AnalysisDriverForPackageBuild))
+          withDriverResource,
+      {required bool transitive}) async {
+    var idsToSyncOntoResourceProvider = entryPoints;
+    Iterable<AssetId> inputIds = entryPoints;
 
-      // Skip if not readable. Note that calling `canRead` still makes it a
-      // dependency of the `BuildStep`.
-      if (!await reader.canRead(nextId)) continue;
+    // If requested, find transitive imports.
+    if (transitive) {
+      await _graph.load(buildStep, entryPoints);
+      idsToSyncOntoResourceProvider = _graph.nodes.keys.toList();
+      inputIds = _graph.inputsFor(entryPoints);
 
-      final content = await reader.readAsString(nextId);
-      final deps = _parseDependencies(content, nextId);
-
-      // For each dep, if it's not in `result` yet, it's newly-discovered:
-      // add it to `nextIds`.
-      for (final dep in deps) {
-        if (result.add(dep)) {
-          nextIds.add(dep);
+      // Check for missing inputs that were written during the build.
+      for (final id in inputIds
+          .where((id) => !id.path.endsWith(_transitiveDigestExtension))) {
+        if (_graph.nodes[id]!.isMissing) {
+          if (await buildStep.canRead(id)) {
+            idsToSyncOntoResourceProvider.add(id);
+            _syncedOntoResourceProvider.remove(id);
+          }
         }
       }
     }
-    return result;
+
+    // Notify [buildStep] of its inputs.
+    for (final id in inputIds) {
+      await buildStep.canRead(id);
+    }
+
+    // Sync changes onto the "URI resolver", the in-memory filesystem.
+    final changedIds = <AssetId>[];
+    for (final id in idsToSyncOntoResourceProvider) {
+      if (!_syncedOntoResourceProvider.add(id)) continue;
+      final content =
+          await buildStep.canRead(id) ? await buildStep.readAsString(id) : null;
+      final inMemoryFile = resourceProvider.getFile(id.asPath);
+      final inMemoryContent =
+          inMemoryFile.exists ? inMemoryFile.readAsStringSync() : null;
+
+      if (content != inMemoryContent) {
+        if (content == null) {
+          // TODO(davidmorgan): per "globallySeenAssets" in
+          // BuildAssetUriResolver, deletes should only be applied at the end
+          // of the build, in case the file is actually there but not visible
+          // to the current reader.
+          resourceProvider.deleteFile(id.asPath);
+          changedIds.add(id);
+        } else {
+          if (inMemoryContent == null) {
+            resourceProvider.newFile(id.asPath, content);
+          } else {
+            resourceProvider.modifyFile(id.asPath, content);
+          }
+          changedIds.add(id);
+        }
+      }
+    }
+
+    // Notify the analyzer of changes and wait for it to update its internal
+    // state.
+    for (final id in changedIds) {
+      driver.changeFile(id.asPath);
+    }
+    await driver.applyPendingFileChanges();
   }
 }
 
@@ -167,3 +193,108 @@ extension _AssetIdExtensions on AssetId {
   /// Asset path for the in-memory filesystem.
   String get asPath => AnalysisDriverModelUriResolver.assetPath(this);
 }
+
+/// The directive graph of all known sources.
+///
+/// Also tracks whether there is a `.transitive_digest` file next to each source
+/// asset, and tracks missing files.
+class _Graph {
+  final Map<AssetId, _Node> nodes = {};
+
+  /// Walks the import graph from [ids] loading into [nodes].
+  Future<void> load(AssetReader reader, Iterable<AssetId> ids) async {
+    final nextIds = Queue.of(ids);
+    while (nextIds.isNotEmpty) {
+      final nextId = nextIds.removeFirst();
+
+      // Skip if already seen.
+      if (nodes.containsKey(nextId)) continue;
+
+      final hasTransitiveDigestAsset =
+          await reader.canRead(nextId.addExtension(_transitiveDigestExtension));
+
+      // Skip if not readable.
+      if (!await reader.canRead(nextId)) {
+        nodes[nextId] = _Node.missing(
+            id: nextId, hasTransitiveDigestAsset: hasTransitiveDigestAsset);
+        continue;
+      }
+
+      final content = await reader.readAsString(nextId);
+      final deps = _parseDependencies(content, nextId);
+      nodes[nextId] = _Node(
+          id: nextId,
+          deps: deps,
+          hasTransitiveDigestAsset: hasTransitiveDigestAsset);
+      nextIds.addAll(deps.where((id) => !nodes.containsKey(id)));
+    }
+  }
+
+  void clear() {
+    nodes.clear();
+  }
+
+  /// The inputs for a build action analyzing [entryPoints].
+  ///
+  /// This is transitive deps, but cut off by the presence of any
+  /// `.transitive_digest` file next to an asset.
+  Set<AssetId> inputsFor(Iterable<AssetId> entryPoints) {
+    final result = entryPoints.toSet();
+    final nextIds = Queue.of(entryPoints);
+
+    while (nextIds.isNotEmpty) {
+      final nextId = nextIds.removeFirst();
+      final node = nodes[nextId]!;
+
+      // Add the transitive digest file as an input. If it exists, skip deps.
+      result.add(nextId.addExtension(_transitiveDigestExtension));
+      if (node.hasTransitiveDigestAsset) {
+        continue;
+      }
+
+      // Skip if there are no deps because the file is missing.
+      if (node.isMissing) continue;
+
+      // For each dep, if it's not in `result` yet, it's newly-discovered:
+      // add it to `nextIds`.
+      for (final dep in node.deps!) {
+        if (result.add(dep)) {
+          nextIds.add(dep);
+        }
+      }
+    }
+    return result;
+  }
+
+  @override
+  String toString() => nodes.toString();
+}
+
+/// A node in the directive graph.
+class _Node {
+  final AssetId id;
+  final List<AssetId> deps;
+  final bool isMissing;
+  final bool hasTransitiveDigestAsset;
+
+  _Node(
+      {required this.id,
+      required this.deps,
+      required this.hasTransitiveDigestAsset})
+      : isMissing = false;
+
+  _Node.missing({required this.id, required this.hasTransitiveDigestAsset})
+      : isMissing = true,
+        deps = const [];
+
+  @override
+  String toString() => '$id:'
+      '${hasTransitiveDigestAsset ? 'digest:' : ''}'
+      '${isMissing ? 'missing' : deps}';
+}
+
+// Transitive digest files are built next to source inputs. As the name
+// suggests, they contain the transitive digest of all deps of the file.
+// So, establishing a dependency on a transitive digest file is equivalent
+// to establishing a dependency on all deps of the file.
+const _transitiveDigestExtension = '.transitive_digest';

--- a/build_resolvers/lib/src/analysis_driver_model.dart
+++ b/build_resolvers/lib/src/analysis_driver_model.dart
@@ -257,7 +257,7 @@ class _Graph {
 
       // For each dep, if it's not in `result` yet, it's newly-discovered:
       // add it to `nextIds`.
-      for (final dep in node.deps!) {
+      for (final dep in node.deps) {
         if (result.add(dep)) {
           nextIds.add(dep);
         }

--- a/build_resolvers/lib/src/analysis_driver_model.dart
+++ b/build_resolvers/lib/src/analysis_driver_model.dart
@@ -116,7 +116,8 @@ class AnalysisDriverModel {
       idsToSyncOntoResourceProvider = _graph.nodes.keys.toList();
       inputIds = _graph.inputsFor(entryPoints);
 
-      // Check for missing inputs that were written during the build.
+      // Check for inputs that were missing when the directive graph was read
+      // but have since been written by another build action.
       for (final id in inputIds
           .where((id) => !id.path.endsWith(_transitiveDigestExtension))) {
         if (_graph.nodes[id]!.isMissing) {
@@ -203,6 +204,7 @@ class _Graph {
 
   /// Walks the import graph from [ids] loading into [nodes].
   Future<void> load(AssetReader reader, Iterable<AssetId> ids) async {
+    // TODO(davidmorgan): check if List is faster.
     final nextIds = Queue.of(ids);
     while (nextIds.isNotEmpty) {
       final nextId = nextIds.removeFirst();

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.2.4-wip
 
+- Support checks on reader state after a build acion in `resolveSources`.
+
 ## 2.2.3
 
 - Bump the min sdk to 3.6.0.


### PR DESCRIPTION
For #3811 

Run the tests with both "shared" instances, re-used between tests (as before) and "new" instances.

The new implementation is still not used, and is not finished: it's a further step towards adding tests / simplifying to understand what's going on and what can be done to improve performance.

This version does already save some time on the big builds :)

skip-changelog-check