### PR TITLE
More inputs invalidation test; fix for deletions

### DIFF
--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -361,6 +361,10 @@ void main() {
           readerWriter,
         );
 
+        var aTxtId = makeAssetId('a|web/a.txt');
+        var aTxtNode = AssetNode.missingSource(aTxtId);
+        var aTxtCopyId = makeAssetId('a|web/a.txt.copy');
+        var aTxtCopyNode = AssetNode.missingSource(aTxtCopyId);
         var bCopyId = makeAssetId('a|web/b.txt.copy');
         var bTxtId = makeAssetId('a|web/b.txt');
         var bCopyNode = AssetNode.generated(
@@ -374,7 +378,10 @@ void main() {
           inputs: [makeAssetId('a|web/b.txt')],
           isHidden: false,
         );
+
         expectedGraph
+          ..add(aTxtNode)
+          ..add(aTxtCopyNode)
           ..add(bCopyNode)
           ..add(
             makeAssetNode('a|web/b.txt', [

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1673,7 +1673,10 @@ void main() {
               makeAssetId('a|$assetGraphPath'),
             ),
           );
-          expect(graph.get(makeAssetId('a|lib/a.txt.copy')), isNull);
+          expect(
+            graph.get(makeAssetId('a|lib/a.txt.copy'))!.type,
+            NodeType.missingSource,
+          );
         },
       );
     });
@@ -1702,15 +1705,15 @@ void main() {
         resumeFrom: result,
       );
 
-      /// Should be deleted using the writer, and removed from the new graph.
+      /// Should be deleted using the writer, and converted to missingSource.
       var newGraph = AssetGraph.deserialize(
         result.readerWriter.testing.readBytes(makeAssetId('a|$assetGraphPath')),
       );
       var aNodeId = makeAssetId('a|lib/a.txt');
       var aCopyNodeId = makeAssetId('a|lib/a.txt.copy');
       var aCloneNodeId = makeAssetId('a|lib/a.txt.copy.clone');
-      expect(newGraph.contains(aNodeId), isFalse);
-      expect(newGraph.contains(aCopyNodeId), isFalse);
+      expect(newGraph.get(aNodeId)!.type, NodeType.missingSource);
+      expect(newGraph.get(aCopyNodeId)!.type, NodeType.missingSource);
       expect(newGraph.contains(aCloneNodeId), isFalse);
       expect(result.readerWriter.testing.exists(aNodeId), isFalse);
       expect(result.readerWriter.testing.exists(aCopyNodeId), isFalse);

--- a/build_runner_core/test/invalidation/asset_input_invalidation_test.dart
+++ b/build_runner_core/test/invalidation/asset_input_invalidation_test.dart
@@ -6,7 +6,8 @@ import 'package:test/test.dart';
 
 import 'invalidation_tester.dart';
 
-/// Invalidation tests in which the inputs are individually read arbitrary assets.
+/// Invalidation tests in which the inputs are individually read arbitrary
+/// assets.
 void main() {
   late InvalidationTester tester;
 
@@ -35,10 +36,7 @@ void main() {
       await tester.build();
       expect(
         await tester.build(delete: 'z'),
-        // TODO(davidmorgan): a.1 should be rebuilt, but it's not. This is a
-        // regression since the last version on pub: fix it!
-        // Result(written: ['a.1'], deleted: ['z.1'])
-        Result(deleted: ['z.1']),
+        Result(written: ['a.1'], deleted: ['z.1']),
       );
     });
 
@@ -73,14 +71,11 @@ void main() {
       );
     });
 
