### PR TITLE
Update CHANGELOGs and pubspecs for release.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,11 +1,23 @@
-## 2.4.3-wip
+## 2.5.0
 
+User-visible changes:
+
+- Improved performance for large builds. More performance improvements
+  will follow, if your workflow is affected by slow `build_runner` performance
+  then please consider sharing details at
+  https://github.com/dart-lang/build/discussions.
 - Improved logging: show what builders are running and, for long-running
   builders, where the time is spent.
 - `AssetNotFoundException` now also reports the missing `path`.
+
+Versions:
+
 - Bump the min sdk to 3.7.0.
 - Use `build_test` 3.0.0.
 - Use `build_runner_core` 9.0.0.
+
+Internal changes:
+
 - Add `package:build/src/internal.dart` for use by `build_resolvers`,
   `build_runner_core` and `build_test`.
 - Refactor `PathProvidingAssetReader` to `AssetPathProvider`.

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 2.4.3-wip
+version: 2.5.0
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: '>=6.9.0 <8.0.0'
   async: ^2.5.0
-  build_runner_core: ^9.0.0-wip
+  build_runner_core: '9.0.0'
   built_collection: ^5.1.1
   built_value: ^8.9.5
   convert: ^3.0.0
@@ -24,8 +24,8 @@ dependencies:
   pool: ^1.5.0
 
 dev_dependencies:
-  build_resolvers: ^2.4.0
-  build_test: ^3.0.0-wip
+  build_resolvers: '2.5.0'
+  build_test: '3.0.0'
   built_value_generator: ^8.9.5
   dart_flutter_team_lints: ^3.1.0
   test: ^1.16.0

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -32,7 +32,7 @@ dev_dependencies:
     path: test/fixtures/b
   # Used inside tests
   build_runner: ^2.0.0
-  build_runner_core: ^9.0.0-wip
+  build_runner_core: ^9.0.0
   build_test: ^3.0.0-wip
   json_serializable: ^6.9.1
   test: ^1.16.0

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,19 +1,30 @@
-## 2.4.5-wip
+## 2.5.0
 
+User-visible changes:
+
+- Improved performance for large builds. More performance improvements
+  will follow, if your workflow is affected by slow `build_runner` performance
+  then please consider sharing details at
+  https://github.com/dart-lang/build/discussions.
 - Improved logging: show what builders are running and, for long-running
   builders, where the time is spent.
+- Bug fix: fix delay on shutdown for fast builds when the "analyzer out of
+  date" warning is displayed.
+
+Versions:
+
 - Bump the min SDK to 3.7.0.
 - Use `build_test` 3.0.0.
 - Use `build_runner_core` 9.0.0.
-- Use new resolver always; remove `--use-experimental-resolver` flag.
 - Start using `package:build/src/internal.dart`.
+
+Internal changes:
+
 - Switch `BuildAssetUriResolver` dependency crawl to an iterative
   algorithm, preventing stack overflows.
 - Move `BuildStepImpl` to `build_runner_core`, use `SingleStepReader` directly.
 - Stop building `transitive_digest` files by default.
 - Use `LibraryCycleGraphLoader` to load transitive deps for analysis.
-- Bug fix: fix delay on shutdown for fast builds when the "analyzer out of
-  date" warning is displayed.
 - Track resolver dependencies as library cycle graphs.
 - Ignore deprecated analyzer API usages.
 

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 2.4.5-wip
+version: 2.5.0
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 resolution: workspace
@@ -10,8 +10,8 @@ environment:
 dependencies:
   analyzer: '>=6.9.0 <8.0.0'
   async: ^2.5.0
-  build: ^2.4.3-wip
-  build_runner_core: ^9.0.0-wip
+  build: '2.5.0'
+  build_runner_core: '9.0.0'
   collection: ^1.17.0
   convert: ^3.1.1
   crypto: ^3.0.0
@@ -25,7 +25,7 @@ dependencies:
   yaml: ^3.0.0
 
 dev_dependencies:
