### PR TITLE
Bump analyzer version.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.2
+
+- Require `analyzer` 8.0.0. Remove use of deprecated `analyzer` members, use
+  their recommended and compatible replacements.
+
 ## 4.0.1
 
 - Improvements to dartdoc.

--- a/build/lib/src/build_step.dart
+++ b/build/lib/src/build_step.dart
@@ -5,8 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-// ignore: deprecated_member_use until analyzer 7 support is dropped.
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:package_config/package_config_types.dart';
@@ -33,8 +32,7 @@ abstract class BuildStep implements AssetReader, AssetWriter {
   ///
   /// To resolve allowing syntax errors, instead use
   /// `resolver.libraryFor(buildStep.inputId, allowSyntaxErrors: true)`.
-  // ignore: deprecated_member_use until analyzer 7 support is dropped.
-  Future<LibraryElement2> get inputLibrary;
+  Future<LibraryElement> get inputLibrary;
 
   /// A [Resolver] that can parse or resolve any Dart source code visible to
   /// this build step.

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 4.0.1
+version: 4.0.2
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: '>=7.4.0 <9.0.0'
+  analyzer: ^8.0.0
   crypto: ^3.0.0
   glob: ^2.0.0
   logging: ^1.0.0

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -23,16 +23,10 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  # TODO(davidmorgan): add back when released for build 3.0.0.
-  # built_value_generator: ^8.1.0
+  built_value_generator: ^8.1.0
   mockito: ^5.0.0
   test: ^1.25.5
   test_descriptor: ^2.0.0
-
-# TODO(davidmorgan): remove when these are released for build 3.0.0.
-dependency_overrides:
-  mockito: '5.4.6'
-  source_gen: '2.0.0'
 
 topics:
  - build-runner

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.9.1-wip
 
+- Require `analyzer` 8.0.0. Remove use of deprecated `analyzer` members, use
+  their recommended and compatible replacements.
 - Internal changes for `build_test`.
 - Add the `--dart-jit-vm-arg` option. Its values are passed to `dart run` when
   a build script is started in JIT mode. This allows specifying options to

--- a/build_runner/lib/src/build/build_step_impl.dart
+++ b/build_runner/lib/src/build/build_step_impl.dart
@@ -2,14 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: deprecated_member_use until analyzer 7 support is dropped.
-
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:async/async.dart';
 import 'package:build/build.dart';
 import 'package:crypto/crypto.dart';
@@ -34,7 +32,7 @@ class BuildStepImpl implements BuildStep {
   final AssetId inputId;
 
   @override
-  Future<LibraryElement2> get inputLibrary async {
+  Future<LibraryElement> get inputLibrary async {
     if (_isComplete) throw BuildStepCompletedException();
     return resolver.libraryFor(inputId);
   }
@@ -221,8 +219,8 @@ class _DelayedResolver implements Resolver {
       (await _delegate).isLibrary(assetId);
 
   @override
-  Stream<LibraryElement2> get libraries {
-    final completer = StreamCompleter<LibraryElement2>();
+  Stream<LibraryElement> get libraries {
+    final completer = StreamCompleter<LibraryElement>();
     _delegate.then((r) => completer.setSourceStream(r.libraries));
     return completer.stream;
   }
@@ -243,7 +241,7 @@ class _DelayedResolver implements Resolver {
   );
 
   @override
-  Future<LibraryElement2> libraryFor(
+  Future<LibraryElement> libraryFor(
     AssetId assetId, {
     bool allowSyntaxErrors = false,
   }) async => (await _delegate).libraryFor(
@@ -252,10 +250,10 @@ class _DelayedResolver implements Resolver {
   );
 
   @override
-  Future<LibraryElement2?> findLibraryByName(String libraryName) async =>
+  Future<LibraryElement?> findLibraryByName(String libraryName) async =>
       (await _delegate).findLibraryByName(libraryName);
 
   @override
-  Future<AssetId> assetIdForElement(Element2 element) async =>
+  Future<AssetId> assetIdForElement(Element element) async =>
       (await _delegate).assetIdForElement(element);
 }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -13,7 +13,7 @@ platforms:
   macos:
 
 dependencies:
-  analyzer: '>=7.4.0 <9.0.0'
+  analyzer: ^8.0.0
   args: ^2.5.0
   async: ^2.5.0
   build: ^4.0.0

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  build: '4.0.1'
+  build: ^4.0.0
   build_config: ^1.0.0
   build_runner: '2.9.1-wip'
   built_collection: ^5.1.1
@@ -25,7 +25,7 @@ dependencies:
   watcher: ^1.0.0
 
 dev_dependencies:
-  analyzer: '>=5.2.0 <9.0.0'
+  analyzer: ^8.0.0
 
 topics:
  - build-runner


### PR DESCRIPTION
Now that it's possible to roll into google3, require analyzer 8 and remove use of deprecated members so that can roll into google3.

`build` is ready to publish.