### PR TITLE
Skip duplicate checks on startup.

### DIFF
--- a/build_runner/lib/src/bootstrap/kernel_compiler.dart
+++ b/build_runner/lib/src/bootstrap/kernel_compiler.dart
@@ -21,7 +21,11 @@ class KernelCompiler {
   );
 
   /// Checks freshness of the build script compiled kernel.
-  FreshnessResult checkFreshness() => _outputDepfile.checkFreshness();
+  ///
+  /// Set [digestsAreFresh] if digests were very recently updated. Then, they
+  /// will be re-used from disk if possible instead of recomputed.
+  FreshnessResult checkFreshness({required bool digestsAreFresh}) =>
+      _outputDepfile.checkFreshness(digestsAreFresh: digestsAreFresh);
 
   /// Checks whether [path] in a dependency of the build script compiled kernel.
   ///

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -96,14 +96,20 @@ class BuildPlan {
   /// Files that should be deleted before restarting or building are accumulated
   /// in [filesToDelete] and [foldersToDelete]. Call [deleteFilesAndFolders] to
   /// delete them.
+  ///
+  /// Set [recentlyBootstrapped] to false to do checks that are also done during
+  /// bootstrapping.
   static Future<BuildPlan> load({
     required BuilderFactories builderFactories,
     required BuildOptions buildOptions,
     required TestingOverrides testingOverrides,
+    bool recentlyBootstrapped = true,
   }) async {
     final bootstrapper = Bootstrapper();
     var restartIsNeeded = false;
-    final kernelFreshness = await bootstrapper.checkKernelFreshness();
+    final kernelFreshness = await bootstrapper.checkKernelFreshness(
+      digestsAreFresh: recentlyBootstrapped,
+    );
     if (!kernelFreshness.outputIsFresh) {
       restartIsNeeded = true;
     }
@@ -350,8 +356,8 @@ class BuildPlan {
 
   /// Reloads the build plan.
   ///
-  /// Works just like a new load of the build plan, but supresses the usual log
-  /// output.
+  /// Works just like a new load of the build plan, but sets
+  /// `recentlyBootstrapped` to `false` to redo checks from bootstrapping.
   ///
   /// The caller must call [deleteFilesAndFolders] on the result and check
   /// [restartIsNeeded].
@@ -359,6 +365,7 @@ class BuildPlan {
     builderFactories: builderFactories,
     buildOptions: buildOptions,
     testingOverrides: testingOverrides,
+    recentlyBootstrapped: false,
   );
 }
 

--- a/build_runner/lib/src/commands/build_command.dart
+++ b/build_runner/lib/src/commands/build_command.dart
@@ -57,7 +57,7 @@ class BuildCommand implements BuildRunnerCommand {
     }
 
     final buildSeries = BuildSeries(buildPlan);
-    final result = await buildSeries.run({});
+    final result = await buildSeries.run({}, recentlyBootstrapped: true);
     await buildSeries.close();
     return result;
   }

--- a/build_runner/lib/src/commands/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/commands/daemon/daemon_builder.dart
@@ -110,6 +110,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
       final mergedChanges = collectChanges([changes]);
       final result = await buildSeries.run(
         mergedChanges,
+        recentlyBootstrapped: false,
         buildDirs: buildDirs.build(),
         buildFilters: buildFilters.build(),
       );

--- a/build_runner/lib/src/commands/watch/watcher.dart
+++ b/build_runner/lib/src/commands/watch/watcher.dart
@@ -78,13 +78,16 @@ class Watcher {
         .ignore();
 
     await graphWatcher.ready;
-    await _buildSeries.run({});
+    await _buildSeries.run({}, recentlyBootstrapped: true);
   }
 
   Future<BuildResult> _doBuild(List<List<AssetChange>> changes) async {
     final mergedChanges = collectChanges(changes);
     _expectedDeletes.clear();
-    final result = await _buildSeries.run(mergedChanges);
+    final result = await _buildSeries.run(
+      mergedChanges,
+      recentlyBootstrapped: false,
+    );
     return result;
   }
 }

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -154,7 +154,7 @@ Future<TestBuildersResult> testPhases(
 
   BuildResult result;
   final buildSeries = BuildSeries(buildPlan);
-  result = await buildSeries.run({});
+  result = await buildSeries.run({}, recentlyBootstrapped: true);
   await buildSeries.close();
 
   if (checkBuildStatus) {

--- a/build_runner/test/integration_tests/kernel_compiler_test.dart
+++ b/build_runner/test/integration_tests/kernel_compiler_test.dart
@@ -27,7 +27,7 @@ import 'dart:io';
 import 'package:build_runner/src/bootstrap/kernel_compiler.dart';
 void main() async {
   final compiler = KernelCompiler();
-  if (compiler.checkFreshness().outputIsFresh) {
+  if (compiler.checkFreshness(digestsAreFresh: false).outputIsFresh) {
     stdout.write('fresh\n');
   } else {
     stdout.write('compiling\n');

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -467,7 +467,7 @@ Future<TestBuilderResult> testBuilderFactories(
   final buildSeries = BuildSeries(buildPlan);
 
   // Run the build.
-  final buildResult = await buildSeries.run({});
+  final buildResult = await buildSeries.run({}, recentlyBootstrapped: true);
 
   // Do cleanup that would usually happen on process exit.
   await buildSeries.close();


### PR DESCRIPTION
The depfiles/digests check was being done up to three times: in the bootstrapper, creating the `BuildPlan`, and on the first build.

Various places know that they are running immediately on startup after bootstrapping, so they can skip doing the checks again.

This gets no-op startup to within about 50ms of where it was before the refactoring.