### PR TITLE
Fix crash creating a merged output dir with a file called `lib`.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Bug fix: delete transitive generated outputs as well as direct generated
   outputs. So, a generated file now gets deleted if its input was a generated
   file that is no longer output.
+- Bug fix: fix crash creating a merged output dir with a file called `lib`.
 
 ## 2.6.1
 

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bug fix: delete transitive generated outputs as well as direct generated
   outputs. So, a generated file now gets deleted if its input was a generated
   file that is no longer output.
+- Bug fix: fix crash creating a merged output dir with a file called `lib`.
 
 ## 9.2.1
 

--- a/build_runner_core/test/environment/create_merged_dir_test.dart
+++ b/build_runner_core/test/environment/create_merged_dir_test.dart
@@ -36,6 +36,8 @@ void main() {
     final sources = {
       makeAssetId('a|lib/a.txt'): 'a',
       makeAssetId('a|web/b.txt'): 'b',
+      // Regression test for https://github.com/dart-lang/build/issues/4135.
+      makeAssetId('a|web/lib.txt'): 'lib',
       makeAssetId('b|lib/c.txt'): 'c',
       makeAssetId('b|test/outside.txt'): 'not in lib',
       makeAssetId('a|foo/d.txt'): 'd',


### PR DESCRIPTION
Fix #4135.

The code was converting paths with `lib/` to "packages/<package name>" layout twice, the second time it matched on "lib" instead of "lib/" which would catch files _named_ "lib" instead of just in a folder called "lib".

Remove the duplication, simplify by using strings instead of AssetId for the output paths.