### PR TITLE
Fix crash on incremental build after missing package resolve.

### DIFF
--- a/_test/pkgs/provides_builder/lib/builders.dart
+++ b/_test/pkgs/provides_builder/lib/builders.dart
@@ -25,9 +25,15 @@ class _SomeBuilder implements Builder {
   Future build(BuildStep buildStep) async {
     if (!await buildStep.canRead(buildStep.inputId)) return;
 
-    await buildStep.writeAsBytes(
+    final content = await buildStep.readAsString(buildStep.inputId);
+
+    if (content.contains('// resolve_me')) {
+      await buildStep.resolver.libraryFor(buildStep.inputId);
+    }
+
+    await buildStep.writeAsString(
       buildStep.inputId.changeExtension('.something.dart'),
-      buildStep.readAsBytes(buildStep.inputId),
+      content,
     );
   }
 }

--- a/_test/test/build_integration_test.dart
+++ b/_test/test/build_integration_test.dart
@@ -144,5 +144,23 @@ void main() {
         ]),
       );
     });
+
+    test('incremental build after resolve missing import', () async {
+      final dartSource = File(p.join('lib', 'app.dart'));
+      dartSource.writeAsStringSync(
+        // Trigger resolving source in pkgs/provides_builder/lib/builders.dart.
+        '// resolve_me\n'
+        // Resolve an import that does not exist.
+        "import 'package:missing/missing.dart';\n"
+        '${dartSource.readAsStringSync()}',
+      );
+      await runBuild();
+
+      // Rebuild and check the previously-missing import does not cause a crash.
+      dartSource.writeAsStringSync('//\n${dartSource.readAsStringSync()}');
+
+      final result = await runBuild();
+      expect(result.stdout, isNot(contains('PackageNotFoundException')));
+    });
   });
 }

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 9.2.0-wip
 
 - Removed unused dev_deps: `test_process`.
+- Bug fix: fix incremental build after build with import of missing package.
 
 ## 9.2.0-dev.1
 

--- a/build_runner_core/lib/src/generate/single_step_reader_writer.dart
+++ b/build_runner_core/lib/src/generate/single_step_reader_writer.dart
@@ -454,6 +454,8 @@ class SingleStepReaderWriter extends AssetReader
       // Add to the graph for input tracking.
       _runningBuild.assetGraph.add(AssetNode.missingSource(id));
       return PhasedValue.fixed('');
+    } else if (node.type == NodeType.missingSource) {
+      return PhasedValue.fixed('');
     }
 
     if (node.type == NodeType.generated) {


### PR DESCRIPTION
Bug noticed by me :)

Unfortunately this can only be caught by an e2e test: `TestReaderWriter` never throws `MissingPackageException`, so a missing file in another package hits the same codepath as any missing file.