### PR TITLE
Close HttpClient to prevent hang on exit.

### DIFF
--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Move `BuildStepImpl` to `build_runner_core`, use `SingleStepReader` directly.
 - Stop building `transitive_digest` files by default.
 - Use `LibraryCycleGraphLoader` to load transitive deps for analysis.
+- Bug fix: fix delay on shutdown for fast builds when the "analyzer out of
+  date" warning is displayed.
 
 ## 2.4.4
 

--- a/build_resolvers/lib/src/resolver.dart
+++ b/build_resolvers/lib/src/resolver.dart
@@ -550,8 +550,9 @@ class AnalyzerResolvers implements Resolvers {
 void _warnOnLanguageVersionMismatch() async {
   if (sdkLanguageVersion <= ExperimentStatus.currentVersion) return;
 
+  HttpClient? client;
   try {
-    var client = HttpClient();
+    client = HttpClient();
     var request = await client.getUrl(
       Uri.https('pub.dartlang.org', 'api/packages/analyzer'),
     );
@@ -616,6 +617,8 @@ SDK language version: $sdkLanguageVersion
 Please ensure you are on the latest `analyzer` version, which can be seen at
 https://pub.dev/packages/analyzer.
 ''');
+  } finally {
+    client?.close();
   }
 }
 


### PR DESCRIPTION
I noticed a delay on shutdown https://github.com/dart-lang/sdk/issues/60659 that turns out to be caused by the codepath that runs if the analyzer seems to be out of date: the actual current version is checked on pub.

This was causing shutdown to wait for the HTTP client timeout, meaning a minimum runtime of about 19 seconds for any run that did a resolve with an out of date analyzer.