### PR TITLE
Lazily compute outputs

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add `NodeType` to `AssetNode`, remove subtypes. Make mutations explicit.
 - Use `built_value` for `AssetNode` and related types.
 - Add details of what changed and what is built to `--verbose` logging.
+- Compute outputs as needed instead of storing them in the asset graph.
 
 ## 2.4.15
 

--- a/build_runner/bin/graph_inspector.dart
+++ b/build_runner/bin/graph_inspector.dart
@@ -118,6 +118,7 @@ class InspectNodeCommand extends Command<bool> {
 
   @override
   bool run() {
+    var computedOutputs = assetGraph.computeOutputs();
     var argResults = this.argResults!;
     var stringUris = argResults.rest;
     if (stringUris.isEmpty) {
@@ -157,12 +158,16 @@ class InspectNodeCommand extends Command<bool> {
         node.primaryOutputs.forEach(printAsset);
 
         description.writeln('  secondary outputs:');
-        node.outputs.difference(node.primaryOutputs).forEach(printAsset);
+        (computedOutputs[node.id] ?? const <AssetId>{})
+            .difference(node.primaryOutputs.asSet())
+            .forEach(printAsset);
 
         if (node.type == NodeType.generated || node.type == NodeType.glob) {
           description.writeln('  inputs:');
           assetGraph.allNodes
-              .where((n) => n.outputs.contains(node.id))
+              .where(
+                (n) => (computedOutputs[n.id] ?? <AssetId>{}).contains(node.id),
+              )
               .map((n) => n.id)
               .forEach(printAsset);
         }

--- a/build_runner/lib/src/server/asset_graph_handler.dart
+++ b/build_runner/lib/src/server/asset_graph_handler.dart
@@ -115,7 +115,8 @@ class AssetGraphHandler {
       {'id': '${node.id}', 'label': '${node.id}'},
     ];
     var edges = <Map<String, String>>[];
-    for (final output in node.outputs) {
+    var computedOutputs = _assetGraph.computeOutputs();
+    for (final output in (computedOutputs[node.id] ?? <AssetId>{})) {
       if (filterGlob != null && !filterGlob.matches(output.toString())) {
         continue;
       }

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -382,9 +382,6 @@ void main() {
           inputs: [makeAssetId('a|web/b.txt')],
           isHidden: false,
         );
-        builderOptionsNode = builderOptionsNode.rebuild(
-          (b) => b..outputs.add(bCopyNode.id),
-        );
         expectedGraph
           ..add(bCopyNode)
           ..add(
@@ -406,9 +403,6 @@ void main() {
           lastKnownDigest: computeDigest(cCopyId, 'c'),
           inputs: [makeAssetId('a|web/c.txt')],
           isHidden: false,
-        );
-        builderOptionsNode = builderOptionsNode.rebuild(
-          (b) => b..outputs.add(cCopyNode.id),
         );
         expectedGraph
           ..add(cCopyNode)

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Use `LibraryCycleGraphLoader` to load transitive deps for analysis.
 - Track post process builder outputs separately from the main graph Instead of
   in `postProcessAnchor` nodes.
+- Compute outputs as needed instead of storing them in the asset graph.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/src/asset_graph/node.dart
+++ b/build_runner_core/lib/src/asset_graph/node.dart
@@ -57,10 +57,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
   /// when run on this asset.
   BuiltSet<AssetId> get primaryOutputs;
 
-  /// The [AssetId]s of all generated assets which are output by a [Builder]
-  /// which reads this asset.
-  BuiltSet<AssetId> get outputs;
-
   /// The [Digest] for this node in its last known state.
   ///
   /// May be `null` if this asset has no outputs, or if it doesn't actually
@@ -96,7 +92,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
   bool get changesRequireRebuild =>
       type == NodeType.internal ||
       type == NodeType.glob ||
-      outputs.isNotEmpty ||
       lastKnownDigest != null;
 
   factory AssetNode([void Function(AssetNodeBuilder) updates]) = _$AssetNode;
@@ -124,7 +119,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
     b.id = id;
     b.type = NodeType.source;
     b.primaryOutputs.replace(primaryOutputs ?? {});
-    b.outputs.replace(outputs ?? {});
     b.lastKnownDigest = lastKnownDigest;
   });
 
@@ -238,6 +232,19 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
       globNodeConfiguration != null,
       globNodeState != null,
     );
+  }
+
+  /// The generated node inputs, or the glob node inputs, or `null` if the node
+  /// is not of one of those two types.
+  BuiltSet<AssetId>? get inputs {
+    switch (type) {
+      case NodeType.generated:
+        return generatedNodeState!.inputs;
+      case NodeType.glob:
+        return globNodeState!.inputs;
+      default:
+        return null;
+    }
   }
 }
 

--- a/build_runner_core/lib/src/asset_graph/node.g.dart
+++ b/build_runner_core/lib/src/asset_graph/node.g.dart
@@ -133,13 +133,6 @@ class _$AssetNodeSerializer implements StructuredSerializer<AssetNode> {
           const FullType(AssetId),
         ]),
       ),
