### PR TITLE
Bootstrap cleanup.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Bug fix: with `build_runner serve`, special handling of paths containing
   `/packages/` was hiding actual folders called `packages`. Serve the actual
   folders first, before trying the package lookup.
+- Remove `build_script_generate.dart`.
 
 ## 2.7.0
 

--- a/build_runner/lib/build_script_generate.dart
+++ b/build_runner/lib/build_script_generate.dart
@@ -1,7 +1,0 @@
-// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
-export 'src/build_script_generate/bootstrap.dart' show generateAndRun;
-export 'src/build_script_generate/build_script_generate.dart'
-    show findBuilderApplications, generateBuildScript, scriptLocation;

--- a/build_runner/test/build_script_generate/bootstrap_test.dart
+++ b/build_runner/test/build_script_generate/bootstrap_test.dart
@@ -6,7 +6,7 @@ library;
 
 import 'dart:io';
 
-import 'package:build_runner/build_script_generate.dart';
+import 'package:build_runner/src/build_script_generate/bootstrap.dart';
 import 'package:build_runner/src/build_script_generate/build_process_state.dart';
 import 'package:build_runner/src/build_script_generate/build_script_generate.dart';
 import 'package:build_runner_core/build_runner_core.dart';
@@ -28,8 +28,7 @@ void main() {
     test('writes dill', () async {
       await generateAndRun(
         [],
-        generateBuildScript:
-            () async => '''
+        script: '''
 import 'dart:isolate';
 import 'package:build_runner/src/build_script_generate/build_process_state.dart';
 
@@ -55,9 +54,9 @@ void main(_, [SendPort? sendPort]) async {
 ''';
 
       buildProcessState.isolateExitCode = 6;
-      await generateAndRun([], generateBuildScript: () async => script);
+      await generateAndRun([], script: script);
       expect(buildProcessState.isolateExitCode, 7);
-      await generateAndRun([], generateBuildScript: () async => script);
+      await generateAndRun([], script: script);
       expect(buildProcessState.isolateExitCode, 8);
     });
 
@@ -65,8 +64,7 @@ void main(_, [SendPort? sendPort]) async {
       expect(
         await generateAndRun(
           [],
-          generateBuildScript:
-              () async => '''
+          script: '''
 import 'dart:isolate';
 import 'package:build_runner/src/build_script_generate/build_process_state.dart';
 
@@ -84,8 +82,7 @@ void main(_, [SendPort? sendPort]) async {
       expect(
         await generateAndRun(
           [],
-          generateBuildScript:
-              () async => '''
+          script: '''
 import 'dart:isolate';
 import 'package:build_runner/src/build_script_generate/build_process_state.dart';
 
@@ -109,8 +106,7 @@ void main(_, [SendPort? sendPort]) async {
         expect(
           await generateAndRun(
             [],
-            generateBuildScript:
-                () async => '''
+            script: '''
 import 'dart:isolate';
 import 'package:build_runner/src/build_script_generate/build_process_state.dart';
 
@@ -132,8 +128,7 @@ void main(_, [SendPort? sendPort]) async {
         expect(
           await generateAndRun(
             [],
-            generateBuildScript:
-                () async => '''
+            script: '''
 import 'dart:isolate';
 import 'package:build_runner/src/build_script_generate/build_process_state.dart';
 
@@ -148,35 +143,5 @@ void main(_, [SendPort? sendPort]) async {
         );
       },
     );
-
-    test('invokes custom error function', () async {
-      Object? error;
-      StackTrace? stackTrace;
-
-      await expectLater(
-        generateAndRun(
-          [],
-          generateBuildScript: () async {
-            return '''
-import 'dart:isolate';
-import 'package:build_runner/src/build_script_generate/build_process_state.dart';
-
-void main(_, [SendPort? sendPort]) async {
-  await buildProcessState.receive(sendPort);
-  throw 'expected error';
-}
-''';
-          },
-          handleUncaughtError: (err, trace) {
-            error = err;
-            stackTrace = trace;
-          },
-        ),
-        completion(1),
-      );
-
-      expect(error, 'expected error');
-      expect(stackTrace, isNotNull);
-    });
   });
 }

--- a/build_runner/test/build_script_generate/experiments_test.dart
+++ b/build_runner/test/build_script_generate/experiments_test.dart
@@ -6,7 +6,7 @@
 @TestOn('vm')
 library;
 
-import 'package:build_runner/build_script_generate.dart';
+import 'package:build_runner/src/build_script_generate/bootstrap.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
@@ -17,8 +17,7 @@ void main() {
     final exitCode = await generateAndRun(
       [],
       experiments: ['records'],
-      generateBuildScript: () async {
-        return '''
+      script: '''
               // @dart=3.0
               import 'dart:io';
               import 'dart:isolate';
@@ -30,8 +29,7 @@ void main() {
                 buildProcessState.isolateExitCode = (x.\$2);
                 buildProcessState.send(sendPort);
               }
-              ''';
-      },
+              ''',
       logger: logger,
     );
     expect(exitCode, 2);


### PR DESCRIPTION
For #3836

There doesn't seem to be any use of `build_script_generate.dart` in the wild ... two mentions on `pub` in discontinued packages ... so remove and simplify a bit.