### PR TITLE
Use `built_value` for `AssetNode` and related types.

### DIFF
--- a/_test_common/lib/matchers.dart
+++ b/_test_common/lib/matchers.dart
@@ -87,8 +87,9 @@ class _AssetGraphMatcher extends Matcher {
       }
       if (node.type == NodeType.generated) {
         if (expectedNode.type == NodeType.generated) {
-          final configuration = node.generatedNodeConfiguration;
-          final expectedConfiguration = expectedNode.generatedNodeConfiguration;
+          final configuration = node.generatedNodeConfiguration!;
+          final expectedConfiguration =
+              expectedNode.generatedNodeConfiguration!;
 
           if (configuration.primaryInput !=
               expectedConfiguration.primaryInput) {
@@ -99,8 +100,8 @@ class _AssetGraphMatcher extends Matcher {
             matches = false;
           }
 
-          final state = node.generatedNodeState;
-          final expectedState = expectedNode.generatedNodeState;
+          final state = node.generatedNodeState!;
+          final expectedState = expectedNode.generatedNodeState!;
 
           if (state.pendingBuildAction != expectedState.pendingBuildAction) {
             matchState['pendingBuildAction of ${node.id}'] = [
@@ -145,8 +146,8 @@ class _AssetGraphMatcher extends Matcher {
         }
       } else if (node.type == NodeType.glob) {
         if (expectedNode.type == NodeType.glob) {
-          final state = node.globNodeState;
-          final expectedState = expectedNode.globNodeState;
+          final state = node.globNodeState!;
+          final expectedState = expectedNode.globNodeState!;
 
           if (state.pendingBuildAction != expectedState.pendingBuildAction) {
             matchState['pendingBuildAction of ${node.id}'] = [
@@ -166,7 +167,7 @@ class _AssetGraphMatcher extends Matcher {
           }
 
           if (!unorderedEquals(
-            state.results!,
+            state.results,
           ).matches(expectedState.results, {})) {
             matchState['results of ${node.id}'] = [
               state.results,
@@ -175,8 +176,8 @@ class _AssetGraphMatcher extends Matcher {
             matches = false;
           }
 
-          final configuration = node.globNodeConfiguration;
-          final expectedConfiguration = expectedNode.globNodeConfiguration;
+          final configuration = node.globNodeConfiguration!;
+          final expectedConfiguration = expectedNode.globNodeConfiguration!;
           if (configuration.glob.pattern !=
               expectedConfiguration.glob.pattern) {
             matchState['glob of ${node.id}'] = [
@@ -188,9 +189,9 @@ class _AssetGraphMatcher extends Matcher {
         }
       } else if (node.type == NodeType.postProcessAnchor) {
         if (expectedNode.type == NodeType.postProcessAnchor) {
-          final nodeConfiguration = node.postProcessAnchorNodeConfiguration;
+          final nodeConfiguration = node.postProcessAnchorNodeConfiguration!;
           final expectedNodeConfiguration =
-              expectedNode.postProcessAnchorNodeConfiguration;
+              expectedNode.postProcessAnchorNodeConfiguration!;
           if (nodeConfiguration.actionNumber !=
               expectedNodeConfiguration.actionNumber) {
             matchState['actionNumber of ${node.id}'] = [
@@ -207,8 +208,8 @@ class _AssetGraphMatcher extends Matcher {
             ];
             matches = false;
           }
-          final nodeState = node.postProcessAnchorNodeState;
-          final expectedNodeState = expectedNode.postProcessAnchorNodeState;
+          final nodeState = node.postProcessAnchorNodeState!;
+          final expectedNodeState = expectedNode.postProcessAnchorNodeState!;
           if (checkPreviousInputsDigest &&
               nodeState.previousInputsDigest !=
                   expectedNodeState.previousInputsDigest) {
@@ -250,8 +251,9 @@ class _AssetGraphMatcher extends Matcher {
     bool verbose,
   ) {
     matchState.forEach((k, v) {
-      v = v as List;
-      mismatchDescription.add('$k: got ${v[0]} but expected ${v[1]}');
+      if (v is List) {
+        mismatchDescription.add('$k: got ${v[0]} but expected ${v[1]}');
+      }
     });
 
     return mismatchDescription;

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Refactor `FileBasedAssetReader` and `FileBasedAssetWriter` to `ReaderWriter`.
 - Remove `OnDeleteWriter`, add functionality to `ReaderWriter`.
 - Add `NodeType` to `AssetNode`, remove subtypes. Make mutations explicit.
+- Use `built_value` for `AssetNode` and related types.
 
 ## 2.4.15
 

--- a/build_runner/bin/graph_inspector.dart
+++ b/build_runner/bin/graph_inspector.dart
@@ -140,8 +140,8 @@ class InspectNodeCommand extends Command<bool> {
             ..writeln('  type: ${node.runtimeType}');
 
       if (node.type == NodeType.generated) {
-        final nodeState = node.generatedNodeState;
-        final nodeConfiguration = node.generatedNodeConfiguration;
+        final nodeState = node.generatedNodeState!;
+        final nodeConfiguration = node.generatedNodeConfiguration!;
         description
           ..writeln('  state: ${nodeState.pendingBuildAction}')
           ..writeln('  wasOutput: ${nodeState.wasOutput}')
@@ -157,9 +157,7 @@ class InspectNodeCommand extends Command<bool> {
         node.primaryOutputs.forEach(printAsset);
 
         description.writeln('  secondary outputs:');
-        node.inspect.outputs
-            .difference(node.inspect.primaryOutputs)
-            .forEach(printAsset);
+        node.outputs.difference(node.primaryOutputs).forEach(printAsset);
 
         if (node.type == NodeType.generated || node.type == NodeType.glob) {
           description.writeln('  inputs:');

--- a/build_runner/lib/src/entrypoint/clean.dart
+++ b/build_runner/lib/src/entrypoint/clean.dart
@@ -86,7 +86,7 @@ Future<void> _cleanUpSourceOutputs(
   for (var id in assetGraph.outputs) {
     if (id.package != packageGraph.root.name) continue;
     var node = assetGraph.get(id)!;
-    if (node.generatedNodeState.wasOutput) {
+    if (node.generatedNodeState!.wasOutput) {
       // Note that this does a file.exists check in the root package and
       // only tries to delete the file if it exists. This way we only
       // actually delete to_source outputs, without reading in the build

--- a/build_runner/lib/src/server/asset_graph_handler.dart
+++ b/build_runner/lib/src/server/asset_graph_handler.dart
@@ -129,8 +129,8 @@ class AssetGraphHandler {
     if (node.type == NodeType.generated || node.type == NodeType.glob) {
       final inputs =
           node.type == NodeType.generated
-              ? node.generatedNodeState.inputs
-              : node.globNodeState.inputs;
+              ? node.generatedNodeState!.inputs
+              : node.globNodeState!.inputs;
       for (final input in inputs) {
         if (filterGlob != null && !filterGlob.matches(input.toString())) {
           continue;
@@ -148,32 +148,32 @@ class AssetGraphHandler {
         'id': '${node.id}',
         'hidden':
             node.type == NodeType.generated
-                ? node.generatedNodeConfiguration.isHidden
+                ? node.generatedNodeConfiguration!.isHidden
                 : null,
         'state':
             node.type == NodeType.generated
-                ? '${node.generatedNodeState.pendingBuildAction}'
+                ? '${node.generatedNodeState!.pendingBuildAction}'
                 : node.type == NodeType.glob
-                ? '${node.globNodeState.pendingBuildAction}'
+                ? '${node.globNodeState!.pendingBuildAction}'
                 : null,
         'wasOutput':
             node.type == NodeType.generated
-                ? node.generatedNodeState.wasOutput
+                ? node.generatedNodeState!.wasOutput
                 : null,
         'isFailure':
             node.type == NodeType.generated
-                ? node.generatedNodeState.isFailure
+                ? node.generatedNodeState!.isFailure
                 : null,
         'phaseNumber':
             node.type == NodeType.generated
-                ? node.generatedNodeConfiguration.phaseNumber
+                ? node.generatedNodeConfiguration!.phaseNumber
                 : node.type == NodeType.glob
-                ? node.globNodeConfiguration.phaseNumber
+                ? node.globNodeConfiguration!.phaseNumber
                 : null,
         'type': node.runtimeType.toString(),
         'glob':
             node.type == NodeType.glob
-                ? node.globNodeConfiguration.glob.pattern
+                ? node.globNodeConfiguration!.glob.pattern
                 : null,
         'lastKnownDigest': node.lastKnownDigest.toString(),
       },

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -366,7 +366,6 @@ void main() {
           builderOptionsId,
           lastKnownDigest: computeBuilderOptionsDigest(defaultBuilderOptions),
         );
-        expectedGraph.add(builderOptionsNode);
 
         var bCopyId = makeAssetId('a|web/b.txt.copy');
         var bTxtId = makeAssetId('a|web/b.txt');
@@ -374,7 +373,7 @@ void main() {
           bCopyId,
           phaseNumber: 0,
           primaryInput: makeAssetId('a|web/b.txt'),
-          state: PendingBuildAction.none,
+          pendingBuildAction: PendingBuildAction.none,
           wasOutput: true,
           isFailure: false,
           builderOptionsId: builderOptionsId,
@@ -382,7 +381,9 @@ void main() {
           inputs: [makeAssetId('a|web/b.txt')],
           isHidden: false,
         );
-        builderOptionsNode.mutate.outputs.add(bCopyNode.id);
+        builderOptionsNode = builderOptionsNode.rebuild(
+          (b) => b..outputs.add(bCopyNode.id),
+        );
         expectedGraph
           ..add(bCopyNode)
           ..add(
@@ -397,7 +398,7 @@ void main() {
           cCopyId,
           phaseNumber: 0,
           primaryInput: cTxtId,
-          state: PendingBuildAction.none,
+          pendingBuildAction: PendingBuildAction.none,
           wasOutput: true,
           isFailure: false,
           builderOptionsId: builderOptionsId,
@@ -405,7 +406,9 @@ void main() {
           inputs: [makeAssetId('a|web/c.txt')],
           isHidden: false,
         );
-        builderOptionsNode.mutate.outputs.add(cCopyNode.id);
+        builderOptionsNode = builderOptionsNode.rebuild(
+          (b) => b..outputs.add(cCopyNode.id),
+        );
         expectedGraph
           ..add(cCopyNode)
           ..add(
@@ -413,6 +416,8 @@ void main() {
               cCopyNode.id,
             ], computeDigest(cTxtId, 'c')),
           );
+
+        expectedGraph.add(builderOptionsNode);
 
         // TODO: We dont have a shared way of computing the combined input
         // hashes today, but eventually we should test those here too.

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -47,7 +47,9 @@ void main() {
   void addAsset(String id, String content, {bool deleted = false}) {
     var node = makeAssetNode(id, [], computeDigest(AssetId.parse(id), 'a'));
     if (deleted) {
-      node.mutate.deletedBy.add(node.id.addExtension('.post_anchor.1'));
+      node = node.rebuild(
+        (b) => b..deletedBy.add(node.id.addExtension('.post_anchor.1')),
+      );
     }
     graph.add(node);
     delegate.testing.writeString(node.id, content);
@@ -132,7 +134,7 @@ void main() {
         AssetId('a', 'web/main.ddc.js'),
         builderOptionsId: AssetId('_\$fake', 'options_id'),
         phaseNumber: 0,
-        state: PendingBuildAction.none,
+        pendingBuildAction: PendingBuildAction.none,
         isHidden: false,
         wasOutput: true,
         isFailure: true,

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -138,7 +138,9 @@ void main() {
   void addSource(String id, String content, {bool deleted = false}) {
     var node = makeAssetNode(id, [], computeDigest(AssetId.parse(id), content));
     if (deleted) {
-      node.mutate.deletedBy.add(node.id.addExtension('.post_anchor.1'));
+      node = node.rebuild(
+        (b) => b..deletedBy.add(node.id.addExtension('.post_anchor.1')),
+      );
     }
     assetGraph.add(node);
     readerWriter.testing.writeString(node.id, content);
@@ -205,7 +207,7 @@ void main() {
           AssetId('a', 'web/main.ddc.js'),
           builderOptionsId: AssetId('_\$fake', 'options_id'),
           phaseNumber: 0,
-          state: PendingBuildAction.none,
+          pendingBuildAction: PendingBuildAction.none,
           isHidden: false,
           wasOutput: true,
           isFailure: true,

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Refactor `SingleStepReader` to `SingleStepReaderWriter`, incorporating
   `AssetWriterSpy` functionality.
 - Add `NodeType` to `AssetNode`, remove subtypes. Make mutations explicit.
+- Use `built_value` for `AssetNode` and related types.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/src/asset/build_cache.dart
+++ b/build_runner_core/lib/src/asset/build_cache.dart
@@ -38,7 +38,7 @@ class BuildCacheAssetPathProvider implements AssetPathProvider {
     }
     final assetNode = _assetGraph.get(id)!;
     if (assetNode.type == NodeType.generated &&
-        assetNode.generatedNodeConfiguration.isHidden) {
+        assetNode.generatedNodeConfiguration!.isHidden) {
       return AssetId(
         _rootPackage,
         '$generatedOutputDirectory/${id.package}/${id.path}',

--- a/build_runner_core/lib/src/asset/finalized_reader.dart
+++ b/build_runner_core/lib/src/asset/finalized_reader.dart
@@ -62,7 +62,7 @@ class FinalizedReader {
     if (!node.isFile) return UnreadableReason.assetType;
 
     if (node.type == NodeType.generated) {
-      final nodeState = node.generatedNodeState;
+      final nodeState = node.generatedNodeState!;
       if (nodeState.isFailure) return UnreadableReason.failed;
       if (!nodeState.wasOutput) return UnreadableReason.notOutput;
       // No need to explicitly check readability for generated files, their
@@ -121,9 +121,12 @@ class FinalizedReader {
   FutureOr<Digest> _ensureDigest(AssetId id) {
     var node = _assetGraph.get(id)!;
     if (node.lastKnownDigest != null) return node.lastKnownDigest!;
-    return _delegate
-        .digest(id)
-        .then((digest) => node.mutate.lastKnownDigest = digest);
+    return _delegate.digest(id).then((digest) {
+      _assetGraph.updateNode(id, (nodeBuilder) {
+        nodeBuilder.lastKnownDigest = digest;
+      });
+      return digest;
+    });
   }
 }
 

--- a/build_runner_core/lib/src/asset_graph/node.g.dart
+++ b/build_runner_core/lib/src/asset_graph/node.g.dart
@@ -1,0 +1,1249 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'node.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+const NodeType _$builderOptions = const NodeType._('builderOptions');
+const NodeType _$generated = const NodeType._('generated');
+const NodeType _$glob = const NodeType._('glob');
+const NodeType _$internal = const NodeType._('internal');
+const NodeType _$placeholder = const NodeType._('placeholder');
+const NodeType _$postProcessAnchor = const NodeType._('postProcessAnchor');
+const NodeType _$source = const NodeType._('source');
+const NodeType _$missingSource = const NodeType._('missingSource');
+
+NodeType _$nodeTypeValueOf(String name) {
+  switch (name) {
+    case 'builderOptions':
+      return _$builderOptions;
+    case 'generated':
+      return _$generated;
+    case 'glob':
+      return _$glob;
+    case 'internal':
+      return _$internal;
+    case 'placeholder':
+      return _$placeholder;
+    case 'postProcessAnchor':
+      return _$postProcessAnchor;
+    case 'source':
+      return _$source;
+    case 'missingSource':
+      return _$missingSource;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<NodeType> _$nodeTypeValues =
+    new BuiltSet<NodeType>(const <NodeType>[
+      _$builderOptions,
+      _$generated,
+      _$glob,
+      _$internal,
+      _$placeholder,
+      _$postProcessAnchor,
+      _$source,
+      _$missingSource,
+    ]);
+
+const PendingBuildAction _$none = const PendingBuildAction._('none');
+const PendingBuildAction _$buildIfInputsChanged = const PendingBuildAction._(
+  'buildIfInputsChanged',
+);
+const PendingBuildAction _$build = const PendingBuildAction._('build');
+
+PendingBuildAction _$pendingBuildActionValueOf(String name) {
+  switch (name) {
+    case 'none':
+      return _$none;
+    case 'buildIfInputsChanged':
+      return _$buildIfInputsChanged;
+    case 'build':
+      return _$build;
+    default:
+      throw new ArgumentError(name);
+  }
+}
+
+final BuiltSet<PendingBuildAction> _$pendingBuildActionValues =
+    new BuiltSet<PendingBuildAction>(const <PendingBuildAction>[
+      _$none,
+      _$buildIfInputsChanged,
+      _$build,
+    ]);
+
+class _$AssetNode extends AssetNode {
+  @override
+  final AssetId id;
+  @override
+  final NodeType type;
+  @override
+  final GeneratedNodeConfiguration? generatedNodeConfiguration;
+  @override
+  final GeneratedNodeState? generatedNodeState;
+  @override
+  final GlobNodeConfiguration? globNodeConfiguration;
+  @override
+  final GlobNodeState? globNodeState;
+  @override
+  final PostProcessAnchorNodeConfiguration? postProcessAnchorNodeConfiguration;
+  @override
+  final PostProcessAnchorNodeState? postProcessAnchorNodeState;
+  @override
+  final BuiltSet<AssetId> primaryOutputs;
+  @override
+  final BuiltSet<AssetId> outputs;
+  @override
+  final BuiltSet<AssetId> anchorOutputs;
+  @override
+  final Digest? lastKnownDigest;
+  @override
+  final BuiltSet<AssetId> deletedBy;
+
+  factory _$AssetNode([void Function(AssetNodeBuilder)? updates]) =>
+      (new AssetNodeBuilder()..update(updates))._build();
+
+  _$AssetNode._({
+    required this.id,
+    required this.type,
+    this.generatedNodeConfiguration,
+    this.generatedNodeState,
+    this.globNodeConfiguration,
+    this.globNodeState,
+    this.postProcessAnchorNodeConfiguration,
+    this.postProcessAnchorNodeState,
+    required this.primaryOutputs,
+    required this.outputs,
+    required this.anchorOutputs,
+    this.lastKnownDigest,
+    required this.deletedBy,
+  }) : super._() {
+    BuiltValueNullFieldError.checkNotNull(id, r'AssetNode', 'id');
+    BuiltValueNullFieldError.checkNotNull(type, r'AssetNode', 'type');
+    BuiltValueNullFieldError.checkNotNull(
+      primaryOutputs,
+      r'AssetNode',
+      'primaryOutputs',
+    );
+    BuiltValueNullFieldError.checkNotNull(outputs, r'AssetNode', 'outputs');
+    BuiltValueNullFieldError.checkNotNull(
+      anchorOutputs,
+      r'AssetNode',
+      'anchorOutputs',
+    );
+    BuiltValueNullFieldError.checkNotNull(deletedBy, r'AssetNode', 'deletedBy');
+  }
+
+  @override
+  AssetNode rebuild(void Function(AssetNodeBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AssetNodeBuilder toBuilder() => new AssetNodeBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AssetNode &&
+        id == other.id &&
+        type == other.type &&
+        generatedNodeConfiguration == other.generatedNodeConfiguration &&
+        generatedNodeState == other.generatedNodeState &&
+        globNodeConfiguration == other.globNodeConfiguration &&
+        globNodeState == other.globNodeState &&
+        postProcessAnchorNodeConfiguration ==
+            other.postProcessAnchorNodeConfiguration &&
+        postProcessAnchorNodeState == other.postProcessAnchorNodeState &&
+        primaryOutputs == other.primaryOutputs &&
+        outputs == other.outputs &&
+        anchorOutputs == other.anchorOutputs &&
+        lastKnownDigest == other.lastKnownDigest &&
+        deletedBy == other.deletedBy;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, type.hashCode);
+    _$hash = $jc(_$hash, generatedNodeConfiguration.hashCode);
+    _$hash = $jc(_$hash, generatedNodeState.hashCode);
+    _$hash = $jc(_$hash, globNodeConfiguration.hashCode);
+    _$hash = $jc(_$hash, globNodeState.hashCode);
+    _$hash = $jc(_$hash, postProcessAnchorNodeConfiguration.hashCode);
+    _$hash = $jc(_$hash, postProcessAnchorNodeState.hashCode);
+    _$hash = $jc(_$hash, primaryOutputs.hashCode);
+    _$hash = $jc(_$hash, outputs.hashCode);
+    _$hash = $jc(_$hash, anchorOutputs.hashCode);
+    _$hash = $jc(_$hash, lastKnownDigest.hashCode);
+    _$hash = $jc(_$hash, deletedBy.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AssetNode')
+          ..add('id', id)
+          ..add('type', type)
+          ..add('generatedNodeConfiguration', generatedNodeConfiguration)
+          ..add('generatedNodeState', generatedNodeState)
+          ..add('globNodeConfiguration', globNodeConfiguration)
+          ..add('globNodeState', globNodeState)
+          ..add(
+            'postProcessAnchorNodeConfiguration',
+            postProcessAnchorNodeConfiguration,
+          )
+          ..add('postProcessAnchorNodeState', postProcessAnchorNodeState)
+          ..add('primaryOutputs', primaryOutputs)
+          ..add('outputs', outputs)
+          ..add('anchorOutputs', anchorOutputs)
+          ..add('lastKnownDigest', lastKnownDigest)
+          ..add('deletedBy', deletedBy))
+        .toString();
+  }
+}
+
+class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
+  _$AssetNode? _$v;
+
+  AssetId? _id;
+  AssetId? get id => _$this._id;
+  set id(AssetId? id) => _$this._id = id;
+
+  NodeType? _type;
+  NodeType? get type => _$this._type;
+  set type(NodeType? type) => _$this._type = type;
+
+  GeneratedNodeConfigurationBuilder? _generatedNodeConfiguration;
+  GeneratedNodeConfigurationBuilder get generatedNodeConfiguration =>
+      _$this._generatedNodeConfiguration ??=
+          new GeneratedNodeConfigurationBuilder();
+  set generatedNodeConfiguration(
+    GeneratedNodeConfigurationBuilder? generatedNodeConfiguration,
+  ) => _$this._generatedNodeConfiguration = generatedNodeConfiguration;
+
+  GeneratedNodeStateBuilder? _generatedNodeState;
+  GeneratedNodeStateBuilder get generatedNodeState =>
+      _$this._generatedNodeState ??= new GeneratedNodeStateBuilder();
+  set generatedNodeState(GeneratedNodeStateBuilder? generatedNodeState) =>
+      _$this._generatedNodeState = generatedNodeState;
+
+  GlobNodeConfigurationBuilder? _globNodeConfiguration;
+  GlobNodeConfigurationBuilder get globNodeConfiguration =>
+      _$this._globNodeConfiguration ??= new GlobNodeConfigurationBuilder();
+  set globNodeConfiguration(
+    GlobNodeConfigurationBuilder? globNodeConfiguration,
+  ) => _$this._globNodeConfiguration = globNodeConfiguration;
+
+  GlobNodeStateBuilder? _globNodeState;
+  GlobNodeStateBuilder get globNodeState =>
+      _$this._globNodeState ??= new GlobNodeStateBuilder();
+  set globNodeState(GlobNodeStateBuilder? globNodeState) =>
+      _$this._globNodeState = globNodeState;
+
+  PostProcessAnchorNodeConfigurationBuilder?
+  _postProcessAnchorNodeConfiguration;
+  PostProcessAnchorNodeConfigurationBuilder
+  get postProcessAnchorNodeConfiguration =>
+      _$this._postProcessAnchorNodeConfiguration ??=
+          new PostProcessAnchorNodeConfigurationBuilder();
+  set postProcessAnchorNodeConfiguration(
+    PostProcessAnchorNodeConfigurationBuilder?
+    postProcessAnchorNodeConfiguration,
+  ) =>
+      _$this._postProcessAnchorNodeConfiguration =
+          postProcessAnchorNodeConfiguration;
+
+  PostProcessAnchorNodeStateBuilder? _postProcessAnchorNodeState;
+  PostProcessAnchorNodeStateBuilder get postProcessAnchorNodeState =>
+      _$this._postProcessAnchorNodeState ??=
+          new PostProcessAnchorNodeStateBuilder();
+  set postProcessAnchorNodeState(
+    PostProcessAnchorNodeStateBuilder? postProcessAnchorNodeState,
+  ) => _$this._postProcessAnchorNodeState = postProcessAnchorNodeState;
+
+  SetBuilder<AssetId>? _primaryOutputs;
+  SetBuilder<AssetId> get primaryOutputs =>
+      _$this._primaryOutputs ??= new SetBuilder<AssetId>();
+  set primaryOutputs(SetBuilder<AssetId>? primaryOutputs) =>
+      _$this._primaryOutputs = primaryOutputs;
+
+  SetBuilder<AssetId>? _outputs;
+  SetBuilder<AssetId> get outputs =>
+      _$this._outputs ??= new SetBuilder<AssetId>();
+  set outputs(SetBuilder<AssetId>? outputs) => _$this._outputs = outputs;
+
+  SetBuilder<AssetId>? _anchorOutputs;
+  SetBuilder<AssetId> get anchorOutputs =>
+      _$this._anchorOutputs ??= new SetBuilder<AssetId>();
+  set anchorOutputs(SetBuilder<AssetId>? anchorOutputs) =>
+      _$this._anchorOutputs = anchorOutputs;
+
+  Digest? _lastKnownDigest;
+  Digest? get lastKnownDigest => _$this._lastKnownDigest;
+  set lastKnownDigest(Digest? lastKnownDigest) =>
+      _$this._lastKnownDigest = lastKnownDigest;
+
+  SetBuilder<AssetId>? _deletedBy;
+  SetBuilder<AssetId> get deletedBy =>
+      _$this._deletedBy ??= new SetBuilder<AssetId>();
+  set deletedBy(SetBuilder<AssetId>? deletedBy) =>
+      _$this._deletedBy = deletedBy;
+
+  AssetNodeBuilder();
+
+  AssetNodeBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
+      _type = $v.type;
+      _generatedNodeConfiguration = $v.generatedNodeConfiguration?.toBuilder();
+      _generatedNodeState = $v.generatedNodeState?.toBuilder();
+      _globNodeConfiguration = $v.globNodeConfiguration?.toBuilder();
+      _globNodeState = $v.globNodeState?.toBuilder();
+      _postProcessAnchorNodeConfiguration =
+          $v.postProcessAnchorNodeConfiguration?.toBuilder();
+      _postProcessAnchorNodeState = $v.postProcessAnchorNodeState?.toBuilder();
+      _primaryOutputs = $v.primaryOutputs.toBuilder();
+      _outputs = $v.outputs.toBuilder();
+      _anchorOutputs = $v.anchorOutputs.toBuilder();
+      _lastKnownDigest = $v.lastKnownDigest;
+      _deletedBy = $v.deletedBy.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(AssetNode other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AssetNode;
+  }
+
+  @override
+  void update(void Function(AssetNodeBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AssetNode build() => _build();
+
+  _$AssetNode _build() {
+    _$AssetNode _$result;
+    try {
+      _$result =
+          _$v ??
+          new _$AssetNode._(
+            id: BuiltValueNullFieldError.checkNotNull(id, r'AssetNode', 'id'),
+            type: BuiltValueNullFieldError.checkNotNull(
+              type,
+              r'AssetNode',
+              'type',
+            ),
+            generatedNodeConfiguration: _generatedNodeConfiguration?.build(),
+            generatedNodeState: _generatedNodeState?.build(),
+            globNodeConfiguration: _globNodeConfiguration?.build(),
+            globNodeState: _globNodeState?.build(),
+            postProcessAnchorNodeConfiguration:
+                _postProcessAnchorNodeConfiguration?.build(),
+            postProcessAnchorNodeState: _postProcessAnchorNodeState?.build(),
+            primaryOutputs: primaryOutputs.build(),
+            outputs: outputs.build(),
+            anchorOutputs: anchorOutputs.build(),
+            lastKnownDigest: lastKnownDigest,
+            deletedBy: deletedBy.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'generatedNodeConfiguration';
+        _generatedNodeConfiguration?.build();
+        _$failedField = 'generatedNodeState';
+        _generatedNodeState?.build();
+        _$failedField = 'globNodeConfiguration';
+        _globNodeConfiguration?.build();
+        _$failedField = 'globNodeState';
+        _globNodeState?.build();
+        _$failedField = 'postProcessAnchorNodeConfiguration';
+        _postProcessAnchorNodeConfiguration?.build();
+        _$failedField = 'postProcessAnchorNodeState';
+        _postProcessAnchorNodeState?.build();
+        _$failedField = 'primaryOutputs';
+        primaryOutputs.build();
+        _$failedField = 'outputs';
+        outputs.build();
+        _$failedField = 'anchorOutputs';
+        anchorOutputs.build();
+
+        _$failedField = 'deletedBy';
+        deletedBy.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+          r'AssetNode',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
+  @override
+  final AssetId primaryInput;
+  @override
+  final AssetId builderOptionsId;
+  @override
+  final int phaseNumber;
+  @override
+  final bool isHidden;
+
+  factory _$GeneratedNodeConfiguration([
+    void Function(GeneratedNodeConfigurationBuilder)? updates,
+  ]) => (new GeneratedNodeConfigurationBuilder()..update(updates))._build();
+
+  _$GeneratedNodeConfiguration._({
+    required this.primaryInput,
+    required this.builderOptionsId,
+    required this.phaseNumber,
+    required this.isHidden,
+  }) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+      primaryInput,
+      r'GeneratedNodeConfiguration',
+      'primaryInput',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      builderOptionsId,
+      r'GeneratedNodeConfiguration',
+      'builderOptionsId',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      phaseNumber,
+      r'GeneratedNodeConfiguration',
+      'phaseNumber',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      isHidden,
+      r'GeneratedNodeConfiguration',
+      'isHidden',
+    );
+  }
+
+  @override
+  GeneratedNodeConfiguration rebuild(
+    void Function(GeneratedNodeConfigurationBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  GeneratedNodeConfigurationBuilder toBuilder() =>
+      new GeneratedNodeConfigurationBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GeneratedNodeConfiguration &&
+        primaryInput == other.primaryInput &&
+        builderOptionsId == other.builderOptionsId &&
+        phaseNumber == other.phaseNumber &&
+        isHidden == other.isHidden;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, primaryInput.hashCode);
+    _$hash = $jc(_$hash, builderOptionsId.hashCode);
+    _$hash = $jc(_$hash, phaseNumber.hashCode);
+    _$hash = $jc(_$hash, isHidden.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GeneratedNodeConfiguration')
+          ..add('primaryInput', primaryInput)
+          ..add('builderOptionsId', builderOptionsId)
+          ..add('phaseNumber', phaseNumber)
+          ..add('isHidden', isHidden))
+        .toString();
+  }
+}
+
+class GeneratedNodeConfigurationBuilder
+    implements
+        Builder<GeneratedNodeConfiguration, GeneratedNodeConfigurationBuilder> {
+  _$GeneratedNodeConfiguration? _$v;
+
+  AssetId? _primaryInput;
+  AssetId? get primaryInput => _$this._primaryInput;
+  set primaryInput(AssetId? primaryInput) =>
+      _$this._primaryInput = primaryInput;
+
+  AssetId? _builderOptionsId;
+  AssetId? get builderOptionsId => _$this._builderOptionsId;
+  set builderOptionsId(AssetId? builderOptionsId) =>
+      _$this._builderOptionsId = builderOptionsId;
+
+  int? _phaseNumber;
+  int? get phaseNumber => _$this._phaseNumber;
+  set phaseNumber(int? phaseNumber) => _$this._phaseNumber = phaseNumber;
+
+  bool? _isHidden;
+  bool? get isHidden => _$this._isHidden;
+  set isHidden(bool? isHidden) => _$this._isHidden = isHidden;
+
+  GeneratedNodeConfigurationBuilder();
+
+  GeneratedNodeConfigurationBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _primaryInput = $v.primaryInput;
+      _builderOptionsId = $v.builderOptionsId;
+      _phaseNumber = $v.phaseNumber;
+      _isHidden = $v.isHidden;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GeneratedNodeConfiguration other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GeneratedNodeConfiguration;
+  }
+
+  @override
+  void update(void Function(GeneratedNodeConfigurationBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GeneratedNodeConfiguration build() => _build();
+
+  _$GeneratedNodeConfiguration _build() {
+    final _$result =
+        _$v ??
+        new _$GeneratedNodeConfiguration._(
+          primaryInput: BuiltValueNullFieldError.checkNotNull(
+            primaryInput,
+            r'GeneratedNodeConfiguration',
+            'primaryInput',
+          ),
+          builderOptionsId: BuiltValueNullFieldError.checkNotNull(
+            builderOptionsId,
+            r'GeneratedNodeConfiguration',
+            'builderOptionsId',
+          ),
+          phaseNumber: BuiltValueNullFieldError.checkNotNull(
+            phaseNumber,
+            r'GeneratedNodeConfiguration',
+            'phaseNumber',
+          ),
+          isHidden: BuiltValueNullFieldError.checkNotNull(
+            isHidden,
+            r'GeneratedNodeConfiguration',
+            'isHidden',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GeneratedNodeState extends GeneratedNodeState {
+  @override
+  final BuiltSet<AssetId> inputs;
+  @override
+  final PendingBuildAction pendingBuildAction;
+  @override
+  final bool wasOutput;
+  @override
+  final bool isFailure;
+  @override
+  final Digest? previousInputsDigest;
+
+  factory _$GeneratedNodeState([
+    void Function(GeneratedNodeStateBuilder)? updates,
+  ]) => (new GeneratedNodeStateBuilder()..update(updates))._build();
+
+  _$GeneratedNodeState._({
+    required this.inputs,
+    required this.pendingBuildAction,
+    required this.wasOutput,
+    required this.isFailure,
+    this.previousInputsDigest,
+  }) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+      inputs,
+      r'GeneratedNodeState',
+      'inputs',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      pendingBuildAction,
+      r'GeneratedNodeState',
+      'pendingBuildAction',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      wasOutput,
+      r'GeneratedNodeState',
+      'wasOutput',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      isFailure,
+      r'GeneratedNodeState',
+      'isFailure',
+    );
+  }
+
+  @override
+  GeneratedNodeState rebuild(
+    void Function(GeneratedNodeStateBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  GeneratedNodeStateBuilder toBuilder() =>
+      new GeneratedNodeStateBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GeneratedNodeState &&
+        inputs == other.inputs &&
+        pendingBuildAction == other.pendingBuildAction &&
+        wasOutput == other.wasOutput &&
+        isFailure == other.isFailure &&
+        previousInputsDigest == other.previousInputsDigest;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, inputs.hashCode);
+    _$hash = $jc(_$hash, pendingBuildAction.hashCode);
+    _$hash = $jc(_$hash, wasOutput.hashCode);
+    _$hash = $jc(_$hash, isFailure.hashCode);
+    _$hash = $jc(_$hash, previousInputsDigest.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GeneratedNodeState')
+          ..add('inputs', inputs)
+          ..add('pendingBuildAction', pendingBuildAction)
+          ..add('wasOutput', wasOutput)
+          ..add('isFailure', isFailure)
+          ..add('previousInputsDigest', previousInputsDigest))
+        .toString();
+  }
+}
+
+class GeneratedNodeStateBuilder
+    implements Builder<GeneratedNodeState, GeneratedNodeStateBuilder> {
+  _$GeneratedNodeState? _$v;
+
+  SetBuilder<AssetId>? _inputs;
+  SetBuilder<AssetId> get inputs =>
+      _$this._inputs ??= new SetBuilder<AssetId>();
+  set inputs(SetBuilder<AssetId>? inputs) => _$this._inputs = inputs;
+
+  PendingBuildAction? _pendingBuildAction;
+  PendingBuildAction? get pendingBuildAction => _$this._pendingBuildAction;
+  set pendingBuildAction(PendingBuildAction? pendingBuildAction) =>
+      _$this._pendingBuildAction = pendingBuildAction;
+
+  bool? _wasOutput;
+  bool? get wasOutput => _$this._wasOutput;
+  set wasOutput(bool? wasOutput) => _$this._wasOutput = wasOutput;
+
+  bool? _isFailure;
+  bool? get isFailure => _$this._isFailure;
+  set isFailure(bool? isFailure) => _$this._isFailure = isFailure;
+
+  Digest? _previousInputsDigest;
+  Digest? get previousInputsDigest => _$this._previousInputsDigest;
+  set previousInputsDigest(Digest? previousInputsDigest) =>
+      _$this._previousInputsDigest = previousInputsDigest;
+
+  GeneratedNodeStateBuilder();
+
+  GeneratedNodeStateBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _inputs = $v.inputs.toBuilder();
+      _pendingBuildAction = $v.pendingBuildAction;
+      _wasOutput = $v.wasOutput;
+      _isFailure = $v.isFailure;
+      _previousInputsDigest = $v.previousInputsDigest;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GeneratedNodeState other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GeneratedNodeState;
+  }
+
+  @override
+  void update(void Function(GeneratedNodeStateBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GeneratedNodeState build() => _build();
+
+  _$GeneratedNodeState _build() {
+    _$GeneratedNodeState _$result;
+    try {
+      _$result =
+          _$v ??
+          new _$GeneratedNodeState._(
+            inputs: inputs.build(),
+            pendingBuildAction: BuiltValueNullFieldError.checkNotNull(
+              pendingBuildAction,
+              r'GeneratedNodeState',
+              'pendingBuildAction',
+            ),
+            wasOutput: BuiltValueNullFieldError.checkNotNull(
+              wasOutput,
+              r'GeneratedNodeState',
+              'wasOutput',
+            ),
+            isFailure: BuiltValueNullFieldError.checkNotNull(
+              isFailure,
+              r'GeneratedNodeState',
+              'isFailure',
+            ),
+            previousInputsDigest: previousInputsDigest,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'inputs';
+        inputs.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+          r'GeneratedNodeState',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GlobNodeConfiguration extends GlobNodeConfiguration {
+  @override
+  final Glob glob;
+  @override
+  final int phaseNumber;
+
+  factory _$GlobNodeConfiguration([
+    void Function(GlobNodeConfigurationBuilder)? updates,
+  ]) => (new GlobNodeConfigurationBuilder()..update(updates))._build();
+
+  _$GlobNodeConfiguration._({required this.glob, required this.phaseNumber})
+    : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+      glob,
+      r'GlobNodeConfiguration',
+      'glob',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      phaseNumber,
+      r'GlobNodeConfiguration',
+      'phaseNumber',
+    );
+  }
+
+  @override
+  GlobNodeConfiguration rebuild(
+    void Function(GlobNodeConfigurationBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  GlobNodeConfigurationBuilder toBuilder() =>
+      new GlobNodeConfigurationBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GlobNodeConfiguration &&
+        glob == other.glob &&
+        phaseNumber == other.phaseNumber;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, glob.hashCode);
+    _$hash = $jc(_$hash, phaseNumber.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GlobNodeConfiguration')
+          ..add('glob', glob)
+          ..add('phaseNumber', phaseNumber))
+        .toString();
+  }
+}
+
+class GlobNodeConfigurationBuilder
+    implements Builder<GlobNodeConfiguration, GlobNodeConfigurationBuilder> {
+  _$GlobNodeConfiguration? _$v;
+
+  Glob? _glob;
+  Glob? get glob => _$this._glob;
+  set glob(Glob? glob) => _$this._glob = glob;
+
+  int? _phaseNumber;
+  int? get phaseNumber => _$this._phaseNumber;
+  set phaseNumber(int? phaseNumber) => _$this._phaseNumber = phaseNumber;
+
+  GlobNodeConfigurationBuilder();
+
+  GlobNodeConfigurationBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _glob = $v.glob;
+      _phaseNumber = $v.phaseNumber;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GlobNodeConfiguration other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GlobNodeConfiguration;
+  }
+
+  @override
+  void update(void Function(GlobNodeConfigurationBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GlobNodeConfiguration build() => _build();
+
+  _$GlobNodeConfiguration _build() {
+    final _$result =
+        _$v ??
+        new _$GlobNodeConfiguration._(
+          glob: BuiltValueNullFieldError.checkNotNull(
+            glob,
+            r'GlobNodeConfiguration',
+            'glob',
+          ),
+          phaseNumber: BuiltValueNullFieldError.checkNotNull(
+            phaseNumber,
+            r'GlobNodeConfiguration',
+            'phaseNumber',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GlobNodeState extends GlobNodeState {
+  @override
+  final BuiltSet<AssetId> inputs;
+  @override
+  final PendingBuildAction pendingBuildAction;
+  @override
+  final BuiltList<AssetId> results;
+
+  factory _$GlobNodeState([void Function(GlobNodeStateBuilder)? updates]) =>
+      (new GlobNodeStateBuilder()..update(updates))._build();
+
+  _$GlobNodeState._({
+    required this.inputs,
+    required this.pendingBuildAction,
+    required this.results,
+  }) : super._() {
+    BuiltValueNullFieldError.checkNotNull(inputs, r'GlobNodeState', 'inputs');
+    BuiltValueNullFieldError.checkNotNull(
+      pendingBuildAction,
+      r'GlobNodeState',
+      'pendingBuildAction',
+    );
+    BuiltValueNullFieldError.checkNotNull(results, r'GlobNodeState', 'results');
+  }
+
+  @override
+  GlobNodeState rebuild(void Function(GlobNodeStateBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GlobNodeStateBuilder toBuilder() => new GlobNodeStateBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GlobNodeState &&
+        inputs == other.inputs &&
+        pendingBuildAction == other.pendingBuildAction &&
+        results == other.results;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, inputs.hashCode);
+    _$hash = $jc(_$hash, pendingBuildAction.hashCode);
+    _$hash = $jc(_$hash, results.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GlobNodeState')
+          ..add('inputs', inputs)
+          ..add('pendingBuildAction', pendingBuildAction)
+          ..add('results', results))
+        .toString();
+  }
+}
+
+class GlobNodeStateBuilder
+    implements Builder<GlobNodeState, GlobNodeStateBuilder> {
+  _$GlobNodeState? _$v;
+
+  SetBuilder<AssetId>? _inputs;
+  SetBuilder<AssetId> get inputs =>
+      _$this._inputs ??= new SetBuilder<AssetId>();
+  set inputs(SetBuilder<AssetId>? inputs) => _$this._inputs = inputs;
+
+  PendingBuildAction? _pendingBuildAction;
+  PendingBuildAction? get pendingBuildAction => _$this._pendingBuildAction;
+  set pendingBuildAction(PendingBuildAction? pendingBuildAction) =>
+      _$this._pendingBuildAction = pendingBuildAction;
+
+  ListBuilder<AssetId>? _results;
+  ListBuilder<AssetId> get results =>
+      _$this._results ??= new ListBuilder<AssetId>();
+  set results(ListBuilder<AssetId>? results) => _$this._results = results;
+
+  GlobNodeStateBuilder();
+
+  GlobNodeStateBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _inputs = $v.inputs.toBuilder();
+      _pendingBuildAction = $v.pendingBuildAction;
+      _results = $v.results.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GlobNodeState other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GlobNodeState;
+  }
+
+  @override
+  void update(void Function(GlobNodeStateBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GlobNodeState build() => _build();
+
+  _$GlobNodeState _build() {
+    _$GlobNodeState _$result;
+    try {
+      _$result =
+          _$v ??
+          new _$GlobNodeState._(
+            inputs: inputs.build(),
+            pendingBuildAction: BuiltValueNullFieldError.checkNotNull(
+              pendingBuildAction,
+              r'GlobNodeState',
+              'pendingBuildAction',
+            ),
+            results: results.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'inputs';
+        inputs.build();
+
+        _$failedField = 'results';
+        results.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+          r'GlobNodeState',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$PostProcessAnchorNodeConfiguration
+    extends PostProcessAnchorNodeConfiguration {
+  @override
+  final int actionNumber;
+  @override
+  final AssetId builderOptionsId;
+  @override
+  final AssetId primaryInput;
+
+  factory _$PostProcessAnchorNodeConfiguration([
+    void Function(PostProcessAnchorNodeConfigurationBuilder)? updates,
+  ]) =>
+      (new PostProcessAnchorNodeConfigurationBuilder()..update(updates))
+          ._build();
+
+  _$PostProcessAnchorNodeConfiguration._({
+    required this.actionNumber,
+    required this.builderOptionsId,
+    required this.primaryInput,
+  }) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+      actionNumber,
+      r'PostProcessAnchorNodeConfiguration',
+      'actionNumber',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      builderOptionsId,
+      r'PostProcessAnchorNodeConfiguration',
+      'builderOptionsId',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      primaryInput,
+      r'PostProcessAnchorNodeConfiguration',
+      'primaryInput',
+    );
+  }
+
+  @override
+  PostProcessAnchorNodeConfiguration rebuild(
+    void Function(PostProcessAnchorNodeConfigurationBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  PostProcessAnchorNodeConfigurationBuilder toBuilder() =>
+      new PostProcessAnchorNodeConfigurationBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PostProcessAnchorNodeConfiguration &&
+        actionNumber == other.actionNumber &&
+        builderOptionsId == other.builderOptionsId &&
+        primaryInput == other.primaryInput;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, actionNumber.hashCode);
+    _$hash = $jc(_$hash, builderOptionsId.hashCode);
+    _$hash = $jc(_$hash, primaryInput.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PostProcessAnchorNodeConfiguration')
+          ..add('actionNumber', actionNumber)
+          ..add('builderOptionsId', builderOptionsId)
+          ..add('primaryInput', primaryInput))
+        .toString();
+  }
+}
+
+class PostProcessAnchorNodeConfigurationBuilder
+    implements
+        Builder<
+          PostProcessAnchorNodeConfiguration,
+          PostProcessAnchorNodeConfigurationBuilder
+        > {
+  _$PostProcessAnchorNodeConfiguration? _$v;
+
+  int? _actionNumber;
+  int? get actionNumber => _$this._actionNumber;
+  set actionNumber(int? actionNumber) => _$this._actionNumber = actionNumber;
+
+  AssetId? _builderOptionsId;
+  AssetId? get builderOptionsId => _$this._builderOptionsId;
+  set builderOptionsId(AssetId? builderOptionsId) =>
+      _$this._builderOptionsId = builderOptionsId;
+
+  AssetId? _primaryInput;
+  AssetId? get primaryInput => _$this._primaryInput;
+  set primaryInput(AssetId? primaryInput) =>
+      _$this._primaryInput = primaryInput;
+
+  PostProcessAnchorNodeConfigurationBuilder();
+
+  PostProcessAnchorNodeConfigurationBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _actionNumber = $v.actionNumber;
+      _builderOptionsId = $v.builderOptionsId;
+      _primaryInput = $v.primaryInput;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PostProcessAnchorNodeConfiguration other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PostProcessAnchorNodeConfiguration;
+  }
+
+  @override
+  void update(
+    void Function(PostProcessAnchorNodeConfigurationBuilder)? updates,
+  ) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PostProcessAnchorNodeConfiguration build() => _build();
+
+  _$PostProcessAnchorNodeConfiguration _build() {
+    final _$result =
+        _$v ??
+        new _$PostProcessAnchorNodeConfiguration._(
+          actionNumber: BuiltValueNullFieldError.checkNotNull(
+            actionNumber,
+            r'PostProcessAnchorNodeConfiguration',
+            'actionNumber',
+          ),
+          builderOptionsId: BuiltValueNullFieldError.checkNotNull(
+            builderOptionsId,
+            r'PostProcessAnchorNodeConfiguration',
+            'builderOptionsId',
+          ),
+          primaryInput: BuiltValueNullFieldError.checkNotNull(
+            primaryInput,
+            r'PostProcessAnchorNodeConfiguration',
+            'primaryInput',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$PostProcessAnchorNodeState extends PostProcessAnchorNodeState {
+  @override
+  final Digest? previousInputsDigest;
+
+  factory _$PostProcessAnchorNodeState([
+    void Function(PostProcessAnchorNodeStateBuilder)? updates,
+  ]) => (new PostProcessAnchorNodeStateBuilder()..update(updates))._build();
+
+  _$PostProcessAnchorNodeState._({this.previousInputsDigest}) : super._();
+
+  @override
+  PostProcessAnchorNodeState rebuild(
+    void Function(PostProcessAnchorNodeStateBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  PostProcessAnchorNodeStateBuilder toBuilder() =>
+      new PostProcessAnchorNodeStateBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PostProcessAnchorNodeState &&
+        previousInputsDigest == other.previousInputsDigest;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, previousInputsDigest.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PostProcessAnchorNodeState')
+      ..add('previousInputsDigest', previousInputsDigest)).toString();
+  }
+}
+
+class PostProcessAnchorNodeStateBuilder
+    implements
+        Builder<PostProcessAnchorNodeState, PostProcessAnchorNodeStateBuilder> {
+  _$PostProcessAnchorNodeState? _$v;
+
+  Digest? _previousInputsDigest;
+  Digest? get previousInputsDigest => _$this._previousInputsDigest;
+  set previousInputsDigest(Digest? previousInputsDigest) =>
+      _$this._previousInputsDigest = previousInputsDigest;
+
+  PostProcessAnchorNodeStateBuilder();
+
+  PostProcessAnchorNodeStateBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _previousInputsDigest = $v.previousInputsDigest;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PostProcessAnchorNodeState other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PostProcessAnchorNodeState;
+  }
+
+  @override
+  void update(void Function(PostProcessAnchorNodeStateBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PostProcessAnchorNodeState build() => _build();
+
+  _$PostProcessAnchorNodeState _build() {
+    final _$result =
+        _$v ??
+        new _$PostProcessAnchorNodeState._(
+          previousInputsDigest: previousInputsDigest,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/build_runner_core/lib/src/asset_graph/optional_output_tracker.dart
+++ b/build_runner_core/lib/src/asset_graph/optional_output_tracker.dart
@@ -58,7 +58,7 @@ class OptionalOutputTracker {
 
     final node = _assetGraph.get(output)!;
     if (node.type != NodeType.generated) return true;
-    final nodeConfiguration = node.generatedNodeConfiguration;
+    final nodeConfiguration = node.generatedNodeConfiguration!;
     final phase = _buildPhases[nodeConfiguration.phaseNumber];
     if (!phase.isOptional &&
         shouldBuildForDirs(
@@ -78,8 +78,8 @@ class OptionalOutputTracker {
               .outputsForPhase(output.package, nodeConfiguration.phaseNumber)
               .where(
                 (n) =>
-                    n.generatedNodeConfiguration.primaryInput ==
-                    node.generatedNodeConfiguration.primaryInput,
+                    n.generatedNodeConfiguration!.primaryInput ==
+                    node.generatedNodeConfiguration!.primaryInput,
               )
               .map((n) => n.id)
               .any((o) => isRequired(o, currentlyChecking)),

--- a/build_runner_core/lib/src/changes/build_script_updates.dart
+++ b/build_runner_core/lib/src/changes/build_script_updates.dart
@@ -73,7 +73,13 @@ class _MirrorBuildScriptUpdates implements BuildScriptUpdates {
       } else {
         // Make sure we are tracking changes for all ids in [allSources].
         for (var id in allSources) {
-          graph.get(id)!.mutate.lastKnownDigest ??= await reader.digest(id);
+          final node = graph.get(id)!;
+          if (node.lastKnownDigest == null) {
+            final digest = await reader.digest(id);
+            graph.updateNode(id, (nodeBuilder) {
+              nodeBuilder.lastKnownDigest = digest;
+            });
+          }
         }
       }
     } on ArgumentError // ignore: avoid_catching_errors

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -155,7 +155,7 @@ class AssetTracker {
         .where((n) {
           if (!n.isFile) return false;
           if (n.type == NodeType.generated) {
-            return n.generatedNodeState.wasOutput;
+            return n.generatedNodeState!.wasOutput;
           }
           return true;
         })
@@ -508,8 +508,8 @@ class _Loader {
         await Future.wait(
           graph.outputs.map((id) {
             var node = graph.get(id)!;
-            final nodeConfiguration = node.generatedNodeConfiguration;
-            final nodeState = node.generatedNodeState;
+            final nodeConfiguration = node.generatedNodeConfiguration!;
+            final nodeState = node.generatedNodeState!;
             if (nodeState.wasOutput && !nodeConfiguration.isHidden) {
               var idToDelete = id;
               // If the package no longer exists, then the user must have
@@ -604,20 +604,19 @@ class _Loader {
       AssetId builderOptionsId,
       BuilderOptions options,
     ) {
-      var builderOptionsNode = assetGraph.get(builderOptionsId)!;
-      if (builderOptionsNode.type != NodeType.builderOptions) {
-        throw StateError(
-          'Expected node of type NodeType.builderOptionsNode:'
-          '$builderOptionsNode',
-        );
-      }
-      var oldDigest = builderOptionsNode.lastKnownDigest;
-      builderOptionsNode.mutate.lastKnownDigest = computeBuilderOptionsDigest(
-        options,
-      );
-      if (builderOptionsNode.lastKnownDigest != oldDigest) {
-        result[builderOptionsId] = ChangeType.MODIFY;
-      }
+      assetGraph.updateNode(builderOptionsId, (nodeBuilder) {
+        if (nodeBuilder.type != NodeType.builderOptions) {
+          throw StateError(
+            'Expected node of type NodeType.builderOptionsNode:'
+            '${nodeBuilder.build()}',
+          );
+        }
+        var oldDigest = nodeBuilder.lastKnownDigest;
+        nodeBuilder.lastKnownDigest = computeBuilderOptionsDigest(options);
+        if (nodeBuilder.lastKnownDigest != oldDigest) {
+          result[builderOptionsId] = ChangeType.MODIFY;
+        }
+      });
     }
 
     for (var phase = 0; phase < buildPhases.length; phase++) {

--- a/build_runner_core/lib/src/generate/build_impl.dart
+++ b/build_runner_core/lib/src/generate/build_impl.dart
@@ -410,16 +410,18 @@ class _SingleBuild {
       if (!_targetGraph.isVisibleInBuild(node.id, packageNode)) continue;
 
       var input =
-          _assetGraph.get(node.generatedNodeConfiguration.primaryInput)!;
+          _assetGraph.get(node.generatedNodeConfiguration!.primaryInput)!;
       if (input.type == NodeType.generated) {
-        final inputState = input.generatedNodeState;
+        var inputState = input.generatedNodeState!;
         if (inputState.pendingBuildAction != PendingBuildAction.none) {
-          final inputConfiguration = input.generatedNodeConfiguration;
+          final inputConfiguration = input.generatedNodeConfiguration!;
           await _runLazyPhaseForInput(
             inputConfiguration.phaseNumber,
             inputConfiguration.primaryInput,
           );
         }
+        // Read the result of the build.
+        inputState = _assetGraph.get(input.id)!.generatedNodeState!;
         if (!inputState.wasOutput) continue;
         if (inputState.isFailure) continue;
       }
@@ -455,15 +457,17 @@ class _SingleBuild {
       // actually output. If it wasn't then we just return an empty list here.
       var inputNode = _assetGraph.get(input)!;
       if (inputNode.type == NodeType.generated) {
-        final nodeState = inputNode.generatedNodeState;
+        var nodeState = inputNode.generatedNodeState!;
         // Make sure the `inputNode` is up to date, and rebuild it if not.
         if (nodeState.pendingBuildAction != PendingBuildAction.none) {
-          final nodeConfiguration = inputNode.generatedNodeConfiguration;
+          final nodeConfiguration = inputNode.generatedNodeConfiguration!;
           await _runLazyPhaseForInput(
             nodeConfiguration.phaseNumber,
             nodeConfiguration.primaryInput,
           );
         }
+        // Read the result of the build.
+        nodeState = _assetGraph.get(inputNode.id)!.generatedNodeState!;
         if (!nodeState.wasOutput || nodeState.isFailure) return <AssetId>[];
       }
 
@@ -474,10 +478,12 @@ class _SingleBuild {
     });
   }
 
-  Future<void> _buildAsset(AssetNode node) async {
+  Future<void> _buildAsset(AssetId id) async {
+    final node = _assetGraph.get(id)!;
     if (node.type == NodeType.generated &&
-        node.generatedNodeState.pendingBuildAction != PendingBuildAction.none) {
-      final nodeConfiguration = node.generatedNodeConfiguration;
+        node.generatedNodeState!.pendingBuildAction !=
+            PendingBuildAction.none) {
+      final nodeConfiguration = node.generatedNodeConfiguration!;
       await _runLazyPhaseForInput(
         nodeConfiguration.phaseNumber,
         nodeConfiguration.primaryInput,
@@ -501,7 +507,7 @@ class _SingleBuild {
       // Add `builderOutputs` to the primary outputs of the input.
       var inputNode = _assetGraph.get(input)!;
       assert(
-        inputNode.inspect.primaryOutputs.containsAll(builderOutputs),
+        inputNode.primaryOutputs.containsAll(builderOutputs),
         // ignore: prefer_interpolation_to_compose_strings
         'input $input with builder $builder missing primary outputs: \n'
                 'Got ${inputNode.primaryOutputs.join(', ')} '
@@ -623,12 +629,12 @@ class _SingleBuild {
         .packageNodes(action.package)
         .toList(growable: false)) {
       if (node.type != NodeType.postProcessAnchor) continue;
-      final nodeConfiguration = node.postProcessAnchorNodeConfiguration;
+      final nodeConfiguration = node.postProcessAnchorNodeConfiguration!;
       if (nodeConfiguration.actionNumber != actionNum) continue;
       final inputNode = _assetGraph.get(nodeConfiguration.primaryInput)!;
       if (inputNode.type == NodeType.source ||
           inputNode.type == NodeType.generated &&
-              inputNode.generatedNodeState.isSuccessfulFreshOutput) {
+              inputNode.generatedNodeState!.isSuccessfulFreshOutput) {
         outputs.addAll(
           await _runPostProcessBuilderForAnchor(
             phaseNum,
@@ -648,7 +654,7 @@ class _SingleBuild {
     PostProcessBuilder builder,
     AssetNode anchorNode,
   ) async {
-    var input = anchorNode.postProcessAnchorNodeConfiguration.primaryInput;
+    var input = anchorNode.postProcessAnchorNodeConfiguration!.primaryInput;
     var inputNode = _assetGraph.get(input)!;
     var readerWriter = SingleStepReaderWriter(
       runningBuild: RunningBuild(
@@ -680,8 +686,12 @@ class _SingleBuild {
     for (final output in anchorNode.outputs.toList(growable: false)) {
       _assetGraph.remove(output);
     }
-    anchorNode.mutate.outputs.clear();
-    inputNode.mutate.deletedBy.remove(anchorNode.id);
+    _assetGraph.updateNode(anchorNode.id, (nodeBuilder) {
+      nodeBuilder.outputs.clear();
+    });
+    _assetGraph.updateNode(inputNode.id, (nodeBuilder) {
+      nodeBuilder.deletedBy.remove(anchorNode.id);
+    });
 
     var actionDescription = '$builder on $input';
     var logger = BuildForInputLogger(Logger(actionDescription));
@@ -705,15 +715,17 @@ class _SingleBuild {
           assetId,
           primaryInput: input,
           builderOptionsId:
-              anchorNode.postProcessAnchorNodeConfiguration.builderOptionsId,
+              anchorNode.postProcessAnchorNodeConfiguration!.builderOptionsId,
           isHidden: true,
           phaseNumber: phaseNumber,
           wasOutput: true,
           isFailure: false,
-          state: PendingBuildAction.none,
+          pendingBuildAction: PendingBuildAction.none,
         );
         _assetGraph.add(node);
-        anchorNode.mutate.outputs.add(assetId);
+        _assetGraph.updateNode(anchorNode.id, (nodeBuilder) {
+          nodeBuilder.outputs.add(assetId);
+        });
       },
       deleteAsset: (assetId) {
         if (!_assetGraph.contains(assetId)) {
@@ -725,7 +737,9 @@ class _SingleBuild {
             'Can only delete primary input',
           );
         }
-        _assetGraph.get(assetId)!.mutate.deletedBy.add(anchorNode.id);
+        _assetGraph.updateNode(assetId, (nodeBuilder) {
+          nodeBuilder.deletedBy.add(anchorNode.id);
+        });
       },
     ).catchError((void _) {
       // Errors tracked through the logger
@@ -738,7 +752,10 @@ class _SingleBuild {
 
     // Reset the state for all the output nodes based on what was read and
     // written.
-    inputNode.mutate.primaryOutputs.addAll(assetsWritten);
+    _assetGraph.updateNode(inputNode.id, (nodeBuilder) {
+      nodeBuilder.primaryOutputs.addAll(assetsWritten);
+    });
+
     await _setOutputsState(
       input,
       assetsWritten,
@@ -766,7 +783,7 @@ class _SingleBuild {
     // We check if any output definitely needs an update - its possible during
     // manual deletions that only one of the outputs would be marked.
     for (var output in outputs.skip(1)) {
-      if (_assetGraph.get(output)!.generatedNodeState.pendingBuildAction ==
+      if (_assetGraph.get(output)!.generatedNodeState!.pendingBuildAction ==
           PendingBuildAction.build) {
         return true;
       }
@@ -782,15 +799,15 @@ class _SingleBuild {
             (output) =>
                 _assetGraph
                     .get(output)!
-                    .generatedNodeState
+                    .generatedNodeState!
                     .inputs
-                    .difference(firstNode.generatedNodeState.inputs)
+                    .difference(firstNode.generatedNodeState!.inputs)
                     .isEmpty,
           ),
       'All outputs of a build action should share the same inputs.',
     );
 
-    final firstNodeState = firstNode.generatedNodeState;
+    final firstNodeState = firstNode.generatedNodeState!;
 
     // No need to build an up to date output
     if (firstNodeState.pendingBuildAction == PendingBuildAction.none) {
@@ -806,7 +823,7 @@ class _SingleBuild {
 
     var digest = await _computeCombinedDigest(
       firstNodeState.inputs,
-      firstNode.generatedNodeConfiguration.builderOptionsId,
+      firstNode.generatedNodeConfiguration!.builderOptionsId,
       reader,
     );
     if (digest != firstNodeState.previousInputsDigest) {
@@ -814,12 +831,15 @@ class _SingleBuild {
     } else {
       // Make sure to update the `state` field for all outputs.
       for (var id in outputs) {
-        final node = _assetGraph.get(id)!;
-        if (node.type == NodeType.generated) {
-          node.generatedNodeState.pendingBuildAction = PendingBuildAction.none;
-        } else if (node.type == NodeType.glob) {
-          node.globNodeState.pendingBuildAction = PendingBuildAction.none;
-        }
+        _assetGraph.updateNode(id, (nodeBuilder) {
+          if (nodeBuilder.type == NodeType.generated) {
+            nodeBuilder.generatedNodeState.pendingBuildAction =
+                PendingBuildAction.none;
+          } else if (nodeBuilder.type == NodeType.glob) {
+            nodeBuilder.globNodeState.pendingBuildAction =
+                PendingBuildAction.none;
+          }
+        });
       }
       return false;
     }
@@ -830,16 +850,19 @@ class _SingleBuild {
     AssetNode anchorNode,
     AssetReader reader,
   ) async {
-    final nodeConfiguration = anchorNode.postProcessAnchorNodeConfiguration;
+    final nodeConfiguration = anchorNode.postProcessAnchorNodeConfiguration!;
     var inputsDigest = await _computeCombinedDigest(
       [nodeConfiguration.primaryInput],
       nodeConfiguration.builderOptionsId,
       reader,
     );
 
-    final nodeState = anchorNode.postProcessAnchorNodeState;
+    final nodeState = anchorNode.postProcessAnchorNodeState!;
     if (inputsDigest != nodeState.previousInputsDigest) {
-      nodeState.previousInputsDigest = inputsDigest;
+      _assetGraph.updateNode(anchorNode.id, (nodeBuilder) {
+        nodeBuilder.postProcessAnchorNodeState.previousInputsDigest =
+            inputsDigest;
+      });
       return true;
     }
 
@@ -855,60 +878,63 @@ class _SingleBuild {
     for (final output in outputs) {
       final node = _assetGraph.get(output)!;
       if (node.type == NodeType.generated &&
-          node.generatedNodeState.wasOutput) {
+          node.generatedNodeState!.wasOutput) {
         await _delete(output);
       }
     }
   }
 
-  Future<void> _buildGlobNode(AssetNode globNode) async {
-    if (globNode.globNodeState.pendingBuildAction == PendingBuildAction.none) {
+  Future<void> _buildGlobNode(AssetId id) async {
+    if (_assetGraph.get(id)!.globNodeState!.pendingBuildAction ==
+        PendingBuildAction.none) {
       return;
     }
 
-    return _lazyGlobs.putIfAbsent(globNode.id, () async {
-      var potentialNodes =
+    return _lazyGlobs.putIfAbsent(id, () async {
+      final globNodeConfiguration = _assetGraph.get(id)!.globNodeConfiguration!;
+      var potentialIds =
           _assetGraph
-              .packageNodes(globNode.id.package)
+              .packageNodes(id.package)
               .where((n) => n.isFile && n.isTrackedInput)
               .where(
                 (n) =>
                     n.type != NodeType.generated ||
-                    n.generatedNodeConfiguration.phaseNumber <
-                        globNode.globNodeConfiguration.phaseNumber,
+                    n.generatedNodeConfiguration!.phaseNumber <
+                        globNodeConfiguration.phaseNumber,
               )
-              .where(
-                (n) => globNode.globNodeConfiguration.glob.matches(n.id.path),
-              )
+              .where((n) => globNodeConfiguration.glob.matches(n.id.path))
+              .map((node) => node.id)
               .toList();
 
-      for (final node in potentialNodes) {
+      for (final potentialId in potentialIds) {
+        final node = _assetGraph.get(potentialId)!;
         if (node.type == NodeType.generated) {
-          await _buildAsset(node);
+          await _buildAsset(node.id);
         }
       }
 
       var actualMatches = <AssetId>[];
-      for (var node in potentialNodes) {
-        node.mutate.outputs.add(globNode.id);
+      for (var potentialId in potentialIds) {
+        final node = _assetGraph.updateNode(potentialId, (nodeBuilder) {
+          nodeBuilder.outputs.add(id);
+        });
         if (node.type == NodeType.generated &&
-            (!node.generatedNodeState.wasOutput ||
-                node.generatedNodeState.isFailure)) {
+            (!node.generatedNodeState!.wasOutput ||
+                node.generatedNodeState!.isFailure)) {
           continue;
         }
-        actualMatches.add(node.id);
+        actualMatches.add(potentialId);
       }
 
-      globNode.globNodeState
-        ..results = actualMatches
-        ..inputs = HashSet.of(potentialNodes.map((n) => n.id))
-        ..pendingBuildAction = PendingBuildAction.none;
-      globNode.mutate.lastKnownDigest = md5.convert(
-        utf8.encode(actualMatches.join(' ')),
-      );
+      _assetGraph.updateNode(id, (nodeBuilder) {
+        nodeBuilder
+          ..globNodeState.results.replace(actualMatches)
+          ..globNodeState.inputs.replace(potentialIds)
+          ..globNodeState.pendingBuildAction = PendingBuildAction.none
+          ..lastKnownDigest = md5.convert(utf8.encode(actualMatches.join(' ')));
+      });
 
-      // TODO: remove ?? fallback after 2.15 sdk.
-      unawaited(_lazyGlobs.remove(globNode.id) ?? Future.value());
+      unawaited(_lazyGlobs.remove(id));
     });
   }
 
@@ -933,7 +959,8 @@ class _SingleBuild {
     for (final id in ids) {
       var node = _assetGraph.get(id)!;
       if (node.type == NodeType.glob) {
-        await _buildGlobNode(node);
+        await _buildGlobNode(node.id);
+        node = _assetGraph.get(id)!;
       } else if (!await reader.canRead(id)) {
         // We want to add something here, a missing/unreadable input should be
         // different from no input at all.
@@ -943,8 +970,11 @@ class _SingleBuild {
         continue;
       } else {
         if (node.lastKnownDigest == null) {
+          final digest = await reader.digest(id);
           await reader.cache.invalidate([id]);
-          node.mutate.lastKnownDigest = await reader.digest(id);
+          node = _assetGraph.updateNode(node.id, (nodeBuilder) {
+            nodeBuilder.lastKnownDigest = digest;
+          });
         }
       }
       combine(node.lastKnownDigest!.bytes as Uint8List);
@@ -981,7 +1011,7 @@ class _SingleBuild {
       usedInputs,
       _assetGraph
           .get(outputs.first)!
-          .generatedNodeConfiguration
+          .generatedNodeConfiguration!
           .builderOptionsId,
       readerWriter,
     );
@@ -991,68 +1021,81 @@ class _SingleBuild {
     for (var output in outputs) {
       var wasOutput = readerWriter.assetsWritten.contains(output);
       var digest = wasOutput ? await _readerWriter.digest(output) : null;
-      var node = _assetGraph.get(output)!;
 
-      // **IMPORTANT**: All updates to `node` must be synchronous. With lazy
-      // builders we can run arbitrary code between updates otherwise, at which
-      // time a node might not be in a valid state.
-      _removeOldInputs(node, usedInputs);
-      _addNewInputs(node, usedInputs);
-      final nodeState = node.generatedNodeState;
-      nodeState
-        ..pendingBuildAction = PendingBuildAction.none
-        ..wasOutput = wasOutput
-        ..isFailure = isFailure
-        ..previousInputsDigest = inputsDigest;
-      node.mutate.lastKnownDigest = digest;
+      _removeOldInputs(output, usedInputs);
+      _addNewInputs(output, usedInputs);
+      _assetGraph.updateNode(output, (nodeBuilder) {
+        nodeBuilder.generatedNodeState
+          ..pendingBuildAction = PendingBuildAction.none
+          ..wasOutput = wasOutput
+          ..isFailure = isFailure
+          ..previousInputsDigest = inputsDigest;
+        nodeBuilder.lastKnownDigest = digest;
+      });
 
       if (isFailure) {
+        final node = _assetGraph.get(output)!;
         await _failureReporter.markReported(actionDescription, node, errors);
         var needsMarkAsFailure = Queue.of(node.primaryOutputs);
-        var allSkippedFailures = <AssetNode>[];
+        var allSkippedFailures = <AssetId>[];
         while (needsMarkAsFailure.isNotEmpty) {
           var output = needsMarkAsFailure.removeLast();
-          var outputNode = _assetGraph.get(output)!;
-          outputNode.generatedNodeState
-            ..pendingBuildAction = PendingBuildAction.none
-            ..wasOutput = false
-            ..isFailure = true
-            ..previousInputsDigest = null;
-          outputNode.mutate.lastKnownDigest = null;
-          allSkippedFailures.add(outputNode);
-          needsMarkAsFailure.addAll(outputNode.primaryOutputs);
+          _assetGraph.updateNode(output, (nodeBuilder) {
+            nodeBuilder.generatedNodeState
+              ..pendingBuildAction = PendingBuildAction.none
+              ..wasOutput = false
+              ..isFailure = true
+              ..previousInputsDigest = null;
+            nodeBuilder.lastKnownDigest = null;
+          });
+          allSkippedFailures.add(output);
+          needsMarkAsFailure.addAll(_assetGraph.get(output)!.primaryOutputs);
 
           // Make sure output invalidation follows primary outputs for builds
-          // that won't run.
-          node.mutate.outputs.add(output);
-          outputNode.generatedNodeState.inputs.add(node.id);
+          // that won't run
+          _assetGraph.updateNode(node.id, (nodeBuilder) {
+            nodeBuilder.outputs.add(output);
+          });
+          _assetGraph.updateNode(output, (nodeBuilder) {
+            nodeBuilder.generatedNodeState.inputs.add(node.id);
+          });
         }
-        await _failureReporter.markSkipped(allSkippedFailures);
+        await _failureReporter.markSkipped(
+          allSkippedFailures.map((id) => _assetGraph.get(id)!),
+        );
       }
     }
   }
 
-  /// Removes old inputs from [node] based on [updatedInputs], and cleans up all
-  /// the old edges.
-  void _removeOldInputs(AssetNode node, Set<AssetId> updatedInputs) {
-    final nodeState = node.generatedNodeState;
-    var removedInputs = nodeState.inputs.difference(updatedInputs);
-    nodeState.inputs.removeAll(removedInputs);
+  /// Removes old inputs from node with [id] based on [updatedInputs], and
+  /// cleans up all the old edges.
+  void _removeOldInputs(AssetId id, Set<AssetId> updatedInputs) {
+    final node = _assetGraph.get(id)!;
+    final nodeState = node.generatedNodeState!;
+    var removedInputs = nodeState.inputs.asSet().difference(updatedInputs);
+    _assetGraph.updateNode(node.id, (nodeBuilder) {
+      nodeBuilder.generatedNodeState.inputs.removeAll(removedInputs);
+    });
     for (var input in removedInputs) {
-      var inputNode = _assetGraph.get(input)!;
-      inputNode.mutate.outputs.remove(node.id);
+      _assetGraph.updateNode(input, (nodeBuilder) {
+        nodeBuilder.outputs.remove(node.id);
+      });
     }
   }
 
-  /// Adds new inputs to [node] based on [updatedInputs], and adds the
+  /// Adds new inputs to node with [id] based on [updatedInputs], and adds the
   /// appropriate edges.
-  void _addNewInputs(AssetNode node, Set<AssetId> updatedInputs) {
-    final nodeState = node.generatedNodeState;
-    var newInputs = updatedInputs.difference(nodeState.inputs);
-    nodeState.inputs.addAll(newInputs);
+  void _addNewInputs(AssetId id, Set<AssetId> updatedInputs) {
+    final node = _assetGraph.get(id)!;
+    final nodeState = node.generatedNodeState!;
+    var newInputs = updatedInputs.difference(nodeState.inputs.asSet());
+    _assetGraph.updateNode(node.id, (nodeBuilder) {
+      nodeBuilder.generatedNodeState.inputs.addAll(newInputs);
+    });
     for (var input in newInputs) {
-      var inputNode = _assetGraph.get(input)!;
-      inputNode.mutate.outputs.add(node.id);
+      _assetGraph.updateNode(input, (nodeBuilder) {
+        nodeBuilder.outputs.add(node.id);
+      });
     }
   }
 

--- a/build_runner_core/lib/src/generate/finalized_assets_view.dart
+++ b/build_runner_core/lib/src/generate/finalized_assets_view.dart
@@ -74,7 +74,7 @@ bool _shouldSkipNode(
 
   if (node.type == NodeType.internal || node.type == NodeType.glob) return true;
   if (node.type == NodeType.generated) {
-    final nodeState = node.generatedNodeState;
+    final nodeState = node.generatedNodeState!;
     if (!nodeState.wasOutput ||
         nodeState.isFailure ||
         nodeState.pendingBuildAction != PendingBuildAction.none) {

--- a/build_runner_core/lib/src/logging/failure_reporter.dart
+++ b/build_runner_core/lib/src/logging/failure_reporter.dart
@@ -76,7 +76,7 @@ class FailureReporter {
   Future<void> markSkipped(Iterable<AssetNode> outputs) => Future.wait(
     outputs.map((output) async {
       if (!_reportedActions.add(_actionKey(output))) return;
-      final outputConfiguration = output.generatedNodeConfiguration;
+      final outputConfiguration = output.generatedNodeConfiguration!;
       await clean(
         outputConfiguration.phaseNumber,
         outputConfiguration.primaryInput,
@@ -124,14 +124,14 @@ class ErrorReport {
 }
 
 String _actionKey(AssetNode node) =>
-    '${node.generatedNodeConfiguration.builderOptionsId} on '
-    '${node.generatedNodeConfiguration.primaryInput}';
+    '${node.generatedNodeConfiguration!.builderOptionsId} on '
+    '${node.generatedNodeConfiguration!.primaryInput}';
 
 String _errorPathForOutput(AssetNode output) => p.joinAll([
   errorCachePath,
   output.id.package,
-  '${output.generatedNodeConfiguration.phaseNumber}',
-  ...p.posix.split(output.generatedNodeConfiguration.primaryInput.path),
+  '${output.generatedNodeConfiguration!.phaseNumber}',
+  ...p.posix.split(output.generatedNodeConfiguration!.primaryInput.path),
 ]);
 
 String _errorPathForPrimaryInput(int phaseNumber, AssetId primaryInput) =>

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   build: ^2.4.3-wip
   build_config: ^1.0.0
   build_resolvers: ^2.4.0
+  built_collection: ^5.1.1
+  built_value: ^8.9.5
   collection: ^1.15.0
   convert: ^3.0.0
   crypto: ^3.0.0
@@ -38,6 +40,7 @@ dev_dependencies:
     path: ../_test_common
   build_runner: ^2.0.0
   build_test: ^3.0.0-wip
+  built_value_generator: ^8.9.5
   dart_flutter_team_lints: ^3.1.0
   json_serializable: ^6.0.0
   test: ^1.16.0

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -49,7 +49,10 @@ void main() {
         [],
         computeDigest(AssetId('a', 'lib/b.txt'), 'b'),
       );
-      deleted.mutate.deletedBy.add(deleted.id.addExtension('.post_anchor.1'));
+
+      deleted = deleted.rebuild(
+        (b) => b..deletedBy.add(deleted.id.addExtension('.post_anchor.1')),
+      );
 
       graph
         ..add(notDeleted)
@@ -68,7 +71,7 @@ void main() {
       var id = AssetId('a', 'web/a.txt');
       var node = AssetNode.generated(
         id,
-        state: PendingBuildAction.none,
+        pendingBuildAction: PendingBuildAction.none,
         phaseNumber: 0,
         wasOutput: true,
         isFailure: true,

--- a/build_runner_core/test/fixtures/workspace/.dart_tool/package_config.json
+++ b/build_runner_core/test/fixtures/workspace/.dart_tool/package_config.json
@@ -5,19 +5,25 @@
       "name": "workspace",
       "rootUri": "../",
       "packageUri": "lib/",
-      "languageVersion": "3.5"
+      "languageVersion": "3.7"
     },
     {
       "name": "a",
       "rootUri": "../pkgs/a",
       "packageUri": "lib/",
-      "languageVersion": "3.5"
+      "languageVersion": "3.7"
     },
     {
       "name": "b",
       "rootUri": "../pkgs/b",
       "packageUri": "lib/",
-      "languageVersion": "3.5"
+      "languageVersion": "3.7"
     }
-  ]
+  ],
+  "generated": "2025-03-06T13:52:35.390409Z",
+  "generator": "pub",
+  "generatorVersion": "3.8.0-edge",
+  "flutterRoot": "file:///usr/local/google/home/davidmorgan/opt/flutter-sdk/flutter",
+  "flutterVersion": "3.29.0",
+  "pubCache": "file:///usr/local/google/home/davidmorgan/.pub-cache"
 }

--- a/build_runner_core/test/fixtures/workspace/pubspec.lock
+++ b/build_runner_core/test/fixtures/workspace/pubspec.lock
@@ -2,4 +2,4 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"

--- a/build_runner_core/test/generate/asset_tracker_test.dart
+++ b/build_runner_core/test/generate/asset_tracker_test.dart
@@ -51,7 +51,10 @@ void main() {
       );
       // We need to pre-emptively assign a digest so we determine that the
       // node is "interesting".
-      assetGraph.get(aId)!.mutate.lastKnownDigest = await reader.digest(aId);
+      final digest = await reader.digest(aId);
+      assetGraph.updateNode(aId, (nodeBuilder) {
+        nodeBuilder.lastKnownDigest = digest;
+      });
 
       var targetGraph = await TargetGraph.forPackageGraph(
         packageGraph,

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -154,10 +154,12 @@ targets:
           environment.reader,
         );
         var generatedAId = makeAssetId('a|lib/a.txt.copy');
-        originalAssetGraph.get(generatedAId)!.generatedNodeState
-          ..wasOutput = true
-          ..isFailure = false
-          ..pendingBuildAction = PendingBuildAction.none;
+        originalAssetGraph.updateNode(generatedAId, (nodeBuilder) {
+          nodeBuilder.generatedNodeState
+            ..wasOutput = true
+            ..isFailure = false
+            ..pendingBuildAction = PendingBuildAction.none;
+        });
 
         await createFile(assetGraphPath, originalAssetGraph.serialize());
 
@@ -172,7 +174,7 @@ targets:
         var generatedANode = newAssetGraph.get(generatedAId)!;
         expect(generatedANode, isNotNull);
         expect(
-          generatedANode.generatedNodeState.pendingBuildAction,
+          generatedANode.generatedNodeState!.pendingBuildAction,
           PendingBuildAction.build,
         );
 
@@ -211,7 +213,7 @@ targets:
         expect(generatedANode, isNotNull);
         // New nodes definitely need an update.
         expect(
-          generatedANode.generatedNodeState.pendingBuildAction,
+          generatedANode.generatedNodeState!.pendingBuildAction,
           PendingBuildAction.build,
         );
       });
@@ -231,10 +233,14 @@ targets:
         );
 
         // pretend a build happened
-        originalAssetGraph.get(aTxtCopy)!.generatedNodeState
-          ..pendingBuildAction = PendingBuildAction.none
-          ..inputs.add(aTxt);
-        originalAssetGraph.get(aTxt)!.mutate.outputs.add(aTxtCopy);
+        originalAssetGraph.updateNode(aTxtCopy, (nodeBuilder) {
+          nodeBuilder.generatedNodeState
+            ..pendingBuildAction = PendingBuildAction.none
+            ..inputs.add(aTxt);
+        });
+        originalAssetGraph.updateNode(aTxt, (nodeBuilder) {
+          nodeBuilder.outputs.add(aTxtCopy);
+        });
         await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         await modifyFile(p.join('lib', 'a.txt'), 'b');
@@ -249,7 +255,7 @@ targets:
             newAssetGraph.get(makeAssetId('a|lib/a.txt.copy'))!;
         expect(generatedANode, isNotNull);
         expect(
-          generatedANode.generatedNodeState.pendingBuildAction,
+          generatedANode.generatedNodeState!.pendingBuildAction,
           PendingBuildAction.buildIfInputsChanged,
         );
       });
@@ -268,9 +274,11 @@ targets:
           environment.reader,
         );
         var generatedSrcId = makeAssetId('a|lib/test.txt.copy');
-        originalAssetGraph.get(generatedSrcId)!.generatedNodeState
-          ..wasOutput = false
-          ..isFailure = false;
+        originalAssetGraph.updateNode(generatedSrcId, (nodeBuilder) {
+          nodeBuilder.generatedNodeState
+            ..wasOutput = false
+            ..isFailure = false;
+        });
 
         await createFile(assetGraphPath, originalAssetGraph.serialize());
 
@@ -312,10 +320,12 @@ targets:
         var generatedACopyId = makeAssetId('a|lib/a.txt.copy');
         var generatedACloneId = makeAssetId('a|lib/a.txt.clone');
         for (var id in [generatedACopyId, generatedACloneId]) {
-          originalAssetGraph.get(id)!.generatedNodeState
-            ..wasOutput = true
-            ..isFailure = false
-            ..pendingBuildAction = PendingBuildAction.none;
+          originalAssetGraph.updateNode(id, (nodeBuilder) {
+            nodeBuilder.generatedNodeState
+              ..wasOutput = true
+              ..isFailure = false
+              ..pendingBuildAction = PendingBuildAction.none;
+          });
         }
 
         await createFile(assetGraphPath, originalAssetGraph.serialize());
@@ -347,7 +357,7 @@ targets:
         var generatedACopyNode = newAssetGraph.get(generatedACopyId)!;
         expect(generatedACopyNode, isNotNull);
         expect(
-          generatedACopyNode.generatedNodeState.pendingBuildAction,
+          generatedACopyNode.generatedNodeState!.pendingBuildAction,
           PendingBuildAction.buildIfInputsChanged,
         );
 
@@ -355,7 +365,7 @@ targets:
         var generatedACloneNode = newAssetGraph.get(generatedACloneId)!;
         expect(generatedACloneNode, isNotNull);
         expect(
-          generatedACloneNode.generatedNodeState.pendingBuildAction,
+          generatedACloneNode.generatedNodeState!.pendingBuildAction,
           PendingBuildAction.none,
         );
       });
@@ -730,7 +740,9 @@ targets:
 
         var aTxtCopy = AssetId('a', 'lib/a.txt.copy');
         // Pretend we already output this without actually running a build.
-        originalAssetGraph.get(aTxtCopy)!.generatedNodeState.wasOutput = true;
+        originalAssetGraph.updateNode(aTxtCopy, (nodeBuilder) {
+          nodeBuilder.generatedNodeState.wasOutput = true;
+        });
         await createFile(aTxtCopy.path, 'hello');
 
         await createFile(assetGraphPath, originalAssetGraph.serialize());
@@ -770,7 +782,9 @@ targets:
 
         var aTxtCopy = AssetId('a', 'lib/a.txt.copy');
         // Pretend we already output this without actually running a build.
-        originalAssetGraph.get(aTxtCopy)!.generatedNodeState.wasOutput = true;
+        originalAssetGraph.updateNode(aTxtCopy, (nodeBuilder) {
+          nodeBuilder.generatedNodeState.wasOutput = true;
+        });
         await createFile(aTxtCopy.path, 'hello');
 
         await createFile(assetGraphPath, originalAssetGraph.serialize());


### PR DESCRIPTION
For #3811, review and merge #3908 first.

`built_value` gives a way to represent immutable data and serialize it, which looks like a very good fit here.

The code is closely equivalent to what was there before; the biggest change is that because `AssetNode` is now immutable it's necessary to fetch updated nodes rather than getting mutations "for free".

This is still an intermediate state: the next PR can switch to using `built_value` for serialization and test (value comparison) code, then it becomes much easier to make changes to the data model.

As expected this is worse for performance

```
before this PR:
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms
loop,1,24385,4365,5483
loop,100,26646,4417,7557
loop,250,30159,4582,12666
loop,500,41991,5000,25656
loop,750,59208,6361,43598
loop,1000,78480,8256,69272

after:
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms
loop,1,24672,4336,5726
loop,100,27260,4521,8359
loop,250,31512,5230,13349
loop,500,55433,13681,33311
loop,750,108009,38464,71159
loop,1000,204181,80411,130737
```

which is fine: the `AssetGraph` updates that are expensive were already too expensive before this PR, it's exactly duplicate work in these updates that needs addressing.