### PR TITLE
Deprecations before `build` major version release.

### DIFF
--- a/_test_common/lib/runner_asset_writer_spy.dart
+++ b/_test_common/lib/runner_asset_writer_spy.dart
@@ -3,17 +3,35 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:build/build.dart';
 import 'package:build_runner_core/build_runner_core.dart';
 
-class RunnerAssetWriterSpy extends AssetWriterSpy implements RunnerAssetWriter {
+class RunnerAssetWriterSpy implements RunnerAssetWriter {
   final RunnerAssetWriter _delegate;
+  final _assetsWritten = <AssetId>{};
 
   final _assetsDeleted = <AssetId>{};
   Iterable<AssetId> get assetsDeleted => _assetsDeleted;
 
-  RunnerAssetWriterSpy(this._delegate) : super(_delegate);
+  RunnerAssetWriterSpy(this._delegate);
+
+  @override
+  Future<void> writeAsBytes(AssetId id, List<int> bytes) {
+    _assetsWritten.add(id);
+    return _delegate.writeAsBytes(id, bytes);
+  }
+
+  @override
+  Future<void> writeAsString(
+    AssetId id,
+    String contents, {
+    Encoding encoding = utf8,
+  }) {
+    _assetsWritten.add(id);
+    return _delegate.writeAsString(id, contents, encoding: encoding);
+  }
 
   @override
   Future<void> delete(AssetId id) {

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,11 +1,15 @@
 ## 3.0.3-wip
 
 - Deprecate `runBuilder`. It has been moved to `package:build_runner_core` and
-  will be deleted from `package:build`. Please note: the currently supported
+  will be removed from `package:build`. Please note: the currently supported
   ways to run builders are using `build_runner` on the command line or
   `build_test` in tests. If you need ongoing support for a different way to run
   builders please get in touch at
   https://github.com/dart-lang/build/discussions.
+- Deprecate `runPostProcessBuilder`. Like `runBuilder`, it has been moved to
+  `package:build_runner_core` and will be removed from `package:build`.
+- Deprecate `AssetWriterSpy`. It will be removed.
+- Deprecate `MultiplexingBuilder`. It will be removed.
 - Use `build_runner_core` 9.3.1.
 
 ## 3.0.2

--- a/build/lib/build.dart
+++ b/build/lib/build.dart
@@ -13,10 +13,9 @@ export 'src/builder/exceptions.dart';
 export 'src/builder/file_deleting_builder.dart' show FileDeletingBuilder;
 export 'src/builder/logging.dart' show log;
 export 'src/builder/multiplexing_builder.dart';
-export 'src/builder/post_process_build_step.dart' show PostProcessBuildStep;
-export 'src/builder/post_process_builder.dart'
-    show PostProcessBuilder, PostProcessBuilderFactory;
+export 'src/builder/post_process_build_step.dart';
+export 'src/builder/post_process_builder.dart';
 export 'src/generate/expected_outputs.dart';
 export 'src/generate/run_builder.dart';
-export 'src/generate/run_post_process_builder.dart' show runPostProcessBuilder;
+export 'src/generate/run_post_process_builder.dart';
 export 'src/resource/resource.dart';

--- a/build/lib/src/asset/writer.dart
+++ b/build/lib/src/asset/writer.dart
@@ -29,6 +29,7 @@ abstract class AssetWriter {
 }
 
 /// An [AssetWriter] which tracks all [assetsWritten] during its lifetime.
+@Deprecated('This class will be deleted without replacement in 4.0.0.')
 class AssetWriterSpy implements AssetWriter {
   final AssetWriter _delegate;
   final _assetsWritten = <AssetId>{};

--- a/build/lib/src/builder/build_step.dart
+++ b/build/lib/src/builder/build_step.dart
@@ -135,7 +135,3 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   /// [readAsBytes] or [readAsString].
   Future<PackageConfig> get packageConfig;
 }
-
-abstract class StageTracker {
-  T trackStage<T>(String label, T Function() action, {bool isExternal = false});
-}

--- a/build/lib/src/builder/multiplexing_builder.dart
+++ b/build/lib/src/builder/multiplexing_builder.dart
@@ -11,6 +11,7 @@ import 'builder.dart';
 /// **Note**: All builders are ran without ordering guarantees. Thus, none of
 /// the builders can use the outputs of other builders in this group. All
 /// builders must also have distinct outputs.
+@Deprecated('This class will be deleted without replacement in 4.0.0.')
 class MultiplexingBuilder implements Builder {
   final Iterable<Builder> _builders;
 

--- a/build/lib/src/generate/run_builder.dart
+++ b/build/lib/src/generate/run_builder.dart
@@ -12,13 +12,15 @@ import '../analyzer/resolver.dart';
 import '../asset/id.dart';
 import '../asset/reader.dart';
 import '../asset/writer.dart';
-import '../builder/build_step.dart';
 import '../builder/builder.dart';
 import '../resource/resource.dart';
 
+export 'package:build_runner_core/src/generate/run_builder.dart'
+    show StageTracker;
+
 @Deprecated('''
 This method has moved to `package:build_runner_core` and will be
-deleted from `package:build`.
+removed from `package:build` in 4.0.0.
 
 The currently supported ways to run builders are using `build_runner`
 on the command line or `build_test` in tests. If you need ongoing
@@ -33,7 +35,7 @@ Future<void> runBuilder(
   Resolvers? resolvers, {
   Logger? logger,
   ResourceManager? resourceManager,
-  StageTracker? stageTracker,
+  build_runner_core.StageTracker? stageTracker,
   void Function(AssetId input, Iterable<AssetId> assets)?
   reportUnusedAssetsForInput,
   PackageConfig? packageConfig,

--- a/build_runner_core/CHANGELOG.md
+++ b/build_runner_core/CHANGELOG.md
@@ -6,6 +6,7 @@
   `build_test` in tests. If you need ongoing support for a different way to run
   builders please get in touch at
   https://github.com/dart-lang/build/discussions.
+- Similarly, move `runPostProcessBuilder` to here from `package:build`.
 - Use `build_runner` 2.7.1.
 - Remove `overrideGeneratedOutputDirectory`, `pubBinary`.
 

--- a/build_runner_core/lib/src/generate/build.dart
+++ b/build_runner_core/lib/src/generate/build.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:build/build.dart' hide runBuilder;
+import 'package:build/build.dart' hide runBuilder, runPostProcessBuilder;
 import 'package:build_resolvers/build_resolvers.dart';
 // ignore: implementation_imports
 import 'package:build_resolvers/src/internal.dart';
@@ -46,6 +46,7 @@ import 'input_tracker.dart';
 import 'performance_tracker.dart';
 import 'phase.dart';
 import 'run_builder.dart';
+import 'run_post_process_builder.dart';
 import 'single_step_reader_writer.dart';
 
 /// A single build.

--- a/build_runner_core/lib/src/generate/post_process_build_step_impl.dart
+++ b/build_runner_core/lib/src/generate/post_process_build_step_impl.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:async/async.dart';
+import 'package:build/build.dart';
+import 'package:crypto/crypto.dart' show Digest;
+
+class PostProcessBuildStepImpl implements PostProcessBuildStep {
+  @override
+  final AssetId inputId;
+
+  final AssetReader _reader;
+  final AssetWriter _writer;
+  final void Function(AssetId) _addAsset;
+  final void Function(AssetId) _deleteAsset;
+
+  /// The result of any writes which are starting during this step.
+  final _writeResults = <Future<Result<void>>>[];
+
+  PostProcessBuildStepImpl(
+    this.inputId,
+    this._reader,
+    this._writer,
+    this._addAsset,
+    this._deleteAsset,
+  );
+
+  @override
+  Future<Digest> digest(AssetId id) =>
+      inputId == id
+          ? _reader.digest(id)
+          : Future.error(InvalidInputException(id));
+
+  @override
+  Future<List<int>> readInputAsBytes() => _reader.readAsBytes(inputId);
+
+  @override
+  Future<String> readInputAsString({Encoding encoding = utf8}) =>
+      _reader.readAsString(inputId, encoding: encoding);
+
+  @override
+  Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes) {
+    _addAsset(id);
+    var done = _futureOrWrite(
+      bytes,
+      (List<int> b) => _writer.writeAsBytes(id, b),
+    );
+    _writeResults.add(Result.capture(done));
+    return done;
+  }
+
+  @override
+  Future<void> writeAsString(
+    AssetId id,
+    FutureOr<String> content, {
+    Encoding encoding = utf8,
+  }) {
+    _addAsset(id);
+    var done = _futureOrWrite(
+      content,
+      (String c) => _writer.writeAsString(id, c, encoding: encoding),
+    );
+    _writeResults.add(Result.capture(done));
+    return done;
+  }
+
+  /// Marks an asset for deletion in the post process step.
+  @override
+  void deletePrimaryInput() {
+    _deleteAsset(inputId);
+  }
+
+  /// Waits for work to finish and cleans up resources.
+  ///
+  /// This method should be called after a build has completed. After the
+  /// returned [Future] completes then all outputs have been written.
+  @override
+  Future<void> complete() async {
+    await Future.wait(_writeResults.map(Result.release));
+  }
+}
+
+Future<void> _futureOrWrite<T>(
+  FutureOr<T> content,
+  Future<void> Function(T content) write,
+) => (content is Future<T>) ? content.then(write) : write(content);

--- a/build_runner_core/lib/src/generate/run_builder.dart
+++ b/build_runner_core/lib/src/generate/run_builder.dart
@@ -127,6 +127,10 @@ extension on PackageConfig {
   }
 }
 
+abstract class StageTracker {
+  T trackStage<T>(String label, T Function() action, {bool isExternal = false});
+}
+
 class NoOpStageTracker implements StageTracker {
   static const StageTracker instance = NoOpStageTracker._();
 


### PR DESCRIPTION
Deprecate things that look unused and will be removed shortly in 4.0.0:

- `AssetWriterSpy` is obsoleted by comprehensive testing support in `build_test` `TestReaderWriter`.
- `MultiplexingBuilder` looks like a remnant of a long-gone era; the only use of it on pub is in `build_barback`, barback was from before `build`.
- To match how `BuildStep` works, move `PostProcessBuildStep` implementation to `build_runner_core`, leaving just the API. Constructing a `PostProcessBuildStep` was package private (under src/, not exported), so this is non breaking.
- Move `StageTracker` to `build_runner_core` since it's only used in APIs that will move there. Re-export it for now.