### PR TITLE
LogDisplay.block support for writing fewer lines than previous block.

### DIFF
--- a/build_runner_core/lib/src/logging/ansi_buffer.dart
+++ b/build_runner_core/lib/src/logging/ansi_buffer.dart
@@ -21,7 +21,7 @@ class AnsiBuffer {
   final List<String> lines = [];
 
   /// The width that the buffer wraps to.
-  int get width =>
+  static int get width =>
       buildLog.configuration.forceConsoleWidthForTesting ??
       (stdout.hasTerminal ? stdout.terminalColumns : 80);
 
@@ -40,7 +40,7 @@ class AnsiBuffer {
   /// In addition to ANSI codes, [nbsp] is a non-breaking space which will not
   /// be used for wrapping. In the buffer it is replaced with a normal space.
   void writeLine(List<String> items, {int indent = 0, int? hangingIndent}) {
-    final width = this.width;
+    final width = AnsiBuffer.width;
     hangingIndent ??= indent;
     indent = min(indent, width ~/ 2);
     hangingIndent = min(hangingIndent, width ~/ 2);

--- a/build_runner_core/lib/src/logging/log_display.dart
+++ b/build_runner_core/lib/src/logging/log_display.dart
@@ -60,8 +60,13 @@ class LogDisplay {
     // https://en.wikipedia.org/wiki/ANSI_escape_code#:~:text=Cursor%20Previous
     // Moves cursor to the beginning of the line n lines up.
     final moveCursor = _displayedLines == 0 ? '' : '\x1b[${_displayedLines}F';
-    _displayedLines = lines.length;
     stdout.writeln('$moveCursor${lines.join('\n')}');
+    if (_displayedLines > lines.length) {
+      // If the block is smaller than last time, erase the rest of the display.
+      // https://en.wikipedia.org/wiki/ANSI_escape_code#:~:text=Erase%20in%20Display
+      stdout.write('\x1b[J');
+    }
+    _displayedLines = lines.length;
 
     if (block.overflowsConsole) {
       prompt('Log overflowed the console, switching to line-by-line logging.');

--- a/build_runner_core/test/logging/log_display_example.dart
+++ b/build_runner_core/test/logging/log_display_example.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build_runner_core/src/logging/ansi_buffer.dart';
+import 'package:build_runner_core/src/logging/log_display.dart';
+
+// TODO(davidmorgan): figure out how to make this a test.
+void main() async {
+  final display = LogDisplay();
+  display.block(
+    AnsiBuffer()
+      ..writeLine(['start with'])
+      ..writeLine(['two lines']),
+  );
+  await Future<void>.delayed(const Duration(seconds: 2));
+  display.block(AnsiBuffer()..writeLine(['now there should be one line']));
+  await Future<void>.delayed(const Duration(seconds: 2));
+  display.block(
+    AnsiBuffer()
+      ..writeLine(['now'])
+      ..writeLine(['three'])
+      ..writeLine(['lines']),
+  );
+  await Future<void>.delayed(const Duration(seconds: 2));
+  display.block(AnsiBuffer()..writeLine(['finally one line again']));
+}


### PR DESCRIPTION
`BuildLog` should never actually do this: progress accumulates incrementally, so it should always render the same number of lines or more.

Still, it seems worth having it do something that does not corrupt the display.