### PR TITLE
Support testing builder factories.

### DIFF
--- a/build_runner_core/test/generate/build_test.dart
+++ b/build_runner_core/test/generate/build_test.dart
@@ -243,22 +243,19 @@ void main() {
       });
 
       test('with placeholder as input', () async {
-        await testPhases(
-          [
-            applyToRoot(
-              PlaceholderBuilder(
-                {'lib.txt': 'libText'}.build(),
-                inputPlaceholder: r'$lib$',
-              ),
-            ),
-            applyToRoot(
-              PlaceholderBuilder(
-                {'root.txt': 'rootText'}.build(),
-                inputPlaceholder: r'$package$',
-              ),
-            ),
-          ],
+        final builder1 = PlaceholderBuilder(
+          {'lib.txt': 'libText'}.build(),
+          inputPlaceholder: r'$lib$',
+        );
+        final builder2 = PlaceholderBuilder(
+          {'root.txt': 'rootText'}.build(),
+          inputPlaceholder: r'$package$',
+        );
+        await testBuilders(
+          [builder1, builder2],
           {},
+          visibleOutputBuilders: {builder1, builder2},
+          rootPackage: 'a',
           outputs: {'a|lib/lib.txt': 'libText', 'a|root.txt': 'rootText'},
         );
       });
@@ -1030,16 +1027,12 @@ targets:
     });
 
     test('can\'t read files in .dart_tool', () async {
-      await testPhases(
-        [
-          apply('', [
-            (_) => TestBuilder(
-              build: copyFrom(makeAssetId('a|.dart_tool/any_file')),
-            ),
-          ], toRoot()),
-        ],
-        {'a|lib/a.txt': 'a', 'a|.dart_tool/any_file': 'content'},
-        status: BuildStatus.failure,
+      expect(
+        (await testBuilders(
+          [TestBuilder(build: copyFrom(makeAssetId('a|.dart_tool/any_file')))],
+          {'a|lib/a.txt': 'a', 'a|.dart_tool/any_file': 'content'},
+        )).buildResult.status,
+        BuildStatus.failure,
       );
     });
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.4.0-wip
+
+- Add `testBuilderFactories`: like `testBuilders`, but provide the builder
+  factories instead of the builders. Use this to allow config read from
+  `build.yaml` to be passed in to the factory.
+- `TestBuilder` now accepts a `name`: this is the name that will be shown
+  in logging and can be used to refer to the builder in `build.yaml`.
+- More realistic test builds: in `resolveSources` and `testBuilders`, stop
+  builders reading from `.dart_tool`.
+- Bug fix: in `testBuilders`, configure the root package correctly when it
+  has no sources.
+
 ## 3.3.0
 
 - Read build configs using `AssetReader` so they're easier to test: you can now

--- a/build_test/lib/src/builder.dart
+++ b/build_test/lib/src/builder.dart
@@ -94,6 +94,7 @@ class TestBuilder implements Builder {
   @override
   final Map<String, List<String>> buildExtensions;
 
+  final String name;
   final BuildBehavior _build;
   final BuildBehavior? _extraWork;
 
@@ -109,14 +110,24 @@ class TestBuilder implements Builder {
   final _buildsCompletedController = StreamController<AssetId>.broadcast();
   Stream<AssetId> get buildsCompleted => _buildsCompletedController.stream;
 
+  /// A test [Builder].
+  ///
+  /// Runs for all inputs and write outputs with  `.copy` appended. Or, pass
+  /// [buildExtensions] to specify input and output extensions.
+  ///
+  /// Copy its input to all possible outputs. Pass [build] to replace this
+  /// behavior, and/or [extraWork] to add additional behavior.
+  ///
+  /// Default name for logging and for `build.yaml` is `TestBuilder`. Pass
+  /// [name] to set the name.
   TestBuilder({
     Map<String, List<String>>? buildExtensions,
     BuildBehavior? build,
     BuildBehavior? extraWork,
+    this.name = 'TestBuilder',
   }) : buildExtensions = buildExtensions ?? appendExtension('.copy'),
        _build = build ?? _defaultBehavior,
        _extraWork = extraWork;
-
   @override
   Future build(BuildStep buildStep) async {
     if (!await buildStep.canRead(buildStep.inputId)) return;
@@ -125,4 +136,7 @@ class TestBuilder implements Builder {
     await _extraWork?.call(buildStep, buildExtensions);
     _buildsCompletedController.add(buildStep.inputId);
   }
+
+  @override
+  String toString() => name;
 }

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.3.0
+version: 3.4.0-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 


### PR DESCRIPTION
Improvements to `build_test` so I can test #4084, and a few bug fixes for minor issues discovered along the way.

I plan to replace most use of the private `testPhases` with the methods from `build_test`, improving them as needed. There are a lot of tests to update, though, so in this PR just update 1-2 tests to cover the `build_test` fixes and new functionality.