### PR TITLE
Remove most `AssetNode` subtypes.

### DIFF
--- a/_test_common/lib/assets.dart
+++ b/_test_common/lib/assets.dart
@@ -13,7 +13,7 @@ AssetNode makeAssetNode([
   Digest? lastKnownDigest,
 ]) {
   var id = makeAssetId(assetIdString);
-  var node = SourceAssetNode(id, lastKnownDigest: lastKnownDigest);
+  var node = AssetNode.source(id, lastKnownDigest: lastKnownDigest);
   if (outputs != null) {
     node.outputs.addAll(outputs);
     node.primaryOutputs.addAll(outputs);

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Refactor `CachingAssetReader` to `FilesystemCache`.
 - Refactor `FileBasedAssetReader` and `FileBasedAssetWriter` to `ReaderWriter`.
 - Remove `OnDeleteWriter`, add functionality to `ReaderWriter`.
+- Add `NodeType` to `AssetNode`, remove subtypes.
 
 ## 2.4.15
 

--- a/build_runner/lib/src/watcher/change_filter.dart
+++ b/build_runner/lib/src/watcher/change_filter.dart
@@ -27,7 +27,7 @@ FutureOr<bool> shouldProcess(
   if (_isCacheFile(change) && !assetGraph.contains(change.id)) return false;
   var node = assetGraph.get(change.id);
   if (node != null) {
-    if (!willCreateOutputDir && !node.isInteresting) return false;
+    if (!willCreateOutputDir && !node.changesRequireRebuild) return false;
     if (_isAddOrEditOnGeneratedFile(node, change.type)) return false;
     if (change.type == ChangeType.MODIFY) {
       // Was it really modified or just touched?
@@ -45,7 +45,7 @@ FutureOr<bool> shouldProcess(
 }
 
 bool _isAddOrEditOnGeneratedFile(AssetNode node, ChangeType changeType) =>
-    node.isGenerated && changeType != ChangeType.REMOVE;
+    node.type == NodeType.generated && changeType != ChangeType.REMOVE;
 
 bool _isCacheFile(AssetChange change) => change.id.path.startsWith(cacheDir);
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   build_config: ">=1.1.0 <1.2.0"
   build_daemon: ^4.0.0
   build_resolvers: ^2.4.4
-  build_runner_core: ^8.0.0
+  build_runner_core: ^8.0.1-wip
   code_builder: ^4.2.0
   collection: ^1.15.0
   crypto: ^3.0.0

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -362,7 +362,7 @@ void main() {
         );
 
         var builderOptionsId = makeAssetId('a|Phase0.builderOptions');
-        var builderOptionsNode = BuilderOptionsAssetNode(
+        var builderOptionsNode = AssetNode.builderOptions(
           builderOptionsId,
           lastKnownDigest: computeBuilderOptionsDigest(defaultBuilderOptions),
         );

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Remove `BuildCacheWriter`, functionality is handled by `AssetPathProvider`.
 - Refactor `SingleStepReader` to `SingleStepReaderWriter`, incorporating
   `AssetWriterSpy` functionality.
+- Add `NodeType` to `AssetNode`, remove subtypes.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/src/asset/finalized_reader.dart
+++ b/build_runner_core/lib/src/asset/finalized_reader.dart
@@ -59,7 +59,7 @@ class FinalizedReader {
       return UnreadableReason.notOutput;
     }
     if (node.isDeleted) return UnreadableReason.deleted;
-    if (!node.isReadable) return UnreadableReason.assetType;
+    if (!node.isFile) return UnreadableReason.assetType;
 
     if (node is GeneratedAssetNode) {
       if (node.isFailure) return UnreadableReason.failed;
@@ -69,7 +69,7 @@ class FinalizedReader {
       return null;
     }
 
-    if (node.isValidInput && await _delegate.canRead(id)) return null;
+    if (node.isTrackedInput && await _delegate.canRead(id)) return null;
     return UnreadableReason.unknown;
   }
 

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -105,11 +105,11 @@ class _AssetGraphDeserializer {
     switch (typeId) {
       case _NodeType.source:
         assert(serializedNode.length == _WrappedAssetNode._length);
-        node = SourceAssetNode(id, lastKnownDigest: digest);
+        node = AssetNode.source(id, lastKnownDigest: digest);
         break;
       case _NodeType.syntheticSource:
         assert(serializedNode.length == _WrappedAssetNode._length);
-        node = SyntheticSourceAssetNode(id);
+        node = AssetNode.missingSource(id);
         break;
       case _NodeType.generated:
         assert(serializedNode.length == _WrappedGeneratedAssetNode._length);
@@ -164,15 +164,15 @@ class _AssetGraphDeserializer {
         break;
       case _NodeType.internal:
         assert(serializedNode.length == _WrappedAssetNode._length);
-        node = InternalAssetNode(id, lastKnownDigest: digest);
+        node = AssetNode.internal(id, lastKnownDigest: digest);
         break;
       case _NodeType.builderOptions:
         assert(serializedNode.length == _WrappedAssetNode._length);
-        node = BuilderOptionsAssetNode(id, lastKnownDigest: digest!);
+        node = AssetNode.builderOptions(id, lastKnownDigest: digest!);
         break;
       case _NodeType.placeholder:
         assert(serializedNode.length == _WrappedAssetNode._length);
-        node = PlaceHolderAssetNode(id);
+        node = AssetNode.placeholder(id);
         break;
       case _NodeType.postProcessAnchor:
         assert(serializedNode.length == _WrappedPostProcessAnchorNode._length);

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -146,14 +146,14 @@ class AssetTracker {
 
     var newSources = inputSources.difference(
       assetGraph.allNodes
-          .where((node) => node.isValidInput)
+          .where((node) => node.isTrackedInput)
           .map((node) => node.id)
           .toSet(),
     );
     addUpdates(newSources, ChangeType.ADD);
     var removedAssets = assetGraph.allNodes
         .where((n) {
-          if (!n.isReadable) return false;
+          if (!n.isFile) return false;
           if (n is GeneratedAssetNode) return n.wasOutput;
           return true;
         })
@@ -588,7 +588,7 @@ class _Loader {
     ),
   );
 
-  /// Checks for any updates to the [BuilderOptionsAssetNode]s for
+  /// Checks for any updates to the [AssetNode.builderOptions] for
   /// [buildPhases] compared to the last known state.
   Map<AssetId, ChangeType> _computeBuilderOptionsUpdates(
     AssetGraph assetGraph,

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -836,7 +836,7 @@ class _SingleBuild {
       var potentialNodes =
           _assetGraph
               .packageNodes(globNode.id.package)
-              .where((n) => n.isReadable && n.isValidInput)
+              .where((n) => n.isFile && n.isTrackedInput)
               .where(
                 (n) =>
                     n is! GeneratedAssetNode ||

--- a/build_runner_core/lib/src/generate/finalized_assets_view.dart
+++ b/build_runner_core/lib/src/generate/finalized_assets_view.dart
@@ -62,7 +62,7 @@ bool _shouldSkipNode(
   PackageGraph packageGraph,
   OptionalOutputTracker optionalOutputTracker,
 ) {
-  if (!node.isReadable) return true;
+  if (!node.isFile) return true;
   if (node.isDeleted) return true;
 
   // Exclude non-lib assets if they're outside of the root directory or not from

--- a/build_runner_core/lib/src/generate/single_step_reader_writer.dart
+++ b/build_runner_core/lib/src/generate/single_step_reader_writer.dart
@@ -276,7 +276,7 @@ class SingleStepReaderWriter extends AssetReader
     final node = _runningBuild.assetGraph.get(id);
     if (node == null) {
       inputTracker.add(id);
-      _runningBuild.assetGraph.add(SyntheticSourceAssetNode(id));
+      _runningBuild.assetGraph.add(AssetNode.missingSource(id));
       return false;
     }
 
@@ -391,7 +391,7 @@ class SingleStepReaderWriter extends AssetReader
       await _runningBuild!.nodeBuilder(node);
       return Readability.fromPreviousPhase(node.wasOutput && !node.isFailure);
     }
-    return Readability.fromPreviousPhase(node.isReadable && node.isValidInput);
+    return Readability.fromPreviousPhase(node.isFile && node.isTrackedInput);
   }
 
   void _checkInvalidInput(AssetId id) {

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -105,7 +105,7 @@ void main() {
           node.outputs.add(globNode.id);
           graph.add(node);
           var phaseNum = n;
-          var builderOptionsNode = BuilderOptionsAssetNode(
+          var builderOptionsNode = AssetNode.builderOptions(
             makeAssetId(),
             lastKnownDigest: Digest([n]),
           );
@@ -118,7 +118,7 @@ void main() {
           graph.add(anchorNode);
           node.anchorOutputs.add(anchorNode.id);
           for (var g = 0; g < 5 - n; g++) {
-            var builderOptionsNode = BuilderOptionsAssetNode(
+            var builderOptionsNode = AssetNode.builderOptions(
               makeAssetId(),
               lastKnownDigest: md5.convert(utf8.encode('test')),
             );
@@ -141,7 +141,7 @@ void main() {
               node.deletedBy.add(anchorNode.id);
             }
 
-            var syntheticNode = SyntheticSourceAssetNode(makeAssetId());
+            var syntheticNode = AssetNode.missingSource(makeAssetId());
             syntheticNode.outputs.add(generatedNode.id);
 
             generatedNode.inputs.addAll([
@@ -271,7 +271,7 @@ void main() {
           reason: 'Nodes with no output shouldn\'t get an eager digest.',
         );
 
-        expect(graph.get(internalId), const TypeMatcher<InternalAssetNode>());
+        expect(graph.get(internalId)?.type, NodeType.internal);
 
         var primaryOutputNode =
             graph.get(primaryOutputId) as GeneratedAssetNode;
@@ -355,7 +355,7 @@ void main() {
         });
 
         test('add new primary input which replaces a synthetic node', () async {
-          var syntheticNode = SyntheticSourceAssetNode(syntheticId);
+          var syntheticNode = AssetNode.missingSource(syntheticId);
           graph.add(syntheticNode);
           expect(graph.get(syntheticId), syntheticNode);
 
@@ -391,7 +391,7 @@ void main() {
         test(
           'add new generated asset which replaces a synthetic node',
           () async {
-            var syntheticNode = SyntheticSourceAssetNode(syntheticOutputId);
+            var syntheticNode = AssetNode.missingSource(syntheticOutputId);
             graph.add(syntheticNode);
             expect(graph.get(syntheticOutputId), syntheticNode);
 
@@ -417,7 +417,7 @@ void main() {
           'removing nodes deletes primary outputs and secondary edges',
           () async {
             var secondaryId = makeAssetId('foo|secondary.txt');
-            var secondaryNode = SourceAssetNode(secondaryId);
+            var secondaryNode = AssetNode.source(secondaryId);
             secondaryNode.outputs.add(primaryOutputId);
             var primaryOutputNode =
                 graph.get(primaryOutputId) as GeneratedAssetNode;
@@ -662,7 +662,7 @@ void main() {
 
         // Pretend a build happened
         graph.add(
-          SyntheticSourceAssetNode(nodeToRead)..outputs.add(outputReadingNode),
+          AssetNode.missingSource(nodeToRead)..outputs.add(outputReadingNode),
         );
         (graph.get(outputReadingNode) as GeneratedAssetNode)
           ..state = NodeState.upToDate
@@ -714,7 +714,7 @@ void main() {
 
         // Pretend a build happened
         graph.add(
-          SyntheticSourceAssetNode(toBeGeneratedDart)
+          AssetNode.missingSource(toBeGeneratedDart)
             ..outputs.add(generatedPart),
         );
         (graph.get(generatedDart) as GeneratedAssetNode)

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1272,7 +1272,7 @@ void main() {
 
     // Regular generated asset nodes and supporting nodes.
     var builderOptionsId = makeAssetId('a|Phase0.builderOptions');
-    var builderOptionsNode = BuilderOptionsAssetNode(
+    var builderOptionsNode = AssetNode.builderOptions(
       builderOptionsId,
       lastKnownDigest: computeBuilderOptionsDigest(defaultBuilderOptions),
     );
@@ -1316,7 +1316,7 @@ void main() {
 
     // Post build generates asset nodes and supporting nodes
     var postBuilderOptionsId = makeAssetId('a|PostPhase0.builderOptions');
-    var postBuilderOptionsNode = BuilderOptionsAssetNode(
+    var postBuilderOptionsNode = AssetNode.builderOptions(
       postBuilderOptionsId,
       lastKnownDigest: computeBuilderOptionsDigest(defaultBuilderOptions),
     );


### PR DESCRIPTION
For #3811.

Remove subtypes that don't add any fields.

Improve naming in a few places, at least I hope these are clearer :) suggestions welcome.

`syntheticSource` -> `missingSource`
`isReadable` -> `isFile`
`isInteresting` -> `changesRequireRebuild`
`isValidInput` -> `isTrackedInput`

Improved docs in a few places.