### PR TITLE
Fix delete of transitive stale outputs.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Remove interactive prompts for whether to delete files.
 - Ignore `-d` flag: always delete files as if `-d` was passed.
 - Documentation revamp.
+- Bug fix: delete transitive generated outputs as well as direct generated
+  outputs. So, a generated file now gets deleted if its input was a generated
+  file that is no longer output.
 
 ## 2.6.1
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Add support for build.yaml `triggers`. See `build_runner` 2.7.0 for usage.
 - Remove interactive prompts for whether to delete files.
 - Ignore `-d` flag: always delete files as if `-d` was passed.
+- Bug fix: delete transitive generated outputs as well as direct generated
+  outputs. So, a generated file now gets deleted if its input was a generated
+  file that is no longer output.
 
 ## 9.2.1
 

--- a/build_runner_core/lib/src/generate/build.dart
+++ b/build_runner_core/lib/src/generate/build.dart
@@ -784,8 +784,6 @@ class Build {
   void _markOutputsSkipped(Iterable<AssetId> outputs) {
     for (final output in outputs) {
       assetGraph.updateNode(output, (nodeBuilder) {
-        // TODO(davidmorgan): deleting the file here may be the fix for
-        // https://github.com/dart-lang/build/issues/3875.
         nodeBuilder.digest = null;
         nodeBuilder.generatedNodeState.result = null;
       });
@@ -797,8 +795,6 @@ class Build {
   Future<void> _markOutputsTransitivelyFailed(Iterable<AssetId> outputs) async {
     for (final output in outputs) {
       assetGraph.updateNode(output, (nodeBuilder) {
-        // TODO(davidmorgan): deleting the file here may be the fix for
-        // https://github.com/dart-lang/build/issues/3875.
         nodeBuilder.digest = null;
         nodeBuilder.generatedNodeState.result = false;
         nodeBuilder.generatedNodeState.errors.clear();
@@ -830,6 +826,7 @@ class Build {
       // If the primary input has been deleted, the build is skipped.
       if (deletedAssets.contains(primaryInput)) {
         if (primaryInputNode.type == NodeType.missingSource) {
+          await _cleanUpStaleOutputs(outputs);
           _markOutputsSkipped(outputs);
           return false;
         }
@@ -846,6 +843,7 @@ class Build {
         // If the primary input succeeded but was not output, this build is
         // skipped.
         if (!primaryInputNode.wasOutput) {
+          await _cleanUpStaleOutputs(outputs);
           _markOutputsSkipped(outputs);
           return false;
         }

--- a/build_runner_core/test/invalidation/primary_input_invalidation_test.dart
+++ b/build_runner_core/test/invalidation/primary_input_invalidation_test.dart
@@ -170,13 +170,7 @@ void main() {
     test('change a, on rebuild a.1 is not output, a.2 is deleted', () async {
       expect(await tester.build(), Result(written: ['a.1', 'a.2']));
       tester.skipOutput('a.1');
-      expect(
-        await tester.build(change: 'a'),
-        // TODO(davidmorgan): this would be the correct result, see
-        // https://github.com/dart-lang/build/issues/3875.
-        // Result(deleted: ['a.1', 'a.2']),
-        Result(deleted: ['a.1']),
-      );
+      expect(await tester.build(change: 'a'), Result(deleted: ['a.1', 'a.2']));
     });
   });
 
@@ -221,13 +215,7 @@ void main() {
     test('change a, on rebuild a.1 is not output, a.2 is deleted', () async {
       expect(await tester.build(), Result(written: ['a.1', 'a.2']));
       tester.skipOutput('a.1');
-      expect(
-        await tester.build(change: 'a'),
-        // TODO(davidmorgan): this would be the correct result, see
-        // https://github.com/dart-lang/build/issues/3875.
-        // Result(deleted: ['a.1', 'a.2']),
-        Result(deleted: ['a.1']),
-      );
+      expect(await tester.build(change: 'a'), Result(deleted: ['a.1', 'a.2']));
     });
   });
 
@@ -355,10 +343,7 @@ void main() {
       tester.skipOutput('a.2');
       expect(
         await tester.build(change: 'a'),
-        // TODO(davidmorgan): this would be the correct result, see
-        // https://github.com/dart-lang/build/issues/3875.
-        // Result(written: ['a.1'], deleted: ['a.2', 'a.3', 'a.4']),
-        Result(written: ['a.1'], deleted: ['a.2']),
+        Result(written: ['a.1'], deleted: ['a.2', 'a.3', 'a.4']),
       );
     });
   });


### PR DESCRIPTION
Fix #3875.

This was already clear in the tests added during the refactor, so the fix turns out to be straightforward. With any luck :)