### PR TITLE
Simplify `FinalizedReader`.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Use `build_test` 3.0.0.
 - Start using `package:build/src/internal.dart'.
 - Refactor `MultiPackageAssetReader` to internal `AssetFinder`.
+- `FinalizedReader` no longer implements `AssetReader`.
 
 ## 2.4.15
 

--- a/build_runner/lib/src/server/asset_graph_handler.dart
+++ b/build_runner/lib/src/server/asset_graph_handler.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';
+import 'package:build_runner_core/build_runner_core.dart';
 // ignore: implementation_imports
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 // ignore: implementation_imports
@@ -18,7 +19,7 @@ import 'path_to_asset_id.dart';
 
 /// A handler for `/$graph` requests under a specific `rootDir`.
 class AssetGraphHandler {
-  final AssetReader _reader;
+  final FinalizedReader _reader;
   final String _rootPackage;
   final AssetGraph _assetGraph;
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Use `build_test` 3.0.0.
 - Refactor `PathProvidingAssetReader` to `AssetPathProvider`.
 - Refactor `MultiPackageAssetReader` to internal `AssetFinder`.
+- `FinalizedReader` no longer implements `AssetReader`.
 
 ## 8.0.0
 


### PR DESCRIPTION
For #3811.

`FinalizedReader` is always used as its concrete type, there is no need for it to be part of the `AssetReader` class hierarchy.

Improve docs and remove a few unused methods.