### PR TITLE
Remove AssetGraphCorruptedException.

### DIFF
--- a/build_runner/lib/src/build/asset_graph/exceptions.dart
+++ b/build_runner/lib/src/build/asset_graph/exceptions.dart
@@ -22,5 +22,3 @@ class DuplicateAssetNodeException implements Exception {
     return 'Builders $builder1 and $builder2 outputs collide: $id';
   }
 }
-
-class AssetGraphCorruptedException implements Exception {}

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -102,8 +102,10 @@ class AssetGraph implements GeneratedAssetHider {
     this.enabledExperiments,
   );
 
-  /// Deserializes this graph.
-  factory AssetGraph.deserialize(List<int> serializedGraph) =>
+  /// Deserializes an [AssetGraph] from a [Map].
+  ///
+  /// Returns `null` if deserialization fails.
+  static AssetGraph? deserialize(List<int> serializedGraph) =>
       deserializeAssetGraph(serializedGraph);
 
   static Future<AssetGraph> build(

--- a/build_runner/lib/src/build/asset_graph/serialization.dart
+++ b/build_runner/lib/src/build/asset_graph/serialization.dart
@@ -11,17 +11,17 @@ part of 'graph.dart';
 const _version = 31;
 
 /// Deserializes an [AssetGraph] from a [Map].
-AssetGraph deserializeAssetGraph(List<int> bytes) {
+///
+/// Returns `null` if deserialization fails.
+AssetGraph? deserializeAssetGraph(List<int> bytes) {
   dynamic serializedGraph;
   try {
     serializedGraph = jsonDecode(utf8.decode(bytes));
   } on FormatException {
-    throw AssetGraphCorruptedException();
+    return null;
   }
-  if (serializedGraph is! Map) throw AssetGraphCorruptedException();
-  if (serializedGraph['version'] != _version) {
-    throw AssetGraphCorruptedException();
-  }
+  if (serializedGraph is! Map) return null;
+  if (serializedGraph['version'] != _version) return null;
 
   identityAssetIdSerializer.deserializeWithObjects(
     (serializedGraph['ids'] as List).map(

--- a/build_runner/test/build/asset_graph/graph_test.dart
+++ b/build_runner/test/build/asset_graph/graph_test.dart
@@ -147,7 +147,7 @@ void main() {
         graph.add(globNode);
 
         final encoded = graph.serialize();
-        final decoded = AssetGraph.deserialize(encoded);
+        final decoded = AssetGraph.deserialize(encoded)!;
         expect(decoded, equalsAssetGraph(graph));
         expect(
           decoded.allPostProcessBuildStepOutputs,
@@ -163,19 +163,13 @@ void main() {
               json.decode(utf8.decode(bytes)) as Map<String, dynamic>;
           serialized['version'] = -1;
           final encoded = utf8.encode(json.encode(serialized));
-          expect(
-            () => AssetGraph.deserialize(encoded),
-            throwsA(isA<AssetGraphCorruptedException>()),
-          );
+          expect(AssetGraph.deserialize(encoded), null);
         },
       );
 
       test('Throws an AssetGraphCorruptedException on invalid json', () {
         final bytes = List.of(graph.serialize())..removeLast();
-        expect(
-          () => AssetGraph.deserialize(bytes),
-          throwsA(isA<AssetGraphCorruptedException>()),
-        );
+        expect(AssetGraph.deserialize(bytes), null);
       });
     });
 

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -485,9 +485,10 @@ targets:
 
         final graphId = makeAssetId('a|$assetGraphPath');
         expect(result.readerWriter.testing.exists(graphId), isTrue);
-        final cachedGraph = AssetGraph.deserialize(
-          result.readerWriter.testing.readBytes(graphId),
-        );
+        final cachedGraph =
+            AssetGraph.deserialize(
+              result.readerWriter.testing.readBytes(graphId),
+            )!;
         expect(
           cachedGraph.allNodes.map((node) => node.id),
           unorderedEquals([
@@ -1114,9 +1115,8 @@ targets:
 
     final graphId = makeAssetId('a|$assetGraphPath');
     expect(result.readerWriter.testing.exists(graphId), isTrue);
-    final cachedGraph = AssetGraph.deserialize(
-      result.readerWriter.testing.readBytes(graphId),
-    );
+    final cachedGraph =
+        AssetGraph.deserialize(result.readerWriter.testing.readBytes(graphId))!;
 
     final expectedGraph = await AssetGraph.build(
       BuildPhases([]),
@@ -1243,9 +1243,10 @@ targets:
       );
 
       final graphId = makeAssetId('a|$assetGraphPath');
-      final cachedGraph = AssetGraph.deserialize(
-        result.readerWriter.testing.readBytes(graphId),
-      );
+      final cachedGraph =
+          AssetGraph.deserialize(
+            result.readerWriter.testing.readBytes(graphId),
+          )!;
       final outputId = AssetId('a', 'lib/a.txt.out');
 
       final outputNode = cachedGraph.get(outputId)!;
@@ -1451,11 +1452,12 @@ targets:
             resumeFrom: result,
           );
 
-          final graph = AssetGraph.deserialize(
-            result.readerWriter.testing.readBytes(
-              makeAssetId('a|$assetGraphPath'),
-            ),
-          );
+          final graph =
+              AssetGraph.deserialize(
+                result.readerWriter.testing.readBytes(
+                  makeAssetId('a|$assetGraphPath'),
+                ),
+              )!;
           expect(
             graph.get(makeAssetId('a|lib/a.txt.copy'))!.type,
             NodeType.missingSource,
@@ -1489,9 +1491,12 @@ targets:
       );
 
       /// Should be deleted using the writer, and converted to missingSource.
-      final newGraph = AssetGraph.deserialize(
-        result.readerWriter.testing.readBytes(makeAssetId('a|$assetGraphPath')),
-      );
+      final newGraph =
+          AssetGraph.deserialize(
+            result.readerWriter.testing.readBytes(
+              makeAssetId('a|$assetGraphPath'),
+            ),
+          )!;
       final aNodeId = makeAssetId('a|lib/a.txt');
       final aCopyNodeId = makeAssetId('a|lib/a.txt.copy');
       final aCloneNodeId = makeAssetId('a|lib/a.txt.copy.clone');
@@ -1574,9 +1579,12 @@ targets:
       );
 
       // Read cached graph and validate.
-      final graph = AssetGraph.deserialize(
-        result.readerWriter.testing.readBytes(makeAssetId('a|$assetGraphPath')),
-      );
+      final graph =
+          AssetGraph.deserialize(
+            result.readerWriter.testing.readBytes(
+              makeAssetId('a|$assetGraphPath'),
+            ),
+          )!;
       final outputNode = graph.get(makeAssetId('a|lib/file.a.copy'))!;
       final fileANode = graph.get(makeAssetId('a|lib/file.a'))!;
       final fileBNode = graph.get(makeAssetId('a|lib/file.b'))!;
@@ -1795,9 +1803,10 @@ targets:
         resumeFrom: result,
       );
 
-      final finalGraph = AssetGraph.deserialize(
-        result.readerWriter.testing.readBytes(AssetId('a', assetGraphPath)),
-      );
+      final finalGraph =
+          AssetGraph.deserialize(
+            result.readerWriter.testing.readBytes(AssetId('a', assetGraphPath)),
+          )!;
 
       expect(
         finalGraph.get(AssetId('a', 'web/a.g1'))!.generatedNodeState!.result,

--- a/build_runner/test/commands/watch/watcher_test.dart
+++ b/build_runner/test/commands/watch/watcher_test.dart
@@ -394,9 +394,10 @@ targets:
           readerWriter: readerWriter,
         );
 
-        final cachedGraph = AssetGraph.deserialize(
-          readerWriter.testing.readBytes(makeAssetId('a|$assetGraphPath')),
-        );
+        final cachedGraph =
+            AssetGraph.deserialize(
+              readerWriter.testing.readBytes(makeAssetId('a|$assetGraphPath')),
+            )!;
 
         final expectedGraph = await AssetGraph.build(
           BuildPhases([]),


### PR DESCRIPTION
Start to use return values instead of exceptions for cases that should be handled.