### PR TITLE
Refactor `BuildCacheReader` to `BuildCacheAssetPathProvider`.

### DIFF
--- a/_test_common/lib/common.dart
+++ b/_test_common/lib/common.dart
@@ -20,13 +20,11 @@ export 'sdk.dart';
 export 'test_phases.dart';
 
 Digest computeDigest(AssetId id, String contents) {
-  // Special handling for `$$` assets, these are generated under the .dart_tool
-  // dir and unfortunately that leaks into the digest computations.
-  if (id.package.startsWith(r'$$')) {
-    var package = id.package.substring(2);
-    id = AssetId(package, '.dart_tool/build/generated/$package/${id.path}');
-  }
-  return md5.convert([...utf8.encode(contents), ...id.toString().codeUnits]);
+  // Tests use `$$` at the start of an ID to signal "generated", remove it.
+  var idString = id.toString();
+  if (idString.startsWith(r'$$')) idString = idString.substring(2);
+
+  return md5.convert([...utf8.encode(contents), ...idString.codeUnits]);
 }
 
 class PlaceholderBuilder extends Builder {

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.4.3-wip
 
+- `AssetNotFoundException` now also reports the missing `path`.
 - Bump the min sdk to 3.7.0.
 - Use `build_test` 3.0.0.
 - Add `package:build/src/internal.dart` for use by `build_resolvers`,
@@ -9,6 +10,7 @@
 - Add internal `Filesystem` that backs `AssetReader` and `AssetWriter`
   implementations.
 - Refactor `CachingAssetReader` to `FilesystemCache`.
+- Refactor `BuildCacheReader` to `BuildCacheAssetPathProvider`.
 
 ## 2.4.2
 

--- a/build/lib/src/asset/exceptions.dart
+++ b/build/lib/src/asset/exceptions.dart
@@ -5,11 +5,15 @@ import 'id.dart';
 
 class AssetNotFoundException implements Exception {
   final AssetId assetId;
+  final String? path;
 
-  AssetNotFoundException(this.assetId);
+  AssetNotFoundException(this.assetId, {this.path});
 
   @override
-  String toString() => 'AssetNotFoundException: $assetId';
+  String toString() {
+    if (path == null) return 'AssetNotFoundException: $assetId';
+    return 'AssetNotFoundException: $assetId ($path)';
+  }
 }
 
 class PackageNotFoundException implements Exception {

--- a/build/lib/src/builder/build_step_impl.dart
+++ b/build/lib/src/builder/build_step_impl.dart
@@ -85,10 +85,13 @@ class BuildStepImpl implements BuildStep, AssetReaderState {
        _reportUnusedAssets = reportUnusedAssets;
 
   @override
-  BuildStepImpl copyWith({FilesystemCache? cache}) => BuildStepImpl(
+  BuildStepImpl copyWith({
+    AssetPathProvider? assetPathProvider,
+    FilesystemCache? cache,
+  }) => BuildStepImpl(
     inputId,
     allowedOutputs,
-    _reader.copyWith(cache: cache),
+    _reader.copyWith(assetPathProvider: assetPathProvider, cache: cache),
     _writer,
     _resolvers,
     _resourceManager,
@@ -107,7 +110,7 @@ class BuildStepImpl implements BuildStep, AssetReaderState {
   AssetFinder get assetFinder => _reader.assetFinder;
 
   @override
-  AssetPathProvider? get assetPathProvider => _reader.assetPathProvider;
+  AssetPathProvider get assetPathProvider => _reader.assetPathProvider;
 
   @override
   InputTracker? get inputTracker => _reader.inputTracker;

--- a/build/lib/src/state/asset_path_provider.dart
+++ b/build/lib/src/state/asset_path_provider.dart
@@ -4,18 +4,7 @@
 
 import '../asset/id.dart';
 
-/// Converts [AssetId] to paths.
+/// Converts [AssetId]s to paths.
 abstract interface class AssetPathProvider {
   String pathFor(AssetId id);
-}
-
-/// Applies a function to an existing [AssetPathProvider].
-class OverlayAssetPathProvider implements AssetPathProvider {
-  AssetPathProvider delegate;
-  AssetId Function(AssetId) overlay;
-
-  OverlayAssetPathProvider({required this.delegate, required this.overlay});
-
-  @override
-  String pathFor(AssetId id) => delegate.pathFor(overlay(id));
 }

--- a/build/lib/src/state/reader_state.dart
+++ b/build/lib/src/state/reader_state.dart
@@ -12,9 +12,15 @@ import 'input_tracker.dart';
 /// Provides access to the state backing an [AssetReader].
 extension AssetReaderStateExtension on AssetReader {
   /// Returns a new instance with optionally updated [cache].
-  AssetReader copyWith({FilesystemCache? cache}) {
+  AssetReader copyWith({
+    AssetPathProvider? assetPathProvider,
+    FilesystemCache? cache,
+  }) {
     _requireIsAssetReaderState();
-    return (this as AssetReaderState).copyWith(cache: cache);
+    return (this as AssetReaderState).copyWith(
+      assetPathProvider: assetPathProvider,
+      cache: cache,
+    );
   }
 
   Filesystem get filesystem {
@@ -35,6 +41,11 @@ extension AssetReaderStateExtension on AssetReader {
   InputTracker? get inputTracker =>
       this is AssetReaderState ? (this as AssetReaderState).inputTracker : null;
 
+  AssetPathProvider get assetPathProvider {
+    _requireIsAssetReaderState();
+    return (this as AssetReaderState).assetPathProvider;
+  }
+
   /// Gets [inputTracker] or throws a descriptive error if it is `null`.
   InputTracker get requireInputTracker {
     final result = inputTracker;
@@ -46,11 +57,6 @@ extension AssetReaderStateExtension on AssetReader {
     }
     return result;
   }
-
-  AssetPathProvider? get assetPathProvider =>
-      this is AssetReaderState
-          ? (this as AssetReaderState).assetPathProvider
-          : null;
 
   /// Throws if `this` is not an [AssetReaderState].
   void _requireIsAssetReaderState() {
@@ -64,8 +70,11 @@ extension AssetReaderStateExtension on AssetReader {
 
 /// The state backing an [AssetReader].
 abstract interface class AssetReaderState {
-  /// Returns a new instance with optionally updated [cache].
-  AssetReader copyWith({FilesystemCache? cache});
+  /// Returns a new instance with optionally updated [assetPathProvider] and/or [cache].
+  AssetReader copyWith({
+    AssetPathProvider? assetPathProvider,
+    FilesystemCache? cache,
+  });
 
   /// The [Filesystem] that this reader reads from.
   ///
@@ -86,7 +95,6 @@ abstract interface class AssetReaderState {
   /// not have one.
   InputTracker? get inputTracker;
 
-  /// The [AssetPathProvider] associated with this reader, or `null` if it does
-  /// not have one.
-  AssetPathProvider? get assetPathProvider;
+  /// The [AssetPathProvider] associated with this reader.
+  AssetPathProvider get assetPathProvider;
 }

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add internal `Filesystem` that backs `AssetReader` and `AssetWriter`
   implementations.
 - Refactor `CachingAssetReader` to `FilesystemCache`.
+- Refactor `BuildCacheReader` to `BuildCacheAssetPathProvider`.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/build_runner_core.dart
+++ b/build_runner_core/lib/build_runner_core.dart
@@ -4,7 +4,6 @@
 
 export 'package:build/build.dart' show PostProcessBuildStep, PostProcessBuilder;
 
-export 'src/asset/batch.dart' show wrapInBatch;
 export 'src/asset/file_based.dart';
 export 'src/asset/finalized_reader.dart';
 export 'src/asset/writer.dart';

--- a/build_runner_core/lib/src/asset/build_cache.dart
+++ b/build_runner_core/lib/src/asset/build_cache.dart
@@ -4,84 +4,37 @@ import 'dart:convert';
 import 'package:build/build.dart';
 // ignore: implementation_imports
 import 'package:build/src/internal.dart';
-import 'package:crypto/crypto.dart';
-import 'package:glob/glob.dart';
 
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../util/constants.dart';
 import 'writer.dart';
 
-/// Wraps an [AssetReader] and translates reads for generated files into reads
-/// from the build cache directory
-class BuildCacheReader implements AssetReader, AssetReaderState {
-  @override
-  final AssetPathProvider? assetPathProvider;
-
-  final AssetReader _delegate;
+/// Wraps an [AssetPathProvider] to place hidden generated files in the build
+/// cache directory.
+///
+/// Assets that are in the provided [AssetGraph], have node type
+/// [GeneratedAssetNode] and have `isHidden == true` are mapped to
+/// [generatedOutputDirectory].
+class BuildCacheAssetPathProvider implements AssetPathProvider {
+  final AssetPathProvider _delegate;
   final AssetGraph _assetGraph;
   final String _rootPackage;
 
-  BuildCacheReader(
-    AssetReader delegate,
-    AssetGraph assetGraph,
-    String rootPackage,
-  ) : _delegate = delegate,
-      _assetGraph = assetGraph,
-      _rootPackage = rootPackage,
-      assetPathProvider =
-          delegate.assetPathProvider == null
-              ? null
-              : OverlayAssetPathProvider(
-                delegate: delegate.assetPathProvider!,
-                overlay: (id) => _cacheLocation(id, assetGraph, rootPackage),
-              );
+  BuildCacheAssetPathProvider({
+    required AssetPathProvider delegate,
+    required AssetGraph assetGraph,
+    required String rootPackage,
+  }) : _delegate = delegate,
+       _assetGraph = assetGraph,
+       _rootPackage = rootPackage;
 
   @override
-  BuildCacheReader copyWith({FilesystemCache? cache}) => BuildCacheReader(
-    _delegate.copyWith(cache: cache),
-    _assetGraph,
-    _rootPackage,
-  );
-
-  @override
-  Filesystem get filesystem => _delegate.filesystem;
-
-  @override
-  FilesystemCache get cache => _delegate.cache;
-
-  @override
-  AssetFinder get assetFinder => _delegate.assetFinder;
-
-  @override
-  InputTracker? get inputTracker => _delegate.inputTracker;
-
-  @override
-  Future<bool> canRead(AssetId id) =>
-      _delegate.canRead(_cacheLocation(id, _assetGraph, _rootPackage));
-
-  @override
-  Future<Digest> digest(AssetId id) =>
-      _delegate.digest(_cacheLocation(id, _assetGraph, _rootPackage));
-
-  @override
-  Future<List<int>> readAsBytes(AssetId id) =>
-      _delegate.readAsBytes(_cacheLocation(id, _assetGraph, _rootPackage));
-
-  @override
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) =>
-      _delegate.readAsString(
-        _cacheLocation(id, _assetGraph, _rootPackage),
-        encoding: encoding,
-      );
-
-  @override
-  Stream<AssetId> findAssets(Glob glob) =>
-      throw UnimplementedError(
-        'Asset globbing should be done per phase with the AssetGraph',
-      );
+  String pathFor(AssetId id) =>
+      _delegate.pathFor(_cacheLocation(id, _assetGraph, _rootPackage));
 }
 
+// TODO(davidmorgan): refactor in the same way as the reader.
 class BuildCacheWriter implements RunnerAssetWriter {
   final AssetGraph _assetGraph;
   final RunnerAssetWriter _delegate;

--- a/build_runner_core/lib/src/asset/reader.dart
+++ b/build_runner_core/lib/src/asset/reader.dart
@@ -92,8 +92,11 @@ class SingleStepReader extends AssetReader implements AssetReaderState {
   ]);
 
   @override
-  SingleStepReader copyWith({FilesystemCache? cache}) => SingleStepReader(
-    _delegate.copyWith(cache: cache),
+  SingleStepReader copyWith({
+    AssetPathProvider? assetPathProvider,
+    FilesystemCache? cache,
+  }) => SingleStepReader(
+    _delegate.copyWith(assetPathProvider: assetPathProvider, cache: cache),
     _assetGraph,
     _phaseNumber,
     _primaryPackage,
@@ -110,7 +113,7 @@ class SingleStepReader extends AssetReader implements AssetReaderState {
   FilesystemCache get cache => _delegate.cache;
 
   @override
-  AssetPathProvider? get assetPathProvider => _delegate.assetPathProvider;
+  AssetPathProvider get assetPathProvider => _delegate.assetPathProvider;
 
   /// Checks whether [id] can be read by this step - attempting to build the
   /// asset if necessary.

--- a/build_runner_core/lib/src/environment/create_merged_dir.dart
+++ b/build_runner_core/lib/src/environment/create_merged_dir.dart
@@ -37,7 +37,7 @@ Future<bool> createMergedOutputDirectories(
   FinalizedAssetsView finalizedAssetsView,
   bool outputSymlinksOnly,
 ) async {
-  if (outputSymlinksOnly && reader.assetPathProvider == null) {
+  if (outputSymlinksOnly && reader.filesystem is! IoFilesystem) {
     _logger.severe(
       'The current environment does not support symlinks, but symlinks were '
       'requested.',
@@ -263,12 +263,11 @@ Future<AssetId> _writeAsset(
     var outputId = AssetId(packageGraph.root.name, assetPath);
     try {
       if (symlinkOnly) {
-        await Link(_filePathFor(outputDir, outputId)).create(
-          // We assert at the top of `createMergedOutputDirectories` that the
-          // reader implements this type when requesting symlinks.
-          reader.assetPathProvider!.pathFor(id),
-          recursive: true,
-        );
+        // We assert at the top of `createMergedOutputDirectories` that the
+        // reader filesystem is `IoFilesystem`, so symlinks make sense.
+        await Link(
+          _filePathFor(outputDir, outputId),
+        ).create(reader.assetPathProvider.pathFor(id), recursive: true);
       } else {
         await _writeAsBytes(outputDir, outputId, await reader.readAsBytes(id));
       }

--- a/build_runner_core/lib/src/environment/io_environment.dart
+++ b/build_runner_core/lib/src/environment/io_environment.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 import 'package:build/build.dart';
 import 'package:logging/logging.dart';
 
-import '../asset/batch.dart';
 import '../asset/file_based.dart';
 import '../asset/writer.dart';
 import '../generate/build_directory.dart';
@@ -46,7 +45,6 @@ class IOEnvironment implements BuildEnvironment {
     PackageGraph packageGraph, {
     bool? assumeTty,
     bool outputSymlinksOnly = false,
-    bool lowResourcesMode = false,
   }) {
     if (outputSymlinksOnly && Platform.isWindows) {
       _logger.warning(
@@ -56,17 +54,9 @@ class IOEnvironment implements BuildEnvironment {
       );
     }
 
-    var fileReader = FileBasedAssetReader(packageGraph);
-    var fileWriter = FileBasedAssetWriter(packageGraph);
-
-    var (reader, writer) =
-        lowResourcesMode
-            ? (fileReader, fileWriter)
-            : wrapInBatch(reader: fileReader, writer: fileWriter);
-
     return IOEnvironment._(
-      reader,
-      writer,
+      FileBasedAssetReader(packageGraph),
+      FileBasedAssetWriter(packageGraph),
       assumeTty == true || _canPrompt(),
       outputSymlinksOnly,
       packageGraph,

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -338,7 +338,10 @@ class _Loader {
     return BuildDefinition._(
       assetGraph!,
       _options.targetGraph,
-      _wrapReader(_environment.reader, assetGraph!),
+      _copyReaderWithBuildCacheAssetPathProvider(
+        _environment.reader,
+        assetGraph!,
+      ),
       _wrapWriter(_environment.writer, assetGraph!),
       _options.packageGraph,
       _options.deleteFilesByDefault,
@@ -545,7 +548,10 @@ class _Loader {
       updates,
       _options.packageGraph.root.name,
       (id) => _wrapWriter(_environment.writer, assetGraph).delete(id),
-      _wrapReader(_environment.reader, assetGraph),
+      _copyReaderWithBuildCacheAssetPathProvider(
+        _environment.reader,
+        assetGraph,
+      ),
     );
     return updates;
   }
@@ -562,14 +568,16 @@ class _Loader {
     );
   }
 
-  /// Wraps [original] in a [BuildCacheReader].
-  AssetReader _wrapReader(AssetReader original, AssetGraph assetGraph) {
-    return BuildCacheReader(
-      original,
-      assetGraph,
-      _options.packageGraph.root.name,
-    );
-  }
+  AssetReader _copyReaderWithBuildCacheAssetPathProvider(
+    AssetReader original,
+    AssetGraph assetGraph,
+  ) => original.copyWith(
+    assetPathProvider: BuildCacheAssetPathProvider(
+      delegate: original.assetPathProvider,
+      assetGraph: assetGraph,
+      rootPackage: _options.packageGraph.root.name,
+    ),
+  );
 
   /// Checks for any updates to the [BuilderOptionsAssetNode]s for
   /// [buildPhases] compared to the last known state.

--- a/build_runner_core/test/asset/batch_test.dart
+++ b/build_runner_core/test/asset/batch_test.dart
@@ -7,9 +7,8 @@ library;
 import 'dart:io';
 
 import 'package:build/build.dart';
-// ignore: implementation_imports
-import 'package:build/src/internal.dart';
 import 'package:build_runner_core/build_runner_core.dart';
+import 'package:build_runner_core/src/asset/batch.dart';
 import 'package:glob/glob.dart';
 import 'package:package_config/package_config_types.dart';
 import 'package:test/test.dart';
@@ -17,7 +16,7 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 
 void main() {
   late PackageGraph packageGraph;
-  late AssetReader reader;
+  late BatchReader reader;
   late RunnerAssetWriter writer;
 
   setUp(() async {

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Breaking change: Remove `StubAssetReader`. Use `TestReaderWriter` instead.
 - Support checks on reader state after a build action in `resolveSources`.
 - Start using `package:build/src/internal.dart`.
+- Refactor `BuildCacheReader` to `BuildCacheAssetPathProvider`.
 
 ## 2.2.3
 

--- a/build_test/lib/src/in_memory_reader_writer.dart
+++ b/build_test/lib/src/in_memory_reader_writer.dart
@@ -49,12 +49,15 @@ class InMemoryAssetReaderWriter extends AssetReader
            assetPathProvider ?? const InMemoryAssetPathProvider();
 
   @override
-  InMemoryAssetReaderWriter copyWith({FilesystemCache? cache}) =>
-      InMemoryAssetReaderWriter(
-        rootPackage: rootPackage,
-        filesystem: _filesystem,
-        cache: cache ?? this.cache,
-      );
+  InMemoryAssetReaderWriter copyWith({
+    AssetPathProvider? assetPathProvider,
+    FilesystemCache? cache,
+  }) => InMemoryAssetReaderWriter(
+    rootPackage: rootPackage,
+    filesystem: _filesystem,
+    assetPathProvider: assetPathProvider ?? this.assetPathProvider,
+    cache: cache ?? this.cache,
+  );
 
   @override
   ReaderWriterTesting get testing => _ReaderWriterTestingImpl(this);

--- a/build_test/lib/src/written_asset_reader.dart
+++ b/build_test/lib/src/written_asset_reader.dart
@@ -27,8 +27,13 @@ class WrittenAssetReader extends AssetReader implements AssetReaderState {
   WrittenAssetReader(this.source, [this.filterSpy]);
 
   @override
-  WrittenAssetReader copyWith({FilesystemCache? cache}) =>
-      WrittenAssetReader(source.copyWith(cache: cache), filterSpy);
+  WrittenAssetReader copyWith({
+    AssetPathProvider? assetPathProvider,
+    FilesystemCache? cache,
+  }) => WrittenAssetReader(
+    source.copyWith(assetPathProvider: assetPathProvider, cache: cache),
+    filterSpy,
+  );
 
   @override
   Filesystem get filesystem => source.filesystem;
@@ -40,7 +45,7 @@ class WrittenAssetReader extends AssetReader implements AssetReaderState {
   late final AssetFinder assetFinder = FunctionAssetFinder(_findAssets);
 
   @override
-  AssetPathProvider? get assetPathProvider => null;
+  AssetPathProvider get assetPathProvider => source.assetPathProvider;
 
   @override
   InputTracker? get inputTracker => null;
@@ -54,8 +59,8 @@ class WrittenAssetReader extends AssetReader implements AssetReaderState {
   }
 
   @override
-  Future<bool> canRead(AssetId id) {
-    var canRead = source.testing.exists(id);
+  Future<bool> canRead(AssetId id) async {
+    var canRead = await source.canRead(id);
     if (filterSpy != null) {
       canRead =
           canRead &&


### PR DESCRIPTION
For #3811.

Move handling of generated asset paths into the base `Reader`.

Disable `BatchReader`/`BatchWriter` for now, write caching should go next to `Filesystem`, that's easier to redo after the refactor.