### PR TITLE
Stop digesting dill output.

### DIFF
--- a/build_runner/lib/src/bootstrap/kernel_compiler.dart
+++ b/build_runner/lib/src/bootstrap/kernel_compiler.dart
@@ -15,6 +15,7 @@ const entrypointDillDigestPath = '$entrypointScriptPath.dill.digest';
 /// Compiles the build script to kernel.
 class KernelCompiler {
   final Depfile _outputDepfile = Depfile(
+    outputPath: entrypointDillPath,
     depfilePath: entrypointDillDepfilePath,
     digestPath: entrypointDillDigestPath,
   );

--- a/build_runner/test/bootstrap/depfile_test.dart
+++ b/build_runner/test/bootstrap/depfile_test.dart
@@ -8,11 +8,7 @@ import 'package:test/test.dart';
 void main() {
   group('Depfile', () {
     test('parses', () async {
-      expect(Depfile.parse('output: input1 input2\n'), [
-        'output',
-        'input1',
-        'input2',
-      ]);
+      expect(Depfile.parse('output: input1 input2\n'), ['input1', 'input2']);
     });
 
     test('parses when filenames have spaces and backslashes', () async {
@@ -21,14 +17,7 @@ void main() {
           r'output: input1 input2 input\ with\ space input4 path\\input5'
           '\n',
         ),
-        [
-          'output',
-          'input1',
-          'input2',
-          'input with space',
-          'input4',
-          r'path\input5',
-        ],
+        ['input1', 'input2', 'input with space', 'input4', r'path\input5'],
       );
     });
   });


### PR DESCRIPTION
The bootstrap rewrite regressed no-op startup time about 1s, a big chunk of that is because of computing the digest of the dill file. Just checking for existence seems sufficient.

No-op build, average over six samples, measured on real Linux box so stdev is pretty low (29ms)
Before bootstrap rewrite: 2448ms
After rewrite: 3533ms
With this change: 2822ms

The remainder of the slowdown can be recovered by not computing recomputing digests if they were very recently calculated, will send that as a follow-up.