### PR TITLE
Split post process builder state out of the main graph.

### DIFF
--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -426,6 +426,10 @@ void main() {
           cachedGraph,
           equalsAssetGraph(expectedGraph, checkPreviousInputsDigest: false),
         );
+        expect(
+          cachedGraph.allPostProcessBuildStepOutputs,
+          expectedGraph.allPostProcessBuildStepOutputs,
+        );
       });
 
       test('ignores events from nested packages', () async {

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -10,6 +10,7 @@ import 'package:build_runner/src/server/server.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/asset_graph/post_process_build_step_id.dart';
 import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/options.dart';
 import 'package:build_runner_core/src/package_graph/target_graph.dart';
@@ -48,9 +49,11 @@ void main() {
   void addAsset(String id, String content, {bool deleted = false}) {
     var node = makeAssetNode(id, [], computeDigest(AssetId.parse(id), 'a'));
     if (deleted) {
-      node = node.rebuild(
-        (b) => b..deletedBy.add(node.id.addExtension('.post_anchor.1')),
-      );
+      node = node.rebuild((b) {
+        b.deletedBy.add(
+          PostProcessBuildStepId(input: node.id, actionNumber: 1),
+        );
+      });
     }
     graph.add(node);
     delegate.testing.writeString(node.id, content);

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -15,6 +15,7 @@ import 'package:build_runner/src/server/server.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/asset_graph/post_process_build_step_id.dart';
 import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/options.dart';
 import 'package:build_runner_core/src/generate/performance_tracker.dart';
@@ -139,9 +140,11 @@ void main() {
   void addSource(String id, String content, {bool deleted = false}) {
     var node = makeAssetNode(id, [], computeDigest(AssetId.parse(id), content));
     if (deleted) {
-      node = node.rebuild(
-        (b) => b..deletedBy.add(node.id.addExtension('.post_anchor.1')),
-      );
+      node = node.rebuild((b) {
+        b.deletedBy.add(
+          PostProcessBuildStepId(input: node.id, actionNumber: 1),
+        );
+      });
     }
     assetGraph.add(node);
     readerWriter.testing.writeString(node.id, content);

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Add `reportUnusedAssetsForInput` to `BuildOptions`, to listen for when
   a builder notifies that an asset is unused.
 - Use `LibraryCycleGraphLoader` to load transitive deps for analysis.
+- Track post process builder outputs separately from the main graph Instead of
+  in `postProcessAnchor` nodes.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/src/asset_graph/node.g.dart
+++ b/build_runner_core/lib/src/asset_graph/node.g.dart
@@ -11,7 +11,6 @@ const NodeType _$generated = const NodeType._('generated');
 const NodeType _$glob = const NodeType._('glob');
 const NodeType _$internal = const NodeType._('internal');
 const NodeType _$placeholder = const NodeType._('placeholder');
-const NodeType _$postProcessAnchor = const NodeType._('postProcessAnchor');
 const NodeType _$source = const NodeType._('source');
 const NodeType _$missingSource = const NodeType._('missingSource');
 
@@ -27,8 +26,6 @@ NodeType _$nodeTypeValueOf(String name) {
       return _$internal;
     case 'placeholder':
       return _$placeholder;
-    case 'postProcessAnchor':
-      return _$postProcessAnchor;
     case 'source':
       return _$source;
     case 'missingSource':
@@ -45,7 +42,6 @@ final BuiltSet<NodeType> _$nodeTypeValues =
       _$glob,
       _$internal,
       _$placeholder,
-      _$postProcessAnchor,
       _$source,
       _$missingSource,
     ]);
@@ -76,45 +72,6 @@ final BuiltSet<PendingBuildAction> _$pendingBuildActionValues =
       _$build,
     ]);
 
-Serializers _$serializers =
-    (new Serializers().toBuilder()
-          ..add(AssetNode.serializer)
-          ..add(GeneratedNodeConfiguration.serializer)
-          ..add(GeneratedNodeState.serializer)
-          ..add(GlobNodeConfiguration.serializer)
-          ..add(GlobNodeState.serializer)
-          ..add(NodeType.serializer)
-          ..add(PendingBuildAction.serializer)
-          ..add(PostProcessAnchorNodeConfiguration.serializer)
-          ..addBuilderFactory(
-            const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltList, const [const FullType(AssetId)]),
-            () => new ListBuilder<AssetId>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
-          ))
-        .build();
 Serializer<NodeType> _$nodeTypeSerializer = new _$NodeTypeSerializer();
 Serializer<AssetNode> _$assetNodeSerializer = new _$AssetNodeSerializer();
 Serializer<GeneratedNodeConfiguration> _$generatedNodeConfigurationSerializer =
@@ -125,9 +82,6 @@ Serializer<GlobNodeConfiguration> _$globNodeConfigurationSerializer =
     new _$GlobNodeConfigurationSerializer();
 Serializer<GlobNodeState> _$globNodeStateSerializer =
     new _$GlobNodeStateSerializer();
-Serializer<PostProcessAnchorNodeConfiguration>
-_$postProcessAnchorNodeConfigurationSerializer =
-    new _$PostProcessAnchorNodeConfigurationSerializer();
 Serializer<PendingBuildAction> _$pendingBuildActionSerializer =
     new _$PendingBuildActionSerializer();
 
@@ -186,18 +140,11 @@ class _$AssetNodeSerializer implements StructuredSerializer<AssetNode> {
           const FullType(AssetId),
         ]),
       ),
