### PR TITLE
Introduce `BuildProcessState`, sent to and returned from spawned isolates.

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -9,8 +9,10 @@ import 'package:build_config/build_config.dart' as _i5;
 import 'package:build_modules/builders.dart' as _i6;
 import 'package:build/build.dart' as _i7;
 import 'dart:isolate' as _i8;
-import 'package:build_runner/build_runner.dart' as _i9;
-import 'dart:io' as _i10;
+import 'package:build_runner/src/build_script_generate/build_process_state.dart'
+    as _i9;
+import 'package:build_runner/build_runner.dart' as _i10;
+import 'dart:io' as _i11;
 
 final _builders = <_i1.BuilderApplication>[
   _i1.apply(
@@ -169,10 +171,11 @@ void main(
   List<String> args, [
   _i8.SendPort? sendPort,
 ]) async {
-  var result = await _i9.run(
+  await _i9.buildProcessState.receive(sendPort);
+  _i9.buildProcessState.isolateExitCode = await _i10.run(
     args,
     _builders,
   );
-  sendPort?.send(result);
-  _i10.exitCode = result;
+  _i11.exitCode = _i9.buildProcessState.isolateExitCode!;
+  await _i9.buildProcessState.send(sendPort);
 }

--- a/build_runner/lib/src/build_script_generate/build_process_state.dart
+++ b/build_runner/lib/src/build_script_generate/build_process_state.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:isolate';
+
+/// State for the whole build process.
+///
+/// It's passed from the entrypoint to the spawned build script isolate, then
+/// updated in the host when the isolate exits.
+final BuildProcessState buildProcessState = BuildProcessState({});
+
+extension type BuildProcessState(Map<String, Object?> state) {
+  /// The exit code of the most recent build script isolate, or `null` if there
+  /// was none or it is currently running.
+  int? get isolateExitCode => state['isolateExitCode'] as int?;
+  set isolateExitCode(int? value) => state['isolateExitCode'] = value;
+
+  /// Sends `this` to [sendPort].
+  Future<void> send(SendPort? sendPort) async {
+    sendPort?.send(state);
+  }
+
+  /// Receives `this` from [sendPort], by sending a `SendPort` then listening
+  /// on its corresponding `ReceivePort`.
+  Future<void> receive(SendPort? sendPort) async {
+    if (sendPort == null) {
+      state.clear();
+      return;
+    }
+    final receivePort = ReceivePort();
+    sendPort.send(receivePort.sendPort);
+    final received = await receivePort.first;
+    state
+      ..clear()
+      ..addAll(received as Map<String, Object?>);
+  }
+
+  /// Receives `this` from [receivePort].
+  StreamSubscription<void> listen(ReceivePort receivePort) {
+    StreamSubscription<void>? result;
+    result = receivePort.listen((isolateState) {
+      if (isolateState is Map<String, Object?>) {
+        state
+          ..clear()
+          ..addAll(isolateState);
+      } else {
+        throw StateError(
+          'Bad response from isolate, expected Map but got $isolateState',
+        );
+      }
+      result!.cancel();
+    });
+    return result;
+  }
+}

--- a/build_runner/lib/src/build_script_generate/build_script_generate.dart
+++ b/build_runner/lib/src/build_script_generate/build_script_generate.dart
@@ -227,8 +227,16 @@ Method _main() => Method((b) {
       });
     }),
   );
