### PR TITLE
Split out `AssetTracker`, create `AssetGraphLoader` and `BuildPhases`.

### DIFF
--- a/build_runner/lib/src/daemon/change_providers.dart
+++ b/build_runner/lib/src/daemon/change_providers.dart
@@ -8,7 +8,7 @@ import 'package:build_daemon/change_provider.dart';
 // ignore: implementation_imports
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 // ignore: implementation_imports
-import 'package:build_runner_core/src/generate/build_definition.dart';
+import 'package:build_runner_core/src/generate/asset_tracker.dart';
 import 'package:watcher/watcher.dart' show WatchEvent;
 
 /// Continually updates the [changes] stream as watch events are seen on the

--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -17,7 +17,7 @@ import 'package:build_runner_core/build_runner_core.dart'
 import 'package:build_runner_core/build_runner_core.dart'
     hide BuildResult, BuildStatus;
 // ignore: implementation_imports
-import 'package:build_runner_core/src/generate/build_definition.dart';
+import 'package:build_runner_core/src/generate/asset_tracker.dart';
 // ignore: implementation_imports
 import 'package:build_runner_core/src/generate/build_series.dart';
 import 'package:stream_transform/stream_transform.dart';

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -14,6 +14,7 @@ import 'package:build_runner/src/generate/watch_impl.dart' as watch_impl;
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_test/src/in_memory_reader_writer.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -354,7 +355,7 @@ void main() {
         );
 
         var expectedGraph = await AssetGraph.build(
-          [],
+          BuildPhases([]),
           <AssetId>{},
           {packageConfigId},
           buildPackageGraph({rootPackage('a'): []}),

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -10,6 +10,7 @@ import 'package:build_runner/src/server/server.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/options.dart';
 import 'package:build_runner_core/src/package_graph/target_graph.dart';
 import 'package:shelf/shelf.dart';
@@ -23,7 +24,7 @@ void main() {
 
   setUp(() async {
     graph = await AssetGraph.build(
-      [],
+      BuildPhases([]),
       <AssetId>{},
       <AssetId>{},
       buildPackageGraph({rootPackage('a'): []}),
@@ -38,7 +39,7 @@ void main() {
         packageGraph,
         defaultRootPackageSources: defaultRootPackageSources,
       ),
-      [],
+      BuildPhases([]),
       'a',
     );
     handler = AssetHandler(reader, 'a');

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -15,6 +15,7 @@ import 'package:build_runner/src/server/server.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/options.dart';
 import 'package:build_runner_core/src/generate/performance_tracker.dart';
 import 'package:build_runner_core/src/package_graph/target_graph.dart';
@@ -107,7 +108,7 @@ void main() {
     final packageGraph = buildPackageGraph({rootPackage('a'): []});
     readerWriter = TestReaderWriter(rootPackage: packageGraph.root.name);
     assetGraph = await AssetGraph.build(
-      [],
+      BuildPhases([]),
       <AssetId>{},
       <AssetId>{},
       packageGraph,
@@ -122,7 +123,7 @@ void main() {
             packageGraph,
             defaultRootPackageSources: defaultRootPackageSources,
           ),
-          [],
+          BuildPhases([]),
           'a',
         ),
       ),

--- a/build_runner_core/lib/src/asset/finalized_reader.dart
+++ b/build_runner_core/lib/src/asset/finalized_reader.dart
@@ -15,7 +15,7 @@ import '../../build_runner_core.dart';
 import '../asset_graph/graph.dart';
 import '../asset_graph/node.dart';
 import '../asset_graph/optional_output_tracker.dart';
-import '../generate/phase.dart';
+import '../generate/build_phases.dart';
 import '../package_graph/target_graph.dart';
 
 /// A view of the build output.
@@ -30,7 +30,7 @@ class FinalizedReader {
   final TargetGraph _targetGraph;
   OptionalOutputTracker? _optionalOutputTracker;
   final String _rootPackage;
-  final List<BuildPhase> _buildPhases;
+  final BuildPhases _buildPhases;
 
   void reset(Set<String> buildDirs, Set<BuildFilter> buildFilters) {
     _optionalOutputTracker = OptionalOutputTracker(

--- a/build_runner_core/lib/src/asset_graph/graph_loader.dart
+++ b/build_runner_core/lib/src/asset_graph/graph_loader.dart
@@ -1,0 +1,151 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:build/experiments.dart';
+import 'package:built_collection/built_collection.dart';
+// ignore: implementation_imports
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+
+import '../asset/writer.dart';
+import '../asset_graph/exceptions.dart';
+import '../asset_graph/graph.dart';
+import '../generate/build_phases.dart';
+import '../generate/exceptions.dart';
+import '../logging/failure_reporter.dart';
+import '../logging/logging.dart';
+import '../package_graph/package_graph.dart';
+import '../util/constants.dart';
+import '../util/sdk_version_match.dart';
+
+final _logger = Logger('AssetGraphLoader');
+
+/// Loads and verifies an [AssetGraph].
+class AssetGraphLoader {
+  final AssetReader reader;
+  final RunnerAssetWriter writer;
+  final PackageGraph packageGraph;
+  final BuildPhases buildPhases;
+
+  AssetGraphLoader({
+    required this.reader,
+    required this.writer,
+    required this.packageGraph,
+    required this.buildPhases,
+  });
+
+  /// Loads and verifies an [AssetGraph].
+  ///
+  /// If there is no graph on disk, just returns `null`.
+  ///
+  /// If something has changed that invalidates the graph:
+  ///
+  ///  - deletes the invalid graph
+  ///  - deletes outputs
+  ///  - deletes the generated output directory
+  ///  - if running from a snapshot, throws `BuildScriptChangedException`,
+  ///    otherwise returns `null`
+  Future<AssetGraph?> load() async {
+    final assetGraphId = AssetId(packageGraph.root.name, assetGraphPath);
+    if (!await reader.canRead(assetGraphId)) {
+      return null;
+    }
+
+    return logTimedAsync(_logger, 'Reading cached asset graph', () async {
+      try {
+        return await _load(assetGraphId);
+      } on AssetGraphCorruptedException catch (_) {
+        // Start fresh if the cached asset_graph cannot be deserialized
+        _logger.warning(
+          'Throwing away cached asset graph due to '
+          'version mismatch or corrupted asset graph.',
+        );
+        await Future.wait([
+          _deleteGeneratedDir(),
+          FailureReporter.cleanErrorCache(),
+        ]);
+        return null;
+      }
+    });
+  }
+
+  Future<AssetGraph?> _load(AssetId assetGraphId) async {
+    final cachedGraph = AssetGraph.deserialize(
+      await reader.readAsBytes(assetGraphId),
+    );
+    final buildPhasesChanged =
+        buildPhases.digest != cachedGraph.buildPhasesDigest;
+    final pkgVersionsChanged =
+        cachedGraph.packageLanguageVersions != packageGraph.languageVersions;
+    final enabledExperimentsChanged =
+        cachedGraph.enabledExperiments != enabledExperiments.build();
+    if (buildPhasesChanged || pkgVersionsChanged || enabledExperimentsChanged) {
+      if (buildPhasesChanged) {
+        _logger.warning(
+          'Throwing away cached asset graph because the build phases '
+          'have changed. This most commonly would happen as a result of '
+          'adding a new dependency or updating your dependencies.',
+        );
+      }
+      if (pkgVersionsChanged) {
+        _logger.warning(
+          'Throwing away cached asset graph because the language '
+          'version of some package(s) changed. This would most commonly '
+          'happen when updating dependencies or changing your min sdk '
+          'constraint.',
+        );
+      }
+      if (enabledExperimentsChanged) {
+        _logger.warning(
+          'Throwing away cached asset graph because the enabled Dart '
+          'language experiments changed:\n\n'
+          'Previous value: ${cachedGraph.enabledExperiments.join(' ')}\n'
+          'Current value: ${enabledExperiments.join(' ')}',
+        );
+      }
+      await Future.wait([
+        _deleteAssetGraph(packageGraph),
+        cachedGraph.deleteOutputs(packageGraph, writer),
+        _deleteGeneratedDir(),
+        FailureReporter.cleanErrorCache(),
+      ]);
+      if (_runningFromSnapshot) {
+        throw const BuildScriptChangedException();
+      }
+      return null;
+    }
+    if (!isSameSdkVersion(cachedGraph.dartVersion, Platform.version)) {
+      _logger.warning(
+        'Throwing away cached asset graph due to Dart SDK update.',
+      );
+      await Future.wait([
+        _deleteAssetGraph(packageGraph),
+        cachedGraph.deleteOutputs(packageGraph, writer),
+        _deleteGeneratedDir(),
+        FailureReporter.cleanErrorCache(),
+      ]);
+      if (_runningFromSnapshot) {
+        throw const BuildScriptChangedException();
+      }
+      return null;
+    }
+    return cachedGraph;
+  }
+}
+
+Future<void> _deleteAssetGraph(PackageGraph packageGraph) =>
+    File(p.join(packageGraph.root.path, assetGraphPath)).delete();
+
+Future<void> _deleteGeneratedDir() async {
+  var generatedDir = Directory(generatedOutputDirectory);
+  if (await generatedDir.exists()) {
+    await generatedDir.delete(recursive: true);
+  }
+}
+
+bool get _runningFromSnapshot => !Platform.script.path.endsWith('.dart');

--- a/build_runner_core/lib/src/asset_graph/optional_output_tracker.dart
+++ b/build_runner_core/lib/src/asset_graph/optional_output_tracker.dart
@@ -5,7 +5,7 @@
 import 'package:build/build.dart';
 
 import '../../build_runner_core.dart';
-import '../generate/phase.dart';
+import '../generate/build_phases.dart';
 import '../package_graph/target_graph.dart';
 import '../util/build_dirs.dart';
 import 'graph.dart';
@@ -35,7 +35,7 @@ class OptionalOutputTracker {
   final TargetGraph _targetGraph;
   final Set<String> _buildDirs;
   final Set<BuildFilter> _buildFilters;
-  final List<BuildPhase> _buildPhases;
+  final BuildPhases _buildPhases;
 
   OptionalOutputTracker(
     this._assetGraph,

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -47,8 +47,8 @@ class _AssetGraphDeserializer {
     var graph = AssetGraph._(
       _deserializeDigest(_serializedGraph['buildActionsDigest'] as String)!,
       _serializedGraph['dart_version'] as String,
-      packageLanguageVersions,
-      List.from(_serializedGraph['enabledExperiments'] as List),
+      packageLanguageVersions.build(),
+      BuiltList<String>.from(_serializedGraph['enabledExperiments'] as List),
     );
 
     var packageNames = _serializedGraph['packages'] as List;
@@ -107,10 +107,11 @@ class _AssetGraphSerializer {
       'buildActionsDigest': _serializeDigest(_graph.buildPhasesDigest),
       'packages': packages,
       'assetPaths': assetPaths,
-      'packageLanguageVersions': _graph.packageLanguageVersions.map(
-        (pkg, version) => MapEntry(pkg, version?.toString()),
-      ),
-      'enabledExperiments': _graph.enabledExperiments,
+      'packageLanguageVersions':
+          _graph.packageLanguageVersions
+              .map((pkg, version) => MapEntry(pkg, version?.toString()))
+              .toMap(),
+      'enabledExperiments': _graph.enabledExperiments.toList(),
     };
     return utf8.encode(json.encode(result));
   }

--- a/build_runner_core/lib/src/generate/asset_tracker.dart
+++ b/build_runner_core/lib/src/generate/asset_tracker.dart
@@ -1,0 +1,168 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:async/async.dart';
+import 'package:build/build.dart';
+// ignore: implementation_imports
+import 'package:build/src/internal.dart';
+import 'package:glob/glob.dart';
+import 'package:watcher/watcher.dart';
+
+import '../asset_graph/graph.dart';
+import '../asset_graph/node.dart';
+import '../package_graph/target_graph.dart';
+import '../util/constants.dart';
+
+/// Finds build assets and computes changes to build assets.
+class AssetTracker {
+  final AssetReader _reader;
+  final TargetGraph _targetGraph;
+
+  AssetTracker(this._reader, this._targetGraph);
+
+  /// Checks for and returns any file system changes compared to the current
+  /// state of the asset graph.
+  Future<Map<AssetId, ChangeType>> collectChanges(AssetGraph assetGraph) async {
+    var inputSources = await findInputSources();
+    var generatedSources = await findCacheDirSources();
+    var internalSources = await findInternalSources();
+    return computeSourceUpdates(
+      inputSources,
+      generatedSources,
+      internalSources,
+      assetGraph,
+    );
+  }
+
+  /// Returns the all the sources found in the cache directory.
+  Future<Set<AssetId>> findCacheDirSources() =>
+      _listGeneratedAssetIds().toSet();
+
+  /// Returns the set of original package inputs on disk.
+  Future<Set<AssetId>> findInputSources() {
+    final targets = Stream<TargetNode>.fromIterable(
+      _targetGraph.allModules.values,
+    );
+    return targets.asyncExpand(_listAssetIds).toSet();
+  }
+
+  /// Returns all the internal sources, such as those under [entryPointDir].
+  Future<Set<AssetId>> findInternalSources() async {
+    var ids = await _listIdsSafe(Glob('$entryPointDir/**')).toSet();
+    var packageConfigId = AssetId(
+      _targetGraph.rootPackageConfig.packageName,
+      '.dart_tool/package_config.json',
+    );
+
+    if (await _reader.canRead(packageConfigId)) {
+      ids.add(packageConfigId);
+    }
+    return ids;
+  }
+
+  /// Finds the asset changes which have happened while unwatched between builds
+  /// by taking a difference between the assets in the graph and the assets on
+  /// disk.
+  Future<Map<AssetId, ChangeType>> computeSourceUpdates(
+    Set<AssetId> inputSources,
+    Set<AssetId> generatedSources,
+    Set<AssetId> internalSources,
+    AssetGraph assetGraph,
+  ) async {
+    final allSources =
+        <AssetId>{}
+          ..addAll(inputSources)
+          ..addAll(generatedSources)
+          ..addAll(internalSources);
+    var updates = <AssetId, ChangeType>{};
+    void addUpdates(Iterable<AssetId> assets, ChangeType type) {
+      for (var asset in assets) {
+        updates[asset] = type;
+      }
+    }
+
+    var newSources = inputSources.difference(
+      assetGraph.allNodes
+          .where((node) => node.isTrackedInput)
+          .map((node) => node.id)
+          .toSet(),
+    );
+    addUpdates(newSources, ChangeType.ADD);
+    var removedAssets = assetGraph.allNodes
+        .where((n) {
+          if (!n.isFile) return false;
+          if (n.type == NodeType.generated) {
+            return n.generatedNodeState!.wasOutput;
+          }
+          return true;
+        })
+        .map((n) => n.id)
+        .where((id) => !allSources.contains(id));
+
+    addUpdates(removedAssets, ChangeType.REMOVE);
+
+    var originalGraphSources = assetGraph.sources.toSet();
+    var preExistingSources = originalGraphSources.intersection(inputSources)
+      ..addAll(internalSources.where(assetGraph.contains));
+    var modifyChecks = preExistingSources.map((id) async {
+      var node = assetGraph.get(id)!;
+      var originalDigest = node.lastKnownDigest;
+      if (originalDigest == null) return;
+      await _reader.cache.invalidate([id]);
+      var currentDigest = await _reader.digest(id);
+      if (currentDigest != originalDigest) {
+        updates[id] = ChangeType.MODIFY;
+      }
+    });
+    await Future.wait(modifyChecks);
+    return updates;
+  }
+
+  Stream<AssetId> _listAssetIds(TargetNode targetNode) {
+    return targetNode.sourceIncludes.isEmpty
+        ? const Stream<AssetId>.empty()
+        : StreamGroup.merge(
+          targetNode.sourceIncludes.map(
+            (glob) => _listIdsSafe(glob, package: targetNode.package.name)
+                .where(
+                  (id) => _targetGraph.isVisibleInBuild(id, targetNode.package),
+                )
+                .where((id) => !targetNode.excludesSource(id)),
+          ),
+        );
+  }
+
+  Stream<AssetId> _listGeneratedAssetIds() {
+    var glob = Glob('$generatedOutputDirectory/**');
+
+    return _listIdsSafe(glob)
+        .map((id) {
+          var packagePath = id.path.substring(
+            generatedOutputDirectory.length + 1,
+          );
+          var firstSlash = packagePath.indexOf('/');
+          if (firstSlash == -1) return null;
+          var package = packagePath.substring(0, firstSlash);
+          var path = packagePath.substring(firstSlash + 1);
+          return AssetId(package, path);
+        })
+        .where((id) => id != null)
+        .cast<AssetId>();
+  }
+
+  /// Lists asset IDs and swallows file not found errors.
+  ///
+  /// Ideally we would warn but in practice the default sources list will give
+  /// this error a lot and it would be noisy.
+  Stream<AssetId> _listIdsSafe(Glob glob, {String? package}) => _reader
+      .assetFinder
+      .find(glob, package: package)
+      .handleError(
+        (void _) {},
+        test: (e) => e is FileSystemException && e.osError?.errorCode == 2,
+      );
+}

--- a/build_runner_core/lib/src/generate/asset_tracker.dart
+++ b/build_runner_core/lib/src/generate/asset_tracker.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/build_runner_core/lib/src/generate/build.dart
+++ b/build_runner_core/lib/src/generate/build.dart
@@ -31,6 +31,7 @@ import '../performance_tracking/performance_tracking_resolvers.dart';
 import '../util/build_dirs.dart';
 import '../util/constants.dart';
 import 'build_directory.dart';
+import 'build_phases.dart';
 import 'build_result.dart';
 import 'build_series.dart';
 import 'finalized_assets_view.dart';
@@ -47,7 +48,7 @@ final _logger = Logger('Build');
 class Build {
   final AssetGraph _assetGraph;
   final Set<BuildFilter> _buildFilters;
-  final List<BuildPhase> _buildPhases;
+  final BuildPhases _buildPhases;
   final BuildEnvironment _environment;
   final _lazyPhases = <String, Future<Iterable<AssetId>>>{};
   final _lazyGlobs = <AssetId, Future<void>>{};

--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -5,13 +5,11 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:async/async.dart';
 import 'package:build/build.dart';
 import 'package:build/experiments.dart';
 // ignore: implementation_imports
 import 'package:build/src/internal.dart';
 import 'package:collection/collection.dart';
-import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:watcher/watcher.dart';
@@ -25,9 +23,9 @@ import '../environment/build_environment.dart';
 import '../logging/failure_reporter.dart';
 import '../logging/logging.dart';
 import '../package_graph/package_graph.dart';
-import '../package_graph/target_graph.dart';
 import '../util/constants.dart';
 import '../util/sdk_version_match.dart';
+import 'asset_tracker.dart';
 import 'exceptions.dart';
 import 'options.dart';
 import 'phase.dart';
@@ -49,157 +47,6 @@ class BuildDefinition {
   ) => _Loader(environment, options, buildPhases).prepareWorkspace();
 }
 
-/// Understands how to find all assets relevant to a build as well as compute
-/// updates to those assets.
-class AssetTracker {
-  final AssetReader _reader;
-  final TargetGraph _targetGraph;
-
-  AssetTracker(this._reader, this._targetGraph);
-
-  /// Checks for and returns any file system changes compared to the current
-  /// state of the asset graph.
-  Future<Map<AssetId, ChangeType>> collectChanges(AssetGraph assetGraph) async {
-    var inputSources = await _findInputSources();
-    var generatedSources = await _findCacheDirSources();
-    var internalSources = await _findInternalSources();
-    return _computeSourceUpdates(
-      inputSources,
-      generatedSources,
-      internalSources,
-      assetGraph,
-    );
-  }
-
-  /// Returns the all the sources found in the cache directory.
-  Future<Set<AssetId>> _findCacheDirSources() =>
-      _listGeneratedAssetIds().toSet();
-
-  /// Returns the set of original package inputs on disk.
-  Future<Set<AssetId>> _findInputSources() {
-    final targets = Stream<TargetNode>.fromIterable(
-      _targetGraph.allModules.values,
-    );
-    return targets.asyncExpand(_listAssetIds).toSet();
-  }
-
-  /// Returns all the internal sources, such as those under [entryPointDir].
-  Future<Set<AssetId>> _findInternalSources() async {
-    var ids = await _listIdsSafe(Glob('$entryPointDir/**')).toSet();
-    var packageConfigId = AssetId(
-      _targetGraph.rootPackageConfig.packageName,
-      '.dart_tool/package_config.json',
-    );
-
-    if (await _reader.canRead(packageConfigId)) {
-      ids.add(packageConfigId);
-    }
-    return ids;
-  }
-
-  /// Finds the asset changes which have happened while unwatched between builds
-  /// by taking a difference between the assets in the graph and the assets on
-  /// disk.
-  Future<Map<AssetId, ChangeType>> _computeSourceUpdates(
-    Set<AssetId> inputSources,
-    Set<AssetId> generatedSources,
-    Set<AssetId> internalSources,
-    AssetGraph assetGraph,
-  ) async {
-    final allSources =
-        <AssetId>{}
-          ..addAll(inputSources)
-          ..addAll(generatedSources)
-          ..addAll(internalSources);
-    var updates = <AssetId, ChangeType>{};
-    void addUpdates(Iterable<AssetId> assets, ChangeType type) {
-      for (var asset in assets) {
-        updates[asset] = type;
-      }
-    }
-
-    var newSources = inputSources.difference(
-      assetGraph.allNodes
-          .where((node) => node.isTrackedInput)
-          .map((node) => node.id)
-          .toSet(),
-    );
-    addUpdates(newSources, ChangeType.ADD);
-    var removedAssets = assetGraph.allNodes
-        .where((n) {
-          if (!n.isFile) return false;
-          if (n.type == NodeType.generated) {
-            return n.generatedNodeState!.wasOutput;
-          }
-          return true;
-        })
-        .map((n) => n.id)
-        .where((id) => !allSources.contains(id));
-
-    addUpdates(removedAssets, ChangeType.REMOVE);
-
-    var originalGraphSources = assetGraph.sources.toSet();
-    var preExistingSources = originalGraphSources.intersection(inputSources)
-      ..addAll(internalSources.where(assetGraph.contains));
-    var modifyChecks = preExistingSources.map((id) async {
-      var node = assetGraph.get(id)!;
-      var originalDigest = node.lastKnownDigest;
-      if (originalDigest == null) return;
-      await _reader.cache.invalidate([id]);
-      var currentDigest = await _reader.digest(id);
-      if (currentDigest != originalDigest) {
-        updates[id] = ChangeType.MODIFY;
-      }
-    });
-    await Future.wait(modifyChecks);
-    return updates;
-  }
-
-  Stream<AssetId> _listAssetIds(TargetNode targetNode) {
-    return targetNode.sourceIncludes.isEmpty
-        ? const Stream<AssetId>.empty()
-        : StreamGroup.merge(
-          targetNode.sourceIncludes.map(
-            (glob) => _listIdsSafe(glob, package: targetNode.package.name)
-                .where(
-                  (id) => _targetGraph.isVisibleInBuild(id, targetNode.package),
-                )
-                .where((id) => !targetNode.excludesSource(id)),
-          ),
-        );
-  }
-
-  Stream<AssetId> _listGeneratedAssetIds() {
-    var glob = Glob('$generatedOutputDirectory/**');
-
-    return _listIdsSafe(glob)
-        .map((id) {
-          var packagePath = id.path.substring(
-            generatedOutputDirectory.length + 1,
-          );
-          var firstSlash = packagePath.indexOf('/');
-          if (firstSlash == -1) return null;
-          var package = packagePath.substring(0, firstSlash);
-          var path = packagePath.substring(firstSlash + 1);
-          return AssetId(package, path);
-        })
-        .where((id) => id != null)
-        .cast<AssetId>();
-  }
-
-  /// Lists asset IDs and swallows file not found errors.
-  ///
-  /// Ideally we would warn but in practice the default sources list will give
-  /// this error a lot and it would be noisy.
-  Stream<AssetId> _listIdsSafe(Glob glob, {String? package}) => _reader
-      .assetFinder
-      .find(glob, package: package)
-      .handleError(
-        (void _) {},
-        test: (e) => e is FileSystemException && e.osError?.errorCode == 2,
-      );
-}
-
 class _Loader {
   final List<BuildPhase> _buildPhases;
   final BuildOptions _options;
@@ -214,9 +61,9 @@ class _Loader {
 
     var assetGraph = await _tryReadCachedAssetGraph();
     var assetTracker = AssetTracker(_environment.reader, _options.targetGraph);
-    var inputSources = await assetTracker._findInputSources();
-    var cacheDirSources = await assetTracker._findCacheDirSources();
-    var internalSources = await assetTracker._findInternalSources();
+    var inputSources = await assetTracker.findInputSources();
+    var cacheDirSources = await assetTracker.findCacheDirSources();
+    var internalSources = await assetTracker.findInternalSources();
 
     BuildScriptUpdates? buildScriptUpdates;
     if (assetGraph != null) {
@@ -501,7 +348,7 @@ class _Loader {
     Set<AssetId> cacheDirSources,
     Set<AssetId> internalSources,
   ) async {
-    var updates = await assetTracker._computeSourceUpdates(
+    var updates = await assetTracker.computeSourceUpdates(
       inputSources,
       cacheDirSources,
       internalSources,

--- a/build_runner_core/lib/src/generate/build_phases.dart
+++ b/build_runner_core/lib/src/generate/build_phases.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'package:logging/logging.dart';
+
+import 'exceptions.dart';
+import 'phase.dart';
+
+/// The [BuildPhases] defining the sequence of actions in a build, and their
+/// [Digest].
+class BuildPhases {
+  final BuiltList<BuildPhase> phases;
+
+  /// A [Digest] that can be used to detect any change to the phases.
+  final Digest digest;
+
+  BuildPhases(Iterable<BuildPhase> phases)
+    : phases = phases.toBuiltList(),
+      digest = _computeDigest(phases);
+
+  BuildPhase operator [](int index) => phases[index];
+  int get length => phases.length;
+
+  static Digest _computeDigest(Iterable<BuildPhase> phases) {
+    final digestSink = AccumulatorSink<Digest>();
+    md5.startChunkedConversion(digestSink)
+      ..add(phases.map((phase) => phase.identity).toList())
+      ..close();
+    assert(digestSink.events.length == 1);
+    return digestSink.events.first;
+  }
+
+  /// Checks that outputs are to allowed locations.
+  ///
+  /// To be valid, all outputs must be under the package [root], or hidden,
+  /// meaning they will generate to the hidden generated output directory.
+  ///
+  /// If the phases are not valid, logs to [logger] then throws
+  /// [CannotBuildException].
+  void checkOutputLocations(String root, Logger logger) {
+    for (final action in phases) {
+      if (!action.hideOutput) {
+        // Only `InBuildPhase`s can be not hidden.
+        if (action is InBuildPhase && action.package != root) {
+          // This should happen only with a manual build script since the build
+          // script generation filters these out.
+          logger.severe(
+            'A build phase (${action.builderLabel}) is attempting '
+            'to operate on package "${action.package}", but the build script '
+            'is located in package "$root". It\'s not valid to attempt to '
+            'generate files for another package unless the BuilderApplication'
+            'specified "hideOutput".'
+            '\n\n'
+            'Did you mean to write:\n'
+            '  new BuilderApplication(..., toRoot())\n'
+            'or\n'
+            '  new BuilderApplication(..., hideOutput: true)\n'
+            '... instead?',
+          );
+          throw const CannotBuildException();
+        }
+      }
+    }
+  }
+}

--- a/build_runner_core/lib/src/generate/build_series.dart
+++ b/build_runner_core/lib/src/generate/build_series.dart
@@ -100,11 +100,13 @@ class BuildSeries {
     if (buildPhases.isEmpty) {
       _logger.severe('Nothing can be built, yet a build was requested.');
     }
+
     var buildDefinition = await BuildDefinition.prepareWorkspace(
       environment,
       options,
       buildPhases,
     );
+
     var finalizedReader = FinalizedReader(
       environment.reader.copyWith(
         generatedAssetHider: buildDefinition.assetGraph,

--- a/build_runner_core/lib/src/generate/build_series.dart
+++ b/build_runner_core/lib/src/generate/build_series.dart
@@ -20,9 +20,9 @@ import '../util/constants.dart';
 import 'build.dart';
 import 'build_definition.dart';
 import 'build_directory.dart';
+import 'build_phases.dart';
 import 'build_result.dart';
 import 'options.dart';
-import 'phase.dart';
 
 final _logger = Logger('BuildSeries');
 
@@ -43,7 +43,7 @@ class BuildSeries {
   final AssetGraph assetGraph;
   final BuildScriptUpdates? buildScriptUpdates;
   final BuildOptions options;
-  final List<BuildPhase> buildPhases;
+  final BuildPhases buildPhases;
 
   final FinalizedReader finalizedReader;
   final AssetReaderWriter readerWriter;
@@ -97,7 +97,7 @@ class BuildSeries {
       builderConfigOverrides,
       isReleaseBuild,
     );
-    if (buildPhases.isEmpty) {
+    if (buildPhases.phases.isEmpty) {
       _logger.severe('Nothing can be built, yet a build was requested.');
     }
 

--- a/build_runner_core/lib/src/package_graph/apply_builders.dart
+++ b/build_runner_core/lib/src/package_graph/apply_builders.dart
@@ -12,6 +12,7 @@ import 'package:build_config/build_config.dart';
 import 'package:graphs/graphs.dart';
 import 'package:logging/logging.dart';
 
+import '../generate/build_phases.dart';
 import '../generate/exceptions.dart';
 import '../generate/phase.dart';
 import '../validation/config_validation.dart';
@@ -292,7 +293,7 @@ final _logger = Logger('ApplyBuilders');
 /// Builders may be filtered, for instance to run only on package which have a
 /// dependency on some other package by choosing the appropriate
 /// [BuilderApplication].
-Future<List<BuildPhase>> createBuildPhases(
+Future<BuildPhases> createBuildPhases(
   TargetGraph targetGraph,
   Iterable<BuilderApplication> builderApplications,
   Map<String, Map<String, dynamic>> builderConfigOverrides,
@@ -370,7 +371,7 @@ Future<List<BuildPhase>> createBuildPhases(
     );
   }
 
-  return <BuildPhase>[...inBuildPhases, ...collapsedPostBuildPhase];
+  return BuildPhases([...inBuildPhases, ...collapsedPostBuildPhase]);
 }
 
 Iterable<BuildPhase> _createBuildPhasesWithinCycle(

--- a/build_runner_core/lib/src/package_graph/package_graph.dart
+++ b/build_runner_core/lib/src/package_graph/package_graph.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:build/build.dart';
 // ignore: implementation_imports
 import 'package:build/src/internal.dart';
+import 'package:built_collection/built_collection.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
@@ -191,6 +192,13 @@ class PackageGraph implements AssetPathProvider {
 
   /// Shorthand to get a package by name.
   PackageNode? operator [](String packageName) => allPackages[packageName];
+
+  /// Map from package name to package language version.
+  BuiltMap<String, LanguageVersion?> get languageVersions =>
+      {
+        for (final package in allPackages.values)
+          package.name: package.languageVersion,
+      }.build();
 
   @override
   String pathFor(AssetId id) {

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -10,6 +10,7 @@ import 'package:build/build.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/options.dart';
 import 'package:build_runner_core/src/generate/phase.dart';
 import 'package:build_runner_core/src/package_graph/target_graph.dart';
@@ -30,7 +31,7 @@ void main() {
       );
 
       graph = await AssetGraph.build(
-        [],
+        BuildPhases([]),
         <AssetId>{},
         <AssetId>{},
         packageGraph,
@@ -62,7 +63,13 @@ void main() {
       delegate.testing.writeString(notDeleted.id, '');
       delegate.testing.writeString(deleted.id, '');
 
-      reader = FinalizedReader(delegate, graph, targetGraph, [], 'a');
+      reader = FinalizedReader(
+        delegate,
+        graph,
+        targetGraph,
+        BuildPhases([]),
+        'a',
+      );
       expect(await reader.canRead(notDeleted.id), true);
       expect(await reader.canRead(deleted.id), false);
     });
@@ -82,9 +89,13 @@ void main() {
       graph.add(node);
       var delegate = TestReaderWriter();
       delegate.testing.writeString(id, '');
-      reader = FinalizedReader(delegate, graph, targetGraph, [
-        InBuildPhase(TestBuilder(), 'a', isOptional: false),
-      ], 'a')..reset({'web'}, {});
+      reader = FinalizedReader(
+        delegate,
+        graph,
+        targetGraph,
+        BuildPhases([InBuildPhase(TestBuilder(), 'a', isOptional: false)]),
+        'a',
+      )..reset({'web'}, {});
       expect(
         await reader.unreadableReason(id),
         UnreadableReason.failed,

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -11,6 +11,7 @@ import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/phase.dart';
 import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
@@ -48,7 +49,7 @@ void main() {
     group('simple graph', () {
       setUp(() async {
         graph = await AssetGraph.build(
-          [],
+          BuildPhases([]),
           <AssetId>{},
           <AssetId>{},
           fooPackageGraph,
@@ -212,7 +213,7 @@ void main() {
 
     group('with buildPhases', () {
       var targetSources = const InputSet(exclude: ['excluded.txt']);
-      final buildPhases = [
+      final buildPhases = BuildPhases([
         InBuildPhase(
           TestBuilder(buildExtensions: appendExtension('.copy', from: '.txt')),
           'foo',
@@ -227,7 +228,7 @@ void main() {
             generateFor: const InputSet(),
           ),
         ]),
-      ];
+      ]);
       final primaryInputId = makeAssetId('foo|file.txt');
       final excludedInputId = makeAssetId('foo|excluded.txt');
       final primaryOutputId = makeAssetId('foo|file.txt.copy');
@@ -577,7 +578,7 @@ void main() {
     test('overlapping build phases cause an error', () async {
       expect(
         () => AssetGraph.build(
-          List.filled(2, InBuildPhase(TestBuilder(), 'foo')),
+          BuildPhases(List.filled(2, InBuildPhase(TestBuilder(), 'foo'))),
           {makeAssetId('foo|file')},
           <AssetId>{},
           fooPackageGraph,
@@ -604,7 +605,7 @@ void main() {
           digestReader.testing.writeString(id, 'contents of $id');
         }
         final graph = await AssetGraph.build(
-          [
+          BuildPhases([
             InBuildPhase(
               TestBuilder(buildExtensions: replaceExtension('.txt', '.a.txt')),
               'foo',
@@ -622,7 +623,7 @@ void main() {
               'foo',
               hideOutput: false,
             ),
-          ],
+          ]),
           sources,
           <AssetId>{},
           fooPackageGraph,
@@ -657,7 +658,7 @@ void main() {
           digestReader.testing.writeString(id, 'contents of $id');
         }
         final graph = await AssetGraph.build(
-          [
+          BuildPhases([
             InBuildPhase(
               TestBuilder(buildExtensions: appendExtension('.1', from: '.txt')),
               'foo',
@@ -667,7 +668,7 @@ void main() {
               'foo',
               targetSources: const InputSet(include: ['lib/*.txt']),
             ),
-          ],
+          ]),
           sources,
           <AssetId>{},
           fooPackageGraph,
@@ -687,7 +688,7 @@ void main() {
         final nodeToRead = AssetId('foo', 'lib/a.1');
         final outputReadingNode = AssetId('foo', 'lib/b.2');
         final lastPrimaryOutputNode = AssetId('foo', 'lib/b.3');
-        final buildPhases = [
+        final buildPhases = BuildPhases([
           InBuildPhase(
             TestBuilder(buildExtensions: replaceExtension('.txt', '.1')),
             'foo',
@@ -700,7 +701,7 @@ void main() {
             TestBuilder(buildExtensions: replaceExtension('.2', '.3')),
             'foo',
           ),
-        ];
+        ]);
         final sources = {makeAssetId('foo|lib/b.anchor')};
         for (final id in sources) {
           digestReader.testing.writeString(id, 'contents of $id');
@@ -750,7 +751,7 @@ void main() {
         final generatedDart = AssetId('a', 'lib/a.g.dart');
         final generatedPart = AssetId('a', 'lib/a.g.part');
         final toBeGeneratedDart = AssetId('a', 'lib/A.g.dart');
-        final buildPhases = [
+        final buildPhases = BuildPhases([
           InBuildPhase(
             TestBuilder(buildExtensions: replaceExtension('.dart', '.g.part')),
             'a',
@@ -761,7 +762,7 @@ void main() {
             ),
             'a',
           ),
-        ];
+        ]);
         final packageGraph = buildPackageGraph({rootPackage('a'): []});
         final graph = await AssetGraph.build(
           buildPhases,

--- a/build_runner_core/test/environment/create_merged_dir_test.dart
+++ b/build_runner_core/test/environment/create_merged_dir_test.dart
@@ -13,6 +13,7 @@ import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
 import 'package:build_runner_core/src/asset_graph/optional_output_tracker.dart';
 import 'package:build_runner_core/src/environment/create_merged_dir.dart';
+import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/options.dart';
 import 'package:build_runner_core/src/generate/phase.dart';
 import 'package:build_runner_core/src/package_graph/target_graph.dart';
@@ -22,7 +23,7 @@ import 'package:test/test.dart';
 void main() {
   group('createMergedDir', () {
     late AssetGraph graph;
-    final phases = [
+    final phases = BuildPhases([
       InBuildPhase(
         TestBuilder(buildExtensions: appendExtension('.copy', from: '.txt')),
         'a',
@@ -31,7 +32,7 @@ void main() {
         TestBuilder(buildExtensions: appendExtension('.copy', from: '.txt')),
         'b',
       ),
-    ];
+    ]);
     final sources = {
       makeAssetId('a|lib/a.txt'): 'a',
       makeAssetId('a|web/b.txt'): 'b',

--- a/build_runner_core/test/generate/asset_tracker_test.dart
+++ b/build_runner_core/test/generate/asset_tracker_test.dart
@@ -9,6 +9,7 @@ import 'package:build/build.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/generate/asset_tracker.dart';
+import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/package_graph/target_graph.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
@@ -43,7 +44,7 @@ void main() {
       var reader = ReaderWriter(packageGraph);
       var aId = AssetId('a', 'web/a.txt');
       assetGraph = await AssetGraph.build(
-        [],
+        BuildPhases([]),
         {aId},
         <AssetId>{},
         packageGraph,
@@ -63,7 +64,7 @@ void main() {
       assetTracker = AssetTracker(reader, targetGraph);
       var updates = await assetTracker.collectChanges(assetGraph);
       await assetGraph.updateAndInvalidate(
-        [],
+        BuildPhases([]),
         updates,
         'a',
         (_) async {},

--- a/build_runner_core/test/generate/asset_tracker_test.dart
+++ b/build_runner_core/test/generate/asset_tracker_test.dart
@@ -8,7 +8,7 @@ import 'dart:io';
 import 'package:build/build.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
-import 'package:build_runner_core/src/generate/build_definition.dart';
+import 'package:build_runner_core/src/generate/asset_tracker.dart';
 import 'package:build_runner_core/src/package_graph/target_graph.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -14,6 +14,7 @@ import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/options.dart'
     show defaultNonRootVisibleAssets;
 import 'package:glob/glob.dart';
@@ -1248,7 +1249,7 @@ void main() {
     );
 
     var expectedGraph = await AssetGraph.build(
-      [],
+      BuildPhases([]),
       <AssetId>{},
       {makeAssetId('a|.dart_tool/package_config.json')},
       buildPackageGraph({rootPackage('a'): []}),

--- a/build_runner_core/test/package_graph/apply_builders_test.dart
+++ b/build_runner_core/test/package_graph/apply_builders_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:_test_common/common.dart';
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
+import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/exceptions.dart';
 import 'package:build_runner_core/src/generate/phase.dart';
 import 'package:build_runner_core/src/package_graph/apply_builders.dart';
@@ -29,7 +30,7 @@ void main() {
       var phases = await createBuildPhases(targetGraph, builderApplications, {
         'b:cool_builder': {'option_a': 'a', 'option_c': 'c'},
       }, false);
-      for (final phase in phases.cast<InBuildPhase>()) {
+      for (final phase in phases.phases.cast<InBuildPhase>()) {
         expect((phase.builder as CoolBuilder).optionA, equals('a'));
         expect((phase.builder as CoolBuilder).optionB, equals('defaultB'));
         expect((phase.builder as CoolBuilder).optionC, equals('c'));
@@ -78,7 +79,7 @@ void main() {
               },
               true,
             );
-            for (final phase in phases.cast<InBuildPhase>()) {
+            for (final phase in phases.phases.cast<InBuildPhase>()) {
               expect(
                 (phase.builder as CoolBuilder).optionA,
                 equals('global a'),
@@ -118,7 +119,7 @@ void main() {
         false,
       );
       expect(phases, hasLength(1));
-      expect((phases.first as InBuildPhase).package, 'a');
+      expect((phases.phases.first as InBuildPhase).package, 'a');
     });
 
     test('honors appliesBuilders', () async {
@@ -147,7 +148,7 @@ void main() {
       );
       expect(phases, hasLength(2));
       expect(
-        phases,
+        phases.phases,
         everyElement(
           const TypeMatcher<InBuildPhase>().having(
             (p) => p.package,
@@ -184,7 +185,7 @@ void main() {
       );
       expect(phases, hasLength(1));
       expect(
-        phases,
+        phases.phases,
         everyElement(
           const TypeMatcher<InBuildPhase>().having(
             (p) => p.package,
@@ -229,7 +230,7 @@ void main() {
         );
         expect(phases, hasLength(2));
         expect(
-          phases,
+          phases.phases,
           everyElement(
             const TypeMatcher<InBuildPhase>().having(
               (p) => p.package,
@@ -276,7 +277,7 @@ void main() {
     });
 
     group('autoApplyBuilders', () {
-      Future<List<BuildPhase>> createPhases({
+      Future<BuildPhases> createPhases({
         Map<String, TargetBuilderConfig>? builderConfigs,
       }) async {
         var packageGraph = buildPackageGraph({
@@ -321,7 +322,7 @@ void main() {
 
       test('can be disabled for a target', () async {
         var phases = await createPhases();
-        expect(phases, isEmpty);
+        expect(phases.phases, isEmpty);
       });
 
       test('individual builders can still be enabled', () async {
@@ -332,7 +333,7 @@ void main() {
         );
         expect(phases, hasLength(1));
         expect(
-          phases.first,
+          phases.phases.first,
           isA<InBuildPhase>()
               .having((p) => p.package, 'package', 'a')
               .having(
@@ -353,7 +354,7 @@ void main() {
           );
           expect(phases, hasLength(2));
           expect(
-            phases,
+            phases.phases,
             equals([
               isA<InBuildPhase>()
                   .having((p) => p.package, 'package', 'a')


### PR DESCRIPTION
Split `AssetTracker` out of `build_definition.dart`.

Add `BuildPhases` wrapping a `List<BuildPhase>` to hold validation and digest computation for the list.

Move move load+verify of the graph from `build_definition.dart` to new `AssetGraphLoader`. Move "delete graph outputs" from that to `AssetGraph`.