-      'anchorOutputs',
-      serializers.serialize(
-        object.anchorOutputs,
-        specifiedType: const FullType(BuiltSet, const [
-          const FullType(AssetId),
-        ]),
-      ),
       'deletedBy',
       serializers.serialize(
         object.deletedBy,
         specifiedType: const FullType(BuiltSet, const [
-          const FullType(AssetId),
+          const FullType(PostProcessBuildStepId),
         ]),
       ),
     ];
@@ -243,17 +190,6 @@ class _$AssetNodeSerializer implements StructuredSerializer<AssetNode> {
           serializers.serialize(
             value,
             specifiedType: const FullType(GlobNodeState),
-          ),
-        );
-    }
-    value = object.postProcessAnchorNodeConfiguration;
-    if (value != null) {
-      result
-        ..add('postProcessAnchorNodeConfiguration')
-        ..add(
-          serializers.serialize(
-            value,
-            specifiedType: const FullType(PostProcessAnchorNodeConfiguration),
           ),
         );
     }
@@ -334,17 +270,6 @@ class _$AssetNodeSerializer implements StructuredSerializer<AssetNode> {
                 as GlobNodeState,
           );
           break;
-        case 'postProcessAnchorNodeConfiguration':
-          result.postProcessAnchorNodeConfiguration.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(
-                    PostProcessAnchorNodeConfiguration,
-                  ),
-                )!
-                as PostProcessAnchorNodeConfiguration,
-          );
-          break;
         case 'primaryOutputs':
           result.primaryOutputs.replace(
             serializers.deserialize(
@@ -367,17 +292,6 @@ class _$AssetNodeSerializer implements StructuredSerializer<AssetNode> {
                 as BuiltSet<Object?>,
           );
           break;
-        case 'anchorOutputs':
-          result.anchorOutputs.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltSet, const [
-                    const FullType(AssetId),
-                  ]),
-                )!
-                as BuiltSet<Object?>,
-          );
-          break;
         case 'lastKnownDigest':
           result.lastKnownDigest =
               serializers.deserialize(
@@ -391,7 +305,7 @@ class _$AssetNodeSerializer implements StructuredSerializer<AssetNode> {
             serializers.deserialize(
                   value,
                   specifiedType: const FullType(BuiltSet, const [
-                    const FullType(AssetId),
+                    const FullType(PostProcessBuildStepId),
                   ]),
                 )!
                 as BuiltSet<Object?>,
@@ -750,88 +664,6 @@ class _$GlobNodeStateSerializer implements StructuredSerializer<GlobNodeState> {
   }
 }
 
-class _$PostProcessAnchorNodeConfigurationSerializer
-    implements StructuredSerializer<PostProcessAnchorNodeConfiguration> {
-  @override
-  final Iterable<Type> types = const [
-    PostProcessAnchorNodeConfiguration,
-    _$PostProcessAnchorNodeConfiguration,
-  ];
-  @override
-  final String wireName = 'PostProcessAnchorNodeConfiguration';
-
-  @override
-  Iterable<Object?> serialize(
-    Serializers serializers,
-    PostProcessAnchorNodeConfiguration object, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = <Object?>[
-      'actionNumber',
-      serializers.serialize(
-        object.actionNumber,
-        specifiedType: const FullType(int),
-      ),
-      'builderOptionsId',
-      serializers.serialize(
-        object.builderOptionsId,
-        specifiedType: const FullType(AssetId),
-      ),
-      'primaryInput',
-      serializers.serialize(
-        object.primaryInput,
-        specifiedType: const FullType(AssetId),
-      ),
-    ];
-
-    return result;
-  }
-
-  @override
-  PostProcessAnchorNodeConfiguration deserialize(
-    Serializers serializers,
-    Iterable<Object?> serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) {
-    final result = new PostProcessAnchorNodeConfigurationBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'actionNumber':
-          result.actionNumber =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(int),
-                  )!
-                  as int;
-          break;
-        case 'builderOptionsId':
-          result.builderOptionsId =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(AssetId),
-                  )!
-                  as AssetId;
-          break;
-        case 'primaryInput':
-          result.primaryInput =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(AssetId),
-                  )!
-                  as AssetId;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$PendingBuildActionSerializer
     implements PrimitiveSerializer<PendingBuildAction> {
   @override
@@ -868,17 +700,13 @@ class _$AssetNode extends AssetNode {
   @override
   final GlobNodeState? globNodeState;
   @override
-  final PostProcessAnchorNodeConfiguration? postProcessAnchorNodeConfiguration;
-  @override
   final BuiltSet<AssetId> primaryOutputs;
   @override
   final BuiltSet<AssetId> outputs;
   @override
-  final BuiltSet<AssetId> anchorOutputs;
-  @override
   final Digest? lastKnownDigest;
   @override
-  final BuiltSet<AssetId> deletedBy;
+  final BuiltSet<PostProcessBuildStepId> deletedBy;
 
   factory _$AssetNode([void Function(AssetNodeBuilder)? updates]) =>
       (new AssetNodeBuilder()..update(updates))._build();
@@ -890,10 +718,8 @@ class _$AssetNode extends AssetNode {
     this.generatedNodeState,
     this.globNodeConfiguration,
     this.globNodeState,
-    this.postProcessAnchorNodeConfiguration,
     required this.primaryOutputs,
     required this.outputs,
-    required this.anchorOutputs,
     this.lastKnownDigest,
     required this.deletedBy,
   }) : super._() {
@@ -905,11 +731,6 @@ class _$AssetNode extends AssetNode {
       'primaryOutputs',
     );
     BuiltValueNullFieldError.checkNotNull(outputs, r'AssetNode', 'outputs');
-    BuiltValueNullFieldError.checkNotNull(
-      anchorOutputs,
-      r'AssetNode',
-      'anchorOutputs',
-    );
     BuiltValueNullFieldError.checkNotNull(deletedBy, r'AssetNode', 'deletedBy');
   }
 
@@ -930,11 +751,8 @@ class _$AssetNode extends AssetNode {
         generatedNodeState == other.generatedNodeState &&
         globNodeConfiguration == other.globNodeConfiguration &&
         globNodeState == other.globNodeState &&
-        postProcessAnchorNodeConfiguration ==
-            other.postProcessAnchorNodeConfiguration &&
         primaryOutputs == other.primaryOutputs &&
         outputs == other.outputs &&
-        anchorOutputs == other.anchorOutputs &&
         lastKnownDigest == other.lastKnownDigest &&
         deletedBy == other.deletedBy;
   }
@@ -948,10 +766,8 @@ class _$AssetNode extends AssetNode {
     _$hash = $jc(_$hash, generatedNodeState.hashCode);
     _$hash = $jc(_$hash, globNodeConfiguration.hashCode);
     _$hash = $jc(_$hash, globNodeState.hashCode);
-    _$hash = $jc(_$hash, postProcessAnchorNodeConfiguration.hashCode);
     _$hash = $jc(_$hash, primaryOutputs.hashCode);
     _$hash = $jc(_$hash, outputs.hashCode);
-    _$hash = $jc(_$hash, anchorOutputs.hashCode);
     _$hash = $jc(_$hash, lastKnownDigest.hashCode);
     _$hash = $jc(_$hash, deletedBy.hashCode);
     _$hash = $jf(_$hash);
@@ -967,13 +783,8 @@ class _$AssetNode extends AssetNode {
           ..add('generatedNodeState', generatedNodeState)
           ..add('globNodeConfiguration', globNodeConfiguration)
           ..add('globNodeState', globNodeState)
-          ..add(
-            'postProcessAnchorNodeConfiguration',
-            postProcessAnchorNodeConfiguration,
-          )
           ..add('primaryOutputs', primaryOutputs)
           ..add('outputs', outputs)
-          ..add('anchorOutputs', anchorOutputs)
           ..add('lastKnownDigest', lastKnownDigest)
           ..add('deletedBy', deletedBy))
         .toString();
@@ -1018,19 +829,6 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
   set globNodeState(GlobNodeStateBuilder? globNodeState) =>
       _$this._globNodeState = globNodeState;
 
-  PostProcessAnchorNodeConfigurationBuilder?
-  _postProcessAnchorNodeConfiguration;
-  PostProcessAnchorNodeConfigurationBuilder
-  get postProcessAnchorNodeConfiguration =>
-      _$this._postProcessAnchorNodeConfiguration ??=
-          new PostProcessAnchorNodeConfigurationBuilder();
-  set postProcessAnchorNodeConfiguration(
-    PostProcessAnchorNodeConfigurationBuilder?
-    postProcessAnchorNodeConfiguration,
-  ) =>
-      _$this._postProcessAnchorNodeConfiguration =
-          postProcessAnchorNodeConfiguration;
-
   SetBuilder<AssetId>? _primaryOutputs;
   SetBuilder<AssetId> get primaryOutputs =>
       _$this._primaryOutputs ??= new SetBuilder<AssetId>();
@@ -1042,21 +840,15 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
       _$this._outputs ??= new SetBuilder<AssetId>();
   set outputs(SetBuilder<AssetId>? outputs) => _$this._outputs = outputs;
 
-  SetBuilder<AssetId>? _anchorOutputs;
-  SetBuilder<AssetId> get anchorOutputs =>
-      _$this._anchorOutputs ??= new SetBuilder<AssetId>();
-  set anchorOutputs(SetBuilder<AssetId>? anchorOutputs) =>
-      _$this._anchorOutputs = anchorOutputs;
-
   Digest? _lastKnownDigest;
   Digest? get lastKnownDigest => _$this._lastKnownDigest;
   set lastKnownDigest(Digest? lastKnownDigest) =>
       _$this._lastKnownDigest = lastKnownDigest;
 
-  SetBuilder<AssetId>? _deletedBy;
-  SetBuilder<AssetId> get deletedBy =>
-      _$this._deletedBy ??= new SetBuilder<AssetId>();
-  set deletedBy(SetBuilder<AssetId>? deletedBy) =>
+  SetBuilder<PostProcessBuildStepId>? _deletedBy;
+  SetBuilder<PostProcessBuildStepId> get deletedBy =>
+      _$this._deletedBy ??= new SetBuilder<PostProcessBuildStepId>();
+  set deletedBy(SetBuilder<PostProcessBuildStepId>? deletedBy) =>
       _$this._deletedBy = deletedBy;
 
   AssetNodeBuilder();
@@ -1070,11 +862,8 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
       _generatedNodeState = $v.generatedNodeState?.toBuilder();
       _globNodeConfiguration = $v.globNodeConfiguration?.toBuilder();
       _globNodeState = $v.globNodeState?.toBuilder();
-      _postProcessAnchorNodeConfiguration =
-          $v.postProcessAnchorNodeConfiguration?.toBuilder();
       _primaryOutputs = $v.primaryOutputs.toBuilder();
       _outputs = $v.outputs.toBuilder();
-      _anchorOutputs = $v.anchorOutputs.toBuilder();
       _lastKnownDigest = $v.lastKnownDigest;
       _deletedBy = $v.deletedBy.toBuilder();
       _$v = null;
@@ -1112,11 +901,8 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
             generatedNodeState: _generatedNodeState?.build(),
             globNodeConfiguration: _globNodeConfiguration?.build(),
             globNodeState: _globNodeState?.build(),
-            postProcessAnchorNodeConfiguration:
-                _postProcessAnchorNodeConfiguration?.build(),
             primaryOutputs: primaryOutputs.build(),
             outputs: outputs.build(),
-            anchorOutputs: anchorOutputs.build(),
             lastKnownDigest: lastKnownDigest,
             deletedBy: deletedBy.build(),
           );
@@ -1131,14 +917,10 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
         _globNodeConfiguration?.build();
         _$failedField = 'globNodeState';
         _globNodeState?.build();
-        _$failedField = 'postProcessAnchorNodeConfiguration';
-        _postProcessAnchorNodeConfiguration?.build();
         _$failedField = 'primaryOutputs';
         primaryOutputs.build();
         _$failedField = 'outputs';
         outputs.build();
-        _$failedField = 'anchorOutputs';
-        anchorOutputs.build();
 
         _$failedField = 'deletedBy';
         deletedBy.build();
@@ -1750,157 +1532,6 @@ class GlobNodeStateBuilder
       }
       rethrow;
     }
