### PR TITLE
Move AssetReader input tracking to new class InputTracker.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.3-wip
+
+- Add `package:build/internal.dart` for use by `build_resolvers`,
+  `build_runner_core` and `build_test` only.
+
 ## 2.4.2
 
 - Bump the min sdk to 3.6.0.

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.4.3-wip
 
-- Add `package:build/internal.dart` for use by `build_resolvers`,
-  `build_runner_core` and `build_test` only.
+- Add `package:build/src/internal.dart` for use by `build_resolvers`,
+  `build_runner_core` and `build_test`.
 
 ## 2.4.2
 

--- a/build/lib/internal.dart
+++ b/build/lib/internal.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Internal build state for `build_resolvers`, `build_runner_core` and
+/// `build_test` only.
+///
+/// In particular, generators must not use
+library;
+
+export 'src/state/input_tracker.dart';
+export 'src/state/reader_state.dart';

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -18,6 +18,8 @@ import '../asset/id.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
 import '../resource/resource.dart';
+import '../state/input_tracker.dart';
+import '../state/reader_state.dart';
 import 'build_step.dart';
 import 'exceptions.dart';
 
@@ -25,7 +27,7 @@ import 'exceptions.dart';
 ///
 /// This represents a single input and its expected and real outputs. It also
 /// handles tracking of dependencies.
