### PR TITLE
Tweak warnings errors

### DIFF
--- a/build_runner_core/lib/src/generate/build_definition.dart
+++ b/build_runner_core/lib/src/generate/build_definition.dart
@@ -212,11 +212,6 @@ class _Loader {
     RunnerAssetWriter writer,
   ) async {
     if (conflictingAssets.isEmpty) return;
-
-    buildLog.info(
-      'Deleting ${conflictingAssets.length} declared outputs '
-      'which already existed on disk.',
-    );
     await Future.wait(conflictingAssets.map((id) => writer.delete(id)));
   }
 }

--- a/build_runner_core/lib/src/logging/ansi_buffer.dart
+++ b/build_runner_core/lib/src/logging/ansi_buffer.dart
@@ -14,6 +14,7 @@ class AnsiBuffer {
   static const String nbsp = '\u00A0';
   static const reset = '\x1B[0m';
   static const bold = '\x1B[1m';
+  static const boldRed = '\x1B[1;31m';
   static const _nbspCodeUnit = 0xA0;
   static const _spaceCodeUnit = 32;
 
@@ -127,7 +128,7 @@ class AnsiBuffer {
 
   /// Removes all ANSI constants from [string], for testing.
   static String removeAnsi(String string) =>
-      string.replaceAll(reset, '').replaceAll(bold, '');
+      string.replaceAll(reset, '').replaceAll(bold, '').replaceAll(boldRed, '');
 }
 
 /// A line for writing to an [AnsiBuffer].
@@ -167,7 +168,9 @@ class AnsiBufferLine {
 }
 
 bool _isAnsi(String item) =>
-    item == AnsiBuffer.reset || item == AnsiBuffer.bold;
+    item == AnsiBuffer.reset ||
+    item == AnsiBuffer.bold ||
+    item == AnsiBuffer.boldRed;
 
 bool get _showingAnsi =>
     buildLog.configuration.forceAnsiConsoleForTesting ??

--- a/build_runner_core/lib/src/logging/build_log.dart
+++ b/build_runner_core/lib/src/logging/build_log.dart
@@ -419,7 +419,11 @@ class BuildLog {
       _display.block(render());
       _display.flush();
     } else {
-      _display.message(Severity.info, _status.join(''));
+      _display.message(
+        Severity.info,
+        // Removes ANSI codes if necessary.
+        AnsiBufferLine(_status).toString(),
+      );
     }
   }
 
@@ -498,14 +502,22 @@ class BuildLog {
     if (displayedProgressEntries.isNotEmpty) {
       result.writeLine([]);
     }
+
+    final renderedMessages = _messages.render();
+    if (renderedMessages.warningLines.isNotEmpty) {
+      for (final line in renderedMessages.warningLines) {
+        result.write(line);
+      }
+      result.writeEmptyLine();
+    }
+
     if (_status.isNotEmpty) {
       result.writeLine(_status);
     }
 
-    final renderedMessages = _messages.render();
-    if (renderedMessages.isNotEmpty) {
+    if (renderedMessages.errorLines.isNotEmpty) {
       result.writeEmptyLine();
-      for (final line in renderedMessages) {
+      for (final line in renderedMessages.errorLines) {
         result.write(line);
       }
     }

--- a/build_runner_core/test/logging/build_log_console_mode_test.dart
+++ b/build_runner_core/test/logging/build_log_console_mode_test.dart
@@ -62,7 +62,7 @@ columns because it will not fit.'''),
         padLinesRight('''
 Some setup.
 
-log output for build_runner
+build_runner
   Some info.
 W A warning.
 W Another warning.
@@ -238,15 +238,16 @@ Building, full build.'''),
 0s builder1 on 10 inputs; pkg|lib/l0.dart
 0s builder2 on 15 inputs
 
-Building, full build.
-
-log output for builder1 on lib/l0.dart
+lib/l0.dart builder1
   Some info.
   Some more info.
-log output for builder2 on lib/l1.dart
+
+Building, full build.
+
+lib/l1.dart builder2
 W A warning.
 E An error.
-log output for builder2 on lib/l3.dart
+lib/l3.dart builder2
 E An error.'''),
       );
 
@@ -275,17 +276,18 @@ E An error.'''),
 0s builder2 on 15 inputs
 0s builder1 (lazy): 1 no-op
 
-Building, full build.
-
-log output for builder1 on lib/l0.dart
+lib/l0.dart builder1
   Some info.
   Some more info.
-log output for builder2 on lib/l1.dart
+
+Building, full build.
+
+lib/l1.dart builder2
 W A warning.
 E An error.
-log output for builder2 on lib/l3.dart
+lib/l3.dart builder2
 E An error.
-log output for builder1 (lazy) on lib/l3.dart
+lib/l3.dart builder1 (lazy)
 E An error.'''),
       );
     });
@@ -343,11 +345,12 @@ E An error.'''),
 0s builder1 on 1 input: 1 output
 0s builder2 on 1 input: 1 output
 
+lib/l0.dart builder1
+  Some info.
+
 Built with build_runner in 0s with warnings; wrote 2 outputs.
 
-log output for builder1 on lib/l0.dart
-  Some info.
-log output for builder2 on lib/l0.dart
+lib/l0.dart builder2
 W A warning.
 E An error.'''),
       );

--- a/build_runner_core/test/logging/build_log_messages_test.dart
+++ b/build_runner_core/test/logging/build_log_messages_test.dart
@@ -95,18 +95,21 @@ void main() {
         context: 'file1',
         severity: Severity.info,
       );
-      expect(messages.render().map((l) => l.toString()).toList(), [
-        'log output for phase1 on file1',
-        'E message1',
-        'W message3',
-        'log output for phase2 on file1',
+      final rendered = messages.render();
+      expect(rendered.warningLines.map((l) => l.toString()).toList(), [
+        'file1 phase2',
         '  message2',
         '  message6',
-        'log output for phase1 on file2',
+        'file2 phase1',
         '  message4',
-        'log output for build_runner',
+        'build_runner',
         'W message0',
         '  message5',
+      ]);
+      expect(rendered.errorLines.map((l) => l.toString()).toList(), [
+        'file1 phase1',
+        'E message1',
+        'W message3',
       ]);
     });
   });


### PR DESCRIPTION
For #4127 

Changes to make failures more prominent/actionable:

 - move blocks of log output that do _not_ contain errors before the status line; only errors go after the status line
 - remove "log output for" and "on" from the block header, move the filename first so it's "<filename> <builder>", and make the filename bold red if the block contains any error
 - make the "E" prefix that indicates an error bold red

And, remove the "deleting declared outputs" warning, it's not actionable.