### PR TITLE
Fix trigger lookup

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.10.1-wip
+
+- Bug fix: look up triggers in the `triggers` section of `build.yaml` using the
+  full name. For the case in which the builder name matched the package name,
+  the abbreviated name was being used instead.
+
 ## 2.10.0
 
 - Add AOT compilation of builders. A future release will AOT compile builders

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -664,8 +664,8 @@ class AssetGraph implements GeneratedAssetHider {
             existing.id,
             buildPhases
                 .inBuildPhases[existingConfiguration.phaseNumber]
-                .builderLabel,
-            buildPhases.inBuildPhases[phaseNumber].builderLabel,
+                .displayName,
+            buildPhases.inBuildPhases[phaseNumber].displayName,
           );
         }
         _removeRecursive(output, removedIds: removed);

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -461,7 +461,7 @@ class Build {
     final builder = phase.builder;
     final tracker = performanceTracker.addBuilderAction(
       primaryInput,
-      phase.builderLabel,
+      phase.displayName,
     );
     return tracker.track(() async {
       final readerWriter = SingleStepReaderWriter(
@@ -483,7 +483,7 @@ class Build {
         inputTracker: InputTracker(
           this.readerWriter.filesystem,
           primaryInput: primaryInput,
-          builderLabel: phase.builderLabel,
+          builderLabel: phase.displayName,
         ),
         assetsWritten: {},
       );
@@ -587,12 +587,11 @@ class Build {
     required InBuildPhase phase,
     required AssetId primaryInput,
   }) async {
-    final runsIfTriggered =
-        phase.builderOptions.config['run_only_if_triggered'];
+    final runsIfTriggered = phase.options.config['run_only_if_triggered'];
     if (runsIfTriggered != true) {
       return true;
     }
-    final buildTriggers = targetGraph.buildTriggers[phase.builderLabel];
+    final buildTriggers = targetGraph.buildTriggers[phase.key];
     if (buildTriggers == null) {
       return false;
     }

--- a/build_runner/lib/src/build/performance_tracker.dart
+++ b/build_runner/lib/src/build/performance_tracker.dart
@@ -222,7 +222,7 @@ class BuildPhaseTracker extends SimpleAsyncTimeTracker
   BuildPhaseTracker(BuildPhase action)
     : builderKeys =
           action is InBuildPhase
-              ? [action.builderLabel]
+              ? [action.displayName]
               : (action as PostBuildPhase).builderActions
                   .map((action) => action.builderLabel)
                   .toList();

--- a/build_runner/lib/src/build_plan/apply_builders.dart
+++ b/build_runner/lib/src/build_plan/apply_builders.dart
@@ -114,7 +114,7 @@ BuilderApplication applyPostProcess(
 );
 
 BuilderApplication _forBuilder(
-  String builderKey,
+  String key,
   Iterable<BuilderFactory> builderFactories,
   PackageFilter filter, {
   bool isOptional = false,
@@ -149,24 +149,24 @@ BuilderApplication _forBuilder(
 
           final builder = BuildLogLogger.scopeLogSync(
             () => builderFactory(optionsWithDefaults),
-            buildLog.loggerForOther(builderKey),
+            buildLog.loggerForOther(key),
           );
           if (builder == null) throw const CannotBuildException();
           _validateBuilder(builder);
           return InBuildPhase(
-            builder,
-            package.name,
-            builderKey: builderKey,
+            builder: builder,
+            key: key,
+            package: package.name,
             targetSources: targetSources,
             generateFor: generateFor,
-            builderOptions: optionsWithDefaults,
+            options: optionsWithDefaults,
             hideOutput: hideOutput,
             isOptional: isOptional,
           );
         };
       }).toList();
   return BuilderApplication(
-    builderKey,
+    key,
     phaseFactories,
     filter,
     hideOutput,
@@ -211,9 +211,9 @@ BuilderApplication _forPostProcessBuilder(
     if (builder == null) throw const CannotBuildException();
     _validatePostProcessBuilder(builder);
     final builderAction = PostBuildAction(
-      builder,
-      package.name,
-      builderOptions: optionsWithDefaults,
+      builder: builder,
+      package: package.name,
+      options: optionsWithDefaults,
       generateFor: generateFor,
       targetSources: targetSources,
     );

--- a/build_runner/lib/src/build_plan/build_phases.dart
+++ b/build_runner/lib/src/build_plan/build_phases.dart
@@ -79,7 +79,7 @@ class BuildPhases {
   static BuiltList<Digest> _digestsOf(Iterable<BuildAction> actions) {
     final result = ListBuilder<Digest>();
     for (final action in actions) {
-      result.add(_digestOf(action.builderOptions));
+      result.add(_digestOf(action.options));
     }
     return result.build();
   }
@@ -103,7 +103,7 @@ class BuildPhases {
       // This should happen only with a manual build script since the build
       // script generation filters these out.
       buildLog.error(
-        'A build phase (${action.builderLabel}) is attempting '
+        'A build phase (${action.displayName}) is attempting '
         'to operate on package "${action.package}", but the build script '
         'is located in package "$root". It\'s not valid to attempt to '
         'generate files for another package unless the BuilderApplication'

--- a/build_runner/lib/src/logging/build_log.dart
+++ b/build_runner/lib/src/logging/build_log.dart
@@ -546,7 +546,7 @@ extension _IntExtension on int {
 
 extension _PhaseExtension on InBuildPhase {
   String name({required bool lazy}) =>
-      lazy ? '$builderLabel (lazy)' : builderLabel;
+      lazy ? '$displayName (lazy)' : displayName;
 }
 
 /// Progress metrics tracked for each build phase.

--- a/build_runner/lib/src/logging/timed_activities.dart
+++ b/build_runner/lib/src/logging/timed_activities.dart
@@ -37,7 +37,7 @@ extension type TimedActivity(String name) {
   ///
   /// Only lazy builds, which means builds that are triggered by a required
   /// build, are tracked in this way.
-  TimedActivity.lazyPhase(InBuildPhase phase) : name = phase.builderLabel;
+  TimedActivity.lazyPhase(InBuildPhase phase) : name = phase.displayName;
 
   /// Runs [function] attributing the time spent to this activity.
   ///

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.10.0
+version: 2.10.1-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/build/asset_graph/graph_test.dart
+++ b/build_runner/test/build/asset_graph/graph_test.dart
@@ -177,19 +177,20 @@ void main() {
       final buildPhases = BuildPhases(
         [
           InBuildPhase(
-            TestBuilder(
+            builder: TestBuilder(
               buildExtensions: appendExtension('.copy', from: '.txt'),
             ),
-            'foo',
+            key: 'TestBuilder',
+            package: 'foo',
             targetSources: targetSources,
           ),
         ],
         PostBuildPhase([
           PostBuildAction(
-            CopyingPostProcessBuilder(outputExtension: '.post'),
-            'foo',
+            builder: CopyingPostProcessBuilder(outputExtension: '.post'),
+            package: 'foo',
             targetSources: targetSources,
-            builderOptions: const BuilderOptions({}),
+            options: const BuilderOptions({}),
             generateFor: const InputSet(),
           ),
         ]),
@@ -407,7 +408,16 @@ void main() {
       test('overlapping build phases cause an error', () async {
         expect(
           () => AssetGraph.build(
-            BuildPhases(List.filled(2, InBuildPhase(TestBuilder(), 'foo'))),
+            BuildPhases(
+              List.filled(
+                2,
+                InBuildPhase(
+                  builder: TestBuilder(),
+                  key: 'TestBuilder',
+                  package: 'foo',
+                ),
+              ),
+            ),
             {makeAssetId('foo|file')},
             fooPackageGraph,
             digestReader,
@@ -435,24 +445,27 @@ void main() {
           final graph = await AssetGraph.build(
             BuildPhases([
               InBuildPhase(
-                TestBuilder(
+                builder: TestBuilder(
                   buildExtensions: replaceExtension('.txt', '.a.txt'),
                 ),
-                'foo',
+                key: 'TestBuilder',
+                package: 'foo',
                 hideOutput: false,
               ),
               InBuildPhase(
-                TestBuilder(
+                builder: TestBuilder(
                   buildExtensions: replaceExtension('.txt', '.b.txt'),
                 ),
-                'foo',
+                key: 'TestBuilder',
+                package: 'foo',
                 hideOutput: false,
               ),
               InBuildPhase(
-                TestBuilder(
+                builder: TestBuilder(
                   buildExtensions: replaceExtension('.a.b.txt', '.a.b.c.txt'),
                 ),
-                'foo',
+                key: 'TestBuilder',
+                package: 'foo',
                 hideOutput: false,
               ),
             ]),
@@ -491,14 +504,18 @@ void main() {
           final graph = await AssetGraph.build(
             BuildPhases([
               InBuildPhase(
-                TestBuilder(
+                builder: TestBuilder(
                   buildExtensions: appendExtension('.1', from: '.txt'),
                 ),
-                'foo',
+                key: 'TestBuilder',
+                package: 'foo',
               ),
               InBuildPhase(
-                TestBuilder(buildExtensions: appendExtension('.2', from: '.1')),
-                'foo',
+                builder: TestBuilder(
+                  buildExtensions: appendExtension('.2', from: '.1'),
+                ),
+                key: 'TestBuilder',
+                package: 'foo',
                 targetSources: const InputSet(include: ['lib/*.txt']),
               ),
             ]),
@@ -524,16 +541,18 @@ void main() {
           final toBeGeneratedDart = AssetId('a', 'lib/A.g.dart');
           final buildPhases = BuildPhases([
             InBuildPhase(
-              TestBuilder(
+              builder: TestBuilder(
                 buildExtensions: replaceExtension('.dart', '.g.part'),
               ),
-              'a',
+              key: 'TestBuilder',
+              package: 'a',
             ),
             InBuildPhase(
-              TestBuilder(
+              builder: TestBuilder(
                 buildExtensions: replaceExtension('.g.part', '.g.dart'),
               ),
-              'a',
+              key: 'TestBuilder',
+              package: 'a',
             ),
           ]);
           final packageGraph = buildPackageGraph({rootPackage('a'): []});

--- a/build_runner/test/build/performance_tracker_test.dart
+++ b/build_runner/test/build/performance_tracker_test.dart
@@ -41,7 +41,16 @@ void main() {
       await scopedTrack(() async {
         final packages = ['a', 'b', 'c'];
         final builder = TestBuilder();
-        phases = packages.map((p) => InBuildPhase(builder, p)).toList();
+        phases =
+            packages
+                .map(
+                  (p) => InBuildPhase(
+                    builder: builder,
+                    key: 'TestBuilder',
+                    package: p,
+                  ),
+                )
+                .toList();
 
         for (final phase in phases) {
           final package = phase.package;
@@ -54,7 +63,7 @@ void main() {
       expect(
         tracker.phases.map((p) => p.builderKeys),
         orderedEquals(
-          phases.map((phase) => orderedEquals([phase.builderLabel])),
+          phases.map((phase) => orderedEquals([phase.displayName])),
         ),
       );
 

--- a/build_runner/test/build_plan/apply_builders_test.dart
+++ b/build_runner/test/build_plan/apply_builders_test.dart
@@ -367,11 +367,7 @@ void main() {
           phases.inBuildPhases.first,
           isA<InBuildPhase>()
               .having((p) => p.package, 'package', 'a')
-              .having(
-                (p) => p.builderLabel,
-                'builderLabel',
-                'b:cool_builder_2',
-              ),
+              .having((p) => p.displayName, 'builderLabel', 'b:cool_builder_2'),
         );
       });
 
@@ -390,14 +386,14 @@ void main() {
               isA<InBuildPhase>()
                   .having((p) => p.package, 'package', 'a')
                   .having(
-                    (p) => p.builderLabel,
+                    (p) => p.displayName,
                     'builderLabel',
                     'b:cool_builder',
                   ),
               isA<InBuildPhase>()
                   .having((p) => p.package, 'package', 'a')
                   .having(
-                    (p) => p.builderLabel,
+                    (p) => p.displayName,
                     'builderLabel',
                     'b:cool_builder_2',
                   ),

--- a/build_runner/test/build_plan/build_phases_test.dart
+++ b/build_runner/test/build_plan/build_phases_test.dart
@@ -13,28 +13,37 @@ import '../common/common.dart';
 void main() {
   group('BuildPhases', () {
     test('digest is equal for equal phases', () {
-      final buildPhases1 = BuildPhases([InBuildPhase(TestBuilder(), 'a')]);
-      final buildPhases2 = BuildPhases([InBuildPhase(TestBuilder(), 'a')]);
+      final buildPhases1 = BuildPhases([
+        InBuildPhase(builder: TestBuilder(), key: 'TestBuilder', package: 'a'),
+      ]);
+      final buildPhases2 = BuildPhases([
+        InBuildPhase(builder: TestBuilder(), key: 'TestBuilder', package: 'a'),
+      ]);
 
       expect(buildPhases1.digest, buildPhases2.digest);
     });
 
     test('digest changes on additional builder', () {
-      final buildPhases1 = BuildPhases([InBuildPhase(TestBuilder(), 'a')]);
+      final buildPhases1 = BuildPhases([
+        InBuildPhase(builder: TestBuilder(), key: 'TestBuilder', package: 'a'),
+      ]);
       final buildPhases2 = BuildPhases([
-        InBuildPhase(TestBuilder(), 'a'),
-        InBuildPhase(TestBuilder(), 'a'),
+        InBuildPhase(builder: TestBuilder(), key: 'TestBuilder', package: 'a'),
+        InBuildPhase(builder: TestBuilder(), key: 'TestBuilder', package: 'a'),
       ]);
 
       expect(buildPhases1.digest, isNot(buildPhases2.digest));
     });
 
     test('digest changes on extension change', () {
-      final buildPhases1 = BuildPhases([InBuildPhase(TestBuilder(), 'a')]);
+      final buildPhases1 = BuildPhases([
+        InBuildPhase(builder: TestBuilder(), key: 'TestBuilder', package: 'a'),
+      ]);
       final buildPhases2 = BuildPhases([
         InBuildPhase(
-          TestBuilder(buildExtensions: appendExtension('different')),
-          'a',
+          builder: TestBuilder(buildExtensions: appendExtension('different')),
+          key: 'TestBuilder',
+          package: 'a',
         ),
       ]);
 
@@ -44,8 +53,12 @@ void main() {
     test('digest does not change on builder change', () {
       // Changes to builder code is checked via changes to the build script and
       // deps, not by `BuildPhases`.
-      final buildPhases1 = BuildPhases([InBuildPhase(TestBuilder(), 'a')]);
-      final buildPhases2 = BuildPhases([InBuildPhase(TestBuilder2(), 'a')]);
+      final buildPhases1 = BuildPhases([
+        InBuildPhase(builder: TestBuilder(), key: 'TestBuilder', package: 'a'),
+      ]);
+      final buildPhases2 = BuildPhases([
+        InBuildPhase(builder: TestBuilder2(), key: 'TestBuilder', package: 'a'),
+      ]);
 
       expect(buildPhases1.digest, buildPhases2.digest);
     });
@@ -53,12 +66,15 @@ void main() {
     test('digest does not change on builder options change', () {
       // Changes to builder code is checked via changes to the build script and
       // deps, not by `BuildPhases`.
-      final buildPhases1 = BuildPhases([InBuildPhase(TestBuilder(), 'a')]);
+      final buildPhases1 = BuildPhases([
+        InBuildPhase(builder: TestBuilder(), key: 'TestBuilder', package: 'a'),
+      ]);
       final buildPhases2 = BuildPhases([
         InBuildPhase(
-          TestBuilder(),
-          'a',
-          builderOptions: const BuilderOptions({'a': 'b'}),
+          builder: TestBuilder(),
+          key: 'TestBuilder',
+          package: 'a',
+          options: const BuilderOptions({'a': 'b'}),
         ),
       ]);
 
@@ -68,12 +84,15 @@ void main() {
     test('options digest changes on builder options change', () {
       // Changes to builder code is checked via changes to the build script and
       // deps, not by `BuildPhases`.
-      final buildPhases1 = BuildPhases([InBuildPhase(TestBuilder(), 'a')]);
+      final buildPhases1 = BuildPhases([
+        InBuildPhase(builder: TestBuilder(), key: 'TestBuilder', package: 'a'),
+      ]);
       final buildPhases2 = BuildPhases([
         InBuildPhase(
-          TestBuilder(),
-          'a',
-          builderOptions: const BuilderOptions({'a': 'b'}),
+          builder: TestBuilder(),
+          key: 'TestBuilder',
+          package: 'a',
+          options: const BuilderOptions({'a': 'b'}),
         ),
       ]);
 
@@ -90,9 +109,9 @@ void main() {
         [],
         PostBuildPhase([
           PostBuildAction(
-            const FileDeletingBuilder(['']),
-            'a',
-            builderOptions: const BuilderOptions({}),
+            builder: const FileDeletingBuilder(['']),
+            package: 'a',
+            options: const BuilderOptions({}),
             targetSources: const InputSet(),
             generateFor: const InputSet(),
           ),
@@ -102,9 +121,9 @@ void main() {
         [],
         PostBuildPhase([
           PostBuildAction(
-            const FileDeletingBuilder(['']),
-            'a',
-            builderOptions: const BuilderOptions({'a': 'b'}),
+            builder: const FileDeletingBuilder(['']),
+            package: 'a',
+            options: const BuilderOptions({'a': 'b'}),
             targetSources: const InputSet(),
             generateFor: const InputSet(),
           ),

--- a/build_runner/test/invalidation/build_yaml_invalidation_test.dart
+++ b/build_runner/test/invalidation/build_yaml_invalidation_test.dart
@@ -31,7 +31,7 @@ void main() {
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 ''');
@@ -58,12 +58,12 @@ targets:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 
 triggers:
-  pkg:invalidation_tester_builder:
+  invalidation_tester_builder:invalidation_tester_builder:
     - import trigger/trigger.dart
 ''');
         tester.importGraph({
@@ -96,12 +96,12 @@ triggers:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 
 triggers:
-  pkg:invalidation_tester_builder:
+  invalidation_tester_builder:invalidation_tester_builder:
     - import trigger/trigger.dart
 ''');
         expect(await tester.build(), Result(written: []));
@@ -112,12 +112,12 @@ triggers:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 
 triggers:
-  pkg:invalidation_tester_builder:
+  invalidation_tester_builder:invalidation_tester_builder:
     - import trigger/trigger.dart
 ''');
         await tester.build();
@@ -133,7 +133,7 @@ triggers:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 ''');
@@ -147,12 +147,12 @@ targets:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 
 triggers:
-  pkg:invalidation_tester_builder:
+  invalidation_tester_builder:invalidation_tester_builder:
     - import trigger/trigger.dart
 ''',
           ),
@@ -166,7 +166,7 @@ triggers:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: false
 ''');
@@ -177,7 +177,7 @@ targets:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 ''',
@@ -192,12 +192,12 @@ targets:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 
 triggers:
-  pkg:invalidation_tester_builder:
+  invalidation_tester_builder:invalidation_tester_builder:
     - import trigger/trigger.dart
 ''');
         expect(await tester.build(), Result(written: []));
@@ -207,7 +207,7 @@ triggers:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: false
 ''',
@@ -221,12 +221,12 @@ targets:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 
 triggers:
-  pkg:invalidation_tester_builder:
+  invalidation_tester_builder:invalidation_tester_builder:
     - import trigger/trigger.dart
 ''');
         tester.importGraph({
@@ -243,12 +243,12 @@ triggers:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 
 triggers:
-  pkg:invalidation_tester_builder:
+  invalidation_tester_builder:invalidation_tester_builder:
     - import trigger/trigger.dart
 ''');
         tester.importGraph({
@@ -261,7 +261,7 @@ triggers:
 targets:
   $default:
     builders:
-      pkg:invalidation_tester_builder:
+      invalidation_tester_builder:invalidation_tester_builder:
         options:
           run_only_if_triggered: true
 ''',

--- a/build_runner/test/invalidation/invalidation_tester.dart
+++ b/build_runner/test/invalidation/invalidation_tester.dart
@@ -557,7 +557,8 @@ class TestBuilder implements Builder {
 
   // Name that will refer to the builder in `build.yaml`.
   @override
-  String toString() => 'pkg:invalidation_tester_builder';
+  String toString() =>
+      'invalidation_tester_builder:invalidation_tester_builder';
 }
 
 extension LogRecordExtension on LogRecord {

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -104,7 +104,12 @@ void main() {
       readerWriter.testing.writeString(id, '');
 
       buildPhases = BuildPhases([
-        InBuildPhase(TestBuilder(), 'a', isOptional: false),
+        InBuildPhase(
+          builder: TestBuilder(),
+          key: 'TestBuilder',
+          package: 'a',
+          isOptional: false,
+        ),
       ]);
 
       var buildPlan = await BuildPlan.load(

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -31,12 +31,18 @@ void main() {
     late AssetGraph graph;
     final phases = BuildPhases([
       InBuildPhase(
-        TestBuilder(buildExtensions: appendExtension('.copy', from: '.txt')),
-        'a',
+        builder: TestBuilder(
+          buildExtensions: appendExtension('.copy', from: '.txt'),
+        ),
+        key: 'TestBuilder',
+        package: 'a',
       ),
       InBuildPhase(
-        TestBuilder(buildExtensions: appendExtension('.copy', from: '.txt')),
-        'b',
+        builder: TestBuilder(
+          buildExtensions: appendExtension('.copy', from: '.txt'),
+        ),
+        key: 'TestBuilder',
+        package: 'b',
         hideOutput: true,
       ),
     ]);

--- a/build_runner/test/logging/build_log_console_mode_test.dart
+++ b/build_runner/test/logging/build_log_console_mode_test.dart
@@ -330,9 +330,9 @@ List<String> padLinesRight(String output) {
 
 class _TestPhase implements InBuildPhase {
   @override
-  final String builderLabel;
+  final String displayName;
 
-  _TestPhase(this.builderLabel);
+  _TestPhase(this.displayName);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/build_runner/test/logging/build_log_line_mode_test.dart
+++ b/build_runner/test/logging/build_log_line_mode_test.dart
@@ -285,9 +285,9 @@ Map<InBuildPhase, int> _createPhases(Map<String, int> countsByName) {
 
 class _TestPhase implements InBuildPhase {
   @override
-  final String builderLabel;
+  final String displayName;
 
-  _TestPhase(this.builderLabel);
+  _TestPhase(this.displayName);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.1-wip
+
+- Use `build_runner` 2.10.1.
+
 ## 3.5.0
 
 - Improve `TestBuilderResult`: add `succeeded`, `outputs` and `errors`.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.0
+version: 3.5.1-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.10.0'
+  build_runner: '2.10.1-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Fix #4255

The problem relates to build names like `json_serializable:json_serializable` being shortened for display, so separate the display name from the key.

Take the opportunity to clean up the `BuildPhase` classes so the change is clear:

 - `builderKey` is always passed, require it; use named parameters for all parameters
 - remove some members for `BuildAction` that aren't used
 - rename `builderKey` -> `key` and `builderOptions` -> `options`
 - rename the old `builderLabel` to `displayName`, add new `key` which is the unmodified key
