### PR TITLE
Add --use-experimental-resolver flag.

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -4,6 +4,8 @@
   `AnalysisDriverFilesystem`. Add new implementation of
   `AnalysisDriverModel`.
 - Make resolver only throw `SyntaxErrorInAssetException` on severe syntax errors
+- Add `BuildAssetUriResolver.useExperimentalResolver` for
+  `--use-experimental-resolver` flag. This will be removed.
 
 ## 2.4.3
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.4.15
+## 2.4.15-wip
 
 - Update to package:web and dart:js_interop.
 - Support the latest `package:shelf_web_socket`.

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Update to package:web and dart:js_interop.
 - Support the latest `package:shelf_web_socket`.
+- Add hidden `--use-experimental-resolver` flag for issue #3811 performance
+  work. This flag will be removed.
 
 ## 2.4.14
 

--- a/build_runner/lib/src/entrypoint/base_command.dart
+++ b/build_runner/lib/src/entrypoint/base_command.dart
@@ -97,7 +97,8 @@ abstract class BuildRunnerCommand extends Command<int> {
               'If multiple filters are applied then outputs matching any '
               'filter will be built (they do not need to match all filters).')
       ..addMultiOption(enableExperimentOption,
-          help: 'A list of dart language experiments to enable.');
+          help: 'A list of dart language experiments to enable.')
+      ..addFlag(useExperimentalResolverOption, hide: true);
   }
 
   /// Must be called inside [run] so that [argResults] is non-null.

--- a/build_runner/lib/src/entrypoint/build.dart
+++ b/build_runner/lib/src/entrypoint/build.dart
@@ -5,6 +5,9 @@
 import 'dart:async';
 
 import 'package:build/experiments.dart';
+// ignore: implementation_imports
+import 'package:build_resolvers/src/build_asset_uri_resolver.dart'
+    as uri_resolver;
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:io/io.dart';
 
@@ -32,6 +35,10 @@ class BuildCommand extends BuildRunnerCommand {
   }
 
   Future<int> _run(SharedOptions options) async {
+    // TODO(davidmorgan): remove when experiment is over.
+    if (options.useExperimentalResolver) {
+      uri_resolver.useExperimentalResolver();
+    }
     var result = await build(
       builderApplications,
       buildFilters: options.buildFilters,

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -31,6 +31,7 @@ const releaseOption = 'release';
 const trackPerformanceOption = 'track-performance';
 const skipBuildScriptCheckOption = 'skip-build-script-check';
 const symlinkOption = 'symlink';
+const useExperimentalResolverOption = 'use-experimental-resolver';
 const usePollingWatcherOption = 'use-polling-watcher';
 const verboseOption = 'verbose';
 
@@ -86,6 +87,8 @@ class SharedOptions {
 
   final List<String> enableExperiments;
 
+  final bool useExperimentalResolver;
+
   SharedOptions._({
     required this.buildFilters,
     required this.deleteFilesByDefault,
@@ -100,6 +103,7 @@ class SharedOptions {
     required this.isReleaseBuild,
     required this.logPerformanceDir,
     required this.enableExperiments,
+    required this.useExperimentalResolver,
   });
 
   SharedOptions.fromParsedArgs(ArgResults argResults,
@@ -122,6 +126,8 @@ class SharedOptions {
           isReleaseBuild: argResults[releaseOption] as bool,
           logPerformanceDir: argResults[logPerformanceOption] as String?,
           enableExperiments: argResults[enableExperimentOption] as List<String>,
+          useExperimentalResolver:
+              argResults[useExperimentalResolverOption] as bool,
         );
 }
 
@@ -147,6 +153,7 @@ class DaemonOptions extends WatchOptions {
     required super.logPerformanceDir,
     required super.usePollingWatcher,
     required super.enableExperiments,
+    required super.useExperimentalResolver,
   }) : super._();
 
   factory DaemonOptions.fromParsedArgs(ArgResults argResults,
@@ -187,6 +194,8 @@ class DaemonOptions extends WatchOptions {
       logPerformanceDir: argResults[logPerformanceOption] as String?,
       usePollingWatcher: argResults[usePollingWatcherOption] as bool,
       enableExperiments: argResults[enableExperimentOption] as List<String>,
+      useExperimentalResolver:
+          argResults[useExperimentalResolverOption] as bool,
     );
   }
 }
@@ -214,6 +223,7 @@ class WatchOptions extends SharedOptions {
     required super.isReleaseBuild,
     required super.logPerformanceDir,
     required super.enableExperiments,
+    required super.useExperimentalResolver,
   }) : super._();
 
   WatchOptions.fromParsedArgs(ArgResults argResults,
@@ -237,6 +247,8 @@ class WatchOptions extends SharedOptions {
           logPerformanceDir: argResults[logPerformanceOption] as String?,
           usePollingWatcher: argResults[usePollingWatcherOption] as bool,
           enableExperiments: argResults[enableExperimentOption] as List<String>,
+          useExperimentalResolver:
+              argResults[useExperimentalResolverOption] as bool,
         );
 }
 
@@ -266,6 +278,7 @@ class ServeOptions extends WatchOptions {
     required super.logPerformanceDir,
     required super.usePollingWatcher,
     required super.enableExperiments,
+    required super.useExperimentalResolver,
   }) : super._();
 
   factory ServeOptions.fromParsedArgs(ArgResults argResults,
@@ -337,6 +350,8 @@ class ServeOptions extends WatchOptions {
       logPerformanceDir: argResults[logPerformanceOption] as String?,
       usePollingWatcher: argResults[usePollingWatcherOption] as bool,
       enableExperiments: argResults[enableExperimentOption] as List<String>,
+      useExperimentalResolver:
+          argResults[useExperimentalResolverOption] as bool,
     );
   }
 }

