### PR TITLE
Add invalidation stress test.

### DIFF
--- a/build/lib/src/library_cycle_graph/asset_deps_loader.dart
+++ b/build/lib/src/library_cycle_graph/asset_deps_loader.dart
@@ -72,12 +72,20 @@ class _InMemoryAssetDepsLoader implements AssetDepsLoader {
   );
   PhasedAssetDeps phasedAssetDeps;
 
-  _InMemoryAssetDepsLoader(this.phasedAssetDeps);
+  _InMemoryAssetDepsLoader(PhasedAssetDeps phasedAssetDeps)
+    : phasedAssetDeps = phasedAssetDeps.complete();
 
-  // This is important: it prevents LibraryCycleGraphLoader from trying to load
-  // data that is not in an incomplete [phasedAssetDeps].
+  // Return very high phase to tell `LibraryCycleGraphLoader` that all data is
+  // available.
+  //
+  // Returning incomplete data would then cause `LibraryCycleGraphLoader` to
+  // get stuck, which is why `phasedAssetDeps.complete` was called to mark
+  // all the data complete.
+  //
+  // This loader is only used for rebuilding graphs constructed in an earlier
+  // run, so incomplete data won't actually be used.
   @override
-  int get phase => phasedAssetDeps.phase;
+  int get phase => 0xffffffff;
 
   @override
   ExpiringValue<AssetDeps> _parse(AssetId id, ExpiringValue<String> content) =>

--- a/build/lib/src/library_cycle_graph/phased_asset_deps.dart
+++ b/build/lib/src/library_cycle_graph/phased_asset_deps.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:math';
-
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
@@ -29,9 +27,6 @@ abstract class PhasedAssetDeps
       _$PhasedAssetDeps;
   PhasedAssetDeps._();
 
-  factory PhasedAssetDeps.of(Map<AssetId, PhasedValue<AssetDeps>> assetDeps) =>
-      _$PhasedAssetDeps._(assetDeps: assetDeps.build());
-
   /// Returns `this` data with [other] added to it.
   ///
   /// For each asset: if [other] has a complete value for that asset, use the
@@ -53,20 +48,12 @@ abstract class PhasedAssetDeps
     return result.build();
   }
 
