### PR TITLE
Remove dead code.

### DIFF
--- a/_test_common/lib/matchers.dart
+++ b/_test_common/lib/matchers.dart
@@ -16,23 +16,16 @@ final Matcher throwsCorruptedException = throwsA(
 final Matcher duplicateAssetNodeException =
     const TypeMatcher<DuplicateAssetNodeException>();
 
-Matcher equalsAssetGraph(
-  AssetGraph expected, {
-  bool checkPreviousInputsDigest = true,
-}) => _AssetGraphMatcher(expected, checkPreviousInputsDigest);
+Matcher equalsAssetGraph(AssetGraph expected) => _AssetGraphMatcher(expected);
 
 class _AssetGraphMatcher extends Matcher {
   final AssetGraph _expected;
-  final bool checkPreviousInputsDigest;
   final Matcher _matcher;
 
-  _AssetGraphMatcher(this._expected, this.checkPreviousInputsDigest)
+  _AssetGraphMatcher(this._expected)
     : _matcher = equals(_graphToList(_expected));
 
   /// Converts [graph] to a list of [AssetNode], sorted by ID, for comparison.
-  ///
-  /// If [checkPreviousInputsDigest] is false, removes `previousInputDigest`
-  /// fields so they won't be compared.
   static List<AssetNode> _graphToList(AssetGraph graph) =>
       graph.allNodes.toList()
         ..sort((a, b) => a.id.toString().compareTo(b.id.toString()));

--- a/build_runner/test/generate/watch_test.dart
+++ b/build_runner/test/generate/watch_test.dart
@@ -410,12 +410,7 @@ void main() {
             ], computeDigest(cTxtId, 'c')),
           );
 
-        // TODO: We dont have a shared way of computing the combined input
-        // hashes today, but eventually we should test those here too.
-        expect(
-          cachedGraph,
-          equalsAssetGraph(expectedGraph, checkPreviousInputsDigest: false),
-        );
+        expect(cachedGraph, equalsAssetGraph(expectedGraph));
         expect(
           cachedGraph.allPostProcessBuildStepOutputs,
           expectedGraph.allPostProcessBuildStepOutputs,

--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -1357,12 +1357,7 @@ void main() {
         outputs: {bPostCopyNode.id},
       );
 
-    // TODO: We dont have a shared way of computing the combined input hashes
-    // today, but eventually we should test those here too.
-    expect(
-      cachedGraph,
-      equalsAssetGraph(expectedGraph, checkPreviousInputsDigest: false),
-    );
+    expect(cachedGraph, equalsAssetGraph(expectedGraph));
     expect(
       cachedGraph.allPostProcessBuildStepOutputs,
       expectedGraph.allPostProcessBuildStepOutputs,


### PR DESCRIPTION
There are no "input digests" any more, clean up the test code.