+  final isolateExitCode = refer(
+    'buildProcessState.isolateExitCode',
+    'package:build_runner/src/build_script_generate/build_process_state.dart',
+  );
   b.body = Block.of([
-    declareVar('result')
+    refer(
+      'buildProcessState.receive',
+      'package:build_runner/src/build_script_generate/build_process_state.dart',
+    ).call([refer('sendPort')]).awaited.statement,
+    isolateExitCode
         .assign(
           refer(
             'run',
@@ -236,10 +244,11 @@ Method _main() => Method((b) {
           ).call([refer('args'), refer('_builders')]).awaited,
         )
         .statement,
+    refer('exitCode', 'dart:io').assign(isolateExitCode).nullChecked.statement,
     refer(
-      'sendPort',
-    ).nullSafeProperty('send').call([refer('result')]).statement,
-    refer('exitCode', 'dart:io').assign(refer('result')).statement,
+      'buildProcessState.send',
+      'package:build_runner/src/build_script_generate/build_process_state.dart',
+    ).call([refer('sendPort')]).awaited.statement,
   ]);
 });
 

--- a/build_runner/test/build_script_generate/bootstrap_test.dart
+++ b/build_runner/test/build_script_generate/bootstrap_test.dart
@@ -4,35 +4,179 @@
 @Timeout.factor(2)
 library;
 
+import 'dart:io';
+
 import 'package:build_runner/build_script_generate.dart';
+import 'package:build_runner/src/build_script_generate/build_process_state.dart';
+import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
+import 'package:build_runner_core/build_runner_core.dart';
 import 'package:test/test.dart';
 
