### PR TITLE
Remove unused field, fix LruCache.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1-wip
+
+- Small improvements to RAM usage.
+
 ## 3.0.0
 
 - Removed unused deps: `meta`, `pool`.

--- a/build/lib/src/library_cycle_graph/library_cycle_graph_loader.dart
+++ b/build/lib/src/library_cycle_graph/library_cycle_graph_loader.dart
@@ -73,8 +73,6 @@ class LibraryCycleGraphLoader {
   /// for its sorting, so earlier phases are processed first in [_nextIdToLoad].
   final SplayTreeMap<int, List<AssetId>> _idsToLoad = SplayTreeMap();
 
-  final List<(int, AssetId)> _loadingIds = [];
-
   /// All loaded library cycles, by asset.
   final Map<AssetId, PhasedValue<LibraryCycle>> _cycles = {};
 
@@ -136,7 +134,6 @@ class LibraryCycleGraphLoader {
     // Return the last ID from the list of IDs at this phase because it's
     // cheapest to remove in `_removeIdToLoad`.
     final result = first.value.last;
-    _loadingIds.add((first.key, result));
     return (first.key, result);
   }
 

--- a/build/lib/src/state/lru_cache.dart
+++ b/build/lib/src/state/lru_cache.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+
 /// A basic LRU Cache.
 class LruCache<K, V> {
   _Entry<K, V>? _head;
@@ -55,13 +57,15 @@ class LruCache<K, V> {
     _currentWeightTotal -= entry.weight;
     _entries.remove(key);
 
+    // Remove from linked list.
+    entry.previous?.next = entry.next;
+    entry.next?.previous = entry.previous;
+
     if (entry == _tail) {
       _tail = entry.next;
-      _tail?.previous = null;
     }
     if (entry == _head) {
       _head = entry.previous;
-      _head?.next = null;
     }
 
     return entry.value;
@@ -75,18 +79,26 @@ class LruCache<K, V> {
       _tail = link.next;
     }
 
-    if (link.previous != null) {
-      link.previous!.next = link.next;
-    }
-    if (link.next != null) {
-      link.next!.previous = link.previous;
-    }
+    // Remove from linked list.
+    link.previous?.next = link.next;
+    link.next?.previous = link.previous;
 
     _head?.next = link;
     link.previous = _head;
     _head = link;
     _tail ??= link;
     link.next = null;
+  }
+
+  @visibleForTesting
+  int get linkedListLength {
+    var result = 0;
+    var current = _head;
+    while (current != null) {
+      ++result;
+      current = current.previous;
+    }
+    return result;
   }
 }
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 3.0.0
+version: 3.0.1-wip
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: '>=7.4.0 <8.0.0'
   async: ^2.5.0
-  build_runner_core: '9.2.0'
+  build_runner_core: '9.2.1-wip'
   built_collection: ^5.1.1
   built_value: ^8.9.5
   convert: ^3.0.0
@@ -18,6 +18,7 @@ dependencies:
   glob: ^2.0.0
   graphs: ^2.2.0
   logging: ^1.0.0
+  meta: ^1.17.0
   package_config: ^2.1.0
   path: ^1.8.0
 

--- a/build/test/state/lru_cache_test.dart
+++ b/build/test/state/lru_cache_test.dart
@@ -120,4 +120,36 @@ void main() {
       expect(cache['$i'], maxIndividualWeight);
     }
   });
+
+  test('removes also remove from linked list', () {
+    cache['a'] = 1;
+    expect(cache.linkedListLength, 1);
+    cache.remove('a');
+    expect(cache.linkedListLength, 0);
+  });
+
+  test('removes also remove from middle of linked list', () {
+    cache['a'] = 1;
+    cache['b'] = 1;
+    cache['c'] = 1;
+    expect(cache.linkedListLength, 3);
+    cache.remove('b');
+    expect(cache.linkedListLength, 2);
+  });
+
+  test('updates remove old from linked list', () {
+    cache['a'] = 1;
+    expect(cache.linkedListLength, 1);
+    cache['a'] = 2;
+    expect(cache.linkedListLength, 1);
+  });
+
+  test('updates remove old from middle of linked list', () {
+    cache['a'] = 1;
+    cache['b'] = 1;
+    cache['c'] = 1;
+    expect(cache.linkedListLength, 3);
+    cache['b'] = 2;
+    expect(cache.linkedListLength, 3);
+  });
 }

--- a/build_resolvers/CHANGELOG.md
+++ b/build_resolvers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1-wip
+
+- Use `build` 3.0.1.
+
 ## 3.0.0
 
 - Remove unused deps: `graphs`, `logging`, `stream_transform`.

