### PR TITLE
Resolver should only throw for severe errors

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Refactor `BuildAssetUriResolver` into `AnalysisDriverModel` and
   `AnalysisDriverModelUriResolver`. Add new implementation of
   `AnalysisDriverModel`.
+- Make resolver only throw `SyntaxErrorInAssetException` on severe syntax errors
 
 ## 2.4.3
 

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -12,6 +12,7 @@ import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/diagnostic/diagnostic.dart';
 import 'package:analyzer/error/error.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
@@ -238,7 +239,8 @@ class AnalyzerResolver implements ReleasableResolver {
 
       var parsedResult =
           _driver.currentSession.getParsedUnit(path) as ParsedUnitResult;
-      if (!allowSyntaxErrors && parsedResult.errors.isNotEmpty) {
+      if (!allowSyntaxErrors &&
+          parsedResult.errors.any((e) => e.severity == Severity.error)) {
         throw SyntaxErrorInAssetException(assetId, [parsedResult]);
       }
       return parsedResult.unit;

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -739,6 +739,23 @@ int? get x => 1;
           );
         });
       });
+      test('are only reported if severe', () {
+        return resolveSources({
+          'a|errors.dart': '''
+            /// {@code }
+            class A{}
+          ''',
+        }, (resolver) async {
+          await expectLater(
+            resolver.libraryFor(AssetId.parse('a|errors.dart')),
+            completion(isNotNull),
+          );
+          await expectLater(
+            resolver.compilationUnitFor(AssetId.parse('a|errors.dart')),
+            completion(isNotNull),
+          );
+        });
+      });
 
       test('are reported for part files with errors', () {
         return resolveSources({


### PR DESCRIPTION
Closes https://github.com/dart-lang/build/issues/3827

While using a code generator package I ran into an issue where I was being told that a file had a syntax error.
There was no error, analyzer reported no issues.

After further debugging, it turned out to be a `Doc directive 'hello' is unknown.` error.
Because this error is not severe, it should be ignored.

This PR makes build_resolver only throw on severe syntax errors

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