-  build_test: ^3.0.0-wip
+  build_test: ^3.0.0
   dart_flutter_team_lints: ^3.1.0
   test: ^1.16.0
 

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,11 +1,22 @@
-## 2.4.16-wip
+## 2.5.0
 
+User-visible changes:
+
+- Improved performance for large builds. More performance improvements
+  will follow, if your workflow is affected by slow `build_runner` performance
+  then please consider sharing details at
+  https://github.com/dart-lang/build/discussions.
 - Improved logging: show what builders are running and, for long-running
   builders, where the time is spent.
+
+Versions:
+
 - Bump the min SDK to 3.7.0.
 - Use `build_test` 3.0.0.
 - Use `build_runner_core` 9.0.0.
-- Use new resolver always; remove `--use-experimental-resolver` flag.
+
+Internal changes:
+
 - Start using `package:build/src/internal.dart'.
 - Refactor `MultiPackageAssetReader` to internal `AssetFinder`.
 - `FinalizedReader` no longer implements `AssetReader`.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.4.16-wip
+version: 2.5.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace
@@ -16,11 +16,11 @@ dependencies:
   analyzer: '>=4.4.0 <8.0.0'
   args: ^2.0.0
   async: ^2.5.0
-  build: ^2.3.4-wip
+  build: '2.5.0'
   build_config: ">=1.1.0 <1.2.0"
   build_daemon: ^4.0.0
-  build_resolvers: ^2.4.4
-  build_runner_core: ^9.0.0-wip
+  build_resolvers: '2.5.0'
+  build_runner_core: '9.0.0'
   code_builder: ^4.2.0
   collection: ^1.15.0
   crypto: ^3.0.0
@@ -53,7 +53,7 @@ dependencies:
 dev_dependencies:
   _test_common:
     path: ../_test_common
-  build_test: ^3.0.0-wip
+  build_test: ^3.0.0
   build_web_compilers: ^4.0.0
   dart_flutter_team_lints: ^3.1.0
   stream_channel: ^2.0.0

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,15 +1,28 @@
-## 9.0.0-wip
+## 9.0.0
 
+- Improved performance for large builds. More performance improvements
+  will follow, if your workflow is affected by slow `build_runner` performance
+  then please consider sharing details at
+  https://github.com/dart-lang/build/discussions.
 - Improved logging: show what builders are running and, for long-running
   builders, where the time is spent.
+
+Breaking changes:
+
 - Breaking: refactor `OverridableEnvironment` and `IOEnvironment` into
   `BuildEnvironment`
 - Breaking: add `deleteDirectory` to `RunnerAssetWriter`, make `delete`
   return `Future<void>`, remove deprecated `OnDelete`.
+
+Versions:
+
 - Bump the min SDK to 3.7.0.
+- Use `build_test` 3.0.0.
+
+Internal changes:
+
 - Fix crash when running on assets ending in a dot.
 - Start using `package:build/src/internal.dart'.
-- Use `build_test` 3.0.0.
 - Refactor `PathProvidingAssetReader` to `AssetPathProvider`.
 - Refactor `MultiPackageAssetReader` to internal `AssetFinder`.
 - `FinalizedReader` no longer implements `AssetReader`.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 9.0.0-wip
+version: 9.0.0
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 resolution: workspace
@@ -15,10 +15,10 @@ platforms:
 dependencies:
   analyzer: '>=6.9.0 <8.0.0'
   async: ^2.5.0
-  build: ^2.4.3-wip
+  build: '2.5.0'
   build_config: ^1.0.0
-  build_resolvers: ^2.4.0
-  build_runner: ^2.4.16-wip
+  build_resolvers: '2.5.0'
+  build_runner: '2.5.0'
   built_collection: ^5.1.1
   built_value: ^8.10.1
   collection: ^1.15.0
@@ -39,7 +39,7 @@ dependencies:
 dev_dependencies:
   _test_common:
     path: ../_test_common
