### PR TITLE
Flatten remaining `AssetNode` subclasses into `AssetNode`.

### DIFF
--- a/_test_common/lib/matchers.dart
+++ b/_test_common/lib/matchers.dart
@@ -85,104 +85,144 @@ class _AssetGraphMatcher extends Matcher {
         ];
         matches = false;
       }
-      if (node is NodeWithInputs) {
-        if (expectedNode is NodeWithInputs) {
-          if (node.state != expectedNode.state) {
-            matchState['needsUpdate of ${node.id}'] = [
-              node.state,
-              expectedNode.state,
+      if (node.type == NodeType.generated) {
+        if (expectedNode.type == NodeType.generated) {
+          final configuration = node.generatedNodeConfiguration;
+          final expectedConfiguration = expectedNode.generatedNodeConfiguration;
+
+          if (configuration.primaryInput !=
+              expectedConfiguration.primaryInput) {
+            matchState['primaryInput of ${node.id}'] = [
+              configuration.primaryInput,
+              expectedConfiguration.primaryInput,
             ];
             matches = false;
           }
-          if (!unorderedEquals(node.inputs).matches(expectedNode.inputs, {})) {
+
+          final state = node.generatedNodeState;
+          final expectedState = expectedNode.generatedNodeState;
+
+          if (state.pendingBuildAction != expectedState.pendingBuildAction) {
+            matchState['pendingBuildAction of ${node.id}'] = [
+              state.pendingBuildAction,
+              expectedState.pendingBuildAction,
+            ];
+            matches = false;
+          }
+          if (!unorderedEquals(
+            state.inputs,
+          ).matches(expectedState.inputs, {})) {
             matchState['Inputs of ${node.id}'] = [
-              node.inputs,
-              expectedNode.inputs,
+              state.inputs,
+              expectedState.inputs,
             ];
             matches = false;
           }
-        }
-        if (node is GeneratedAssetNode) {
-          if (expectedNode is GeneratedAssetNode) {
-            if (node.primaryInput != expectedNode.primaryInput) {
-              matchState['primaryInput of ${node.id}'] = [
-                node.primaryInput,
-                expectedNode.primaryInput,
-              ];
-              matches = false;
-            }
-            if (node.wasOutput != expectedNode.wasOutput) {
-              matchState['wasOutput of ${node.id}'] = [
-                node.wasOutput,
-                expectedNode.wasOutput,
-              ];
-              matches = false;
-            }
-            if (node.isFailure != expectedNode.isFailure) {
-              matchState['isFailure of ${node.id}'] = [
-                node.isFailure,
-                expectedNode.isFailure,
-              ];
-              matches = false;
-            }
-            if (checkPreviousInputsDigest &&
-                node.previousInputsDigest !=
-                    expectedNode.previousInputsDigest) {
-              matchState['previousInputDigest of ${node.id}'] = [
-                node.previousInputsDigest,
-                expectedNode.previousInputsDigest,
-              ];
-              matches = false;
-            }
-          }
-        } else if (node is GlobAssetNode) {
-          if (expectedNode is GlobAssetNode) {
-            if (!unorderedEquals(
-              node.results!,
-            ).matches(expectedNode.results, {})) {
-              matchState['results of ${node.id}'] = [
-                node.results,
-                expectedNode.results,
-              ];
-              matches = false;
-            }
-            if (node.glob.pattern != expectedNode.glob.pattern) {
-              matchState['glob of ${node.id}'] = [
-                node.glob.pattern,
-                expectedNode.glob.pattern,
-              ];
-              matches = false;
-            }
-          }
-        }
-      } else if (node is PostProcessAnchorNode) {
-        if (expectedNode is PostProcessAnchorNode) {
-          if (node.actionNumber != expectedNode.actionNumber) {
-            matchState['actionNumber of ${node.id}'] = [
-              node.actionNumber,
-              expectedNode.actionNumber,
+
+          if (state.wasOutput != expectedState.wasOutput) {
+            matchState['wasOutput of ${node.id}'] = [
+              state.wasOutput,
+              expectedState.wasOutput,
             ];
             matches = false;
           }
-          if (node.builderOptionsId != expectedNode.builderOptionsId) {
-            matchState['builderOptionsId of ${node.id}'] = [
-              node.builderOptionsId,
-              expectedNode.builderOptionsId,
+          if (state.isFailure != expectedState.isFailure) {
+            matchState['isFailure of ${node.id}'] = [
+              state.isFailure,
+              expectedState.isFailure,
             ];
             matches = false;
           }
           if (checkPreviousInputsDigest &&
-              node.previousInputsDigest != expectedNode.previousInputsDigest) {
-            matchState['previousInputsDigest of ${node.id}'] = [
-              node.previousInputsDigest,
-              expectedNode.previousInputsDigest,
+              state.previousInputsDigest !=
+                  expectedState.previousInputsDigest) {
+            matchState['previousInputDigest of ${node.id}'] = [
+              state.previousInputsDigest,
+              expectedState.previousInputsDigest,
             ];
             matches = false;
           }
-          if (node.primaryInput != expectedNode.primaryInput) {
+        }
+      } else if (node.type == NodeType.glob) {
+        if (expectedNode.type == NodeType.glob) {
+          final state = node.globNodeState;
+          final expectedState = expectedNode.globNodeState;
+
+          if (state.pendingBuildAction != expectedState.pendingBuildAction) {
+            matchState['pendingBuildAction of ${node.id}'] = [
+              state.pendingBuildAction,
+              expectedState.pendingBuildAction,
+            ];
+            matches = false;
+          }
+          if (!unorderedEquals(
+            state.inputs,
+          ).matches(expectedState.inputs, {})) {
+            matchState['Inputs of ${node.id}'] = [
+              state.inputs,
+              expectedState.inputs,
+            ];
+            matches = false;
+          }
+
+          if (!unorderedEquals(
+            state.results!,
+          ).matches(expectedState.results, {})) {
+            matchState['results of ${node.id}'] = [
+              state.results,
+              expectedState.results,
+            ];
+            matches = false;
+          }
+
+          final configuration = node.globNodeConfiguration;
+          final expectedConfiguration = expectedNode.globNodeConfiguration;
+          if (configuration.glob.pattern !=
+              expectedConfiguration.glob.pattern) {
+            matchState['glob of ${node.id}'] = [
+              configuration.glob.pattern,
+              expectedConfiguration.glob.pattern,
+            ];
+            matches = false;
+          }
+        }
+      } else if (node.type == NodeType.postProcessAnchor) {
+        if (expectedNode.type == NodeType.postProcessAnchor) {
+          final nodeConfiguration = node.postProcessAnchorNodeConfiguration;
+          final expectedNodeConfiguration =
+              expectedNode.postProcessAnchorNodeConfiguration;
+          if (nodeConfiguration.actionNumber !=
+              expectedNodeConfiguration.actionNumber) {
+            matchState['actionNumber of ${node.id}'] = [
+              nodeConfiguration.actionNumber,
+              expectedNodeConfiguration.actionNumber,
+            ];
+            matches = false;
+          }
+          if (nodeConfiguration.builderOptionsId !=
+              expectedNodeConfiguration.builderOptionsId) {
+            matchState['builderOptionsId of ${node.id}'] = [
+              nodeConfiguration.builderOptionsId,
+              expectedNodeConfiguration.builderOptionsId,
+            ];
+            matches = false;
+          }
+          final nodeState = node.postProcessAnchorNodeState;
+          final expectedNodeState = expectedNode.postProcessAnchorNodeState;
+          if (checkPreviousInputsDigest &&
+              nodeState.previousInputsDigest !=
+                  expectedNodeState.previousInputsDigest) {
+            matchState['previousInputsDigest of ${node.id}'] = [
+              nodeState.previousInputsDigest,
+              expectedNodeState.previousInputsDigest,
+            ];
+            matches = false;
+          }
+          if (nodeConfiguration.primaryInput !=
+              expectedNodeConfiguration.primaryInput) {
             matchState['primaryInput of ${node.id}'] = [
-              node.primaryInput,
-              expectedNode.primaryInput,
+              nodeConfiguration.primaryInput,
+              expectedNodeConfiguration.primaryInput,
             ];
             matches = false;
           }

--- a/build_runner/bin/graph_inspector.dart
+++ b/build_runner/bin/graph_inspector.dart
@@ -139,12 +139,14 @@ class InspectNodeCommand extends Command<bool> {
             ..writeln('Asset: $stringUri')
             ..writeln('  type: ${node.runtimeType}');
 
-      if (node is GeneratedAssetNode) {
+      if (node.type == NodeType.generated) {
+        final nodeState = node.generatedNodeState;
+        final nodeConfiguration = node.generatedNodeConfiguration;
         description
-          ..writeln('  state: ${node.state}')
-          ..writeln('  wasOutput: ${node.wasOutput}')
-          ..writeln('  phase: ${node.phaseNumber}')
-          ..writeln('  isFailure: ${node.isFailure}');
+          ..writeln('  state: ${nodeState.pendingBuildAction}')
+          ..writeln('  wasOutput: ${nodeState.wasOutput}')
+          ..writeln('  phase: ${nodeConfiguration.phaseNumber}')
+          ..writeln('  isFailure: ${nodeState.isFailure}');
       }
 
       void printAsset(AssetId asset) =>
@@ -159,7 +161,7 @@ class InspectNodeCommand extends Command<bool> {
             .difference(node.inspect.primaryOutputs)
             .forEach(printAsset);
 
-        if (node is NodeWithInputs) {
+        if (node.type == NodeType.generated || node.type == NodeType.glob) {
           description.writeln('  inputs:');
           assetGraph.allNodes
               .where((n) => n.outputs.contains(node.id))

--- a/build_runner/lib/src/entrypoint/clean.dart
+++ b/build_runner/lib/src/entrypoint/clean.dart
@@ -10,8 +10,6 @@ import 'package:args/command_runner.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 // ignore: implementation_imports
 import 'package:build_runner_core/src/asset_graph/graph.dart';
-// ignore: implementation_imports
-import 'package:build_runner_core/src/asset_graph/node.dart';
 import 'package:logging/logging.dart';
 
 import '../logging/std_io_logging.dart';
@@ -87,8 +85,8 @@ Future<void> _cleanUpSourceOutputs(
   var writer = ReaderWriter(packageGraph);
   for (var id in assetGraph.outputs) {
     if (id.package != packageGraph.root.name) continue;
-    var node = assetGraph.get(id) as GeneratedAssetNode;
-    if (node.wasOutput) {
+    var node = assetGraph.get(id)!;
+    if (node.generatedNodeState.wasOutput) {
       // Note that this does a file.exists check in the root package and
       // only tries to delete the file if it exists. This way we only
       // actually delete to_source outputs, without reading in the build

--- a/build_runner/lib/src/server/asset_graph_handler.dart
+++ b/build_runner/lib/src/server/asset_graph_handler.dart
@@ -126,8 +126,12 @@ class AssetGraphHandler {
       });
       nodes.add({'id': '$output', 'label': '$output'});
     }
-    if (node is NodeWithInputs) {
-      for (final input in node.inputs) {
+    if (node.type == NodeType.generated || node.type == NodeType.glob) {
+      final inputs =
+          node.type == NodeType.generated
+              ? node.generatedNodeState.inputs
+              : node.globNodeState.inputs;
+      for (final input in inputs) {
         if (filterGlob != null && !filterGlob.matches(input.toString())) {
           continue;
         }
@@ -142,13 +146,35 @@ class AssetGraphHandler {
     var result = <String, dynamic>{
       'primary': {
         'id': '${node.id}',
-        'hidden': node is GeneratedAssetNode ? node.isHidden : null,
-        'state': node is NodeWithInputs ? '${node.state}' : null,
-        'wasOutput': node is GeneratedAssetNode ? node.wasOutput : null,
-        'isFailure': node is GeneratedAssetNode ? node.isFailure : null,
-        'phaseNumber': node is NodeWithInputs ? node.phaseNumber : null,
+        'hidden':
+            node.type == NodeType.generated
+                ? node.generatedNodeConfiguration.isHidden
+                : null,
+        'state':
+            node.type == NodeType.generated
+                ? '${node.generatedNodeState.pendingBuildAction}'
+                : node.type == NodeType.glob
+                ? '${node.globNodeState.pendingBuildAction}'
+                : null,
+        'wasOutput':
+            node.type == NodeType.generated
+                ? node.generatedNodeState.wasOutput
+                : null,
+        'isFailure':
+            node.type == NodeType.generated
+                ? node.generatedNodeState.isFailure
+                : null,
+        'phaseNumber':
+            node.type == NodeType.generated
+                ? node.generatedNodeConfiguration.phaseNumber
+                : node.type == NodeType.glob
+                ? node.globNodeConfiguration.phaseNumber
+                : null,
         'type': node.runtimeType.toString(),
-        'glob': node is GlobAssetNode ? node.glob.pattern : null,
+        'glob':
+            node.type == NodeType.glob
+                ? node.globNodeConfiguration.glob.pattern
+                : null,
         'lastKnownDigest': node.lastKnownDigest.toString(),
       },
       'edges': edges,

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -370,11 +370,11 @@ void main() {
 
         var bCopyId = makeAssetId('a|web/b.txt.copy');
         var bTxtId = makeAssetId('a|web/b.txt');
-        var bCopyNode = GeneratedAssetNode(
+        var bCopyNode = AssetNode.generated(
           bCopyId,
           phaseNumber: 0,
           primaryInput: makeAssetId('a|web/b.txt'),
-          state: NodeState.upToDate,
+          state: PendingBuildAction.none,
           wasOutput: true,
           isFailure: false,
           builderOptionsId: builderOptionsId,
@@ -393,11 +393,11 @@ void main() {
 
         var cCopyId = makeAssetId('a|web/c.txt.copy');
         var cTxtId = makeAssetId('a|web/c.txt');
-        var cCopyNode = GeneratedAssetNode(
+        var cCopyNode = AssetNode.generated(
           cCopyId,
           phaseNumber: 0,
           primaryInput: cTxtId,
-          state: NodeState.upToDate,
+          state: PendingBuildAction.none,
           wasOutput: true,
           isFailure: false,
           builderOptionsId: builderOptionsId,

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -128,11 +128,11 @@ void main() {
 
   test('Fails request for failed outputs', () async {
     graph.add(
-      GeneratedAssetNode(
+      AssetNode.generated(
         AssetId('a', 'web/main.ddc.js'),
         builderOptionsId: AssetId('_\$fake', 'options_id'),
         phaseNumber: 0,
-        state: NodeState.upToDate,
+        state: PendingBuildAction.none,
         isHidden: false,
         wasOutput: true,
         isFailure: true,

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -201,11 +201,11 @@ void main() {
     setUp(() async {
       addSource('a|web/index.html', '');
       assetGraph.add(
-        GeneratedAssetNode(
+        AssetNode.generated(
           AssetId('a', 'web/main.ddc.js'),
           builderOptionsId: AssetId('_\$fake', 'options_id'),
           phaseNumber: 0,
-          state: NodeState.upToDate,
+          state: PendingBuildAction.none,
           isHidden: false,
           wasOutput: true,
           isFailure: true,

--- a/build_runner_core/lib/src/asset/build_cache.dart
+++ b/build_runner_core/lib/src/asset/build_cache.dart
@@ -10,7 +10,7 @@ import '../util/constants.dart';
 /// cache directory.
 ///
 /// Assets that are in the provided [AssetGraph], have node type
-/// [GeneratedAssetNode] and have `isHidden == true` are mapped to
+/// [NodeType.generated] and have `isHidden == true` are mapped to
 /// [generatedOutputDirectory].
 class BuildCacheAssetPathProvider implements AssetPathProvider {
   final AssetPathProvider _delegate;
@@ -36,8 +36,9 @@ class BuildCacheAssetPathProvider implements AssetPathProvider {
     if (!_assetGraph.contains(id)) {
       return id;
     }
-    final assetNode = _assetGraph.get(id);
-    if (assetNode is GeneratedAssetNode && assetNode.isHidden) {
+    final assetNode = _assetGraph.get(id)!;
+    if (assetNode.type == NodeType.generated &&
+        assetNode.generatedNodeConfiguration.isHidden) {
       return AssetId(
         _rootPackage,
         '$generatedOutputDirectory/${id.package}/${id.path}',

--- a/build_runner_core/lib/src/asset/finalized_reader.dart
+++ b/build_runner_core/lib/src/asset/finalized_reader.dart
@@ -61,9 +61,10 @@ class FinalizedReader {
     if (node.isDeleted) return UnreadableReason.deleted;
     if (!node.isFile) return UnreadableReason.assetType;
 
-    if (node is GeneratedAssetNode) {
-      if (node.isFailure) return UnreadableReason.failed;
-      if (!node.wasOutput) return UnreadableReason.notOutput;
+    if (node.type == NodeType.generated) {
+      final nodeState = node.generatedNodeState;
+      if (nodeState.isFailure) return UnreadableReason.failed;
+      if (!nodeState.wasOutput) return UnreadableReason.notOutput;
       // No need to explicitly check readability for generated files, their
       // readability is recorded in the node state.
       return null;

--- a/build_runner_core/lib/src/asset_graph/node.dart
+++ b/build_runner_core/lib/src/asset_graph/node.dart
@@ -28,6 +28,18 @@ class AssetNode {
   final AssetId id;
   final NodeType type;
 
+  /// Additional node configuration that's available before the build runs.
+  ///
+  /// [NodeType.generated], [NodeType.glob] and [NodeType.postProcessAnchor]
+  /// have additional configuration.
+  final AdditionalNodeConfiguration? configuration;
+
+  /// Additional node state that changes during the build.
+  ///
+  /// [NodeType.generated], [NodeType.glob] and [NodeType.postProcessAnchor]
+  /// have additional state.
+  final AdditionalNodeState? state;
+
   /// The assets that any [Builder] in the build graph declares it may output
   /// when run on this asset.
   final Set<AssetId> _primaryOutputs;
@@ -38,8 +50,8 @@ class AssetNode {
   final Set<AssetId> _outputs;
   Iterable<AssetId> get outputs => _outputs;
 
-  /// The [AssetId]s of all [PostProcessAnchorNode] assets for which this node
-  /// is the primary input.
+  /// The [AssetId]s of all [AssetNode.postProcessAnchor] assets for which this
+  /// node is the primary input.
   final Set<AssetId> _anchorOutputs;
   Iterable<AssetId> get anchorOutputs => _anchorOutputs;
 
@@ -50,8 +62,8 @@ class AssetNode {
   Digest? _lastKnownDigest;
   Digest? get lastKnownDigest => _lastKnownDigest;
 
-  /// The IDs of the [PostProcessAnchorNode] for post process builder which
-  /// requested to delete this asset.
+  /// The IDs of the [AssetNode.postProcessAnchor] for post process builder
+  /// which requested to delete this asset.
   final Set<AssetId> _deletedBy;
   Iterable<AssetId> get deletedBy => _deletedBy;
 
@@ -84,13 +96,6 @@ class AssetNode {
       outputs.isNotEmpty ||
       lastKnownDigest != null;
 
-  AssetNode(this.id, {required this.type, Digest? lastKnownDigest})
-    : _primaryOutputs = {},
-      _outputs = {},
-      _anchorOutputs = {},
-      _lastKnownDigest = lastKnownDigest,
-      _deletedBy = {};
-
   /// An internal asset.
   ///
   /// Examples: `build_runner` generated entrypoint, package config.
@@ -99,6 +104,8 @@ class AssetNode {
   /// tracked as inputs.
   AssetNode.internal(this.id, {Digest? lastKnownDigest})
     : type = NodeType.internal,
+      configuration = null,
+      state = null,
       _primaryOutputs = {},
       _outputs = {},
       _anchorOutputs = {},
@@ -112,6 +119,8 @@ class AssetNode {
     Iterable<AssetId>? outputs,
     Iterable<AssetId>? primaryOutputs,
   }) : type = NodeType.source,
+       configuration = null,
+       state = null,
        _primaryOutputs = primaryOutputs?.toSet() ?? {},
        _outputs = outputs?.toSet() ?? {},
        _anchorOutputs = {},
@@ -120,10 +129,12 @@ class AssetNode {
 
   /// A [BuilderOptions] object.
   ///
-  /// Each [GeneratedAssetNode] has one describing its configuration, so it
+  /// Each [AssetNode.generated] has one describing its configuration, so it
   /// rebuilds when the configuration changes.
   AssetNode.builderOptions(this.id, {Digest? lastKnownDigest})
     : type = NodeType.builderOptions,
+      configuration = null,
+      state = null,
       _primaryOutputs = {},
       _outputs = {},
       _anchorOutputs = {},
@@ -138,6 +149,8 @@ class AssetNode {
   /// produce different output.
   AssetNode.missingSource(this.id, {Digest? lastKnownDigest})
     : type = NodeType.syntheticSource,
+      configuration = null,
+      state = null,
       _primaryOutputs = {},
       _outputs = {},
       _anchorOutputs = {},
@@ -152,11 +165,113 @@ class AssetNode {
   /// TODO(davidmorgan): describe how these are used.
   AssetNode.placeholder(this.id, {Digest? lastKnownDigest})
     : type = NodeType.placeholder,
+      configuration = null,
+      state = null,
       _primaryOutputs = {},
       _outputs = {},
       _anchorOutputs = {},
       _lastKnownDigest = lastKnownDigest,
       _deletedBy = {};
+
+  /// A generated node.
+  AssetNode.generated(
+    this.id, {
+    Digest? lastKnownDigest,
+    required AssetId primaryInput,
+    required AssetId builderOptionsId,
+    required int phaseNumber,
+    required bool isHidden,
+    Iterable<AssetId>? inputs,
+    Digest? previousInputsDigest,
+    required PendingBuildAction state,
+    required bool wasOutput,
+    required bool isFailure,
+  }) : type = NodeType.generated,
+       configuration = GeneratedNodeConfiguration(
+         primaryInput: primaryInput,
+         builderOptionsId: builderOptionsId,
+         phaseNumber: phaseNumber,
+         isHidden: isHidden,
+       ),
+       state = GeneratedNodeState(
+         inputs: inputs == null ? HashSet() : HashSet.of(inputs),
+         previousInputsDigest: previousInputsDigest,
+         pendingBuildAction: state,
+         wasOutput: wasOutput,
+         isFailure: isFailure,
+       ),
+       _primaryOutputs = {},
+       _outputs = {},
+       _anchorOutputs = {},
+       _lastKnownDigest = lastKnownDigest,
+       _deletedBy = {};
+
+  /// A glob node.
+  AssetNode.glob(
+    this.id, {
+    Digest? lastKnownDigest,
+    required Glob glob,
+    required int phaseNumber,
+    Iterable<AssetId>? inputs,
+    required PendingBuildAction pendingBuildAction,
+    List<AssetId>? results,
+  }) : type = NodeType.glob,
+       configuration = GlobNodeConfiguration(
+         glob: glob,
+         phaseNumber: phaseNumber,
+       ),
+       state = GlobNodeState(
+         inputs: HashSet(),
+         pendingBuildAction: pendingBuildAction,
+         results: results,
+       ),
+       _primaryOutputs = {},
+       _outputs = {},
+       _anchorOutputs = {},
+       _lastKnownDigest = lastKnownDigest,
+       _deletedBy = {};
+
+  static AssetId createGlobNodeId(String package, Glob glob, int phaseNum) =>
+      AssetId(
+        package,
+        'glob.$phaseNum.${base64.encode(utf8.encode(glob.pattern))}',
+      );
+
+  /// A [primaryInput] to a [PostBuildAction].
+  ///
+  /// The [outputs] of this node are the individual outputs created for the
+  /// [primaryInput] during the [PostBuildAction] at index [actionNumber].
+  AssetNode.postProcessAnchor(
+    this.id, {
+    required AssetId primaryInput,
+    required int actionNumber,
+    required AssetId builderOptionsId,
+    Digest? previousInputsDigest,
+  }) : type = NodeType.postProcessAnchor,
+       configuration = PostProcessAnchorNodeConfiguration(
+         actionNumber: actionNumber,
+         builderOptionsId: builderOptionsId,
+         primaryInput: primaryInput,
+       ),
+       state = PostProcessAnchorNodeState(
+         previousInputsDigest: previousInputsDigest,
+       ),
+       _primaryOutputs = {},
+       _outputs = {},
+       _anchorOutputs = {},
+       _lastKnownDigest = null,
+       _deletedBy = {};
+
+  AssetNode.postProcessAnchorForInputAndAction(
+    AssetId primaryInput,
+    int actionNumber,
+    AssetId builderOptionsId,
+  ) : this.postProcessAnchor(
+        primaryInput.addExtension('.post_anchor.$actionNumber'),
+        primaryInput: primaryInput,
+        actionNumber: actionNumber,
+        builderOptionsId: builderOptionsId,
+      );
 
   @override
   String toString() => 'AssetNode: $id';
@@ -166,6 +281,137 @@ class AssetNode {
 
   /// Access to unmodifable views on collections in the node.
   AssetNodeInspector get inspect => AssetNodeInspector(this);
+
+  GeneratedNodeConfiguration get generatedNodeConfiguration =>
+      configuration as GeneratedNodeConfiguration;
+  GeneratedNodeState get generatedNodeState => state as GeneratedNodeState;
+
+  GlobNodeConfiguration get globNodeConfiguration =>
+      configuration as GlobNodeConfiguration;
+  GlobNodeState get globNodeState => state as GlobNodeState;
+
+  PostProcessAnchorNodeConfiguration get postProcessAnchorNodeConfiguration =>
+      configuration as PostProcessAnchorNodeConfiguration;
+  PostProcessAnchorNodeState get postProcessAnchorNodeState =>
+      state as PostProcessAnchorNodeState;
+}
+
+/// Additional immutable configuration for some node types.
+abstract interface class AdditionalNodeConfiguration {}
+
+/// Additional mutable state for some node types.
+abstract interface class AdditionalNodeState {}
+
+/// Additional configuration for an [AssetNode.generated].
+class GeneratedNodeConfiguration implements AdditionalNodeConfiguration {
+  /// The primary input which generated this node.
+  final AssetId primaryInput;
+
+  /// The [AssetId] of the node representing the [BuilderOptions] used to create
+  /// this node.
+  final AssetId builderOptionsId;
+
+  /// The phase in which this node is generated.
+  ///
+  /// The generator that produces this node can only read files from earlier
+  /// phases plus any files it writes itself.
+  ///
+  /// Other generators and globs can only read this node if they run in a
+  /// later phase.
+  final int phaseNumber;
+
+  /// Whether the asset should be placed in the build cache.
+  final bool isHidden;
+
+  GeneratedNodeConfiguration({
+    required this.primaryInput,
+    required this.builderOptionsId,
+    required this.phaseNumber,
+    required this.isHidden,
+  });
+}
+
+/// State for an [AssetNode.generated] that changes during the build.
+class GeneratedNodeState implements AdditionalNodeState {
+  /// All the inputs that were read when generating this asset, or deciding not
+  /// to generate it.
+  final HashSet<AssetId> inputs;
+
+  /// The next work that needs doing on this node.
+  PendingBuildAction pendingBuildAction;
+
+  /// Whether the asset was actually output.
+  bool wasOutput;
+
+  /// Whether the action which did or would produce this node failed.
+  bool isFailure;
+
+  /// A digest combining all digests of all previous inputs.
+  ///
+  /// Used to determine whether all the inputs to a build step are identical to
+  /// the previous run, indicating that the previous output is still valid.
+  Digest? previousInputsDigest;
+
+  bool get isSuccessfulFreshOutput =>
+      wasOutput && !isFailure && pendingBuildAction == PendingBuildAction.none;
+
+  GeneratedNodeState({
+    required this.inputs,
+    required this.pendingBuildAction,
+    required this.wasOutput,
+    required this.isFailure,
+    required this.previousInputsDigest,
+  });
+}
+
+/// Additional configuration for an [AssetNode.glob].
+class GlobNodeConfiguration implements AdditionalNodeConfiguration {
+  final Glob glob;
+  final int phaseNumber;
+
+  GlobNodeConfiguration({required this.glob, required this.phaseNumber});
+}
+
+/// State for an [AssetNode.glob] that changes during the build.
+class GlobNodeState implements AdditionalNodeState {
+  /// All the potential inputs matching this glob.
+  ///
+  /// This field differs from [results] in that [AssetNode.generated] which may
+  /// have been readable but were not output are included here and not in
+  /// [results].
+  HashSet<AssetId> inputs;
+
+  PendingBuildAction pendingBuildAction;
+
+  /// The actual results of the glob.
+  List<AssetId>? results;
+
+  GlobNodeState({
+    required this.inputs,
+    required this.pendingBuildAction,
+    required this.results,
+  });
+}
+
+// Additional configuration for an [AssetNode.postProcessAnchor].
+class PostProcessAnchorNodeConfiguration
+    implements AdditionalNodeConfiguration {
+  final int actionNumber;
+  final AssetId builderOptionsId;
+  final AssetId primaryInput;
+
+  PostProcessAnchorNodeConfiguration({
+    required this.actionNumber,
+    required this.builderOptionsId,
+    required this.primaryInput,
+  });
+}
+
+/// State for an [AssetNode.postProcessAnchor].
+class PostProcessAnchorNodeState implements AdditionalNodeState {
+  Digest? previousInputsDigest;
+
+  PostProcessAnchorNodeState({this.previousInputsDigest});
 }
 
 /// Write access to collections in the node.
@@ -189,151 +435,5 @@ extension type AssetNodeInspector(AssetNode node) {
   Set<AssetId> get outputs => UnmodifiableSetView(node._outputs);
 }
 
-/// States for nodes that can be invalidated.
-enum NodeState {
-  // This node does not need an update, and no checks need to be performed.
-  upToDate,
-  // This node may need an update, the inputs hash should be checked for
-  // changes.
-  mayNeedUpdate,
-  // This node definitely needs an update, the inputs hash check can be skipped.
-  definitelyNeedsUpdate,
-}
-
-/// A generated node in the asset graph.
-class GeneratedAssetNode extends AssetNode implements NodeWithInputs {
-  @override
-  final int phaseNumber;
-
-  /// The primary input which generated this node.
-  final AssetId primaryInput;
-
-  @override
-  NodeState state;
-
-  /// Whether the asset was actually output.
-  bool wasOutput;
-
-  /// All the inputs that were read when generating this asset, or deciding not
-  /// to generate it.
-  ///
-  /// This needs to be an ordered set because we compute combined input digests
-  /// using this later on.
-  @override
-  HashSet<AssetId> inputs;
-
-  /// A digest combining all digests of all previous inputs.
-  ///
-  /// Used to determine whether all the inputs to a build step are identical to
-  /// the previous run, indicating that the previous output is still valid.
-  Digest? previousInputsDigest;
-
-  /// Whether the action which did or would produce this node failed.
-  bool isFailure;
-
-  /// The [AssetId] of the node representing the [BuilderOptions] used to create
-  /// this node.
-  final AssetId builderOptionsId;
-
-  /// Whether the asset should be placed in the build cache.
-  final bool isHidden;
-
-  GeneratedAssetNode(
-    super.id, {
-    super.lastKnownDigest,
-    Iterable<AssetId>? inputs,
-    this.previousInputsDigest,
-    required this.isHidden,
-    required this.state,
-    required this.phaseNumber,
-    required this.wasOutput,
-    required this.isFailure,
-    required this.primaryInput,
-    required this.builderOptionsId,
-  }) : inputs = inputs != null ? HashSet.from(inputs) : HashSet(),
-       super(type: NodeType.generated);
-
-  @override
-  String toString() =>
-      'GeneratedAssetNode: $id generated from input $primaryInput.';
-}
-
-/// A [primaryInput] to a [PostBuildAction].
-///
-/// The [outputs] of this node are the individual outputs created for the
-/// [primaryInput] during the [PostBuildAction] at index [actionNumber].
-class PostProcessAnchorNode extends AssetNode {
-  final int actionNumber;
-  final AssetId builderOptionsId;
-  final AssetId primaryInput;
-  Digest? previousInputsDigest;
-
-  PostProcessAnchorNode(
-    super.id,
-    this.primaryInput,
-    this.actionNumber,
-    this.builderOptionsId, {
-    this.previousInputsDigest,
-  }) : super(type: NodeType.postProcessAnchor);
-
-  PostProcessAnchorNode.forInputAndAction(
-    AssetId primaryInput,
-    int actionNumber,
-    AssetId builderOptionsId,
-  ) : this(
-        primaryInput.addExtension('.post_anchor.$actionNumber'),
-        primaryInput,
-        actionNumber,
-        builderOptionsId,
-      );
-}
-
-/// A node representing a glob ran from a builder.
-///
-/// The [id] must always be unique to a given package, phase, and glob
-/// pattern.
-class GlobAssetNode extends AssetNode implements NodeWithInputs {
-  final Glob glob;
-
-  /// All the potential inputs matching this glob.
-  ///
-  /// This field differs from [results] in that [GeneratedAssetNode] which may
-  /// have been readable but were not output are included here and not in
-  /// [results].
-  @override
-  HashSet<AssetId> inputs;
-
-  @override
-  final int phaseNumber;
-
-  /// The actual results of the glob.
-  List<AssetId>? results;
-
-  @override
-  NodeState state;
-
-  GlobAssetNode(
-    super.id,
-    this.glob,
-    this.phaseNumber,
-    this.state, {
-    HashSet<AssetId>? inputs,
-    super.lastKnownDigest,
-    this.results,
-  }) : inputs = inputs ?? HashSet(),
-       super(type: NodeType.glob);
-
-  static AssetId createId(String package, Glob glob, int phaseNum) => AssetId(
-    package,
-    'glob.$phaseNum.${base64.encode(utf8.encode(glob.pattern))}',
-  );
-}
-
-/// A node which has [inputs], a [NodeState], and a [phaseNumber].
-abstract class NodeWithInputs implements AssetNode {
-  HashSet<AssetId> get inputs;
-
-  int get phaseNumber;
-
-  abstract NodeState state;
-}
+/// Work that needs doing for a node that tracks its inputs.
+enum PendingBuildAction { none, buildIfInputsChanged, build }

--- a/build_runner_core/lib/src/asset_graph/optional_output_tracker.dart
+++ b/build_runner_core/lib/src/asset_graph/optional_output_tracker.dart
@@ -3,8 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
-import '../../build_runner_core.dart';
 
+import '../../build_runner_core.dart';
 import '../generate/phase.dart';
 import '../package_graph/target_graph.dart';
 import '../util/build_dirs.dart';
@@ -56,9 +56,10 @@ class OptionalOutputTracker {
     if (currentlyChecking.contains(output)) return false;
     currentlyChecking.add(output);
 
-    final node = _assetGraph.get(output);
-    if (node is! GeneratedAssetNode) return true;
-    final phase = _buildPhases[node.phaseNumber];
+    final node = _assetGraph.get(output)!;
+    if (node.type != NodeType.generated) return true;
+    final nodeConfiguration = node.generatedNodeConfiguration;
+    final phase = _buildPhases[nodeConfiguration.phaseNumber];
     if (!phase.isOptional &&
         shouldBuildForDirs(
           output,
@@ -74,8 +75,12 @@ class OptionalOutputTracker {
       () =>
           node.outputs.any((o) => isRequired(o, currentlyChecking)) ||
           _assetGraph
-              .outputsForPhase(output.package, node.phaseNumber)
-              .where((n) => n.primaryInput == node.primaryInput)
+              .outputsForPhase(output.package, nodeConfiguration.phaseNumber)
+              .where(
+                (n) =>
+                    n.generatedNodeConfiguration.primaryInput ==
+                    node.generatedNodeConfiguration.primaryInput,
+              )
               .map((n) => n.id)
               .any((o) => isRequired(o, currentlyChecking)),
     );

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -154,7 +154,9 @@ class AssetTracker {
     var removedAssets = assetGraph.allNodes
         .where((n) {
           if (!n.isFile) return false;
-          if (n is GeneratedAssetNode) return n.wasOutput;
+          if (n.type == NodeType.generated) {
+            return n.generatedNodeState.wasOutput;
+          }
           return true;
         })
         .map((n) => n.id)
@@ -505,8 +507,10 @@ class _Loader {
         // Delete all the non-hidden outputs.
         await Future.wait(
           graph.outputs.map((id) {
-            var node = graph.get(id) as GeneratedAssetNode;
-            if (node.wasOutput && !node.isHidden) {
+            var node = graph.get(id)!;
+            final nodeConfiguration = node.generatedNodeConfiguration;
+            final nodeState = node.generatedNodeState;
+            if (nodeState.wasOutput && !nodeConfiguration.isHidden) {
               var idToDelete = id;
               // If the package no longer exists, then the user must have
               // renamed the root package.

--- a/build_runner_core/lib/src/generate/finalized_assets_view.dart
+++ b/build_runner_core/lib/src/generate/finalized_assets_view.dart
@@ -73,8 +73,11 @@ bool _shouldSkipNode(
   }
 
   if (node.type == NodeType.internal || node.type == NodeType.glob) return true;
-  if (node is GeneratedAssetNode) {
-    if (!node.wasOutput || node.isFailure || node.state != NodeState.upToDate) {
+  if (node.type == NodeType.generated) {
+    final nodeState = node.generatedNodeState;
+    if (!nodeState.wasOutput ||
+        nodeState.isFailure ||
+        nodeState.pendingBuildAction != PendingBuildAction.none) {
       return true;
     }
     return !optionalOutputTracker.isRequired(node.id);

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -66,9 +66,9 @@ void main() {
 
     test('Failure nodes interact well with build filters ', () async {
       var id = AssetId('a', 'web/a.txt');
-      var node = GeneratedAssetNode(
+      var node = AssetNode.generated(
         id,
-        state: NodeState.upToDate,
+        state: PendingBuildAction.none,
         phaseNumber: 0,
         wasOutput: true,
         isFailure: true,

--- a/build_runner_core/test/environment/create_merged_dir_test.dart
+++ b/build_runner_core/test/environment/create_merged_dir_test.dart
@@ -97,12 +97,15 @@ void main() {
         optionalOutputTracker,
       );
       for (var id in graph.outputs) {
-        var node =
-            graph.get(id) as GeneratedAssetNode
-              ..state = NodeState.upToDate
-              ..wasOutput = true
-              ..isFailure = false;
-        readerWriter.testing.writeString(id, sources[node.primaryInput]!);
+        var node = graph.get(id)!;
+        node.generatedNodeState
+          ..pendingBuildAction = PendingBuildAction.none
+          ..wasOutput = true
+          ..isFailure = false;
+        readerWriter.testing.writeString(
+          id,
+          sources[node.generatedNodeConfiguration.primaryInput]!,
+        );
       }
       tmpDir = await Directory.systemTemp.createTemp('build_tests');
       anotherTmpDir = await Directory.systemTemp.createTemp('build_tests');
@@ -127,8 +130,7 @@ void main() {
     });
 
     test('doesnt write deleted files', () async {
-      var node =
-          graph.get(AssetId('b', 'lib/c.txt.copy')) as GeneratedAssetNode;
+      var node = graph.get(AssetId('b', 'lib/c.txt.copy'))!;
       node.mutate.deletedBy.add(node.id.addExtension('.post_anchor.1'));
 
       var success = await createMergedOutputDirectories(
@@ -326,7 +328,7 @@ void main() {
     });
 
     test('doesnt write files that werent output', () async {
-      graph.get(AssetId('b', 'lib/c.txt.copy')) as GeneratedAssetNode
+      graph.get(AssetId('b', 'lib/c.txt.copy'))!.generatedNodeState
         ..wasOutput = false
         ..isFailure = false;
 

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1279,11 +1279,11 @@ void main() {
     expectedGraph.add(builderOptionsNode);
 
     var aCopyId = makeAssetId('a|web/a.txt.copy');
-    var aCopyNode = GeneratedAssetNode(
+    var aCopyNode = AssetNode.generated(
       aCopyId,
       phaseNumber: 0,
       primaryInput: makeAssetId('a|web/a.txt'),
-      state: NodeState.upToDate,
+      state: PendingBuildAction.none,
       wasOutput: true,
       isFailure: false,
       builderOptionsId: builderOptionsId,
@@ -1298,11 +1298,11 @@ void main() {
       ..primaryOutputs.add(aCopyNode.id);
 
     var bCopyId = makeAssetId('a|lib/b.txt.copy'); //;
-    var bCopyNode = GeneratedAssetNode(
+    var bCopyNode = AssetNode.generated(
       bCopyId,
       phaseNumber: 0,
       primaryInput: makeAssetId('a|lib/b.txt'),
-      state: NodeState.upToDate,
+      state: PendingBuildAction.none,
       wasOutput: true,
       isFailure: false,
       builderOptionsId: builderOptionsId,
@@ -1324,12 +1324,12 @@ void main() {
     );
     expectedGraph.add(postBuilderOptionsNode);
 
-    var aAnchorNode = PostProcessAnchorNode.forInputAndAction(
+    var aAnchorNode = AssetNode.postProcessAnchorForInputAndAction(
       aSourceNode.id,
       0,
       postBuilderOptionsId,
     );
-    var bAnchorNode = PostProcessAnchorNode.forInputAndAction(
+    var bAnchorNode = AssetNode.postProcessAnchorForInputAndAction(
       bSourceNode.id,
       0,
       postBuilderOptionsId,
@@ -1338,11 +1338,11 @@ void main() {
       ..add(aAnchorNode)
       ..add(bAnchorNode);
 
-    var aPostCopyNode = GeneratedAssetNode(
+    var aPostCopyNode = AssetNode.generated(
       makeAssetId('a|web/a.txt.post'),
       phaseNumber: 1,
       primaryInput: makeAssetId('a|web/a.txt'),
-      state: NodeState.upToDate,
+      state: PendingBuildAction.none,
       wasOutput: true,
       isFailure: false,
       builderOptionsId: postBuilderOptionsId,
@@ -1359,11 +1359,11 @@ void main() {
     aAnchorNode.mutate.outputs.add(aPostCopyNode.id);
     aSourceNode.mutate.primaryOutputs.add(aPostCopyNode.id);
 
-    var bPostCopyNode = GeneratedAssetNode(
+    var bPostCopyNode = AssetNode.generated(
       makeAssetId('a|lib/b.txt.post'),
       phaseNumber: 1,
       primaryInput: makeAssetId('a|lib/b.txt'),
-      state: NodeState.upToDate,
+      state: PendingBuildAction.none,
       wasOutput: true,
       isFailure: false,
       builderOptionsId: postBuilderOptionsId,
@@ -1422,8 +1422,8 @@ void main() {
       );
       final outputId = AssetId('a', 'lib/a.txt.out');
 
-      final outputNode = cachedGraph.get(outputId) as GeneratedAssetNode;
-      expect(outputNode.inputs, isNot(contains(outputId)));
+      final outputNode = cachedGraph.get(outputId)!;
+      expect(outputNode.generatedNodeState.inputs, isNot(contains(outputId)));
     },
   );
 
@@ -1810,12 +1810,14 @@ void main() {
       var graph = AssetGraph.deserialize(
         result.readerWriter.testing.readBytes(makeAssetId('a|$assetGraphPath')),
       );
-      var outputNode =
-          graph.get(makeAssetId('a|lib/file.a.copy')) as GeneratedAssetNode;
+      var outputNode = graph.get(makeAssetId('a|lib/file.a.copy'))!;
       var fileANode = graph.get(makeAssetId('a|lib/file.a'))!;
       var fileBNode = graph.get(makeAssetId('a|lib/file.b'))!;
       var fileCNode = graph.get(makeAssetId('a|lib/file.c'))!;
-      expect(outputNode.inputs, unorderedEquals([fileANode.id, fileCNode.id]));
+      expect(
+        outputNode.generatedNodeState.inputs,
+        unorderedEquals([fileANode.id, fileCNode.id]),
+      );
       expect(fileANode.outputs, contains(outputNode.id));
       expect(fileBNode.outputs, isEmpty);
       expect(fileCNode.outputs, unorderedEquals([outputNode.id]));
@@ -2031,9 +2033,8 @@ void main() {
         result.readerWriter.testing.readBytes(AssetId('a', assetGraphPath)),
       );
       for (var i = 1; i < 4; i++) {
-        var node =
-            finalGraph.get(AssetId('a', 'web/a.g$i')) as GeneratedAssetNode;
-        expect(node.isFailure, isTrue);
+        var node = finalGraph.get(AssetId('a', 'web/a.g$i'))!;
+        expect(node.generatedNodeState.isFailure, isTrue);
       }
     });
 


### PR DESCRIPTION
For #3811.

The more complex node types do share some fields, but on inspection of where they are used, there is very little actual polymorphism: e.g. "primaryInputId" is used differently for a "post process anchor node" and for a "glob node". So, just remove it, and always access concrete fields defined per node type. A bit of polymorphism can be added back later if it looks worth it, it's not clear if `AssetNode` is the right place for it, it might end up on `AssetGraph`.

Introduce separate "configuration" and "state" classes for each complex node types, to separate state that changes during from the build from state that doesn't.

Rename `NodeState` enum to `PendingBuildAction`

 - `NodeState.definitelyNeedsUpdate` -> `PendingBuildAction.build`
 - `NodeState.mayNeedUpdate` -> `PendingBuildAction.buildIfInputsChanged`
 - `NodeState.upToDate` -> `PendingBuildAction.none`

Where all this is headed:

 - move all mutations to the asset graph state into the asset graph instead of mutating nodes directly
 - switch to using `built_value` codegen, removing the handwritten serialization and test matcher code
 - asset graph keeps a bit more state to remove the need for computing transitive digests -> performance improvement
 - deduplicate common subsets of IDs from transitive deps across inputs/outputs of nodes, both in memory and when serializing/deserializing -> performance improvement