### PR TITLE
Use sync I/O.

### DIFF
--- a/build/lib/src/state/filesystem.dart
+++ b/build/lib/src/state/filesystem.dart
@@ -6,35 +6,19 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:pool/pool.dart';
-
 /// The filesystem the build is running on.
 ///
 /// Methods behave as the `dart:io` methods with the same names, with some
 /// exceptions noted in the docs.
 abstract interface class Filesystem {
   /// Whether the file exists.
-  Future<bool> exists(String path);
-
-  /// Whether the file exists.
   bool existsSync(String path);
-
-  /// Reads a file as a string.
-  Future<String> readAsString(String path, {Encoding encoding = utf8});
 
   /// Reads a file as a string.
   String readAsStringSync(String path, {Encoding encoding = utf8});
 
   /// Reads a file as bytes.
-  Future<Uint8List> readAsBytes(String path);
-
-  /// Reads a file as bytes.
   Uint8List readAsBytesSync(String path);
-
-  /// Deletes a file.
-  ///
-  /// If the file does not exist, does nothing.
-  Future<void> delete(String path);
 
   /// Deletes a file.
   ///
@@ -44,7 +28,7 @@ abstract interface class Filesystem {
   /// Deletes a directory recursively.
   ///
   /// If the directory does not exist, does nothing.
-  Future<void> deleteDirectory(String path);
+  void deleteDirectorySync(String path);
 
   /// Writes a file.
   ///
@@ -58,44 +42,16 @@ abstract interface class Filesystem {
   /// Writes a file.
   ///
   /// Creates enclosing directories as needed if they don't exist.
-  Future<void> writeAsString(
-    String path,
-    String contents, {
-    Encoding encoding = utf8,
-  });
-
-  /// Writes a file.
-  ///
-  /// Creates enclosing directories as needed if they don't exist.
   void writeAsBytesSync(String path, List<int> contents);
-
-  /// Writes a file.
-  ///
-  /// Creates enclosing directories as needed if they don't exist.
-  Future<void> writeAsBytes(String path, List<int> contents);
 }
 
 /// The `dart:io` filesystem.
 class IoFilesystem implements Filesystem {
-  /// Pool for async file operations.
-  final _pool = Pool(32);
-
-  @override
-  Future<bool> exists(String path) => _pool.withResource(File(path).exists);
-
   @override
   bool existsSync(String path) => File(path).existsSync();
 
   @override
-  Future<Uint8List> readAsBytes(String path) =>
-      _pool.withResource(File(path).readAsBytes);
-
-  @override
   Uint8List readAsBytesSync(String path) => File(path).readAsBytesSync();
-
-  @override
-  Future<String> readAsString(String path, {Encoding encoding = utf8}) =>
-      _pool.withResource(() => File(path).readAsString(encoding: encoding));
 
   @override
   String readAsStringSync(String path, {Encoding encoding = utf8}) =>
@@ -108,19 +64,9 @@ class IoFilesystem implements Filesystem {
   }
 
   @override
-  Future<void> delete(String path) {
-    return _pool.withResource(() async {
-      final file = File(path);
-      if (await file.exists()) await file.delete();
-    });
-  }
-
-  @override
-  Future<void> deleteDirectory(String path) {
-    return _pool.withResource(() async {
-      final directory = Directory(path);
-      if (await directory.exists()) await directory.delete(recursive: true);
-    });
+  void deleteDirectorySync(String path) {
+    final directory = Directory(path);
+    if (directory.existsSync()) directory.deleteSync(recursive: true);
   }
 
   @override
@@ -135,15 +81,6 @@ class IoFilesystem implements Filesystem {
   }
 
   @override
-  Future<void> writeAsBytes(String path, List<int> contents) {
-    return _pool.withResource(() async {
-      final file = File(path);
-      await file.parent.create(recursive: true);
-      await file.writeAsBytes(contents);
-    });
-  }
-
-  @override
   void writeAsStringSync(
     String path,
     String contents, {
@@ -152,19 +89,6 @@ class IoFilesystem implements Filesystem {
     final file = File(path);
     file.parent.createSync(recursive: true);
     file.writeAsStringSync(contents, encoding: encoding);
-  }
-
-  @override
-  Future<void> writeAsString(
-    String path,
-    String contents, {
-    Encoding encoding = utf8,
-  }) {
-    return _pool.withResource(() async {
-      final file = File(path);
-      await file.parent.create(recursive: true);
-      await file.writeAsString(contents, encoding: encoding);
-    });
   }
 }
 
@@ -176,50 +100,27 @@ class InMemoryFilesystem implements Filesystem {
   Iterable<String> get filePaths => _files.keys;
 
   @override
-  Future<bool> exists(String path) => Future.value(_files.containsKey(path));
-
-  @override
   bool existsSync(String path) => _files.containsKey(path);
 
   @override
-  Future<Uint8List> readAsBytes(String path) => Future.value(_files[path]!);
-
-  @override
   Uint8List readAsBytesSync(String path) => _files[path]!;
-
-  @override
-  Future<String> readAsString(String path, {Encoding encoding = utf8}) =>
-      Future.value(encoding.decode(_files[path]!));
 
   @override
   String readAsStringSync(String path, {Encoding encoding = utf8}) =>
       encoding.decode(_files[path]!);
 
   @override
-  Future<void> delete(String path) {
-    _files.remove(path);
-    return Future.value();
-  }
-
-  @override
   void deleteSync(String path) => _files.remove(path);
 
   @override
-  Future<void> deleteDirectory(String path) {
+  void deleteDirectorySync(String path) {
     final prefix = '$path/';
     _files.removeWhere((filePath, _) => filePath.startsWith(prefix));
-    return Future.value();
   }
 
   @override
   void writeAsBytesSync(String path, List<int> contents) {
     _files[path] = Uint8List.fromList(contents);
-  }
-
-  @override
-  Future<void> writeAsBytes(String path, List<int> contents) {
-    _files[path] = Uint8List.fromList(contents);
-    return Future.value();
   }
 
   @override
@@ -229,15 +130,5 @@ class InMemoryFilesystem implements Filesystem {
     Encoding encoding = utf8,
   }) {
     _files[path] = Uint8List.fromList(encoding.encode(contents));
-  }
-
-  @override
-  Future<void> writeAsString(
-    String path,
-    String contents, {
-    Encoding encoding = utf8,
-  }) {
-    _files[path] = Uint8List.fromList(encoding.encode(contents));
-    return Future.value();
   }
 }

--- a/build/test/state/filesystem_cache_test.dart
+++ b/build/test/state/filesystem_cache_test.dart
@@ -24,88 +24,70 @@ void main() {
   });
 
   group('exists', () {
-    test('reads from ifAbsent', () async {
-      expect(await cache.exists(txt1, ifAbsent: () async => true), isTrue);
-      expect(await cache.exists(txt2, ifAbsent: () async => false), isFalse);
+    test('reads from ifAbsent', () {
+      expect(cache.exists(txt1, ifAbsent: () => true), isTrue);
+      expect(cache.exists(txt2, ifAbsent: () => false), isFalse);
     });
 
-    test('does not re-read from ifAbsent', () async {
-      expect(await cache.exists(txt1, ifAbsent: () async => true), isTrue);
+    test('does not re-read from ifAbsent', () {
+      expect(cache.exists(txt1, ifAbsent: () => true), isTrue);
       expect(
-        await cache.exists(txt1, ifAbsent: () async => false),
+        cache.exists(txt1, ifAbsent: () => false),
         isTrue /* cached value */,
       );
     });
 
-    test('can be invalidated with invalidate', () async {
-      expect(await cache.exists(txt1, ifAbsent: () async => true), isTrue);
-      await cache.invalidate([txt1]);
+    test('can be invalidated with invalidate', () {
+      expect(cache.exists(txt1, ifAbsent: () => true), isTrue);
+      cache.invalidate([txt1]);
       expect(
-        await cache.exists(txt1, ifAbsent: () async => false),
+        cache.exists(txt1, ifAbsent: () => false),
         isFalse /* updated value */,
       );
     });
   });
 
   group('readAsBytes', () {
-    test('reads from ifAbsent', () async {
-      expect(
-        await cache.readAsBytes(txt1, ifAbsent: () async => txt1Bytes),
-        txt1Bytes,
-      );
+    test('reads from ifAbsent', () {
+      expect(cache.readAsBytes(txt1, ifAbsent: () => txt1Bytes), txt1Bytes);
     });
 
-    test('does not re-read from ifAbsent', () async {
+    test('does not re-read from ifAbsent', () {
+      expect(cache.readAsBytes(txt1, ifAbsent: () => txt1Bytes), txt1Bytes);
       expect(
-        await cache.readAsBytes(txt1, ifAbsent: () async => txt1Bytes),
-        txt1Bytes,
-      );
-      expect(
-        await cache.readAsBytes(txt1, ifAbsent: () async => txt2Bytes),
+        cache.readAsBytes(txt1, ifAbsent: () => txt2Bytes),
         txt1Bytes /* cached value */,
       );
     });
 
-    test('can be invalidated with invalidate', () async {
+    test('can be invalidated with invalidate', () {
+      expect(cache.readAsBytes(txt1, ifAbsent: () => txt1Bytes), txt1Bytes);
+      cache.invalidate([txt1]);
       expect(
-        await cache.readAsBytes(txt1, ifAbsent: () async => txt1Bytes),
-        txt1Bytes,
-      );
-      await cache.invalidate([txt1]);
-      expect(
-        await cache.readAsBytes(txt1, ifAbsent: () async => txt2Bytes),
+        cache.readAsBytes(txt1, ifAbsent: () => txt2Bytes),
         txt2Bytes /* updated value */,
       );
     });
   });
 
   group('readAsString', () {
-    test('reads from isAbsent', () async {
-      expect(
-        await cache.readAsString(txt1, ifAbsent: () async => txt1Bytes),
-        txt1String,
-      );
+    test('reads from isAbsent', () {
+      expect(cache.readAsString(txt1, ifAbsent: () => txt1Bytes), txt1String);
     });
 
-    test('does not re-read from isAbsent', () async {
+    test('does not re-read from isAbsent', () {
+      expect(cache.readAsString(txt1, ifAbsent: () => txt1Bytes), txt1String);
       expect(
-        await cache.readAsString(txt1, ifAbsent: () async => txt1Bytes),
-        txt1String,
-      );
-      expect(
-        await cache.readAsString(txt1, ifAbsent: () async => txt2Bytes),
+        cache.readAsString(txt1, ifAbsent: () => txt2Bytes),
         txt1String /* cached value */,
       );
     });
 
-    test('can be invalidated with invalidate', () async {
+    test('can be invalidated with invalidate', () {
+      expect(cache.readAsString(txt1, ifAbsent: () => txt1Bytes), txt1String);
+      cache.invalidate([txt1]);
       expect(
-        await cache.readAsString(txt1, ifAbsent: () async => txt1Bytes),
-        txt1String,
-      );
-      await cache.invalidate([txt1]);
-      expect(
-        await cache.readAsString(txt1, ifAbsent: () async => txt2Bytes),
+        cache.readAsString(txt1, ifAbsent: () => txt2Bytes),
         txt2String /* updated value */,
       );
     });

--- a/build_runner_core/lib/src/asset/reader_writer.dart
+++ b/build_runner_core/lib/src/asset/reader_writer.dart
@@ -83,41 +83,47 @@ class ReaderWriter extends AssetReader
 
   @override
   Future<bool> canRead(AssetId id) {
-    return cache.exists(
-      id,
-      ifAbsent: () async {
-        final path = _pathFor(id);
-        return filesystem.exists(path);
-      },
+    return Future.value(
+      cache.exists(
+        id,
+        ifAbsent: () {
+          final path = _pathFor(id);
+          return filesystem.existsSync(path);
+        },
+      ),
     );
   }
 
   @override
-  Future<List<int>> readAsBytes(AssetId id) async {
-    return cache.readAsBytes(
-      id,
-      ifAbsent: () async {
-        final path = _pathFor(id);
-        if (!await filesystem.exists(path)) {
-          throw AssetNotFoundException(id, path: path);
-        }
-        return filesystem.readAsBytes(path);
-      },
+  Future<List<int>> readAsBytes(AssetId id) {
+    return Future.value(
+      cache.readAsBytes(
+        id,
+        ifAbsent: () {
+          final path = _pathFor(id);
+          if (!filesystem.existsSync(path)) {
+            throw AssetNotFoundException(id, path: path);
+          }
+          return filesystem.readAsBytesSync(path);
+        },
+      ),
     );
   }
 
   @override
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) async {
-    return cache.readAsString(
-      id,
-      encoding: encoding,
-      ifAbsent: () async {
-        final path = _pathFor(id);
-        if (!await filesystem.exists(path)) {
-          throw AssetNotFoundException(id, path: path);
-        }
-        return filesystem.readAsBytes(path);
-      },
+  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) {
+    return Future.value(
+      cache.readAsString(
+        id,
+        encoding: encoding,
+        ifAbsent: () {
+          final path = _pathFor(id);
+          if (!filesystem.existsSync(path)) {
+            throw AssetNotFoundException(id, path: path);
+          }
+          return filesystem.readAsBytesSync(path);
+        },
+      ),
     );
   }
 
@@ -128,9 +134,10 @@ class ReaderWriter extends AssetReader
   // [AssetWriter] methods.
 
   @override
-  Future<void> writeAsBytes(AssetId id, List<int> bytes) async {
+  Future<void> writeAsBytes(AssetId id, List<int> bytes) {
     final path = _pathFor(id);
-    await filesystem.writeAsBytes(path, bytes);
+    filesystem.writeAsBytesSync(path, bytes);
+    return Future.value();
   }
 
   @override
@@ -138,13 +145,14 @@ class ReaderWriter extends AssetReader
     AssetId id,
     String contents, {
     Encoding encoding = utf8,
-  }) async {
+  }) {
     final path = _pathFor(id);
-    await filesystem.writeAsString(path, contents, encoding: encoding);
+    filesystem.writeAsStringSync(path, contents, encoding: encoding);
+    return Future.value();
   }
 
   @override
-  Future<void> delete(AssetId id) async {
+  Future<void> delete(AssetId id) {
     onDelete?.call(id);
     final path = _pathFor(id);
     // Hidden generated files are moved by `assetPathProvider` under the root
@@ -160,13 +168,15 @@ class ReaderWriter extends AssetReader
         'Should not delete assets outside of $rootPackage',
       );
     }
-    await filesystem.delete(path);
+    filesystem.deleteSync(path);
+    return Future.value();
   }
 
   @override
-  Future<void> deleteDirectory(AssetId id) async {
+  Future<void> deleteDirectory(AssetId id) {
     final path = _pathFor(id);
-    await filesystem.deleteDirectory(path);
+    filesystem.deleteDirectorySync(path);
+    return Future.value();
   }
 
   @override

--- a/build_runner_core/lib/src/asset_graph/graph.dart
+++ b/build_runner_core/lib/src/asset_graph/graph.dart
@@ -252,7 +252,7 @@ class AssetGraph implements GeneratedAssetHider {
     Iterable<AssetId> ids,
     AssetReader digestReader,
   ) async {
-    await digestReader.cache.invalidate(ids);
+    digestReader.cache.invalidate(ids);
     await Future.wait(
       ids.map((id) async {
         final digest = await digestReader.digest(id);

--- a/build_runner_core/lib/src/generate/asset_tracker.dart
+++ b/build_runner_core/lib/src/generate/asset_tracker.dart
@@ -112,7 +112,7 @@ class AssetTracker {
       var node = assetGraph.get(id)!;
       var originalDigest = node.digest;
       if (originalDigest == null) return;
-      await _reader.cache.invalidate([id]);
+      _reader.cache.invalidate([id]);
       var currentDigest = await _reader.digest(id);
       if (currentDigest != originalDigest) {
         updates[id] = ChangeType.MODIFY;

--- a/build_runner_core/lib/src/generate/build.dart
+++ b/build_runner_core/lib/src/generate/build.dart
@@ -231,7 +231,7 @@ class Build {
       deletedAssets.addAll(deleted);
       // TODO(davidmorgan): there are a few places that invalidate, check that
       // it's once per file, add test coverage.
-      await readerWriter.cache.invalidate(changedInputs);
+      readerWriter.cache.invalidate(changedInputs);
     });
   }
 
@@ -1209,7 +1209,7 @@ class Build {
 
     final result = errors.isEmpty;
 
-    await readerWriter.cache.invalidate(outputs);
+    readerWriter.cache.invalidate(outputs);
     for (final output in outputs) {
       final wasOutput = readerWriter.assetsWritten.contains(output);
       final digest = wasOutput ? await this.readerWriter.digest(output) : null;

--- a/build_runner_core/test/asset/file_based_test.dart
+++ b/build_runner_core/test/asset/file_based_test.dart
@@ -76,15 +76,15 @@ void main() async {
 
     test('throws when attempting to read a non-existent file', () async {
       expect(
-        readerWriter.readAsString(makeAssetId('basic_pkg|foo.txt')),
+        () => readerWriter.readAsString(makeAssetId('basic_pkg|foo.txt')),
         throwsA(assetNotFoundException),
       );
       expect(
-        readerWriter.readAsString(makeAssetId('a|lib/b.txt')),
+        () => readerWriter.readAsString(makeAssetId('a|lib/b.txt')),
         throwsA(assetNotFoundException),
       );
       expect(
-        readerWriter.readAsString(makeAssetId('foo|lib/bar.txt')),
+        () => readerWriter.readAsString(makeAssetId('foo|lib/bar.txt')),
         throwsA(packageNotFoundException),
       );
     });


### PR DESCRIPTION
For #3811.

Use sync I/O for file operations, simplify caching.

Also: when reading as string, check the bytes cache before reading; in some cases this saves a read.

Split out from https://github.com/dart-lang/build/pull/3995. It looks like the 10% speedup was due to the sync change (+maybe saving one read) and not the write cache, which makes sense: we could only see a performance benefit of write caching if one generator read the output of another, which is not the case in those benchmarks.