--- a/build_runner/lib/src/entrypoint/watch.dart
+++ b/build_runner/lib/src/entrypoint/watch.dart
@@ -5,6 +5,9 @@
 import 'dart:async';
 
 import 'package:build/experiments.dart';
+// ignore: implementation_imports
+import 'package:build_resolvers/src/build_asset_uri_resolver.dart'
+    as uri_resolver;
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:io/io.dart';
 
@@ -46,6 +49,10 @@ class WatchCommand extends BuildRunnerCommand {
   }
 
   Future<int> _run(WatchOptions options) async {
+    // TODO(davidmorgan): remove when experiment is over.
+    if (options.useExperimentalResolver) {
+      uri_resolver.useExperimentalResolver();
+    }
     var handler = await watch(
       builderApplications,
       deleteFilesByDefault: options.deleteFilesByDefault,

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   build: ">=2.1.0 <2.5.0"
   build_config: ">=1.1.0 <1.2.0"
   build_daemon: ^4.0.0
-  build_resolvers: ^2.4.4
+  build_resolvers: ^2.4.4-wip
   build_runner_core: ^8.0.0
   code_builder: ^4.2.0
   collection: ^1.15.0

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.15
+version: 2.4.15-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   build: ">=2.1.0 <2.5.0"
   build_config: ">=1.1.0 <1.2.0"
   build_daemon: ^4.0.0
-  build_resolvers: ^2.0.0
+  build_resolvers: ^2.4.4
   build_runner_core: ^8.0.0
   code_builder: ^4.2.0
   collection: ^1.15.0


### PR DESCRIPTION
This makes it easier for me to compare, and for external users to try the new implementation before it's live.

@jakemac53 could you please help me figure out what I need to do with `pubspec.yaml` here?

It introduces new API in `build_resolvers` that is needed in `build_runner`, I tried bumping the dep but that obviously doesn't work because `pub get` fails on CI. Should I change to a path dependency until everything is released? Is there anything else I need to do / be aware of?

Thanks :)

