### PR TITLE
Remove links to deleted FAQ entries.

### DIFF
--- a/build_runner_core/lib/src/asset_graph/exceptions.dart
+++ b/build_runner_core/lib/src/asset_graph/exceptions.dart
@@ -7,23 +7,19 @@ import 'package:build/build.dart';
 class DuplicateAssetNodeException implements Exception {
   final String rootPackage;
   final AssetId assetId;
-  final String initialBuilderLabel;
-  final String newBuilderLabel;
+  final String builder1;
+  final String builder2;
 
   DuplicateAssetNodeException(
     this.rootPackage,
     this.assetId,
-    this.initialBuilderLabel,
-    this.newBuilderLabel,
+    this.builder1,
+    this.builder2,
   );
   @override
   String toString() {
-    final friendlyAsset =
-        assetId.package == rootPackage ? assetId.path : assetId.uri;
-    return 'Both $initialBuilderLabel and $newBuilderLabel may output '
-        '$friendlyAsset. Potential outputs must be unique across all builders. '
-        'See https://github.com/dart-lang/build/blob/master/docs/faq.md'
-        '#why-do-builders-need-unique-outputs';
+    final id = assetId.package == rootPackage ? assetId.path : assetId.uri;
+    return 'Builders $builder1 and $builder2 outputs collide: $id';
   }
 }
 

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -70,8 +70,6 @@ Skipping compiling ${buildStep.inputId} with dart2js because some of its
 transitive libraries have sdk dependencies that are not supported on this platform:
 
 $librariesString
-
-https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-skipped-compiling-warnings
 ''');
       return;
     }

--- a/build_web_compilers/lib/src/dart2wasm_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2wasm_bootstrap.dart
@@ -91,8 +91,6 @@ Skipping compiling ${buildStep.inputId} with dart2wasm because some of its
 transitive libraries have sdk dependencies that are not supported on this platform:
 
 $librariesString
-
-https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-skipped-compiling-warnings
 ''');
       return const Dart2WasmBootstrapResult.didNotCompile();
     }

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -62,8 +62,6 @@ Skipping compiling ${buildStep.inputId} with ddc because some of its
 transitive libraries have sdk dependencies that not supported on this platform:
 
 $librariesString
-
-https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-skipped-compiling-warnings
 ''');
     return;
   }


### PR DESCRIPTION
Fix #4138 

The "output collision" issue does not happen with widely-used builders as they all use their own extension or use `source_gen` shared part builder.