### PR TITLE
Grant pull request and id-token permissions to publish workflow.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,4 +17,5 @@ jobs:
       write-comments: false
       sdk: dev
     permissions:
+      id-token: write
       pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,3 +16,5 @@ jobs:
     with:
       write-comments: false
       sdk: dev
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
It always needed the permission, but it now needs granting explicitly.