### PR TITLE
Fix processed globs check.

### DIFF
--- a/build_runner_core/lib/src/generate/build.dart
+++ b/build_runner_core/lib/src/generate/build.dart
@@ -1031,7 +1031,7 @@ class Build {
       }
     } else if (inputNode.type == NodeType.glob) {
       // Ensure that the glob was evaluated, so [changedOutputs] is updated.
-      if (!processedOutputs.contains(input)) {
+      if (!processedGlobs.contains(input)) {
         await _buildGlobNode(input);
       }
       if (changedOutputs.contains(input)) {


### PR DESCRIPTION
It really doesn't make a lot of difference, since _buildGlobNode does the correct check immediately, and anyway globs are not reused very much.

But it saves the async call and it's consistent with how generated files are handled, so, might as well fix it.