-    test('delete a.1, a.2+b.4 are rebuilt', () async {
+    test('delete a.1, a.2 is deleted and b.4 is rebuilt', () async {
       await tester.build();
       expect(
         await tester.build(delete: 'a.1'),
-        // TODO(davidmorgan): a.1 should be rebuilt, but it's not. This is a
-        // regression since the last version on pub: fix it!
-        // Result(written: ['a.2', 'b.4']),
-        Result(deleted: ['a.2']),
+        Result(deleted: ['a.2'], written: ['b.4']),
       );
     });
 

--- a/build_runner_core/test/invalidation/asset_input_invalidation_test.dart
+++ b/build_runner_core/test/invalidation/asset_input_invalidation_test.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'invalidation_tester.dart';
+
+/// Invalidation tests in which the inputs are individually read arbitrary assets.
+void main() {
+  late InvalidationTester tester;
+
+  setUp(() {
+    tester = InvalidationTester();
+  });
+
+  group('a+(z) <-- a.1', () {
+    setUp(() {
+      tester.sources(['a', 'z']);
+      tester.builder(from: '', to: '.1')
+        ..readsOther('z')
+        ..writes('.1');
+    });
+
+    test('a.1 is built', () async {
+      expect(await tester.build(), Result(written: ['a.1', 'z.1']));
+    });
+
+    test('change z, a.1 is rebuilt', () async {
+      await tester.build();
+      expect(await tester.build(change: 'z'), Result(written: ['a.1', 'z.1']));
+    });
+
+    test('delete z, a.1 is rebuilt', () async {
+      await tester.build();
+      expect(
+        await tester.build(delete: 'z'),
+        // TODO(davidmorgan): a.1 should be rebuilt, but it's not. This is a
+        // regression since the last version on pub: fix it!
+        // Result(written: ['a.1'], deleted: ['z.1'])
+        Result(deleted: ['z.1']),
+      );
+    });
+
+    test('create z, a.1 is rebuilt', () async {
+      tester.sources(['a']);
+      expect(await tester.build(), Result(written: ['a.1']));
+      expect(await tester.build(create: 'z'), Result(written: ['a.1', 'z.1']));
+    });
+  });
+
+  group('a.1 <== a.2, b.3+(a.2) <== b.4', () {
+    setUp(() {
+      tester.sources(['a.1', 'b.3']);
+      tester.builder(from: '.1', to: '.2')
+        ..reads('.1')
+        ..writes('.2');
+      tester.builder(from: '.3', to: '.4')
+        ..reads('.3')
+        ..readsOther('a.2')
+        ..writes('.4');
+    });
+
+    test('a.4 is built', () async {
+      expect(await tester.build(), Result(written: ['a.2', 'b.4']));
+    });
+
+    test('change a.1, a.2+b.4 are rebuilt', () async {
+      await tester.build();
+      expect(
+        await tester.build(change: 'a.1'),
+        Result(written: ['a.2', 'b.4']),
+      );
+    });
+
+    test('delete a.1, a.2+b.4 are rebuilt', () async {
+      await tester.build();
+      expect(
+        await tester.build(delete: 'a.1'),
+        // TODO(davidmorgan): a.1 should be rebuilt, but it's not. This is a
+        // regression since the last version on pub: fix it!
+        // Result(written: ['a.2', 'b.4']),
+        Result(deleted: ['a.2']),
+      );
+    });
+
+    test('create a.1, a.2+b.4 are rebuilt', () async {
+      tester.sources(['b.3']);
+      await tester.build();
+      expect(
+        await tester.build(create: 'a.1'),
+        Result(written: ['a.2', 'b.4']),
+      );
+    });
+  });
+}

--- a/build_runner_core/test/invalidation/invalidation_tester.dart
+++ b/build_runner_core/test/invalidation/invalidation_tester.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:build/build.dart';
-import 'package:build_runner_core/src/changes/asset_updates.dart';
 import 'package:build_test/build_test.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:crypto/crypto.dart';


### PR DESCRIPTION
For #3811.

More test coverage. I found another bug which _is_ a regression from published behaviour, so the second commit fixes it. 

The bug is about a change of input from present->deleted not triggering generation.

The problem is that the graph update code removes inputs if the input was removed, so by the time `_buildShouldRun` is reached there is no more record of the dependency. There must have been some code accounting for that case that got simplified away :) ... fix it by keeping the inputs for deleted files, changing the deleted nodes to `missingSource` nodes.