### PR TITLE
Release build_runner 2.9.0, build 4.0.1.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.1-wip
+## 4.0.1
 
 - Improvements to dartdoc.
 

--- a/build/lib/src/logging.dart
+++ b/build/lib/src/logging.dart
@@ -21,7 +21,7 @@ final _default = Logger('build.fallback');
 ///
 /// At [Level.WARNING] but below [Level.SEVERE] is called a "warning".
 ///
-/// Warnings are aways shown, and the final build status will indicate that
+/// Warnings are always shown, and the final build status will indicate that
 /// the build completed with warnings.
 ///
 /// At or above [Level.SEVERE] is an "error".

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 4.0.1-wip
+version: 4.0.1
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,11 +1,12 @@
-## 2.8.1-wip
+## 2.9.0
 
-- Rewrite bootstrap code to remove use of `dart:mirrors`.
-- Watch mode: handle builder code and config changes without exiting.
+- Watch mode: handle builder code and config changes without recompiling or
+  exiting.
 - Remove log output about `build_runner` internals.
 - Print the port that gets picked if you pass 0 for a port number, for example
   with `dart run build_runner serve web:0`.
-- Improved warnings when an option is specified for an unknown builder.
+- Improve warnings when an option is specified for an unknown builder.
+- Rewrite bootstrap code to remove use of `dart:mirrors`.
 - Bug fix: require `args` 2.5.0.
 
 ## 2.8.0

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.8.1-wip
+version: 2.9.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 3.4.1-wip
+## 3.4.1
 
-- Use `build_runner` 2.8.1-wip.
-- Use `build` 4.0.1-wip.
+- Use `build_runner` 2.9.0.
+- Use `build` 4.0.1.
 
 ## 3.4.0
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.4.1-wip
+version: 3.4.1
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -8,9 +8,9 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  build: '4.0.1-wip'
+  build: '4.0.1'
   build_config: ^1.0.0
-  build_runner: '2.8.1-wip'
+  build_runner: '2.9.0'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Release the bootstrap refactoring before the AOT compilation it's there to allow, so we have a better chance to detect if I broke/regressed anything.

Fix a typo in build API docs.

Release build (API docs) and build_test (pins to build+build_runner).