-class BuildStepImpl implements BuildStep {
+class BuildStepImpl implements BuildStep, AssetReaderState {
   final Resolvers? _resolvers;
   final StageTracker _stageTracker;
 
@@ -77,6 +79,9 @@ class BuildStepImpl implements BuildStep {
       : allowedOutputs = UnmodifiableSetView(expectedOutputs.toSet()),
         _stageTracker = stageTracker ?? NoOpStageTracker.instance,
         _reportUnusedAssets = reportUnusedAssets;
+
+  @override
+  InputTracker? get inputTracker => _reader.inputTracker;
 
   @override
   Future<PackageConfig> get packageConfig async {

--- a/build/lib/src/internal.dart
+++ b/build/lib/src/internal.dart
@@ -4,9 +4,7 @@
 
 /// Internal build state for `build_resolvers`, `build_runner_core` and
 /// `build_test` only.
-///
-/// In particular, generators must not use
 library;
 
-export 'src/state/input_tracker.dart';
-export 'src/state/reader_state.dart';
+export 'state/input_tracker.dart';
+export 'state/reader_state.dart';

--- a/build/lib/src/state/input_tracker.dart
+++ b/build/lib/src/state/input_tracker.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import '../asset/id.dart';
+
+/// Records inputs for one generator run.
+class InputTracker {
+  final assetsRead = HashSet<AssetId>();
+}

--- a/build/lib/src/state/reader_state.dart
+++ b/build/lib/src/state/reader_state.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../asset/reader.dart';
+import 'input_tracker.dart';
+
+/// Provides access to the state backing an [AssetReader].
+extension AssetReaderStateExtension on AssetReader {
+  InputTracker? get inputTracker =>
+      this is AssetReaderState ? (this as AssetReaderState).inputTracker : null;
+
+  /// Gets [inputTracker] or throws a descriptive error if it is `null`.
+  InputTracker get requireInputTracker {
+    final result = inputTracker;
+    if (result == null) {
+      _requireIsAssetReaderState();
+      throw StateError(
+          '`AssetReader` is missing required `inputTracker`: $this');
+    }
+    return result;
+  }
+
+  /// Throws if `this` is not an [AssetReaderState].
+  void _requireIsAssetReaderState() {
+    if (this is! AssetReaderState) {
+      throw StateError(
+          '`AssetReader` must implement `AssetReaderState`: $this');
+    }
+  }
+}
+
+/// The state backing an [AssetReader].
+abstract interface class AssetReaderState {
+  /// The [InputTracker] that this reader records reads to; or `null` if it does
+  /// not have one.
+  InputTracker? get inputTracker;
+}

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 2.4.2
+version: 2.4.3-wip
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.5-wip
+
+- Start using `package:build/internal.dart`.
+
 ## 2.4.4
 
 - Refactor `BuildAssetUriResolver` into `AnalysisDriverModel` and

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.4.5-wip
 
-- Start using `package:build/internal.dart`.
+- Start using `package:build/src/internal.dart`.
 
 ## 2.4.4
 

--- a/build_resolvers/lib/src/analysis_driver_model.dart
+++ b/build_resolvers/lib/src/analysis_driver_model.dart
@@ -10,7 +10,8 @@ import 'package:analyzer/dart/ast/ast.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
 import 'package:build/build.dart';
-import 'package:build/internal.dart';
+// ignore: implementation_imports
+import 'package:build/src/internal.dart';
 
 import 'analysis_driver_filesystem.dart';
 

--- a/build_resolvers/lib/src/analysis_driver_model.dart
+++ b/build_resolvers/lib/src/analysis_driver_model.dart
@@ -10,6 +10,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
 import 'package:build/build.dart';
+import 'package:build/internal.dart';
 
 import 'analysis_driver_filesystem.dart';
 
@@ -116,9 +117,7 @@ class AnalysisDriverModel {
     }
 
     // Notify [buildStep] of its inputs.
-    for (final id in inputIds) {
-      await buildStep.canRead(id);
-    }
+    buildStep.requireInputTracker.assetsRead.addAll(inputIds);
 
     // Sync changes onto the "URI resolver", the in-memory filesystem.
     for (final id in idsToSyncOntoFilesystem) {

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.4.4
+version: 2.4.5-wip
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 resolution: workspace
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: '>=6.9.0 <8.0.0'
   async: ^2.5.0
-  build: ^2.0.0
+  build: ^2.4.3-wip
   collection: ^1.17.0
   convert: ^3.1.1
   crypto: ^3.0.0

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 8.0.1-wip
 
 - Fix crash when running on assets ending in a dot.
-- Start using `package:build/internal.dart'.
+- Start using `package:build/src/internal.dart'.
 
 ## 8.0.0
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 8.0.1-dev
+## 8.0.1-wip
 
 - Fix crash when running on assets ending in a dot.
+- Start using `package:build/internal.dart'.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -7,7 +7,8 @@ import 'dart:convert';
 
 import 'package:async/async.dart';
 import 'package:build/build.dart';
-import 'package:build/internal.dart';
+// ignore: implementation_imports
+import 'package:build/src/internal.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -3,13 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:collection';
 import 'dart:convert';
 
 import 'package:async/async.dart';
 import 'package:build/build.dart';
+import 'package:build/internal.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
+
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../util/async.dart';
@@ -60,7 +61,7 @@ typedef CheckInvalidInput = void Function(AssetId id);
 ///
 /// Tracks the assets and globs read during this step for input dependency
 /// tracking.
-class SingleStepReader implements AssetReader {
+class SingleStepReader implements AssetReader, AssetReaderState {
   final AssetGraph _assetGraph;
   final AssetReader _delegate;
   final int _phaseNumber;
@@ -71,8 +72,8 @@ class SingleStepReader implements AssetReader {
   final FutureOr<GlobAssetNode> Function(
       Glob glob, String package, int phaseNum)? _getGlobNode;
 
-  /// The assets read during this step.
-  final assetsRead = HashSet<AssetId>();
+  @override
+  final InputTracker inputTracker = InputTracker();
 
   SingleStepReader(this._delegate, this._assetGraph, this._phaseNumber,
       this._primaryPackage, this._isReadableNode, this._checkInvalidInput,
@@ -97,7 +98,7 @@ class SingleStepReader implements AssetReader {
 
     final node = _assetGraph.get(id);
     if (node == null) {
-      assetsRead.add(id);
+      inputTracker.assetsRead.add(id);
       _assetGraph.add(SyntheticSourceAssetNode(id));
       return false;
     }
@@ -105,7 +106,7 @@ class SingleStepReader implements AssetReader {
     return doAfter(_isReadableNode(node, _phaseNumber, _writtenAssets),
         (Readability readability) {
       if (!readability.inSamePhase) {
-        assetsRead.add(id);
+        inputTracker.assetsRead.add(id);
       }
 
       return readability.canRead;
@@ -175,7 +176,7 @@ class SingleStepReader implements AssetReader {
 
     doAfter(_getGlobNode(glob, _primaryPackage, _phaseNumber),
         (GlobAssetNode globNode) {
-      assetsRead.add(globNode.id);
+      inputTracker.assetsRead.add(globNode.id);
       streamCompleter.setSourceStream(Stream.fromIterable(globNode.results!));
     });
     return streamCompleter.stream;

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:build/build.dart';
+import 'package:build/internal.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
@@ -512,7 +513,7 @@ class _SingleBuild {
 
         // We may have read some inputs in the call to `_buildShouldRun`, we
         // want to remove those.
-        wrappedReader.assetsRead.clear();
+        wrappedReader.inputTracker.assetsRead.clear();
 
         var actionDescription =
             _actionLoggerName(phase, input, _packageGraph.root.name);
@@ -552,6 +553,7 @@ class _SingleBuild {
             () => _setOutputsState(
                   builderOutputs,
                   wrappedReader,
+                  wrappedReader.inputTracker,
                   wrappedWriter,
                   actionDescription,
                   logger.errorsSeen,
@@ -617,7 +619,7 @@ class _SingleBuild {
     }
     // We may have read some inputs in the call to `_buildShouldRun`, we want
     // to remove those.
-    wrappedReader.assetsRead.clear();
+    wrappedReader.inputTracker.assetsRead.clear();
 
     // Clean out the impacts of the previous run
     await FailureReporter.clean(phaseNum, input);
@@ -671,8 +673,13 @@ class _SingleBuild {
     // Reset the state for all the output nodes based on what was read and
     // written.
     inputNode.primaryOutputs.addAll(assetsWritten);
-    await _setOutputsState(assetsWritten, wrappedReader, wrappedWriter,
-        actionDescription, logger.errorsSeen);
+    await _setOutputsState(
+        assetsWritten,
+        wrappedReader,
+        wrappedReader.inputTracker,
+        wrappedWriter,
+        actionDescription,
+        logger.errorsSeen);
 
     return assetsWritten;
   }
@@ -853,15 +860,16 @@ class _SingleBuild {
   /// - Storing the error message with the [_failureReporter].
   Future<void> _setOutputsState(
       Iterable<AssetId> outputs,
-      SingleStepReader reader,
+      AssetReader reader,
+      InputTracker inputTracker,
       AssetWriterSpy writer,
       String actionDescription,
       Iterable<ErrorReport> errors,
       {Set<AssetId>? unusedAssets}) async {
     if (outputs.isEmpty) return;
     var usedInputs = unusedAssets != null
-        ? reader.assetsRead.difference(unusedAssets)
-        : reader.assetsRead;
+        ? inputTracker.assetsRead.difference(unusedAssets)
+        : inputTracker.assetsRead;
 
     final inputsDigest = await _computeCombinedDigest(
         usedInputs,

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -8,7 +8,8 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:build/build.dart';
-import 'package:build/internal.dart';
+// ignore: implementation_imports
+import 'package:build/src/internal.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 8.0.1-dev
+version: 8.0.1-wip
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 
@@ -17,7 +17,7 @@ platforms:
 
 dependencies:
   async: ^2.5.0
-  build: ^2.4.0
+  build: ^2.4.3-wip
   build_config: ^1.0.0
   build_resolvers: ^2.4.0
   collection: ^1.15.0

--- a/build_runner_core/test/asset/cache_test.dart
+++ b/build_runner_core/test/asset/cache_test.dart
@@ -27,7 +27,7 @@ void main() {
     test('should read from the delegate', () async {
       expect(await reader.canRead(fooTxt), isTrue);
       expect(await reader.canRead(missingTxt), isFalse);
-      expect(delegate.assetsRead, [fooTxt, missingTxt]);
+      expect(delegate.assetsRead, {fooTxt, missingTxt});
     });
 
     test('should not re-read from the delegate', () async {

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.2.4-wip
 
 - Support checks on reader state after a build action in `resolveSources`.
-- Start using `package:build/internal.dart`.
+- Start using `package:build/src/internal.dart`.
 
 ## 2.2.3
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.4-wip
 
-- Support checks on reader state after a build acion in `resolveSources`.
+- Support checks on reader state after a build action in `resolveSources`.
+- Start using `package:build/internal.dart`.
 
 ## 2.2.3
 

--- a/build_test/lib/src/in_memory_reader.dart
+++ b/build_test/lib/src/in_memory_reader.dart
@@ -4,7 +4,8 @@
 import 'dart:convert';
 
 import 'package:build/build.dart';
-import 'package:build/internal.dart';
+// ignore: implementation_imports
+import 'package:build/src/internal.dart';
 import 'package:glob/glob.dart';
 
 /// An [AssetReader] that records which assets have been read to [assetsRead].

--- a/build_test/lib/src/in_memory_reader.dart
+++ b/build_test/lib/src/in_memory_reader.dart
@@ -4,6 +4,7 @@
 import 'dart:convert';
 
 import 'package:build/build.dart';
+import 'package:build/internal.dart';
 import 'package:glob/glob.dart';
 
 /// An [AssetReader] that records which assets have been read to [assetsRead].
@@ -13,12 +14,15 @@ abstract class RecordingAssetReader implements AssetReader {
 
 /// An implementation of [AssetReader] with primed in-memory assets.
 class InMemoryAssetReader extends AssetReader
-    implements MultiPackageAssetReader, RecordingAssetReader {
+    implements MultiPackageAssetReader, RecordingAssetReader, AssetReaderState {
   final Map<AssetId, List<int>> assets;
   final String? rootPackage;
 
   @override
-  final Set<AssetId> assetsRead = <AssetId>{};
+  final InputTracker inputTracker = InputTracker();
+
+  @override
+  Set<AssetId> get assetsRead => inputTracker.assetsRead;
 
   /// Create a new asset reader that contains [sourceAssets].
   ///
@@ -51,21 +55,21 @@ class InMemoryAssetReader extends AssetReader
 
   @override
   Future<bool> canRead(AssetId id) async {
-    assetsRead.add(id);
+    inputTracker.assetsRead.add(id);
     return assets.containsKey(id);
   }
 
   @override
   Future<List<int>> readAsBytes(AssetId id) async {
     if (!await canRead(id)) throw AssetNotFoundException(id);
-    assetsRead.add(id);
+    inputTracker.assetsRead.add(id);
     return assets[id]!;
   }
 
   @override
   Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) async {
     if (!await canRead(id)) throw AssetNotFoundException(id);
-    assetsRead.add(id);
+    inputTracker.assetsRead.add(id);
     return encoding.decode(assets[id]!);
   }
 

--- a/build_test/lib/src/multi_asset_reader.dart
+++ b/build_test/lib/src/multi_asset_reader.dart
@@ -6,7 +6,8 @@ import 'dart:convert';
 
 import 'package:async/async.dart';
 import 'package:build/build.dart';
-import 'package:build/internal.dart';
+// ignore: implementation_imports
+import 'package:build/src/internal.dart';
 import 'package:glob/glob.dart';
 
 /// A [MultiPackageAssetReader] that delegates to multiple other asset

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   async: ^2.5.0
-  build: ^2.1.0
+  build: ^2.4.3-wip
   build_config: ^1.0.0
   build_resolvers: ^2.4.0
   crypto: ^3.0.0


### PR DESCRIPTION
The `AssetReader` API is user-facing, or rather generator-facing: it provides generators a way to read files, and `build_runner` then records that those files are inputs of the action.

But for `build_runner` itself it's useful to separate reading from tracking. So, this PR starts splitting out reader state and making it accessible to `build_runner` internal code.