### PR TITLE
Change detection by comparing changed input lists

### DIFF
--- a/_test_common/lib/matchers.dart
+++ b/_test_common/lib/matchers.dart
@@ -45,11 +45,6 @@ class _AssetGraphMatcher extends Matcher {
     final result = <AssetNode>[];
     for (var node in graph.allNodes) {
       if (!checkPreviousInputsDigest) {
-        if (node.type == NodeType.generated) {
-          node = node.rebuild(
-            (b) => b.generatedNodeState.previousInputsDigest = null,
-          );
-        }
         if (node.type == NodeType.postProcessAnchor) {
           node = node.rebuild(
             (b) => b..postProcessAnchorNodeState.previousInputsDigest = null,

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add `NodeType` to `AssetNode`, remove subtypes. Make mutations explicit.
 - Use `built_value` for `AssetNode` and related types, and for serialization.
 - Add details of what changed and what is built to `--verbose` logging.
+- New change detection algorithm.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/src/asset_graph/node.dart
+++ b/build_runner_core/lib/src/asset_graph/node.dart
@@ -198,7 +198,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
     required int phaseNumber,
     required bool isHidden,
     Iterable<AssetId>? inputs,
-    Digest? previousInputsDigest,
     required PendingBuildAction pendingBuildAction,
     required bool wasOutput,
     required bool isFailure,
@@ -212,7 +211,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
           ..generatedNodeConfiguration.phaseNumber = phaseNumber
           ..generatedNodeConfiguration.isHidden = isHidden
           ..generatedNodeState.inputs.replace(inputs ?? [])
-          ..generatedNodeState.previousInputsDigest = previousInputsDigest
           ..generatedNodeState.pendingBuildAction = pendingBuildAction
           ..generatedNodeState.wasOutput = wasOutput
           ..generatedNodeState.isFailure = isFailure
@@ -361,12 +359,6 @@ abstract class GeneratedNodeState
 
   /// Whether the action which did or would produce this node failed.
   bool get isFailure;
-
-  /// A digest combining all digests of all previous inputs.
-  ///
-  /// Used to determine whether all the inputs to a build step are identical to
-  /// the previous run, indicating that the previous output is still valid.
-  Digest? get previousInputsDigest;
 
   bool get isSuccessfulFreshOutput =>
       wasOutput && !isFailure && pendingBuildAction == PendingBuildAction.none;

--- a/build_runner_core/lib/src/asset_graph/node.g.dart
+++ b/build_runner_core/lib/src/asset_graph/node.g.dart
@@ -559,15 +559,7 @@ class _$GeneratedNodeStateSerializer
         specifiedType: const FullType(bool),
       ),
     ];
-    Object? value;
-    value = object.previousInputsDigest;
-    if (value != null) {
-      result
-        ..add('previousInputsDigest')
-        ..add(
-          serializers.serialize(value, specifiedType: const FullType(Digest)),
-        );
-    }
+
     return result;
   }
 
@@ -619,14 +611,6 @@ class _$GeneratedNodeStateSerializer
                     specifiedType: const FullType(bool),
                   )!
                   as bool;
-          break;
-        case 'previousInputsDigest':
-          result.previousInputsDigest =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(Digest),
-                  )
-                  as Digest?;
           break;
       }
     }
