### PR TITLE
Release build_web_compilers 4.1.2.

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.1.2-wip
+## 4.1.2
 
 - Bump the min SDK to 3.7.0.
 - Use `build_test` 3.0.0.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.1.2-wip
+version: 4.1.2
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
The breaking `build_test` changes are not released, but it's not actually needed as it's a dev dependency.

Publish this so the wasm startup change, independent of recent refactorings, is published.