### PR TITLE
Revert "use 'compile js-dev' command for compilation"

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 - Bump the min SDK to 3.7.0.
 - Use `build_test` 3.0.0.
-- Use the command 'compile js-dev' for compilation instead of invoking
-  dart with the snapshot name (uses internal implementation detail of
-  the dart sdk which could change).
 
 ## 5.0.11
 

--- a/build_modules/lib/src/workers.dart
+++ b/build_modules/lib/src/workers.dart
@@ -55,7 +55,10 @@ BazelWorkerDriver get _dartdevkDriver {
   return __dartdevkDriver ??= BazelWorkerDriver(
     () => Process.start(
       p.join(sdkDir, 'bin', 'dart'),
-      ['compile', 'js-dev', '--persistent_worker'],
+      [
+        p.join(sdkDir, 'bin', 'snapshots', 'dartdevc.dart.snapshot'),
+        '--persistent_worker',
+      ],
       mode: _processMode,
       workingDirectory: scratchSpace.tempDir.path,
     ),

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -3,9 +3,6 @@
 - Bump the min SDK to 3.7.0.
 - Use `build_test` 3.0.0.
 - Use support-detection scripts emitted by `dart2wasm`.
-- Use the command 'compile js-dev' for compilation instead of invoking
-  dart with the snapshot name (uses internal implementation detail of
-  the dart sdk which could change).
 
 ## 4.1.1
 

--- a/build_web_compilers/lib/src/sdk_js_compile_builder.dart
+++ b/build_web_compilers/lib/src/sdk_js_compile_builder.dart
@@ -92,11 +92,25 @@ Future<void> _createDevCompilerModule(
   try {
     // Use standalone process instead of the worker due to
     // https://github.com/dart-lang/sdk/issues/49441
+    var snapshotPath = p.join(
+      sdkDir,
+      'bin',
+      'snapshots',
+      'dartdevc_aot.dart.snapshot',
+    );
     var execSuffix = Platform.isWindows ? '.exe' : '';
-    var dartPath = p.join(sdkDir, 'bin', 'dart$execSuffix');
+    var dartPath = p.join(sdkDir, 'bin', 'dartaotruntime$execSuffix');
+    if (!File(snapshotPath).existsSync()) {
+      snapshotPath = p.join(
+        sdkDir,
+        'bin',
+        'snapshots',
+        'dartdevc.dart.snapshot',
+      );
+      dartPath = p.join(sdkDir, 'bin', 'dart$execSuffix');
+    }
     result = await Process.run(dartPath, [
-      'compile',
-      'js-dev',
+      snapshotPath,
       '--multi-root-scheme=org-dartlang-sdk',
       '--modules=amd',
       if (canaryFeatures) '--canary',


### PR DESCRIPTION
Reverts dart-lang/build#3872

Checking if this is the cause of timeouts on Windows https://github.com/dart-lang/build/actions/runs/13501493388