### PR TITLE
Add `readAllSourcesFromFilesystem` to `resolveSources`.

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,8 +1,11 @@
-## 3.1.2
+## 3.2.0
 
 - Fixes when passing a `readerWriter` to `testBuilders`: don't count initial
   assets as outputs; do set up packages for initial assets; only apply builders
   to packages mentioned in `sourceAssets`.
+- Add `readAllSourcesFromFilesystem` parameter to `resolveSources`. Set it to
+  `true` to make the method behave as it did in `build_test` 2.2.0.
+- Fix to `resolveSources` error handling.
 
 ## 3.1.1
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.1.2
+version: 3.2.0
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 

--- a/build_test/test/resolve_source_test.dart
+++ b/build_test/test/resolve_source_test.dart
@@ -141,6 +141,27 @@ void main() {
         ),
       );
     });
+
+    test('all sources from real filesystem', () async {
+      await resolveSource(
+        r'''
+        library example;
+
+        import 'package:collection/collection.dart';
+
+        abstract class Foo implements Equality {}
+      ''',
+        readAllSourcesFromFilesystem: true,
+        (resolver) async {
+          var libExample = await resolver.findLibraryNotNull('example');
+          var classFoo = libExample.getClass('Foo')!;
+          expect(
+            classFoo.allSupertypes.map(_toStringId),
+            contains(endsWith(':collection#Equality')),
+          );
+        },
+      );
+    });
   });
 
   group('should resolveAsset', () {


### PR DESCRIPTION
For the benefit of `source_gen_test` which relies on the old behaviour https://github.com/davidmorgan/source_gen_test.

And, tweak error handling: something totally incomprehensible to do with zones and error handling was making one `source_gen_test` test fail despite the exception being caught.