### PR TITLE
Fix doc comment typo in resolver.dart

### DIFF
--- a/build/lib/src/resolver.dart
+++ b/build/lib/src/resolver.dart
@@ -15,7 +15,7 @@ import 'build_step.dart';
 
 /// Standard interface for resolving Dart source code as part of a build.
 abstract class Resolver {
-  /// Returns whether [assetId] represents an Dart library file.
+  /// Returns whether [assetId] represents a Dart library file.
   ///
   /// This will be `false` in the case where the file is not Dart source code,
   /// or is a `part of` file (not a standalone Dart library).


### PR DESCRIPTION
This PR fixes a typo in a doc comment changing "**an** Dart library" to "**a** Dart library".

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
