### PR TITLE
Add `flattenOutput` to `testBuilder`.

### DIFF
--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -15,6 +15,7 @@ import '../commands/watch/asset_change.dart';
 import '../constants.dart';
 import '../io/asset_tracker.dart';
 import '../io/filesystem_cache.dart';
+import '../io/generated_asset_hider.dart';
 import '../io/reader_writer.dart';
 import '../logging/build_log.dart';
 import 'asset_graph/graph.dart';
@@ -69,7 +70,10 @@ class BuildSeries {
   factory BuildSeries(BuildPlan buildPlan) {
     final assetGraph = buildPlan.takeAssetGraph();
     final readerWriter = buildPlan.readerWriter.copyWith(
-      generatedAssetHider: assetGraph,
+      generatedAssetHider:
+          buildPlan.testingOverrides.flattenOutput
+              ? const NoopGeneratedAssetHider()
+              : assetGraph,
       cache:
           buildPlan.buildOptions.enableLowResourcesMode
               ? const PassthroughFilesystemCache()
@@ -247,7 +251,10 @@ class BuildSeries {
       }
       _assetGraph = _buildPlan.takeAssetGraph();
       _readerWriter = _buildPlan.readerWriter.copyWith(
-        generatedAssetHider: _assetGraph,
+        generatedAssetHider:
+            _buildPlan.testingOverrides.flattenOutput
+                ? const NoopGeneratedAssetHider()
+                : _assetGraph,
         cache:
             _buildPlan.buildOptions.enableLowResourcesMode
                 ? const PassthroughFilesystemCache()

--- a/build_runner/lib/src/build_plan/testing_overrides.dart
+++ b/build_runner/lib/src/build_plan/testing_overrides.dart
@@ -29,6 +29,7 @@ class TestingOverrides {
   final void Function(AssetId, Iterable<AssetId>)? reportUnusedAssetsForInput;
   final Resolvers? resolvers;
   final Stream<ProcessSignal>? terminateEventStream;
+  final bool flattenOutput;
 
   const TestingOverrides({
     this.builderApplications,
@@ -43,6 +44,7 @@ class TestingOverrides {
     this.reportUnusedAssetsForInput,
     this.resolvers,
     this.terminateEventStream,
+    this.flattenOutput = false,
   });
 
   TestingOverrides copyWith({
@@ -62,5 +64,6 @@ class TestingOverrides {
     reportUnusedAssetsForInput: reportUnusedAssetsForInput,
     resolvers: resolvers,
     terminateEventStream: terminateEventStream,
+    flattenOutput: flattenOutput,
   );
 }

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -4,6 +4,9 @@
   Deprecate `buildResult` in favor of these new members.
 - Add `verbose` to `testBuilders` and related methods. Like the command line
   flag it enables info logging from builders.
+- Add `flattenOutput` to `testBuilders`. Use it for a less realistic but simpler
+  build in which generated outputs are always written directly to each package
+  instead of "hidden" output being written to `.dart_tool/build/generated`.
 
 ## 3.4.1
 

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -139,6 +139,7 @@ Future<TestBuilderResult> testBuilder(
   TestReaderWriter? readerWriter,
   bool verbose = false,
   bool enableLowResourceMode = false,
+  bool flattenOutput = false,
 }) async {
   return testBuilders(
     [builder],
@@ -154,6 +155,7 @@ Future<TestBuilderResult> testBuilder(
     readerWriter: readerWriter,
     verbose: verbose,
     enableLowResourceMode: enableLowResourceMode,
+    flattenOutput: flattenOutput,
   );
 }
 
@@ -186,6 +188,7 @@ Future<TestBuilderResult> testBuilders(
   TestReaderWriter? readerWriter,
   bool verbose = false,
   bool enableLowResourceMode = false,
+  bool flattenOutput = false,
 }) {
   final builderFactories = <BuilderFactory>[];
   final optionalBuilderFactories = Set<BuilderFactory>.identity();
@@ -227,6 +230,7 @@ Future<TestBuilderResult> testBuilders(
     readerWriter: readerWriter,
     verbose: verbose,
     enableLowResourceMode: enableLowResourceMode,
+    flattenOutput: flattenOutput,
   );
 }
 
@@ -293,6 +297,11 @@ Future<TestBuilderResult> testBuilders(
 /// Optionally pass [enableLowResourceMode], which acts like the command
 /// line flag; in particular it disables file caching.
 ///
+/// By default generated outputs are written to the `TestReaderWriter` where
+/// they would be written in a real `build_runner` build, which means "hidden"
+/// outputs go in the `.dart_tool/build/generated` folder in the root package.
+/// Pass [flattenOutput] to instead output next to each package source.
+///
 /// Returns a [TestBuilderResult] with the [BuildResult] and the
 /// [TestReaderWriter] used for the build, which can be used for further
 /// checks.
@@ -315,6 +324,7 @@ Future<TestBuilderResult> testBuilderFactories(
   TestReaderWriter? readerWriter,
   bool verbose = false,
   bool enableLowResourceMode = false,
+  bool flattenOutput = false,
 }) async {
   onLog ??= _printOnFailureOrWrite;
 
@@ -412,14 +422,14 @@ Future<TestBuilderResult> testBuilderFactories(
       ),
     );
   }
-  for (final postProcessBuiderFactory in postProcessBuilderFactories) {
+  for (final postProcessBuilderFactory in postProcessBuilderFactories) {
     String name;
     try {
-      name = builderName(postProcessBuiderFactory(const BuilderOptions({})));
+      name = builderName(postProcessBuilderFactory(const BuilderOptions({})));
     } catch (e) {
       name = e.toString();
     }
-    builderApplications.add(applyPostProcess(name, postProcessBuiderFactory));
+    builderApplications.add(applyPostProcess(name, postProcessBuilderFactory));
   }
 
   final testingOverrides = TestingOverrides(
@@ -461,6 +471,7 @@ Future<TestBuilderResult> testBuilderFactories(
             }.build()
             : null,
     reportUnusedAssetsForInput: reportUnusedAssetsForInput,
+    flattenOutput: flattenOutput,
   );
 
   final buildPlan = await BuildPlan.load(

--- a/build_test/test/test_builder_test.dart
+++ b/build_test/test/test_builder_test.dart
@@ -483,6 +483,40 @@ import 'package:glob/glob.dart';
     expect(logs.join('\n'), contains('Exception: some exception'));
     expect(result.errors.join('\n'), contains('Exception: some exception'));
   });
+
+  test('restricts inputs to `generateFor`', () {
+    return testBuilder(
+      TestBuilder(),
+      {'a|a.txt': '', 'a|b.txt': ''},
+      generateFor: {'a|a.txt'},
+      outputs: {'a|a.txt.copy': ''},
+    );
+  });
+
+  test('output is under `.dart_tool` by default', () async {
+    final result = await testBuilder(
+      TestBuilder(),
+      {'a|a.txt': ''},
+      outputs: {'a|a.txt.copy': ''},
+    );
+    expect(
+      result.readerWriter.testing.assets,
+      contains(AssetId('a', '.dart_tool/build/generated/a/a.txt.copy')),
+    );
+  });
+
+  test('output is flattened with `flattenOutput`', () async {
+    final result = await testBuilder(
+      TestBuilder(),
+      {'a|a.txt': ''},
+      outputs: {'a|a.txt.copy': ''},
+      flattenOutput: true,
+    );
+    expect(
+      result.readerWriter.testing.assets,
+      contains(AssetId('a', 'a.txt.copy')),
+    );
+  });
 }
 
 /// Concatenates the contents of multiple text files into a single output.


### PR DESCRIPTION
Again for google3, which never cares about `.dart_tool/build/generated` so it's a bit weird to have to mention it in tests.