-    replace(_$result);
-    return _$result;
-  }
-}
-
-class _$PostProcessAnchorNodeConfiguration
-    extends PostProcessAnchorNodeConfiguration {
-  @override
-  final int actionNumber;
-  @override
-  final AssetId builderOptionsId;
-  @override
-  final AssetId primaryInput;
-
-  factory _$PostProcessAnchorNodeConfiguration([
-    void Function(PostProcessAnchorNodeConfigurationBuilder)? updates,
-  ]) =>
-      (new PostProcessAnchorNodeConfigurationBuilder()..update(updates))
-          ._build();
-
-  _$PostProcessAnchorNodeConfiguration._({
-    required this.actionNumber,
-    required this.builderOptionsId,
-    required this.primaryInput,
-  }) : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-      actionNumber,
-      r'PostProcessAnchorNodeConfiguration',
-      'actionNumber',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      builderOptionsId,
-      r'PostProcessAnchorNodeConfiguration',
-      'builderOptionsId',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      primaryInput,
-      r'PostProcessAnchorNodeConfiguration',
-      'primaryInput',
-    );
-  }
-
-  @override
-  PostProcessAnchorNodeConfiguration rebuild(
-    void Function(PostProcessAnchorNodeConfigurationBuilder) updates,
-  ) => (toBuilder()..update(updates)).build();
-
-  @override
-  PostProcessAnchorNodeConfigurationBuilder toBuilder() =>
-      new PostProcessAnchorNodeConfigurationBuilder()..replace(this);
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(other, this)) return true;
-    return other is PostProcessAnchorNodeConfiguration &&
-        actionNumber == other.actionNumber &&
-        builderOptionsId == other.builderOptionsId &&
-        primaryInput == other.primaryInput;
-  }
-
-  @override
-  int get hashCode {
-    var _$hash = 0;
-    _$hash = $jc(_$hash, actionNumber.hashCode);
-    _$hash = $jc(_$hash, builderOptionsId.hashCode);
-    _$hash = $jc(_$hash, primaryInput.hashCode);
-    _$hash = $jf(_$hash);
-    return _$hash;
-  }
-
-  @override
-  String toString() {
-    return (newBuiltValueToStringHelper(r'PostProcessAnchorNodeConfiguration')
-          ..add('actionNumber', actionNumber)
-          ..add('builderOptionsId', builderOptionsId)
-          ..add('primaryInput', primaryInput))
-        .toString();
-  }
-}
-
-class PostProcessAnchorNodeConfigurationBuilder
-    implements
-        Builder<
-          PostProcessAnchorNodeConfiguration,
-          PostProcessAnchorNodeConfigurationBuilder
-        > {
-  _$PostProcessAnchorNodeConfiguration? _$v;
-
-  int? _actionNumber;
-  int? get actionNumber => _$this._actionNumber;
-  set actionNumber(int? actionNumber) => _$this._actionNumber = actionNumber;
-
-  AssetId? _builderOptionsId;
-  AssetId? get builderOptionsId => _$this._builderOptionsId;
-  set builderOptionsId(AssetId? builderOptionsId) =>
-      _$this._builderOptionsId = builderOptionsId;
-
-  AssetId? _primaryInput;
-  AssetId? get primaryInput => _$this._primaryInput;
-  set primaryInput(AssetId? primaryInput) =>
-      _$this._primaryInput = primaryInput;
-
-  PostProcessAnchorNodeConfigurationBuilder();
-
-  PostProcessAnchorNodeConfigurationBuilder get _$this {
-    final $v = _$v;
-    if ($v != null) {
-      _actionNumber = $v.actionNumber;
-      _builderOptionsId = $v.builderOptionsId;
-      _primaryInput = $v.primaryInput;
-      _$v = null;
-    }
-    return this;
-  }
-
-  @override
-  void replace(PostProcessAnchorNodeConfiguration other) {
-    ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$PostProcessAnchorNodeConfiguration;
-  }
-
-  @override
-  void update(
-    void Function(PostProcessAnchorNodeConfigurationBuilder)? updates,
-  ) {
-    if (updates != null) updates(this);
-  }
-
-  @override
-  PostProcessAnchorNodeConfiguration build() => _build();
-
-  _$PostProcessAnchorNodeConfiguration _build() {
-    final _$result =
-        _$v ??
-        new _$PostProcessAnchorNodeConfiguration._(
-          actionNumber: BuiltValueNullFieldError.checkNotNull(
-            actionNumber,
-            r'PostProcessAnchorNodeConfiguration',
-            'actionNumber',
-          ),
-          builderOptionsId: BuiltValueNullFieldError.checkNotNull(
-            builderOptionsId,
-            r'PostProcessAnchorNodeConfiguration',
-            'builderOptionsId',
-          ),
-          primaryInput: BuiltValueNullFieldError.checkNotNull(
-            primaryInput,
-            r'PostProcessAnchorNodeConfiguration',
-            'primaryInput',
-          ),
-        );
     replace(_$result);
     return _$result;
   }

--- a/build_runner_core/lib/src/asset_graph/post_process_build_step_id.dart
+++ b/build_runner_core/lib/src/asset_graph/post_process_build_step_id.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart' hide Builder;
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'post_process_build_step_id.g.dart';
+
+/// Identifies a `PostProcessBuildStep` within a build: the application of a
+/// `PostProcessBuilder` to one input.
+abstract class PostProcessBuildStepId
+    implements Built<PostProcessBuildStepId, PostProcessBuildStepIdBuilder> {
+  static Serializer<PostProcessBuildStepId> get serializer =>
+      _$postProcessBuildStepIdSerializer;
+
+  AssetId get input;
+
+  /// The [actionNumber] identifying which `PostProcessBuilder` runs.
+  int get actionNumber;
+
+  PostProcessBuildStepId._();
+
+  factory PostProcessBuildStepId({
+    required AssetId input,
+    required int actionNumber,
+  }) = _$PostProcessBuildStepId._;
+
+  /// The [AssetId] used to store the hash of the build options for the step.
+  AssetId get builderOptionsId =>
+      builderOptionsIdFor(package: input.package, actionNumber: actionNumber);
+
+  static AssetId builderOptionsIdFor({
+    required String package,
+    required int actionNumber,
+  }) => AssetId(package, 'PostPhase$actionNumber.builderOptions');
+}

--- a/build_runner_core/lib/src/asset_graph/post_process_build_step_id.g.dart
+++ b/build_runner_core/lib/src/asset_graph/post_process_build_step_id.g.dart
@@ -1,0 +1,198 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'post_process_build_step_id.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<PostProcessBuildStepId> _$postProcessBuildStepIdSerializer =
+    new _$PostProcessBuildStepIdSerializer();
+
+class _$PostProcessBuildStepIdSerializer
+    implements StructuredSerializer<PostProcessBuildStepId> {
+  @override
+  final Iterable<Type> types = const [
+    PostProcessBuildStepId,
+    _$PostProcessBuildStepId,
+  ];
+  @override
+  final String wireName = 'PostProcessBuildStepId';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    PostProcessBuildStepId object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'input',
+      serializers.serialize(
+        object.input,
+        specifiedType: const FullType(AssetId),
+      ),
+      'actionNumber',
+      serializers.serialize(
+        object.actionNumber,
+        specifiedType: const FullType(int),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  PostProcessBuildStepId deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = new PostProcessBuildStepIdBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'input':
+          result.input =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(AssetId),
+                  )!
+                  as AssetId;
+          break;
+        case 'actionNumber':
+          result.actionNumber =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PostProcessBuildStepId extends PostProcessBuildStepId {
+  @override
+  final AssetId input;
+  @override
+  final int actionNumber;
+
+  factory _$PostProcessBuildStepId([
+    void Function(PostProcessBuildStepIdBuilder)? updates,
+  ]) => (new PostProcessBuildStepIdBuilder()..update(updates))._build();
+
+  _$PostProcessBuildStepId._({required this.input, required this.actionNumber})
+    : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+      input,
+      r'PostProcessBuildStepId',
+      'input',
+    );
+    BuiltValueNullFieldError.checkNotNull(
+      actionNumber,
+      r'PostProcessBuildStepId',
+      'actionNumber',
+    );
+  }
+
+  @override
+  PostProcessBuildStepId rebuild(
+    void Function(PostProcessBuildStepIdBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  PostProcessBuildStepIdBuilder toBuilder() =>
+      new PostProcessBuildStepIdBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PostProcessBuildStepId &&
+        input == other.input &&
+        actionNumber == other.actionNumber;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, input.hashCode);
+    _$hash = $jc(_$hash, actionNumber.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PostProcessBuildStepId')
+          ..add('input', input)
+          ..add('actionNumber', actionNumber))
+        .toString();
+  }
+}
+
+class PostProcessBuildStepIdBuilder
+    implements Builder<PostProcessBuildStepId, PostProcessBuildStepIdBuilder> {
+  _$PostProcessBuildStepId? _$v;
+
+  AssetId? _input;
+  AssetId? get input => _$this._input;
+  set input(AssetId? input) => _$this._input = input;
+
+  int? _actionNumber;
+  int? get actionNumber => _$this._actionNumber;
+  set actionNumber(int? actionNumber) => _$this._actionNumber = actionNumber;
+
+  PostProcessBuildStepIdBuilder();
+
+  PostProcessBuildStepIdBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _input = $v.input;
+      _actionNumber = $v.actionNumber;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PostProcessBuildStepId other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PostProcessBuildStepId;
+  }
+
+  @override
+  void update(void Function(PostProcessBuildStepIdBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PostProcessBuildStepId build() => _build();
+
+  _$PostProcessBuildStepId _build() {
+    final _$result =
+        _$v ??
+        new _$PostProcessBuildStepId._(
+          input: BuiltValueNullFieldError.checkNotNull(
+            input,
+            r'PostProcessBuildStepId',
+            'input',
+          ),
+          actionNumber: BuiltValueNullFieldError.checkNotNull(
+            actionNumber,
+            r'PostProcessBuildStepId',
+            'actionNumber',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/build_runner_core/lib/src/asset_graph/serializers.dart
+++ b/build_runner_core/lib/src/asset_graph/serializers.dart
@@ -1,0 +1,233 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:build/build.dart' show AssetId, PostProcessBuildStep;
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:crypto/crypto.dart';
+
+import 'node.dart';
+import 'post_process_build_step_id.dart';
+
+part 'serializers.g.dart';
+
+final postProcessBuildStepOutputsInnerFullType = const FullType(Map, [
+  FullType(PostProcessBuildStep),
+  FullType(Set, [FullType(AssetId)]),
+]);
+
+final postProcessBuildStepOutputsFullType = FullType(Map, [
+  const FullType(String),
+  postProcessBuildStepOutputsInnerFullType,
+]);
+
+@SerializersFor([AssetNode])
+final Serializers serializers =
+    (_$serializers.toBuilder()
+          ..add(AssetIdSerializer())
+          ..add(DigestSerializer())
+          ..add(MapSerializer())
+          ..add(SetSerializer())
+          ..addBuilderFactory(
+            const FullType(Set, [FullType(AssetId)]),
+            () => <AssetId>{},
+          )
+          ..addBuilderFactory(
+            postProcessBuildStepOutputsInnerFullType,
+            () => <PostProcessBuildStepId, Set<AssetId>>{},
+          )
+          ..addBuilderFactory(
+            postProcessBuildStepOutputsFullType,
+            () => <String, Map<PostProcessBuildStepId, Set<AssetId>>>{},
+          ))
+        .build();
+
+/// Serializer for [AssetId].
+///
+/// It would also work to make `AssetId` a `built_value` class, but there's
+/// little benefit and it's nicer to keep codegen local to this package.
+class AssetIdSerializer implements PrimitiveSerializer<AssetId> {
+  @override
+  Iterable<Type> get types => [AssetId];
+
+  @override
+  String get wireName => 'AssetId';
+
+  @override
+  AssetId deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => AssetId.parse(serialized as String);
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    AssetId object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => object.toString();
+}
+
+/// Serializer for [Digest].
+class DigestSerializer implements PrimitiveSerializer<Digest> {
+  @override
+  Iterable<Type> get types => [Digest];
+
+  @override
+  String get wireName => 'Digest';
+
+  @override
+  Digest deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => Digest(base64.decode(serialized as String));
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    Digest object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => base64.encode(object.bytes);
+}
+
+// TODO(davidmorgan): this is a fork of `BuiltMapSerializer` from `built_value`
+// adapted for SDK maps, upstream it.
+class MapSerializer implements StructuredSerializer<Map> {
+  final bool structured = true;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([
+    Map,
+    <Object, Object>{}.runtimeType,
+  ]);
+  @override
+  final String wireName = 'map';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Map builtMap, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+
+    var keyType =
+        specifiedType.parameters.isEmpty
+            ? FullType.unspecified
+            : specifiedType.parameters[0];
+    var valueType =
+        specifiedType.parameters.isEmpty
+            ? FullType.unspecified
+            : specifiedType.parameters[1];
+
+    var result = <Object?>[];
+    for (var key in builtMap.keys) {
+      result.add(serializers.serialize(key, specifiedType: keyType));
+      final value = builtMap[key];
+      result.add(serializers.serialize(value, specifiedType: valueType));
+    }
+    return result;
+  }
+
+  @override
+  Map deserialize(
+    Serializers serializers,
+    Iterable serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    var keyType =
+        specifiedType.parameters.isEmpty
+            ? FullType.unspecified
+            : specifiedType.parameters[0];
+    var valueType =
+        specifiedType.parameters.isEmpty
+            ? FullType.unspecified
+            : specifiedType.parameters[1];
+
+    var result =
+        isUnderspecified
+            ? <Object, Object>{}
+            : serializers.newBuilder(specifiedType) as Map;
+
+    if (serialized.length.isOdd) {
+      throw ArgumentError('odd length');
+    }
+
+    for (var i = 0; i != serialized.length; i += 2) {
+      final key = serializers.deserialize(
+        serialized.elementAt(i),
+        specifiedType: keyType,
+      );
+      final value = serializers.deserialize(
+        serialized.elementAt(i + 1),
+        specifiedType: valueType,
+      );
+      result[key] = value;
+    }
+
+    return result;
+  }
+}
+
+// TODO(davidmorgan): this is a fork of `BuiltSetSerializer` from `built_value`
+// adapted for SDK sets, upstream it.
+class SetSerializer implements StructuredSerializer<Set> {
+  final bool structured = true;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([Set, <Object>{}.runtimeType]);
+  @override
+  final String wireName = 'set';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    Set builtSet, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+
+    var elementType =
+        specifiedType.parameters.isEmpty
+            ? FullType.unspecified
+            : specifiedType.parameters[0];
+
+    return builtSet.map(
+      (item) => serializers.serialize(item, specifiedType: elementType),
+    );
+  }
+
+  @override
+  Set deserialize(
+    Serializers serializers,
+    Iterable serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    var elementType =
+        specifiedType.parameters.isEmpty
+            ? FullType.unspecified
+            : specifiedType.parameters[0];
+    var result =
+        isUnderspecified
+            ? <Object>{}
+            : serializers.newBuilder(specifiedType) as Set;
+
+    for (final item in serialized) {
+      result.add(serializers.deserialize(item, specifiedType: elementType));
+    }
+
+    return result;
+  }
+}

--- a/build_runner_core/lib/src/asset_graph/serializers.g.dart
+++ b/build_runner_core/lib/src/asset_graph/serializers.g.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'serializers.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializers _$serializers =
+    (new Serializers().toBuilder()
+          ..add(AssetNode.serializer)
+          ..add(GeneratedNodeConfiguration.serializer)
+          ..add(GeneratedNodeState.serializer)
+          ..add(GlobNodeConfiguration.serializer)
+          ..add(GlobNodeState.serializer)
+          ..add(NodeType.serializer)
+          ..add(PendingBuildAction.serializer)
+          ..add(PostProcessBuildStepId.serializer)
+          ..addBuilderFactory(
+            const FullType(BuiltSet, const [const FullType(AssetId)]),
+            () => new SetBuilder<AssetId>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSet, const [const FullType(AssetId)]),
+            () => new SetBuilder<AssetId>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(AssetId)]),
+            () => new ListBuilder<AssetId>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSet, const [const FullType(AssetId)]),
+            () => new SetBuilder<AssetId>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSet, const [const FullType(AssetId)]),
+            () => new SetBuilder<AssetId>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSet, const [
+              const FullType(PostProcessBuildStepId),
+            ]),
+            () => new SetBuilder<PostProcessBuildStepId>(),
+          ))
+        .build();
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -10,6 +10,7 @@ import 'package:build/build.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
+import 'package:build_runner_core/src/asset_graph/post_process_build_step_id.dart';
 import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/options.dart';
 import 'package:build_runner_core/src/generate/phase.dart';