+// These tests write to the real `build_runner/.dart_tool/build/entrypoint`
+// but that's reasonably harmless as it can always contain invalid output
+// due to version skew.
 void main() {
-  test('invokes custom error function', () async {
-    Object? error;
-    StackTrace? stackTrace;
+  final scriptFile = File(scriptLocation);
+  final kernelFile = File(scriptKernelLocation);
 
-    // TODO: https://github.com/dart-lang/sdk/issues/52469 Use IOOverrides to
-    // run this is a tmp dir, this currently bashes over the actual cache dir.
-    await expectLater(
-      generateAndRun(
+  setUp(() {
+    if (scriptFile.existsSync()) scriptFile.deleteSync();
+    if (kernelFile.existsSync()) kernelFile.deleteSync();
+  });
+
+  group('generateAndRun', () {
+    test('writes dill', () async {
+      await generateAndRun(
         [],
-        generateBuildScript: () async {
-          return '''
-              void main() {
-                throw 'expected error';
-              }
-              ''';
-        },
-        handleUncaughtError: (err, trace) {
-          error = err;
-          stackTrace = trace;
-        },
-      ),
-      completion(1),
+        generateBuildScript:
+            () async => '''
+import 'dart:isolate';
+import 'package:build_runner/src/build_script_generate/build_process_state.dart';
+
+void main(_, [SendPort? sendPort]) async {
+  await buildProcessState.receive(sendPort);
+  buildProcessState.send(sendPort);
+}
+''',
+      );
+      expect(kernelFile.existsSync(), true);
+    });
+
+    test('sends and receives buildProcessState', () async {
+      final script = '''
+import 'dart:isolate';
+import 'package:build_runner/src/build_script_generate/build_process_state.dart';
+
+void main(_, [SendPort? sendPort]) async {
+  await buildProcessState.receive(sendPort);
+  buildProcessState.isolateExitCode = buildProcessState.isolateExitCode! + 1;
+  buildProcessState.send(sendPort);
+}
+''';
+
+      buildProcessState.isolateExitCode = 6;
+      await generateAndRun([], generateBuildScript: () async => script);
+      expect(buildProcessState.isolateExitCode, 7);
+      await generateAndRun([], generateBuildScript: () async => script);
+      expect(buildProcessState.isolateExitCode, 8);
+    });
+
+    test('rewrites dill if script changed', () async {
+      expect(
+        await generateAndRun(
+          [],
+          generateBuildScript:
+              () async => '''
+import 'dart:isolate';
+import 'package:build_runner/src/build_script_generate/build_process_state.dart';
+
+void main(_, [SendPort? sendPort]) async {
+  await buildProcessState.receive(sendPort);
+  buildProcessState.isolateExitCode = 3;
+  buildProcessState.send(sendPort);
+}
+''',
+        ),
+        3,
+      );
+      expect(kernelFile.existsSync(), true);
+
+      expect(
+        await generateAndRun(
+          [],
+          generateBuildScript:
+              () async => '''
+import 'dart:isolate';
+import 'package:build_runner/src/build_script_generate/build_process_state.dart';
+
+void main(_, [SendPort? sendPort]) async {
+  await buildProcessState.receive(sendPort);
+  buildProcessState.isolateExitCode = 4;
+  buildProcessState.send(sendPort);
+}
+''',
+        ),
+        4,
+      );
+    });
+
+    test(
+      'rewrites dill if there is an asset graph and script changed',
+      () async {
+        File(
+          assetGraphPathFor(scriptKernelLocation),
+        ).createSync(recursive: true);
+        expect(
+          await generateAndRun(
+            [],
+            generateBuildScript:
+                () async => '''
+import 'dart:isolate';
+import 'package:build_runner/src/build_script_generate/build_process_state.dart';
+
+void main(_, [SendPort? sendPort]) async {
+  await buildProcessState.receive(sendPort);
+  buildProcessState.isolateExitCode = 3;
+  buildProcessState.send(sendPort);
+}
+''',
+          ),
+          3,
+        );
+        expect(kernelFile.existsSync(), true);
+        expect(
+          File(assetGraphPathFor(scriptKernelLocation)).existsSync(),
+          true,
+        );
+
+        expect(
+          await generateAndRun(
+            [],
+            generateBuildScript:
+                () async => '''
+import 'dart:isolate';
+import 'package:build_runner/src/build_script_generate/build_process_state.dart';
+
+void main(_, [SendPort? sendPort]) async {
+  await buildProcessState.receive(sendPort);
+  buildProcessState.isolateExitCode = 4;
+  buildProcessState.send(sendPort);
+}
+''',
+          ),
+          4,
+        );
+      },
     );
 
-    expect(error, 'expected error');
-    expect(stackTrace, isNotNull);
+    test('invokes custom error function', () async {
+      Object? error;
+      StackTrace? stackTrace;
+
+      await expectLater(
+        generateAndRun(
+          [],
+          generateBuildScript: () async {
+            return '''
+import 'dart:isolate';
+import 'package:build_runner/src/build_script_generate/build_process_state.dart';
+
+void main(_, [SendPort? sendPort]) async {
+  await buildProcessState.receive(sendPort);
+  throw 'expected error';
+}
+''';
+          },
+          handleUncaughtError: (err, trace) {
+            error = err;
+            stackTrace = trace;
+          },
+        ),
+        completion(1),
+      );
+
+      expect(error, 'expected error');
+      expect(stackTrace, isNotNull);
+    });
   });
 }

--- a/build_runner/test/build_script_generate/experiments_test.dart
+++ b/build_runner/test/build_script_generate/experiments_test.dart
@@ -22,10 +22,13 @@ void main() {
               // @dart=3.0
               import 'dart:io';
               import 'dart:isolate';
+              import 'package:build_runner/src/build_script_generate/build_process_state.dart';
 
               void main(List<String> _, SendPort sendPort) {
+                buildProcessState.receive(sendPort);
                 var x = (1, 2);
-                sendPort.send(x.\$2);
+                buildProcessState.isolateExitCode = (x.\$2);
+                buildProcessState.send(sendPort);
               }
               ''';
       },


### PR DESCRIPTION
For #4005.

For logging I need to pass some state between host and spawned isolates, to get the console display right and to know why an isolate decided it is invalid and needs rebuilding. So, introduce `BuildProcessState` that is passed between host and isolates via send ports. For now it just holds the exit code.

The host can always ensure host<->isolate compatibility, but the checks in place were not sufficient, make it always rebuild if the script changed, which seems like a good idea anyway and means we definitely get a rebuild when switching between versions that know about `BuildProcessState` and versions that don't.