### PR TITLE
Remove --use-polling-watcher flag.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -7,6 +7,7 @@
   for more information.
 - Remove interactive prompts for whether to delete files.
 - Ignore `-d` flag: always delete files as if `-d` was passed.
+- Remove `--use-polling-watcher` flag.
 - Documentation revamp.
 
 ## 2.6.1

--- a/build_runner/lib/src/entrypoint/options.dart
+++ b/build_runner/lib/src/entrypoint/options.dart
@@ -11,9 +11,6 @@ import 'package:build_config/build_config.dart';
 import 'package:build_daemon/constants.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:path/path.dart' as p;
-import 'package:watcher/watcher.dart';
-
-import '../generate/directory_watcher_factory.dart';
 
 const buildFilterOption = 'build-filter';
 const configOption = 'config';
@@ -31,7 +28,6 @@ const releaseOption = 'release';
 const trackPerformanceOption = 'track-performance';
 const skipBuildScriptCheckOption = 'skip-build-script-check';
 const symlinkOption = 'symlink';
-const usePollingWatcherOption = 'use-polling-watcher';
 const verboseOption = 'verbose';
 
 enum BuildUpdatesOption { none, liveReload }
@@ -141,7 +137,6 @@ class DaemonOptions extends WatchOptions {
     required super.builderConfigOverrides,
     required super.isReleaseBuild,
     required super.logPerformanceDir,
-    required super.usePollingWatcher,
     required super.enableExperiments,
   }) : super._();
 
@@ -187,22 +182,13 @@ class DaemonOptions extends WatchOptions {
       ),
       isReleaseBuild: argResults[releaseOption] as bool,
       logPerformanceDir: argResults[logPerformanceOption] as String?,
-      usePollingWatcher: argResults[usePollingWatcherOption] as bool,
       enableExperiments: argResults[enableExperimentOption] as List<String>,
     );
   }
 }
 
 class WatchOptions extends SharedOptions {
-  final bool usePollingWatcher;
-
-  DirectoryWatcher Function(String) get directoryWatcherFactory =>
-      usePollingWatcher
-          ? pollingDirectoryWatcherFactory
-          : defaultDirectoryWatcherFactory;
-
   WatchOptions._({
-    required this.usePollingWatcher,
     required super.buildFilters,
     required super.enableLowResourcesMode,
     required super.configKey,
@@ -240,7 +226,6 @@ class WatchOptions extends SharedOptions {
         ),
         isReleaseBuild: argResults[releaseOption] as bool,
         logPerformanceDir: argResults[logPerformanceOption] as String?,
-        usePollingWatcher: argResults[usePollingWatcherOption] as bool,
         enableExperiments: argResults[enableExperimentOption] as List<String>,
       );
 }
@@ -268,7 +253,6 @@ class ServeOptions extends WatchOptions {
     required super.builderConfigOverrides,
     required super.isReleaseBuild,
     required super.logPerformanceDir,
-    required super.usePollingWatcher,
     required super.enableExperiments,
   }) : super._();
 
@@ -349,7 +333,6 @@ class ServeOptions extends WatchOptions {
       ),
       isReleaseBuild: argResults[releaseOption] as bool,
       logPerformanceDir: argResults[logPerformanceOption] as String?,
-      usePollingWatcher: argResults[usePollingWatcherOption] as bool,
       enableExperiments: argResults[enableExperimentOption] as List<String>,
     );
   }

--- a/build_runner/lib/src/entrypoint/serve.dart
+++ b/build_runner/lib/src/entrypoint/serve.dart
@@ -115,7 +115,6 @@ class ServeCommand extends WatchCommand {
       builderConfigOverrides: options.builderConfigOverrides,
       isReleaseBuild: options.isReleaseBuild,
       logPerformanceDir: options.logPerformanceDir,
-      directoryWatcherFactory: options.directoryWatcherFactory,
       buildFilters: options.buildFilters,
     );
 

