### PR TITLE
Release build_runner 2.10.0.

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.5-wip
+## 4.1.0
 
 - Bug fix: resolve symlinks when identifying workspaces, so symlinks can't
   cause the same workspace to be treated as a different workspace.

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version:  4.0.5-wip
+version:  4.1.0
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 resolution: workspace

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.9.1-wip
+## 2.10.0
 
 - Add AOT compilation of builders. A future release will AOT compile builders
   automatically, for this release it's behind a flag. AOT compiled builders
@@ -15,8 +15,7 @@
 
 ## 2.9.0
 
-- Watch mode: handle builder code and config changes without recompiling or
-  exiting.
+- Watch mode: handle builder config changes without recompiling or exiting.
 - Remove log output about `build_runner` internals.
 - Print the port that gets picked if you pass 0 for a port number, for example
   with `dart run build_runner serve web:0`.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.9.1-wip
+version: 2.10.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.5.0-wip
+## 3.5.0
 
 - Improve `TestBuilderResult`: add `succeeded`, `outputs` and `errors`.
   Deprecate `buildResult` in favor of these new members.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.0-wip
+version: 3.5.0
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.9.1-wip'
+  build_runner: '2.10.0'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Also release `build_test`, which is pinned to build_runner, and build_daemon, which happened to get a minor bug fix and testability improvement.

Fix the 2.9 changelog entry which said "...code changes...without recompiling" which doesn't make sense, it's also true that some config changes are _no longer_ code changes, but that's going into too much detail :)