@@ -52,7 +53,11 @@ void main() {
       );
 
       deleted = deleted.rebuild(
-        (b) => b..deletedBy.add(deleted.id.addExtension('.post_anchor.1')),
+        (b) =>
+            b
+              ..deletedBy.add(
+                PostProcessBuildStepId(input: notDeleted.id, actionNumber: 0),
+              ),
       );
 
       graph

--- a/build_runner_core/test/environment/create_merged_dir_test.dart
+++ b/build_runner_core/test/environment/create_merged_dir_test.dart
@@ -12,6 +12,7 @@ import 'package:build_runner_core/build_runner_core.dart';
 import 'package:build_runner_core/src/asset_graph/graph.dart';
 import 'package:build_runner_core/src/asset_graph/node.dart';
 import 'package:build_runner_core/src/asset_graph/optional_output_tracker.dart';
+import 'package:build_runner_core/src/asset_graph/post_process_build_step_id.dart';
 import 'package:build_runner_core/src/environment/create_merged_dir.dart';
 import 'package:build_runner_core/src/generate/build_phases.dart';
 import 'package:build_runner_core/src/generate/options.dart';
@@ -134,7 +135,9 @@ void main() {
     test('doesnt write deleted files', () async {
       var node = graph.get(AssetId('b', 'lib/c.txt.copy'))!;
       graph.updateNode(node.id, (nodeBuilder) {
-        nodeBuilder.deletedBy.add(node.id.addExtension('.post_anchor.1'));
+        nodeBuilder.deletedBy.add(
+          PostProcessBuildStepId(input: node.id, actionNumber: 1),
+        );
       });
 
       var success = await createMergedOutputDirectories(
@@ -536,7 +539,10 @@ void main() {
         for (var remove in removes) {
           graph.updateNode(makeAssetId(remove), (nodeBuilder) {
             nodeBuilder.deletedBy.add(
-              makeAssetId(remove).addExtension('.post_anchor.1'),
+              PostProcessBuildStepId(
+                input: makeAssetId(remove),
+                actionNumber: 1,
+              ),
             );
           });
         }


### PR DESCRIPTION
For #3811.

Per [the docs on PostProcessBuilder](https://github.com/dart-lang/build/blob/ec6d4346c13a005c16f4de6192e9ba293aae4a05/build/lib/src/builder/post_process_builder.dart), post process build steps interact in a very limited way with the rest of the build.

So, split them out.

`built_value` serialization doesn't support serializing mutable `Map` or `Set` out of the box, but I don't particularly want to use `BuildMap` / `BuiltSet` for these as there's no advantage to having them be immutable. So add the code for serializing `Map`+`Set` here, I'll upstream it.

An explanation of the `FullType` boilerplate added:

`built_value` differentiates between generic types known at compile time and at runtime. If the types are known at compile time they're specified with a `FullType` and don't get written on the wire. So: `serializers.serialize([1, 2, 3], specifiedType: FullType(List, [FullType(int)])` gives you back JSON that is minimal, `[1,2,3]`. If the types are not known, `serializers.serialize([1, 2, 3])` then the types do get written on the wire: `['list', ['int', 1], ['int', 2], ['int', 3]]`. This works for arbitrarily nested generics, for example a [list of lists of int](https://github.com/google/built_value.dart/blob/11bb8eee011e8c7cd40ffe8acd8e70f6bd64bf4a/built_value/test/built_list_serializer_test.dart#L59).

The "builderFactories" are used on deserializing to instantiate the types with the right generics--as without mirrors there is no other way to do this in Dart. For fields in serializable types `built_value` can generate code to add builder factories, but here I'm just serializing collections directly so codegen can't help.

Sorry for the complexity here! It would also work to handcode the new (de)serialization, I [did that first](https://github.com/dart-lang/build/blob/04dcd632f339459a8085a1135a9b9ad3dd973da5/build_runner_core/lib/src/asset_graph/serialization.dart#L70), and can switch to that or something like it if you prefer. Both options are not pretty--but I have a slight preference for going fully with codegen/built_value as that seems better long term. We can improve some rought edges in built_value :) and the community can benefit as a result.

Thanks.