### PR TITLE
Update markdown link checker.

### DIFF
--- a/.github/workflows/markdown_linter.yml
+++ b/.github/workflows/markdown_linter.yml
@@ -12,4 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-      - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368
+      - uses: tcort/github-action-markdown-link-check@75e8eff79b17a74255f5d39b8e8fe66b9ce891f6
+        with:
+          use-quiet-mode: 'yes'
+          config-file: 'mlc_config.json'

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,3 @@
+{
+  "aliveStatusCodes": [429, 200]
+}

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -962,7 +962,7 @@ also work when you create an output directory.
 
 - Switch to use a `PollingDirectoryWatcher` on windows, which should fix file
   watching with the `--output` option. Follow along at
-  https://github.com/dart-lang/watcher/issues/52 for more details.
+  https://github.com/dart-lang/tools/issues/1713 for more details.
 
 ## 0.7.11
 

--- a/docs/build_yaml_format.md
+++ b/docs/build_yaml_format.md
@@ -13,7 +13,7 @@ key                      | value                                                
 targets                  | Map<String, [BuildTarget](#buildtarget)>                                   | a single target with the same name as the package
 builders                 | Map<String, [BuilderDefinition](#builderdefinition)>                       | empty
 post_process_builders    | Map<String, [PostProcessBuilderDefinition](#postprocessbuilderdefinition)> | empty
-global_options           | Map<String, [GlobalBuilderOptions](#globalBuilderOptions)>                 | empty
+global_options           | Map<String, [GlobalBuilderOptions](#globalbuilderoptions)>                 | empty
 additional_public_assets | List<String>                                                               | empty
 
 ## BuildTarget


### PR DESCRIPTION
The current checker used is deprecated and points to this new one.

Which has a way of avoiding the flakiness we've been having with 429 responses :)

Fix a couple of links it complained about.