### PR TITLE
Use a synchronous StreamController for daemon logs

### DIFF
--- a/build_runner/lib/src/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/daemon/daemon_builder.dart
@@ -231,7 +231,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
     DaemonOptions daemonOptions,
   ) async {
     var expectedDeletes = <AssetId>{};
-    var outputStreamController = StreamController<ServerLog>();
+    var outputStreamController = StreamController<ServerLog>(sync: true);
 
     var environment = BuildEnvironment(
       packageGraph,


### PR DESCRIPTION
The logging from build_runner when running builds through a daemon was asynchronous and was causing some `webdev build` commands to missing the final status message.

Fixes: https://github.com/dart-lang/webdev/issues/2489