-  build_test: ^3.0.0-wip
+  build_test: ^3.0.0
   built_value_generator: ^8.10.1
   dart_flutter_team_lints: ^3.1.0
   json_serializable: ^6.0.0

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,18 +1,7 @@
-## 3.0.0-wip
+## 3.0.0
 
-- Bump the min SDK to 3.7.0.
-- Use `build_runner_core` 9.0.0.
-- `resolveSources` and `testBuilder` now do a full `build_runner` build, with
-  configuration as much as possible based on the some parameters.
-- Add `testBuilders` to run a test build with multiple builders.
-- Add `optionalBuilders` to `testBuilders` to have some builders be optional.
-- Add `visibleOutputBuilders` to `testBuilders` to have some builders write
-  their output next to their inputs.
-- Add `testingBuilderConfig` to `testBuilders` to control builder config
-  override.
-- Add `resolvers` parameter to `testBuild` and `testBuilders`.
-- Add `readerWriter` and `enableLowResourceMode` parameters to `testBuild`
-  and `testBuilders`.
+Breaking changes:
+
 - Breaking change: removed `tearDown` parameter to `resolveSources` for
   keeping resolvers across multiple tests.
 - Breaking change: tests must use new `TestReaderWriter` instead of
@@ -31,9 +20,31 @@
   resolver entrypoints are now tracked separately from inputs, see
   `TestReaderWriter.resolverEntrypointsTracked`.
 - Breaking change: Remove `StubAssetReader`. Use `TestReaderWriter` instead.
+
+Other user-visible changes:
+
+- `resolveSources` and `testBuilder` now do a full `build_runner` build, with
+  configuration as much as possible based on the some parameters.
+- Add `testBuilders` to run a test build with multiple builders.
+- Add `optionalBuilders` to `testBuilders` to have some builders be optional.
+- Add `visibleOutputBuilders` to `testBuilders` to have some builders write
+  their output next to their inputs.
+- Add `testingBuilderConfig` to `testBuilders` to control builder config
+  override.
+- Add `resolvers` parameter to `testBuild` and `testBuilders`.
+- Add `readerWriter` and `enableLowResourceMode` parameters to `testBuild`
+  and `testBuilders`.
 - `TestReaderWriter` writes and deletes are notified to `FakeWatcher`.
 - `TestReaderWriter` tracks `assetsWritten`.
 - Support checks on reader state after a build action in `resolveSources`.
+
+Versions:
+
+- Bump the min SDK to 3.7.0.
+- Use `build_runner_core` 9.0.0.
+
+Internal changes:
+
 - Start using `package:build/src/internal.dart`.
 - Refactor `BuildCacheReader` to `BuildCacheAssetPathProvider`.
 - Refactor `FileBasedAssetReader` and `FileBasedAssetWriter` to `ReaderWriter`.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.0.0-wip
+version: 3.0.0
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -9,10 +9,10 @@ environment:
 
 dependencies:
   async: ^2.5.0
-  build: ^2.4.3-wip
+  build: ^2.5.0
   build_config: ^1.0.0
-  build_resolvers: ^2.4.0
-  build_runner_core: ^9.0.0-wip
+  build_resolvers: ^2.5.0
+  build_runner_core: ^9.0.0
   convert: ^3.0.0
   crypto: ^3.0.0
   glob: ^2.0.0

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -30,7 +30,7 @@ dev_dependencies:
   b:
     path: ../build_modules/test/fixtures/b
   build_runner: ^2.0.0
-  build_test: ^3.0.0-wip
+  build_test: ^3.0.0
   c:
     path: test/fixtures/c
   d:


### PR DESCRIPTION
The four core packages

`build`
`build_resolvers`
`build_runner_core`
`build_runner`

now form a dependency cycle due to extra "internal" dependencies adding during the refactoring, I'll want to entangle that at some point :) perhaps by merging packages, not sure yet.

For now I'll instead treat them as a single unit: I add exact deps between them and will version+release them together.