### PR TITLE
Simplify and fix clean command.

### DIFF
--- a/build_runner/bin/src/commands/clean.dart
+++ b/build_runner/bin/src/commands/clean.dart
@@ -6,10 +6,8 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
-import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
 import 'package:build_runner/src/entrypoint/base_command.dart' show lineLength;
-import 'package:build_runner/src/entrypoint/clean.dart' show cleanFor;
-import 'package:build_runner_core/build_runner_core.dart';
+import 'package:build_runner/src/entrypoint/clean.dart' show clean;
 import 'package:logging/logging.dart';
 
 class CleanCommand extends Command<int> {
@@ -22,12 +20,11 @@ class CleanCommand extends Command<int> {
 
   @override
   String get description =>
-      'Cleans up output from previous builds. Does not clean up --output '
-      'directories.';
+      'Deletes the build cache. The next build will be a full build.';
 
   @override
   Future<int> run() async {
-    await cleanFor(assetGraphPathFor(scriptLocation));
+    clean();
     return 0;
   }
 }

--- a/build_runner/test/entrypoint/clean_integration_test.dart
+++ b/build_runner/test/entrypoint/clean_integration_test.dart
@@ -42,11 +42,10 @@ void main() {
       ]).validate();
     });
 
-    test('cleans up .dart_tool and generated source files', () async {
+    test('cleans up .dart_tool', () async {
       var cleanResult = await runDart('a', 'tool/build.dart', args: ['clean']);
       expect(cleanResult.exitCode, 0);
       await d.dir('a', [
-        d.dir('web', [d.nothing('a.txt.copy')]),
         d.dir('.dart_tool', [d.nothing('build')]),
       ]).validate();
     });


### PR DESCRIPTION
The previous PR broke the `clean` command because I removed a timing block and changed the meaning of the early `return` statements.

On closer inspection, `clean` can't actually find the asset graph in normal use because the `assetGraphPath` changes based on the script location, and `clean` runs from the main script while all the `build` commands run from the generated build script. So I think `clean` never actually deleted "generated source files".

So remove that code, including the early return that I broke, and just delete the whole cache folder.