### PR TITLE
Expand benchmarks to different dep graph shapes.

### DIFF
--- a/_benchmark/bin/_benchmark.dart
+++ b/_benchmark/bin/_benchmark.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:_benchmark/commands.dart';
 import 'package:_benchmark/generators.dart';
+import 'package:_benchmark/shape.dart';
 import 'package:args/command_runner.dart';
 
 final commandRunner =
@@ -16,6 +17,10 @@ final commandRunner =
       ..addCommand(BenchmarkCommand())
       ..addCommand(MeasureCommand())
       ..addCommand(CreateCommand())
+      ..argParser.addFlag(
+        'allow-failures',
+        help: 'Whether to continue benchmarking despite failures.',
+      )
       ..argParser.addOption(
         'build-repo-path',
         help: 'Path to build repo to benchmark.',
@@ -30,6 +35,21 @@ final commandRunner =
         'root-directory',
         help: 'Root directory for generated source and builds.',
         defaultsTo: '${Directory.systemTemp.path}/build_benchmark',
+      )
+      ..argParser.addOption(
+        'size',
+        help:
+            'Benchmark size: number of libraries. Omit to run for a range of '
+            'sizes.',
+      )
+      ..argParser.addOption(
+        'shape',
+        help: 'Shape of the dependency graph. Omit to run for all shapes.',
+        allowed: Shape.values.map((e) => e.name).toList(),
+      )
+      ..argParser.addFlag(
+        'use-experimental-resolver',
+        help: 'Whether to pass `--use-experimental-resolver` to build_runner.',
       );
 
 Future<void> main(List<String> arguments) async {

--- a/_benchmark/lib/benchmarks/built_value_generator_benchmark.dart
+++ b/_benchmark/lib/benchmarks/built_value_generator_benchmark.dart
@@ -38,17 +38,12 @@ ${config.dependencyOverrides}
 ''',
     );
 
-    final appLines = ['// ignore_for_file: unused_import', '// CACHEBUSTER'];
-    for (var libraryNumber = 0; libraryNumber != size; ++libraryNumber) {
-      final libraryName = Benchmarks.libraryName(
-        libraryNumber,
-        benchmarkSize: size,
-      );
-      appLines.add("import '$libraryName';");
-    }
     workspace.write(
       'lib/app.dart',
-      source: appLines.map((l) => '$l\n').join(''),
+      source: '''
+/// ignore_for_file: unused_import
+/// CACHEBUSTER
+''',
     );
 
     for (var libraryNumber = 0; libraryNumber != size; ++libraryNumber) {
@@ -57,13 +52,17 @@ ${config.dependencyOverrides}
         benchmarkSize: size,
       );
       final partName = Benchmarks.partName(libraryNumber, benchmarkSize: size);
+      final importNames = config.shape.importNames(
+        libraryNumber,
+        benchmarkSize: size,
+      );
       workspace.write(
         'lib/$libraryName',
         source: '''
 // ignore_for_file: unused_import
 import 'package:built_value/built_value.dart';
 
-import 'app.dart';
+${[for (final importName in importNames) "import '$importName';"].join('\n')}
 
 part '$partName';
 

--- a/_benchmark/lib/benchmarks/freezed_generator_benchmark.dart
+++ b/_benchmark/lib/benchmarks/freezed_generator_benchmark.dart
@@ -38,17 +38,12 @@ ${config.dependencyOverrides}
 ''',
     );
 
-    final appLines = ['// ignore_for_file: unused_import', '// CACHEBUSTER'];
-    for (var libraryNumber = 0; libraryNumber != size; ++libraryNumber) {
-      final libraryName = Benchmarks.libraryName(
-        libraryNumber,
-        benchmarkSize: size,
-      );
-      appLines.add("import '$libraryName';");
-    }
     workspace.write(
       'lib/app.dart',
-      source: appLines.map((l) => '$l\n').join(''),
+      source: '''
+/// ignore_for_file: unused_import
+/// CACHEBUSTER
+''',
     );
 
     for (var libraryNumber = 0; libraryNumber != size; ++libraryNumber) {
@@ -61,13 +56,17 @@ ${config.dependencyOverrides}
         benchmarkSize: size,
         infix: 'freezed',
       );
+      final importNames = config.shape.importNames(
+        libraryNumber,
+        benchmarkSize: size,
+      );
       workspace.write(
         'lib/$libraryName',
         source: '''
 // ignore_for_file: unused_import
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-import 'app.dart';
+${[for (final importName in importNames) "import '$importName';"].join('\n')}
 
 part '$partName';
 

--- a/_benchmark/lib/benchmarks/json_serializable_generator_benchmark.dart
+++ b/_benchmark/lib/benchmarks/json_serializable_generator_benchmark.dart
@@ -39,17 +39,12 @@ ${config.dependencyOverrides}
 ''',
     );
 
-    final appLines = ['// ignore_for_file: unused_import', '// CACHEBUSTER'];
-    for (var libraryNumber = 0; libraryNumber != size; ++libraryNumber) {
-      final libraryName = Benchmarks.libraryName(
-        libraryNumber,
-        benchmarkSize: size,
-      );
-      appLines.add("import '$libraryName';");
-    }
     workspace.write(
       'lib/app.dart',
-      source: appLines.map((l) => '$l\n').join(''),
+      source: '''
+/// ignore_for_file: unused_import
+/// CACHEBUSTER
+''',
     );
 
     for (var libraryNumber = 0; libraryNumber != size; ++libraryNumber) {
@@ -58,13 +53,17 @@ ${config.dependencyOverrides}
         benchmarkSize: size,
       );
       final partName = Benchmarks.partName(libraryNumber, benchmarkSize: size);
+      final importNames = config.shape.importNames(
+        libraryNumber,
+        benchmarkSize: size,
+      );
       workspace.write(
         'lib/$libraryName',
         source: '''
 // ignore_for_file: unused_import
 import 'package:json_annotation/json_annotation.dart';
 
-import 'app.dart';
+${[for (final importName in importNames) "import '$importName';"].join('\n')}
 
 part '$partName';
 

--- a/_benchmark/lib/benchmarks/mockito_generator_benchmark.dart
+++ b/_benchmark/lib/benchmarks/mockito_generator_benchmark.dart
@@ -40,17 +40,12 @@ ${config.dependencyOverrides}
 ''',
     );
 
-    final appLines = ['// ignore_for_file: unused_import', '// CACHEBUSTER'];
-    for (var libraryNumber = 0; libraryNumber != size; ++libraryNumber) {
-      final libraryName = Benchmarks.libraryName(
-        libraryNumber,
-        benchmarkSize: size,
-      );
-      appLines.add("import '$libraryName';");
-    }
     workspace.write(
       'lib/app.dart',
-      source: appLines.map((l) => '$l\n').join(''),
+      source: '''
+/// ignore_for_file: unused_import
+/// CACHEBUSTER
+''',
     );
 
     for (var testNumber = 0; testNumber != size; ++testNumber) {
@@ -81,11 +76,15 @@ ${config.dependencyOverrides}
         libraryNumber,
         benchmarkSize: size,
       );
+      final importNames = config.shape.importNames(
+        libraryNumber,
+        benchmarkSize: size,
+      );
       workspace.write(
         'lib/$libraryName',
         source: '''
 // ignore_for_file: unused_import
-import 'app.dart';
+${[for (final importName in importNames) "import '$importName';"].join('\n')}
 
 class Service$libraryNumber {
   void doSomething(int value) {}

--- a/_benchmark/lib/config.dart
+++ b/_benchmark/lib/config.dart
@@ -7,27 +7,45 @@ import 'dart:io';
 import 'package:args/args.dart';
 
 import 'generators.dart';
+import 'shape.dart';
 import 'workspace.dart';
 
 /// Benchmark tool config.
 class Config {
   final String? buildRepoPath;
   final Generator generator;
+  final List<Shape> shapes;
   final Directory rootDirectory;
-  final List<int> sizes = const [1, 100, 250, 500, 750, 1000];
+  final List<int> sizes;
+  final bool useExperimentalResolver;
+  final bool allowFailures;
 
   Config({
+    required this.allowFailures,
     required this.buildRepoPath,
     required this.generator,
     required this.rootDirectory,
+    required this.sizes,
+    required this.shapes,
+    required this.useExperimentalResolver,
   });
 
   factory Config.fromArgResults(ArgResults argResults) => Config(
+    allowFailures: argResults['allow-failures'] as bool,
     buildRepoPath: argResults['build-repo-path'] as String?,
     generator: Generator.values.singleWhere(
       (e) => e.packageName == argResults['generator'],
     ),
     rootDirectory: Directory(argResults['root-directory'] as String),
+    sizes:
+        argResults['size'] == null
+            ? [1, 100, 250, 500, 750, 1000]
+            : [int.parse(argResults['size'] as String)],
+    shapes:
+        argResults['shape'] == null
+            ? Shape.values
+            : [Shape.values.singleWhere((e) => e.name == argResults['shape'])],
+    useExperimentalResolver: argResults['use-experimental-resolver'] as bool,
   );
 }
 
@@ -35,6 +53,7 @@ class Config {
 class RunConfig {
   final Config config;
   final int size;
+  final Shape shape;
 
   /// [size] as a padded-to-consistent-width `String`.
   final String paddedSize;
@@ -46,6 +65,7 @@ class RunConfig {
     required this.workspace,
     required this.size,
     required this.paddedSize,
+    required this.shape,
   });
 
   String get dependencyOverrides {

--- a/_benchmark/lib/shape.dart
+++ b/_benchmark/lib/shape.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'benchmark.dart';
+
+/// The shape of the dependency graph.
+///
+/// Ordering matters because dependencies are read as needed for each build. If
+/// the first build already depends on everything, as in `forwards`, that's very
+/// different to if each build brings in a new dependency, as in `backwards`.
+///
+/// `app.dart` is the file that will be changed to trigger an incremental build,
+/// in all cases all files transitively depend on it.
+enum Shape {
+  /// A single library cycle.
+  loop,
+
+  /// A line of libraries.
+  ///
+  /// Considered in alphanumeric order, each one has a dependency on the next.
+  /// The final library depends on `app.dart`.
+  forwards,
+
+  /// A line of libraries.
+  ///
+  /// Considered in alphanumeric order, each one has a dependency on the one
+  /// before. The first library depends on `app.dart`.
+  backwards;
+
+  Iterable<String> importNames(
+    int libraryNumber, {
+    required int benchmarkSize,
+  }) {
+    switch (this) {
+      case Shape.loop:
+        return [
+          if (libraryNumber == 0) 'app.dart',
+          Benchmarks.libraryName(
+            (libraryNumber - 1) % benchmarkSize,
+            benchmarkSize: benchmarkSize,
+          ),
+        ];
+      case Shape.forwards:
+        return [
+          if (libraryNumber == benchmarkSize - 1) 'app.dart',
+          if (libraryNumber != benchmarkSize - 1)
+            Benchmarks.libraryName(
+              libraryNumber + 1,
+              benchmarkSize: benchmarkSize,
+            ),
+        ];
+      case Shape.backwards:
+        return [
+          if (libraryNumber == 0) 'app.dart',
+          if (libraryNumber != 0)
+            Benchmarks.libraryName(
+              libraryNumber - 1,
+              benchmarkSize: benchmarkSize,
+            ),
+        ];
+    }
+  }
+}

--- a/_benchmark/lib/workspace.dart
+++ b/_benchmark/lib/workspace.dart
@@ -60,10 +60,12 @@ class Workspace {
       'build_runner',
       'build',
       '-d',
+      if (config.useExperimentalResolver) '--use-experimental-resolver',
     ], workingDirectory: directory.path);
     var exitCode = await process.exitCode;
-    result.cleanBuildTime = stopwatch.elapsed;
-    if (exitCode != 0) {
+    if (exitCode == 0) {
+      result.cleanBuildTime = stopwatch.elapsed;
+    } else {
       final stdout = await process.stdout.transform(utf8.decoder).join();
       final stderr = await process.stderr.transform(utf8.decoder).join();
       result.failure = 'Initial build failed:\n$stdout\n$stderr';
@@ -77,10 +79,12 @@ class Workspace {
       'build_runner',
       'build',
       '-d',
+      if (config.useExperimentalResolver) '--use-experimental-resolver',
     ], workingDirectory: directory.path);
     exitCode = await process.exitCode;
-    result.noChangesBuildTime = stopwatch.elapsed;
-    if (exitCode != 0) {
+    if (exitCode == 0) {
+      result.noChangesBuildTime = stopwatch.elapsed;
+    } else {
       final stdout = await process.stdout.transform(utf8.decoder).join();
       final stderr = await process.stderr.transform(utf8.decoder).join();
       result.failure = 'No changes build failed:\n$stdout\n$stderr';
@@ -95,10 +99,12 @@ class Workspace {
       'build_runner',
       'build',
       '-d',
+      if (config.useExperimentalResolver) '--use-experimental-resolver',
     ], workingDirectory: directory.path);
     exitCode = await process.exitCode;
-    result.incrementalBuildTime = stopwatch.elapsed;
-    if (exitCode != 0) {
+    if (exitCode == 0) {
+      result.incrementalBuildTime = stopwatch.elapsed;
+    } else {
       final stdout = await process.stdout.transform(utf8.decoder).join();
       final stderr = await process.stderr.transform(utf8.decoder).join();
       result.failure = 'Incremental build failed:\n$stdout\n$stderr';
@@ -117,6 +123,7 @@ class PendingResult {
   String? failure;
 
   bool get isFailure => failure != null;
+
   bool get isSuccess =>
       !isFailure &&
       cleanBuildTime != null &&


### PR DESCRIPTION
Also add: support for setting the benchmark size, support for ignoring failures, and support for the `--use-experimental-resolver` flag.

The current implementation stack overflows for sizes >500 libraries, because the import walking uses a recursive algorithm; I'll fix that in the next PR. That's what the "ignore failures" flag is for :) as it allows getting output.

```
> dart run _benchmark --generator=json_serializable --build-repo-path=$PWD/.. benchmark --ignore-failures
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms
loop,1,21831,3934,5459
loop,100,23374,4075,7510
loop,250,29461,4285,13947
loop,500,44638,5220,32247
loop,750,X,X,X
loop,1000,X,X,X
forwards,1,22090,3879,5176
forwards,100,23912,4173,7610
forwards,250,26549,4230,10493
forwards,500,36675,4727,22571
forwards,750,X,X,X
forwards,1000,X,X,X
backwards,1,22396,4115,5306
backwards,100,23500,4204,7321
backwards,250,27423,4164,11095
backwards,500,38999,4895,21654
backwards,750,X,X,X
backwards,1000,X,X,X
```