### PR TITLE
Add `NodeType` to `AssetNode`.

### DIFF
--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -364,7 +364,7 @@ void main() {
         var builderOptionsId = makeAssetId('a|Phase0.builderOptions');
         var builderOptionsNode = BuilderOptionsAssetNode(
           builderOptionsId,
-          computeBuilderOptionsDigest(defaultBuilderOptions),
+          lastKnownDigest: computeBuilderOptionsDigest(defaultBuilderOptions),
         );
         expectedGraph.add(builderOptionsNode);
 

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -71,7 +71,7 @@ class _AssetGraphDeserializer {
     // current nodes.
     for (var node in graph.allNodes) {
       // These aren't explicitly added as inputs.
-      if (node is BuilderOptionsAssetNode) continue;
+      if (node.type == NodeType.builderOptions) continue;
 
       for (var output in node.outputs) {
         var inputsNode = graph.get(output) as NodeWithInputs?;
@@ -168,7 +168,7 @@ class _AssetGraphDeserializer {
         break;
       case _NodeType.builderOptions:
         assert(serializedNode.length == _WrappedAssetNode._length);
-        node = BuilderOptionsAssetNode(id, digest!);
+        node = BuilderOptionsAssetNode(id, lastKnownDigest: digest!);
         break;
       case _NodeType.placeholder:
         assert(serializedNode.length == _WrappedAssetNode._length);
@@ -346,24 +346,24 @@ class _WrappedAssetNode extends Object with ListMixin implements List {
     var fieldId = _AssetField.values[index];
     switch (fieldId) {
       case _AssetField.nodeType:
-        if (node is SourceAssetNode) {
-          return _NodeType.source.index;
-        } else if (node is GeneratedAssetNode) {
-          return _NodeType.generated.index;
-        } else if (node is GlobAssetNode) {
-          return _NodeType.glob.index;
-        } else if (node is SyntheticSourceAssetNode) {
-          return _NodeType.syntheticSource.index;
-        } else if (node is InternalAssetNode) {
-          return _NodeType.internal.index;
-        } else if (node is BuilderOptionsAssetNode) {
-          return _NodeType.builderOptions.index;
-        } else if (node is PlaceHolderAssetNode) {
-          return _NodeType.placeholder.index;
-        } else if (node is PostProcessAnchorNode) {
-          return _NodeType.postProcessAnchor.index;
-        } else {
-          throw StateError('Unrecognized node type');
+        switch (node.type) {
+          case NodeType.source:
+            return _NodeType.source.index;
+          case NodeType.generated:
+            return _NodeType.generated.index;
+          case NodeType.glob:
+            return _NodeType.glob.index;
+          case NodeType.syntheticSource:
+            return _NodeType.syntheticSource.index;
+          case NodeType.internal:
+            return _NodeType.internal.index;
+          case NodeType.builderOptions:
+            return _NodeType.builderOptions.index;
+
+          case NodeType.placeholder:
+            return _NodeType.placeholder.index;
+          case NodeType.postProcessAnchor:
+            return _NodeType.postProcessAnchor.index;
         }
       case _AssetField.id:
         return serializer.findAssetIndex(node.id, from: node.id, field: 'id');

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -600,8 +600,13 @@ class _Loader {
       AssetId builderOptionsId,
       BuilderOptions options,
     ) {
-      var builderOptionsNode =
-          assetGraph.get(builderOptionsId) as BuilderOptionsAssetNode;
+      var builderOptionsNode = assetGraph.get(builderOptionsId)!;
+      if (builderOptionsNode.type != NodeType.builderOptions) {
+        throw StateError(
+          'Expected node of type NodeType.builderOptionsNode:'
+          '$builderOptionsNode',
+        );
+      }
       var oldDigest = builderOptionsNode.lastKnownDigest;
       builderOptionsNode.lastKnownDigest = computeBuilderOptionsDigest(options);
       if (builderOptionsNode.lastKnownDigest != oldDigest) {

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -611,8 +611,8 @@ class _SingleBuild {
         .toList(growable: false)) {
       if (node is! PostProcessAnchorNode) continue;
       if (node.actionNumber != actionNum) continue;
-      final inputNode = _assetGraph.get(node.primaryInput);
-      if (inputNode is SourceAssetNode ||
+      final inputNode = _assetGraph.get(node.primaryInput)!;
+      if (inputNode.type == NodeType.source ||
           inputNode is GeneratedAssetNode &&
               inputNode.wasOutput &&
               !inputNode.isFailure &&

--- a/build_runner_core/lib/src/generate/finalized_assets_view.dart
+++ b/build_runner_core/lib/src/generate/finalized_assets_view.dart
@@ -72,7 +72,7 @@ bool _shouldSkipNode(
     if (node.id.package != packageGraph.root.name) return true;
   }
 
-  if (node is InternalAssetNode) return true;
+  if (node.type == NodeType.internal || node.type == NodeType.glob) return true;
   if (node is GeneratedAssetNode) {
     if (!node.wasOutput || node.isFailure || node.state != NodeState.upToDate) {
       return true;

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -107,7 +107,7 @@ void main() {
           var phaseNum = n;
           var builderOptionsNode = BuilderOptionsAssetNode(
             makeAssetId(),
-            Digest([n]),
+            lastKnownDigest: Digest([n]),
           );
           graph.add(builderOptionsNode);
           var anchorNode = PostProcessAnchorNode.forInputAndAction(
@@ -120,7 +120,7 @@ void main() {
           for (var g = 0; g < 5 - n; g++) {
             var builderOptionsNode = BuilderOptionsAssetNode(
               makeAssetId(),
-              md5.convert(utf8.encode('test')),
+              lastKnownDigest: md5.convert(utf8.encode('test')),
             );
 
             var generatedNode = GeneratedAssetNode(
@@ -280,12 +280,12 @@ void main() {
         expect(primaryOutputNode.inputs, isEmpty);
         expect(primaryOutputNode.primaryInput, primaryInputId);
 
-        var builderOptionsNode =
-            graph.get(builderOptionsId) as BuilderOptionsAssetNode;
+        var builderOptionsNode = graph.get(builderOptionsId)!;
+        expect(builderOptionsNode.type, NodeType.builderOptions);
         expect(builderOptionsNode.outputs, unorderedEquals([primaryOutputId]));
 
-        var postBuilderOptionsNode =
-            graph.get(postBuilderOptionsId) as BuilderOptionsAssetNode;
+        var postBuilderOptionsNode = graph.get(postBuilderOptionsId)!;
+        expect(postBuilderOptionsNode.type, NodeType.builderOptions);
         expect(postBuilderOptionsNode, isNotNull);
         expect(postBuilderOptionsNode.outputs, isEmpty);
         var anchorNode =
@@ -369,7 +369,7 @@ void main() {
           );
 
           expect(graph.contains(syntheticId), isTrue);
-          expect(graph.get(syntheticId), const TypeMatcher<SourceAssetNode>());
+          expect(graph.get(syntheticId)?.type, NodeType.source);
           expect(graph.contains(syntheticOutputId), isTrue);
           expect(
             graph.get(syntheticOutputId),
@@ -720,7 +720,9 @@ void main() {
         (graph.get(generatedDart) as GeneratedAssetNode)
           ..state = NodeState.upToDate
           ..inputs.addAll([generatedPart, toBeGeneratedDart]);
-        (graph.get(source) as SourceAssetNode).outputs.add(generatedPart);
+        final node = graph.get(source)!;
+        expect(node.type, NodeType.source);
+        node.outputs.add(generatedPart);
 
         await graph.updateAndInvalidate(
           buildPhases,

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1274,7 +1274,7 @@ void main() {
     var builderOptionsId = makeAssetId('a|Phase0.builderOptions');
     var builderOptionsNode = BuilderOptionsAssetNode(
       builderOptionsId,
-      computeBuilderOptionsDigest(defaultBuilderOptions),
+      lastKnownDigest: computeBuilderOptionsDigest(defaultBuilderOptions),
     );
     expectedGraph.add(builderOptionsNode);
 
@@ -1318,7 +1318,7 @@ void main() {
     var postBuilderOptionsId = makeAssetId('a|PostPhase0.builderOptions');
     var postBuilderOptionsNode = BuilderOptionsAssetNode(
       postBuilderOptionsId,
-      computeBuilderOptionsDigest(defaultBuilderOptions),
+      lastKnownDigest: computeBuilderOptionsDigest(defaultBuilderOptions),
     );
     expectedGraph.add(postBuilderOptionsNode);
 


### PR DESCRIPTION
For #3811.

Stop using type checks where they don't give access to more fields, use the enum instead. Remove mixins.

Next PR will remove the types that are no longer needed.