-  /// The max phase before there is any incomplete data, or 0xffffffff if there
-  /// is no incomplete data.
-  @memoized
-  int get phase {
-    int? result;
-    for (final entry in assetDeps.values) {
-      if (!entry.isComplete) {
-        if (result == null) {
-          result = entry.expiresAfter;
-        } else {
-          result = min(result, entry.expiresAfter!);
-        }
+  PhasedAssetDeps complete() => rebuild((b) {
+    for (final entry in assetDeps.entries) {
+      final value = entry.value;
+      if (!value.isComplete) {
+        b.assetDeps[entry.key] = PhasedValue.fixed(value.values.single.value);
       }
     }
-    return result ?? 0xffffffff;
-  }
+  });
 }

--- a/build/lib/src/library_cycle_graph/phased_asset_deps.g.dart
+++ b/build/lib/src/library_cycle_graph/phased_asset_deps.g.dart
@@ -71,7 +71,6 @@ class _$PhasedAssetDepsSerializer
 class _$PhasedAssetDeps extends PhasedAssetDeps {
   @override
   final BuiltMap<AssetId, PhasedValue<AssetDeps>> assetDeps;
-  int? __phase;
 
   factory _$PhasedAssetDeps([void Function(PhasedAssetDepsBuilder)? updates]) =>
       (new PhasedAssetDepsBuilder()..update(updates))._build();
@@ -83,9 +82,6 @@ class _$PhasedAssetDeps extends PhasedAssetDeps {
       'assetDeps',
     );
   }
-
-  @override
-  int get phase => __phase ??= super.phase;
 
   @override
   PhasedAssetDeps rebuild(void Function(PhasedAssetDepsBuilder) updates) =>

--- a/build_runner_core/test/invalidation/invalidation_stress_test.dart
+++ b/build_runner_core/test/invalidation/invalidation_stress_test.dart
@@ -1,0 +1,146 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:math';
+
+import 'package:build/build.dart' show AssetId;
+import 'package:test/test.dart';
+
+import 'invalidation_tester.dart';
+
+/// Tests correctness of invalidation over many randomly generated scenarios.
+///
+/// The test builders write output that is a list of files read/resolved and their
+/// content hashes. This does two things: it ensures that if any input changes,
+/// the output changes; and it makes it possible to determine what will
+/// invalidate that output.
+///
+/// In this way the test can know what output changes to assert due to a
+/// particular input change.
+Future<void> main() async {
+  for (var iteration = 0; iteration != 500; ++iteration) {
+    test('invalidation stress test $iteration', () async {
+      final tester = InvalidationTester()..logSetup();
+      final random = Random(iteration);
+
+      // Whether to change the imports in source files between builds.
+      final changeImports = iteration % 10 == 0;
+
+      // How many checked in sources and how many builders; the build is
+      // a rectangle of size numberOfSources x numberOfBuilders.
+      final numberOfSources = random.nextInt(8) + 1;
+      final numberOfBuilders = random.nextInt(4) + 1;
+
+      final sources = [
+        for (var i = 0; i != numberOfSources; ++i) 'a${i + 1}.1',
+      ];
+
+      // Inputs that can be randomly read/resolved.
+      // `numberOfBuilders + 2` to add some reads/resolves of files that
+      // don't exist.
+      final pickableInputs = <String>[];
+      for (var i = 1; i != (numberOfBuilders + 2); ++i) {
+        for (final source in sources) {
+          pickableInputs.add(source.replaceAll('.1', '.$i'));
+        }
+      }
+
+      // All outputs.
+      final outputs = <String>[];
+      for (var i = 2; i != (numberOfBuilders + 1); ++i) {
+        for (final source in sources) {
+          outputs.add(source.replaceAll('.1', '.$i'));
+        }
+      }
+
+      // Picks a list of files to import from `pickableInputs`.
+      List<String> randomImportList() {
+        final result = <String>[];
+        final length = random.nextInt(numberOfSources);
+        for (var i = 0; i != length; ++i) {
+          result.add(pickableInputs[random.nextInt(pickableInputs.length)]);
+        }
+        return result;
+      }
+
+      tester
+        ..sources(sources)
+        ..pickableInputs(pickableInputs);
+
+      // Set up builders.
+      for (var i = 1; i != numberOfBuilders; ++i) {
+        tester.builder(
+            from: '.$i',
+            to: '.${i + 1}',
+            // Cover optional+required builders.
+            isOptional: random.nextBool(),
+            // Cover builders with hidden+visible output.
+            outputIsVisible: random.nextBool(),
+          )
+          // Use the input as the seed for what additional reads to do,
+          // so reads won't change between identical runs.
+          ..readsForSeedThenReadsRandomly('.$i')
+          ..writes('.${i + 1}');
+      }
+
+      // Initial random import graph.
+      final importGraph = {
+        for (var source in pickableInputs) source: randomImportList(),
+      };
+      tester.importGraph(importGraph);
+
+      // Initial build should succeed.
+      expect((await tester.build()).succeeded, true);
+
+      // Do five additional builds making changes and checking what was written.
+      for (var build = 0; build != 5; ++build) {
+        // Pick which source to change, compute expected outputs.
+        final sourceToChange = sources[random.nextInt(sources.length)];
+        final expectedOutputs = <String>{};
+
+        Future<void> addExpectedOutputs(String invalidatedInput) async {
+          for (final output in outputs) {
+            final assetId = AssetId('pkg', 'lib/$output.dart');
+            final hiddenAssetId = AssetId(
+              'pkg',
+              '.dart_tool/build/generated/pkg/lib/$output.dart',
+            );
+            final outputContents =
+                tester.readerWriter!.testing.exists(assetId)
+                    ? tester.readerWriter!.testing.readString(assetId)
+                    : tester.readerWriter!.testing.exists(hiddenAssetId)
+                    ? tester.readerWriter!.testing.readString(hiddenAssetId)
+                    : '';
+            // The test builder output is a list of "$name,$hash" for each input
+            // that was read, including transitively resolved sources. Check it
+            // for [input]. If found, this output is invalidated: recursively
+            // add its invalidated outputs.
+            if (outputContents.contains('$invalidatedInput.dart,')) {
+              if (expectedOutputs.add(output)) {
+                await addExpectedOutputs(output);
+              }
+            }
+          }
+        }
+
+        await addExpectedOutputs(sourceToChange);
+
+        // If [changeImports] then change some imports; it's only possible to
+        // change imports for files that will be output.
+        if (changeImports && expectedOutputs.isNotEmpty) {
+          final sourceToChangeImports =
+              expectedOutputs.toList()[random.nextInt(expectedOutputs.length)];
+          importGraph[sourceToChangeImports] = randomImportList();
+          tester.importGraph(importGraph);
+        }
+
+        // Build and check exactly the expected outputs change.
+        expect(
+          await tester.build(change: sourceToChange),
+          Result(written: expectedOutputs),
+        );
+      }
+    });
+  }
+}

--- a/build_runner_core/test/invalidation/invalidation_tester.dart
+++ b/build_runner_core/test/invalidation/invalidation_tester.dart
@@ -266,7 +266,7 @@ enum OutputStrategy {
   /// that could be read, or `$name` if not.
   ///
   /// If a builder resolves files, this includes all transitively resolved
-  /// files and their hashes.s
+  /// files and their hashes.
   inputDigest,
 }
 


### PR DESCRIPTION
For #3811.

Add invalidation stress test, add smaller test cases for and fix two bugs that it found. It also would have caught #3999.

`PhasedAssetDeps` bug: this is related to but distinct from #3999, the loaded asset deps data was reporting its phase as the first phase with incomplete data, causing data at later phases to be not readable. In fact, it can have incomplete data for arbitrary phases, if the load was scheduled for load at a later phase but no later phase picked up the work because there was no more resolution done. Fix by just treating the data as complete for this case: it won't be used, because the loaded data is only used to reconstruct the import graphs exactly as they were in the previous build.

`LibraryCycleGraphLoader` bug: the comment states that `_idsToLoad` is either empty or unchanged; this is not quite true: a recursive call can add work at a later phase; it's possible for a recursive call to add work at the current phase, breaking that invariant. This is unlikely to actually happen in practice, so just fall back to a slower remove.