### PR TITLE
Iterative crawl

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.5-wip
+
+- Switch `BuildAssetUriResolver` dependency crawl to an iterative
+  algorithm, preventing stack overflows.
+
 ## 2.4.4
 
 - Refactor `BuildAssetUriResolver` into `AnalysisDriverModel` and
@@ -6,8 +11,6 @@
 - Make resolver only throw `SyntaxErrorInAssetException` on severe syntax errors
 - Add `BuildAssetUriResolver.useExperimentalResolver` for
   `--use-experimental-resolver` flag. This will be removed.
-- Switch `BuildAssetUriResolver` dependency crawl to an iterative
-  algorithm, preventing stack overflows.
 
 ## 2.4.3
 

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Make resolver only throw `SyntaxErrorInAssetException` on severe syntax errors
 - Add `BuildAssetUriResolver.useExperimentalResolver` for
   `--use-experimental-resolver` flag. This will be removed.
+- Switch `BuildAssetUriResolver` dependency crawl to an iterative
+  algorithm, preventing stack overflows.
 
 ## 2.4.3
 

--- a/build_resolvers/lib/src/build_asset_uri_resolver.dart
+++ b/build_resolvers/lib/src/build_asset_uri_resolver.dart
@@ -13,11 +13,11 @@ import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
 import 'package:build/build.dart' show AssetId, BuildStep;
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
-import 'package:graphs/graphs.dart';
 import 'package:path/path.dart' as p;
 
 import 'analysis_driver_filesystem.dart';
 import 'analysis_driver_model.dart';
+import 'crawl_async.dart';
 
 const _ignoredSchemes = ['dart', 'dart-ext'];
 

--- a/build_resolvers/lib/src/crawl_async.dart
+++ b/build_resolvers/lib/src/crawl_async.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:collection';
+
+final _empty = Future<void>.value();
+
+/// Finds and returns every node in a graph who's nodes and edges are
+/// asynchronously resolved.
+///
+/// Cycles are allowed. If this is an undirected graph the [edges] function
+/// may be symmetric. In this case the [roots] may be any node in each connected
+/// graph.
+///
+/// [V] is the type of values in the graph nodes. [K] must be a type suitable
+/// for using as a Map or Set key. [edges] should return the next reachable
+/// nodes.
+///
+/// There are no ordering guarantees. This is useful for ensuring some work is
+/// performed at every node in an asynchronous graph, but does not give
+/// guarantees that the work is done in topological order.
+///
+/// If either [readNode] or [edges] throws the error will be forwarded
+/// through the result stream and no further nodes will be crawled, though some
+/// work may have already been started.
+///
+/// Crawling is eager, so calls to [edges] may overlap with other calls that
+/// have not completed. If the [edges] callback needs to be limited or throttled
+/// that must be done by wrapping it before calling [crawlAsync].
+///
+/// This is a fork of the `package:graph` algorithm changed from recursive to
+/// iterative; it is mostly for benchmarking, as `AnalysisDriverModel` will
+/// replace the use of this method entirely.
+Stream<V> crawlAsync<K extends Object, V>(
+  Iterable<K> roots,
+  FutureOr<V> Function(K) readNode,
+  FutureOr<Iterable<K>> Function(K, V) edges,
+) {
+  final crawl = _CrawlAsync(roots, readNode, edges)..run();
+  return crawl.result.stream;
+}
+
+class _CrawlAsync<K, V> {
+  final result = StreamController<V>();
+
+  final FutureOr<V> Function(K) readNode;
+  final FutureOr<Iterable<K>> Function(K, V) edges;
+  final Iterable<K> roots;
+
+  final _seen = HashSet<K>();
+  final _next = Queue<K>();
+
+  _CrawlAsync(this.roots, this.readNode, this.edges);
+
+  /// Add all nodes in the graph to [result] and return a Future which fires
+  /// after all nodes have been seen.
+  Future<void> run() async {
+    try {
+      _next.addAll(roots);
+      while (_next.isNotEmpty) {
+        await _crawlNext();
+      }
+      await result.close();
+    } catch (e, st) {
+      result.addError(e, st);
+      await result.close();
+    }
+  }
+
+  /// Remove the next `key` from [_next], queue up any of its its edges
+  /// that haven't been seen.
+  Future<void> _crawlNext() async {
+    final key = _next.removeFirst();
+    final value = await readNode(key);
+    if (result.isClosed) return;
+    result.add(value);
+    for (final edge in await edges(key, value)) {
+      if (_seen.add(edge)) _next.add(edge);
+    }
+  }
+}

--- a/build_resolvers/lib/src/crawl_async.dart
+++ b/build_resolvers/lib/src/crawl_async.dart
@@ -5,8 +5,6 @@
 import 'dart:async';
 import 'dart:collection';
 
-final _empty = Future<void>.value();
-
 /// Finds and returns every node in a graph who's nodes and edges are
 /// asynchronously resolved.
 ///

--- a/build_resolvers/lib/src/crawl_async.dart
+++ b/build_resolvers/lib/src/crawl_async.dart
@@ -70,8 +70,7 @@ class _CrawlAsync<K, V> {
     }
   }
 
