### PR TITLE
Refactor `PathProvidingAssetReader` to `AssetPathProvider`

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `package:build/src/internal.dart` for use by `build_resolvers`,
   `build_runner_core` and `build_test`.
 - Use `build_test` 3.0.0.
+- Refactor `PathProvidingAssetReader` to `AssetPathProvider`.
 
 ## 2.4.2
 

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -18,6 +18,7 @@ import '../asset/id.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
 import '../resource/resource.dart';
+import '../state/asset_path_provider.dart';
 import '../state/input_tracker.dart';
 import '../state/reader_state.dart';
 import 'build_step.dart';
@@ -79,6 +80,9 @@ class BuildStepImpl implements BuildStep, AssetReaderState {
       : allowedOutputs = UnmodifiableSetView(expectedOutputs.toSet()),
         _stageTracker = stageTracker ?? NoOpStageTracker.instance,
         _reportUnusedAssets = reportUnusedAssets;
+
+  @override
+  AssetPathProvider? get assetPathProvider => _reader.assetPathProvider;
 
   @override
   InputTracker? get inputTracker => _reader.inputTracker;

--- a/build/lib/src/internal.dart
+++ b/build/lib/src/internal.dart
@@ -6,5 +6,6 @@
 /// `build_test` only.
 library;
 
+export 'state/asset_path_provider.dart';
 export 'state/input_tracker.dart';
 export 'state/reader_state.dart';

--- a/build/lib/src/state/asset_path_provider.dart
+++ b/build/lib/src/state/asset_path_provider.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../asset/id.dart';
+
+/// Converts [AssetId] to paths.
+abstract interface class AssetPathProvider {
+  String pathFor(AssetId id);
+}
+
+/// Applies a function to an existing [AssetPathProvider].
+class OverlayAssetPathProvider implements AssetPathProvider {
+  AssetPathProvider delegate;
+  AssetId Function(AssetId) overlay;
+
+  OverlayAssetPathProvider({required this.delegate, required this.overlay});
+
+  @override
+  String pathFor(AssetId id) => delegate.pathFor(overlay(id));
+}

--- a/build/lib/src/state/reader_state.dart
+++ b/build/lib/src/state/reader_state.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../asset/reader.dart';
+import 'asset_path_provider.dart';
 import 'input_tracker.dart';
 
 /// Provides access to the state backing an [AssetReader].
@@ -21,6 +22,10 @@ extension AssetReaderStateExtension on AssetReader {
     return result;
   }
 
+  AssetPathProvider? get assetPathProvider => this is AssetReaderState
+      ? (this as AssetReaderState).assetPathProvider
+      : null;
+
   /// Throws if `this` is not an [AssetReaderState].
   void _requireIsAssetReaderState() {
     if (this is! AssetReaderState) {
@@ -35,4 +40,8 @@ abstract interface class AssetReaderState {
   /// The [InputTracker] that this reader records reads to; or `null` if it does
   /// not have one.
   InputTracker? get inputTracker;
+
+  /// The [AssetPathProvider] associated with this reader, or `null` if it does
+  /// not have one.
+  AssetPathProvider? get assetPathProvider;
 }

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix crash when running on assets ending in a dot.
 - Start using `package:build/src/internal.dart'.
 - Use `build_test` 3.0.0.
+- Refactor `PathProvidingAssetReader` to `AssetPathProvider`.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -19,11 +19,6 @@ import '../util/async.dart';
 /// A [RunnerAssetReader] must implement [MultiPackageAssetReader].
 abstract class RunnerAssetReader implements MultiPackageAssetReader {}
 
-/// An [AssetReader] that can provide actual paths to assets on disk.
-abstract class PathProvidingAssetReader implements AssetReader {
-  String pathTo(AssetId id);
-}
-
 /// Describes if and how a [SingleStepReader] should read an [AssetId].
 class Readability {
   final bool canRead;
@@ -79,6 +74,9 @@ class SingleStepReader implements AssetReader, AssetReaderState {
   SingleStepReader(this._delegate, this._assetGraph, this._phaseNumber,
       this._primaryPackage, this._isReadableNode, this._checkInvalidInput,
       [this._getGlobNode, this._writtenAssets]);
+
+  @override
+  AssetPathProvider? get assetPathProvider => _delegate.assetPathProvider;
 
   /// Checks whether [id] can be read by this step - attempting to build the
   /// asset if necessary.

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -7,11 +7,12 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';
+// ignore: implementation_imports
+import 'package:build/src/internal.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 
-import '../asset/reader.dart';
 import '../environment/build_environment.dart';
 import '../generate/build_directory.dart';
 import '../generate/finalized_assets_view.dart';
@@ -35,7 +36,7 @@ Future<bool> createMergedOutputDirectories(
     AssetReader reader,
     FinalizedAssetsView finalizedAssetsView,
     bool outputSymlinksOnly) async {
-  if (outputSymlinksOnly && reader is! PathProvidingAssetReader) {
+  if (outputSymlinksOnly && reader.assetPathProvider == null) {
     _logger.severe(
         'The current environment does not support symlinks, but symlinks were '
         'requested.');
@@ -229,7 +230,7 @@ Future<AssetId> _writeAsset(
         await Link(_filePathFor(outputDir, outputId)).create(
             // We assert at the top of `createMergedOutputDirectories` that the
             // reader implements this type when requesting symlinks.
-            (reader as PathProvidingAssetReader).pathTo(id),
+            reader.assetPathProvider!.pathFor(id),
             recursive: true);
       } else {
         await _writeAsBytes(outputDir, outputId, await reader.readAsBytes(id));

--- a/build_runner_core/lib/src/environment/io_environment.dart
+++ b/build_runner_core/lib/src/environment/io_environment.dart
@@ -55,10 +55,7 @@ class IOEnvironment implements BuildEnvironment {
 
     var (reader, writer) = lowResourcesMode
         ? (fileReader, fileWriter)
-        : wrapInBatch(
-            reader: fileReader,
-            pathProvidingReader: fileReader,
-            writer: fileWriter);
+        : wrapInBatch(reader: fileReader, writer: fileWriter);
 
     return IOEnvironment._(reader, writer, assumeTty == true || _canPrompt(),
         outputSymlinksOnly, packageGraph);

--- a/build_runner_core/lib/src/package_graph/package_graph.dart
+++ b/build_runner_core/lib/src/package_graph/package_graph.dart
@@ -4,6 +4,9 @@
 
 import 'dart:io';
 
+import 'package:build/build.dart';
+// ignore: implementation_imports
+import 'package:build/src/internal.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
@@ -16,7 +19,7 @@ final _sdkPackageNode =
     PackageNode(r'$sdk', sdkPath, DependencyType.hosted, null);
 
 /// A graph of the package dependencies for an application.
-class PackageGraph {
+class PackageGraph implements AssetPathProvider {
   /// The root application package.
   final PackageNode root;
 
@@ -166,6 +169,15 @@ class PackageGraph {
 
   /// Shorthand to get a package by name.
   PackageNode? operator [](String packageName) => allPackages[packageName];
+
+  @override
+  String pathFor(AssetId id) {
+    var package = this[id.package];
+    if (package == null) {
+      throw PackageNotFoundException(id.package);
+    }
+    return p.join(package.path, id.path);
+  }
 
   @override
   String toString() {

--- a/build_runner_core/test/asset/batch_test.dart
+++ b/build_runner_core/test/asset/batch_test.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import 'package:build/build.dart';
 import 'package:build_runner_core/build_runner_core.dart';
-
 import 'package:glob/glob.dart';
 import 'package:package_config/package_config_types.dart';
 import 'package:test/test.dart';
@@ -24,10 +23,7 @@ void main() {
     final fileReader = FileBasedAssetReader(packageGraph);
     final fileWriter = FileBasedAssetWriter(packageGraph);
 
-    (reader, writer) = wrapInBatch(
-        reader: fileReader,
-        pathProvidingReader: fileReader,
-        writer: fileWriter);
+    (reader, writer) = wrapInBatch(reader: fileReader, writer: fileWriter);
   });
 
   test('delays writes until end', () async {

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -13,6 +13,7 @@
   in-memory reader instead of providing multiple readers.
 - Support checks on reader state after a build action in `resolveSources`.
 - Start using `package:build/src/internal.dart`.
+- Refactor `PathProvidingAssetReader` to `AssetPathProvider`
 
 ## 2.2.3
 

--- a/build_test/lib/src/in_memory_reader.dart
+++ b/build_test/lib/src/in_memory_reader.dart
@@ -42,8 +42,8 @@ class InMemoryAssetReaderWriter extends AssetReader
       {Map<AssetId, dynamic>? sourceAssets, this.rootPackage})
       : assets = _assetsAsBytes(sourceAssets);
 
-  /// Create a new asset reader backed by [assets].
-  InMemoryAssetReaderWriter.shareAssetCache(this.assets, {this.rootPackage});
+  @override
+  AssetPathProvider? get assetPathProvider => null;
 
   static Map<AssetId, List<int>> _assetsAsBytes(Map<AssetId, dynamic>? assets) {
     if (assets == null || assets.isEmpty) {


### PR DESCRIPTION
For #3811.

Refactor `PathProvidingAssetReader` to `AssetPathProvider`.

Inheritance just gets in the way here, the capability to map `AssetId`->path is better expressed via composition.