### PR TITLE
Fix library cycle graph update.

### DIFF
--- a/build/lib/src/library_cycle_graph/asset_deps_loader.dart
+++ b/build/lib/src/library_cycle_graph/asset_deps_loader.dart
@@ -41,22 +41,26 @@ class AssetDepsLoader {
     final result =
         ExpiringValueBuilder<AssetDeps>()..expiresAfter = content.expiresAfter;
 
-    final parsed =
-        parseString(content: content.value, throwIfDiagnostics: false).unit;
-
     final depsNodeBuilder = AssetDepsBuilder();
 
-    for (final directive in parsed.directives) {
-      if (directive is! UriBasedDirective) continue;
-      final uri = directive.uri.stringValue;
-      if (uri == null) continue;
-      final parsedUri = Uri.parse(uri);
-      if (_ignoredSchemes.any(parsedUri.isScheme)) continue;
-      final assetId = AssetId.resolve(parsedUri, from: id);
-      depsNodeBuilder.deps.add(assetId);
-    }
+    if (content.value == '') {
+      result.value = AssetDeps.empty;
+    } else {
+      final parsed =
+          parseString(content: content.value, throwIfDiagnostics: false).unit;
 
-    result.value = depsNodeBuilder.build();
+      for (final directive in parsed.directives) {
+        if (directive is! UriBasedDirective) continue;
+        final uri = directive.uri.stringValue;
+        if (uri == null) continue;
+        final parsedUri = Uri.parse(uri);
+        if (_ignoredSchemes.any(parsedUri.isScheme)) continue;
+        final assetId = AssetId.resolve(parsedUri, from: id);
+        depsNodeBuilder.deps.add(assetId);
+      }
+
+      result.value = depsNodeBuilder.build();
+    }
     return result.build();
   }
 }

--- a/build/lib/src/library_cycle_graph/phased_asset_deps.dart
+++ b/build/lib/src/library_cycle_graph/phased_asset_deps.dart
@@ -32,11 +32,23 @@ abstract class PhasedAssetDeps
   factory PhasedAssetDeps.of(Map<AssetId, PhasedValue<AssetDeps>> assetDeps) =>
       _$PhasedAssetDeps._(assetDeps: assetDeps.build());
 
-  /// Returns this data with [other] added to it.
-  PhasedAssetDeps addAll(PhasedAssetDeps other) {
+  /// Returns `this` data with [other] added to it.
+  ///
+  /// For each asset: if [other] has a complete value for that asset, use the
+  /// new value. Otherwise, use the old value from `this`.
+  PhasedAssetDeps update(PhasedAssetDeps other) {
     final result = toBuilder();
     for (final entry in other.assetDeps.entries) {
-      result.assetDeps[entry.key] = entry.value;
+      final updatedValue = entry.value;
+      if (updatedValue.isComplete) {
+        result.assetDeps[entry.key] = updatedValue;
+      } else {
+        // The only allow "not available yet" value is `AssetDeps.empty`.
+        if (updatedValue.values.length != 1 ||
+            updatedValue.values.single.value != AssetDeps.empty) {
+          throw StateError('Unexpected value: $updatedValue');
+        }
+      }
     }
     return result.build();
   }

--- a/build/lib/src/library_cycle_graph/phased_value.dart
+++ b/build/lib/src/library_cycle_graph/phased_value.dart
@@ -58,14 +58,14 @@ abstract class PhasedValue<T>
     b.values.add(ExpiringValue<T>(value));
   });
 
-  /// A value that will be generated during [untilAfterPhase].
+  /// A value that will be generated in phase [expiresAfter].
   ///
   /// Pass the "missing" value for T as [before].
   factory PhasedValue.unavailable({
-    required int untilAfterPhase,
+    required int expiresAfter,
     required T before,
   }) => PhasedValue((b) {
-    b.values.add(ExpiringValue<T>(before, expiresAfter: untilAfterPhase));
+    b.values.add(ExpiringValue<T>(before, expiresAfter: expiresAfter));
   });
 
   /// A value that is generated during [atPhase], changing from [before] to
@@ -108,7 +108,7 @@ abstract class PhasedValue<T>
         return value;
       }
     }
-    throw StateError('No value for phase $phase in $this.');
+    throw StateError('No value for phase $phase.');
   }
 
   /// The value at [phase].
@@ -121,7 +121,7 @@ abstract class PhasedValue<T>
   ///
   /// Throws if not [isComplete], meaning the last value is not known.
   T get lastValue {
-    if (!isComplete) throw StateError('Not complete, no last value: $this');
+    if (!isComplete) throw StateError('Not complete, no last value.');
     return values.last.value;
   }
 
