### PR TITLE
Remove builder options nodes; store and check builder options by phase.

### DIFF
--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -26,7 +26,6 @@ void main() {
   final copyABuildApplication = applyToRoot(
     TestBuilder(buildExtensions: appendExtension('.copy', from: '.txt')),
   );
-  final defaultBuilderOptions = const BuilderOptions({});
   final packageConfigId = makeAssetId('a|.dart_tool/package_config.json');
   final packageGraph = buildPackageGraph({
     rootPackage('a', path: path.absolute('a')): [],
@@ -362,12 +361,6 @@ void main() {
           readerWriter,
         );
 
-        var builderOptionsId = makeAssetId('a|Phase0.builderOptions');
-        var builderOptionsNode = AssetNode.builderOptions(
-          builderOptionsId,
-          lastKnownDigest: computeBuilderOptionsDigest(defaultBuilderOptions),
-        );
-
         var bCopyId = makeAssetId('a|web/b.txt.copy');
         var bTxtId = makeAssetId('a|web/b.txt');
         var bCopyNode = AssetNode.generated(
@@ -377,7 +370,6 @@ void main() {
           pendingBuildAction: PendingBuildAction.none,
           wasOutput: true,
           isFailure: false,
-          builderOptionsId: builderOptionsId,
           lastKnownDigest: computeDigest(bCopyId, 'b2'),
           inputs: [makeAssetId('a|web/b.txt')],
           isHidden: false,
@@ -399,7 +391,6 @@ void main() {
           pendingBuildAction: PendingBuildAction.none,
           wasOutput: true,
           isFailure: false,
-          builderOptionsId: builderOptionsId,
           lastKnownDigest: computeDigest(cCopyId, 'c'),
           inputs: [makeAssetId('a|web/c.txt')],
           isHidden: false,
@@ -411,8 +402,6 @@ void main() {
               cCopyNode.id,
             ], computeDigest(cTxtId, 'c')),
           );
-
-        expectedGraph.add(builderOptionsNode);
 
         // TODO: We dont have a shared way of computing the combined input
         // hashes today, but eventually we should test those here too.

--- a/build_runner/test/server/asset_handler_test.dart
+++ b/build_runner/test/server/asset_handler_test.dart
@@ -136,7 +136,6 @@ void main() {
     graph.add(
       AssetNode.generated(
         AssetId('a', 'web/main.ddc.js'),
-        builderOptionsId: AssetId('_\$fake', 'options_id'),
         phaseNumber: 0,
         pendingBuildAction: PendingBuildAction.none,
         isHidden: false,

--- a/build_runner/test/server/serve_handler_test.dart
+++ b/build_runner/test/server/serve_handler_test.dart
@@ -209,7 +209,6 @@ void main() {
       assetGraph.add(
         AssetNode.generated(
           AssetId('a', 'web/main.ddc.js'),
-          builderOptionsId: AssetId('_\$fake', 'options_id'),
           phaseNumber: 0,
           pendingBuildAction: PendingBuildAction.none,
           isHidden: false,

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -30,6 +30,8 @@
 - Track post process builder outputs separately from the main graph Instead of
   in `postProcessAnchor` nodes.
 - Compute outputs as needed instead of storing them in the asset graph.
+- Check build options for changes in the phase setup instead of storing them
+  in the asset graph.
 
 ## 8.0.0
 

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -71,7 +71,7 @@ class AssetGraph implements GeneratedAssetHider {
 
   /// Digests from the previous build's [BuildPhases], or `null` if this is a
   /// clean build.
-  BuiltList<Digest>? previousPostBuildOptionsDigests;
+  BuiltList<Digest>? previousPostBuildActionsOptionsDigests;
 
   /// Digests from the current build's [BuildPhases].
   BuiltList<Digest> postBuildActionsOptionsDigests;

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -12,6 +12,7 @@ import 'package:build/experiments.dart' as experiments_zone;
 // ignore: implementation_imports
 import 'package:build/src/internal.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:meta/meta.dart';
@@ -61,8 +62,34 @@ class AssetGraph implements GeneratedAssetHider {
   final Map<String, Map<PostProcessBuildStepId, Set<AssetId>>>
   _postProcessBuildStepOutputs = {};
 
+  /// Digests from the previous build's [BuildPhases], or `null` if this is a
+  /// clean build.
+  BuiltList<Digest>? previousInBuildPhasesOptionsDigests;
+
+  /// Digests from the current build's [BuildPhases].
+  BuiltList<Digest> inBuildPhasesOptionsDigests;
+
+  /// Digests from the previous build's [BuildPhases], or `null` if this is a
+  /// clean build.
+  BuiltList<Digest>? previousPostBuildOptionsDigests;
+
+  /// Digests from the current build's [BuildPhases].
+  BuiltList<Digest> postBuildActionsOptionsDigests;
+
   AssetGraph._(
+    BuildPhases buildPhases,
+    this.dartVersion,
+    this.packageLanguageVersions,
+    this.enabledExperiments,
+  ) : buildPhasesDigest = buildPhases.digest,
+      inBuildPhasesOptionsDigests = buildPhases.inBuildPhasesOptionsDigests,
+      postBuildActionsOptionsDigests =
+          buildPhases.postBuildActionsOptionsDigests;
+
+  AssetGraph._fromSerialized(
     this.buildPhasesDigest,
+    this.inBuildPhasesOptionsDigests,
+    this.postBuildActionsOptionsDigests,
     this.dartVersion,
     this.packageLanguageVersions,
     this.enabledExperiments,
@@ -80,21 +107,19 @@ class AssetGraph implements GeneratedAssetHider {
     AssetReader digestReader,
   ) async {
     var graph = AssetGraph._(
-      buildPhases.digest,
+      buildPhases,
       Platform.version,
       packageGraph.languageVersions,
       experiments_zone.enabledExperiments.build(),
     );
     var placeholders = graph._addPlaceHolderNodes(packageGraph);
     graph._addSources(sources);
-    graph
-      .._addBuilderOptionsNodes(buildPhases)
-      .._addOutputsForSources(
-        buildPhases,
-        sources,
-        packageGraph.root.name,
-        placeholders: placeholders,
-      );
+    graph._addOutputsForSources(
+      buildPhases,
+      sources,
+      packageGraph.root.name,
+      placeholders: placeholders,
+    );
     // Pre-emptively compute digests for the nodes we know have outputs.
     await graph._setLastKnownDigests(
       sources.where((id) => graph.get(id)!.primaryOutputs.isNotEmpty),
@@ -111,6 +136,10 @@ class AssetGraph implements GeneratedAssetHider {
   @visibleForTesting
   Map<String, Map<PostProcessBuildStepId, Set<AssetId>>>
   get allPostProcessBuildStepOutputs => _postProcessBuildStepOutputs;
+
+  /// Whether this is a clean build, meaning there was no previous build state
+  /// loaded or it was discarded as incompatible.
+  bool get cleanBuild => previousInBuildPhasesOptionsDigests == null;
 
   /// Checks if [id] exists in the graph.
   bool contains(AssetId id) =>
@@ -217,36 +246,6 @@ class AssetGraph implements GeneratedAssetHider {
     }
   }
 
-  /// Adds [AssetNode.builderOptions] for all [buildPhases] to this graph.
-  void _addBuilderOptionsNodes(BuildPhases buildPhases) {
-    for (var phaseNum = 0; phaseNum < buildPhases.length; phaseNum++) {
-      var phase = buildPhases[phaseNum];
-      if (phase is InBuildPhase) {
-        add(
-          AssetNode.builderOptions(
-            builderOptionsIdForAction(phase, phaseNum),
-            lastKnownDigest: computeBuilderOptionsDigest(phase.builderOptions),
-          ),
-        );
-      } else if (phase is PostBuildPhase) {
-        var actionNum = 0;
-        for (var builderAction in phase.builderActions) {
-          add(
-            AssetNode.builderOptions(
-              builderOptionsIdForAction(builderAction, actionNum),
-              lastKnownDigest: computeBuilderOptionsDigest(
-                builderAction.builderOptions,
-              ),
-            ),
-          );
-          actionNum++;
-        }
-      } else {
-        throw StateError('Invalid action type $phase');
-      }
-    }
-  }
-
   /// Uses [digestReader] to compute the [Digest] for nodes with [ids] and set
   /// the `lastKnownDigest` field.
   Future<void> _setLastKnownDigests(
@@ -333,12 +332,6 @@ class AssetGraph implements GeneratedAssetHider {
         for (final input in node.generatedNodeState!.inputs) {
           result.putIfAbsent(input, () => {}).add(node.id);
         }
-        result
-            .putIfAbsent(
-              node.generatedNodeConfiguration!.builderOptionsId,
-              () => {},
-            )
-            .add(node.id);
       } else if (node.type == NodeType.glob) {
         for (final input in node.globNodeState!.inputs) {
           result.putIfAbsent(input, () => {}).add(node.id);
@@ -496,6 +489,8 @@ class AssetGraph implements GeneratedAssetHider {
     var invalidatedIds = <AssetId>{};
     final computedOutputs = computeOutputs();
 
+    // TODO(davidmorgan): it should be possible to track what needs building in
+    // the `Build` class instead of this invalidation logic.
     void invalidateNodeAndDeps(AssetId startNodeId) {
       if (!invalidatedIds.add(startNodeId)) return;
       var nodesToInvalidate = [startNodeId];
@@ -534,6 +529,26 @@ class AssetGraph implements GeneratedAssetHider {
 
     for (var changed in updates.keys.followedBy(newGeneratedOutputs)) {
       invalidateNodeAndDeps(changed);
+    }
+
+    // Invalidate nodes that depend on nodes that will be rebuilt due to changed
+    // build options.
+    if (previousInBuildPhasesOptionsDigests != null) {
+      final invalidatedPhases = <int>{};
+      for (var i = 0; i != buildPhases.inBuildPhases.length; i++) {
+        if (previousInBuildPhasesOptionsDigests![i] !=
+            inBuildPhasesOptionsDigests[i]) {
+          invalidatedPhases.add(i);
+        }
+      }
+      for (final node in allNodes) {
+        if (node.type == NodeType.generated &&
+            invalidatedPhases.contains(
+              node.generatedNodeConfiguration!.phaseNumber,
+            )) {
+          invalidateNodeAndDeps(node.id);
+        }
+      }
     }
 
     // For all new or deleted assets, check if they match any glob nodes and
@@ -615,25 +630,22 @@ class AssetGraph implements GeneratedAssetHider {
   }) {
     var allInputs = Set<AssetId>.from(newSources);
     if (placeholders != null) allInputs.addAll(placeholders);
-
-    for (var phaseNum = 0; phaseNum < buildPhases.length; phaseNum++) {
-      var phase = buildPhases[phaseNum];
-      if (phase is InBuildPhase) {
-        allInputs.addAll(
-          _addInBuildPhaseOutputs(
-            phase,
-            phaseNum,
-            allInputs,
-            buildPhases,
-            rootPackage,
-          ),
-        );
-      } else if (phase is PostBuildPhase) {
-        _addPostBuildActionApplications(phase, allInputs);
-      } else {
-        throw StateError('Unrecognized phase type $phase');
-      }
+    for (
+      var phaseNum = 0;
+      phaseNum < buildPhases.inBuildPhases.length;
+      phaseNum++
+    ) {
+      allInputs.addAll(
+        _addInBuildPhaseOutputs(
+          buildPhases.inBuildPhases[phaseNum],
+          phaseNum,
+          allInputs,
+          buildPhases,
+          rootPackage,
+        ),
+      );
     }
+    _addPostBuildActionApplications(buildPhases.postBuildPhase, allInputs);
     return allInputs;
   }
 
@@ -651,8 +663,6 @@ class AssetGraph implements GeneratedAssetHider {
     String rootPackage,
   ) {
     var phaseOutputs = <AssetId>{};
-    var buildOptionsNodeId = builderOptionsIdForAction(phase, phaseNum);
-    var builderOptionsNode = get(buildOptionsNodeId)!;
     var inputs =
         allInputs.where((input) => _actionMatches(phase, input)).toList();
     for (var input in inputs) {
@@ -667,7 +677,6 @@ class AssetGraph implements GeneratedAssetHider {
       var deleted = _addGeneratedOutputs(
         outputs,
         phaseNum,
-        builderOptionsNode,
         buildPhases,
         rootPackage,
         primaryInput: input,
@@ -710,15 +719,11 @@ class AssetGraph implements GeneratedAssetHider {
   Set<AssetId> _addGeneratedOutputs(
     Iterable<AssetId> outputs,
     int phaseNumber,
-    AssetNode builderOptionsNode,
     BuildPhases buildPhases,
     String rootPackage, {
     required AssetId primaryInput,
     required bool isHidden,
   }) {
-    if (builderOptionsNode.type != NodeType.builderOptions) {
-      throw ArgumentError('Expected node of type NodeType.builderOptionsNode');
-    }
     var removed = <AssetId>{};
     Map<AssetId, Set<AssetId>>? computedOutputsBeforeRemoves;
     for (var output in outputs) {
@@ -734,9 +739,10 @@ class AssetGraph implements GeneratedAssetHider {
           throw DuplicateAssetNodeException(
             rootPackage,
             existing.id,
-            (buildPhases[existingConfiguration.phaseNumber] as InBuildPhase)
+            buildPhases
+                .inBuildPhases[existingConfiguration.phaseNumber]
                 .builderLabel,
-            (buildPhases[phaseNumber] as InBuildPhase).builderLabel,
+            buildPhases.inBuildPhases[phaseNumber].builderLabel,
           );
         }
         _removeRecursive(output, removedIds: removed);
@@ -749,7 +755,6 @@ class AssetGraph implements GeneratedAssetHider {
         pendingBuildAction: PendingBuildAction.build,
         wasOutput: false,
         isFailure: false,
-        builderOptionsId: builderOptionsNode.id,
         isHidden: isHidden,
       );
       if (existing != null) {
@@ -830,22 +835,6 @@ class AssetGraph implements GeneratedAssetHider {
       }
     }
     return deletedSources;
-  }
-}
-
-Digest computeBuilderOptionsDigest(BuilderOptions options) =>
-    md5.convert(utf8.encode(json.encode(options.config)));
-
-AssetId builderOptionsIdForAction(BuildAction action, int actionNumber) {
-  if (action is InBuildPhase) {
-    return AssetId(action.package, 'Phase$actionNumber.builderOptions');
-  } else if (action is PostBuildAction) {
-    return PostProcessBuildStepId.builderOptionsIdFor(
-      package: action.package,
-      actionNumber: actionNumber,
-    );
-  } else {
-    throw StateError('Unsupported action type $action');
   }
 }
 

--- a/build_runner_core/lib/src/asset_graph/graph_loader.dart
+++ b/build_runner_core/lib/src/asset_graph/graph_loader.dart
@@ -140,7 +140,7 @@ class AssetGraphLoader {
         cachedGraph.inBuildPhasesOptionsDigests;
     cachedGraph.inBuildPhasesOptionsDigests =
         buildPhases.inBuildPhasesOptionsDigests;
-    cachedGraph.previousPostBuildOptionsDigests =
+    cachedGraph.previousPostBuildActionsOptionsDigests =
         cachedGraph.postBuildActionsOptionsDigests;
     cachedGraph.postBuildActionsOptionsDigests =
         buildPhases.postBuildActionsOptionsDigests;

--- a/build_runner_core/lib/src/asset_graph/graph_loader.dart
+++ b/build_runner_core/lib/src/asset_graph/graph_loader.dart
@@ -133,6 +133,18 @@ class AssetGraphLoader {
       }
       return null;
     }
+
+    // Move old build phases digests to "previous" fields, set the new ones.
+    // These are used to check for phases to fully rerun due to changed options.
+    cachedGraph.previousInBuildPhasesOptionsDigests =
+        cachedGraph.inBuildPhasesOptionsDigests;
+    cachedGraph.inBuildPhasesOptionsDigests =
+        buildPhases.inBuildPhasesOptionsDigests;
+    cachedGraph.previousPostBuildOptionsDigests =
+        cachedGraph.postBuildActionsOptionsDigests;
+    cachedGraph.postBuildActionsOptionsDigests =
+        buildPhases.postBuildActionsOptionsDigests;
+
     return cachedGraph;
   }
 

--- a/build_runner_core/lib/src/asset_graph/node.dart
+++ b/build_runner_core/lib/src/asset_graph/node.dart
@@ -18,7 +18,6 @@ part 'node.g.dart';
 class NodeType extends EnumClass {
   static Serializer<NodeType> get serializer => _$nodeTypeSerializer;
 
-  static const NodeType builderOptions = _$builderOptions;
   static const NodeType generated = _$generated;
   static const NodeType glob = _$glob;
   static const NodeType internal = _$internal;
@@ -122,17 +121,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
     b.lastKnownDigest = lastKnownDigest;
   });
 
-  /// A [BuilderOptions] object.
-  ///
-  /// Each [AssetNode.generated] has one describing its configuration, so it
-  /// rebuilds when the configuration changes.
-  factory AssetNode.builderOptions(AssetId id, {Digest? lastKnownDigest}) =>
-      AssetNode((b) {
-        b.id = id;
-        b.type = NodeType.builderOptions;
-        b.lastKnownDigest = lastKnownDigest;
-      });
-
   /// A missing source file.
   ///
   /// Created when a builder tries to read a non-existent file.
@@ -164,7 +152,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
     AssetId id, {
     Digest? lastKnownDigest,
     required AssetId primaryInput,
-    required AssetId builderOptionsId,
     required int phaseNumber,
     required bool isHidden,
     Iterable<AssetId>? inputs,
@@ -175,7 +162,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
     b.id = id;
     b.type = NodeType.generated;
     b.generatedNodeConfiguration.primaryInput = primaryInput;
-    b.generatedNodeConfiguration.builderOptionsId = builderOptionsId;
     b.generatedNodeConfiguration.phaseNumber = phaseNumber;
     b.generatedNodeConfiguration.isHidden = isHidden;
     b.generatedNodeState.inputs.replace(inputs ?? []);
@@ -257,10 +243,6 @@ abstract class GeneratedNodeConfiguration
 
   /// The primary input which generated this node.
   AssetId get primaryInput;
-
-  /// The [AssetId] of the node representing the [BuilderOptions] used to create
-  /// this node.
-  AssetId get builderOptionsId;
 
   /// The phase in which this node is generated.
   ///

--- a/build_runner_core/lib/src/asset_graph/node.g.dart
+++ b/build_runner_core/lib/src/asset_graph/node.g.dart
@@ -6,7 +6,6 @@ part of 'node.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-const NodeType _$builderOptions = const NodeType._('builderOptions');
 const NodeType _$generated = const NodeType._('generated');
 const NodeType _$glob = const NodeType._('glob');
 const NodeType _$internal = const NodeType._('internal');
@@ -16,8 +15,6 @@ const NodeType _$missingSource = const NodeType._('missingSource');
 
 NodeType _$nodeTypeValueOf(String name) {
   switch (name) {
-    case 'builderOptions':
-      return _$builderOptions;
     case 'generated':
       return _$generated;
     case 'glob':
@@ -35,16 +32,16 @@ NodeType _$nodeTypeValueOf(String name) {
   }
 }
 
-final BuiltSet<NodeType> _$nodeTypeValues =
-    new BuiltSet<NodeType>(const <NodeType>[
-      _$builderOptions,
-      _$generated,
-      _$glob,
-      _$internal,
-      _$placeholder,
-      _$source,
-      _$missingSource,
-    ]);
+final BuiltSet<NodeType> _$nodeTypeValues = new BuiltSet<NodeType>(
+  const <NodeType>[
+    _$generated,
+    _$glob,
+    _$internal,
+    _$placeholder,
+    _$source,
+    _$missingSource,
+  ],
+);
 
 const PendingBuildAction _$none = const PendingBuildAction._('none');
 const PendingBuildAction _$buildIfInputsChanged = const PendingBuildAction._(
@@ -322,11 +319,6 @@ class _$GeneratedNodeConfigurationSerializer
         object.primaryInput,
         specifiedType: const FullType(AssetId),
       ),
-      'builderOptionsId',
-      serializers.serialize(
-        object.builderOptionsId,
-        specifiedType: const FullType(AssetId),
-      ),
       'phaseNumber',
       serializers.serialize(
         object.phaseNumber,
@@ -358,14 +350,6 @@ class _$GeneratedNodeConfigurationSerializer
       switch (key) {
         case 'primaryInput':
           result.primaryInput =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(AssetId),
-                  )!
-                  as AssetId;
-          break;
-        case 'builderOptionsId':
-          result.builderOptionsId =
               serializers.deserialize(
                     value,
                     specifiedType: const FullType(AssetId),
@@ -908,8 +892,6 @@ class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
   @override
   final AssetId primaryInput;
   @override
-  final AssetId builderOptionsId;
-  @override
   final int phaseNumber;
   @override
   final bool isHidden;
@@ -920,7 +902,6 @@ class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
 
   _$GeneratedNodeConfiguration._({
     required this.primaryInput,
-    required this.builderOptionsId,
     required this.phaseNumber,
     required this.isHidden,
   }) : super._() {
@@ -928,11 +909,6 @@ class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
       primaryInput,
       r'GeneratedNodeConfiguration',
       'primaryInput',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      builderOptionsId,
-      r'GeneratedNodeConfiguration',
-      'builderOptionsId',
     );
     BuiltValueNullFieldError.checkNotNull(
       phaseNumber,
@@ -960,7 +936,6 @@ class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
     if (identical(other, this)) return true;
     return other is GeneratedNodeConfiguration &&
         primaryInput == other.primaryInput &&
-        builderOptionsId == other.builderOptionsId &&
         phaseNumber == other.phaseNumber &&
         isHidden == other.isHidden;
   }
@@ -969,7 +944,6 @@ class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, primaryInput.hashCode);
-    _$hash = $jc(_$hash, builderOptionsId.hashCode);
     _$hash = $jc(_$hash, phaseNumber.hashCode);
     _$hash = $jc(_$hash, isHidden.hashCode);
     _$hash = $jf(_$hash);
@@ -980,7 +954,6 @@ class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
   String toString() {
     return (newBuiltValueToStringHelper(r'GeneratedNodeConfiguration')
           ..add('primaryInput', primaryInput)
-          ..add('builderOptionsId', builderOptionsId)
           ..add('phaseNumber', phaseNumber)
           ..add('isHidden', isHidden))
         .toString();
@@ -997,11 +970,6 @@ class GeneratedNodeConfigurationBuilder
   set primaryInput(AssetId? primaryInput) =>
       _$this._primaryInput = primaryInput;
 
-  AssetId? _builderOptionsId;
-  AssetId? get builderOptionsId => _$this._builderOptionsId;
-  set builderOptionsId(AssetId? builderOptionsId) =>
-      _$this._builderOptionsId = builderOptionsId;
-
   int? _phaseNumber;
   int? get phaseNumber => _$this._phaseNumber;
   set phaseNumber(int? phaseNumber) => _$this._phaseNumber = phaseNumber;
@@ -1016,7 +984,6 @@ class GeneratedNodeConfigurationBuilder
     final $v = _$v;
     if ($v != null) {
       _primaryInput = $v.primaryInput;
-      _builderOptionsId = $v.builderOptionsId;
       _phaseNumber = $v.phaseNumber;
       _isHidden = $v.isHidden;
       _$v = null;
@@ -1046,11 +1013,6 @@ class GeneratedNodeConfigurationBuilder
             primaryInput,
             r'GeneratedNodeConfiguration',
             'primaryInput',
-          ),
-          builderOptionsId: BuiltValueNullFieldError.checkNotNull(
-            builderOptionsId,
-            r'GeneratedNodeConfiguration',
-            'builderOptionsId',
           ),
           phaseNumber: BuiltValueNullFieldError.checkNotNull(
             phaseNumber,

--- a/build_runner_core/lib/src/asset_graph/post_process_build_step_id.dart
+++ b/build_runner_core/lib/src/asset_graph/post_process_build_step_id.dart
@@ -26,13 +26,4 @@ abstract class PostProcessBuildStepId
     required AssetId input,
     required int actionNumber,
   }) = _$PostProcessBuildStepId._;
-
-  /// The [AssetId] used to store the hash of the build options for the step.
-  AssetId get builderOptionsId =>
-      builderOptionsIdFor(package: input.package, actionNumber: actionNumber);
-
-  static AssetId builderOptionsIdFor({
-    required String package,
-    required int actionNumber,
-  }) => AssetId(package, 'PostPhase$actionNumber.builderOptions');
 }

--- a/build_runner_core/lib/src/asset_graph/serialization.dart
+++ b/build_runner_core/lib/src/asset_graph/serialization.dart
@@ -8,7 +8,7 @@ part of 'graph.dart';
 ///
 /// This should be incremented any time the serialize/deserialize formats
 /// change.
-const _version = 28;
+const _version = 29;
 
 /// Deserializes an [AssetGraph] from a [Map].
 AssetGraph deserializeAssetGraph(List<int> bytes) {
@@ -38,8 +38,18 @@ AssetGraph deserializeAssetGraph(List<int> bytes) {
               ? LanguageVersion.parse(entry.value as String)
               : null,
   };
-  var graph = AssetGraph._(
+  var graph = AssetGraph._fromSerialized(
     _deserializeDigest(serializedGraph['buildActionsDigest'] as String)!,
+    serializers.deserialize(
+          serializedGraph['inBuildPhasesOptionsDigests'],
+          specifiedType: const FullType(BuiltList, [FullType(Digest)]),
+        )
+        as BuiltList<Digest>,
+    serializers.deserialize(
+          serializedGraph['postBuildActionsOptionsDigests'],
+          specifiedType: const FullType(BuiltList, [FullType(Digest)]),
+        )
+        as BuiltList<Digest>,
     serializedGraph['dart_version'] as String,
     packageLanguageVersions.build(),
     BuiltList<String>.from(serializedGraph['enabledExperiments'] as List),
@@ -92,6 +102,14 @@ List<int> serializeAssetGraph(AssetGraph graph) {
     'postProcessOutputs': serializers.serialize(
       graph._postProcessBuildStepOutputs,
       specifiedType: postProcessBuildStepOutputsFullType,
+    ),
+    'inBuildPhasesOptionsDigests': serializers.serialize(
+      graph.inBuildPhasesOptionsDigests,
+      specifiedType: const FullType(BuiltList, [FullType(Digest)]),
+    ),
+    'postBuildActionsOptionsDigests': serializers.serialize(
+      graph.postBuildActionsOptionsDigests,
+      specifiedType: const FullType(BuiltList, [FullType(Digest)]),
     ),
   };
 

--- a/build_runner_core/lib/src/asset_graph/serializers.dart
+++ b/build_runner_core/lib/src/asset_graph/serializers.dart
@@ -48,6 +48,10 @@ final Serializers serializers =
           ..addBuilderFactory(
             postProcessBuildStepOutputsFullType,
             () => <String, Map<PostProcessBuildStepId, Set<AssetId>>>{},
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(Digest)]),
+            ListBuilder<Digest>.new,
           ))
         .build();
 

--- a/build_runner_core/lib/src/asset_graph/serializers.g.dart
+++ b/build_runner_core/lib/src/asset_graph/serializers.g.dart
@@ -33,10 +33,6 @@ Serializers _$serializers =
             () => new SetBuilder<AssetId>(),
           )
           ..addBuilderFactory(
-            const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
-          )
-          ..addBuilderFactory(
             const FullType(BuiltSet, const [
               const FullType(PostProcessBuildStepId),
             ]),

--- a/build_runner_core/lib/src/generate/build.dart
+++ b/build_runner_core/lib/src/generate/build.dart
@@ -52,9 +52,6 @@ class Build {
   final Set<BuildDirectory> buildDirs;
   final Set<BuildFilter> buildFilters;
 
-  /// Whether this is a build starting from no previous state or outputs.
-  final bool cleanBuild;
-
   // Collaborators.
   final ResourceManager resourceManager;
   final AssetReaderWriter readerWriter;
@@ -86,6 +83,8 @@ class Build {
   /// checked against the digest from the previous build.
   final Set<AssetId> changedOutputs = {};
 
+  final Set<int> changedOptionPhases = {};
+
   Build({
     required this.environment,
     required this.options,
@@ -96,7 +95,6 @@ class Build {
     required this.deleteWriter,
     required this.resourceManager,
     required this.assetGraph,
-    required this.cleanBuild,
   }) : renderer = LogRenderer(rootPackageName: options.packageGraph.root.name),
        performanceTracker =
            options.trackPerformance
@@ -201,9 +199,10 @@ class Build {
 
     runZonedGuarded(
       () async {
-        if (updates.isNotEmpty) {
+        if (!assetGraph.cleanBuild) {
           await _updateAssetGraph(updates);
         }
+
         // Run a fresh build.
         var result = await logTimedAsync(_logger, 'Running build', _runPhases);
 
@@ -216,6 +215,13 @@ class Build {
               AssetId(options.packageGraph.root.name, assetGraphPath),
               assetGraph.serialize(),
             );
+            // Phases options don't change during a build series, so for all
+            // subsequent builds "previous" and current build options digests
+            // match.
+            assetGraph.previousInBuildPhasesOptionsDigests =
+                assetGraph.inBuildPhasesOptionsDigests;
+            assetGraph.postBuildActionsOptionsDigests =
+                assetGraph.postBuildActionsOptionsDigests;
           },
         );
 
@@ -264,25 +270,41 @@ class Build {
   Future<BuildResult> _runPhases() {
     return performanceTracker.track(() async {
       final outputs = <AssetId>[];
-      for (var phaseNum = 0; phaseNum < buildPhases.length; phaseNum++) {
-        var phase = buildPhases[phaseNum];
+
+      // Main build phases.
+      for (
+        var phaseNum = 0;
+        phaseNum < buildPhases.inBuildPhases.length;
+        phaseNum++
+      ) {
+        var phase = buildPhases.inBuildPhases[phaseNum];
         if (phase.isOptional) continue;
         outputs.addAll(
           await performanceTracker.trackBuildPhase(phase, () async {
-            if (phase is InBuildPhase) {
-              var primaryInputs = await _matchingPrimaryInputs(
-                phase.package,
-                phaseNum,
-              );
-              return _runBuilder(phaseNum, phase, primaryInputs);
-            } else if (phase is PostBuildPhase) {
-              return _runPostBuildPhase(phaseNum, phase);
-            } else {
-              throw StateError('Unrecognized BuildPhase type $phase');
-            }
+            var primaryInputs = await _matchingPrimaryInputs(
+              phase.package,
+              phaseNum,
+            );
+            return _runBuilder(phaseNum, phase, primaryInputs);
           }),
         );
       }
+
+      // Post build phase.
+      if (buildPhases.postBuildPhase.builderActions.isNotEmpty) {
+        outputs.addAll(
+          await performanceTracker.trackBuildPhase(
+            buildPhases.postBuildPhase,
+            () async {
+              return _runPostBuildPhase(
+                buildPhases.inBuildPhases.length,
+                buildPhases.postBuildPhase,
+              );
+            },
+          ),
+        );
+      }
+
       await Future.forEach(
         lazyPhases.values,
         (Future<Iterable<AssetId>> lazyOuts) async =>
@@ -390,10 +412,11 @@ class Build {
         if (!nodeState.wasOutput || nodeState.isFailure) return <AssetId>[];
       }
 
-      // We can never lazily build `PostProcessBuildAction`s.
-      var action = buildPhases[phaseNumber] as InBuildPhase;
-
-      return _runForInput(phaseNumber, action, input);
+      return _runForInput(
+        phaseNumber,
+        buildPhases.inBuildPhases[phaseNumber],
+        input,
+      );
     });
   }
 
@@ -581,7 +604,7 @@ class Build {
       ),
       runningBuildStep: RunningBuildStep(
         phaseNumber: phaseNumber,
-        buildPhase: buildPhases[phaseNumber],
+        buildPhase: buildPhases.postBuildPhase,
         primaryPackage: input.package,
       ),
       readerWriter: this.readerWriter,
@@ -633,7 +656,6 @@ class Build {
         var node = AssetNode.generated(
           assetId,
           primaryInput: input,
-          builderOptionsId: postProcessBuildStepId.builderOptionsId,
           isHidden: true,
           phaseNumber: phaseNumber,
           wasOutput: true,
@@ -704,6 +726,27 @@ class Build {
     );
     assert(outputs.isNotEmpty, 'Can\'t run a build with no outputs');
 
+    if (assetGraph.previousInBuildPhasesOptionsDigests == null) {
+      if (logFine) {
+        _logger.fine(
+          'Build ${renderer.build(forInput, outputs)} because this is a clean '
+          'build.',
+        );
+      }
+      return true;
+    }
+
+    if (assetGraph.previousInBuildPhasesOptionsDigests![phaseNumber] !=
+        assetGraph.inBuildPhasesOptionsDigests[phaseNumber]) {
+      if (logFine) {
+        _logger.fine(
+          'Build ${renderer.build(forInput, outputs)} because builder options '
+          'changed.',
+        );
+      }
+      return true;
+    }
+
     // We check if any output definitely needs an update - its possible during
     // manual deletions that only one of the outputs would be marked.
     for (var output in outputs.skip(1)) {
@@ -750,18 +793,6 @@ class Build {
         _logger.fine(
           'Build ${renderer.build(forInput, outputs)} because '
           '${renderer.id(firstNode.id)} was marked for build.',
-        );
-      }
-      return true;
-    }
-
-    final builderOptionsId =
-        firstNode.generatedNodeConfiguration!.builderOptionsId;
-    if (changedInputs.contains(builderOptionsId)) {
-      if (logFine) {
-        _logger.fine(
-          'Build ${renderer.build(forInput, outputs)} because '
-          'builder options changed.',
         );
       }
       return true;
@@ -842,12 +873,13 @@ class Build {
     final input = buildStepId.input;
     final node = assetGraph.get(input)!;
 
-    if (cleanBuild) {
+    if (assetGraph.previousPostBuildOptionsDigests == null) {
+      // It's a clean build.
       return true;
     }
 
-    final builderOptionsId = buildStepId.builderOptionsId;
-    if (changedInputs.contains(builderOptionsId)) {
+    if (assetGraph.previousPostBuildOptionsDigests![buildStepId.actionNumber] !=
+        assetGraph.postBuildActionsOptionsDigests[buildStepId.actionNumber]) {
       return true;
     }
 

--- a/build_runner_core/lib/src/generate/build.dart
+++ b/build_runner_core/lib/src/generate/build.dart
@@ -83,8 +83,6 @@ class Build {
   /// checked against the digest from the previous build.
   final Set<AssetId> changedOutputs = {};
 
-  final Set<int> changedOptionPhases = {};
-
   Build({
     required this.environment,
     required this.options,

--- a/build_runner_core/lib/src/generate/build.dart
+++ b/build_runner_core/lib/src/generate/build.dart
@@ -218,7 +218,7 @@ class Build {
             // match.
             assetGraph.previousInBuildPhasesOptionsDigests =
                 assetGraph.inBuildPhasesOptionsDigests;
-            assetGraph.postBuildActionsOptionsDigests =
+            assetGraph.previousPostBuildActionsOptionsDigests =
                 assetGraph.postBuildActionsOptionsDigests;
           },
         );
@@ -871,12 +871,13 @@ class Build {
     final input = buildStepId.input;
     final node = assetGraph.get(input)!;
 
-    if (assetGraph.previousPostBuildOptionsDigests == null) {
+    if (assetGraph.previousPostBuildActionsOptionsDigests == null) {
       // It's a clean build.
       return true;
     }
 
-    if (assetGraph.previousPostBuildOptionsDigests![buildStepId.actionNumber] !=
+    if (assetGraph.previousPostBuildActionsOptionsDigests![buildStepId
+            .actionNumber] !=
         assetGraph.postBuildActionsOptionsDigests[buildStepId.actionNumber]) {
       return true;
     }

--- a/build_runner_core/lib/src/generate/build_series.dart
+++ b/build_runner_core/lib/src/generate/build_series.dart
@@ -120,7 +120,6 @@ class BuildSeries {
       readerWriter: readerWriter,
       deleteWriter: deleteWriter,
       resourceManager: resourceManager,
-      cleanBuild: cleanBuild && firstBuild,
     );
     if (firstBuild) firstBuild = false;
     final result = await build.run(updates);
@@ -145,7 +144,8 @@ class BuildSeries {
       builderConfigOverrides,
       isReleaseBuild,
     );
-    if (buildPhases.phases.isEmpty) {
+    if (buildPhases.inBuildPhases.isEmpty &&
+        buildPhases.postBuildPhase.builderActions.isEmpty) {
       _logger.severe('Nothing can be built, yet a build was requested.');
     }
 

--- a/build_runner_core/lib/src/generate/phase.dart
+++ b/build_runner_core/lib/src/generate/phase.dart
@@ -139,7 +139,7 @@ class InBuildPhase extends BuildPhase implements BuildAction {
 ///
 /// There should only be one of these per build, and it should be the final
 /// phase.
-class PostBuildPhase extends BuildPhase {
+class PostBuildPhase implements BuildPhase {
   final List<PostBuildAction> builderActions;
 
   @override

--- a/build_runner_core/lib/src/logging/failure_reporter.dart
+++ b/build_runner_core/lib/src/logging/failure_reporter.dart
@@ -124,7 +124,7 @@ class ErrorReport {
 }
 
 String _actionKey(AssetNode node) =>
-    '${node.generatedNodeConfiguration!.builderOptionsId} on '
+    '${node.generatedNodeConfiguration!.phaseNumber} on '
     '${node.generatedNodeConfiguration!.primaryInput}';
 
 String _errorPathForOutput(AssetNode output) => p.joinAll([

--- a/build_runner_core/lib/src/package_graph/apply_builders.dart
+++ b/build_runner_core/lib/src/package_graph/apply_builders.dart
@@ -371,7 +371,7 @@ Future<BuildPhases> createBuildPhases(
     );
   }
 
-  return BuildPhases([...inBuildPhases, ...collapsedPostBuildPhase]);
+  return BuildPhases(inBuildPhases, collapsedPostBuildPhase.singleOrNull);
 }
 
 Iterable<BuildPhase> _createBuildPhasesWithinCycle(

--- a/build_runner_core/test/asset/finalized_reader_test.dart
+++ b/build_runner_core/test/asset/finalized_reader_test.dart
@@ -89,7 +89,6 @@ void main() {
         isFailure: true,
         primaryInput: AssetId('a', 'web/a.dart'),
         isHidden: true,
-        builderOptionsId: AssetId('a', 'builder_options'),
       );
       graph.add(node);
       var delegate = TestReaderWriter();

--- a/build_runner_core/test/generate/build_definition_test.dart
+++ b/build_runner_core/test/generate/build_definition_test.dart
@@ -336,25 +336,13 @@ targets:
         );
 
         var newAssetGraph = buildDefinition.assetGraph;
-
-        // The *.copy node should be invalidated, its builder options changed.
-        var generatedACopyNode = newAssetGraph.get(generatedACopyId)!;
         expect(
-          buildDefinition.updates![generatedACopyNode
-              .generatedNodeConfiguration!
-              .builderOptionsId],
-          ChangeType.MODIFY,
+          newAssetGraph.inBuildPhasesOptionsDigests[0],
+          isNot(newAssetGraph.previousInBuildPhasesOptionsDigests![0]),
         );
-
-        // But the *.clone node should remain the same since its options didn't.
-        var generatedACloneNode = newAssetGraph.get(generatedACloneId)!;
         expect(
-          buildDefinition.updates!.keys,
-          isNot(
-            contains(
-              generatedACloneNode.generatedNodeConfiguration!.builderOptionsId,
-            ),
-          ),
+          newAssetGraph.inBuildPhasesOptionsDigests[1],
+          newAssetGraph.previousInBuildPhasesOptionsDigests![1],
         );
       });
     });
@@ -383,8 +371,7 @@ targets:
           aPackageGraph,
           environment.reader,
         );
-        var expectedIds = placeholderIdsFor(aPackageGraph)
-          ..addAll([makeAssetId('a|Phase0.builderOptions')]);
+        var expectedIds = placeholderIdsFor(aPackageGraph);
         expect(
           assetGraph.allNodes.map((node) => node.id),
           unorderedEquals(expectedIds),
@@ -491,7 +478,7 @@ targets:
         await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         buildPhases = BuildPhases([
-          ...buildPhases.phases,
+          ...buildPhases.inBuildPhases,
           InBuildPhase(
             TestBuilder(),
             'a',
@@ -745,7 +732,7 @@ targets:
         await createFile(assetGraphPath, originalAssetGraph.serialize());
 
         buildPhases = BuildPhases([
-          ...buildPhases.phases,
+          ...buildPhases.inBuildPhases,
           InBuildPhase(
             TestBuilder(),
             'a',

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -41,7 +41,6 @@ void main() {
     ),
   );
   final globBuilder = GlobbingBuilder(Glob('**.txt'));
-  final defaultBuilderOptions = const BuilderOptions({});
   final placeholders = placeholderIdsFor(
     buildPackageGraph({rootPackage('a'): []}),
   );
@@ -571,8 +570,6 @@ void main() {
             makeAssetId('a|web/a.txt'),
             makeAssetId('a|web/a.txt.copy'),
             makeAssetId('a|web/a.txt.copy.clone'),
-            makeAssetId('a|Phase0.builderOptions'),
-            makeAssetId('a|Phase1.builderOptions'),
             ...placeholders,
             makeAssetId('a|.dart_tool/package_config.json'),
           ]),
@@ -1267,13 +1264,7 @@ void main() {
       computeDigest(AssetId('a', 'lib/b.txt'), 'b'),
     );
 
-    // Regular generated asset nodes and supporting nodes.
-    var builderOptionsId = makeAssetId('a|Phase0.builderOptions');
-    var builderOptionsNode = AssetNode.builderOptions(
-      builderOptionsId,
-      lastKnownDigest: computeBuilderOptionsDigest(defaultBuilderOptions),
-    );
-
+    // Regular generated asset nodes.
     var aCopyId = makeAssetId('a|web/a.txt.copy');
     var aCopyNode = AssetNode.generated(
       aCopyId,
@@ -1282,7 +1273,6 @@ void main() {
       pendingBuildAction: PendingBuildAction.none,
       wasOutput: true,
       isFailure: false,
-      builderOptionsId: builderOptionsId,
       lastKnownDigest: computeDigest(aCopyId, 'a'),
       inputs: [makeAssetId('a|web/a.txt')],
       isHidden: false,
@@ -1299,7 +1289,6 @@ void main() {
       pendingBuildAction: PendingBuildAction.none,
       wasOutput: true,
       isFailure: false,
-      builderOptionsId: builderOptionsId,
       lastKnownDigest: computeDigest(bCopyId, 'b'),
       inputs: [makeAssetId('a|lib/b.txt')],
       isHidden: false,
@@ -1308,13 +1297,7 @@ void main() {
       (b) => b..primaryOutputs.add(bCopyNode.id),
     );
 
-    // Post build generates asset nodes and supporting nodes
-    var postBuilderOptionsId = makeAssetId('a|PostPhase0.builderOptions');
-    var postBuilderOptionsNode = AssetNode.builderOptions(
-      postBuilderOptionsId,
-      lastKnownDigest: computeBuilderOptionsDigest(defaultBuilderOptions),
-    );
-
+    // Post build generates asset nodes.
     var aPostProcessBuildStepId = PostProcessBuildStepId(
       input: aSourceNode.id,
       actionNumber: 0,
@@ -1331,7 +1314,6 @@ void main() {
       pendingBuildAction: PendingBuildAction.none,
       wasOutput: true,
       isFailure: false,
-      builderOptionsId: postBuilderOptionsId,
       lastKnownDigest: computeDigest(makeAssetId(r'$$a|web/a.txt.post'), 'a'),
       inputs: [makeAssetId('a|web/a.txt')],
       isHidden: true,
@@ -1349,7 +1331,6 @@ void main() {
       pendingBuildAction: PendingBuildAction.none,
       wasOutput: true,
       isFailure: false,
-      builderOptionsId: postBuilderOptionsId,
       lastKnownDigest: computeDigest(makeAssetId(r'$$a|lib/b.txt.post'), 'b'),
       inputs: [makeAssetId('a|lib/b.txt')],
       isHidden: true,
@@ -1363,10 +1344,8 @@ void main() {
     expectedGraph
       ..add(aSourceNode)
       ..add(bSourceNode)
-      ..add(builderOptionsNode)
       ..add(aCopyNode)
       ..add(bCopyNode)
-      ..add(postBuilderOptionsNode)
       ..add(aPostCopyNode)
       ..add(bPostCopyNode)
       ..updatePostProcessBuildStep(

--- a/build_runner_core/test/package_graph/apply_builders_test.dart
+++ b/build_runner_core/test/package_graph/apply_builders_test.dart
@@ -30,7 +30,7 @@ void main() {
       var phases = await createBuildPhases(targetGraph, builderApplications, {
         'b:cool_builder': {'option_a': 'a', 'option_c': 'c'},
       }, false);
-      for (final phase in phases.phases.cast<InBuildPhase>()) {
+      for (final phase in phases.inBuildPhases) {
         expect((phase.builder as CoolBuilder).optionA, equals('a'));
         expect((phase.builder as CoolBuilder).optionB, equals('defaultB'));
         expect((phase.builder as CoolBuilder).optionC, equals('c'));
@@ -79,7 +79,7 @@ void main() {
               },
               true,
             );
-            for (final phase in phases.phases.cast<InBuildPhase>()) {
+            for (final phase in phases.inBuildPhases) {
               expect(
                 (phase.builder as CoolBuilder).optionA,
                 equals('global a'),
@@ -119,7 +119,7 @@ void main() {
         false,
       );
       expect(phases, hasLength(1));
-      expect((phases.phases.first as InBuildPhase).package, 'a');
+      expect(phases.inBuildPhases.first.package, 'a');
     });
 
     test('honors appliesBuilders', () async {
@@ -148,7 +148,7 @@ void main() {
       );
       expect(phases, hasLength(2));
       expect(
-        phases.phases,
+        phases.inBuildPhases,
         everyElement(
           const TypeMatcher<InBuildPhase>().having(
             (p) => p.package,
@@ -185,7 +185,7 @@ void main() {
       );
       expect(phases, hasLength(1));
       expect(
-        phases.phases,
+        phases.inBuildPhases,
         everyElement(
           const TypeMatcher<InBuildPhase>().having(
             (p) => p.package,
@@ -230,7 +230,7 @@ void main() {
         );
         expect(phases, hasLength(2));
         expect(
-          phases.phases,
+          phases.inBuildPhases,
           everyElement(
             const TypeMatcher<InBuildPhase>().having(
               (p) => p.package,
@@ -322,7 +322,7 @@ void main() {
 
       test('can be disabled for a target', () async {
         var phases = await createPhases();
-        expect(phases.phases, isEmpty);
+        expect(phases.inBuildPhases, isEmpty);
       });
 
       test('individual builders can still be enabled', () async {
@@ -333,7 +333,7 @@ void main() {
         );
         expect(phases, hasLength(1));
         expect(
-          phases.phases.first,
+          phases.inBuildPhases.first,
           isA<InBuildPhase>()
               .having((p) => p.package, 'package', 'a')
               .having(
@@ -354,7 +354,7 @@ void main() {
           );
           expect(phases, hasLength(2));
           expect(
-            phases.phases,
+            phases.inBuildPhases,
             equals([
               isA<InBuildPhase>()
                   .having((p) => p.package, 'package', 'a')


### PR DESCRIPTION
For #3811.

Prior to this PR builder options are stored as nodes in the asset graph, with each generation / post generation pointing to its builder options node. This is used to know to rerun generations when builder options change.

Builder options are set per phase in `BuildPhases`, so instead map the list of phases to a list of digests, and store/compare that, removing builder options entirely from the asset graph.

Checking whether in-build and post build actions rerun when options change is already covered by tests.