### PR TITLE
Make  mutations to `AssetNode` explicit.

### DIFF
--- a/_test_common/lib/assets.dart
+++ b/_test_common/lib/assets.dart
@@ -13,14 +13,10 @@ AssetNode makeAssetNode([
   Digest? lastKnownDigest,
 ]) {
   var id = makeAssetId(assetIdString);
-  if (outputs == null) {
-    return AssetNode.source(id, lastKnownDigest: lastKnownDigest);
-  } else {
-    return AssetNode.source(
-      id,
-      lastKnownDigest: lastKnownDigest,
-      outputs: outputs,
-      primaryOutputs: outputs,
-    );
-  }
+  return AssetNode.source(
+    id,
+    lastKnownDigest: lastKnownDigest,
+    outputs: outputs,
+    primaryOutputs: outputs,
+  );
 }

--- a/_test_common/lib/assets.dart
+++ b/_test_common/lib/assets.dart
@@ -13,10 +13,14 @@ AssetNode makeAssetNode([
   Digest? lastKnownDigest,
 ]) {
   var id = makeAssetId(assetIdString);
-  var node = AssetNode.source(id, lastKnownDigest: lastKnownDigest);
-  if (outputs != null) {
-    node.outputs.addAll(outputs);
-    node.primaryOutputs.addAll(outputs);
+  if (outputs == null) {
+    return AssetNode.source(id, lastKnownDigest: lastKnownDigest);
+  } else {
+    return AssetNode.source(
+      id,
+      lastKnownDigest: lastKnownDigest,
+      outputs: outputs,
+      primaryOutputs: outputs,
+    );
   }
-  return node;
 }

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Refactor `CachingAssetReader` to `FilesystemCache`.
 - Refactor `FileBasedAssetReader` and `FileBasedAssetWriter` to `ReaderWriter`.
 - Remove `OnDeleteWriter`, add functionality to `ReaderWriter`.
-- Add `NodeType` to `AssetNode`, remove subtypes.
+- Add `NodeType` to `AssetNode`, remove subtypes. Make mutations explicit.
 
 ## 2.4.15
 

--- a/build_runner/bin/graph_inspector.dart
+++ b/build_runner/bin/graph_inspector.dart
@@ -155,7 +155,9 @@ class InspectNodeCommand extends Command<bool> {
         node.primaryOutputs.forEach(printAsset);
 
         description.writeln('  secondary outputs:');
-        node.outputs.difference(node.primaryOutputs).forEach(printAsset);
+        node.inspect.outputs
+            .difference(node.inspect.primaryOutputs)
+            .forEach(printAsset);
 
         if (node is NodeWithInputs) {
           description.writeln('  inputs:');

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -382,7 +382,7 @@ void main() {
           inputs: [makeAssetId('a|web/b.txt')],
           isHidden: false,
         );
-        builderOptionsNode.outputs.add(bCopyNode.id);
+        builderOptionsNode.mutate.outputs.add(bCopyNode.id);
         expectedGraph
           ..add(bCopyNode)
           ..add(
@@ -405,7 +405,7 @@ void main() {
           inputs: [makeAssetId('a|web/c.txt')],
           isHidden: false,
         );
-        builderOptionsNode.outputs.add(cCopyNode.id);
+        builderOptionsNode.mutate.outputs.add(cCopyNode.id);
         expectedGraph
           ..add(cCopyNode)
           ..add(

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -47,7 +47,7 @@ void main() {
   void addAsset(String id, String content, {bool deleted = false}) {
     var node = makeAssetNode(id, [], computeDigest(AssetId.parse(id), 'a'));
     if (deleted) {
-      node.deletedBy.add(node.id.addExtension('.post_anchor.1'));
+      node.mutate.deletedBy.add(node.id.addExtension('.post_anchor.1'));
     }
     graph.add(node);
     delegate.testing.writeString(node.id, content);

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -138,7 +138,7 @@ void main() {
   void addSource(String id, String content, {bool deleted = false}) {
     var node = makeAssetNode(id, [], computeDigest(AssetId.parse(id), content));
     if (deleted) {
-      node.deletedBy.add(node.id.addExtension('.post_anchor.1'));
+      node.mutate.deletedBy.add(node.id.addExtension('.post_anchor.1'));
     }
     assetGraph.add(node);
     readerWriter.testing.writeString(node.id, content);

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Remove `BuildCacheWriter`, functionality is handled by `AssetPathProvider`.
 - Refactor `SingleStepReader` to `SingleStepReaderWriter`, incorporating
   `AssetWriterSpy` functionality.
-- Add `NodeType` to `AssetNode`, remove subtypes.
+- Add `NodeType` to `AssetNode`, remove subtypes. Make mutations explicit.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/src/asset/finalized_reader.dart
+++ b/build_runner_core/lib/src/asset/finalized_reader.dart
@@ -120,7 +120,9 @@ class FinalizedReader {
   FutureOr<Digest> _ensureDigest(AssetId id) {
     var node = _assetGraph.get(id)!;
     if (node.lastKnownDigest != null) return node.lastKnownDigest!;
-    return _delegate.digest(id).then((digest) => node.lastKnownDigest = digest);
+    return _delegate
+        .digest(id)
+        .then((digest) => node.mutate.lastKnownDigest = digest);
   }
 }
 

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -116,8 +116,9 @@ class AssetGraph {
         // Don't call _removeRecursive, that recursively removes all transitive
         // primary outputs. We only want to remove this node.
         _nodesByPackage[existing.id.package]!.remove(existing.id.path);
-        node.outputs.addAll(existing.outputs);
-        node.primaryOutputs.addAll(existing.primaryOutputs);
+        node.mutate
+          ..outputs.addAll(existing.outputs)
+          ..primaryOutputs.addAll(existing.primaryOutputs);
       } else {
         throw StateError(
           'Tried to add node ${node.id} to the asset graph but it already '
@@ -195,7 +196,7 @@ class AssetGraph {
     await digestReader.cache.invalidate(nodes.map((n) => n.id));
     await Future.wait(
       nodes.map((node) async {
-        node.lastKnownDigest = await digestReader.digest(node.id);
+        node.mutate.lastKnownDigest = await digestReader.digest(node.id);
       }),
     );
   }
@@ -231,12 +232,13 @@ class AssetGraph {
         var inputNode = get(input);
         // We may have already removed this node entirely.
         if (inputNode != null) {
-          inputNode.outputs.remove(id);
-          inputNode.primaryOutputs.remove(id);
+          inputNode.mutate
+            ..outputs.remove(id)
+            ..primaryOutputs.remove(id);
         }
       }
       if (node is GeneratedAssetNode) {
-        get(node.builderOptionsId)!.outputs.remove(id);
+        get(node.builderOptionsId)!.mutate.outputs.remove(id);
       }
     }
     // Synthetic nodes need to be kept to retain dependency tracking.
@@ -498,7 +500,7 @@ class AssetGraph {
       var node = get(input)!;
       var outputs = expectedOutputs(phase.builder, input);
       phaseOutputs.addAll(outputs);
-      node.primaryOutputs.addAll(outputs);
+      node.mutate.primaryOutputs.addAll(outputs);
       var deleted = _addGeneratedOutputs(
         outputs,
         phaseNum,
@@ -533,7 +535,7 @@ class AssetGraph {
           buildOptionsNodeId,
         );
         add(anchor);
-        get(input)!.anchorOutputs.add(anchor.id);
+        get(input)!.mutate.anchorOutputs.add(anchor.id);
       }
       actionNum++;
     }
@@ -588,11 +590,11 @@ class AssetGraph {
         isHidden: isHidden,
       );
       if (existing != null) {
-        newNode.outputs.addAll(existing.outputs);
+        newNode.mutate.outputs.addAll(existing.outputs);
         // Ensure we set up the reverse link for NodeWithInput nodes.
         _addInput(existing.outputs, output);
       }
-      builderOptionsNode.outputs.add(output);
+      builderOptionsNode.mutate.outputs.add(output);
       _add(newNode);
     }
     return removed;

--- a/build_runner_core/lib/src/asset_graph/node.dart
+++ b/build_runner_core/lib/src/asset_graph/node.dart
@@ -169,6 +169,9 @@ class AssetNode {
 }
 
 /// Write access to collections in the node.
+///
+/// This allows the same access as if they were directly exposed, but makes it
+/// easy to search the code for mutates.
 extension type AssetNodeMutator(AssetNode node) {
   Set<AssetId> get primaryOutputs => node._primaryOutputs;
   Set<AssetId> get outputs => node._outputs;

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -88,7 +88,7 @@ class _AssetGraphDeserializer {
       }
 
       if (node is PostProcessAnchorNode) {
-        graph.get(node.primaryInput)!.anchorOutputs.add(node.id);
+        graph.get(node.primaryInput)!.mutate.anchorOutputs.add(node.id);
       }
     }
 
@@ -193,15 +193,15 @@ class _AssetGraphDeserializer {
         );
         break;
     }
-    node.outputs.addAll(
+    node.mutate.outputs.addAll(
       _deserializeAssetIds(serializedNode[_AssetField.outputs.index] as List),
     );
-    node.primaryOutputs.addAll(
+    node.mutate.primaryOutputs.addAll(
       _deserializeAssetIds(
         serializedNode[_AssetField.primaryOutputs.index] as List,
       ),
     );
-    node.deletedBy.addAll(
+    node.mutate.deletedBy.addAll(
       _deserializeAssetIds(
         (serializedNode[_AssetField.deletedBy.index] as List).cast<int>(),
       ),

--- a/build_runner_core/lib/src/changes/build_script_updates.dart
+++ b/build_runner_core/lib/src/changes/build_script_updates.dart
@@ -73,7 +73,7 @@ class _MirrorBuildScriptUpdates implements BuildScriptUpdates {
       } else {
         // Make sure we are tracking changes for all ids in [allSources].
         for (var id in allSources) {
-          graph.get(id)!.lastKnownDigest ??= await reader.digest(id);
+          graph.get(id)!.mutate.lastKnownDigest ??= await reader.digest(id);
         }
       }
     } on ArgumentError // ignore: avoid_catching_errors

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -608,7 +608,9 @@ class _Loader {
         );
       }
       var oldDigest = builderOptionsNode.lastKnownDigest;
-      builderOptionsNode.lastKnownDigest = computeBuilderOptionsDigest(options);
+      builderOptionsNode.mutate.lastKnownDigest = computeBuilderOptionsDigest(
+        options,
+      );
       if (builderOptionsNode.lastKnownDigest != oldDigest) {
         result[builderOptionsId] = ChangeType.MODIFY;
       }

--- a/build_runner_core/lib/src/generate/single_step_reader_writer.dart
+++ b/build_runner_core/lib/src/generate/single_step_reader_writer.dart
@@ -369,7 +369,9 @@ class SingleStepReaderWriter extends AssetReader
     if (_runningBuild == null) return _delegate.digest(id);
     var node = _runningBuild.assetGraph.get(id)!;
     if (node.lastKnownDigest != null) return node.lastKnownDigest!;
-    return _delegate.digest(id).then((digest) => node.lastKnownDigest = digest);
+    return _delegate
+        .digest(id)
+        .then((digest) => node.mutate.lastKnownDigest = digest);
   }
 
   /// Checks whether [node] can be read by this step.

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -49,7 +49,7 @@ void main() {
         [],
         computeDigest(AssetId('a', 'lib/b.txt'), 'b'),
       );
-      deleted.deletedBy.add(deleted.id.addExtension('.post_anchor.1'));
+      deleted.mutate.deletedBy.add(deleted.id.addExtension('.post_anchor.1'));
 
       graph
         ..add(notDeleted)

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -102,7 +102,7 @@ void main() {
           var node = makeAssetNode();
           globNode.inputs.add(node.id);
           globNode.results!.add(node.id);
-          node.outputs.add(globNode.id);
+          node.mutate.outputs.add(globNode.id);
           graph.add(node);
           var phaseNum = n;
           var builderOptionsNode = AssetNode.builderOptions(
@@ -116,7 +116,7 @@ void main() {
             builderOptionsNode.id,
           );
           graph.add(anchorNode);
-          node.anchorOutputs.add(anchorNode.id);
+          node.mutate.anchorOutputs.add(anchorNode.id);
           for (var g = 0; g < 5 - n; g++) {
             var builderOptionsNode = AssetNode.builderOptions(
               makeAssetId(),
@@ -133,16 +133,16 @@ void main() {
               builderOptionsId: builderOptionsNode.id,
               isHidden: g % 3 == 0,
             );
-            node.outputs.add(generatedNode.id);
-            node.primaryOutputs.add(generatedNode.id);
-            globNode.outputs.add(generatedNode.id);
-            builderOptionsNode.outputs.add(generatedNode.id);
+            node.mutate.outputs.add(generatedNode.id);
+            node.mutate.primaryOutputs.add(generatedNode.id);
+            globNode.mutate.outputs.add(generatedNode.id);
+            builderOptionsNode.mutate.outputs.add(generatedNode.id);
             if (g.isEven) {
-              node.deletedBy.add(anchorNode.id);
+              node.mutate.deletedBy.add(anchorNode.id);
             }
 
             var syntheticNode = AssetNode.missingSource(makeAssetId());
-            syntheticNode.outputs.add(generatedNode.id);
+            syntheticNode.mutate.outputs.add(generatedNode.id);
 
             generatedNode.inputs.addAll([
               node.id,
@@ -337,7 +337,7 @@ void main() {
           (graph.get(primaryOutputId) as GeneratedAssetNode)
             ..state = NodeState.upToDate
             ..inputs.add(primaryInputId);
-          graph.get(primaryInputId)!.outputs.add(primaryOutputId);
+          graph.get(primaryInputId)!.mutate.outputs.add(primaryOutputId);
           await graph.updateAndInvalidate(
             buildPhases,
             changes,
@@ -418,7 +418,7 @@ void main() {
           () async {
             var secondaryId = makeAssetId('foo|secondary.txt');
             var secondaryNode = AssetNode.source(secondaryId);
-            secondaryNode.outputs.add(primaryOutputId);
+            secondaryNode.mutate.outputs.add(primaryOutputId);
             var primaryOutputNode =
                 graph.get(primaryOutputId) as GeneratedAssetNode;
             primaryOutputNode.inputs.add(secondaryNode.id);
@@ -460,7 +460,7 @@ void main() {
                 graph.get(primaryOutputId) as GeneratedAssetNode
                   ..state = NodeState.upToDate
                   ..inputs.add(globNode.id);
-            globNode.outputs.add(primaryOutputId);
+            globNode.mutate.outputs.add(primaryOutputId);
             graph.add(globNode);
 
             var coolAssetId = AssetId('foo', 'lib/really.cool');
@@ -508,7 +508,7 @@ void main() {
             globNode.state = NodeState.upToDate;
             globNode.inputs.add(coolAssetId);
             globNode.results!.add(coolAssetId);
-            graph.get(coolAssetId)!.outputs.add(globNode.id);
+            graph.get(coolAssetId)!.mutate.outputs.add(globNode.id);
             await checkChangeType(ChangeType.MODIFY);
 
             expect(globNode.inputs, contains(coolAssetId));
@@ -662,12 +662,13 @@ void main() {
 
         // Pretend a build happened
         graph.add(
-          AssetNode.missingSource(nodeToRead)..outputs.add(outputReadingNode),
+          AssetNode.missingSource(nodeToRead)
+            ..mutate.outputs.add(outputReadingNode),
         );
         (graph.get(outputReadingNode) as GeneratedAssetNode)
           ..state = NodeState.upToDate
           ..inputs.add(nodeToRead)
-          ..outputs.add(lastPrimaryOutputNode);
+          ..mutate.outputs.add(lastPrimaryOutputNode);
         (graph.get(lastPrimaryOutputNode) as GeneratedAssetNode)
           ..state = NodeState.upToDate
           ..inputs.add(outputReadingNode);
@@ -715,14 +716,14 @@ void main() {
         // Pretend a build happened
         graph.add(
           AssetNode.missingSource(toBeGeneratedDart)
-            ..outputs.add(generatedPart),
+            ..mutate.outputs.add(generatedPart),
         );
         (graph.get(generatedDart) as GeneratedAssetNode)
           ..state = NodeState.upToDate
           ..inputs.addAll([generatedPart, toBeGeneratedDart]);
         final node = graph.get(source)!;
         expect(node.type, NodeType.source);
-        node.outputs.add(generatedPart);
+        node.mutate.outputs.add(generatedPart);
 
         await graph.updateAndInvalidate(
           buildPhases,

--- a/build_runner_core/test/environment/create_merged_dir_test.dart
+++ b/build_runner_core/test/environment/create_merged_dir_test.dart
@@ -129,7 +129,7 @@ void main() {
     test('doesnt write deleted files', () async {
       var node =
           graph.get(AssetId('b', 'lib/c.txt.copy')) as GeneratedAssetNode;
-      node.deletedBy.add(node.id.addExtension('.post_anchor.1'));
+      node.mutate.deletedBy.add(node.id.addExtension('.post_anchor.1'));
 
       var success = await createMergedOutputDirectories(
         {BuildDirectory('', outputLocation: OutputLocation(tmpDir.path))},
@@ -527,6 +527,7 @@ void main() {
         for (var remove in removes) {
           graph
               .get(makeAssetId(remove))!
+              .mutate
               .deletedBy
               .add(makeAssetId(remove).addExtension('.post_anchor.1'));
         }

--- a/build_runner_core/test/generate/asset_tracker_test.dart
+++ b/build_runner_core/test/generate/asset_tracker_test.dart
@@ -51,7 +51,7 @@ void main() {
       );
       // We need to pre-emptively assign a digest so we determine that the
       // node is "interesting".
-      assetGraph.get(aId)!.lastKnownDigest = await reader.digest(aId);
+      assetGraph.get(aId)!.mutate.lastKnownDigest = await reader.digest(aId);
 
       var targetGraph = await TargetGraph.forPackageGraph(
         packageGraph,

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -230,7 +230,7 @@ targets:
         (originalAssetGraph.get(aTxtCopy) as GeneratedAssetNode)
           ..state = NodeState.upToDate
           ..inputs.add(aTxt);
-        originalAssetGraph.get(aTxt)!.outputs.add(aTxtCopy);
+        originalAssetGraph.get(aTxt)!.mutate.outputs.add(aTxtCopy);
         await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         await modifyFile(p.join('lib', 'a.txt'), 'b');

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1291,10 +1291,11 @@ void main() {
       inputs: [makeAssetId('a|web/a.txt')],
       isHidden: false,
     );
-    builderOptionsNode.outputs.add(aCopyNode.id);
+    builderOptionsNode.mutate.outputs.add(aCopyNode.id);
     expectedGraph.add(aCopyNode);
-    aSourceNode.outputs.add(aCopyNode.id);
-    aSourceNode.primaryOutputs.add(aCopyNode.id);
+    aSourceNode.mutate
+      ..outputs.add(aCopyNode.id)
+      ..primaryOutputs.add(aCopyNode.id);
 
     var bCopyId = makeAssetId('a|lib/b.txt.copy'); //;
     var bCopyNode = GeneratedAssetNode(
@@ -1309,10 +1310,11 @@ void main() {
       inputs: [makeAssetId('a|lib/b.txt')],
       isHidden: false,
     );
-    builderOptionsNode.outputs.add(bCopyNode.id);
+    builderOptionsNode.mutate.outputs.add(bCopyNode.id);
     expectedGraph.add(bCopyNode);
-    bSourceNode.outputs.add(bCopyNode.id);
-    bSourceNode.primaryOutputs.add(bCopyNode.id);
+    bSourceNode.mutate
+      ..outputs.add(bCopyNode.id)
+      ..primaryOutputs.add(bCopyNode.id);
 
     // Post build generates asset nodes and supporting nodes
     var postBuilderOptionsId = makeAssetId('a|PostPhase0.builderOptions');
@@ -1351,10 +1353,11 @@ void main() {
     // Note we don't expect this node to get added to the builder options node
     // outputs.
     expectedGraph.add(aPostCopyNode);
-    aSourceNode.outputs.add(aPostCopyNode.id);
-    aSourceNode.anchorOutputs.add(aAnchorNode.id);
-    aAnchorNode.outputs.add(aPostCopyNode.id);
-    aSourceNode.primaryOutputs.add(aPostCopyNode.id);
+    aSourceNode.mutate
+      ..outputs.add(aPostCopyNode.id)
+      ..anchorOutputs.add(aAnchorNode.id);
+    aAnchorNode.mutate.outputs.add(aPostCopyNode.id);
+    aSourceNode.mutate.primaryOutputs.add(aPostCopyNode.id);
 
     var bPostCopyNode = GeneratedAssetNode(
       makeAssetId('a|lib/b.txt.post'),
@@ -1371,10 +1374,11 @@ void main() {
     // Note we don't expect this node to get added to the builder options node
     // outputs.
     expectedGraph.add(bPostCopyNode);
-    bSourceNode.outputs.add(bPostCopyNode.id);
-    bSourceNode.anchorOutputs.add(bAnchorNode.id);
-    bAnchorNode.outputs.add(bPostCopyNode.id);
-    bSourceNode.primaryOutputs.add(bPostCopyNode.id);
+    bSourceNode.mutate
+      ..outputs.add(bPostCopyNode.id)
+      ..anchorOutputs.add(bAnchorNode.id);
+    bAnchorNode.mutate.outputs.add(bPostCopyNode.id);
+    bSourceNode.mutate.primaryOutputs.add(bPostCopyNode.id);
 
     // TODO: We dont have a shared way of computing the combined input hashes
     // today, but eventually we should test those here too.


### PR DESCRIPTION
I think `AssetGraph` can be used to figure out what changed so that it's not necessary to compute transitive digests.

But, that requires clarity on exactly how `AssetGraph`/`AssetNode` state gets updated :) which this starts to introduce.

I guess where this is probably headed is that `AssetGraph` owns most of the updates, rather than users making them directly on the nodes.