@@ -138,8 +138,7 @@ abstract class PhasedValue<T>
     if (value.expiresAfter != null &&
         value.expiresAfter! <= values.last.expiresAfter!) {
       throw StateError(
-        "Can't follow with a value expiring before or at the existing value."
-        ' This: $this, followedBy: $value',
+        "Can't follow with a value expiring before or at the existing value.",
       );
     }
     return rebuild((b) {

--- a/build/test/library_cycle_graph/library_cycle_graph_loader_test.dart
+++ b/build/test/library_cycle_graph/library_cycle_graph_loader_test.dart
@@ -151,10 +151,7 @@ void main() {
   group('with generated nodes', () {
     test('single generated node', () async {
       final nodeLoader0 = TestAssetDepsLoader(0, {
-        a1: PhasedValue.unavailable(
-          untilAfterPhase: 1,
-          before: AssetDeps.empty,
-        ),
+        a1: PhasedValue.unavailable(expiresAfter: 1, before: AssetDeps.empty),
       });
       final nodeLoader2 = TestAssetDepsLoader(2, {
         a1: PhasedValue.generated(

--- a/build_runner_core/lib/src/generate/build.dart
+++ b/build_runner_core/lib/src/generate/build.dart
@@ -263,10 +263,13 @@ class Build {
           _logger,
           'Caching finalized dependency graph',
           () async {
+            // Combine previous phased asset deps, if any, with the newly loaded
+            // deps. Because of skipped builds, the newly loaded deps might just
+            // say "not generated yet", in which case the old value is retained.
             final updatedPhasedAssetDeps =
                 assetGraph.previousPhasedAssetDeps == null
                     ? AnalysisDriverModel.sharedInstance.phasedAssetDeps()
-                    : assetGraph.previousPhasedAssetDeps!.addAll(
+                    : assetGraph.previousPhasedAssetDeps!.update(
                       AnalysisDriverModel.sharedInstance.phasedAssetDeps(),
                     );
             assetGraph.previousPhasedAssetDeps = updatedPhasedAssetDeps;

--- a/build_runner_core/lib/src/generate/single_step_reader_writer.dart
+++ b/build_runner_core/lib/src/generate/single_step_reader_writer.dart
@@ -457,7 +457,7 @@ class SingleStepReaderWriter extends AssetReader
     if (node.type == NodeType.generated) {
       final nodePhase = node.generatedNodeConfiguration!.phaseNumber;
       if (nodePhase >= phase) {
-        return PhasedValue.unavailable(before: '', untilAfterPhase: nodePhase);
+        return PhasedValue.unavailable(before: '', expiresAfter: nodePhase);
       } else {
         // If needed, trigger a build at an earlier phase.
         if (!_runningBuild.assetIsProcessedOutput(id)) {

--- a/build_runner_core/test/invalidation/library_cycle_graph_update_test.dart
+++ b/build_runner_core/test/invalidation/library_cycle_graph_update_test.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'invalidation_tester.dart';
+
+void main() {
+  late InvalidationTester tester;
+
+  setUp(() {
+    tester = InvalidationTester();
+  });
+
+  // Builds a.2 and a.3 both resolve z; the resolved library cycle graph
+  // differs because z.4 is generated between a.2 and a.3.
+  group('a.1 <== a.2, a.1 <== a.3, z.4 <== z.5, '
+      'a.2 resolves: z --> z.5, a.3 resolves: z --> z.5 --> z2', () {
+    setUp(() {
+      tester = InvalidationTester();
+      tester.sources(['a.1', 'x1', 'z', 'z.4', 'z2']);
+      tester.importGraph({
+        'z': ['z.5'],
+        'z.5': ['z2'],
+      });
+
+      tester.builder(from: '.1', to: '.2')
+        ..reads('.1')
+        ..readsOther('x1')
+        ..resolvesOther('z')
+        ..writes('.2');
+
+      tester.builder(from: '.4', to: '.5')
+        ..reads('.4')
+        ..writes('.5');
+
+      tester.builder(from: '.1', to: '.3')
+        ..reads('.1')
+        ..resolvesOther('z')
+        ..writes('.3');
+    });
+
+    test('a.2+a.3 are built', () async {
+      expect(await tester.build(), Result(written: ['a.2', 'z.5', 'a.3']));
+    });
+
+    test('change z2, a.3 is rebuilt', () async {
+      await tester.build();
+      expect(await tester.build(change: 'z2'), Result(written: ['a.3']));
+    });
+
+    test('partial library cycle graph update does not lose data', () async {
+      // Full build: full library cycle graph is computed.
+      expect(await tester.build(), Result(written: ['a.2', 'z.5', 'a.3']));
+      // Trigger only a.2: library cycle graph is only computed up to a.2 phase.
+      expect(await tester.build(change: 'x1'), Result(written: ['a.2']));
+
+      // Next build still needs the full library cycle graph, if it succeeds
+      // part of the graph was retained from the first build.
+      expect(await tester.build(), Result());
+
+      // Change using the graph still rebuilds as expected.
+      expect(await tester.build(change: 'z2'), Result(written: ['a.3']));
+    });
+  });
+}


### PR DESCRIPTION
For #3999.

The OOM was a distraction: it was because of the `$this` in `throw StateError('No value for phase $phase in $this.');`, the library cycle graph is too big to flatten to a String for display. I removed those exception messages: better stack trace than a hang->OOM.

The failure was because a partial build could cause information about deps of an asset to be discarded, leading "no value for phase" in the next build.