### PR TITLE
Glob escape testBuilder asset paths.

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1-wip
+
+- Bug fix: stop parsing `testBuilder` asset paths as globs.
+
 ## 3.1.0
 
 - Add `inputsTrackedFor` and `resolverEntrypointsTrackedFor` to

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -11,6 +11,7 @@ import 'package:build_resolvers/build_resolvers.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 // ignore: implementation_imports
 import 'package:build_runner_core/src/generate/build_series.dart';
+import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 import 'package:package_config/package_config.dart';
 import 'package:test/test.dart';
@@ -312,7 +313,7 @@ Future<TestBuilderResult> testBuilders(
                         r'web/$web$',
                         ...inputIds
                             .where((id) => id.package == package)
-                            .map((id) => id.path),
+                            .map((id) => Glob.quote(id.path)),
                       ],
                     },
                   },

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.1.0
+version: 3.1.1-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 

--- a/build_test/test/test_builder_test.dart
+++ b/build_test/test/test_builder_test.dart
@@ -356,6 +356,18 @@ Future<void> main() async {
       outputs: {'a|foo.out': 'new input'},
     );
   });
+
+  test('input paths are not parsed as globs', () {
+    return testBuilder(
+      TestBuilder(
+        buildExtensions: {
+          '.in': ['.out'],
+        },
+      ),
+      {'a|[.in': 'input'},
+      outputs: {'a|[.out': 'input'},
+    );
+  });
 }
 
 /// Concatenates the contents of multiple text files into a single output.


### PR DESCRIPTION
Another issue encountered in the `source_gen` tests, this time a new bug in `build_test`.