### PR TITLE
Add json size to benchmark.

### DIFF
--- a/_benchmark/lib/commands.dart
+++ b/_benchmark/lib/commands.dart
@@ -89,7 +89,10 @@ class MeasureCommand extends Command<void> {
       await Future<void>.delayed(const Duration(seconds: 1));
 
       final update = StringBuffer('${config.generator.packageName}\n');
-      update.write('shape,libraries,clean/ms,no changes/ms,incremental/ms\n');
+      update.write(
+        'shape,libraries,clean/ms,no changes/ms,incremental/ms,'
+        'json/KiB\n',
+      );
       for (final shape in config.shapes) {
         for (final size in config.sizes) {
           final pendingResult = pendingResults[(shape, size)]!;
@@ -104,6 +107,7 @@ class MeasureCommand extends Command<void> {
                 pendingResult.cleanBuildTime.renderFailed,
                 pendingResult.noChangesBuildTime.renderFailed,
                 pendingResult.incrementalBuildTime.renderFailed,
+                pendingResult.graphSize.renderFailed,
               ].join(','),
             );
           } else {
@@ -114,6 +118,7 @@ class MeasureCommand extends Command<void> {
                 pendingResult.cleanBuildTime.render,
                 pendingResult.noChangesBuildTime.render,
                 pendingResult.incrementalBuildTime.render,
+                pendingResult.graphSize.render,
               ].join(','),
             );
           }
@@ -137,4 +142,12 @@ extension DurationExtension on Duration? {
   /// Renders with X` for `null`, to mean "failed".
   String get renderFailed =>
       this == null ? 'X' : this!.inMilliseconds.toString();
+}
+
+extension IntExtension on int? {
+  /// Renders with `---` for `null`, to mean "pending".
+  String get render => this == null ? '---' : (this! / 1024).round().toString();
+
+  /// Renders with X` for `null`, to mean "failed".
+  String get renderFailed => this == null ? 'X' : this!.toString();
 }

--- a/_benchmark/lib/workspace.dart
+++ b/_benchmark/lib/workspace.dart
@@ -72,6 +72,8 @@ class Workspace {
       return;
     }
 
+    result.graphSize = _readGraphSize();
+
     // Build with no changes.
     stopwatch.reset();
     process = await Process.start('dart', [
@@ -111,6 +113,17 @@ class Workspace {
       return;
     }
   }
+
+  /// Returns the `build_runner` asset graph size, or `null` if not found.
+  int? _readGraphSize() {
+    for (final entry in Directory.fromUri(
+      directory.uri.resolve('.dart_tool/build'),
+    ).listSync(recursive: true)) {
+      if (entry is! File) continue;
+      if (entry.path.endsWith('asset_graph.json')) return entry.lengthSync();
+    }
+    return null;
+  }
 }
 
 /// Benchmark results.
@@ -120,6 +133,7 @@ class PendingResult {
   Duration? cleanBuildTime;
   Duration? noChangesBuildTime;
   Duration? incrementalBuildTime;
+  int? graphSize;
   String? failure;
 
   bool get isFailure => failure != null;


### PR DESCRIPTION
For #3811.

So we can see the coming improvements :)

Current output ... yes, the biggest one is 420MB.

```
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms,json/KiB
loop,1,23898,3880,5264,506
loop,100,25214,4205,7814,5100
loop,250,28638,5057,11263,27233
loop,500,44939,7361,18271,104746
loop,750,81607,12244,26289,233040
loop,1000,142847,18559,32439,419976
forwards,1,22143,3788,5312,507
forwards,100,24645,4010,7375,3267
forwards,250,28664,4691,10824,15619
forwards,500,36589,6209,16613,58082
forwards,750,48166,8959,24655,127888
forwards,1000,78474,11346,28550,228996
backwards,1,21719,3837,5240,507
backwards,100,25152,4139,7780,3312
backwards,250,28480,4413,12578,15877
backwards,500,36281,6406,18998,59086
backwards,750,57325,8617,26358,130126
backwards,1000,82449,11933,30403,232957
```