-      'outputs',
-      serializers.serialize(
-        object.outputs,
-        specifiedType: const FullType(BuiltSet, const [
-          const FullType(AssetId),
-        ]),
-      ),
       'deletedBy',
       serializers.serialize(
         object.deletedBy,
@@ -272,17 +265,6 @@ class _$AssetNodeSerializer implements StructuredSerializer<AssetNode> {
           break;
         case 'primaryOutputs':
           result.primaryOutputs.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltSet, const [
-                    const FullType(AssetId),
-                  ]),
-                )!
-                as BuiltSet<Object?>,
-          );
-          break;
-        case 'outputs':
-          result.outputs.replace(
             serializers.deserialize(
                   value,
                   specifiedType: const FullType(BuiltSet, const [
@@ -702,8 +684,6 @@ class _$AssetNode extends AssetNode {
   @override
   final BuiltSet<AssetId> primaryOutputs;
   @override
-  final BuiltSet<AssetId> outputs;
-  @override
   final Digest? lastKnownDigest;
   @override
   final BuiltSet<PostProcessBuildStepId> deletedBy;
@@ -719,7 +699,6 @@ class _$AssetNode extends AssetNode {
     this.globNodeConfiguration,
     this.globNodeState,
     required this.primaryOutputs,
-    required this.outputs,
     this.lastKnownDigest,
     required this.deletedBy,
   }) : super._() {
@@ -730,7 +709,6 @@ class _$AssetNode extends AssetNode {
       r'AssetNode',
       'primaryOutputs',
     );
-    BuiltValueNullFieldError.checkNotNull(outputs, r'AssetNode', 'outputs');
     BuiltValueNullFieldError.checkNotNull(deletedBy, r'AssetNode', 'deletedBy');
   }
 
@@ -752,7 +730,6 @@ class _$AssetNode extends AssetNode {
         globNodeConfiguration == other.globNodeConfiguration &&
         globNodeState == other.globNodeState &&
         primaryOutputs == other.primaryOutputs &&
-        outputs == other.outputs &&
         lastKnownDigest == other.lastKnownDigest &&
         deletedBy == other.deletedBy;
   }
@@ -767,7 +744,6 @@ class _$AssetNode extends AssetNode {
     _$hash = $jc(_$hash, globNodeConfiguration.hashCode);
     _$hash = $jc(_$hash, globNodeState.hashCode);
     _$hash = $jc(_$hash, primaryOutputs.hashCode);
-    _$hash = $jc(_$hash, outputs.hashCode);
     _$hash = $jc(_$hash, lastKnownDigest.hashCode);
     _$hash = $jc(_$hash, deletedBy.hashCode);
     _$hash = $jf(_$hash);
@@ -784,7 +760,6 @@ class _$AssetNode extends AssetNode {
           ..add('globNodeConfiguration', globNodeConfiguration)
           ..add('globNodeState', globNodeState)
           ..add('primaryOutputs', primaryOutputs)
-          ..add('outputs', outputs)
           ..add('lastKnownDigest', lastKnownDigest)
           ..add('deletedBy', deletedBy))
         .toString();
@@ -835,11 +810,6 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
   set primaryOutputs(SetBuilder<AssetId>? primaryOutputs) =>
       _$this._primaryOutputs = primaryOutputs;
 
-  SetBuilder<AssetId>? _outputs;
-  SetBuilder<AssetId> get outputs =>
-      _$this._outputs ??= new SetBuilder<AssetId>();
-  set outputs(SetBuilder<AssetId>? outputs) => _$this._outputs = outputs;
-
   Digest? _lastKnownDigest;
   Digest? get lastKnownDigest => _$this._lastKnownDigest;
   set lastKnownDigest(Digest? lastKnownDigest) =>
@@ -863,7 +833,6 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
       _globNodeConfiguration = $v.globNodeConfiguration?.toBuilder();
       _globNodeState = $v.globNodeState?.toBuilder();
       _primaryOutputs = $v.primaryOutputs.toBuilder();
-      _outputs = $v.outputs.toBuilder();
       _lastKnownDigest = $v.lastKnownDigest;
       _deletedBy = $v.deletedBy.toBuilder();
       _$v = null;
@@ -902,7 +871,6 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
             globNodeConfiguration: _globNodeConfiguration?.build(),
             globNodeState: _globNodeState?.build(),
             primaryOutputs: primaryOutputs.build(),
-            outputs: outputs.build(),
             lastKnownDigest: lastKnownDigest,
             deletedBy: deletedBy.build(),
           );
@@ -919,8 +887,6 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
         _globNodeState?.build();
         _$failedField = 'primaryOutputs';
         primaryOutputs.build();
-        _$failedField = 'outputs';
-        outputs.build();
 
         _$failedField = 'deletedBy';
         deletedBy.build();

--- a/build_runner_core/lib/src/asset_graph/optional_output_tracker.dart
+++ b/build_runner_core/lib/src/asset_graph/optional_output_tracker.dart
@@ -73,7 +73,9 @@ class OptionalOutputTracker {
     return _checkedOutputs.putIfAbsent(
       output,
       () =>
-          node.outputs.any((o) => isRequired(o, currentlyChecking)) ||
+          (_assetGraph.computeOutputs()[node.id] ?? <AssetId>{}).any(
+            (o) => isRequired(o, currentlyChecking),
+          ) ||
           _assetGraph
               .outputsForPhase(output.package, nodeConfiguration.phaseNumber)
               .where(

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -228,9 +228,6 @@ targets:
             ..pendingBuildAction = PendingBuildAction.none
             ..inputs.add(aTxt);
         });
-        originalAssetGraph.updateNode(aTxt, (nodeBuilder) {
-          nodeBuilder.outputs.add(aTxtCopy);
-        });
         await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         await modifyFile(p.join('lib', 'a.txt'), 'b');

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1287,14 +1287,8 @@ void main() {
       inputs: [makeAssetId('a|web/a.txt')],
       isHidden: false,
     );
-    builderOptionsNode = builderOptionsNode.rebuild(
-      (b) => b..outputs.add(aCopyNode.id),
-    );
     aSourceNode = aSourceNode.rebuild(
-      (b) =>
-          b
-            ..outputs.add(aCopyNode.id)
-            ..primaryOutputs.add(aCopyNode.id),
+      (b) => b..primaryOutputs.add(aCopyNode.id),
     );
 
     var bCopyId = makeAssetId('a|lib/b.txt.copy'); //;
@@ -1310,14 +1304,8 @@ void main() {
       inputs: [makeAssetId('a|lib/b.txt')],
       isHidden: false,
     );
-    builderOptionsNode = builderOptionsNode.rebuild(
-      (b) => b..outputs.add(bCopyNode.id),
-    );
     bSourceNode = bSourceNode.rebuild(
-      (b) =>
-          b
-            ..outputs.add(bCopyNode.id)
-            ..primaryOutputs.add(bCopyNode.id),
+      (b) => b..primaryOutputs.add(bCopyNode.id),
     );
 
     // Post build generates asset nodes and supporting nodes
@@ -1350,7 +1338,6 @@ void main() {
     );
     // Note we don't expect this node to get added to the builder options node
     // outputs.
-    aSourceNode = aSourceNode.rebuild((b) => b..outputs.add(aPostCopyNode.id));
     aSourceNode = aSourceNode.rebuild(
       (b) => b..primaryOutputs.add(aPostCopyNode.id),
     );
@@ -1369,7 +1356,6 @@ void main() {
     );
     // Note we don't expect this node to get added to the builder options node
     // outputs.
-    bSourceNode = bSourceNode.rebuild((b) => b..outputs.add(bPostCopyNode.id));
     bSourceNode = bSourceNode.rebuild(
       (b) => b..primaryOutputs.add(bPostCopyNode.id),
     );
@@ -1834,9 +1820,10 @@ void main() {
         outputNode.generatedNodeState!.inputs,
         unorderedEquals([fileANode.id, fileCNode.id]),
       );
-      expect(fileANode.outputs, contains(outputNode.id));
-      expect(fileBNode.outputs, isEmpty);
-      expect(fileCNode.outputs, unorderedEquals([outputNode.id]));
+      final computedOutputs = graph.computeOutputs();
+      expect(computedOutputs[fileANode.id]!, contains(outputNode.id));
+      expect(computedOutputs[fileBNode.id] ?? const <AssetId>{}, isEmpty);
+      expect(computedOutputs[fileCNode.id]!, unorderedEquals([outputNode.id]));
     });
 
     test('Ouputs aren\'t rebuilt if their inputs didn\'t change', () async {


### PR DESCRIPTION
For #3811.

"outputs" are used at the start of the build to know what to invalidate/remove when updating the graph. Since they're not used during the build, they can be computed in one go instead of incrementally. It's not clear if there is a benefit to serializing them--stop doing that for now.

Benchmarks improve quite a bit due to no longer doing many repeated copies of the immutable "outputs" sets, and the JSON size is about halved.

```
before this PR
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms,json/KiB
loop,1,21805,3912,5216,454
loop,100,24872,4058,7354,5002
loop,250,27289,4901,11688,27067
loop,500,41936,7753,16928,104465
loop,750,76779,12352,23427,232645
loop,1000,133677,18266,37324,419464
forwards,1,21847,3851,5081,455
forwards,100,24577,3687,7520,3169
forwards,250,28194,4798,10244,15451
forwards,500,34165,5963,16175,57796
forwards,750,47009,8607,22132,127484
forwards,1000,70189,10267,26040,228472
backwards,1,22138,3970,5189,455
backwards,100,24881,4113,7513,3213
backwards,250,28388,4596,11579,15708
backwards,500,34640,5917,17745,58798
backwards,750,51449,8806,25058,129720
backwards,1000,75859,12535,32259,232430

with this PR
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms,json/KiB
loop,1,23492,3887,5292,417
loop,100,23786,3900,6928,2564
loop,250,27987,4494,9667,12674
loop,500,32715,5789,16602,47884
loop,750,37391,8292,22735,106042
loop,1000,43723,11432,30665,191073
forwards,1,22246,3762,5264,417
forwards,100,24092,3960,7265,1741
forwards,250,27831,4231,9800,7467
forwards,500,29865,5024,14991,26973
forwards,750,36458,6234,20061,58929
forwards,1000,39756,8070,28756,105307
backwards,1,22162,3845,5364,417
backwards,100,24036,4054,7900,1762
backwards,250,27503,4349,10938,7594
backwards,500,31306,5024,15695,27471
backwards,750,37975,6045,22651,60042
backwards,1000,43777,8021,27442,107280
```