### PR TITLE
Release build_modules 5.0.12.

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 5.0.12-wip
+## 5.0.12
 
 - Bump the min SDK to 3.7.0.
 - Use `build_test` 3.0.0.
-- use AOT snapshot for kernel_worker
+- Use AOT snapshot for kernel_worker.
 
 ## 5.0.11
 

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 5.0.12-wip
+version: 5.0.12
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.


### PR DESCRIPTION
For the AOT kernel snapshot change, so the AOT snapshot can be removed from the SDK.