-  /// Remove the next `key` from [_next], queue up any of its its edges
-  /// that haven't been seen.
+  /// Process [key], queue up any of its its edges that haven't been seen.
   Future<void> _crawlNext(K key) async {
     final value = await readNode(key);
     if (result.isClosed) return;

--- a/build_resolvers/test/crawl_async_test.dart
+++ b/build_resolvers/test/crawl_async_test.dart
@@ -1,0 +1,129 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build_resolvers/src/crawl_async.dart';
+import 'package:test/test.dart';
+
+// This is a fork of the `package:graph` test of the same name, there are
+// no changes. TODO(davidmorgan): remove when `crawlAsync` is removed
+// in favor of the new `AnalysisDriverModel`.
+
+void main() {
+  group('asyncCrawl', () {
+    Future<List<String?>> crawl(
+      Map<String, List<String>?> g,
+      Iterable<String> roots,
+    ) {
+      final graph = AsyncGraph(g);
+      return crawlAsync(roots, graph.readNode, graph.edges).toList();
+    }
+
+    test('empty result for empty graph', () async {
+      final result = await crawl({}, []);
+      expect(result, isEmpty);
+    });
+
+    test('single item for a single node', () async {
+      final result = await crawl({'a': []}, ['a']);
+      expect(result, ['a']);
+    });
+
+    test('hits every node in a graph', () async {
+      final result = await crawl({
+        'a': ['b', 'c'],
+        'b': ['c'],
+        'c': ['d'],
+        'd': [],
+      }, [
+        'a',
+      ]);
+      expect(result, hasLength(4));
+      expect(
+        result,
+        allOf(contains('a'), contains('b'), contains('c'), contains('d')),
+      );
+    });
+
+    test('handles cycles', () async {
+      final result = await crawl({
+        'a': ['b'],
+        'b': ['c'],
+        'c': ['b'],
+      }, [
+        'a',
+      ]);
+      expect(result, hasLength(3));
+      expect(result, allOf(contains('a'), contains('b'), contains('c')));
+    });
+
+    test('handles self cycles', () async {
+      final result = await crawl({
+        'a': ['b'],
+        'b': ['b'],
+      }, [
+        'a',
+      ]);
+      expect(result, hasLength(2));
+      expect(result, allOf(contains('a'), contains('b')));
+    });
+
+    test('allows null edges', () async {
+      final result = await crawl({
+        'a': ['b'],
+        'b': null,
+      }, [
+        'a',
+      ]);
+      expect(result, hasLength(2));
+      expect(result, allOf(contains('a'), contains('b')));
+    });
+
+    test('allows null nodes', () async {
+      final result = await crawl({
+        'a': ['b'],
+      }, [
+        'a',
+      ]);
+      expect(result, ['a', null]);
+    });
+
+    test('surfaces exceptions for crawling edges', () {
+      final graph = {
+        'a': ['b'],
+      };
+      final nodes = crawlAsync(
+        ['a'],
+        (n) => n,
+        (k, n) => k == 'b' ? throw ArgumentError() : graph[k] ?? <String>[],
+      );
+      expect(nodes, emitsThrough(emitsError(isArgumentError)));
+    });
+
+    test('surfaces exceptions for resolving keys', () {
+      final graph = {
+        'a': ['b'],
+      };
+      final nodes = crawlAsync(
+        ['a'],
+        (n) => n == 'b' ? throw ArgumentError() : n,
+        (k, n) => graph[k] ?? <Never>[],
+      );
+      expect(nodes, emitsThrough(emitsError(isArgumentError)));
+    });
+  });
+}
+
+/// A representation of a Graph where keys can asynchronously be resolved to
+/// real values or to edges.
+class AsyncGraph {
+  final Map<String, List<String>?> graph;
+
+  AsyncGraph(this.graph);
+
+  Future<String?> readNode(String node) async =>
+      graph.containsKey(node) ? node : null;
+
+  Future<Iterable<String>> edges(String key, String? node) async =>
+      graph[key] ?? <Never>[];
+}

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -82,6 +82,24 @@ void runTests(ResolversFactory resolversFactory) {
     }, resolvers: createResolvers());
   });
 
+  test('does not stack overflow on long import chain', () {
+    return resolveSources(
+      {
+        'a|web/main.dart': '''
+              import 'lib0.dart';
+
+              main() {
+              } ''',
+        for (var i = 0; i != 750; ++i)
+          'a|web/lib$i.dart': i == 749 ? '' : 'import "lib${i + 1}.dart";',
+      },
+      (resolver) async {
+        await resolver.libraryFor(entryPoint);
+      },
+      resolvers: createResolvers(),
+    );
+  });
+
   test('should follow package imports', () {
     return resolveSources({
       'a|web/main.dart': '''


### PR DESCRIPTION
The current `build_runner` can't actually run the benchmarks I want due to getting a stack overflow, this is a minimal fix: copy the `crawlAsync` algorithm and test out of `package:graph` (which we own), make it iterative. The algorithm is significantly changed, the tests are the same.

Per suggestion on another PR I benchmarked using `List` instead of `Queue`, there was no consistent difference; so this uses `Queue` to make the processing order closer to the previous version.

Here is the same benchmark pasted in #3841 but now without failures due to stack overflows :)

```
dart run _benchmark --generator=json_serializable --build-repo-path=$PWD/.. benchmark
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms
loop,1,21745,4099,5313
loop,100,23777,4064,7543
loop,250,29418,4356,13627
loop,500,43098,5677,32238
loop,750,66256,8050,58112
loop,1000,110803,9825,102674
forwards,1,21460,4230,5508
forwards,100,24546,4102,7274
forwards,250,27010,4248,11152
forwards,500,35351,4809,21441
forwards,750,47161,6263,38171
forwards,1000,66103,8188,63542
backwards,1,22323,3930,5465
backwards,100,23352,4199,7667
backwards,250,27895,4307,11313
backwards,500,38363,5085,21476
backwards,750,53312,6178,42027
backwards,1000,66276,7393,62432
```