--- a/build_resolvers/pubspec.yaml
+++ b/build_resolvers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_resolvers
-version: 3.0.0
+version: 3.0.1-wip
 description: Resolve Dart code in a Builder
 repository: https://github.com/dart-lang/build/tree/master/build_resolvers
 resolution: workspace
@@ -10,8 +10,8 @@ environment:
 dependencies:
   analyzer: '>=7.4.0 <8.0.0'
   async: ^2.5.0
-  build: '3.0.0'
-  build_runner_core: '9.2.0'
+  build: '3.0.1-wip'
+  build_runner_core: '9.2.1-wip'
   collection: ^1.17.0
   convert: ^3.1.1
   crypto: ^3.0.0

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1-wip
+
+- Use `build` 3.0.1.
+
 ## 2.6.0
 
 - Remove unused deps: `analyzer`, `build_resolvers`, `collection`, `http`,

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.6.0
+version: 2.6.1-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace
@@ -15,10 +15,10 @@ platforms:
 dependencies:
   args: ^2.0.0
   async: ^2.5.0
-  build: '3.0.0'
+  build: '3.0.1-wip'
   build_config: ">=1.1.0 <1.2.0"
   build_daemon: ^4.0.0
-  build_runner_core: '9.2.0'
+  build_runner_core: '9.2.1-wip'
   code_builder: ^4.2.0
   crypto: ^3.0.0
   dart_style: '>=2.3.7 <4.0.0'

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.2.1-wip
+
+- Use `build` 3.0.1.
+
 ## 9.2.0
 
 - Removed unused dev_deps: `test_process`.

--- a/build_runner_core/pubspec.yaml
+++ b/build_runner_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner_core
-version: 9.2.0
+version: 9.2.1-wip
 description: Core tools to organize the structure of a build and run Builders.
 repository: https://github.com/dart-lang/build/tree/master/build_runner_core
 resolution: workspace
@@ -15,10 +15,10 @@ platforms:
 dependencies:
   analyzer: '>=6.9.0 <8.0.0'
   async: ^2.5.0
-  build: '3.0.0'
+  build: '3.0.1-wip'
   build_config: ^1.0.0
-  build_resolvers: '3.0.0'
-  build_runner: '2.6.0'
+  build_resolvers: '3.0.1-wip'
+  build_runner: '2.6.1-wip'
   built_collection: ^5.1.1
   built_value: ^8.10.1
   collection: ^1.15.0

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.1-wip
+
+- Use `build` 3.0.1.
+
 ## 3.3.0
 
 - Read build configs using `AssetReader` so they're easier to test: you can now

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.3.0
+version: 3.3.1-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -8,10 +8,10 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  build: '3.0.0'
+  build: '3.0.1-wip'
   build_config: ^1.0.0
-  build_resolvers: '3.0.0'
-  build_runner_core: '9.2.0'
+  build_resolvers: '3.0.1-wip'
+  build_runner_core: '9.2.1-wip'
   crypto: ^3.0.0
   glob: ^2.0.0
   html: ^0.15.0

--- a/tool/leak_check.sh
+++ b/tool/leak_check.sh
@@ -14,9 +14,9 @@ fi
 dart test/invalidation/invalidation_leak_checker.dart setup
 
 leak_amount=$(dart test/invalidation/invalidation_leak_checker.dart)
-leak_limit=60000
+leak_limit=15000
 
-if test $((leak_amount)) -gt 60000; then
+if test $((leak_amount)) -gt "$leak_limit"; then
   echo "Measured leak size $leak_amount > $leak_limit, failing!"
   exit 1
 else
@@ -30,4 +30,7 @@ fi
 #   52455, 52332, 52308
 #
 # Initial check-in with https://dart-review.googlesource.com/c/sdk/+/441740:
-#  21482, 11568, 13186
+#   21482, 11568, 13186
+#
+# After `build_runner` leak fixes and analyzer 7.7.1 with 441740:
+#   13147, 12515, 13320


### PR DESCRIPTION
For #4025.

The field `_loadingIds` is unused, remove it. This was wasting some RAM but not actually a leak as the enclosing class gets discarded/recreated every build.

`LruCache` maintains both a map ID->Entry and a linked list of entries. On remove, it was removing from the map but not from the list. This would cause the data to be retained longer than necessary, but only up to the max size of the cache, so it's not a full leak. It's anyway not measurable in the leak test because files are stored in RAM for testing so they are retained whether or not they are in the cache.

Update the max leak size in the leak test, as the latest analyzer version fixed the leak to do with analyzer integration.

I ran several thousand builds in watch mode with this version and don't see anything else that needs fixing; the resident size ended up larger than I'd like (~4.5GB) but the retained size was still small, under 1GB. Maybe that's something we can still improve but if so I guess it should be after moving to AOT compilation. 