### PR TITLE
Improve TestBuilderResult.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.1-wip
+
+- Internal changes for `build_test`.
+
 ## 2.9.0
 
 - Watch mode: handle builder code and config changes without recompiling or

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -190,9 +190,11 @@ class Build {
     }
 
     _resolvers.reset();
-    buildLog.finishBuild(
-      result: result.status == BuildStatus.success,
-      outputs: result.outputs.length,
+    result = result.copyWith(
+      errors: buildLog.finishBuild(
+        result: result.status == BuildStatus.success,
+        outputs: result.outputs.length,
+      ),
     );
     return result;
   }

--- a/build_runner/lib/src/build/build_result.dart
+++ b/build_runner/lib/src/build/build_result.dart
@@ -18,6 +18,9 @@ class BuildResult {
   /// The type of failure.
   final FailureType? failureType;
 
+  /// Errors reported.
+  final BuiltList<String> errors;
+
   /// All outputs created/updated during this build.
   final BuiltList<AssetId> outputs;
 
@@ -30,6 +33,7 @@ class BuildResult {
 
   BuildResult({
     required this.status,
+    BuiltList<String>? errors,
     BuiltList<AssetId>? outputs,
     required this.buildOutputReader,
     this.performance,
@@ -38,16 +42,21 @@ class BuildResult {
            failureType == null && status == BuildStatus.failure
                ? FailureType.general
                : failureType,
+       errors = errors ?? BuiltList(),
        outputs = outputs ?? BuiltList();
 
-  BuildResult copyWith({BuildStatus? status, FailureType? failureType}) =>
-      BuildResult(
-        status: status ?? this.status,
-        outputs: outputs,
-        buildOutputReader: buildOutputReader,
-        performance: performance,
-        failureType: failureType ?? this.failureType,
-      );
+  BuildResult copyWith({
+    BuildStatus? status,
+    FailureType? failureType,
+    BuiltList<String>? errors,
+  }) => BuildResult(
+    status: status ?? this.status,
+    errors: errors ?? this.errors,
+    outputs: outputs,
+    buildOutputReader: buildOutputReader,
+    performance: performance,
+    failureType: failureType ?? this.failureType,
+  );
 
   @override
   String toString() {

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.9.0
+version: 2.9.1-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -889,8 +889,8 @@ targets:
         (await testBuilders(
           [TestBuilder(build: copyFrom(makeAssetId('a|.dart_tool/any_file')))],
           {'a|lib/a.txt': 'a', 'a|.dart_tool/any_file': 'content'},
-        )).buildResult.status,
-        BuildStatus.failure,
+        )).succeeded,
+        false,
       );
     });
 

--- a/build_runner/test/build/write_cache_test.dart
+++ b/build_runner/test/build/write_cache_test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:build/build.dart';
-import 'package:build_runner/src/build/build_result.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
@@ -25,7 +24,7 @@ void main() {
       readerWriter: readerWriter,
       enableLowResourceMode: true,
     );
-    expect(result.buildResult.status, BuildStatus.success);
+    expect(result.succeeded, true);
   });
 
   test('with caching writes wait until build completion', () async {
@@ -40,7 +39,7 @@ void main() {
       readerWriter: readerWriter,
       enableLowResourceMode: false,
     );
-    expect(result.buildResult.status, BuildStatus.success);
+    expect(result.succeeded, true);
     expect(
       readerWriter.testing.assets,
       containsAll([
@@ -66,7 +65,7 @@ void main() {
       readerWriter: readerWriter,
       enableLowResourceMode: false,
     );
-    expect(result.buildResult.status, BuildStatus.success);
+    expect(result.succeeded, true);
   });
 }
 

--- a/build_runner/test/build_plan/build_triggers_test.dart
+++ b/build_runner/test/build_plan/build_triggers_test.dart
@@ -6,7 +6,6 @@ import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
-import 'package:build_runner/src/build/build_result.dart';
 import 'package:build_runner/src/build_plan/build_triggers.dart';
 import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
@@ -250,7 +249,7 @@ triggers:
         outputs: {},
         testingBuilderConfig: false,
       );
-      expect(result.buildResult.status, BuildStatus.success);
+      expect(result.succeeded, true);
     });
 
     test('trigger builder in same file', () async {
@@ -295,7 +294,7 @@ triggers:
         outputs: {},
         testingBuilderConfig: false,
       );
-      expect(result.buildResult.status, BuildStatus.success);
+      expect(result.succeeded, true);
     });
 
     test('trigger builder in part file', () async {

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.5.0-wip
+
+- Improve `TestBuilderResult`: add `succeeded`, `outputs` and `errors`.
+  Deprecate `buildResult` in favor of these new members.
+- Add `verbose` to `testBuilders` and related methods. Like the command line
+  flag it enables info logging from builders.
+
 ## 3.4.1
 
 - Use `build_runner` 2.9.0.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.4.1
+version: 3.5.0-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: '4.0.1'
   build_config: ^1.0.0
-  build_runner: '2.9.0'
+  build_runner: '2.9.1-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Improvements that help with syncing into google3.

Return build errors, it's very common to check them and you currently have to use a log interceptor to do that.

Return success boolean outputs from `BuildResult` because it's not a public type, deprecate using it directly. Fix #4100 

Give a way to set verbose logging.