### PR TITLE
Make `FinalizedReader` work without `SingleStepReader`.

### DIFF
--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -123,7 +123,7 @@ void main() {
   });
 
   void addSource(String id, String content, {bool deleted = false}) {
-    var node = makeAssetNode(id, [], computeDigest(AssetId.parse(id), 'a'));
+    var node = makeAssetNode(id, [], computeDigest(AssetId.parse(id), content));
     if (deleted) {
       node.deletedBy.add(node.id.addExtension('.post_anchor.1'));
     }
@@ -388,7 +388,7 @@ void main() {
         clientChannel2.sink.close();
       });
 
-      test('emmits a message to all listners', () async {
+      test('emits a message to all listeners', () async {
         expect(clientChannel1.stream, emitsInOrder(['{}', emitsDone]));
         expect(clientChannel2.stream, emitsInOrder(['{}', emitsDone]));
         await createMockConnection(serverChannel1, 'web');
@@ -398,7 +398,7 @@ void main() {
         await clientChannel2.sink.close();
       });
 
-      test('deletes listners on disconect', () async {
+      test('deletes listeners on disconnect', () async {
         expect(clientChannel1.stream, emitsInOrder(['{}', '{}', emitsDone]));
         expect(clientChannel2.stream, emitsInOrder(['{}', emitsDone]));
         await createMockConnection(serverChannel1, 'web');
@@ -409,21 +409,21 @@ void main() {
         await clientChannel1.sink.close();
       });
 
-      test('emmits only on successful builds', () async {
+      test('emits only on successful builds', () async {
         expect(clientChannel1.stream, emitsDone);
         await createMockConnection(serverChannel1, 'web');
         await handler.emitUpdateMessage(BuildResult(BuildStatus.failure, []));
         await clientChannel1.sink.close();
       });
 
-      test('closes listners', () async {
+      test('closes listeners', () async {
         expect(clientChannel1.stream, emitsDone);
         await createMockConnection(serverChannel1, 'web');
         await handler.close();
         expect(clientChannel1.closeCode, isNotNull);
       });
 
-      test('emmits build results digests', () async {
+      test('emits build results digests', () async {
         addSource('a|web/index.html', 'content1');
         addSource('a|lib/some.dart.js', 'content2');
         var indexHash =

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -114,16 +114,8 @@ class BuildImpl {
     }
     var buildDefinition = await BuildDefinition.prepareWorkspace(
         environment, options, buildPhases);
-    var singleStepReader = SingleStepReader(
-        buildDefinition.reader,
-        buildDefinition.assetGraph,
-        buildPhases.length,
-        options.packageGraph.root.name,
-        _isReadableAfterBuildFactory(buildPhases),
-        _checkInvalidInputFactory(
-            buildDefinition.targetGraph, buildDefinition.packageGraph));
     var finalizedReader = FinalizedReader(
-        singleStepReader,
+        buildDefinition.reader,
         buildDefinition.assetGraph,
         buildDefinition.targetGraph,
         buildPhases,
@@ -131,17 +123,6 @@ class BuildImpl {
     var build =
         BuildImpl._(buildDefinition, options, buildPhases, finalizedReader);
     return build;
-  }
-
-  static IsReadable _isReadableAfterBuildFactory(List<BuildPhase> buildPhases) {
-    return (AssetNode node, int phaseNum, AssetWriterSpy? writtenAssets) {
-      if (node is GeneratedAssetNode) {
-        return Readability.fromPreviousPhase(node.wasOutput && !node.isFailure);
-      }
-
-      return Readability.fromPreviousPhase(
-          node.isReadable && node.isValidInput);
-    };
   }
 }
 


### PR DESCRIPTION
It looks like all `SingleStepReader` was doing was reading hashes from `assetGraph`, which `FinalizedReader` also has access to, and checking `node.validInput`, which `FinalizedReader` likewise has access to.

Fix `serve_handler_test.dart` to add the correct hash to the asset graph, since the tests now behave more like the real codepath and read hashes from the asset graph.