### PR TITLE
Pin the analyzer to 7.3.0 for `build_modules`.

### DIFF
--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <3.9.0-z'
 
 dependencies:
-  analyzer: '>=5.1.0 <8.0.0'
+  analyzer: '>=5.1.0 <7.4.0'
   async: ^2.5.0
   bazel_worker: ^1.0.0
   build: ^2.0.0


### PR DESCRIPTION
`json_serializable` breaks with the analyzer 7.4.0, which breaks a test.

7.4.0 also introduces deprecation warnings for element1, which need suppressing until the migration can be done #3977.