### PR TITLE
Fix analysis options.

### DIFF
--- a/_test/analysis_options.yaml
+++ b/_test/analysis_options.yaml
@@ -1,1 +1,7 @@
 include: ../analysis_options.yaml
+
+analyzer:
+  exclude:
+    # Exclude this here because if added to ../analysis_options.yaml it also
+    # excludes package:build.
+    - "build/**"

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,5 +12,4 @@ analyzer:
     # Prevents extra work during some e2e test runs.
     - "dart2js_test/**"
     # Common top level directories containing generated files in any package.
-    - "build/**"
     - ".dart_tool/**"


### PR DESCRIPTION
Move exclude for `_test/build/**` from the top level into `_test`, because it was also incorrectly excluding the whole `build` package.