### PR TITLE
testBuilders default package setup.

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0-dev.2
+
+- Files loaded from disk for `resolveSources` and `testBuilders` that are in
+  the same package as explicitly-passed test inputs are now loaded if they
+  match the default globs, such as `lib/**`, instead of ignored. This more
+  closely matches version 2 behavior.
+
 ## 3.3.0-dev.1
 
 - Use `build` 3.0.0-dev.1.

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -11,6 +11,8 @@ import 'package:build_resolvers/build_resolvers.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 // ignore: implementation_imports
 import 'package:build_runner_core/src/generate/build_series.dart';
+// ignore: implementation_imports
+import 'package:build_runner_core/src/generate/options.dart';
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 import 'package:package_config/package_config.dart';
@@ -305,10 +307,10 @@ Future<TestBuilderResult> testBuilders(
     reportUnusedAssetsForInput: reportUnusedAssetsForInput,
     resolvers: resolvers,
     overrideBuildConfig:
-        // Override sources to all inputs, optionally restricted by
-        // [inputFilter] or [generateFor]. Or if [testingBuilderConfig] is
-        // false, use the defaults. These skip some files, for example
-        // picking up `lib/**` but not all files in the package root.
+        // Override sources to defaults plus all explicitly passed inputs,
+        // optionally restricted by [inputFilter] or [generateFor]. Or if
+        // [testingBuilderConfig] is false, use the defaults. These skip some
+        // files, for example picking up `lib/**` but not all files in the package root.
         testingBuilderConfig
             ? {
               for (final package in inputPackages)
@@ -320,6 +322,10 @@ Future<TestBuilderResult> testBuilders(
                         r'lib/$lib$',
                         r'test/$test$',
                         r'web/$web$',
+                        if (package == rootPackage)
+                          ...defaultRootPackageSources,
+                        if (package != rootPackage)
+                          ...defaultNonRootVisibleAssets,
                         ...inputIds
                             .where((id) => id.package == package)
                             .map((id) => Glob.quote(id.path)),

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.3.0-dev.1
+version: 3.3.0-dev.2
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 


### PR DESCRIPTION
Match old behavior better for the benefit of external package `expect_error`.

This is the first change that will need to be backported to release for element1, but let's land on main first.