### PR TITLE
Run phases sequentially

### DIFF
--- a/build_runner_core/lib/src/generate/single_step_reader_writer.dart
+++ b/build_runner_core/lib/src/generate/single_step_reader_writer.dart
@@ -56,14 +56,12 @@ class RunningBuild {
   final PackageGraph packageGraph;
   final TargetGraph targetGraph;
   final AssetGraph assetGraph;
-  final AssetBuilder nodeBuilder;
   final GlobNodeBuilder globNodeBuilder;
 
   RunningBuild({
     required this.packageGraph,
     required this.targetGraph,
     required this.assetGraph,
-    required this.nodeBuilder,
     required this.globNodeBuilder,
   });
 }
@@ -388,7 +386,6 @@ class SingleStepReaderWriter extends AssetReader
         return isInBuild ? Readability.ownOutput : Readability.notReadable;
       }
 
-      await _runningBuild!.nodeBuilder(node);
       return Readability.fromPreviousPhase(node.wasOutput && !node.isFailure);
     }
     return Readability.fromPreviousPhase(node.isReadable && node.isValidInput);


### PR DESCRIPTION
For #3811, review and merge #3897 first.

With the removal of transitive digest files, "optional" generators are no longer heavily relied on for performance.

So, just run all the generators eagerly.

This means each phase can complete sequentially, so drop support for running optional actions from earlier phases. And, run the build actions one by one, removing all use of `Future.wait` to run things "in parallel".

This all has no big effect on performance

```
before this PR:

shape,libraries,clean/ms,no changes/ms,incremental/ms
loop,1,24385,4365,5483
loop,100,26646,4417,7557
loop,250,30159,4582,12666
loop,500,41991,5000,25656
loop,750,59208,6361,43598
loop,1000,78480,8256,69272

after:

shape,libraries,clean/ms,no changes/ms,incremental/ms
loop,1,23703,4171,5535
loop,100,26758,4142,8487
loop,250,31544,4645,12700
loop,500,40896,4984,23992
loop,750,56848,6023,41003
loop,1000,74130,7545,66228
```