### PR TITLE
Ignore element2 deprecation warnings.

### DIFF
--- a/build/lib/src/analyzer/resolver.dart
+++ b/build/lib/src/analyzer/resolver.dart
@@ -10,6 +10,8 @@ import 'package:analyzer/error/error.dart';
 import '../asset/id.dart';
 import '../builder/build_step.dart';
 
+// ignore_for_file: deprecated_member_use, #3977 Element2 migration.
+
 /// Standard interface for resolving Dart source code as part of a build.
 abstract class Resolver {
   /// Returns whether [assetId] represents an Dart library file.

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -13,6 +13,8 @@ import '../asset/reader.dart';
 import '../asset/writer.dart';
 import '../resource/resource.dart';
 
+// ignore_for_file: deprecated_member_use, #3977 Element2 migration.
+
 /// A single step in a build process.
 ///
 /// This represents a single [inputId], logic around resolving as a library,

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -31,6 +31,8 @@ import 'analysis_driver_model.dart';
 import 'sdk_summary.dart';
 import 'shared_resource_pool.dart';
 
+// ignore_for_file: deprecated_member_use, #3977 Element2 migration.
+
 /// Implements [Resolver.libraries] and [Resolver.findLibraryByName] by crawling
 /// down from entrypoints.
 class PerActionResolver implements ReleasableResolver {

--- a/build_resolvers/test/resolver_test.dart
+++ b/build_resolvers/test/resolver_test.dart
@@ -21,6 +21,8 @@ import 'package:package_config/package_config.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
+// ignore_for_file: deprecated_member_use, #3977 Element2 migration.
+
 void main() {
   for (final resolversFactory in [
     AnalysisDriverModelFactory(),

--- a/build_runner_core/lib/src/generate/build_step_impl.dart
+++ b/build_runner_core/lib/src/generate/build_step_impl.dart
@@ -20,6 +20,8 @@ import 'package:package_config/package_config_types.dart';
 import 'input_tracker.dart';
 import 'single_step_reader_writer.dart';
 
+// ignore_for_file: deprecated_member_use, #3977 Element2 migration.
+
 /// A single step in the build processes.
 ///
 /// This represents a single input and its expected and real outputs. It also

--- a/build_runner_core/test/generate/build_step_impl_test.dart
+++ b/build_runner_core/test/generate/build_step_impl_test.dart
@@ -16,6 +16,8 @@ import 'package:build_test/build_test.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/test.dart';
 
+// ignore_for_file: deprecated_member_use, #3977 Element2 migration.
+
 void main() {
   late ResourceManager resourceManager;
 

--- a/build_runner_core/test/generate/resolution_test.dart
+++ b/build_runner_core/test/generate/resolution_test.dart
@@ -9,6 +9,8 @@ import 'package:build/build.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:test/test.dart';
 
+// ignore_for_file: deprecated_member_use, #3977 Element2 migration.
+
 void main() {
   test('should resolve a dart file with a part file', () async {
     await testPhases(

--- a/build_runner_core/test/generate/resolver_reuse_test.dart
+++ b/build_runner_core/test/generate/resolver_reuse_test.dart
@@ -10,6 +10,8 @@ import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:test/test.dart';
 
+// ignore_for_file: deprecated_member_use, #3977 Element2 migration.
+
 void main() {
   group('Resolver Reuse', () {
     test(

--- a/build_test/test/resolve_source_test.dart
+++ b/build_test/test/resolve_source_test.dart
@@ -12,6 +12,8 @@ import 'package:build_test/build_test.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/test.dart';
 
+// ignore_for_file: deprecated_member_use, #3977 Element2 migration.
+
 void main() {
   group('resolveSource can resolve', () {
     test('a simple dart file', () async {


### PR DESCRIPTION
The warnings break the CI, so we need to ignore them for now.

Filed #3977 for the migration.