### PR TITLE
Split apply_builders.dart.

### DIFF
--- a/_test/test/goldens/generated_build_script.dart
+++ b/_test/test/goldens/generated_build_script.dart
@@ -2,89 +2,90 @@
 // ignore_for_file: directives_ordering
 // build_runner >=2.4.16
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:build_runner/src/bootstrap/apply_builders.dart' as _i1;
-import 'package:provides_builder/builders.dart' as _i2;
-import 'package:build_web_compilers/builders.dart' as _i3;
-import 'package:build_test/builder.dart' as _i4;
-import 'package:build_config/build_config.dart' as _i5;
-import 'package:build_modules/builders.dart' as _i6;
-import 'package:build/build.dart' as _i7;
-import 'dart:isolate' as _i8;
-import 'package:build_runner/src/bootstrap/build_process_state.dart' as _i9;
-import 'package:build_runner/build_runner.dart' as _i10;
-import 'dart:io' as _i11;
+import 'package:build_runner/src/build_plan/builder_application.dart' as _i1;
+import 'package:build_runner/src/bootstrap/apply_builders.dart' as _i2;
+import 'package:provides_builder/builders.dart' as _i3;
+import 'package:build_web_compilers/builders.dart' as _i4;
+import 'package:build_test/builder.dart' as _i5;
+import 'package:build_config/build_config.dart' as _i6;
+import 'package:build_modules/builders.dart' as _i7;
+import 'package:build/build.dart' as _i8;
+import 'dart:isolate' as _i9;
+import 'package:build_runner/src/bootstrap/build_process_state.dart' as _i10;
+import 'package:build_runner/build_runner.dart' as _i11;
+import 'dart:io' as _i12;
 
 final _builders = <_i1.BuilderApplication>[
-  _i1.apply(
+  _i2.apply(
     r'provides_builder:throwing_builder',
-    [_i2.throwingBuilder],
-    _i1.toDependentsOf(r'provides_builder'),
+    [_i3.throwingBuilder],
+    _i2.toDependentsOf(r'provides_builder'),
     hideOutput: true,
   ),
-  _i1.apply(
+  _i2.apply(
     r'provides_builder:some_not_applied_builder',
-    [_i2.notApplied],
-    _i1.toNoneByDefault(),
+    [_i3.notApplied],
+    _i2.toNoneByDefault(),
     hideOutput: true,
   ),
-  _i1.apply(
+  _i2.apply(
     r'provides_builder:some_builder',
-    [_i2.someBuilder],
-    _i1.toDependentsOf(r'provides_builder'),
+    [_i3.someBuilder],
+    _i2.toDependentsOf(r'provides_builder'),
     hideOutput: true,
     appliesBuilders: const [r'provides_builder:some_post_process_builder'],
   ),
-  _i1.apply(
+  _i2.apply(
     r'build_web_compilers:sdk_js',
     [
-      _i3.sdkJsCompile,
-      _i3.sdkJsCopyRequirejs,
+      _i4.sdkJsCompile,
+      _i4.sdkJsCopyRequirejs,
     ],
-    _i1.toNoneByDefault(),
+    _i2.toNoneByDefault(),
     isOptional: true,
     hideOutput: true,
   ),
-  _i1.apply(
+  _i2.apply(
     r'build_test:test_bootstrap',
     [
-      _i4.debugIndexBuilder,
-      _i4.debugTestBuilder,
-      _i4.testBootstrapBuilder,
+      _i5.debugIndexBuilder,
+      _i5.debugTestBuilder,
+      _i5.testBootstrapBuilder,
     ],
-    _i1.toRoot(),
+    _i2.toRoot(),
     hideOutput: true,
-    defaultGenerateFor: const _i5.InputSet(include: [
+    defaultGenerateFor: const _i6.InputSet(include: [
       r'$package$',
       r'test/**',
     ]),
   ),
-  _i1.apply(
+  _i2.apply(
     r'build_modules:module_library',
-    [_i6.moduleLibraryBuilder],
-    _i1.toAllPackages(),
+    [_i7.moduleLibraryBuilder],
+    _i2.toAllPackages(),
     isOptional: true,
     hideOutput: true,
     appliesBuilders: const [r'build_modules:module_cleanup'],
   ),
-  _i1.apply(
+  _i2.apply(
     r'build_web_compilers:ddc_modules',
     [
-      _i3.ddcMetaModuleBuilder,
-      _i3.ddcMetaModuleCleanBuilder,
-      _i3.ddcModuleBuilder,
+      _i4.ddcMetaModuleBuilder,
+      _i4.ddcMetaModuleCleanBuilder,
+      _i4.ddcModuleBuilder,
     ],
-    _i1.toNoneByDefault(),
+    _i2.toNoneByDefault(),
     isOptional: true,
     hideOutput: true,
     appliesBuilders: const [r'build_modules:module_cleanup'],
   ),
-  _i1.apply(
+  _i2.apply(
     r'build_web_compilers:ddc',
     [
-      _i3.ddcKernelBuilder,
-      _i3.ddcBuilder,
+      _i4.ddcKernelBuilder,
+      _i4.ddcBuilder,
     ],
-    _i1.toAllPackages(),
+    _i2.toAllPackages(),
     isOptional: true,
     hideOutput: true,
     appliesBuilders: const [
@@ -94,36 +95,36 @@ final _builders = <_i1.BuilderApplication>[
       r'build_web_compilers:dart_source_cleanup',
     ],
   ),
-  _i1.apply(
+  _i2.apply(
     r'build_web_compilers:dart2wasm_modules',
     [
-      _i3.dart2wasmMetaModuleBuilder,
-      _i3.dart2wasmMetaModuleCleanBuilder,
-      _i3.dart2wasmModuleBuilder,
+      _i4.dart2wasmMetaModuleBuilder,
+      _i4.dart2wasmMetaModuleCleanBuilder,
+      _i4.dart2wasmModuleBuilder,
     ],
-    _i1.toNoneByDefault(),
+    _i2.toNoneByDefault(),
     isOptional: true,
     hideOutput: true,
     appliesBuilders: const [r'build_modules:module_cleanup'],
   ),
-  _i1.apply(
+  _i2.apply(
     r'build_web_compilers:dart2js_modules',
     [
-      _i3.dart2jsMetaModuleBuilder,
-      _i3.dart2jsMetaModuleCleanBuilder,
-      _i3.dart2jsModuleBuilder,
+      _i4.dart2jsMetaModuleBuilder,
+      _i4.dart2jsMetaModuleCleanBuilder,
+      _i4.dart2jsModuleBuilder,
     ],
-    _i1.toNoneByDefault(),
+    _i2.toNoneByDefault(),
     isOptional: true,
     hideOutput: true,
     appliesBuilders: const [r'build_modules:module_cleanup'],
   ),
-  _i1.apply(
+  _i2.apply(
     r'build_web_compilers:entrypoint',
-    [_i3.webEntrypointBuilder],
-    _i1.toRoot(),
+    [_i4.webEntrypointBuilder],
+    _i2.toRoot(),
     hideOutput: true,
-    defaultGenerateFor: const _i5.InputSet(
+    defaultGenerateFor: const _i6.InputSet(
       include: [
         r'web/**',
         r'test/**.dart.browser_test.dart',
@@ -135,47 +136,47 @@ final _builders = <_i1.BuilderApplication>[
         r'test/**.vm_test.dart',
       ],
     ),
-    defaultOptions: const _i7.BuilderOptions(<String, dynamic>{
+    defaultOptions: const _i8.BuilderOptions(<String, dynamic>{
       r'dart2js_args': <dynamic>[r'--minify']
     }),
-    defaultDevOptions: const _i7.BuilderOptions(<String, dynamic>{
+    defaultDevOptions: const _i8.BuilderOptions(<String, dynamic>{
       r'dart2wasm_args': <dynamic>[r'--enable-asserts'],
       r'dart2js_args': <dynamic>[r'--enable-asserts'],
     }),
     defaultReleaseOptions:
-        const _i7.BuilderOptions(<String, dynamic>{r'compiler': r'dart2js'}),
+        const _i8.BuilderOptions(<String, dynamic>{r'compiler': r'dart2js'}),
     appliesBuilders: const [r'build_web_compilers:dart2js_archive_extractor'],
   ),
-  _i1.applyPostProcess(
+  _i2.applyPostProcess(
     r'build_modules:module_cleanup',
-    _i6.moduleCleanup,
+    _i7.moduleCleanup,
   ),
-  _i1.applyPostProcess(
+  _i2.applyPostProcess(
     r'build_web_compilers:dart2js_archive_extractor',
-    _i3.dart2jsArchiveExtractor,
+    _i4.dart2jsArchiveExtractor,
     defaultReleaseOptions:
-        const _i7.BuilderOptions(<String, dynamic>{r'filter_outputs': true}),
+        const _i8.BuilderOptions(<String, dynamic>{r'filter_outputs': true}),
   ),
-  _i1.applyPostProcess(
+  _i2.applyPostProcess(
     r'build_web_compilers:dart_source_cleanup',
-    _i3.dartSourceCleanup,
+    _i4.dartSourceCleanup,
     defaultReleaseOptions:
-        const _i7.BuilderOptions(<String, dynamic>{r'enabled': true}),
+        const _i8.BuilderOptions(<String, dynamic>{r'enabled': true}),
   ),
-  _i1.applyPostProcess(
+  _i2.applyPostProcess(
     r'provides_builder:some_post_process_builder',
-    _i2.somePostProcessBuilder,
+    _i3.somePostProcessBuilder,
   ),
 ];
 void main(
   List<String> args, [
-  _i8.SendPort? sendPort,
+  _i9.SendPort? sendPort,
 ]) async {
-  await _i9.buildProcessState.receive(sendPort);
-  _i9.buildProcessState.isolateExitCode = await _i10.run(
+  await _i10.buildProcessState.receive(sendPort);
+  _i10.buildProcessState.isolateExitCode = await _i11.run(
     args,
     _builders,
   );
-  _i11.exitCode = _i9.buildProcessState.isolateExitCode!;
-  await _i9.buildProcessState.send(sendPort);
+  _i12.exitCode = _i10.buildProcessState.isolateExitCode!;
+  await _i10.buildProcessState.send(sendPort);
 }

--- a/build_runner/lib/build_runner.dart
+++ b/build_runner/lib/build_runner.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'src/bootstrap/apply_builders.dart';
+import 'src/build_plan/builder_application.dart';
 import 'src/build_runner.dart' show BuildRunner;
 
 export 'src/commands/daemon/constants.dart' show assetServerPort;

--- a/build_runner/lib/src/bootstrap/apply_builders.dart
+++ b/build_runner/lib/src/bootstrap/apply_builders.dart
@@ -2,31 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
-import 'package:built_collection/built_collection.dart';
-import 'package:graphs/graphs.dart';
 
-import '../build_plan/build_phases.dart';
+import '../build_plan/builder_application.dart';
 import '../build_plan/package_graph.dart';
 import '../build_plan/phase.dart';
-import '../build_plan/target_graph.dart';
 import '../exceptions.dart';
 import '../logging/build_log.dart';
 import '../logging/build_log_logger.dart';
-
-typedef BuildPhaseFactory =
-    BuildPhase Function(
-      PackageNode package,
-      BuilderOptions options,
-      InputSet targetSources,
-      InputSet? generateFor,
-      bool isReleaseBuild,
-    );
-
-typedef PackageFilter = bool Function(PackageNode node);
 
 /// Run a builder on all packages in the package graph.
 PackageFilter toAllPackages() => (_) => true;
@@ -60,7 +44,7 @@ BuilderApplication applyToRoot(
   bool isOptional = false,
   bool hideOutput = false,
   InputSet generateFor = const InputSet(),
-}) => BuilderApplication.forBuilder(
+}) => _forBuilder(
   '',
   [(_) => builder],
   toRoot(),
@@ -95,7 +79,7 @@ BuilderApplication apply(
   BuilderOptions? defaultDevOptions,
   BuilderOptions? defaultReleaseOptions,
   Iterable<String> appliesBuilders = const [],
-}) => BuilderApplication.forBuilder(
+}) => _forBuilder(
   builderKey,
   builderFactories,
   filter,
@@ -120,7 +104,7 @@ BuilderApplication applyPostProcess(
   BuilderOptions defaultOptions = BuilderOptions.empty,
   BuilderOptions? defaultDevOptions,
   BuilderOptions? defaultReleaseOptions,
-}) => BuilderApplication.forPostProcessBuilder(
+}) => _forPostProcessBuilder(
   builderKey,
   builderFactory,
   defaultGenerateFor: defaultGenerateFor,
@@ -129,344 +113,121 @@ BuilderApplication applyPostProcess(
   defaultReleaseOptions: defaultReleaseOptions,
 );
 
-/// A description of which packages need a given [Builder] or
-/// [PostProcessBuilder] applied.
-class BuilderApplication {
-  /// Factories that create [BuildPhase]s for all [Builder]s or
-  /// [PostProcessBuilder]s that should be applied.
-  final List<BuildPhaseFactory> buildPhaseFactories;
+BuilderApplication _forBuilder(
+  String builderKey,
+  List<BuilderFactory> builderFactories,
+  PackageFilter filter, {
+  bool isOptional = false,
+  bool hideOutput = true,
+  InputSet defaultGenerateFor = const InputSet(),
+  BuilderOptions defaultOptions = BuilderOptions.empty,
+  BuilderOptions? defaultDevOptions,
+  BuilderOptions? defaultReleaseOptions,
+  Iterable<String> appliesBuilders = const [],
+}) {
+  final phaseFactories =
+      builderFactories.map((builderFactory) {
+        return (
+          PackageNode package,
+          BuilderOptions options,
+          InputSet targetSources,
+          InputSet? generateFor,
+          bool isReleaseBuild,
+        ) {
+          generateFor ??= defaultGenerateFor;
 
-  /// Determines whether a given package needs builder applied.
-  final PackageFilter filter;
-
-  /// Builder keys which, when applied to a target, will also apply this Builder
-  /// even if [filter] does not match.
-  final Iterable<String> appliesBuilders;
-
-  /// A uniqe key for this builder.
-  ///
-  /// Ignored when null or empty.
-  final String builderKey;
-
-  /// Whether genereated assets should be placed in the build cache.
-  final bool hideOutput;
-
-  const BuilderApplication._(
-    this.builderKey,
-    this.buildPhaseFactories,
-    this.filter,
-    this.hideOutput,
-    this.appliesBuilders,
-  );
-
-  factory BuilderApplication.forBuilder(
-    String builderKey,
-    List<BuilderFactory> builderFactories,
-    PackageFilter filter, {
-    bool isOptional = false,
-    bool hideOutput = true,
-    InputSet defaultGenerateFor = const InputSet(),
-    BuilderOptions defaultOptions = BuilderOptions.empty,
-    BuilderOptions? defaultDevOptions,
-    BuilderOptions? defaultReleaseOptions,
-    Iterable<String> appliesBuilders = const [],
-  }) {
-    final phaseFactories =
-        builderFactories.map((builderFactory) {
-          return (
-            PackageNode package,
-            BuilderOptions options,
-            InputSet targetSources,
-            InputSet? generateFor,
-            bool isReleaseBuild,
-          ) {
-            generateFor ??= defaultGenerateFor;
-
-            var optionsWithDefaults = defaultOptions
-                .overrideWith(
-                  isReleaseBuild ? defaultReleaseOptions : defaultDevOptions,
-                )
-                .overrideWith(options);
-            if (package.isRoot) {
-              optionsWithDefaults = optionsWithDefaults.overrideWith(
-                BuilderOptions.forRoot,
-              );
-            }
-
-            final builder = BuildLogLogger.scopeLogSync(
-              () => builderFactory(optionsWithDefaults),
-              buildLog.loggerForOther(builderKey),
-            );
-            if (builder == null) throw const CannotBuildException();
-            _validateBuilder(builder);
-            return InBuildPhase(
-              builder,
-              package.name,
-              builderKey: builderKey,
-              targetSources: targetSources,
-              generateFor: generateFor,
-              builderOptions: optionsWithDefaults,
-              hideOutput: hideOutput,
-              isOptional: isOptional,
-            );
-          };
-        }).toList();
-    return BuilderApplication._(
-      builderKey,
-      phaseFactories,
-      filter,
-      hideOutput,
-      appliesBuilders,
-    );
-  }
-
-  /// Note that these builder applications each create their own phase, but they
-  /// will all eventually be merged into a single phase.
-  factory BuilderApplication.forPostProcessBuilder(
-    String builderKey,
-    PostProcessBuilderFactory builderFactory, {
-    InputSet defaultGenerateFor = const InputSet(),
-    BuilderOptions defaultOptions = BuilderOptions.empty,
-    BuilderOptions? defaultDevOptions,
-    BuilderOptions? defaultReleaseOptions,
-  }) {
-    PostBuildPhase phaseFactory(
-      PackageNode package,
-      BuilderOptions options,
-      InputSet targetSources,
-      InputSet? generateFor,
-      bool isReleaseBuild,
-    ) {
-      generateFor ??= defaultGenerateFor;
-
-      var optionsWithDefaults = defaultOptions
-          .overrideWith(
-            isReleaseBuild ? defaultReleaseOptions : defaultDevOptions,
-          )
-          .overrideWith(options);
-      if (package.isRoot) {
-        optionsWithDefaults = optionsWithDefaults.overrideWith(
-          BuilderOptions.forRoot,
-        );
-      }
-
-      final builder = BuildLogLogger.scopeLogSync(
-        () => builderFactory(optionsWithDefaults),
-        buildLog.loggerForOther(builderKey),
-      );
-      if (builder == null) throw const CannotBuildException();
-      _validatePostProcessBuilder(builder);
-      final builderAction = PostBuildAction(
-        builder,
-        package.name,
-        builderOptions: optionsWithDefaults,
-        generateFor: generateFor,
-        targetSources: targetSources,
-      );
-      return PostBuildPhase([builderAction]);
-    }
-
-    return BuilderApplication._(
-      builderKey,
-      [phaseFactory],
-      toNoneByDefault(),
-      true,
-      [],
-    );
-  }
-}
-
-/// Creates a [BuildPhase] to apply each builder in [builderApplications] to
-/// each target in [targetGraph] such that all builders are run for dependencies
-/// before moving on to later packages.
-///
-/// When there is a package cycle the builders are applied to each packages
-/// within the cycle before moving on to packages that depend on any package
-/// within the cycle.
-///
-/// Builders may be filtered, for instance to run only on package which have a
-/// dependency on some other package by choosing the appropriate
-/// [BuilderApplication].
-Future<BuildPhases> createBuildPhases(
-  TargetGraph targetGraph,
-  Iterable<BuilderApplication> builderApplications,
-  BuiltMap<String, BuiltMap<String, dynamic>> builderConfigOverrides,
-  bool isReleaseMode,
-) async {
-  validateBuilderConfig(
-    builderApplications,
-    targetGraph.rootPackageConfig,
-    builderConfigOverrides,
-  );
-  final globalOptions = targetGraph.rootPackageConfig.globalOptions.map(
-    (key, config) => MapEntry(
-      key,
-      _options(config.options).overrideWith(
-        isReleaseMode
-            ? _options(config.releaseOptions)
-            : _options(config.devOptions),
-      ),
-    ),
-  );
-  for (final key in builderConfigOverrides.keys) {
-    final overrides = BuilderOptions(builderConfigOverrides[key]!.asMap());
-    globalOptions[key] = (globalOptions[key] ?? BuilderOptions.empty)
-        .overrideWith(overrides);
-  }
-
-  final cycles = stronglyConnectedComponents<TargetNode>(
-    targetGraph.allModules.values,
-    (node) => node.target.dependencies.map((key) {
-      if (!targetGraph.allModules.containsKey(key)) {
-        buildLog.error(
-          '${node.target.key} declares a dependency on $key '
-          'but it does not exist.',
-        );
-        throw const CannotBuildException();
-      }
-      return targetGraph.allModules[key]!;
-    }),
-    equals: (a, b) => a.target.key == b.target.key,
-    hashCode: (node) => node.target.key.hashCode,
-  );
-  final applyWith = _applyWith(builderApplications);
-  final allBuilders = Map<String, BuilderApplication>.fromIterable(
-    builderApplications,
-    key: (b) => (b as BuilderApplication).builderKey,
-  );
-  final expandedPhases =
-      cycles
-          .expand(
-            (cycle) => _createBuildPhasesWithinCycle(
-              cycle,
-              builderApplications,
-              globalOptions,
-              applyWith,
-              allBuilders,
-              isReleaseMode,
-            ),
-          )
-          .toList();
-
-  final inBuildPhases = expandedPhases.whereType<InBuildPhase>();
-
-  final postBuildPhases = expandedPhases.whereType<PostBuildPhase>().toList();
-  final collapsedPostBuildPhase = <PostBuildPhase>[];
-  if (postBuildPhases.isNotEmpty) {
-    collapsedPostBuildPhase.add(
-      postBuildPhases.fold<PostBuildPhase>(PostBuildPhase([]), (
-        previous,
-        next,
-      ) {
-        previous.builderActions.addAll(next.builderActions);
-        return previous;
-      }),
-    );
-  }
-
-  return BuildPhases(inBuildPhases, collapsedPostBuildPhase.singleOrNull);
-}
-
-Iterable<BuildPhase> _createBuildPhasesWithinCycle(
-  Iterable<TargetNode> cycle,
-  Iterable<BuilderApplication> builderApplications,
-  Map<String, BuilderOptions> globalOptions,
-  Map<String, List<BuilderApplication>> applyWith,
-  Map<String, BuilderApplication> allBuilders,
-  bool isReleaseMode,
-) => builderApplications.expand(
-  (builderApplication) => _createBuildPhasesForBuilderInCycle(
-    cycle,
-    builderApplication,
-    globalOptions[builderApplication.builderKey] ?? BuilderOptions.empty,
-    applyWith,
-    allBuilders,
-    isReleaseMode,
-  ),
-);
-
-Iterable<BuildPhase> _createBuildPhasesForBuilderInCycle(
-  Iterable<TargetNode> cycle,
-  BuilderApplication builderApplication,
-  BuilderOptions globalOptionOverrides,
-  Map<String, List<BuilderApplication>> applyWith,
-  Map<String, BuilderApplication> allBuilders,
-  bool isReleaseMode,
-) {
-  TargetBuilderConfig? targetConfig(TargetNode node) =>
-      node.target.builders[builderApplication.builderKey];
-  return builderApplication.buildPhaseFactories.expand(
-    (createPhase) => cycle
-        .where(
-          (targetNode) => _shouldApply(
-            builderApplication,
-            targetNode,
-            applyWith,
-            allBuilders,
-          ),
-        )
-        .map((node) {
-          final builderConfig = targetConfig(node);
-          final options = _options(builderConfig?.options)
+          var optionsWithDefaults = defaultOptions
               .overrideWith(
-                isReleaseMode
-                    ? _options(builderConfig?.releaseOptions)
-                    : _options(builderConfig?.devOptions),
+                isReleaseBuild ? defaultReleaseOptions : defaultDevOptions,
               )
-              .overrideWith(globalOptionOverrides);
-          return createPhase(
-            node.package,
-            options,
-            node.target.sources,
-            builderConfig?.generateFor,
-            isReleaseMode,
+              .overrideWith(options);
+          if (package.isRoot) {
+            optionsWithDefaults = optionsWithDefaults.overrideWith(
+              BuilderOptions.forRoot,
+            );
+          }
+
+          final builder = BuildLogLogger.scopeLogSync(
+            () => builderFactory(optionsWithDefaults),
+            buildLog.loggerForOther(builderKey),
           );
-        }),
+          if (builder == null) throw const CannotBuildException();
+          _validateBuilder(builder);
+          return InBuildPhase(
+            builder,
+            package.name,
+            builderKey: builderKey,
+            targetSources: targetSources,
+            generateFor: generateFor,
+            builderOptions: optionsWithDefaults,
+            hideOutput: hideOutput,
+            isOptional: isOptional,
+          );
+        };
+      }).toList();
+  return BuilderApplication(
+    builderKey,
+    phaseFactories,
+    filter,
+    hideOutput,
+    appliesBuilders,
   );
 }
 
-bool _shouldApply(
-  BuilderApplication builderApplication,
-  TargetNode node,
-  Map<String, List<BuilderApplication>> applyWith,
-  Map<String, BuilderApplication> allBuilders,
-) {
-  if (!(builderApplication.hideOutput &&
-          builderApplication.appliesBuilders.every(
-            (b) => allBuilders[b]?.hideOutput ?? true,
-          )) &&
-      !node.package.isRoot) {
-    return false;
-  }
-  final builderConfig = node.target.builders[builderApplication.builderKey];
-  if (builderConfig?.isEnabled != null) {
-    return builderConfig!.isEnabled;
-  }
-  final shouldAutoApply =
-      node.target.autoApplyBuilders && builderApplication.filter(node.package);
-  return shouldAutoApply ||
-      (applyWith[builderApplication.builderKey] ?? const []).any(
-        (anchorBuilder) =>
-            _shouldApply(anchorBuilder, node, applyWith, allBuilders),
+/// Note that these builder applications each create their own phase, but they
+/// will all eventually be merged into a single phase.
+BuilderApplication _forPostProcessBuilder(
+  String builderKey,
+  PostProcessBuilderFactory builderFactory, {
+  InputSet defaultGenerateFor = const InputSet(),
+  BuilderOptions defaultOptions = BuilderOptions.empty,
+  BuilderOptions? defaultDevOptions,
+  BuilderOptions? defaultReleaseOptions,
+}) {
+  PostBuildPhase phaseFactory(
+    PackageNode package,
+    BuilderOptions options,
+    InputSet targetSources,
+    InputSet? generateFor,
+    bool isReleaseBuild,
+  ) {
+    generateFor ??= defaultGenerateFor;
+
+    var optionsWithDefaults = defaultOptions
+        .overrideWith(
+          isReleaseBuild ? defaultReleaseOptions : defaultDevOptions,
+        )
+        .overrideWith(options);
+    if (package.isRoot) {
+      optionsWithDefaults = optionsWithDefaults.overrideWith(
+        BuilderOptions.forRoot,
       );
-}
-
-/// Inverts the dependency map from 'applies builders' to 'applied with
-/// builders'.
-Map<String, List<BuilderApplication>> _applyWith(
-  Iterable<BuilderApplication> builderApplications,
-) {
-  final applyWith = <String, List<BuilderApplication>>{};
-  for (final builderApplication in builderApplications) {
-    for (final alsoApply in builderApplication.appliesBuilders) {
-      applyWith.putIfAbsent(alsoApply, () => []).add(builderApplication);
     }
-  }
-  return applyWith;
-}
 
-BuilderOptions _options(Map<String, dynamic>? options) =>
-    options?.isEmpty ?? true ? BuilderOptions.empty : BuilderOptions(options!);
+    final builder = BuildLogLogger.scopeLogSync(
+      () => builderFactory(optionsWithDefaults),
+      buildLog.loggerForOther(builderKey),
+    );
+    if (builder == null) throw const CannotBuildException();
+    _validatePostProcessBuilder(builder);
+    final builderAction = PostBuildAction(
+      builder,
+      package.name,
+      builderOptions: optionsWithDefaults,
+      generateFor: generateFor,
+      targetSources: targetSources,
+    );
+    return PostBuildPhase([builderAction]);
+  }
+
+  return BuilderApplication(
+    builderKey,
+    [phaseFactory],
+    toNoneByDefault(),
+    true,
+    [],
+  );
+}
 
 void _validateBuilder(Builder builder) {
   final inputExtensions = builder.buildExtensions.keys.toSet();
@@ -499,40 +260,5 @@ void _validatePostProcessBuilder(PostProcessBuilder builder) {
       'Try generalizing input extensions and manually skip uninteresting '
       'assets in the `build()` method.',
     );
-  }
-}
-
-/// Checks that all configuration is for valid builder keys.
-void validateBuilderConfig(
-  Iterable<BuilderApplication> builders,
-  BuildConfig rootPackageConfig,
-  BuiltMap<String, BuiltMap<String, dynamic>> builderConfigOverrides,
-) {
-  final builderKeys = builders.map((b) => b.builderKey).toSet();
-  for (final key in builderConfigOverrides.keys) {
-    if (!builderKeys.contains(key)) {
-      buildLog.warning(
-        'Overriding configuration for `$key` but this is not a '
-        'known Builder',
-      );
-    }
-  }
-  for (final target in rootPackageConfig.buildTargets.values) {
-    for (final key in target.builders.keys) {
-      if (!builderKeys.contains(key)) {
-        buildLog.warning(
-          'Configuring `$key` in target `${target.key}` but this '
-          'is not a known Builder.',
-        );
-      }
-    }
-  }
-  for (final key in rootPackageConfig.globalOptions.keys) {
-    if (!builderKeys.contains(key)) {
-      buildLog.warning(
-        'Configuring `$key` in global options but this is not a '
-        'known Builder.',
-      );
-    }
   }
 }

--- a/build_runner/lib/src/bootstrap/build_script_generate.dart
+++ b/build_runner/lib/src/bootstrap/build_script_generate.dart
@@ -41,7 +41,7 @@ Future<String> generateBuildScript() async {
               builders,
               refer(
                 'BuilderApplication',
-                'package:build_runner/src/bootstrap/apply_builders.dart',
+                'package:build_runner/src/build_plan/builder_application.dart',
               ),
             ),
           )

--- a/build_runner/lib/src/build_plan/build_phases.dart
+++ b/build_runner/lib/src/build_plan/build_phases.dart
@@ -5,13 +5,17 @@
 import 'dart:convert';
 
 import 'package:build/build.dart';
+import 'package:build_config/build_config.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
+import 'package:graphs/graphs.dart';
 
 import '../exceptions.dart';
 import '../logging/build_log.dart';
+import 'builder_application.dart';
 import 'phase.dart';
+import 'target_graph.dart';
 
 /// The [BuildPhases] defining the sequence of actions in a build, and their
 /// [Digest] and options digests.
@@ -112,6 +116,233 @@ class BuildPhases {
         '... instead?',
       );
       throw const CannotBuildException();
+    }
+  }
+}
+
+/// Creates a [BuildPhase] to apply each builder in [builderApplications] to
+/// each target in [targetGraph] such that all builders are run for dependencies
+/// before moving on to later packages.
+///
+/// When there is a package cycle the builders are applied to each packages
+/// within the cycle before moving on to packages that depend on any package
+/// within the cycle.
+///
+/// Builders may be filtered, for instance to run only on package which have a
+/// dependency on some other package by choosing the appropriate
+/// [BuilderApplication].
+Future<BuildPhases> createBuildPhases(
+  TargetGraph targetGraph,
+  Iterable<BuilderApplication> builderApplications,
+  BuiltMap<String, BuiltMap<String, dynamic>> builderConfigOverrides,
+  bool isReleaseMode,
+) async {
+  validateBuilderConfig(
+    builderApplications,
+    targetGraph.rootPackageConfig,
+    builderConfigOverrides,
+  );
+  final globalOptions = targetGraph.rootPackageConfig.globalOptions.map(
+    (key, config) => MapEntry(
+      key,
+      _options(config.options).overrideWith(
+        isReleaseMode
+            ? _options(config.releaseOptions)
+            : _options(config.devOptions),
+      ),
+    ),
+  );
+  for (final key in builderConfigOverrides.keys) {
+    final overrides = BuilderOptions(builderConfigOverrides[key]!.asMap());
+    globalOptions[key] = (globalOptions[key] ?? BuilderOptions.empty)
+        .overrideWith(overrides);
+  }
+
+  final cycles = stronglyConnectedComponents<TargetNode>(
+    targetGraph.allModules.values,
+    (node) => node.target.dependencies.map((key) {
+      if (!targetGraph.allModules.containsKey(key)) {
+        buildLog.error(
+          '${node.target.key} declares a dependency on $key '
+          'but it does not exist.',
+        );
+        throw const CannotBuildException();
+      }
+      return targetGraph.allModules[key]!;
+    }),
+    equals: (a, b) => a.target.key == b.target.key,
+    hashCode: (node) => node.target.key.hashCode,
+  );
+  final applyWith = _applyWith(builderApplications);
+  final allBuilders = Map<String, BuilderApplication>.fromIterable(
+    builderApplications,
+    key: (b) => (b as BuilderApplication).builderKey,
+  );
+  final expandedPhases =
+      cycles
+          .expand(
+            (cycle) => _createBuildPhasesWithinCycle(
+              cycle,
+              builderApplications,
+              globalOptions,
+              applyWith,
+              allBuilders,
+              isReleaseMode,
+            ),
+          )
+          .toList();
+
+  final inBuildPhases = expandedPhases.whereType<InBuildPhase>();
+
+  final postBuildPhases = expandedPhases.whereType<PostBuildPhase>().toList();
+  final collapsedPostBuildPhase = <PostBuildPhase>[];
+  if (postBuildPhases.isNotEmpty) {
+    collapsedPostBuildPhase.add(
+      postBuildPhases.fold<PostBuildPhase>(PostBuildPhase([]), (
+        previous,
+        next,
+      ) {
+        previous.builderActions.addAll(next.builderActions);
+        return previous;
+      }),
+    );
+  }
+
+  return BuildPhases(inBuildPhases, collapsedPostBuildPhase.singleOrNull);
+}
+
+Iterable<BuildPhase> _createBuildPhasesWithinCycle(
+  Iterable<TargetNode> cycle,
+  Iterable<BuilderApplication> builderApplications,
+  Map<String, BuilderOptions> globalOptions,
+  Map<String, List<BuilderApplication>> applyWith,
+  Map<String, BuilderApplication> allBuilders,
+  bool isReleaseMode,
+) => builderApplications.expand(
+  (builderApplication) => _createBuildPhasesForBuilderInCycle(
+    cycle,
+    builderApplication,
+    globalOptions[builderApplication.builderKey] ?? BuilderOptions.empty,
+    applyWith,
+    allBuilders,
+    isReleaseMode,
+  ),
+);
+
+Iterable<BuildPhase> _createBuildPhasesForBuilderInCycle(
+  Iterable<TargetNode> cycle,
+  BuilderApplication builderApplication,
+  BuilderOptions globalOptionOverrides,
+  Map<String, List<BuilderApplication>> applyWith,
+  Map<String, BuilderApplication> allBuilders,
+  bool isReleaseMode,
+) {
+  TargetBuilderConfig? targetConfig(TargetNode node) =>
+      node.target.builders[builderApplication.builderKey];
+  return builderApplication.buildPhaseFactories.expand(
+    (createPhase) => cycle
+        .where(
+          (targetNode) => _shouldApply(
+            builderApplication,
+            targetNode,
+            applyWith,
+            allBuilders,
+          ),
+        )
+        .map((node) {
+          final builderConfig = targetConfig(node);
+          final options = _options(builderConfig?.options)
+              .overrideWith(
+                isReleaseMode
+                    ? _options(builderConfig?.releaseOptions)
+                    : _options(builderConfig?.devOptions),
+              )
+              .overrideWith(globalOptionOverrides);
+          return createPhase(
+            node.package,
+            options,
+            node.target.sources,
+            builderConfig?.generateFor,
+            isReleaseMode,
+          );
+        }),
+  );
+}
+
+bool _shouldApply(
+  BuilderApplication builderApplication,
+  TargetNode node,
+  Map<String, List<BuilderApplication>> applyWith,
+  Map<String, BuilderApplication> allBuilders,
+) {
+  if (!(builderApplication.hideOutput &&
+          builderApplication.appliesBuilders.every(
+            (b) => allBuilders[b]?.hideOutput ?? true,
+          )) &&
+      !node.package.isRoot) {
+    return false;
+  }
+  final builderConfig = node.target.builders[builderApplication.builderKey];
+  if (builderConfig?.isEnabled != null) {
+    return builderConfig!.isEnabled;
+  }
+  final shouldAutoApply =
+      node.target.autoApplyBuilders && builderApplication.filter(node.package);
+  return shouldAutoApply ||
+      (applyWith[builderApplication.builderKey] ?? const []).any(
+        (anchorBuilder) =>
+            _shouldApply(anchorBuilder, node, applyWith, allBuilders),
+      );
+}
+
+/// Inverts the dependency map from 'applies builders' to 'applied with
+/// builders'.
+Map<String, List<BuilderApplication>> _applyWith(
+  Iterable<BuilderApplication> builderApplications,
+) {
+  final applyWith = <String, List<BuilderApplication>>{};
+  for (final builderApplication in builderApplications) {
+    for (final alsoApply in builderApplication.appliesBuilders) {
+      applyWith.putIfAbsent(alsoApply, () => []).add(builderApplication);
+    }
+  }
+  return applyWith;
+}
+
+BuilderOptions _options(Map<String, dynamic>? options) =>
+    options?.isEmpty ?? true ? BuilderOptions.empty : BuilderOptions(options!);
+
+/// Checks that all configuration is for valid builder keys.
+void validateBuilderConfig(
+  Iterable<BuilderApplication> builders,
+  BuildConfig rootPackageConfig,
+  BuiltMap<String, BuiltMap<String, dynamic>> builderConfigOverrides,
+) {
+  final builderKeys = builders.map((b) => b.builderKey).toSet();
+  for (final key in builderConfigOverrides.keys) {
+    if (!builderKeys.contains(key)) {
+      buildLog.warning(
+        'Overriding configuration for `$key` but this is not a '
+        'known Builder',
+      );
+    }
+  }
+  for (final target in rootPackageConfig.buildTargets.values) {
+    for (final key in target.builders.keys) {
+      if (!builderKeys.contains(key)) {
+        buildLog.warning(
+          'Configuring `$key` in target `${target.key}` but this '
+          'is not a known Builder.',
+        );
+      }
+    }
+  }
+  for (final key in rootPackageConfig.globalOptions.keys) {
+    if (!builderKeys.contains(key)) {
+      buildLog.warning(
+        'Configuring `$key` in global options but this is not a '
+        'known Builder.',
+      );
     }
   }
 }

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -4,13 +4,13 @@
 
 import 'package:built_collection/built_collection.dart';
 
-import '../bootstrap/apply_builders.dart';
 import '../io/reader_writer.dart';
 import '../logging/build_log.dart';
 import 'build_directory.dart';
 import 'build_filter.dart';
 import 'build_options.dart';
 import 'build_phases.dart';
+import 'builder_application.dart';
 import 'package_graph.dart';
 import 'target_graph.dart';
 import 'testing_overrides.dart';

--- a/build_runner/lib/src/build_plan/builder_application.dart
+++ b/build_runner/lib/src/build_plan/builder_application.dart
@@ -1,1 +1,51 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
+import 'package:build/build.dart';
+import 'package:build_config/build_config.dart';
+
+import 'package_graph.dart';
+import 'phase.dart';
+
+typedef BuildPhaseFactory =
+    BuildPhase Function(
+      PackageNode package,
+      BuilderOptions options,
+      InputSet targetSources,
+      InputSet? generateFor,
+      bool isReleaseBuild,
+    );
+
+typedef PackageFilter = bool Function(PackageNode node);
+
+/// A description of which packages need a given [Builder] or
+/// [PostProcessBuilder] applied.
+class BuilderApplication {
+  /// Factories that create [BuildPhase]s for all [Builder]s or
+  /// [PostProcessBuilder]s that should be applied.
+  final List<BuildPhaseFactory> buildPhaseFactories;
+
+  /// Determines whether a given package needs builder applied.
+  final PackageFilter filter;
+
+  /// Builder keys which, when applied to a target, will also apply this Builder
+  /// even if [filter] does not match.
+  final Iterable<String> appliesBuilders;
+
+  /// A uniqe key for this builder.
+  ///
+  /// Ignored when null or empty.
+  final String builderKey;
+
+  /// Whether generated assets should be placed in the build cache.
+  final bool hideOutput;
+
+  const BuilderApplication(
+    this.builderKey,
+    this.buildPhaseFactories,
+    this.filter,
+    this.hideOutput,
+    this.appliesBuilders,
+  );
+}

--- a/build_runner/lib/src/build_runner.dart
+++ b/build_runner/lib/src/build_runner.dart
@@ -11,10 +11,10 @@ import 'package:io/io.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
-import 'bootstrap/apply_builders.dart';
 import 'bootstrap/bootstrap.dart';
 import 'bootstrap/build_script_generate.dart';
 import 'build_plan/build_options.dart';
+import 'build_plan/builder_application.dart';
 import 'build_runner_command_line.dart';
 import 'commands/build_command.dart';
 import 'commands/build_runner_command.dart';

--- a/build_runner/lib/src/commands/build_command.dart
+++ b/build_runner/lib/src/commands/build_command.dart
@@ -6,12 +6,12 @@ import 'package:build/experiments.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:io/io.dart';
 
-import '../bootstrap/apply_builders.dart';
 import '../bootstrap/build_process_state.dart';
 import '../build/build_result.dart';
 import '../build/build_series.dart';
 import '../build_plan/build_options.dart';
 import '../build_plan/build_plan.dart';
+import '../build_plan/builder_application.dart';
 import '../build_plan/testing_overrides.dart';
 import '../logging/build_log.dart';
 import 'build_runner_command.dart';

--- a/build_runner/lib/src/commands/daemon_command.dart
+++ b/build_runner/lib/src/commands/daemon_command.dart
@@ -13,10 +13,10 @@ import 'package:build_daemon/data/serializers.dart';
 import 'package:build_daemon/data/server_log.dart';
 import 'package:built_collection/built_collection.dart';
 
-import '../bootstrap/apply_builders.dart';
 import '../bootstrap/build_process_state.dart';
 import '../build_plan/build_options.dart';
 import '../build_plan/build_plan.dart';
+import '../build_plan/builder_application.dart';
 import '../build_plan/testing_overrides.dart';
 import '../logging/build_log.dart';
 import 'build_runner_command.dart';

--- a/build_runner/lib/src/commands/run_command.dart
+++ b/build_runner/lib/src/commands/run_command.dart
@@ -11,10 +11,10 @@ import 'package:built_collection/built_collection.dart';
 import 'package:io/io.dart';
 import 'package:path/path.dart' as p;
 
-import '../bootstrap/apply_builders.dart';
 import '../bootstrap/build_process_state.dart';
 import '../build_plan/build_directory.dart';
 import '../build_plan/build_options.dart';
+import '../build_plan/builder_application.dart';
 import '../build_plan/testing_overrides.dart';
 import '../logging/build_log.dart';
 import 'build_command.dart';

--- a/build_runner/lib/src/commands/serve_command.dart
+++ b/build_runner/lib/src/commands/serve_command.dart
@@ -11,9 +11,9 @@ import 'package:http_multi_server/http_multi_server.dart';
 import 'package:io/io.dart';
 import 'package:shelf/shelf_io.dart';
 
-import '../bootstrap/apply_builders.dart';
 import '../bootstrap/build_process_state.dart';
 import '../build_plan/build_options.dart';
+import '../build_plan/builder_application.dart';
 import '../build_plan/package_graph.dart';
 import '../build_plan/testing_overrides.dart';
 import '../logging/build_log.dart';

--- a/build_runner/lib/src/commands/test_command.dart
+++ b/build_runner/lib/src/commands/test_command.dart
@@ -10,10 +10,10 @@ import 'package:build/experiments.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:io/io.dart';
 
-import '../bootstrap/apply_builders.dart';
 import '../bootstrap/build_process_state.dart';
 import '../build_plan/build_directory.dart';
 import '../build_plan/build_options.dart';
+import '../build_plan/builder_application.dart';
 import '../build_plan/package_graph.dart';
 import '../build_plan/testing_overrides.dart';
 import '../constants.dart';

--- a/build_runner/lib/src/commands/watch_command.dart
+++ b/build_runner/lib/src/commands/watch_command.dart
@@ -9,11 +9,11 @@ import 'package:build/experiments.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:io/io.dart';
 
-import '../bootstrap/apply_builders.dart';
 import '../bootstrap/build_process_state.dart';
 import '../build/build_result.dart';
 import '../build_plan/build_options.dart';
 import '../build_plan/build_plan.dart';
+import '../build_plan/builder_application.dart';
 import '../build_plan/testing_overrides.dart';
 import '../exceptions.dart';
 import '../logging/build_log.dart';

--- a/build_runner/lib/src/internal.dart
+++ b/build_runner/lib/src/internal.dart
@@ -14,6 +14,7 @@ export 'build_plan/build_filter.dart';
 export 'build_plan/build_options.dart';
 export 'build_plan/build_phases.dart';
 export 'build_plan/build_plan.dart';
+export 'build_plan/builder_application.dart';
 export 'build_plan/package_graph.dart';
 export 'build_plan/target_graph.dart';
 export 'build_plan/testing_overrides.dart';

--- a/build_runner/test/build/build_runner_test.dart
+++ b/build_runner/test/build/build_runner_test.dart
@@ -9,6 +9,7 @@ import 'package:build/build.dart';
 import 'package:build_runner/src/bootstrap/apply_builders.dart';
 import 'package:build_runner/src/build/build_result.dart';
 import 'package:build_runner/src/build_plan/build_options.dart';
+import 'package:build_runner/src/build_plan/builder_application.dart';
 import 'package:build_runner/src/build_plan/package_graph.dart';
 import 'package:build_runner/src/build_plan/testing_overrides.dart';
 import 'package:build_runner/src/commands/build_command.dart';

--- a/build_runner/test/build/serve_test.dart
+++ b/build_runner/test/build/serve_test.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:async/async.dart';
 import 'package:build_runner/src/bootstrap/apply_builders.dart';
 import 'package:build_runner/src/build_plan/build_options.dart';
+import 'package:build_runner/src/build_plan/builder_application.dart';
 import 'package:build_runner/src/build_plan/package_graph.dart';
 import 'package:build_runner/src/build_plan/testing_overrides.dart';
 import 'package:build_runner/src/commands/serve/server.dart';

--- a/build_runner/test/commands/watch/watcher_test.dart
+++ b/build_runner/test/commands/watch/watcher_test.dart
@@ -14,6 +14,7 @@ import 'package:build_runner/src/build/asset_graph/node.dart';
 import 'package:build_runner/src/build/build_result.dart';
 import 'package:build_runner/src/build_plan/build_options.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
+import 'package:build_runner/src/build_plan/builder_application.dart';
 import 'package:build_runner/src/build_plan/package_graph.dart';
 import 'package:build_runner/src/build_plan/testing_overrides.dart';
 import 'package:build_runner/src/commands/watch_command.dart';


### PR DESCRIPTION
Move `createBuildPhases` into ... `build_phases` :)

And, `BuilderApplication` into `build_plan/builder_application`.

Leaving just the code used for bootstrapping, creating `BuilderApplication` instances, under `bootstrap`.