@@ -1444,8 +1428,6 @@ class _$GeneratedNodeState extends GeneratedNodeState {
   final bool wasOutput;
   @override
   final bool isFailure;
-  @override
-  final Digest? previousInputsDigest;
 
   factory _$GeneratedNodeState([
     void Function(GeneratedNodeStateBuilder)? updates,
@@ -1456,7 +1438,6 @@ class _$GeneratedNodeState extends GeneratedNodeState {
     required this.pendingBuildAction,
     required this.wasOutput,
     required this.isFailure,
-    this.previousInputsDigest,
   }) : super._() {
     BuiltValueNullFieldError.checkNotNull(
       inputs,
@@ -1496,8 +1477,7 @@ class _$GeneratedNodeState extends GeneratedNodeState {
         inputs == other.inputs &&
         pendingBuildAction == other.pendingBuildAction &&
         wasOutput == other.wasOutput &&
-        isFailure == other.isFailure &&
-        previousInputsDigest == other.previousInputsDigest;
+        isFailure == other.isFailure;
   }
 
   @override
@@ -1507,7 +1487,6 @@ class _$GeneratedNodeState extends GeneratedNodeState {
     _$hash = $jc(_$hash, pendingBuildAction.hashCode);
     _$hash = $jc(_$hash, wasOutput.hashCode);
     _$hash = $jc(_$hash, isFailure.hashCode);
-    _$hash = $jc(_$hash, previousInputsDigest.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -1518,8 +1497,7 @@ class _$GeneratedNodeState extends GeneratedNodeState {
           ..add('inputs', inputs)
           ..add('pendingBuildAction', pendingBuildAction)
           ..add('wasOutput', wasOutput)
-          ..add('isFailure', isFailure)
-          ..add('previousInputsDigest', previousInputsDigest))
+          ..add('isFailure', isFailure))
         .toString();
   }
 }
@@ -1546,11 +1524,6 @@ class GeneratedNodeStateBuilder
   bool? get isFailure => _$this._isFailure;
   set isFailure(bool? isFailure) => _$this._isFailure = isFailure;
 
-  Digest? _previousInputsDigest;
-  Digest? get previousInputsDigest => _$this._previousInputsDigest;
-  set previousInputsDigest(Digest? previousInputsDigest) =>
-      _$this._previousInputsDigest = previousInputsDigest;
-
   GeneratedNodeStateBuilder();
 
   GeneratedNodeStateBuilder get _$this {
@@ -1560,7 +1533,6 @@ class GeneratedNodeStateBuilder
       _pendingBuildAction = $v.pendingBuildAction;
       _wasOutput = $v.wasOutput;
       _isFailure = $v.isFailure;
-      _previousInputsDigest = $v.previousInputsDigest;
       _$v = null;
     }
     return this;
@@ -1602,7 +1574,6 @@ class GeneratedNodeStateBuilder
               r'GeneratedNodeState',
               'isFailure',
             ),
-            previousInputsDigest: previousInputsDigest,
           );
     } catch (_) {
       late String _$failedField;

--- a/build_runner_core/test/asset_graph/graph_test.dart
+++ b/build_runner_core/test/asset_graph/graph_test.dart
@@ -164,17 +164,6 @@ void main() {
                 globNode.id,
               ]),
             );
-            if (g.isOdd) {
-              // Fake a digest using the id, we just care that this gets
-              // serialized/deserialized properly.
-              generatedNode = generatedNode.rebuild(
-                (b) =>
-                    b
-                      ..generatedNodeState.previousInputsDigest = md5.convert(
-                        utf8.encode(generatedNode.id.toString()),
-                      ),
-              );
-            }
             graph
               ..add(builderOptionsNode)
               ..add(generatedNode)


### PR DESCRIPTION
For #3811.

Determine when to rerun by comparing what changed to the list of inputs, instead of by computing transitive digests.

Anyone who has been watching my draft PRs will know this has taken a lot of attempts to get right :) ... I got it right in the end using [this experimental PR](https://github.com/dart-lang/build/pull/3936) which runs both old and new algorithms side by side and throws if there is any difference. So, this is 100% equivalent over all test cases including e2e tests.

This removes one of the bigger `O(n^2)` algorithms, the transitive digest computation when there is a library cycle. So, there is some fairly nice speedup.

```
Before this PR:
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms
loop,1,22902,3935,5084
loop,100,24758,4193,8395
loop,250,30815,4838,12957
loop,500,56025,6941,27749
loop,750,102795,12461,45304
loop,1000,211007,18776,77577 <--

with this PR:
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms
loop,1,23662,3833,5028
loop,100,25251,4051,7370
loop,250,30820,4974,12545
loop,500,49110,7378,24480
loop,750,101279,12873,37691
loop,1000,159219,17996,56268 <--
```