### PR TITLE
use 'compile js-dev' command for compilation

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Bump the min SDK to 3.7.0.
 - Use `build_test` 3.0.0.
+- Use the command 'compile js-dev' for compilation instead of invoking
+  dart with the snapshot name (uses internal implementation detail of
+  the dart sdk which could change).
 
 ## 5.0.11
 

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -56,7 +56,8 @@ BazelWorkerDriver get _dartdevkDriver {
     () => Process.start(
       p.join(sdkDir, 'bin', 'dart'),
       [
-        p.join(sdkDir, 'bin', 'snapshots', 'dartdevc.dart.snapshot'),
+        'compile',
+        'js-dev',
         '--persistent_worker',
       ],
       mode: _processMode,

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -55,11 +55,7 @@ BazelWorkerDriver get _dartdevkDriver {
   return __dartdevkDriver ??= BazelWorkerDriver(
     () => Process.start(
       p.join(sdkDir, 'bin', 'dart'),
-      [
-        'compile',
-        'js-dev',
-        '--persistent_worker',
-      ],
+      ['compile', 'js-dev', '--persistent_worker'],
       mode: _processMode,
       workingDirectory: scratchSpace.tempDir.path,
     ),

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Bump the min SDK to 3.7.0.
 - Use `build_test` 3.0.0.
 - Use support-detection scripts emitted by `dart2wasm`.
+- Use the command 'compile js-dev' for compilation instead of invoking
+  dart with the snapshot name (uses internal implementation detail of
+  the dart sdk which could change).
 
 ## 4.1.1
 

--- a/build_web_compilers/lib/src/sdk_js_compile_builder.dart
+++ b/build_web_compilers/lib/src/sdk_js_compile_builder.dart
@@ -92,25 +92,11 @@ Future<void> _createDevCompilerModule(
   try {
     // Use standalone process instead of the worker due to
     // https://github.com/dart-lang/sdk/issues/49441
-    var snapshotPath = p.join(
-      sdkDir,
-      'bin',
-      'snapshots',
-      'dartdevc_aot.dart.snapshot',
-    );
     var execSuffix = Platform.isWindows ? '.exe' : '';
-    var dartPath = p.join(sdkDir, 'bin', 'dartaotruntime$execSuffix');
-    if (!File(snapshotPath).existsSync()) {
-      snapshotPath = p.join(
-        sdkDir,
-        'bin',
-        'snapshots',
-        'dartdevc.dart.snapshot',
-      );
-      dartPath = p.join(sdkDir, 'bin', 'dart$execSuffix');
-    }
+    var dartPath = p.join(sdkDir, 'bin', 'dart$execSuffix');
     result = await Process.run(dartPath, [
-      snapshotPath,
+      'compile',
+      'js-dev',
       '--multi-root-scheme=org-dartlang-sdk',
       '--modules=amd',
       if (canaryFeatures) '--canary',


### PR DESCRIPTION
Use the command 'compile js-dev'  for compilation instead of directly invoking the snapshot which uses internal knowledge
about the location of the snapshot.