### PR TITLE
Serialize AssetId by identity.

### DIFF
--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -70,7 +70,7 @@ class AssetGraph implements GeneratedAssetHider {
 
   /// Deserializes this graph.
   factory AssetGraph.deserialize(List<int> serializedGraph) =>
-      _AssetGraphDeserializer(serializedGraph).deserialize();
+      deserializeAssetGraph(serializedGraph);
 
   static Future<AssetGraph> build(
     BuildPhases buildPhases,
@@ -106,7 +106,7 @@ class AssetGraph implements GeneratedAssetHider {
     return graph;
   }
 
-  List<int> serialize() => _AssetGraphSerializer(this).serialize();
+  List<int> serialize() => serializeAssetGraph(this);
 
   @visibleForTesting
   Map<String, Map<PostProcessBuildStepId, Set<AssetId>>>

--- a/build_runner_core/lib/src/asset_graph/identity_serializer.dart
+++ b/build_runner_core/lib/src/asset_graph/identity_serializer.dart
@@ -1,0 +1,91 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:built_value/serializer.dart';
+
+/// Wraps another `built_value` serializer to add serializing by identity.
+///
+/// Integer IDs are created as new values are encountered, and a mapping to
+/// objects and serialized object values is maintained.
+///
+/// The serialized data does not contain the object values, only IDs. This might
+/// not matter if this `IdentitySerializer` will stay in memory and be used to
+/// deserialize. Or, the serialized object values must be serialized separately:
+/// they can be obtained from [serializedObjects], and set via
+/// [deserializeWithObjects].
+///
+/// TODO(davidmorgan): consider upstreaming to `built_value`.
+class IdentitySerializer<T> implements PrimitiveSerializer<T> {
+  final Serializer<T> delegate;
+  final PrimitiveSerializer<T>? _primitiveDelegate;
+  final StructuredSerializer<T>? _structuredDelegate;
+
+  final Map<T, int> _ids = Map.identity();
+  final List<T> _objects = [];
+  List<Object?> _serializedObjects = [];
+
+  /// A serializer wrapping [delegate] to deduplicate by identity.
+  IdentitySerializer(this.delegate)
+    : _primitiveDelegate = delegate is PrimitiveSerializer<T> ? delegate : null,
+      _structuredDelegate =
+          delegate is StructuredSerializer<T> ? delegate : null;
+
+  /// Sets the stored object values to [objects].
+  ///
+  /// Serialized values are indices into this list.
+  void deserializeWithObjects(Iterable<T> objects) {
+    _ids.clear();
+    _objects.clear();
+    _serializedObjects.clear();
+    for (final object in objects) {
+      _objects.add(object);
+      _ids[object] = _objects.length - 1;
+    }
+  }
+
+  /// The list of unique objects encountered since the most recent [reset].
+  List<Object?> get serializedObjects => _serializedObjects;
+
+  /// Clears the ID to object and serialized object mappings.
+  ///
+  /// Call this after serializing or deserializing to avoid retaining objects in
+  /// memory; or, don't call it to continue using the same IDs and objects.
+  void reset() {
+    _ids.clear();
+    _objects.clear();
+    _serializedObjects = [];
+  }
+
+  @override
+  Iterable<Type> get types => delegate.types;
+
+  @override
+  String get wireName => delegate.wireName;
+
+  @override
+  T deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => _objects[serialized as int];
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    T object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    // If it has already been seen, return the ID.
+    return _ids.putIfAbsent(object, () {
+      // Otherwise, serialize it, store the value and serialized value, and
+      // return the index of the last of `_objects` as the ID.
+      final serialized =
+          _primitiveDelegate == null
+              ? _structuredDelegate!.serialize(serializers, object)
+              : _primitiveDelegate.serialize(serializers, object);
+      _serializedObjects.add(serialized);
+      return (_objects..add(object)).length - 1;
+    });
+  }
+}

--- a/build_runner_core/lib/src/asset_graph/serializers.dart
+++ b/build_runner_core/lib/src/asset_graph/serializers.dart
@@ -9,6 +9,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 import 'package:crypto/crypto.dart';
 
+import 'identity_serializer.dart';
 import 'node.dart';
 import 'post_process_build_step_id.dart';
 
@@ -24,10 +25,15 @@ final postProcessBuildStepOutputsFullType = FullType(Map, [
   postProcessBuildStepOutputsInnerFullType,
 ]);
 
+final assetIdSerializer = AssetIdSerializer();
+final identityAssetIdSerializer = IdentitySerializer<AssetId>(
+  assetIdSerializer,
+);
+
 @SerializersFor([AssetNode])
 final Serializers serializers =
     (_$serializers.toBuilder()
-          ..add(AssetIdSerializer())
+          ..add(identityAssetIdSerializer)
           ..add(DigestSerializer())
           ..add(MapSerializer())
           ..add(SetSerializer())


### PR DESCRIPTION
For #3811.

Serialize `AssetId` by identity, with a separate list of values.

Remove some unused/old code that was the old way of doing something similar.

This significantly reduces the graph size, but is still not the final state: next step after this is to keep input sets as trees, and serialize those as trees _and_ by identity.

Benchmarks

```
Before this PR

with this PR
json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms,json/KiB
loop,1,23492,3887,5292,417
loop,100,23786,3900,6928,2564
loop,250,27987,4494,9667,12674
loop,500,32715,5789,16602,47884
loop,750,37391,8292,22735,106042
loop,1000,43723,11432,30665,191073
forwards,1,22246,3762,5264,417
forwards,100,24092,3960,7265,1741
forwards,250,27831,4231,9800,7467
forwards,500,29865,5024,14991,26973
forwards,750,36458,6234,20061,58929
forwards,1000,39756,8070,28756,105307
backwards,1,22162,3845,5364,417
backwards,100,24036,4054,7900,1762
backwards,250,27503,4349,10938,7594
backwards,500,31306,5024,15695,27471
backwards,750,37975,6045,22651,60042
backwards,1000,43777,8021,27442,107280

after

json_serializable
shape,libraries,clean/ms,no changes/ms,incremental/ms,json/KiB
loop,1,23153,3936,5187,339
loop,100,24380,4026,7118,702
loop,250,26753,4199,10192,1982
loop,500,32433,4526,14631,6068
loop,750,35511,5059,19585,12595
loop,1000,41457,5664,26464,21574
forwards,1,23234,3912,5161,339
forwards,100,25944,4070,7481,609
forwards,250,26586,3938,9369,1383
forwards,500,32053,4194,14056,3649
forwards,750,35001,4608,18724,7135
forwards,1000,40243,5003,23503,11853
backwards,1,23745,3929,5077,339
backwards,100,25092,3977,7655,605
backwards,250,27593,4057,10292,1373
backwards,500,33167,4189,15592,3628
backwards,750,38389,4721,19006,7105
backwards,1000,43074,5071,25351,11810
```