--- a/build_runner/lib/src/entrypoint/watch.dart
+++ b/build_runner/lib/src/entrypoint/watch.dart
@@ -27,17 +27,6 @@ class WatchCommand extends BuildRunnerCommand {
       'Builds the specified targets, watching the file system for updates and '
       'rebuilding as appropriate.';
 
-  WatchCommand() {
-    argParser.addFlag(
-      usePollingWatcherOption,
-      help:
-          'Use a polling watcher instead of the current platforms default '
-          'watcher implementation. This should generally only be used if '
-          'you are having problems with the default watcher, as it is '
-          'generally less efficient.',
-    );
-  }
-
   @override
   WatchOptions readOptions() => WatchOptions.fromParsedArgs(
     argResults!,
@@ -73,7 +62,6 @@ class WatchCommand extends BuildRunnerCommand {
       builderConfigOverrides: options.builderConfigOverrides,
       isReleaseBuild: options.isReleaseBuild,
       logPerformanceDir: options.logPerformanceDir,
-      directoryWatcherFactory: options.directoryWatcherFactory,
       buildFilters: options.buildFilters,
     );
 

--- a/build_runner/lib/src/generate/build.dart
+++ b/build_runner/lib/src/generate/build.dart
@@ -9,7 +9,6 @@ import 'package:build/build.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
-import 'package:watcher/watcher.dart';
 
 import '../package_graph/build_config_overrides.dart';
 import '../server/server.dart';
@@ -136,9 +135,6 @@ Future<BuildResult> build(
 /// keep changing with less than that amount of time apart, builds will be put
 /// off.
 ///
-/// The [directoryWatcherFactory] allows you to inject a way of creating custom
-/// `DirectoryWatcher`s. By default a normal `DirectoryWatcher` will be used.
-///
 /// The [terminateEventStream] is a stream which can send termination events.
 /// By default the [ProcessSignal.sigint] stream is used. In this mode, the
 /// first event will allow any ongoing builds to finish, and then the program
@@ -156,7 +152,6 @@ Future<ServeHandler> watch(
   Level? logLevel,
   void Function(LogRecord)? onLog,
   Duration? debounceDelay,
-  required DirectoryWatcher Function(String) directoryWatcherFactory,
   Stream<ProcessSignal>? terminateEventStream,
   bool? enableLowResourcesMode,
   Set<BuildDirectory>? buildDirs,
@@ -177,7 +172,6 @@ Future<ServeHandler> watch(
   resolvers: resolvers,
   onLog: onLog,
   debounceDelay: debounceDelay,
-  directoryWatcherFactory: directoryWatcherFactory,
   terminateEventStream: terminateEventStream,
   enableLowResourcesMode: enableLowResourcesMode,
   buildDirs: buildDirs,

--- a/build_runner/lib/src/generate/watch_impl.dart
+++ b/build_runner/lib/src/generate/watch_impl.dart
@@ -38,7 +38,7 @@ Future<ServeHandler> watch(
   Resolvers? resolvers,
   void Function(LogRecord)? onLog,
   Duration? debounceDelay,
-  required DirectoryWatcher Function(String) directoryWatcherFactory,
+  DirectoryWatcher Function(String)? directoryWatcherFactory,
   Stream<ProcessSignal>? terminateEventStream,
   bool? skipBuildScriptCheck,
   bool? enableLowResourcesMode,
@@ -129,7 +129,7 @@ WatchImpl _runWatch(
   List<BuilderApplication> builders,
   Map<String, Map<String, dynamic>> builderConfigOverrides,
   Future until,
-  DirectoryWatcher Function(String) directoryWatcherFactory,
+  DirectoryWatcher Function(String)? directoryWatcherFactory,
   String? configKey,
   bool willCreateOutputDirs,
   Set<BuildDirectory> buildDirs,
@@ -160,7 +160,7 @@ class WatchImpl implements BuildState {
   final Duration _debounceDelay;
 
   /// Injectable factory for creating directory watchers.
-  final DirectoryWatcher Function(String) _directoryWatcherFactory;
+  final DirectoryWatcher Function(String)? _directoryWatcherFactory;
 
   /// Whether or not we will be creating any output directories.
   ///

--- a/build_runner/lib/src/watcher/graph_watcher.dart
+++ b/build_runner/lib/src/watcher/graph_watcher.dart
@@ -54,11 +54,7 @@ class PackageGraphWatcher {
               ) {
                 buildLog.error(
                   buildLog.renderThrowable(
-                    'Error from directory watcher for '
-                    'package:${w.node.name}\n\n'
-                    'If you see this consistently then it is recommended that '
-                    'you enable the polling file watcher with '
-                    '--use-polling-watcher.',
+                    'Failed to watch files in package:${w.node.name}.',
                     e,
                   ),
                 );


### PR DESCRIPTION
I couldn't find mentions of this being needed for years; I guess the non-polling watchers are good enough.

If there _is_ still an issue it would make more sense to automatically fall back to polling than to ask people to pass a flag.