### PR TITLE
Stop using Future.wait in `build_impl`.

### DIFF
--- a/build_runner_core/lib/src/util/constants.dart
+++ b/build_runner_core/lib/src/util/constants.dart
@@ -100,6 +100,3 @@ final sdkBin = p.join(sdkPath, 'bin');
 
 /// The path to the sdk on the current platform.
 final sdkPath = p.dirname(p.dirname(Platform.resolvedExecutable));
-
-/// The maximum number of concurrent actions to run per build phase.
-const buildPhasePoolSize = 16;

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -16,7 +16,6 @@ import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
 import 'package:build_runner_core/src/generate/options.dart'
     show defaultNonRootVisibleAssets;
-import 'package:build_runner_core/src/util/constants.dart';
 import 'package:glob/glob.dart';
 import 'package:test/test.dart';
 
@@ -157,9 +156,9 @@ void main() {
       );
     });
 
-    test('runs a max of 16 concurrent actions per phase', () async {
+    test('runs a max of one concurrent action per phase', () async {
       var assets = <String, String>{};
-      for (var i = 0; i < buildPhasePoolSize * 2; i++) {
+      for (var i = 0; i < 2; i++) {
         assets['a|web/$i.txt'] = '$i';
       }
       var concurrentCount = 0;
@@ -178,8 +177,7 @@ void main() {
                       concurrentCount,
                       maxConcurrentCount,
                     );
-                    if (concurrentCount >= buildPhasePoolSize &&
-                        !reachedMax.isCompleted) {
+                    if (concurrentCount >= 1 && !reachedMax.isCompleted) {
                       await Future<void>.delayed(
                         const Duration(milliseconds: 100),
                       );
@@ -199,7 +197,7 @@ void main() {
         assets,
         outputs: {},
       );
-      expect(maxConcurrentCount, buildPhasePoolSize);
+      expect(maxConcurrentCount, 1);
     });
 
     group('with root package inputs', () {


### PR DESCRIPTION
It only increases performance in some situations with an I/O bottleneck, which is not obviously the case; for now let's remove as it makes it clearer what's going on. Just do tasks one by one.

It's still the case that there is some "parallelism" because a build action can require an input from an action in an earlier phase that didn't run yet. So the max running actions is one per phase.

Speeds things up a bit.

```
before this PR:

shape,libraries,clean/ms,no changes/ms,incremental/ms
loop,1,24385,4365,5483
loop,100,26646,4417,7557
loop,250,30159,4582,12666
loop,500,41991,5000,25656
loop,750,59208,6361,43598
loop,1000,78480,8256,69272

after:
shape,libraries,clean/ms,no changes/ms,incremental/ms
loop,1,22517,4053,5170
loop,100,25499,4039,7974
loop,250,29008,4456,12994
loop,500,39135,5091,24792
loop,750,54465,6100,38380
loop,1000,72807,7287,59647
```