### PR TITLE
Ignore `discarded_futures` lint.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,11 +3,10 @@ analyzer:
   language:
     strict-casts: true
   errors:
-    unused_import: error
-    unused_local_variable: error
-    dead_code: error
     todo: ignore
     deprecated_member_use_from_same_package: ignore
+    # TODO(davidmorgan): update code for this lint.
+    discarded_futures: ignore
   exclude:
     # Prevents extra work during some e2e test runs.
     - "dart2js_test/**"


### PR DESCRIPTION
`dart_flutter_team_lints 3.5.0` introduces the `discarded_futures` lint, which asks for more use of `async` methods / `unawaited`; the diffs are mostly good but they're huuuuuge so I don't want to land them in a rush, let's get the CI green.

Also remove a few tweaks on top of the default style setting unused/dead code to `error`.