### PR TITLE
Add ability to force JS from query param instead of wasm.

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 4.2.5
+## 4.3.0
 
-- Add support for `force_js=true` query parameter when both wasm and js builds
-  are enabled.
+- When both wasm and js builds are enabled you can now add force_js=true
+  to the URL in your browser to load the js build.
 
 ## 4.2.4
 

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.2.5
+
+- Add support for `force_js=true` query parameter when both wasm and js builds
+  are enabled.
+
 ## 4.2.4
 
 - Allow Dart SDK 3.10.x and 3.11 prerelease.

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -393,7 +393,9 @@ function relativeURL(ref) {
               '[0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 95, 1, 120, 0]))';
 
       loaderResult.writeln('''
-if ($supportCheck) {
+const searchParams = new URLSearchParams(window.location.search);
+const forceJS = searchParams.get('force_js');
+if (!forceJS && $supportCheck) {
 ''');
     }
 

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.2.4
+version: 4.3.0
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
Adds a check for a `force_js` query param in the URL to switch between WASM and JS on-demand.