### PR TITLE
Clean up build.yaml warnings.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.8.1-wip
 
+- Improved warnings when an option is specified for an unknown builder.
 - Bug fix: require `args` 2.5.0.
 
 ## 2.8.0

--- a/build_runner/test/bootstrap/build_script_generate_test.dart
+++ b/build_runner/test/bootstrap/build_script_generate_test.dart
@@ -29,29 +29,6 @@ void main() {
     });
 
     group('of builder imports', () {
-      test('warn about deprecated ../ style imports', () async {
-        await d.dir('a', [
-          d.file('build.yaml', '''
-builders:
-  fake:
-    import: "../../../tool/builder.dart"
-    builder_factories: ["myFactory"]
-    build_extensions: {"foo": ["bar"]}
-'''),
-        ]).create();
-
-        final result = await runPub(
-          'a',
-          'run',
-          args: ['build_runner', 'build'],
-        );
-        expect(result.stderr, isEmpty);
-        expect(
-          result.stdout,
-          contains('The `../` import syntax in build.yaml is now deprecated'),
-        );
-      });
-
       test('support package relative imports', () async {
         await d.dir('a', [
           d.file('build.yaml', '''
@@ -69,13 +46,6 @@ builders:
           args: ['build_runner', 'build'],
         );
         expect(result.stderr, isEmpty);
-        expect(
-          result.stdout,
-          isNot(
-            contains('The `../` import syntax in build.yaml is now deprecated'),
-          ),
-        );
-
         await d.dir('a', [
           d.dir('.dart_tool', [
             d.dir('build', [
@@ -108,31 +78,6 @@ builders:
         expect(result.stderr, isEmpty);
         expect(result.stdout, contains('could not be parsed'));
       });
-
-      test('warn when import not present in packageGraph', () async {
-        await d.dir('a', [
-          d.file('build.yaml', '''
-builders:
-  fake:
-    import: "package:unknown_package/import.dart"
-    builder_factories: ["myFactory"]
-    build_extensions: {"foo": ["bar"]}
-'''),
-        ]).create();
-        final result = await runPub(
-          'a',
-          'run',
-          args: ['build_runner', 'build'],
-        );
-        expect(result.stderr, isEmpty);
-        expect(
-          result.stdout,
-          contains(
-            'Could not load imported package "unknown_package" '
-            'for definition "a:fake".',
-          ),
-        );
-      });
     });
 
     test('checks builder keys in global_options', () async {
@@ -150,13 +95,10 @@ global_options:
       expect(
         result.stdout,
         allOf(
+          contains('Ignoring `global_options` for unknown builder `a:a`.'),
           contains(
-            'Invalid builder key `a:a` found in global_options config of '
-            'build.yaml. This configuration will have no effect.',
-          ),
-          contains(
-            'Invalid builder key `b:b` found in global_options config of '
-            'build.yaml. This configuration will have no effect.',
+            'Ignoring `runs_before` in `global_options` '
+            'referencing unknown builder `b:b`.',
           ),
         ),
       );

--- a/build_runner/test/integration_tests/build_integration_test.dart
+++ b/build_runner/test/integration_tests/build_integration_test.dart
@@ -579,7 +579,12 @@ targets:
 
       final result = await runBuild();
 
-      expect(result, contains('not a known Builder'));
+      expect(
+        result,
+        contains(
+          'Ignoring options for unknown builder `bad:builder` in target `a:a`.',
+        ),
+      );
     });
 
     test('warns on invalid builder key in global options', () async {
@@ -608,7 +613,12 @@ global_options:
 
       final result = await runBuild();
 
-      expect(result, contains('not a known Builder'));
+      expect(
+        result,
+        contains(
+          'Ignoring `global_options` for unknown builder `bad:builder`.',
+        ),
+      );
     });
 
     test('warns on invalid builder key --define', () async {
@@ -632,7 +642,10 @@ global_options:
 
       final result = await runBuild(extraArgs: ['--define=bad:key=foo=bar']);
 
-      expect(result, contains('not a known Builder'));
+      expect(
+        result,
+        contains('Ignoring options overrides for unknown builder `bad:key`.'),
+      );
     });
   });
 


### PR DESCRIPTION
It's awkward for the bootstrap refactor to have warnings issued while generating the build script, fortunately:

 - "Could not load imported package" warning is redundant: the generated script compile will fail with a clear "import not found", and in more cases: wrong filename, not just wrong package.
 - "Relative import is deprecated" ... it's survived quite a lot of years and is harmless, let's un-deprecate it :)
 - References to unknown builders are also warned about later. Improve those warnings and remove the one here.