### PR TITLE
Use `dart2wasm` support-detection scripts

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.2-dev
+
+- Use support-detection scripts emitted by `dart2wasm`.
+
 ## 4.1.1
 
 - Support 3.8.0 pre-release sdks.

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.1.2-dev
+## 4.1.2-wip
 
 - Use support-detection scripts emitted by `dart2wasm`.
 

--- a/build_web_compilers/lib/src/dart2wasm_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2wasm_bootstrap.dart
@@ -134,7 +134,7 @@ https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-ski
   }
 
   var supportFile =
-      scratchSpace.fileFor(dartEntrypointId.changeExtension('support.js'));
+      scratchSpace.fileFor(dartEntrypointId.changeExtension('.support.js'));
   String? supportExpression;
   if (await supportFile.exists()) {
     supportExpression = await supportFile.readAsString();

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -329,9 +329,7 @@ class WebEntrypointBuilder implements Builder {
       AssetId input, Dart2WasmBootstrapResult? dart2WasmResult) {
     var loaderExtension = options.loaderExtension;
     var wasmCompiler = options.optionsFor(WebCompiler.Dart2Wasm);
-    if (loaderExtension == null ||
-        wasmCompiler == null ||
-        dart2WasmResult == null) {
+    if (loaderExtension == null || wasmCompiler == null) {
       // Generating the loader has been disabled or no loader is necessary.
       return null;
     }
@@ -357,7 +355,7 @@ function relativeURL(ref) {
     // If we're compiling to JS, start a feature detection to prefer wasm but
     // fall back to JS if necessary.
     if (jsCompiler != null) {
-      final supportCheck = dart2WasmResult.supportExpression ??
+      final supportCheck = dart2WasmResult?.supportExpression ??
           "'WebAssembly' in self && "
               'WebAssembly.validate(new Uint8Array('
               '[0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 95, 1, 120, 0]));';

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -290,6 +290,7 @@ class WebEntrypointBuilder implements Builder {
     if (!isAppEntrypoint) return;
 
     final compilationSteps = <Future>[];
+    Dart2WasmBootstrapResult? dart2WasmResult;
 
     for (final compiler in options.compilers) {
       switch (compiler.compiler) {
@@ -311,20 +312,26 @@ class WebEntrypointBuilder implements Builder {
             entrypointExtension: compiler.extension,
           ));
         case WebCompiler.Dart2Wasm:
-          compilationSteps.add(bootstrapDart2Wasm(
-              buildStep, compiler.compilerArguments, compiler.extension));
+          compilationSteps.add(Future(() async {
+            dart2WasmResult = await bootstrapDart2Wasm(
+                buildStep, compiler.compilerArguments, compiler.extension);
+          }));
       }
     }
     await Future.wait(compilationSteps);
-    if (_generateLoader(buildStep.inputId) case (var id, var loader)?) {
+    if (_generateLoader(buildStep.inputId, dart2WasmResult)
+        case (var id, var loader)?) {
       await buildStep.writeAsString(id, loader);
     }
   }
 
-  (AssetId, String)? _generateLoader(AssetId input) {
+  (AssetId, String)? _generateLoader(
+      AssetId input, Dart2WasmBootstrapResult? dart2WasmResult) {
     var loaderExtension = options.loaderExtension;
     var wasmCompiler = options.optionsFor(WebCompiler.Dart2Wasm);
-    if (loaderExtension == null || wasmCompiler == null) {
+    if (loaderExtension == null ||
+        wasmCompiler == null ||
+        dart2WasmResult == null) {
       // Generating the loader has been disabled or no loader is necessary.
       return null;
     }
@@ -350,17 +357,13 @@ function relativeURL(ref) {
     // If we're compiling to JS, start a feature detection to prefer wasm but
     // fall back to JS if necessary.
     if (jsCompiler != null) {
-      loaderResult.writeln('''
-function supportsWasmGC() {
-  // This attempts to instantiate a wasm module that only will validate if the
-  // final WasmGC spec is implemented in the browser.
-  //
-  // Copied from https://github.com/GoogleChromeLabs/wasm-feature-detect/blob/main/src/detectors/gc/index.js
-  const bytes = [0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 95, 1, 120, 0];
-  return 'WebAssembly' in self && WebAssembly.validate(new Uint8Array(bytes));
-}
+      final supportCheck = dart2WasmResult.supportExpression ??
+          "'WebAssembly' in self && "
+              'WebAssembly.validate(new Uint8Array('
+              '[0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 95, 1, 120, 0]));';
 
-if (supportsWasmGC()) {
+      loaderResult.writeln('''
+if ($supportCheck) {
 ''');
     }
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.1.1
+version: 4.1.2-dev
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.1.2-dev
+version: 4.1.2-wip
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace

--- a/build_web_compilers/test/dart2wasm_bootstrap_test.dart
+++ b/build_web_compilers/test/dart2wasm_bootstrap_test.dart
@@ -70,6 +70,12 @@ void main() {
             stringContainsInOrder(
               [
                 'if',
+                // Depending on whether dart2wasm emitted a .support.js file,
+                // this check either comes from dart2wasm or from our own script
+                // doing its own feature detection as a fallback. Which one is
+                // used depends on the SDK version, we can only assume that the
+                // check is guaranteed to include WebAssembly.validate to check
+                // for WASM features.
                 'WebAssembly.validate',
                 '{',
                 'compileStreaming',

--- a/build_web_compilers/test/dart2wasm_bootstrap_test.dart
+++ b/build_web_compilers/test/dart2wasm_bootstrap_test.dart
@@ -69,9 +69,11 @@ void main() {
           'a|web/index.dart.js': decodedMatches(
             stringContainsInOrder(
               [
-                'if (supportsWasmGC())',
+                'if',
+                'WebAssembly.validate',
+                '{',
                 'compileStreaming',
-                'else',
+                '} else {',
                 'scriptTag.src = relativeURL("./index.dart2js.js");'
               ],
             ),


### PR DESCRIPTION
`dart2wasm` started emitting a `.support.js` file which contains a JavaScript expression evaluating to `true` if the browser supports the WebAssembly module emitted by `dart2wasm`: https://github.com/dart-lang/sdk/issues/59951.

With this PR, we start reading that file and use that as a feature detection if available.