### PR TITLE
Regenerate with latest built_value_generator.

### DIFF
--- a/build/lib/src/library_cycle_graph/asset_deps.g.dart
+++ b/build/lib/src/library_cycle_graph/asset_deps.g.dart
@@ -6,7 +6,7 @@ part of 'asset_deps.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<AssetDeps> _$assetDepsSerializer = new _$AssetDepsSerializer();
+Serializer<AssetDeps> _$assetDepsSerializer = _$AssetDepsSerializer();
 
 class _$AssetDepsSerializer implements StructuredSerializer<AssetDeps> {
   @override
@@ -39,7 +39,7 @@ class _$AssetDepsSerializer implements StructuredSerializer<AssetDeps> {
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new AssetDepsBuilder();
+    final result = AssetDepsBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -70,18 +70,15 @@ class _$AssetDeps extends AssetDeps {
   final BuiltSet<AssetId> deps;
 
   factory _$AssetDeps([void Function(AssetDepsBuilder)? updates]) =>
-      (new AssetDepsBuilder()..update(updates))._build();
+      (AssetDepsBuilder()..update(updates))._build();
 
-  _$AssetDeps._({required this.deps}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(deps, r'AssetDeps', 'deps');
-  }
-
+  _$AssetDeps._({required this.deps}) : super._();
   @override
   AssetDeps rebuild(void Function(AssetDepsBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  AssetDepsBuilder toBuilder() => new AssetDepsBuilder()..replace(this);
+  AssetDepsBuilder toBuilder() => AssetDepsBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -108,7 +105,7 @@ class AssetDepsBuilder implements Builder<AssetDeps, AssetDepsBuilder> {
   _$AssetDeps? _$v;
 
   SetBuilder<AssetId>? _deps;
-  SetBuilder<AssetId> get deps => _$this._deps ??= new SetBuilder<AssetId>();
+  SetBuilder<AssetId> get deps => _$this._deps ??= SetBuilder<AssetId>();
   set deps(SetBuilder<AssetId>? deps) => _$this._deps = deps;
 
   AssetDepsBuilder();
@@ -124,7 +121,6 @@ class AssetDepsBuilder implements Builder<AssetDeps, AssetDepsBuilder> {
 
   @override
   void replace(AssetDeps other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$AssetDeps;
   }
 
@@ -139,14 +135,14 @@ class AssetDepsBuilder implements Builder<AssetDeps, AssetDepsBuilder> {
   _$AssetDeps _build() {
     _$AssetDeps _$result;
     try {
-      _$result = _$v ?? new _$AssetDeps._(deps: deps.build());
+      _$result = _$v ?? _$AssetDeps._(deps: deps.build());
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'deps';
         deps.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
           r'AssetDeps',
           _$failedField,
           e.toString(),

--- a/build/lib/src/library_cycle_graph/library_cycle.g.dart
+++ b/build/lib/src/library_cycle_graph/library_cycle.g.dart
@@ -11,18 +11,15 @@ class _$LibraryCycle extends LibraryCycle {
   final BuiltSet<AssetId> ids;
 
   factory _$LibraryCycle([void Function(LibraryCycleBuilder)? updates]) =>
-      (new LibraryCycleBuilder()..update(updates))._build();
+      (LibraryCycleBuilder()..update(updates))._build();
 
-  _$LibraryCycle._({required this.ids}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(ids, r'LibraryCycle', 'ids');
-  }
-
+  _$LibraryCycle._({required this.ids}) : super._();
   @override
   LibraryCycle rebuild(void Function(LibraryCycleBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  LibraryCycleBuilder toBuilder() => new LibraryCycleBuilder()..replace(this);
+  LibraryCycleBuilder toBuilder() => LibraryCycleBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -50,7 +47,7 @@ class LibraryCycleBuilder
   _$LibraryCycle? _$v;
 
   SetBuilder<AssetId>? _ids;
-  SetBuilder<AssetId> get ids => _$this._ids ??= new SetBuilder<AssetId>();
+  SetBuilder<AssetId> get ids => _$this._ids ??= SetBuilder<AssetId>();
   set ids(SetBuilder<AssetId>? ids) => _$this._ids = ids;
 
   LibraryCycleBuilder();
@@ -66,7 +63,6 @@ class LibraryCycleBuilder
 
   @override
   void replace(LibraryCycle other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$LibraryCycle;
   }
 
@@ -81,14 +77,14 @@ class LibraryCycleBuilder
   _$LibraryCycle _build() {
     _$LibraryCycle _$result;
     try {
-      _$result = _$v ?? new _$LibraryCycle._(ids: ids.build());
+      _$result = _$v ?? _$LibraryCycle._(ids: ids.build());
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'ids';
         ids.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
           r'LibraryCycle',
           _$failedField,
           e.toString(),

--- a/build/lib/src/library_cycle_graph/library_cycle_graph.g.dart
+++ b/build/lib/src/library_cycle_graph/library_cycle_graph.g.dart
@@ -7,7 +7,7 @@ part of 'library_cycle_graph.dart';
 // **************************************************************************
 
 Serializer<LibraryCycleGraph> _$libraryCycleGraphSerializer =
-    new _$LibraryCycleGraphSerializer();
+    _$LibraryCycleGraphSerializer();
 
 class _$LibraryCycleGraphSerializer
     implements StructuredSerializer<LibraryCycleGraph> {
@@ -46,7 +46,7 @@ class _$LibraryCycleGraphSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new LibraryCycleGraphBuilder();
+    final result = LibraryCycleGraphBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -89,25 +89,17 @@ class _$LibraryCycleGraph extends LibraryCycleGraph {
 
   factory _$LibraryCycleGraph([
     void Function(LibraryCycleGraphBuilder)? updates,
-  ]) => (new LibraryCycleGraphBuilder()..update(updates))._build();
+  ]) => (LibraryCycleGraphBuilder()..update(updates))._build();
 
   _$LibraryCycleGraph._({required this.root, required this.children})
-    : super._() {
-    BuiltValueNullFieldError.checkNotNull(root, r'LibraryCycleGraph', 'root');
-    BuiltValueNullFieldError.checkNotNull(
-      children,
-      r'LibraryCycleGraph',
-      'children',
-    );
-  }
-
+    : super._();
   @override
   LibraryCycleGraph rebuild(void Function(LibraryCycleGraphBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
   LibraryCycleGraphBuilder toBuilder() =>
-      new LibraryCycleGraphBuilder()..replace(this);
+      LibraryCycleGraphBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -140,12 +132,12 @@ class LibraryCycleGraphBuilder
   _$LibraryCycleGraph? _$v;
 
   LibraryCycleBuilder? _root;
-  LibraryCycleBuilder get root => _$this._root ??= new LibraryCycleBuilder();
+  LibraryCycleBuilder get root => _$this._root ??= LibraryCycleBuilder();
   set root(LibraryCycleBuilder? root) => _$this._root = root;
 
   ListBuilder<LibraryCycleGraph>? _children;
   ListBuilder<LibraryCycleGraph> get children =>
-      _$this._children ??= new ListBuilder<LibraryCycleGraph>();
+      _$this._children ??= ListBuilder<LibraryCycleGraph>();
   set children(ListBuilder<LibraryCycleGraph>? children) =>
       _$this._children = children;
 
@@ -163,7 +155,6 @@ class LibraryCycleGraphBuilder
 
   @override
   void replace(LibraryCycleGraph other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$LibraryCycleGraph;
   }
 
@@ -180,10 +171,7 @@ class LibraryCycleGraphBuilder
     try {
       _$result =
           _$v ??
-          new _$LibraryCycleGraph._(
-            root: root.build(),
-            children: children.build(),
-          );
+          _$LibraryCycleGraph._(root: root.build(), children: children.build());
     } catch (_) {
       late String _$failedField;
       try {
@@ -192,7 +180,7 @@ class LibraryCycleGraphBuilder
         _$failedField = 'children';
         children.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
           r'LibraryCycleGraph',
           _$failedField,
           e.toString(),

--- a/build/lib/src/library_cycle_graph/phased_asset_deps.g.dart
+++ b/build/lib/src/library_cycle_graph/phased_asset_deps.g.dart
@@ -7,7 +7,7 @@ part of 'phased_asset_deps.dart';
 // **************************************************************************
 
 Serializer<PhasedAssetDeps> _$phasedAssetDepsSerializer =
-    new _$PhasedAssetDepsSerializer();
+    _$PhasedAssetDepsSerializer();
 
 class _$PhasedAssetDepsSerializer
     implements StructuredSerializer<PhasedAssetDeps> {
@@ -42,7 +42,7 @@ class _$PhasedAssetDepsSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new PhasedAssetDepsBuilder();
+    final result = PhasedAssetDepsBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -73,23 +73,15 @@ class _$PhasedAssetDeps extends PhasedAssetDeps {
   final BuiltMap<AssetId, PhasedValue<AssetDeps>> assetDeps;
 
   factory _$PhasedAssetDeps([void Function(PhasedAssetDepsBuilder)? updates]) =>
-      (new PhasedAssetDepsBuilder()..update(updates))._build();
+      (PhasedAssetDepsBuilder()..update(updates))._build();
 
-  _$PhasedAssetDeps._({required this.assetDeps}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-      assetDeps,
-      r'PhasedAssetDeps',
-      'assetDeps',
-    );
-  }
-
+  _$PhasedAssetDeps._({required this.assetDeps}) : super._();
   @override
   PhasedAssetDeps rebuild(void Function(PhasedAssetDepsBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  PhasedAssetDepsBuilder toBuilder() =>
-      new PhasedAssetDepsBuilder()..replace(this);
+  PhasedAssetDepsBuilder toBuilder() => PhasedAssetDepsBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -118,7 +110,7 @@ class PhasedAssetDepsBuilder
 
   MapBuilder<AssetId, PhasedValue<AssetDeps>>? _assetDeps;
   MapBuilder<AssetId, PhasedValue<AssetDeps>> get assetDeps =>
-      _$this._assetDeps ??= new MapBuilder<AssetId, PhasedValue<AssetDeps>>();
+      _$this._assetDeps ??= MapBuilder<AssetId, PhasedValue<AssetDeps>>();
   set assetDeps(MapBuilder<AssetId, PhasedValue<AssetDeps>>? assetDeps) =>
       _$this._assetDeps = assetDeps;
 
@@ -135,7 +127,6 @@ class PhasedAssetDepsBuilder
 
   @override
   void replace(PhasedAssetDeps other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PhasedAssetDeps;
   }
 
@@ -150,14 +141,14 @@ class PhasedAssetDepsBuilder
   _$PhasedAssetDeps _build() {
     _$PhasedAssetDeps _$result;
     try {
-      _$result = _$v ?? new _$PhasedAssetDeps._(assetDeps: assetDeps.build());
+      _$result = _$v ?? _$PhasedAssetDeps._(assetDeps: assetDeps.build());
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'assetDeps';
         assetDeps.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
           r'PhasedAssetDeps',
           _$failedField,
           e.toString(),

--- a/build/lib/src/library_cycle_graph/phased_value.g.dart
+++ b/build/lib/src/library_cycle_graph/phased_value.g.dart
@@ -7,9 +7,9 @@ part of 'phased_value.dart';
 // **************************************************************************
 
 Serializer<PhasedValue<Object?>> _$phasedValueSerializer =
-    new _$PhasedValueSerializer();
+    _$PhasedValueSerializer();
 Serializer<ExpiringValue<Object?>> _$expiringValueSerializer =
-    new _$ExpiringValueSerializer();
+    _$ExpiringValueSerializer();
 
 class _$PhasedValueSerializer
     implements StructuredSerializer<PhasedValue<Object?>> {
@@ -34,8 +34,8 @@ class _$PhasedValueSerializer
       'values',
       serializers.serialize(
         object.values,
-        specifiedType: new FullType(BuiltList, [
-          new FullType(ExpiringValue, [parameterT]),
+        specifiedType: FullType(BuiltList, [
+          FullType(ExpiringValue, [parameterT]),
         ]),
       ),
     ];
@@ -57,7 +57,7 @@ class _$PhasedValueSerializer
 
     final result =
         isUnderspecified
-            ? new PhasedValueBuilder<Object?>()
+            ? PhasedValueBuilder<Object?>()
             : serializers.newBuilder(specifiedType)
                 as PhasedValueBuilder<Object?>;
 
@@ -71,8 +71,8 @@ class _$PhasedValueSerializer
           result.values.replace(
             serializers.deserialize(
                   value,
-                  specifiedType: new FullType(BuiltList, [
-                    new FullType(ExpiringValue, [parameterT]),
+                  specifiedType: FullType(BuiltList, [
+                    FullType(ExpiringValue, [parameterT]),
                   ]),
                 )!
                 as BuiltList<Object?>,
@@ -132,7 +132,7 @@ class _$ExpiringValueSerializer
 
     final result =
         isUnderspecified
-            ? new ExpiringValueBuilder<Object?>()
+            ? ExpiringValueBuilder<Object?>()
             : serializers.newBuilder(specifiedType)
                 as ExpiringValueBuilder<Object?>;
 
@@ -165,22 +165,15 @@ class _$PhasedValue<T> extends PhasedValue<T> {
   final BuiltList<ExpiringValue<T>> values;
 
   factory _$PhasedValue([void Function(PhasedValueBuilder<T>)? updates]) =>
-      (new PhasedValueBuilder<T>()..update(updates))._build();
+      (PhasedValueBuilder<T>()..update(updates))._build();
 
-  _$PhasedValue._({required this.values}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(values, r'PhasedValue', 'values');
-    if (T == dynamic) {
-      throw new BuiltValueMissingGenericsError(r'PhasedValue', 'T');
-    }
-  }
-
+  _$PhasedValue._({required this.values}) : super._();
   @override
   PhasedValue<T> rebuild(void Function(PhasedValueBuilder<T>) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  PhasedValueBuilder<T> toBuilder() =>
-      new PhasedValueBuilder<T>()..replace(this);
+  PhasedValueBuilder<T> toBuilder() => PhasedValueBuilder<T>()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -209,7 +202,7 @@ class PhasedValueBuilder<T>
 
   ListBuilder<ExpiringValue<T>>? _values;
   ListBuilder<ExpiringValue<T>> get values =>
-      _$this._values ??= new ListBuilder<ExpiringValue<T>>();
+      _$this._values ??= ListBuilder<ExpiringValue<T>>();
   set values(ListBuilder<ExpiringValue<T>>? values) => _$this._values = values;
 
   PhasedValueBuilder();
@@ -225,7 +218,6 @@ class PhasedValueBuilder<T>
 
   @override
   void replace(PhasedValue<T> other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PhasedValue<T>;
   }
 
@@ -240,14 +232,14 @@ class PhasedValueBuilder<T>
   _$PhasedValue<T> _build() {
     _$PhasedValue<T> _$result;
     try {
-      _$result = _$v ?? new _$PhasedValue<T>._(values: values.build());
+      _$result = _$v ?? _$PhasedValue<T>._(values: values.build());
     } catch (_) {
       late String _$failedField;
       try {
         _$failedField = 'values';
         values.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
           r'PhasedValue',
           _$failedField,
           e.toString(),
@@ -267,22 +259,16 @@ class _$ExpiringValue<T> extends ExpiringValue<T> {
   final int? expiresAfter;
 
   factory _$ExpiringValue([void Function(ExpiringValueBuilder<T>)? updates]) =>
-      (new ExpiringValueBuilder<T>()..update(updates))._build();
+      (ExpiringValueBuilder<T>()..update(updates))._build();
 
-  _$ExpiringValue._({required this.value, this.expiresAfter}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(value, r'ExpiringValue', 'value');
-    if (T == dynamic) {
-      throw new BuiltValueMissingGenericsError(r'ExpiringValue', 'T');
-    }
-  }
-
+  _$ExpiringValue._({required this.value, this.expiresAfter}) : super._();
   @override
   ExpiringValue<T> rebuild(void Function(ExpiringValueBuilder<T>) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
   ExpiringValueBuilder<T> toBuilder() =>
-      new ExpiringValueBuilder<T>()..replace(this);
+      ExpiringValueBuilder<T>()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -336,7 +322,6 @@ class ExpiringValueBuilder<T>
 
   @override
   void replace(ExpiringValue<T> other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ExpiringValue<T>;
   }
 
@@ -351,7 +336,7 @@ class ExpiringValueBuilder<T>
   _$ExpiringValue<T> _build() {
     final _$result =
         _$v ??
-        new _$ExpiringValue<T>._(
+        _$ExpiringValue<T>._(
           value: BuiltValueNullFieldError.checkNotNull(
             value,
             r'ExpiringValue',

--- a/build_daemon/lib/data/build_request.g.dart
+++ b/build_daemon/lib/data/build_request.g.dart
@@ -6,8 +6,7 @@ part of 'build_request.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<BuildRequest> _$buildRequestSerializer =
-    new _$BuildRequestSerializer();
+Serializer<BuildRequest> _$buildRequestSerializer = _$BuildRequestSerializer();
 
 class _$BuildRequestSerializer implements StructuredSerializer<BuildRequest> {
   @override
@@ -30,22 +29,21 @@ class _$BuildRequestSerializer implements StructuredSerializer<BuildRequest> {
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    return new BuildRequestBuilder().build();
+    return BuildRequestBuilder().build();
   }
 }
 
 class _$BuildRequest extends BuildRequest {
   factory _$BuildRequest([void Function(BuildRequestBuilder)? updates]) =>
-      (new BuildRequestBuilder()..update(updates))._build();
+      (BuildRequestBuilder()..update(updates))._build();
 
   _$BuildRequest._() : super._();
-
   @override
   BuildRequest rebuild(void Function(BuildRequestBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  BuildRequestBuilder toBuilder() => new BuildRequestBuilder()..replace(this);
+  BuildRequestBuilder toBuilder() => BuildRequestBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -72,7 +70,6 @@ class BuildRequestBuilder
 
   @override
   void replace(BuildRequest other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$BuildRequest;
   }
 
@@ -85,7 +82,7 @@ class BuildRequestBuilder
   BuildRequest build() => _build();
 
   _$BuildRequest _build() {
-    final _$result = _$v ?? new _$BuildRequest._();
+    final _$result = _$v ?? _$BuildRequest._();
     replace(_$result);
     return _$result;
   }

--- a/build_daemon/lib/data/build_status.g.dart
+++ b/build_daemon/lib/data/build_status.g.dart
@@ -19,19 +19,18 @@ BuildStatus _$valueOf(String name) {
     case 'failed':
       return _$failed;
     default:
-      throw new ArgumentError(name);
+      throw ArgumentError(name);
   }
 }
 
-final BuiltSet<BuildStatus> _$values = new BuiltSet<BuildStatus>(
+final BuiltSet<BuildStatus> _$values = BuiltSet<BuildStatus>(
   const <BuildStatus>[_$started, _$succeeded, _$failed],
 );
 
-Serializer<BuildStatus> _$buildStatusSerializer = new _$BuildStatusSerializer();
+Serializer<BuildStatus> _$buildStatusSerializer = _$BuildStatusSerializer();
 Serializer<DefaultBuildResult> _$defaultBuildResultSerializer =
-    new _$DefaultBuildResultSerializer();
-Serializer<BuildResults> _$buildResultsSerializer =
-    new _$BuildResultsSerializer();
+    _$DefaultBuildResultSerializer();
+Serializer<BuildResults> _$buildResultsSerializer = _$BuildResultsSerializer();
 
 class _$BuildStatusSerializer implements PrimitiveSerializer<BuildStatus> {
   @override
@@ -113,7 +112,7 @@ class _$DefaultBuildResultSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new DefaultBuildResultBuilder();
+    final result = DefaultBuildResultBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -212,7 +211,7 @@ class _$BuildResultsSerializer implements StructuredSerializer<BuildResults> {
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new BuildResultsBuilder();
+    final result = BuildResultsBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -263,7 +262,7 @@ class _$DefaultBuildResult extends DefaultBuildResult {
 
   factory _$DefaultBuildResult([
     void Function(DefaultBuildResultBuilder)? updates,
-  ]) => (new DefaultBuildResultBuilder()..update(updates))._build();
+  ]) => (DefaultBuildResultBuilder()..update(updates))._build();
 
   _$DefaultBuildResult._({
     required this.status,
@@ -271,19 +270,7 @@ class _$DefaultBuildResult extends DefaultBuildResult {
     this.buildId,
     this.error,
     this.isCached,
-  }) : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-      status,
-      r'DefaultBuildResult',
-      'status',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      target,
-      r'DefaultBuildResult',
-      'target',
-    );
-  }
-
+  }) : super._();
   @override
   DefaultBuildResult rebuild(
     void Function(DefaultBuildResultBuilder) updates,
@@ -291,7 +278,7 @@ class _$DefaultBuildResult extends DefaultBuildResult {
 
   @override
   DefaultBuildResultBuilder toBuilder() =>
-      new DefaultBuildResultBuilder()..replace(this);
+      DefaultBuildResultBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -369,7 +356,6 @@ class DefaultBuildResultBuilder
 
   @override
   void replace(DefaultBuildResult other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DefaultBuildResult;
   }
 
@@ -384,7 +370,7 @@ class DefaultBuildResultBuilder
   _$DefaultBuildResult _build() {
     final _$result =
         _$v ??
-        new _$DefaultBuildResult._(
+        _$DefaultBuildResult._(
           status: BuiltValueNullFieldError.checkNotNull(
             status,
             r'DefaultBuildResult',
@@ -411,18 +397,15 @@ class _$BuildResults extends BuildResults {
   final BuiltList<Uri>? changedAssets;
 
   factory _$BuildResults([void Function(BuildResultsBuilder)? updates]) =>
-      (new BuildResultsBuilder()..update(updates))._build();
+      (BuildResultsBuilder()..update(updates))._build();
 
-  _$BuildResults._({required this.results, this.changedAssets}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(results, r'BuildResults', 'results');
-  }
-
+  _$BuildResults._({required this.results, this.changedAssets}) : super._();
   @override
   BuildResults rebuild(void Function(BuildResultsBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  BuildResultsBuilder toBuilder() => new BuildResultsBuilder()..replace(this);
+  BuildResultsBuilder toBuilder() => BuildResultsBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -456,12 +439,12 @@ class BuildResultsBuilder
 
   ListBuilder<BuildResult>? _results;
   ListBuilder<BuildResult> get results =>
-      _$this._results ??= new ListBuilder<BuildResult>();
+      _$this._results ??= ListBuilder<BuildResult>();
   set results(ListBuilder<BuildResult>? results) => _$this._results = results;
 
   ListBuilder<Uri>? _changedAssets;
   ListBuilder<Uri> get changedAssets =>
-      _$this._changedAssets ??= new ListBuilder<Uri>();
+      _$this._changedAssets ??= ListBuilder<Uri>();
   set changedAssets(ListBuilder<Uri>? changedAssets) =>
       _$this._changedAssets = changedAssets;
 
@@ -479,7 +462,6 @@ class BuildResultsBuilder
 
   @override
   void replace(BuildResults other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$BuildResults;
   }
 
@@ -496,7 +478,7 @@ class BuildResultsBuilder
     try {
       _$result =
           _$v ??
-          new _$BuildResults._(
+          _$BuildResults._(
             results: results.build(),
             changedAssets: _changedAssets?.build(),
           );
@@ -508,7 +490,7 @@ class BuildResultsBuilder
         _$failedField = 'changedAssets';
         _changedAssets?.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
           r'BuildResults',
           _$failedField,
           e.toString(),

--- a/build_daemon/lib/data/build_target.g.dart
+++ b/build_daemon/lib/data/build_target.g.dart
@@ -7,9 +7,9 @@ part of 'build_target.dart';
 // **************************************************************************
 
 Serializer<DefaultBuildTarget> _$defaultBuildTargetSerializer =
-    new _$DefaultBuildTargetSerializer();
+    _$DefaultBuildTargetSerializer();
 Serializer<OutputLocation> _$outputLocationSerializer =
-    new _$OutputLocationSerializer();
+    _$OutputLocationSerializer();
 
 class _$DefaultBuildTargetSerializer
     implements StructuredSerializer<DefaultBuildTarget> {
@@ -75,7 +75,7 @@ class _$DefaultBuildTargetSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new DefaultBuildTargetBuilder();
+    final result = DefaultBuildTargetBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -174,7 +174,7 @@ class _$OutputLocationSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new OutputLocationBuilder();
+    final result = OutputLocationBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -227,7 +227,7 @@ class _$DefaultBuildTarget extends DefaultBuildTarget {
 
   factory _$DefaultBuildTarget([
     void Function(DefaultBuildTargetBuilder)? updates,
-  ]) => (new DefaultBuildTargetBuilder()..update(updates))._build();
+  ]) => (DefaultBuildTargetBuilder()..update(updates))._build();
 
   _$DefaultBuildTarget._({
     required this.blackListPatterns,
@@ -235,24 +235,7 @@ class _$DefaultBuildTarget extends DefaultBuildTarget {
     this.buildFilters,
     required this.reportChangedAssets,
     required this.target,
-  }) : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-      blackListPatterns,
-      r'DefaultBuildTarget',
-      'blackListPatterns',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      reportChangedAssets,
-      r'DefaultBuildTarget',
-      'reportChangedAssets',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      target,
-      r'DefaultBuildTarget',
-      'target',
-    );
-  }
-
+  }) : super._();
   @override
   DefaultBuildTarget rebuild(
     void Function(DefaultBuildTargetBuilder) updates,
@@ -260,7 +243,7 @@ class _$DefaultBuildTarget extends DefaultBuildTarget {
 
   @override
   DefaultBuildTargetBuilder toBuilder() =>
-      new DefaultBuildTargetBuilder()..replace(this);
+      DefaultBuildTargetBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -303,19 +286,19 @@ class DefaultBuildTargetBuilder
 
   SetBuilder<RegExp>? _blackListPatterns;
   SetBuilder<RegExp> get blackListPatterns =>
-      _$this._blackListPatterns ??= new SetBuilder<RegExp>();
+      _$this._blackListPatterns ??= SetBuilder<RegExp>();
   set blackListPatterns(SetBuilder<RegExp>? blackListPatterns) =>
       _$this._blackListPatterns = blackListPatterns;
 
   OutputLocationBuilder? _outputLocation;
   OutputLocationBuilder get outputLocation =>
-      _$this._outputLocation ??= new OutputLocationBuilder();
+      _$this._outputLocation ??= OutputLocationBuilder();
   set outputLocation(OutputLocationBuilder? outputLocation) =>
       _$this._outputLocation = outputLocation;
 
   SetBuilder<String>? _buildFilters;
   SetBuilder<String> get buildFilters =>
-      _$this._buildFilters ??= new SetBuilder<String>();
+      _$this._buildFilters ??= SetBuilder<String>();
   set buildFilters(SetBuilder<String>? buildFilters) =>
       _$this._buildFilters = buildFilters;
 
@@ -347,7 +330,6 @@ class DefaultBuildTargetBuilder
 
   @override
   void replace(DefaultBuildTarget other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$DefaultBuildTarget;
   }
 
@@ -364,7 +346,7 @@ class DefaultBuildTargetBuilder
     try {
       _$result =
           _$v ??
-          new _$DefaultBuildTarget._(
+          _$DefaultBuildTarget._(
             blackListPatterns: blackListPatterns.build(),
             outputLocation: _outputLocation?.build(),
             buildFilters: _buildFilters?.build(),
@@ -389,7 +371,7 @@ class DefaultBuildTargetBuilder
         _$failedField = 'buildFilters';
         _buildFilters?.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
           r'DefaultBuildTarget',
           _$failedField,
           e.toString(),
@@ -411,29 +393,19 @@ class _$OutputLocation extends OutputLocation {
   final bool hoist;
 
   factory _$OutputLocation([void Function(OutputLocationBuilder)? updates]) =>
-      (new OutputLocationBuilder()..update(updates))._build();
+      (OutputLocationBuilder()..update(updates))._build();
 
   _$OutputLocation._({
     required this.output,
     required this.useSymlinks,
     required this.hoist,
-  }) : super._() {
-    BuiltValueNullFieldError.checkNotNull(output, r'OutputLocation', 'output');
-    BuiltValueNullFieldError.checkNotNull(
-      useSymlinks,
-      r'OutputLocation',
-      'useSymlinks',
-    );
-    BuiltValueNullFieldError.checkNotNull(hoist, r'OutputLocation', 'hoist');
-  }
-
+  }) : super._();
   @override
   OutputLocation rebuild(void Function(OutputLocationBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  OutputLocationBuilder toBuilder() =>
-      new OutputLocationBuilder()..replace(this);
+  OutputLocationBuilder toBuilder() => OutputLocationBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -495,7 +467,6 @@ class OutputLocationBuilder
 
   @override
   void replace(OutputLocation other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$OutputLocation;
   }
 
@@ -510,7 +481,7 @@ class OutputLocationBuilder
   _$OutputLocation _build() {
     final _$result =
         _$v ??
-        new _$OutputLocation._(
+        _$OutputLocation._(
           output: BuiltValueNullFieldError.checkNotNull(
             output,
             r'OutputLocation',

--- a/build_daemon/lib/data/build_target_request.g.dart
+++ b/build_daemon/lib/data/build_target_request.g.dart
@@ -7,7 +7,7 @@ part of 'build_target_request.dart';
 // **************************************************************************
 
 Serializer<BuildTargetRequest> _$buildTargetRequestSerializer =
-    new _$BuildTargetRequestSerializer();
+    _$BuildTargetRequestSerializer();
 
 class _$BuildTargetRequestSerializer
     implements StructuredSerializer<BuildTargetRequest> {
@@ -39,7 +39,7 @@ class _$BuildTargetRequestSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new BuildTargetRequestBuilder();
+    final result = BuildTargetRequestBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -68,16 +68,9 @@ class _$BuildTargetRequest extends BuildTargetRequest {
 
   factory _$BuildTargetRequest([
     void Function(BuildTargetRequestBuilder)? updates,
-  ]) => (new BuildTargetRequestBuilder()..update(updates))._build();
+  ]) => (BuildTargetRequestBuilder()..update(updates))._build();
 
-  _$BuildTargetRequest._({required this.target}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-      target,
-      r'BuildTargetRequest',
-      'target',
-    );
-  }
-
+  _$BuildTargetRequest._({required this.target}) : super._();
   @override
   BuildTargetRequest rebuild(
     void Function(BuildTargetRequestBuilder) updates,
@@ -85,7 +78,7 @@ class _$BuildTargetRequest extends BuildTargetRequest {
 
   @override
   BuildTargetRequestBuilder toBuilder() =>
-      new BuildTargetRequestBuilder()..replace(this);
+      BuildTargetRequestBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -129,7 +122,6 @@ class BuildTargetRequestBuilder
 
   @override
   void replace(BuildTargetRequest other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$BuildTargetRequest;
   }
 
@@ -144,7 +136,7 @@ class BuildTargetRequestBuilder
   _$BuildTargetRequest _build() {
     final _$result =
         _$v ??
-        new _$BuildTargetRequest._(
+        _$BuildTargetRequest._(
           target: BuiltValueNullFieldError.checkNotNull(
             target,
             r'BuildTargetRequest',

--- a/build_daemon/lib/data/serializers.g.dart
+++ b/build_daemon/lib/data/serializers.g.dart
@@ -7,7 +7,7 @@ part of 'serializers.dart';
 // **************************************************************************
 
 Serializers _$serializers =
-    (new Serializers().toBuilder()
+    (Serializers().toBuilder()
           ..add(BuildRequest.serializer)
           ..add(BuildResults.serializer)
           ..add(BuildStatus.serializer)
@@ -20,19 +20,19 @@ Serializers _$serializers =
           ..add(ShutdownNotification.serializer)
           ..addBuilderFactory(
             const FullType(BuiltList, const [const FullType(BuildResult)]),
-            () => new ListBuilder<BuildResult>(),
+            () => ListBuilder<BuildResult>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltList, const [const FullType(Uri)]),
-            () => new ListBuilder<Uri>(),
+            () => ListBuilder<Uri>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltSet, const [const FullType(RegExp)]),
-            () => new SetBuilder<RegExp>(),
+            () => SetBuilder<RegExp>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltSet, const [const FullType(String)]),
-            () => new SetBuilder<String>(),
+            () => SetBuilder<String>(),
           ))
         .build();
 

--- a/build_daemon/lib/data/server_log.g.dart
+++ b/build_daemon/lib/data/server_log.g.dart
@@ -34,11 +34,11 @@ Level _$valueOf(String name) {
     case 'SHOUT':
       return _$shout;
     default:
-      throw new ArgumentError(name);
+      throw ArgumentError(name);
   }
 }
 
-final BuiltSet<Level> _$values = new BuiltSet<Level>(const <Level>[
+final BuiltSet<Level> _$values = BuiltSet<Level>(const <Level>[
   _$finest,
   _$finer,
   _$fine,
@@ -49,8 +49,8 @@ final BuiltSet<Level> _$values = new BuiltSet<Level>(const <Level>[
   _$shout,
 ]);
 
-Serializer<Level> _$levelSerializer = new _$LevelSerializer();
-Serializer<ServerLog> _$serverLogSerializer = new _$ServerLogSerializer();
+Serializer<Level> _$levelSerializer = _$LevelSerializer();
+Serializer<ServerLog> _$serverLogSerializer = _$ServerLogSerializer();
 
 class _$LevelSerializer implements PrimitiveSerializer<Level> {
   @override
@@ -128,7 +128,7 @@ class _$ServerLogSerializer implements StructuredSerializer<ServerLog> {
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new ServerLogBuilder();
+    final result = ServerLogBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -196,7 +196,7 @@ class _$ServerLog extends ServerLog {
   final String? stackTrace;
 
   factory _$ServerLog([void Function(ServerLogBuilder)? updates]) =>
-      (new ServerLogBuilder()..update(updates))._build();
+      (ServerLogBuilder()..update(updates))._build();
 
   _$ServerLog._({
     required this.level,
@@ -204,17 +204,13 @@ class _$ServerLog extends ServerLog {
     this.loggerName,
     this.error,
     this.stackTrace,
-  }) : super._() {
-    BuiltValueNullFieldError.checkNotNull(level, r'ServerLog', 'level');
-    BuiltValueNullFieldError.checkNotNull(message, r'ServerLog', 'message');
-  }
-
+  }) : super._();
   @override
   ServerLog rebuild(void Function(ServerLogBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  ServerLogBuilder toBuilder() => new ServerLogBuilder()..replace(this);
+  ServerLogBuilder toBuilder() => ServerLogBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -291,7 +287,6 @@ class ServerLogBuilder implements Builder<ServerLog, ServerLogBuilder> {
 
   @override
   void replace(ServerLog other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ServerLog;
   }
 
@@ -306,7 +301,7 @@ class ServerLogBuilder implements Builder<ServerLog, ServerLogBuilder> {
   _$ServerLog _build() {
     final _$result =
         _$v ??
-        new _$ServerLog._(
+        _$ServerLog._(
           level: BuiltValueNullFieldError.checkNotNull(
             level,
             r'ServerLog',

--- a/build_daemon/lib/data/shutdown_notification.g.dart
+++ b/build_daemon/lib/data/shutdown_notification.g.dart
@@ -7,7 +7,7 @@ part of 'shutdown_notification.dart';
 // **************************************************************************
 
 Serializer<ShutdownNotification> _$shutdownNotificationSerializer =
-    new _$ShutdownNotificationSerializer();
+    _$ShutdownNotificationSerializer();
 
 class _$ShutdownNotificationSerializer
     implements StructuredSerializer<ShutdownNotification> {
@@ -47,7 +47,7 @@ class _$ShutdownNotificationSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new ShutdownNotificationBuilder();
+    final result = ShutdownNotificationBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -86,22 +86,10 @@ class _$ShutdownNotification extends ShutdownNotification {
 
   factory _$ShutdownNotification([
     void Function(ShutdownNotificationBuilder)? updates,
-  ]) => (new ShutdownNotificationBuilder()..update(updates))._build();
+  ]) => (ShutdownNotificationBuilder()..update(updates))._build();
 
   _$ShutdownNotification._({required this.message, required this.failureType})
-    : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-      message,
-      r'ShutdownNotification',
-      'message',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      failureType,
-      r'ShutdownNotification',
-      'failureType',
-    );
-  }
-
+    : super._();
   @override
   ShutdownNotification rebuild(
     void Function(ShutdownNotificationBuilder) updates,
@@ -109,7 +97,7 @@ class _$ShutdownNotification extends ShutdownNotification {
 
   @override
   ShutdownNotificationBuilder toBuilder() =>
-      new ShutdownNotificationBuilder()..replace(this);
+      ShutdownNotificationBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -163,7 +151,6 @@ class ShutdownNotificationBuilder
 
   @override
   void replace(ShutdownNotification other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$ShutdownNotification;
   }
 
@@ -178,7 +165,7 @@ class ShutdownNotificationBuilder
   _$ShutdownNotification _build() {
     final _$result =
         _$v ??
-        new _$ShutdownNotification._(
+        _$ShutdownNotification._(
           message: BuiltValueNullFieldError.checkNotNull(
             message,
             r'ShutdownNotification',

--- a/build_runner_core/lib/src/asset_graph/node.g.dart
+++ b/build_runner_core/lib/src/asset_graph/node.g.dart
@@ -28,31 +28,29 @@ NodeType _$nodeTypeValueOf(String name) {
     case 'missingSource':
       return _$missingSource;
     default:
-      throw new ArgumentError(name);
+      throw ArgumentError(name);
   }
 }
 
-final BuiltSet<NodeType> _$nodeTypeValues = new BuiltSet<NodeType>(
-  const <NodeType>[
-    _$generated,
-    _$glob,
-    _$internal,
-    _$placeholder,
-    _$source,
-    _$missingSource,
-  ],
-);
+final BuiltSet<NodeType> _$nodeTypeValues = BuiltSet<NodeType>(const <NodeType>[
+  _$generated,
+  _$glob,
+  _$internal,
+  _$placeholder,
+  _$source,
+  _$missingSource,
+]);
 
-Serializer<NodeType> _$nodeTypeSerializer = new _$NodeTypeSerializer();
-Serializer<AssetNode> _$assetNodeSerializer = new _$AssetNodeSerializer();
+Serializer<NodeType> _$nodeTypeSerializer = _$NodeTypeSerializer();
+Serializer<AssetNode> _$assetNodeSerializer = _$AssetNodeSerializer();
 Serializer<GeneratedNodeConfiguration> _$generatedNodeConfigurationSerializer =
-    new _$GeneratedNodeConfigurationSerializer();
+    _$GeneratedNodeConfigurationSerializer();
 Serializer<GeneratedNodeState> _$generatedNodeStateSerializer =
-    new _$GeneratedNodeStateSerializer();
+    _$GeneratedNodeStateSerializer();
 Serializer<GlobNodeConfiguration> _$globNodeConfigurationSerializer =
-    new _$GlobNodeConfigurationSerializer();
+    _$GlobNodeConfigurationSerializer();
 Serializer<GlobNodeState> _$globNodeStateSerializer =
-    new _$GlobNodeStateSerializer();
+    _$GlobNodeStateSerializer();
 
 class _$NodeTypeSerializer implements PrimitiveSerializer<NodeType> {
   @override
@@ -172,7 +170,7 @@ class _$AssetNodeSerializer implements StructuredSerializer<AssetNode> {
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new AssetNodeBuilder();
+    final result = AssetNodeBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -312,7 +310,7 @@ class _$GeneratedNodeConfigurationSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new GeneratedNodeConfigurationBuilder();
+    final result = GeneratedNodeConfigurationBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -405,7 +403,7 @@ class _$GeneratedNodeStateSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new GeneratedNodeStateBuilder();
+    final result = GeneratedNodeStateBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -496,7 +494,7 @@ class _$GlobNodeConfigurationSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new GlobNodeConfigurationBuilder();
+    final result = GlobNodeConfigurationBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -565,7 +563,7 @@ class _$GlobNodeStateSerializer implements StructuredSerializer<GlobNodeState> {
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new GlobNodeStateBuilder();
+    final result = GlobNodeStateBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -623,7 +621,7 @@ class _$AssetNode extends AssetNode {
   final BuiltSet<PostProcessBuildStepId> deletedBy;
 
   factory _$AssetNode([void Function(AssetNodeBuilder)? updates]) =>
-      (new AssetNodeBuilder()..update(updates))._build();
+      (AssetNodeBuilder()..update(updates))._build();
 
   _$AssetNode._({
     required this.id,
@@ -635,23 +633,13 @@ class _$AssetNode extends AssetNode {
     required this.primaryOutputs,
     this.digest,
     required this.deletedBy,
-  }) : super._() {
-    BuiltValueNullFieldError.checkNotNull(id, r'AssetNode', 'id');
-    BuiltValueNullFieldError.checkNotNull(type, r'AssetNode', 'type');
-    BuiltValueNullFieldError.checkNotNull(
-      primaryOutputs,
-      r'AssetNode',
-      'primaryOutputs',
-    );
-    BuiltValueNullFieldError.checkNotNull(deletedBy, r'AssetNode', 'deletedBy');
-  }
-
+  }) : super._();
   @override
   AssetNode rebuild(void Function(AssetNodeBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  AssetNodeBuilder toBuilder() => new AssetNodeBuilder()..replace(this);
+  AssetNodeBuilder toBuilder() => AssetNodeBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -714,33 +702,33 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
   GeneratedNodeConfigurationBuilder? _generatedNodeConfiguration;
   GeneratedNodeConfigurationBuilder get generatedNodeConfiguration =>
       _$this._generatedNodeConfiguration ??=
-          new GeneratedNodeConfigurationBuilder();
+          GeneratedNodeConfigurationBuilder();
   set generatedNodeConfiguration(
     GeneratedNodeConfigurationBuilder? generatedNodeConfiguration,
   ) => _$this._generatedNodeConfiguration = generatedNodeConfiguration;
 
   GeneratedNodeStateBuilder? _generatedNodeState;
   GeneratedNodeStateBuilder get generatedNodeState =>
-      _$this._generatedNodeState ??= new GeneratedNodeStateBuilder();
+      _$this._generatedNodeState ??= GeneratedNodeStateBuilder();
   set generatedNodeState(GeneratedNodeStateBuilder? generatedNodeState) =>
       _$this._generatedNodeState = generatedNodeState;
 
   GlobNodeConfigurationBuilder? _globNodeConfiguration;
   GlobNodeConfigurationBuilder get globNodeConfiguration =>
-      _$this._globNodeConfiguration ??= new GlobNodeConfigurationBuilder();
+      _$this._globNodeConfiguration ??= GlobNodeConfigurationBuilder();
   set globNodeConfiguration(
     GlobNodeConfigurationBuilder? globNodeConfiguration,
   ) => _$this._globNodeConfiguration = globNodeConfiguration;
 
   GlobNodeStateBuilder? _globNodeState;
   GlobNodeStateBuilder get globNodeState =>
-      _$this._globNodeState ??= new GlobNodeStateBuilder();
+      _$this._globNodeState ??= GlobNodeStateBuilder();
   set globNodeState(GlobNodeStateBuilder? globNodeState) =>
       _$this._globNodeState = globNodeState;
 
   SetBuilder<AssetId>? _primaryOutputs;
   SetBuilder<AssetId> get primaryOutputs =>
-      _$this._primaryOutputs ??= new SetBuilder<AssetId>();
+      _$this._primaryOutputs ??= SetBuilder<AssetId>();
   set primaryOutputs(SetBuilder<AssetId>? primaryOutputs) =>
       _$this._primaryOutputs = primaryOutputs;
 
@@ -750,7 +738,7 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
 
   SetBuilder<PostProcessBuildStepId>? _deletedBy;
   SetBuilder<PostProcessBuildStepId> get deletedBy =>
-      _$this._deletedBy ??= new SetBuilder<PostProcessBuildStepId>();
+      _$this._deletedBy ??= SetBuilder<PostProcessBuildStepId>();
   set deletedBy(SetBuilder<PostProcessBuildStepId>? deletedBy) =>
       _$this._deletedBy = deletedBy;
 
@@ -775,7 +763,6 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
 
   @override
   void replace(AssetNode other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$AssetNode;
   }
 
@@ -792,7 +779,7 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
     try {
       _$result =
           _$v ??
-          new _$AssetNode._(
+          _$AssetNode._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'AssetNode', 'id'),
             type: BuiltValueNullFieldError.checkNotNull(
               type,
@@ -824,7 +811,7 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
         _$failedField = 'deletedBy';
         deletedBy.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
           r'AssetNode',
           _$failedField,
           e.toString(),
@@ -847,30 +834,13 @@ class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
 
   factory _$GeneratedNodeConfiguration([
     void Function(GeneratedNodeConfigurationBuilder)? updates,
-  ]) => (new GeneratedNodeConfigurationBuilder()..update(updates))._build();
+  ]) => (GeneratedNodeConfigurationBuilder()..update(updates))._build();
 
   _$GeneratedNodeConfiguration._({
     required this.primaryInput,
     required this.phaseNumber,
     required this.isHidden,
-  }) : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-      primaryInput,
-      r'GeneratedNodeConfiguration',
-      'primaryInput',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      phaseNumber,
-      r'GeneratedNodeConfiguration',
-      'phaseNumber',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      isHidden,
-      r'GeneratedNodeConfiguration',
-      'isHidden',
-    );
-  }
-
+  }) : super._();
   @override
   GeneratedNodeConfiguration rebuild(
     void Function(GeneratedNodeConfigurationBuilder) updates,
@@ -878,7 +848,7 @@ class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
 
   @override
   GeneratedNodeConfigurationBuilder toBuilder() =>
-      new GeneratedNodeConfigurationBuilder()..replace(this);
+      GeneratedNodeConfigurationBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -942,7 +912,6 @@ class GeneratedNodeConfigurationBuilder
 
   @override
   void replace(GeneratedNodeConfiguration other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GeneratedNodeConfiguration;
   }
 
@@ -957,7 +926,7 @@ class GeneratedNodeConfigurationBuilder
   _$GeneratedNodeConfiguration _build() {
     final _$result =
         _$v ??
-        new _$GeneratedNodeConfiguration._(
+        _$GeneratedNodeConfiguration._(
           primaryInput: BuiltValueNullFieldError.checkNotNull(
             primaryInput,
             r'GeneratedNodeConfiguration',
@@ -991,31 +960,14 @@ class _$GeneratedNodeState extends GeneratedNodeState {
 
   factory _$GeneratedNodeState([
     void Function(GeneratedNodeStateBuilder)? updates,
-  ]) => (new GeneratedNodeStateBuilder()..update(updates))._build();
+  ]) => (GeneratedNodeStateBuilder()..update(updates))._build();
 
   _$GeneratedNodeState._({
     required this.inputs,
     required this.resolverEntrypoints,
     this.result,
     required this.errors,
-  }) : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-      inputs,
-      r'GeneratedNodeState',
-      'inputs',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      resolverEntrypoints,
-      r'GeneratedNodeState',
-      'resolverEntrypoints',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      errors,
-      r'GeneratedNodeState',
-      'errors',
-    );
-  }
-
+  }) : super._();
   @override
   GeneratedNodeState rebuild(
     void Function(GeneratedNodeStateBuilder) updates,
@@ -1023,7 +975,7 @@ class _$GeneratedNodeState extends GeneratedNodeState {
 
   @override
   GeneratedNodeStateBuilder toBuilder() =>
-      new GeneratedNodeStateBuilder()..replace(this);
+      GeneratedNodeStateBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1062,13 +1014,12 @@ class GeneratedNodeStateBuilder
   _$GeneratedNodeState? _$v;
 
   SetBuilder<AssetId>? _inputs;
-  SetBuilder<AssetId> get inputs =>
-      _$this._inputs ??= new SetBuilder<AssetId>();
+  SetBuilder<AssetId> get inputs => _$this._inputs ??= SetBuilder<AssetId>();
   set inputs(SetBuilder<AssetId>? inputs) => _$this._inputs = inputs;
 
   SetBuilder<AssetId>? _resolverEntrypoints;
   SetBuilder<AssetId> get resolverEntrypoints =>
-      _$this._resolverEntrypoints ??= new SetBuilder<AssetId>();
+      _$this._resolverEntrypoints ??= SetBuilder<AssetId>();
   set resolverEntrypoints(SetBuilder<AssetId>? resolverEntrypoints) =>
       _$this._resolverEntrypoints = resolverEntrypoints;
 
@@ -1077,8 +1028,7 @@ class GeneratedNodeStateBuilder
   set result(bool? result) => _$this._result = result;
 
   ListBuilder<String>? _errors;
-  ListBuilder<String> get errors =>
-      _$this._errors ??= new ListBuilder<String>();
+  ListBuilder<String> get errors => _$this._errors ??= ListBuilder<String>();
   set errors(ListBuilder<String>? errors) => _$this._errors = errors;
 
   GeneratedNodeStateBuilder();
@@ -1097,7 +1047,6 @@ class GeneratedNodeStateBuilder
 
   @override
   void replace(GeneratedNodeState other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GeneratedNodeState;
   }
 
@@ -1114,7 +1063,7 @@ class GeneratedNodeStateBuilder
     try {
       _$result =
           _$v ??
-          new _$GeneratedNodeState._(
+          _$GeneratedNodeState._(
             inputs: inputs.build(),
             resolverEntrypoints: resolverEntrypoints.build(),
             result: result,
@@ -1131,7 +1080,7 @@ class GeneratedNodeStateBuilder
         _$failedField = 'errors';
         errors.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
           r'GeneratedNodeState',
           _$failedField,
           e.toString(),
@@ -1152,22 +1101,10 @@ class _$GlobNodeConfiguration extends GlobNodeConfiguration {
 
   factory _$GlobNodeConfiguration([
     void Function(GlobNodeConfigurationBuilder)? updates,
-  ]) => (new GlobNodeConfigurationBuilder()..update(updates))._build();
+  ]) => (GlobNodeConfigurationBuilder()..update(updates))._build();
 
   _$GlobNodeConfiguration._({required this.glob, required this.phaseNumber})
-    : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-      glob,
-      r'GlobNodeConfiguration',
-      'glob',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      phaseNumber,
-      r'GlobNodeConfiguration',
-      'phaseNumber',
-    );
-  }
-
+    : super._();
   @override
   GlobNodeConfiguration rebuild(
     void Function(GlobNodeConfigurationBuilder) updates,
@@ -1175,7 +1112,7 @@ class _$GlobNodeConfiguration extends GlobNodeConfiguration {
 
   @override
   GlobNodeConfigurationBuilder toBuilder() =>
-      new GlobNodeConfigurationBuilder()..replace(this);
+      GlobNodeConfigurationBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1229,7 +1166,6 @@ class GlobNodeConfigurationBuilder
 
   @override
   void replace(GlobNodeConfiguration other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GlobNodeConfiguration;
   }
 
@@ -1244,7 +1180,7 @@ class GlobNodeConfigurationBuilder
   _$GlobNodeConfiguration _build() {
     final _$result =
         _$v ??
-        new _$GlobNodeConfiguration._(
+        _$GlobNodeConfiguration._(
           glob: BuiltValueNullFieldError.checkNotNull(
             glob,
             r'GlobNodeConfiguration',
@@ -1268,19 +1204,15 @@ class _$GlobNodeState extends GlobNodeState {
   final BuiltList<AssetId> results;
 
   factory _$GlobNodeState([void Function(GlobNodeStateBuilder)? updates]) =>
-      (new GlobNodeStateBuilder()..update(updates))._build();
+      (GlobNodeStateBuilder()..update(updates))._build();
 
-  _$GlobNodeState._({required this.inputs, required this.results}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(inputs, r'GlobNodeState', 'inputs');
-    BuiltValueNullFieldError.checkNotNull(results, r'GlobNodeState', 'results');
-  }
-
+  _$GlobNodeState._({required this.inputs, required this.results}) : super._();
   @override
   GlobNodeState rebuild(void Function(GlobNodeStateBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  GlobNodeStateBuilder toBuilder() => new GlobNodeStateBuilder()..replace(this);
+  GlobNodeStateBuilder toBuilder() => GlobNodeStateBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -1313,13 +1245,12 @@ class GlobNodeStateBuilder
   _$GlobNodeState? _$v;
 
   SetBuilder<AssetId>? _inputs;
-  SetBuilder<AssetId> get inputs =>
-      _$this._inputs ??= new SetBuilder<AssetId>();
+  SetBuilder<AssetId> get inputs => _$this._inputs ??= SetBuilder<AssetId>();
   set inputs(SetBuilder<AssetId>? inputs) => _$this._inputs = inputs;
 
   ListBuilder<AssetId>? _results;
   ListBuilder<AssetId> get results =>
-      _$this._results ??= new ListBuilder<AssetId>();
+      _$this._results ??= ListBuilder<AssetId>();
   set results(ListBuilder<AssetId>? results) => _$this._results = results;
 
   GlobNodeStateBuilder();
@@ -1336,7 +1267,6 @@ class GlobNodeStateBuilder
 
   @override
   void replace(GlobNodeState other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GlobNodeState;
   }
 
@@ -1353,10 +1283,7 @@ class GlobNodeStateBuilder
     try {
       _$result =
           _$v ??
-          new _$GlobNodeState._(
-            inputs: inputs.build(),
-            results: results.build(),
-          );
+          _$GlobNodeState._(inputs: inputs.build(), results: results.build());
     } catch (_) {
       late String _$failedField;
       try {
@@ -1365,7 +1292,7 @@ class GlobNodeStateBuilder
         _$failedField = 'results';
         results.build();
       } catch (e) {
-        throw new BuiltValueNestedFieldError(
+        throw BuiltValueNestedFieldError(
           r'GlobNodeState',
           _$failedField,
           e.toString(),

--- a/build_runner_core/lib/src/asset_graph/post_process_build_step_id.g.dart
+++ b/build_runner_core/lib/src/asset_graph/post_process_build_step_id.g.dart
@@ -7,7 +7,7 @@ part of 'post_process_build_step_id.dart';
 // **************************************************************************
 
 Serializer<PostProcessBuildStepId> _$postProcessBuildStepIdSerializer =
-    new _$PostProcessBuildStepIdSerializer();
+    _$PostProcessBuildStepIdSerializer();
 
 class _$PostProcessBuildStepIdSerializer
     implements StructuredSerializer<PostProcessBuildStepId> {
@@ -47,7 +47,7 @@ class _$PostProcessBuildStepIdSerializer
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = new PostProcessBuildStepIdBuilder();
+    final result = PostProcessBuildStepIdBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -86,22 +86,10 @@ class _$PostProcessBuildStepId extends PostProcessBuildStepId {
 
   factory _$PostProcessBuildStepId([
     void Function(PostProcessBuildStepIdBuilder)? updates,
-  ]) => (new PostProcessBuildStepIdBuilder()..update(updates))._build();
+  ]) => (PostProcessBuildStepIdBuilder()..update(updates))._build();
 
   _$PostProcessBuildStepId._({required this.input, required this.actionNumber})
-    : super._() {
-    BuiltValueNullFieldError.checkNotNull(
-      input,
-      r'PostProcessBuildStepId',
-      'input',
-    );
-    BuiltValueNullFieldError.checkNotNull(
-      actionNumber,
-      r'PostProcessBuildStepId',
-      'actionNumber',
-    );
-  }
-
+    : super._();
   @override
   PostProcessBuildStepId rebuild(
     void Function(PostProcessBuildStepIdBuilder) updates,
@@ -109,7 +97,7 @@ class _$PostProcessBuildStepId extends PostProcessBuildStepId {
 
   @override
   PostProcessBuildStepIdBuilder toBuilder() =>
-      new PostProcessBuildStepIdBuilder()..replace(this);
+      PostProcessBuildStepIdBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
@@ -163,7 +151,6 @@ class PostProcessBuildStepIdBuilder
 
   @override
   void replace(PostProcessBuildStepId other) {
-    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$PostProcessBuildStepId;
   }
 
@@ -178,7 +165,7 @@ class PostProcessBuildStepIdBuilder
   _$PostProcessBuildStepId _build() {
     final _$result =
         _$v ??
-        new _$PostProcessBuildStepId._(
+        _$PostProcessBuildStepId._(
           input: BuiltValueNullFieldError.checkNotNull(
             input,
             r'PostProcessBuildStepId',

--- a/build_runner_core/lib/src/asset_graph/serializers.g.dart
+++ b/build_runner_core/lib/src/asset_graph/serializers.g.dart
@@ -7,7 +7,7 @@ part of 'serializers.dart';
 // **************************************************************************
 
 Serializers _$serializers =
-    (new Serializers().toBuilder()
+    (Serializers().toBuilder()
           ..add(AssetDeps.serializer)
           ..add(AssetNode.serializer)
           ..add(ExpiringValue.serializer)
@@ -24,41 +24,41 @@ Serializers _$serializers =
               const FullType(AssetId),
               const FullType(PhasedValue, const [const FullType(AssetDeps)]),
             ]),
-            () => new MapBuilder<AssetId, PhasedValue<AssetDeps>>(),
+            () => MapBuilder<AssetId, PhasedValue<AssetDeps>>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
+            () => SetBuilder<AssetId>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
+            () => SetBuilder<AssetId>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltList, const [const FullType(AssetId)]),
-            () => new ListBuilder<AssetId>(),
+            () => ListBuilder<AssetId>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
+            () => SetBuilder<AssetId>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
+            () => SetBuilder<AssetId>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltList, const [const FullType(String)]),
-            () => new ListBuilder<String>(),
+            () => ListBuilder<String>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => new SetBuilder<AssetId>(),
+            () => SetBuilder<AssetId>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltSet, const [
               const FullType(PostProcessBuildStepId),
             ]),
-            () => new SetBuilder<PostProcessBuildStepId>(),
+            () => SetBuilder<PostProcessBuildStepId>(),
           ))
         .build();
 


### PR DESCRIPTION
It removes some checks that are not needed with sound null safety, optional `new` keywords, and check for `dynamic` in generics.