### PR TITLE
Simplify `Filesystem`, introduce `TestReaderWriter`

### DIFF
--- a/_test_common/lib/in_memory_reader_writer.dart
+++ b/_test_common/lib/in_memory_reader_writer.dart
@@ -7,6 +7,8 @@ import 'dart:convert';
 import 'package:build/build.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_test/build_test.dart';
+// ignore: implementation_imports
+import 'package:build_test/src/in_memory_reader_writer.dart';
 import 'package:path/path.dart' as p;
 import 'package:watcher/watcher.dart';
 
@@ -26,7 +28,7 @@ class InMemoryRunnerAssetReaderWriter extends InMemoryAssetReaderWriter
 
   @override
   Future writeAsBytes(AssetId id, List<int> bytes) async {
-    var type = assets.containsKey(id) ? ChangeType.MODIFY : ChangeType.ADD;
+    var type = testing.exists(id) ? ChangeType.MODIFY : ChangeType.ADD;
     await super.writeAsBytes(id, bytes);
     FakeWatcher.notifyWatchers(
       WatchEvent(type, p.absolute(id.package, p.fromUri(id.path))),
@@ -39,7 +41,7 @@ class InMemoryRunnerAssetReaderWriter extends InMemoryAssetReaderWriter
     String contents, {
     Encoding encoding = utf8,
   }) async {
-    var type = assets.containsKey(id) ? ChangeType.MODIFY : ChangeType.ADD;
+    var type = testing.exists(id) ? ChangeType.MODIFY : ChangeType.ADD;
     await super.writeAsString(id, contents, encoding: encoding);
     FakeWatcher.notifyWatchers(
       WatchEvent(type, p.absolute(id.package, p.fromUri(id.path))),
@@ -49,7 +51,7 @@ class InMemoryRunnerAssetReaderWriter extends InMemoryAssetReaderWriter
   @override
   Future delete(AssetId id) async {
     onDelete?.call(id);
-    assets.remove(id);
+    testing.delete(id);
     FakeWatcher.notifyWatchers(
       WatchEvent(ChangeType.REMOVE, p.absolute(id.package, p.fromUri(id.path))),
     );

--- a/_test_common/lib/test_phases.dart
+++ b/_test_common/lib/test_phases.dart
@@ -116,9 +116,9 @@ Future<TestBuildersResult> testBuilders(
   inputs.forEach((serializedId, contents) {
     var id = makeAssetId(serializedId);
     if (contents is String) {
-      readerWriter.filesystem.writeAsStringSync(id, contents);
+      readerWriter.testing.writeString(id, contents);
     } else if (contents is List<int>) {
-      readerWriter.filesystem.writeAsBytesSync(id, contents);
+      readerWriter.testing.writeBytes(id, contents);
     }
   });
 
@@ -179,7 +179,7 @@ Future<TestBuildersResult> testBuilders(
 void checkBuild(
   BuildResult result, {
   Map<String, Object>? outputs,
-  required InMemoryAssetReaderWriter readerWriter,
+  required TestReaderWriter readerWriter,
   BuildStatus status = BuildStatus.success,
   String rootPackage = 'a',
   String expectedGeneratedDir = 'generated',

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -101,6 +101,9 @@ class BuildStepImpl implements BuildStep, AssetReaderState {
   Filesystem get filesystem => _reader.filesystem;
 
   @override
+  FilesystemCache get cache => _reader.cache;
+
+  @override
   AssetFinder get assetFinder => _reader.assetFinder;
 
   @override

--- a/build/lib/src/state/filesystem.dart
+++ b/build/lib/src/state/filesystem.dart
@@ -163,30 +163,33 @@ class InMemoryFilesystem implements Filesystem {
   Iterable<String> get filePaths => _files.keys;
 
   @override
-  Future<bool> exists(String path) async => _files.containsKey(path);
+  Future<bool> exists(String path) => Future.value(_files.containsKey(path));
 
   @override
   bool existsSync(String path) => _files.containsKey(path);
 
   @override
-  Future<Uint8List> readAsBytes(String path) async => _files[path]!;
+  Future<Uint8List> readAsBytes(String path) => Future.value(_files[path]!);
 
   @override
   Uint8List readAsBytesSync(String path) => _files[path]!;
 
   @override
-  Future<String> readAsString(String path, {Encoding encoding = utf8}) async =>
-      encoding.decode(_files[path]!);
+  Future<String> readAsString(String path, {Encoding encoding = utf8}) =>
+      Future.value(encoding.decode(_files[path]!));
 
   @override
   String readAsStringSync(String path, {Encoding encoding = utf8}) =>
       encoding.decode(_files[path]!);
 
   @override
-  Future<void> delete(String path) async => _files.remove(path);
+  Future<void> delete(String path) {
+    _files.remove(path);
+    return Future.value();
+  }
 
   @override
-  void deleteSync(String path) async => _files.remove(path);
+  void deleteSync(String path) => _files.remove(path);
 
   @override
   void writeAsBytesSync(String path, List<int> contents) {
@@ -194,8 +197,9 @@ class InMemoryFilesystem implements Filesystem {
   }
 
   @override
-  Future<void> writeAsBytes(String path, List<int> contents) async {
+  Future<void> writeAsBytes(String path, List<int> contents) {
     _files[path] = Uint8List.fromList(contents);
+    return Future.value();
   }
 
   @override
@@ -212,7 +216,8 @@ class InMemoryFilesystem implements Filesystem {
     String path,
     String contents, {
     Encoding encoding = utf8,
-  }) async {
+  }) {
     _files[path] = Uint8List.fromList(encoding.encode(contents));
+    return Future.value();
   }
 }

--- a/build/lib/src/state/filesystem.dart
+++ b/build/lib/src/state/filesystem.dart
@@ -8,58 +8,44 @@ import 'dart:typed_data';
 
 import 'package:pool/pool.dart';
 
-import '../asset/id.dart';
-import 'asset_path_provider.dart';
-import 'filesystem_cache.dart';
-
 /// The filesystem the build is running on.
 ///
 /// Methods behave as the `dart:io` methods with the same names, with some
 /// exceptions noted in the docs.
-///
-/// Some methods cache, all uses of the cache are noted in the docs.
-///
-/// The cache might be a [PassthroughFilesystemCache] in which case it has no
-/// effect.
-///
-/// TODO(davidmorgan): extend caching to sync methods, deletes, writes.
 abstract interface class Filesystem {
-  FilesystemCache get cache;
-
-  /// Returns a new instance with optionally updated [cache].
-  Filesystem copyWith({FilesystemCache? cache});
+  /// Whether the file exists.
+  Future<bool> exists(String path);
 
   /// Whether the file exists.
-  ///
-  /// Uses [cache].
-  Future<bool> exists(AssetId id);
+  bool existsSync(String path);
 
   /// Reads a file as a string.
-  ///
-  /// Uses [cache]. For `utf8`, the `String` is cached; for any other encoding
-  /// the bytes are cached but the conversion runs on every read.
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8});
+  Future<String> readAsString(String path, {Encoding encoding = utf8});
+
+  /// Reads a file as a string.
+  String readAsStringSync(String path, {Encoding encoding = utf8});
 
   /// Reads a file as bytes.
-  ///
-  /// Uses [cache].
-  Future<Uint8List> readAsBytes(AssetId id);
+  Future<Uint8List> readAsBytes(String path);
+
+  /// Reads a file as bytes.
+  Uint8List readAsBytesSync(String path);
 
   /// Deletes a file.
   ///
   /// If the file does not exist, does nothing.
-  Future<void> delete(AssetId id);
+  Future<void> delete(String path);
 
   /// Deletes a file.
   ///
   /// If the file does not exist, does nothing.
-  void deleteSync(AssetId id);
+  void deleteSync(String path);
 
   /// Writes a file.
   ///
   /// Creates enclosing directories as needed if they don't exist.
   void writeAsStringSync(
-    AssetId id,
+    String path,
     String contents, {
     Encoding encoding = utf8,
   });
@@ -68,7 +54,7 @@ abstract interface class Filesystem {
   ///
   /// Creates enclosing directories as needed if they don't exist.
   Future<void> writeAsString(
-    AssetId id,
+    String path,
     String contents, {
     Encoding encoding = utf8,
   });
@@ -76,88 +62,69 @@ abstract interface class Filesystem {
   /// Writes a file.
   ///
   /// Creates enclosing directories as needed if they don't exist.
-  void writeAsBytesSync(AssetId id, List<int> contents);
+  void writeAsBytesSync(String path, List<int> contents);
 
   /// Writes a file.
   ///
   /// Creates enclosing directories as needed if they don't exist.
-  Future<void> writeAsBytes(AssetId id, List<int> contents);
+  Future<void> writeAsBytes(String path, List<int> contents);
 }
 
-/// A filesystem using [assetPathProvider] to map to the `dart:io` filesystem.
+/// The `dart:io` filesystem.
 class IoFilesystem implements Filesystem {
-  @override
-  final FilesystemCache cache;
-
-  final AssetPathProvider assetPathProvider;
-
   /// Pool for async file operations.
   final _pool = Pool(32);
 
-  IoFilesystem({
-    required this.assetPathProvider,
-    this.cache = const PassthroughFilesystemCache(),
-  });
+  @override
+  Future<bool> exists(String path) => _pool.withResource(File(path).exists);
 
   @override
-  IoFilesystem copyWith({FilesystemCache? cache}) => IoFilesystem(
-    assetPathProvider: assetPathProvider,
-    cache: cache ?? this.cache,
-  );
+  bool existsSync(String path) => File(path).existsSync();
 
   @override
-  Future<bool> exists(AssetId id) =>
-      cache.exists(id, ifAbsent: () => _pool.withResource(_fileFor(id).exists));
+  Future<Uint8List> readAsBytes(String path) =>
+      _pool.withResource(File(path).readAsBytes);
 
   @override
-  Future<Uint8List> readAsBytes(AssetId id) => cache.readAsBytes(
-    id,
-    ifAbsent: () => _pool.withResource(_fileFor(id).readAsBytes),
-  );
+  Uint8List readAsBytesSync(String path) => File(path).readAsBytesSync();
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) async {
-    // The cache only directly supports utf8, for other encodings get the
-    // bytes via the cache then convert.
-    if (encoding == utf8) {
-      return cache.readAsString(
-        id,
-        ifAbsent: () => _pool.withResource(_fileFor(id).readAsString),
-      );
-    } else {
-      return encoding.decode(await readAsBytes(id));
-    }
-  }
+  Future<String> readAsString(String path, {Encoding encoding = utf8}) =>
+      _pool.withResource(() => File(path).readAsString(encoding: encoding));
 
   @override
-  void deleteSync(AssetId id) {
-    final file = _fileFor(id);
+  String readAsStringSync(String path, {Encoding encoding = utf8}) =>
+      File(path).readAsStringSync(encoding: encoding);
+
+  @override
+  void deleteSync(String path) {
+    final file = File(path);
     if (file.existsSync()) file.deleteSync();
   }
 
   @override
-  Future<void> delete(AssetId id) {
+  Future<void> delete(String path) {
     return _pool.withResource(() async {
-      final file = _fileFor(id);
+      final file = File(path);
       if (await file.exists()) await file.delete();
     });
   }
 
   @override
   void writeAsBytesSync(
-    AssetId id,
+    String path,
     List<int> contents, {
     Encoding encoding = utf8,
   }) {
-    final file = _fileFor(id);
+    final file = File(path);
     file.parent.createSync(recursive: true);
     file.writeAsBytesSync(contents);
   }
 
   @override
-  Future<void> writeAsBytes(AssetId id, List<int> contents) {
+  Future<void> writeAsBytes(String path, List<int> contents) {
     return _pool.withResource(() async {
-      final file = _fileFor(id);
+      final file = File(path);
       await file.parent.create(recursive: true);
       await file.writeAsBytes(contents);
     });
@@ -165,108 +132,87 @@ class IoFilesystem implements Filesystem {
 
   @override
   void writeAsStringSync(
-    AssetId id,
+    String path,
     String contents, {
     Encoding encoding = utf8,
   }) {
-    final file = _fileFor(id);
+    final file = File(path);
     file.parent.createSync(recursive: true);
     file.writeAsStringSync(contents, encoding: encoding);
   }
 
   @override
   Future<void> writeAsString(
-    AssetId id,
+    String path,
     String contents, {
     Encoding encoding = utf8,
   }) {
     return _pool.withResource(() async {
-      final file = _fileFor(id);
+      final file = File(path);
       await file.parent.create(recursive: true);
       await file.writeAsString(contents, encoding: encoding);
     });
-  }
-
-  /// Returns a [File] for [id] for the current [assetPathProvider].
-  File _fileFor(AssetId id) {
-    return File(assetPathProvider.pathFor(id));
   }
 }
 
 /// An in-memory [Filesystem].
 class InMemoryFilesystem implements Filesystem {
-  @override
-  FilesystemCache cache;
+  final Map<String, Uint8List> _files = {};
 
-  final Map<AssetId, List<int>> assets;
-
-  InMemoryFilesystem({FilesystemCache? cache})
-    : cache = cache ?? const PassthroughFilesystemCache(),
-      assets = {};
-
-  InMemoryFilesystem._({required this.cache, required this.assets});
+  /// The paths to all files present on the filesystem.
+  Iterable<String> get filePaths => _files.keys;
 
   @override
-  InMemoryFilesystem copyWith({FilesystemCache? cache}) =>
-      InMemoryFilesystem._(assets: assets, cache: cache ?? this.cache);
+  Future<bool> exists(String path) async => _files.containsKey(path);
 
   @override
-  Future<bool> exists(AssetId id) async =>
-      cache.exists(id, ifAbsent: () async => assets.containsKey(id));
+  bool existsSync(String path) => _files.containsKey(path);
 
   @override
-  Future<Uint8List> readAsBytes(AssetId id) async =>
-      cache.readAsBytes(id, ifAbsent: () async => assets[id] as Uint8List);
+  Future<Uint8List> readAsBytes(String path) async => _files[path]!;
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) async {
-    // The cache only directly supports utf8, for other encodings get the
-    // bytes via the cache then convert.
-    if (encoding == utf8) {
-      return cache.readAsString(
-        id,
-        ifAbsent: () async => encoding.decode(assets[id]!),
-      );
-    } else {
-      return encoding.decode(await readAsBytes(id));
-    }
+  Uint8List readAsBytesSync(String path) => _files[path]!;
+
+  @override
+  Future<String> readAsString(String path, {Encoding encoding = utf8}) async =>
+      encoding.decode(_files[path]!);
+
+  @override
+  String readAsStringSync(String path, {Encoding encoding = utf8}) =>
+      encoding.decode(_files[path]!);
+
+  @override
+  Future<void> delete(String path) async => _files.remove(path);
+
+  @override
+  void deleteSync(String path) async => _files.remove(path);
+
+  @override
+  void writeAsBytesSync(String path, List<int> contents) {
+    _files[path] = Uint8List.fromList(contents);
   }
 
   @override
-  Future<void> delete(AssetId id) async {
-    assets.remove(id);
-  }
-
-  @override
-  void deleteSync(AssetId id) async {
-    assets.remove(id);
-  }
-
-  @override
-  void writeAsBytesSync(AssetId id, List<int> contents) {
-    assets[id] = contents;
-  }
-
-  @override
-  Future<void> writeAsBytes(AssetId id, List<int> contents) async {
-    assets[id] = contents;
+  Future<void> writeAsBytes(String path, List<int> contents) async {
+    _files[path] = Uint8List.fromList(contents);
   }
 
   @override
   void writeAsStringSync(
-    AssetId id,
+    String path,
     String contents, {
     Encoding encoding = utf8,
   }) {
-    assets[id] = encoding.encode(contents);
+    _files[path] = Uint8List.fromList(encoding.encode(contents));
   }
 
   @override
   Future<void> writeAsString(
-    AssetId id,
+    String path,
     String contents, {
     Encoding encoding = utf8,
   }) async {
-    assets[id] = encoding.encode(contents);
+    _files[path] = Uint8List.fromList(encoding.encode(contents));
   }
 }

--- a/build/lib/src/state/reader_state.dart
+++ b/build/lib/src/state/reader_state.dart
@@ -22,6 +22,11 @@ extension AssetReaderStateExtension on AssetReader {
     return (this as AssetReaderState).filesystem;
   }
 
+  FilesystemCache get cache {
+    _requireIsAssetReaderState();
+    return (this as AssetReaderState).cache;
+  }
+
   AssetFinder get assetFinder {
     _requireIsAssetReaderState();
     return (this as AssetReaderState).assetFinder;
@@ -67,6 +72,9 @@ abstract interface class AssetReaderState {
   /// Warning: this access to the filesystem bypasses reader functionality
   /// such as read tracking, caching and visibility restriction.
   Filesystem get filesystem;
+
+  /// The [FilesystemCache] that this reader uses for caching.
+  FilesystemCache get cache;
 
   /// The [AssetFinder] associated with this reader.
   ///

--- a/build/test/builder/build_step_impl_test.dart
+++ b/build/test/builder/build_step_impl_test.dart
@@ -32,7 +32,7 @@ void main() {
     late List<AssetId> outputs;
 
     setUp(() {
-      var reader = InMemoryAssetReaderWriter();
+      var reader = TestReaderWriter();
       var writer = const StubAssetWriter();
       primary = makeAssetId();
       outputs = List.generate(5, (index) => makeAssetId());
@@ -87,10 +87,10 @@ void main() {
   });
 
   group('with in memory file system', () {
-    late InMemoryAssetReaderWriter readerWriter;
+    late TestReaderWriter readerWriter;
 
     setUp(() {
-      readerWriter = InMemoryAssetReaderWriter();
+      readerWriter = TestReaderWriter();
     });
 
     test('tracks outputs created by a builder', () async {
@@ -113,7 +113,7 @@ void main() {
       await buildStep.complete();
 
       // One output.
-      expect(readerWriter.assets[outputId], decodedMatches('foo'));
+      expect(readerWriter.testing.readString(outputId), 'foo');
     });
 
     group('resolve', () {
@@ -175,7 +175,7 @@ void main() {
       buildStep = BuildStepImpl(
         primary,
         [outputId],
-        InMemoryAssetReaderWriter(),
+        TestReaderWriter(),
         assetWriter,
         AnalyzerResolvers.custom(),
         resourceManager,
@@ -236,7 +236,7 @@ void main() {
     late AssetId output;
 
     setUp(() {
-      var reader = InMemoryAssetReaderWriter();
+      var reader = TestReaderWriter();
       var writer = const StubAssetWriter();
       primary = makeAssetId();
       output = makeAssetId();
@@ -259,7 +259,7 @@ void main() {
   });
 
   test('reportUnusedAssets forwards calls if provided', () {
-    var reader = InMemoryAssetReaderWriter();
+    var reader = TestReaderWriter();
     var writer = const StubAssetWriter();
     var unused = <AssetId>{};
     var buildStep = BuildStepImpl(

--- a/build/test/generate/run_builder_test.dart
+++ b/build/test/generate/run_builder_test.dart
@@ -12,7 +12,7 @@ import 'package:package_config/package_config_types.dart';
 import 'package:test/test.dart';
 
 void main() {
-  late InMemoryAssetReaderWriter readerWriter;
+  late TestReaderWriter readerWriter;
   final primary = makeAssetId('a|web/primary.txt');
   final inputs = {primary: 'foo'};
   late Resource resource;
@@ -30,7 +30,7 @@ void main() {
     builder = TestBuilder(
       extraWork: (buildStep, __) => buildStep.fetchResource(resource),
     );
-    readerWriter = InMemoryAssetReaderWriter();
+    readerWriter = TestReaderWriter();
     addAssets(inputs, readerWriter);
   });
 
@@ -79,7 +79,11 @@ void main() {
 
   group('can resolve package config', () {
     setUp(() {
-      readerWriter.assets[makeAssetId('build|lib/foo.txt')] = [1, 2, 3];
+      readerWriter.testing.writeBytes(makeAssetId('build|lib/foo.txt'), [
+        1,
+        2,
+        3,
+      ]);
 
       builder = TestBuilder(
         extraWork: (buildStep, __) async {

--- a/build/test/generate/run_post_process_builder_test.dart
+++ b/build/test/generate/run_post_process_builder_test.dart
@@ -11,7 +11,7 @@ import '../common/builders.dart';
 
 void main() {
   group('runPostProcessBuilder', () {
-    late InMemoryAssetReaderWriter readerWriter;
+    late TestReaderWriter readerWriter;
     final copyBuilder = CopyingPostProcessBuilder();
     final deleteBuilder = DeletePostProcessBuilder();
     final aTxt = makeAssetId('a|lib/a.txt');
@@ -24,8 +24,7 @@ void main() {
     void deleteAsset(AssetId id) => deletes[id] = true;
 
     setUp(() async {
-      readerWriter =
-          InMemoryAssetReaderWriter()..filesystem.writeAsStringSync(aTxt, 'a');
+      readerWriter = TestReaderWriter()..testing.writeString(aTxt, 'a');
       adds.clear();
       deletes.clear();
     });
@@ -63,8 +62,8 @@ void main() {
         addAsset: addAsset,
         deleteAsset: deleteAsset,
       );
-      expect(readerWriter.assets, contains(aTxtCopy));
-      expect(readerWriter.assets[aTxtCopy], decodedMatches('a'));
+      expect(readerWriter.testing.exists(aTxt), isTrue);
+      expect(readerWriter.testing.readString(aTxtCopy), 'a');
       expect(adds, contains(aTxtCopy));
     });
 

--- a/build/test/state/filesystem_cache_test.dart
+++ b/build/test/state/filesystem_cache_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:typed_data';
+import 'dart:convert';
 
 import 'package:build/build.dart';
 import 'package:build/src/state/filesystem_cache.dart';
@@ -10,10 +10,12 @@ import 'package:test/test.dart';
 
 void main() {
   final txt1 = AssetId('a', 'foo.txt');
-  final txt2 = AssetId('a', 'missing.txt');
+  final txt1String = 'txt1';
+  final txt1Bytes = utf8.encode(txt1String);
 
-  final txt1Bytes = Uint8List.fromList([1, 2, 3]);
-  final txt2Bytes = Uint8List.fromList([4, 5, 6]);
+  final txt2 = AssetId('a', 'missing.txt');
+  final txt2String = 'txt2';
+  final txt2Bytes = utf8.encode(txt2String);
 
   late FilesystemCache cache;
 
@@ -79,23 +81,32 @@ void main() {
 
   group('readAsString', () {
     test('reads from isAbsent', () async {
-      expect(await cache.readAsString(txt1, ifAbsent: () async => '1'), '1');
+      expect(
+        await cache.readAsString(txt1, ifAbsent: () async => txt1Bytes),
+        txt1String,
+      );
     });
 
     test('does not re-read from isAbsent', () async {
-      expect(await cache.readAsString(txt1, ifAbsent: () async => '1'), '1');
       expect(
-        await cache.readAsString(txt1, ifAbsent: () async => '2'),
-        '1' /* cached value */,
+        await cache.readAsString(txt1, ifAbsent: () async => txt1Bytes),
+        txt1String,
+      );
+      expect(
+        await cache.readAsString(txt1, ifAbsent: () async => txt2Bytes),
+        txt1String /* cached value */,
       );
     });
 
     test('can be invalidated with invalidate', () async {
-      expect(await cache.readAsString(txt1, ifAbsent: () async => '1'), '1');
+      expect(
+        await cache.readAsString(txt1, ifAbsent: () async => txt1Bytes),
+        txt1String,
+      );
       await cache.invalidate([txt1]);
       expect(
-        await cache.readAsString(txt1, ifAbsent: () async => '2'),
-        '2' /* updated value */,
+        await cache.readAsString(txt1, ifAbsent: () async => txt2Bytes),
+        txt2String /* updated value */,
       );
     });
   });

--- a/build_modules/test/decoding_cache_test.dart
+++ b/build_modules/test/decoding_cache_test.dart
@@ -42,21 +42,19 @@ void main() {
 
     test('can fetch from disk', () async {
       final id = AssetId('foo', 'lib/foo');
-      final reader =
-          InMemoryAssetReaderWriter()..filesystem.writeAsStringSync(id, 'foo');
+      final reader = TestReaderWriter()..testing.writeString(id, 'foo');
       expect(await cache.find(id, reader), 'foo');
-      expect(reader.inputTracker.assetsRead, contains(id));
+      expect(reader.testing.assetsRead, contains(id));
       expect(fromBytesCalls, contains('foo'));
     });
 
     test('skips read for value written this build', () async {
       final id = AssetId('foo', 'lib/foo');
-      final reader =
-          InMemoryAssetReaderWriter()..filesystem.writeAsStringSync(id, 'foo');
-      await cache.write(id, InMemoryAssetReaderWriter(), 'bar');
+      final reader = TestReaderWriter()..testing.writeString(id, 'foo');
+      await cache.write(id, TestReaderWriter(), 'bar');
       expect(await cache.find(id, reader), 'bar');
       expect(
-        reader.inputTracker.assetsRead,
+        reader.testing.assetsRead,
         contains(id),
         reason: 'Should call canRead',
       );
@@ -65,15 +63,13 @@ void main() {
 
     test('skips read on subsequent fetches', () async {
       final id = AssetId('foo', 'lib/foo');
-      final reader1 =
-          InMemoryAssetReaderWriter()..filesystem.writeAsStringSync(id, 'foo');
+      final reader1 = TestReaderWriter()..testing.writeString(id, 'foo');
       await cache.find(id, reader1);
       expect(fromBytesCalls['foo'], 1);
-      final reader2 =
-          InMemoryAssetReaderWriter()..filesystem.writeAsStringSync(id, 'foo');
+      final reader2 = TestReaderWriter()..testing.writeString(id, 'foo');
       expect(await cache.find(id, reader2), 'foo');
       expect(
-        reader2.inputTracker.assetsRead,
+        reader2.testing.assetsRead,
         contains(id),
         reason: 'Should call canRead',
       );
@@ -82,16 +78,14 @@ void main() {
 
     test('skips read on subsequent builds if digest has not changed', () async {
       final id = AssetId('foo', 'lib/foo');
-      final reader1 =
-          InMemoryAssetReaderWriter()..filesystem.writeAsStringSync(id, 'foo');
+      final reader1 = TestReaderWriter()..testing.writeString(id, 'foo');
       await cache.find(id, reader1);
       expect(fromBytesCalls['foo'], 1);
       await resourceManager.disposeAll();
-      final reader2 =
-          InMemoryAssetReaderWriter()..filesystem.writeAsStringSync(id, 'foo');
+      final reader2 = TestReaderWriter()..testing.writeString(id, 'foo');
       expect(await cache.find(id, reader2), 'foo');
       expect(
-        reader2.inputTracker.assetsRead,
+        reader2.testing.assetsRead,
         contains(id),
         reason: 'Should call canRead',
       );
@@ -100,15 +94,13 @@ void main() {
 
     test('rereads on subsequent builds if digest has changed', () async {
       final id = AssetId('foo', 'lib/foo');
-      final reader1 =
-          InMemoryAssetReaderWriter()..filesystem.writeAsStringSync(id, 'foo');
+      final reader1 = TestReaderWriter()..testing.writeString(id, 'foo');
       await cache.find(id, reader1);
       expect(fromBytesCalls['foo'], 1);
       await resourceManager.disposeAll();
-      final reader2 =
-          InMemoryAssetReaderWriter()..filesystem.writeAsStringSync(id, 'bar');
+      final reader2 = TestReaderWriter()..testing.writeString(id, 'bar');
       expect(await cache.find(id, reader2), 'bar');
-      expect(reader2.inputTracker.assetsRead, contains(id));
+      expect(reader2.testing.assetsRead, contains(id));
       expect(fromBytesCalls['bar'], 1, reason: 'Deserialize with new value');
     });
   });

--- a/build_modules/test/meta_module_test.dart
+++ b/build_modules/test/meta_module_test.dart
@@ -15,22 +15,22 @@ import 'package:test/test.dart';
 import 'matchers.dart';
 
 void main() {
-  late InMemoryAssetReaderWriter reader;
+  late TestReaderWriter reader;
   final defaultPlatform = DartPlatform.register('test', ['async']);
 
   List<AssetId> makeAssets(Map<String, String> assetDescriptors) {
-    reader = InMemoryAssetReaderWriter();
+    reader = TestReaderWriter();
     var assets = <AssetId>{};
     assetDescriptors.forEach((serializedId, content) {
       var id = AssetId.parse(serializedId);
-      reader.filesystem.writeAsStringSync(id, content);
+      reader.testing.writeString(id, content);
       assets.add(id);
     });
     return assets.toList();
   }
 
   Future<MetaModule> metaModuleFromSources(
-    InMemoryAssetReaderWriter reader,
+    TestReaderWriter reader,
     List<AssetId> sources, {
     DartPlatform? platform,
   }) async {
@@ -44,7 +44,7 @@ void main() {
           ),
     )).where((l) => l.isImportable);
     for (final library in libraries) {
-      reader.filesystem.writeAsStringSync(
+      reader.testing.writeString(
         library.id.changeExtension(moduleLibraryExtension),
         library.serialize(),
       );

--- a/build_modules/test/util.dart
+++ b/build_modules/test/util.dart
@@ -27,7 +27,8 @@ Future<void> testBuilderAndCollectAssets(
     onLog: onLog,
     reportUnusedAssetsForInput: reportUnusedAssetsForInput,
   );
-  result.readerWriter.assets.forEach((id, value) {
+  for (var id in result.readerWriter.testing.assets) {
+    final value = result.readerWriter.testing.readBytes(id);
     assets['${id.package}|${id.path}'] = value;
-  });
+  }
 }

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:io' show Platform;
 import 'dart:isolate';
 
@@ -145,7 +144,7 @@ void runTests(ResolversFactory resolversFactory) {
         await resolver.libraryFor(entryPoint);
       },
       assetReaderChecks: (reader) {
-        expect(reader.inputTracker.assetsRead, {
+        expect(reader.testing.assetsRead, {
           AssetId('a', 'web/main.dart'),
           AssetId('a', 'web/main.dart.transitive_digest'),
           AssetId('a', 'web/a.dart'),
@@ -195,7 +194,7 @@ void runTests(ResolversFactory resolversFactory) {
           await resolver.libraryFor(entryPoint);
         },
         assetReaderChecks: (reader) {
-          expect(reader.inputTracker.assetsRead, {
+          expect(reader.testing.assetsRead, {
             AssetId('a', 'web/main.dart'),
             AssetId('a', 'web/main.dart.transitive_digest'),
             AssetId('a', 'web/a.dart'),
@@ -213,7 +212,7 @@ void runTests(ResolversFactory resolversFactory) {
           await resolver.libraryFor(entryPoint);
         },
         assetReaderChecks: (reader) {
-          expect(reader.inputTracker.assetsRead, {
+          expect(reader.testing.assetsRead, {
             AssetId('a', 'web/main.dart'),
             AssetId('a', 'web/main.dart.transitive_digest'),
             AssetId('a', 'web/a.dart'),
@@ -1176,9 +1175,9 @@ int? get x => 1;
       },
     );
 
-    final readerWriter = InMemoryAssetReaderWriter();
+    final readerWriter = TestReaderWriter();
 
-    readerWriter.assets[makeAssetId('a|lib/a.dart')] = utf8.encode('');
+    readerWriter.testing.writeString(makeAssetId('a|lib/a.dart'), '');
     await runBuilder(
       builder,
       [makeAssetId('a|lib/a.dart')],
@@ -1187,7 +1186,7 @@ int? get x => 1;
       resolvers,
     );
 
-    readerWriter.assets[makeAssetId('a|lib/b.dart')] = utf8.encode('');
+    readerWriter.testing.writeString(makeAssetId('a|lib/b.dart'), '');
     await runBuilder(
       builder,
       [makeAssetId('a|lib/b.dart')],
@@ -1233,9 +1232,9 @@ int? get x => 1;
   });
 
   test('generated part files are not considered libraries', () async {
-    var readerWriter = InMemoryAssetReaderWriter();
+    var readerWriter = TestReaderWriter();
     var input = AssetId('a', 'lib/input.dart');
-    readerWriter.assets[input] = utf8.encode("part 'input.a.dart';");
+    readerWriter.testing.writeString(input, "part 'input.a.dart';");
 
     var builder = TestBuilder(
       buildExtensions: {
@@ -1271,9 +1270,9 @@ int? get x => 1;
   });
 
   test('missing files are not considered libraries', () async {
-    var readerWriter = InMemoryAssetReaderWriter();
+    var readerWriter = TestReaderWriter();
     var input = AssetId('a', 'lib/input.dart');
-    readerWriter.assets[input] = utf8.encode('void doStuff() {}');
+    readerWriter.testing.writeString(input, 'void doStuff() {}');
 
     var builder = TestBuilder(
       buildExtensions: {
@@ -1295,12 +1294,12 @@ int? get x => 1;
   test(
     'assets with extensions other than `.dart` are not considered libraries',
     () async {
-      var readerWriter = InMemoryAssetReaderWriter();
+      var readerWriter = TestReaderWriter();
       var input = AssetId('a', 'lib/input.dart');
-      readerWriter.assets[input] = utf8.encode('void doStuff() {}');
+      readerWriter.testing.writeString(input, 'void doStuff() {}');
 
       var otherFile = AssetId('a', 'lib/input.notdart');
-      readerWriter.assets[otherFile] = utf8.encode('Not a Dart file');
+      readerWriter.testing.writeString(otherFile, 'Not a Dart file');
 
       var builder = TestBuilder(
         buildExtensions: {

--- a/build_runner/lib/src/watcher/change_filter.dart
+++ b/build_runner/lib/src/watcher/change_filter.dart
@@ -31,7 +31,7 @@ FutureOr<bool> shouldProcess(
     if (_isAddOrEditOnGeneratedFile(node, change.type)) return false;
     if (change.type == ChangeType.MODIFY) {
       // Was it really modified or just touched?
-      reader.filesystem.cache.invalidate([change.id]);
+      reader.cache.invalidate([change.id]);
       return reader
           .digest(change.id)
           .then((newDigest) => node.lastKnownDigest != newDigest);

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -172,8 +172,8 @@ void main() {
         );
         // Previous outputs should still exist.
         expect(
-          readerWriter.assets[makeAssetId('a|web/a.txt.copy')],
-          decodedMatches('a'),
+          readerWriter.testing.readString(makeAssetId('a|web/a.txt.copy')),
+          'a',
         );
       });
 
@@ -215,8 +215,10 @@ void main() {
         );
         // Previous outputs should still exist.
         expect(
-          readerWriter.assets[makeAssetId('a|test_files/a.txt.copy')],
-          decodedMatches('a'),
+          readerWriter.testing.readString(
+            makeAssetId('a|test_files/a.txt.copy'),
+          ),
+          'a',
         );
       });
 
@@ -237,7 +239,7 @@ void main() {
         );
 
         // Don't call writer.delete, that has side effects.
-        readerWriter.assets.remove(makeAssetId('a|web/a.txt'));
+        readerWriter.testing.delete(makeAssetId('a|web/a.txt'));
         FakeWatcher.notifyWatchers(
           WatchEvent(ChangeType.REMOVE, path.absolute('a', 'web', 'a.txt')),
         );
@@ -248,11 +250,14 @@ void main() {
         checkBuild(result, outputs: {}, readerWriter: readerWriter);
 
         // The old output file should no longer exist either.
-        expect(readerWriter.assets[makeAssetId('a|web/a.txt.copy')], isNull);
+        expect(
+          readerWriter.testing.exists(makeAssetId('a|web/a.txt.copy')),
+          isFalse,
+        );
         // Previous outputs should still exist.
         expect(
-          readerWriter.assets[makeAssetId('a|web/b.txt.copy')],
-          decodedMatches('b'),
+          readerWriter.testing.readString(makeAssetId('a|web/b.txt.copy')),
+          'b',
         );
       });
 
@@ -285,7 +290,7 @@ void main() {
         );
 
         // Don't call writer.delete, that has side effects.
-        readerWriter.assets.remove(makeAssetId('a|test_files/a.txt'));
+        readerWriter.testing.delete(makeAssetId('a|test_files/a.txt'));
         FakeWatcher.notifyWatchers(
           WatchEvent(
             ChangeType.REMOVE,
@@ -300,13 +305,15 @@ void main() {
 
         // The old output file should no longer exist either.
         expect(
-          readerWriter.assets[makeAssetId('a|test_files/a.txt.copy')],
-          isNull,
+          readerWriter.testing.exists(makeAssetId('a|test_files/a.txt.copy')),
+          isFalse,
         );
         // Previous outputs should still exist.
         expect(
-          readerWriter.assets[makeAssetId('a|test_files/b.txt.copy')],
-          decodedMatches('b'),
+          readerWriter.testing.readString(
+            makeAssetId('a|test_files/b.txt.copy'),
+          ),
+          'b',
         );
       });
 
@@ -331,7 +338,7 @@ void main() {
         await readerWriter.writeAsString(makeAssetId('a|web/b.txt'), 'b2');
 
         // Don't call writer.delete, that has side effects.
-        readerWriter.assets.remove(makeAssetId('a|web/a.txt'));
+        readerWriter.testing.delete(makeAssetId('a|web/a.txt'));
         FakeWatcher.notifyWatchers(
           WatchEvent(ChangeType.REMOVE, path.absolute('a', 'web', 'a.txt')),
         );
@@ -344,7 +351,7 @@ void main() {
         );
 
         var cachedGraph = AssetGraph.deserialize(
-          readerWriter.assets[makeAssetId('a|$assetGraphPath')]!,
+          readerWriter.testing.readBytes(makeAssetId('a|$assetGraphPath')),
         );
 
         var expectedGraph = await AssetGraph.build(
@@ -892,12 +899,12 @@ void main() {
         );
         // Previous outputs should still exist.
         expect(
-          readerWriter.assets[makeAssetId('a|web/a.txt.copy')],
-          decodedMatches('a'),
+          readerWriter.testing.readString(makeAssetId('a|web/a.txt.copy')),
+          'a',
         );
         expect(
-          readerWriter.assets[makeAssetId('a|web/a.txt.copy.copy')],
-          decodedMatches('a'),
+          readerWriter.testing.readString(makeAssetId('a|web/a.txt.copy.copy')),
+          'a',
         );
       });
 
@@ -932,7 +939,7 @@ void main() {
         );
 
         // Don't call writer.delete, that has side effects.
-        readerWriter.assets.remove(makeAssetId('a|web/a.txt'));
+        readerWriter.testing.delete(makeAssetId('a|web/a.txt'));
 
         FakeWatcher.notifyWatchers(
           WatchEvent(ChangeType.REMOVE, path.absolute('a', 'web', 'a.txt')),
@@ -943,19 +950,22 @@ void main() {
         checkBuild(result, outputs: {}, readerWriter: readerWriter);
 
         // Derived outputs should no longer exist.
-        expect(readerWriter.assets[makeAssetId('a|web/a.txt.copy')], isNull);
         expect(
-          readerWriter.assets[makeAssetId('a|web/a.txt.copy.copy')],
-          isNull,
+          readerWriter.testing.exists(makeAssetId('a|web/a.txt.copy')),
+          isFalse,
+        );
+        expect(
+          readerWriter.testing.exists(makeAssetId('a|web/a.txt.copy.copy')),
+          isFalse,
         );
         // Other outputs should still exist.
         expect(
-          readerWriter.assets[makeAssetId('a|web/b.txt.copy')],
-          decodedMatches('b'),
+          readerWriter.testing.readString(makeAssetId('a|web/b.txt.copy')),
+          'b',
         );
         expect(
-          readerWriter.assets[makeAssetId('a|web/b.txt.copy.copy')],
-          decodedMatches('b'),
+          readerWriter.testing.readString(makeAssetId('a|web/b.txt.copy.copy')),
+          'b',
         );
       });
 
@@ -985,7 +995,7 @@ void main() {
         );
 
         // Don't call writer.delete, that has side effects.
-        readerWriter.assets.remove(makeAssetId('a|web/a.txt.copy'));
+        readerWriter.testing.delete(makeAssetId('a|web/a.txt.copy'));
         FakeWatcher.notifyWatchers(
           WatchEvent(
             ChangeType.REMOVE,

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -27,7 +27,7 @@ void main() {
       <AssetId>{},
       <AssetId>{},
       buildPackageGraph({rootPackage('a'): []}),
-      InMemoryAssetReaderWriter(),
+      TestReaderWriter(),
     );
     delegate = InMemoryRunnerAssetReaderWriter();
     final packageGraph = buildPackageGraph({rootPackage('a'): []});
@@ -50,7 +50,7 @@ void main() {
       node.deletedBy.add(node.id.addExtension('.post_anchor.1'));
     }
     graph.add(node);
-    delegate.filesystem.writeAsStringSync(node.id, content);
+    delegate.testing.writeString(node.id, content);
   }
 
   test('can not read deleted nodes', () async {

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -143,7 +143,7 @@ void main() {
       node.deletedBy.add(node.id.addExtension('.post_anchor.1'));
     }
     assetGraph.add(node);
-    readerWriter.filesystem.writeAsStringSync(node.id, content);
+    readerWriter.testing.writeString(node.id, content);
   }
 
   test('can get handlers for a subdirectory', () async {

--- a/build_runner/test/server/serve_integration_test.dart
+++ b/build_runner/test/server/serve_integration_test.dart
@@ -32,15 +32,15 @@ void main() {
     final graph = buildPackageGraph({rootPackage('example', path: path): []});
     readerWriter =
         InMemoryRunnerAssetReaderWriter(rootPackage: 'example')
-          ..filesystem.writeAsStringSync(
+          ..testing.writeString(
             AssetId('example', 'web/initial.txt'),
             'initial',
           )
-          ..filesystem.writeAsStringSync(
+          ..testing.writeString(
             AssetId('example', 'web/large.txt'),
             List.filled(10000, 'large').join(''),
           )
-          ..filesystem.writeAsStringSync(
+          ..testing.writeString(
             makeAssetId('example|.dart_tool/package_config.json'),
             jsonEncode({
               'configVersion': 2,
@@ -106,7 +106,7 @@ void main() {
 
   test('should serve built files', () async {
     final getHello = Uri.parse('http://localhost/initial.g.txt');
-    readerWriter.filesystem.writeAsStringSync(
+    readerWriter.testing.writeString(
       AssetId('example', 'web/initial.g.txt'),
       'INITIAL',
     );
@@ -122,10 +122,7 @@ void main() {
 
   test('should serve newly added files', () async {
     final getNew = Uri.parse('http://localhost/new.txt');
-    readerWriter.filesystem.writeAsStringSync(
-      AssetId('example', 'web/new.txt'),
-      'New',
-    );
+    readerWriter.testing.writeString(AssetId('example', 'web/new.txt'), 'New');
     await Future<void>.value();
     FakeWatcher.notifyWatchers(WatchEvent(ChangeType.ADD, '$path/web/new.txt'));
     await nextBuild.future;
@@ -135,10 +132,7 @@ void main() {
 
   test('should serve built newly added files', () async {
     final getNew = Uri.parse('http://localhost/new.g.txt');
-    readerWriter.filesystem.writeAsStringSync(
-      AssetId('example', 'web/new.txt'),
-      'New',
-    );
+    readerWriter.testing.writeString(AssetId('example', 'web/new.txt'), 'New');
     await Future<void>.value();
     FakeWatcher.notifyWatchers(WatchEvent(ChangeType.ADD, '$path/web/new.txt'));
     await nextBuild.future;

--- a/build_runner/test/server/serve_integration_test.dart
+++ b/build_runner/test/server/serve_integration_test.dart
@@ -38,7 +38,7 @@ void main() {
           )
           ..testing.writeString(
             AssetId('example', 'web/large.txt'),
-            List.filled(10000, 'large').join(''),
+            'large' * 10000,
           )
           ..testing.writeString(
             makeAssetId('example|.dart_tool/package_config.json'),

--- a/build_runner_core/lib/src/asset/batch.dart
+++ b/build_runner_core/lib/src/asset/batch.dart
@@ -88,6 +88,9 @@ final class BatchReader extends AssetReader implements AssetReaderState {
   Filesystem get filesystem => _inner.filesystem;
 
   @override
+  FilesystemCache get cache => _inner.cache;
+
+  @override
   AssetPathProvider? get assetPathProvider => _inner.assetPathProvider;
 
   @override

--- a/build_runner_core/lib/src/asset/build_cache.dart
+++ b/build_runner_core/lib/src/asset/build_cache.dart
@@ -48,6 +48,9 @@ class BuildCacheReader implements AssetReader, AssetReaderState {
   Filesystem get filesystem => _delegate.filesystem;
 
   @override
+  FilesystemCache get cache => _delegate.cache;
+
+  @override
   AssetFinder get assetFinder => _delegate.assetFinder;
 
   @override

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -107,6 +107,9 @@ class SingleStepReader extends AssetReader implements AssetReaderState {
   Filesystem get filesystem => _delegate.filesystem;
 
   @override
+  FilesystemCache get cache => _delegate.cache;
+
+  @override
   AssetPathProvider? get assetPathProvider => _delegate.assetPathProvider;
 
   /// Checks whether [id] can be read by this step - attempting to build the

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -190,7 +190,7 @@ class AssetGraph {
     Iterable<AssetNode> nodes,
     AssetReader digestReader,
   ) async {
-    await digestReader.filesystem.cache.invalidate(nodes.map((n) => n.id));
+    await digestReader.cache.invalidate(nodes.map((n) => n.id));
     await Future.wait(
       nodes.map((node) async {
         node.lastKnownDigest = await digestReader.digest(node.id);

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -168,7 +168,7 @@ class AssetTracker {
       var node = assetGraph.get(id)!;
       var originalDigest = node.lastKnownDigest;
       if (originalDigest == null) return;
-      await _reader.filesystem.cache.invalidate([id]);
+      await _reader.cache.invalidate([id]);
       var currentDigest = await _reader.digest(id);
       if (currentDigest != originalDigest) {
         updates[id] = ChangeType.MODIFY;

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -296,7 +296,7 @@ class _SingleBuild {
         _delete,
         _reader,
       );
-      await _reader.filesystem.cache.invalidate(invalidated);
+      await _reader.cache.invalidate(invalidated);
     });
   }
 
@@ -978,7 +978,7 @@ class _SingleBuild {
           return;
         } else {
           if (node.lastKnownDigest == null) {
-            await reader.filesystem.cache.invalidate([id]);
+            await reader.cache.invalidate([id]);
             node.lastKnownDigest = await reader.digest(id);
           }
         }

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -34,7 +34,7 @@ void main() {
         <AssetId>{},
         <AssetId>{},
         packageGraph,
-        InMemoryAssetReaderWriter(),
+        TestReaderWriter(),
       );
     });
 
@@ -55,8 +55,9 @@ void main() {
         ..add(notDeleted)
         ..add(deleted);
 
-      var delegate = InMemoryAssetReaderWriter();
-      delegate.assets.addAll({notDeleted.id: [], deleted.id: []});
+      var delegate = TestReaderWriter();
+      delegate.testing.writeString(notDeleted.id, '');
+      delegate.testing.writeString(deleted.id, '');
 
       reader = FinalizedReader(delegate, graph, targetGraph, [], 'a');
       expect(await reader.canRead(notDeleted.id), true);
@@ -76,8 +77,8 @@ void main() {
         builderOptionsId: AssetId('a', 'builder_options'),
       );
       graph.add(node);
-      var delegate = InMemoryAssetReaderWriter();
-      delegate.assets.addAll({id: []});
+      var delegate = TestReaderWriter();
+      delegate.testing.writeString(id, '');
       reader = FinalizedReader(delegate, graph, targetGraph, [
         InBuildPhase(TestBuilder(), 'a', isOptional: false),
       ], 'a')..reset({'web'}, {});

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -18,11 +18,11 @@ import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 
 void main() {
-  late InMemoryAssetReaderWriter digestReader;
+  late TestReaderWriter digestReader;
   final fooPackageGraph = buildPackageGraph({rootPackage('foo'): []});
 
   setUp(() async {
-    digestReader = InMemoryAssetReaderWriter();
+    digestReader = TestReaderWriter();
   });
 
   group('AssetGraph', () {
@@ -228,7 +228,7 @@ void main() {
 
       setUp(() async {
         for (final id in [primaryInputId, internalId]) {
-          digestReader.filesystem.writeAsStringSync(id, 'contents of $id');
+          digestReader.testing.writeString(id, 'contents of $id');
         }
         graph = await AssetGraph.build(
           buildPhases,
@@ -464,7 +464,7 @@ void main() {
             graph.add(globNode);
 
             var coolAssetId = AssetId('foo', 'lib/really.cool');
-            digestReader.filesystem.writeAsStringSync(
+            digestReader.testing.writeString(
               coolAssetId,
               'contents of $coolAssetId',
             );
@@ -548,7 +548,7 @@ void main() {
         };
 
         for (final id in sources) {
-          digestReader.filesystem.writeAsStringSync(id, 'contents of $id');
+          digestReader.testing.writeString(id, 'contents of $id');
         }
         final graph = await AssetGraph.build(
           [
@@ -601,7 +601,7 @@ void main() {
           'source globs', () async {
         final sources = {makeAssetId('foo|lib/1.txt')};
         for (final id in sources) {
-          digestReader.filesystem.writeAsStringSync(id, 'contents of $id');
+          digestReader.testing.writeString(id, 'contents of $id');
         }
         final graph = await AssetGraph.build(
           [
@@ -650,7 +650,7 @@ void main() {
         ];
         final sources = {makeAssetId('foo|lib/b.anchor')};
         for (final id in sources) {
-          digestReader.filesystem.writeAsStringSync(id, 'contents of $id');
+          digestReader.testing.writeString(id, 'contents of $id');
         }
         final graph = await AssetGraph.build(
           buildPhases,
@@ -686,10 +686,7 @@ void main() {
 
       test('https://github.com/dart-lang/build/issues/1804', () async {
         final source = AssetId('a', 'lib/a.dart');
-        digestReader.filesystem.writeAsStringSync(
-          source,
-          'contents of $source',
-        );
+        digestReader.testing.writeString(source, 'contents of $source');
         final renamedSource = AssetId('a', 'lib/A.dart');
         final generatedDart = AssetId('a', 'lib/a.g.dart');
         final generatedPart = AssetId('a', 'lib/a.g.part');

--- a/build_runner_core/test/environment/create_merged_dir_test.dart
+++ b/build_runner_core/test/environment/create_merged_dir_test.dart
@@ -70,7 +70,7 @@ void main() {
     setUp(() async {
       readerWriter = InMemoryRunnerAssetReaderWriter();
       for (final source in sources.entries) {
-        readerWriter.filesystem.writeAsStringSync(source.key, source.value);
+        readerWriter.testing.writeString(source.key, source.value);
       }
       environment = TestBuildEnvironment(readerWriter: readerWriter);
       graph = await AssetGraph.build(
@@ -102,10 +102,7 @@ void main() {
               ..state = NodeState.upToDate
               ..wasOutput = true
               ..isFailure = false;
-        readerWriter.filesystem.writeAsStringSync(
-          id,
-          sources[node.primaryInput]!,
-        );
+        readerWriter.testing.writeString(id, sources[node.primaryInput]!);
       }
       tmpDir = await Directory.systemTemp.createTemp('build_tests');
       anotherTmpDir = await Directory.systemTemp.createTemp('build_tests');

--- a/build_runner_core/test/generate/custom_generated_dir_test.dart
+++ b/build_runner_core/test/generate/custom_generated_dir_test.dart
@@ -31,11 +31,10 @@ void main() {
       expectedGeneratedDir: customGeneratedDir,
     );
     expect(
-      result.readerWriter.assets[AssetId(
-        'a',
-        '.dart_tool/build/$customGeneratedDir/a/lib/a.txt.copy',
-      )],
-      isNotNull,
+      result.readerWriter.testing.exists(
+        AssetId('a', '.dart_tool/build/$customGeneratedDir/a/lib/a.txt.copy'),
+      ),
+      isTrue,
     );
   });
 }

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,30 +1,19 @@
 ## 3.0.0-wip
 
 - Bump the min SDK to 3.7.0.
-- `InMemoryAssetReader` and `InMemoryAssetWriter` implementations are merged
-  into `InMemoryAssetReaderWriter` with shared state; it implements both
+- Breaking change: tests must use new `TestReaderWriter` instead of
   `InMemoryAssetReader` and `InMemoryAssetWriter`.
 - Breaking change: `testBuilder` no longer accepts a `reader` and a `writer`.
-  Instead it returns a `TestBuilderResult` with the `InMemoryAssetReaderWriter`
+  Instead it returns a `TestBuilderResult` with the `TestReaderWriter`
   that was used.
 - Breaking change: `resolveSources` no longer automatically reads non-input
   files from the filesystem; specify explicitly which non-input files the
   test should read in `nonInputsToReadFromFilesystem`.
 - Breaking change: remove `MultiAssetReader`. Load the source into one
-  in-memory reader instead of providing multiple readers.
+  `TestReaderWriter` instead.
+- Breaking change: Remove `StubAssetReader`. Use `TestReaderWriter` instead.
 - Support checks on reader state after a build action in `resolveSources`.
 - Start using `package:build/src/internal.dart`.
-- Refactor `PathProvidingAssetReader` to `AssetPathProvider`
-- Refactor `MultiPackageAssetReader` to internal `AssetFinder`.
-- Add internal `Filesystem` that backs `AssetReader` and `AssetWriter`
-  implementations.
-- Breaking change: `InMemoryAssetReader` constrictur no longer accepts sources,
-  and `cacheBytes` methods are removed. Tests should write to its `filesystem`
-  instead.
-- Breaking change: merged `InMemoryAssetReader` and `InMemoryAssetWriter` into
-  `InMemoryAssetReaderWriter`.
-- Refactor `CachingAssetReader` to `FilesystemCache`.
-- Remove `StubAssetReader`. Use `InMemoryAssetReaderWriter` instead.
 
 ## 2.2.3
 

--- a/build_test/lib/build_test.dart
+++ b/build_test/lib/build_test.dart
@@ -8,7 +8,6 @@ export 'src/assets.dart';
 export 'src/builder.dart';
 export 'src/fake_watcher.dart';
 export 'src/globbing_builder.dart';
-export 'src/in_memory_reader_writer.dart';
 export 'src/matchers.dart';
 export 'src/package_reader.dart' show PackageAssetReader;
 export 'src/record_logs.dart';
@@ -16,4 +15,5 @@ export 'src/resolve_source.dart'
     show resolveAsset, resolveSource, resolveSources, useAssetReader;
 export 'src/stub_writer.dart';
 export 'src/test_builder.dart';
+export 'src/test_reader_writer.dart';
 export 'src/written_asset_reader.dart';

--- a/build_test/lib/src/assets.dart
+++ b/build_test/lib/src/assets.dart
@@ -2,11 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:build/build.dart';
 
-import 'in_memory_reader_writer.dart';
+import 'test_reader_writer.dart';
 
 int _nextId = 0;
 AssetId makeAssetId([String? assetIdString]) {
@@ -17,12 +15,12 @@ AssetId makeAssetId([String? assetIdString]) {
   return AssetId.parse(assetIdString);
 }
 
-void addAssets(Map<AssetId, dynamic> assets, InMemoryAssetReaderWriter writer) {
+void addAssets(Map<AssetId, dynamic> assets, TestReaderWriter writer) {
   assets.forEach((id, value) {
     if (value is String) {
-      writer.assets[id] = utf8.encode(value);
+      writer.testing.writeString(id, value);
     } else if (value is List<int>) {
-      writer.assets[id] = value;
+      writer.testing.writeBytes(id, value);
     } else {
       throw ArgumentError(
         '`assets` values must be of type `String` or `List<int>`, got '

--- a/build_test/lib/src/test_reader_writer.dart
+++ b/build_test/lib/src/test_reader_writer.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'dart:typed_data';
+
+import 'package:build/build.dart';
+
+import 'in_memory_reader_writer.dart';
+
+/// In-memory implementation of [AssetReader] and [AssetWriter].
+///
+/// [testing] provides a [ReaderWriterTesting] that gives access to the
+/// in-memory filesystem for tests to directly modify files and check on
+/// files.
+abstract interface class TestReaderWriter implements AssetReader, AssetWriter {
+  factory TestReaderWriter({String? rootPackage}) =>
+      InMemoryAssetReaderWriter(rootPackage: rootPackage);
+
+  ReaderWriterTesting get testing;
+}
+
+/// Access to [TestReaderWriter] state for testing.
+abstract interface class ReaderWriterTesting {
+  /// All the assets that exist on the [TestReaderWriter] in-memory filesystem.
+  Iterable<AssetId> get assets;
+
+  /// The assets that have been read via the [TestReaderWriter]'s non-test
+  /// APIs.
+  Iterable<AssetId> get assetsRead;
+
+  /// Whether [id] exists on the [TestReaderWriter] in-memory filesystem.
+  bool exists(AssetId id);
+
+  /// Writes [id] with [contents] to the [TestReaderWriter] in-memory
+  /// filesystem.
+  void writeString(AssetId id, String contents);
+
+  /// Writes [id] with [contents] to the [TestReaderWriter] in-memory
+  /// filesystem.
+  void writeBytes(AssetId id, List<int> contents);
+
+  /// Reads [id] from the [TestReaderWriter] in-memory filesystem.
+  Uint8List readBytes(AssetId id);
+
+  /// Reads [id] from the [TestReaderWriter] in-memory filesystem.
+  String readString(AssetId id);
+
+  /// Deletes [id] from the [TestReaderWriter] in-memory filesystem.
+  void delete(AssetId id);
+}

--- a/build_test/lib/src/written_asset_reader.dart
+++ b/build_test/lib/src/written_asset_reader.dart
@@ -34,6 +34,9 @@ class WrittenAssetReader extends AssetReader implements AssetReaderState {
   Filesystem get filesystem => source.filesystem;
 
   @override
+  FilesystemCache get cache => source.cache;
+
+  @override
   late final AssetFinder assetFinder = FunctionAssetFinder(_findAssets);
 
   @override
@@ -52,7 +55,7 @@ class WrittenAssetReader extends AssetReader implements AssetReaderState {
 
   @override
   Future<bool> canRead(AssetId id) {
-    var canRead = source.assets.containsKey(id);
+    var canRead = source.testing.exists(id);
     if (filterSpy != null) {
       canRead =
           canRead &&
@@ -68,7 +71,7 @@ class WrittenAssetReader extends AssetReader implements AssetReaderState {
   Stream<AssetId> findAssets(Glob glob) => throw UnimplementedError();
 
   Stream<AssetId> _findAssets(Glob glob, String? package) async* {
-    var available = source.assets.keys.toSet();
+    var available = source.testing.assets.toSet();
     if (filterSpy != null) {
       available = available.intersection(
         filterSpy!.assetsWritten.toSet().union(_additionallyAllowed),
@@ -84,15 +87,9 @@ class WrittenAssetReader extends AssetReader implements AssetReaderState {
   }
 
   @override
-  Future<List<int>> readAsBytes(AssetId id) {
-    if (!source.assets.containsKey(id)) {
-      throw AssetNotFoundException(id);
-    }
-    return Future.value(source.assets[id]!);
-  }
+  Future<List<int>> readAsBytes(AssetId id) => source.readAsBytes(id);
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) async {
-    return encoding.decode(await readAsBytes(id));
-  }
+  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) =>
+      source.readAsString(id, encoding: encoding);
 }

--- a/build_test/test/check_outputs_test.dart
+++ b/build_test/test/check_outputs_test.dart
@@ -7,7 +7,7 @@ void main() {
       var a = makeAssetId('a|lib/a.txt');
       var b = makeAssetId('a|lib/b.txt');
       var actualAssets = [a, b];
-      var readerWriter = InMemoryAssetReaderWriter();
+      var readerWriter = TestReaderWriter();
       await readerWriter.writeAsString(a, 'a');
       await readerWriter.writeAsString(b, 'b');
 
@@ -22,7 +22,7 @@ void main() {
       var a = makeAssetId('a|lib/a.txt');
       var b = makeAssetId('a|lib/b.txt');
       var actualAssets = [a, b];
-      var readerWriter = InMemoryAssetReaderWriter();
+      var readerWriter = TestReaderWriter();
       await readerWriter.writeAsString(a, 'a');
       await readerWriter.writeAsString(b, 'b');
 
@@ -37,7 +37,7 @@ void main() {
     test('with missing output', () async {
       var a = makeAssetId('a|lib/a.txt');
       var actualAssets = [a];
-      var readerWriter = InMemoryAssetReaderWriter();
+      var readerWriter = TestReaderWriter();
       await readerWriter.writeAsString(a, 'a');
 
       var outputs = {'a|lib/a.txt': 'a', 'a|lib/b.txt': 'b'};
@@ -53,7 +53,7 @@ void main() {
       var b = makeAssetId('b|lib/b.txt');
       var bMapped = makeAssetId('a|.generated/b/lib/b.txt');
       var actualAssets = [a, b];
-      var readerWriter = InMemoryAssetReaderWriter();
+      var readerWriter = TestReaderWriter();
       await readerWriter.writeAsString(a, 'a');
       await readerWriter.writeAsString(bMapped, 'b');
 

--- a/build_test/test/in_memory_reader_test.dart
+++ b/build_test/test/in_memory_reader_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
-import 'package:build_test/build_test.dart';
+import 'package:build_test/src/in_memory_reader_writer.dart';
 import 'package:glob/glob.dart';
 import 'package:test/test.dart';
 
@@ -18,8 +18,8 @@ void main() {
     setUp(() {
       readerWriter =
           InMemoryAssetReaderWriter(rootPackage: packageName)
-            ..filesystem.writeAsStringSync(libAsset, 'libAsset')
-            ..filesystem.writeAsStringSync(testAsset, 'testAsset');
+            ..testing.writeString(libAsset, 'libAsset')
+            ..testing.writeString(testAsset, 'testAsset');
     });
 
     test(
@@ -50,10 +50,7 @@ void main() {
       '#findAssets should be able to list files in non-root packages',
       () async {
         var otherLibAsset = AssetId('other', 'lib/other.dart');
-        readerWriter.filesystem.writeAsStringSync(
-          otherLibAsset,
-          'otherLibAsset',
-        );
+        readerWriter.testing.writeString(otherLibAsset, 'otherLibAsset');
         expect(
           await readerWriter.assetFinder
               .find(Glob('lib/*.dart'), package: 'other')

--- a/build_test/test/written_asset_reader_test.dart
+++ b/build_test/test/written_asset_reader_test.dart
@@ -1,5 +1,6 @@
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
+import 'package:build_test/src/in_memory_reader_writer.dart';
 import 'package:glob/glob.dart';
 import 'package:test/test.dart';
 

--- a/build_web_compilers/test/util.dart
+++ b/build_web_compilers/test/util.dart
@@ -18,7 +18,8 @@ Future<void> testBuilderAndCollectAssets(
     assets,
     onLog: (log) => printOnFailure('${log.level}: ${log.message}'),
   );
-  result.readerWriter.assets.forEach((id, value) {
+  for (var id in result.readerWriter.testing.assets) {
+    final value = result.readerWriter.testing.readBytes(id);
     assets['${id.package}|${id.path}'] = value;
-  });
+  }
 }

--- a/scratch_space/test/scratch_space_test.dart
+++ b/scratch_space/test/scratch_space_test.dart
@@ -18,7 +18,7 @@ import 'package:test/test.dart';
 void main() {
   group('ScratchSpace', () {
     late ScratchSpace scratchSpace;
-    late InMemoryAssetReaderWriter readerWriter;
+    late TestReaderWriter readerWriter;
 
     var allAssets = [
       'dep|lib/dep.dart',
@@ -33,9 +33,9 @@ void main() {
 
     setUp(() async {
       scratchSpace = ScratchSpace();
-      readerWriter = InMemoryAssetReaderWriter();
+      readerWriter = TestReaderWriter();
       for (final asset in allAssets.entries) {
-        readerWriter.filesystem.writeAsBytesSync(asset.key, asset.value);
+        readerWriter.testing.writeBytes(asset.key, asset.value);
       }
       await scratchSpace.ensureAssets(allAssets.keys, readerWriter);
     });
@@ -90,10 +90,10 @@ void main() {
       var outputContent = 'test!';
       await outputFile.writeAsString(outputContent);
 
-      var writer = InMemoryAssetReaderWriter();
+      var writer = TestReaderWriter();
       await scratchSpace.copyOutput(outputId, writer);
 
-      expect(writer.assets[outputId], decodedMatches(outputContent));
+      expect(writer.testing.readString(outputId), outputContent);
     });
 
     test('Can delete a ScratchSpace', () async {


### PR DESCRIPTION
For #3811, work in progress. 

Move `FilesystemCache` out of `Filesystem` to `FileBasedAssetReader` and `InMemoryAssetReaderWriter`. `Filesystem` now just always directly reads/writes.

Move `AssetPathProvider` out of `Filesystem` to `FileBasedAssetReader` and `InMemoryAssetReaderWriter`. `Filesystem` now accesses files by path, with the `Reader` handling the mapping from IDs to path. This removes the last big difference between `InMemoryAssetReaderWriter` and `FileBasedAssetReader`, which was that the in-memory version used did not map to paths, storing data by ID.

Add `TestReaderWriter` with `ReaderWriterTesting` member that gives access to the internal state for testing; `InMemoryAssetReaderWriter` and its `Filesystem` and other `AssetReaderState` members are now hidden from tests behind this test-specific API.