### PR TITLE
Add what changed and what is built to verbose logging.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Remove `OnDeleteWriter`, add functionality to `ReaderWriter`.
 - Add `NodeType` to `AssetNode`, remove subtypes. Make mutations explicit.
 - Use `built_value` for `AssetNode` and related types.
+- Add details of what changed and what is built to `--verbose` logging.
 
 ## 2.4.15
 

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -66,7 +66,7 @@ void _stdIOLogListener(LogRecord record, {required bool verbose}) =>
 /// splits the header for levels >= WARNING.
 String _recordHeader(LogRecord record, bool verbose) {
   var maybeSplit = record.level >= Level.WARNING ? '\n' : '';
-  return verbose || record.loggerName.contains(' ')
+  return record.loggerName.contains(' ')
       ? '${record.loggerName}:$maybeSplit'
       : '';
 }

--- a/build_runner/lib/src/logging/std_io_logging.dart
+++ b/build_runner/lib/src/logging/std_io_logging.dart
@@ -26,7 +26,7 @@ StringBuffer colorLog(LogRecord record, {required bool verbose}) {
   final level = color.wrap('[${record.level}]');
   final eraseLine = ansiOutputEnabled && !verbose ? '\x1b[2K\r' : '';
   var lines = <Object>[
-    '$eraseLine$level ${_recordHeader(record, verbose)}${record.message}',
+    '$eraseLine$level ${_recordHeader(record)}${record.message}',
   ];
 
   if (record.error != null) {
@@ -64,7 +64,7 @@ void _stdIOLogListener(LogRecord record, {required bool verbose}) =>
 
 /// Filter out the Logger names which aren't coming from specific builders and
 /// splits the header for levels >= WARNING.
-String _recordHeader(LogRecord record, bool verbose) {
+String _recordHeader(LogRecord record) {
   var maybeSplit = record.level >= Level.WARNING ? '\n' : '';
   return record.loggerName.contains(' ')
       ? '${record.loggerName}:$maybeSplit'

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -20,6 +20,7 @@
   `AssetWriterSpy` functionality.
 - Add `NodeType` to `AssetNode`, remove subtypes. Make mutations explicit.
 - Use `built_value` for `AssetNode` and related types, and for serialization.
+- Add details of what changed and what is built to `--verbose` logging.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/src/changes/asset_updates.dart
+++ b/build_runner_core/lib/src/changes/asset_updates.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:watcher/watcher.dart';
+
+import '../logging/log_renderer.dart';
+
+/// Asset updates for an incremental build.
+class AssetUpdates {
+  final BuiltSet<AssetId> added;
+  final BuiltSet<AssetId> modified;
+  final BuiltSet<AssetId> removed;
+
+  AssetUpdates({
+    required this.added,
+    required this.modified,
+    required this.removed,
+  });
+
+  factory AssetUpdates.from(Map<AssetId, ChangeType> updates) {
+    final added = <AssetId>[];
+    final modified = <AssetId>[];
+    final removed = <AssetId>[];
+    for (final update in updates.entries) {
+      switch (update.value) {
+        case ChangeType.ADD:
+          added.add(update.key);
+          break;
+        case ChangeType.MODIFY:
+          modified.add(update.key);
+          break;
+        case ChangeType.REMOVE:
+          removed.add(update.key);
+          break;
+      }
+    }
+    return AssetUpdates(
+      added: (added..sort()).toBuiltSet(),
+      modified: (modified..sort()).toBuiltSet(),
+      removed: (removed..sort()).toBuiltSet(),
+    );
+  }
+
+  bool get isEmpty => added.isEmpty && modified.isEmpty && removed.isEmpty;
+
+  /// Explain what was updated, for logging.
+  String render(LogRenderer renderer) {
+    if (isEmpty) {
+      return 'Updates: none.';
+    }
+
+    final result = <String>[];
+    if (added.isNotEmpty) {
+      result.add('added ${renderer.trimmedIds(added)}');
+    }
+    if (modified.isNotEmpty) {
+      result.add('modified ${renderer.trimmedIds(modified)}');
+    }
+    if (removed.isNotEmpty) {
+      result.add('removed ${renderer.trimmedIds(removed)}');
+    }
+
+    return 'Updates: ${result.join('; ')}.';
+  }
+}

--- a/build_runner_core/lib/src/logging/log_renderer.dart
+++ b/build_runner_core/lib/src/logging/log_renderer.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:crypto/crypto.dart';
+
+/// Renders objects to strings for display in logs.
+class LogRenderer {
+  final String rootPackageName;
+
+  LogRenderer({required this.rootPackageName});
+
+  /// Renders [id].
+  ///
+  /// Like `AssetId.toString`, except the package name is omitted if it matches
+  /// [rootPackageName].
+  String id(AssetId id) {
+    if (id.package == rootPackageName) {
+      return id.path;
+    } else {
+      return id.toString();
+    }
+  }
+
+  /// Renders a build action with [input] and [outputs].
+  ///
+  /// Output names that mostly match [input] are shortened to remove the
+  /// duplication.
+  ///
+  /// Examples: `foo.dart->.g.dart`, `foo.dart->(.g.dart, .other.dart)`
+  String build(AssetId input, Iterable<AssetId> outputs) {
+    final displayedInput = id(input);
+    // If the input ends in `.dart`, take the base name and trim it from all
+    // outputs. So for example `foo.dart->foo.g.dart` is shortened to
+    // `foo.dart->.g.dart`.
+    final trimPrefix =
+        displayedInput.endsWith('.dart')
+            ? displayedInput.substring(0, displayedInput.length - 5)
+            : null;
+    final displayedOutputs =
+        outputs.length == 1
+            ? _trim(id(outputs.first), trimPrefix: trimPrefix)
+            : '(${trimmedIds(outputs, trimPrefix: trimPrefix)})';
+    return '$displayedInput->$displayedOutputs';
+  }
+
+  /// Returns [ids] converted to `String` as a comma-separated list,
+  /// with all ids beyond the third replaced by "(# more)".
+  ///
+  /// If [trimPrefix] is passed, trim the specified prefix from all items where
+  /// it matches.
+  String trimmedIds(Iterable<AssetId> ids, {String? trimPrefix}) {
+    final firstThree = ids
+        .map(id)
+        .take(3)
+        .map((s) => _trim(s, trimPrefix: trimPrefix));
+    if (firstThree.length == ids.length) {
+      return firstThree.join(', ');
+    } else {
+      return [...firstThree, '(${ids.length - 3} more)'].join(', ');
+    }
+  }
+
+  /// Renders [digest].
+  ///
+  /// Returns `none` for null, or the first seven characters of the digest.
+  String digest(Digest? digest) {
+    if (digest == null) return 'none';
+    var result = digest.toString();
+    if (result.length > 7) result = result.substring(0, 7);
+    return result;
+  }
+
+  /// Returns [string] with [trimPrefix] removed if it matches.
+  static String _trim(String string, {String? trimPrefix}) {
+    if (trimPrefix == null) return string;
+    if (string.startsWith(trimPrefix)) {
+      return string.substring(trimPrefix.length);
+    }
+    return string;
+  }
+}

--- a/build_runner_core/test/changes/asset_updates_test.dart
+++ b/build_runner_core/test/changes/asset_updates_test.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:build_runner_core/src/changes/asset_updates.dart';
+import 'package:build_runner_core/src/logging/log_renderer.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:test/test.dart';
+import 'package:watcher/watcher.dart';
+
+void main() {
+  final renderer = LogRenderer(rootPackageName: 'foo');
+  group('AssetUpdates', () {
+    test('explains no updates', () {
+      expect(
+        AssetUpdates(
+          added: BuiltSet(),
+          modified: BuiltSet(),
+          removed: BuiltSet(),
+        ).render(renderer),
+        'Updates: none.',
+      );
+    });
+
+    test('explains updates', () {
+      expect(
+        AssetUpdates(
+          added: {AssetId('foo', 'lib1.dart')}.build(),
+          modified:
+              {
+                AssetId('foo', 'lib2.dart'),
+                AssetId('foo', 'lib3.dart'),
+                AssetId('foo', 'lib4.dart'),
+              }.build(),
+          removed:
+              {
+                AssetId('foo', 'lib5.dart'),
+                AssetId('foo', 'lib6.dart'),
+                AssetId('foo', 'lib7.dart'),
+                AssetId('foo', 'lib8.dart'),
+                AssetId('foo', 'lib9.dart'),
+              }.build(),
+        ).render(renderer),
+        'Updates: added lib1.dart; '
+        'modified lib2.dart, lib3.dart, lib4.dart; '
+        'removed lib5.dart, lib6.dart, lib7.dart, (2 more).',
+      );
+    });
+
+    test('from Map', () {
+      expect(
+        AssetUpdates.from({
+          // `from` sorts by `AssetId`.
+          AssetId('foo', 'lib1.dart'): ChangeType.ADD,
+          AssetId('foo', 'lib4.dart'): ChangeType.MODIFY,
+          AssetId('foo', 'lib3.dart'): ChangeType.MODIFY,
+          AssetId('foo', 'lib2.dart'): ChangeType.MODIFY,
+          AssetId('foo', 'lib9.dart'): ChangeType.REMOVE,
+          AssetId('foo', 'lib8.dart'): ChangeType.REMOVE,
+          AssetId('foo', 'lib7.dart'): ChangeType.REMOVE,
+          AssetId('foo', 'lib6.dart'): ChangeType.REMOVE,
+          AssetId('foo', 'lib5.dart'): ChangeType.REMOVE,
+        }).render(renderer),
+        'Updates: added lib1.dart; '
+        'modified lib2.dart, lib3.dart, lib4.dart; '
+        'removed lib5.dart, lib6.dart, lib7.dart, (2 more).',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Example output with `<--` marking new lines.

```
[FINE] Updates: added lib/lib2.dart, lib/lib3.dart, lib/lib4.dart, (1 more); modified lib/lib1.dart.  <--
[INFO] Updating asset graph...
[INFO] Updating asset graph completed, took 6ms

[INFO] Running build...
[FINE] Build lib/lib1.dart->.json_serializable.g.part because inputs digest changed from a7b9298 to d12df74. <--
[FINE] json_serializable on lib/lib1.dart:Running JsonSerializableGenerator - 1 of 2
[FINE] json_serializable on lib/lib1.dart:Running JsonLiteralGenerator - 2 of 2
[FINE] Build lib/lib2.dart->.json_serializable.g.part because lib/lib2.json_serializable.g.part was marked for build. <--
[FINE] json_serializable on lib/lib2.dart:Running JsonSerializableGenerator - 1 of 2

...

[FINE] Build lib/lib4.dart->.g.dart because lib/lib4.g.dart was marked for build. <--
[FINE] Build lib/lib5.dart->.g.dart because lib/lib5.g.dart was marked for build. <--
[INFO] Running build completed, took 1.1s
```