### PR TITLE
Retry compiles in "watch" and "serve" modes.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.10.2-wip
+
+- In "serve" and "watch" modes, retry failed compiles instead of exiting.
+
 ## 2.10.1
 
 - Performance: improve `findAssets` scalability, making it much faster for

--- a/build_runner/lib/src/bootstrap/bootstrapper.dart
+++ b/build_runner/lib/src/bootstrap/bootstrapper.dart
@@ -51,6 +51,7 @@ class Bootstrapper {
     BuiltList<String> arguments, {
     required Iterable<String> jitVmArgs,
     Iterable<String>? experiments,
+    bool retryCompileFailures = false,
   }) async {
     while (true) {
       // Write build script based on current config read from disk.
@@ -80,9 +81,11 @@ class Bootstrapper {
             buildLog.error(
               'Failed to compile build script. '
               'Check builder definitions and generated script '
-              '$entrypointScriptPath.',
+              '$entrypointScriptPath.'
+              '${retryCompileFailures ? ' Retrying.' : ''}',
             );
           }
+          if (retryCompileFailures) continue;
           throw const CannotBuildException();
         }
       }

--- a/build_runner/lib/src/build_runner.dart
+++ b/build_runner/lib/src/build_runner.dart
@@ -165,6 +165,9 @@ class BuildRunner {
       arguments,
       jitVmArgs: commandLine.jitVmArgs ?? const Iterable.empty(),
       experiments: commandLine.enableExperiments,
+      retryCompileFailures:
+          commandLine.type == CommandType.watch ||
+          commandLine.type == CommandType.serve,
     );
   }
 }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.10.1
+version: 2.10.2-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/integration_tests/watch_command_test.dart
+++ b/build_runner/test/integration_tests/watch_command_test.dart
@@ -6,7 +6,6 @@
 library;
 
 import 'package:build_runner/src/logging/build_log.dart';
-import 'package:io/io.dart';
 import 'package:test/test.dart';
 
 import '../common/common.dart';
@@ -178,7 +177,23 @@ $yaml
     build_extensions: {'.txt': ['']}
 ''',
     );
-    await watch.expect('Failed to compile build script.');
-    expect(await watch.exitCode, ExitCode.config.code);
+    await watch.expect(
+      'Failed to compile build script. '
+      'Check builder definitions and generated script '
+      '.dart_tool/build/entrypoint/build.dart. '
+      'Retrying.',
+    );
+
+    // Restore the correct build script and it gets compiled and runs.
+    tester.write('builder_pkg/build.yaml', '''
+builders:
+  test_builder:
+    import: 'package:builder_pkg/builder.dart'
+    builder_factories: ['testBuilderFactory2']
+    build_extensions: {'.txt': ['.txt.copy']}
+    auto_apply: root_package
+    build_to: source
+''');
+    await watch.expect(BuildLog.successPattern);
   });
 }

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2-wip
+
+- Use `build_runner` 2.10.2.
+
 ## 3.5.1
 
 - Use `build_runner` 2.10.1.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.1
+version: 3.5.2-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.10.1'
+  build_runner: '2.10.2-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Fix #3840, in modes that are supposed to loop trying to build, also loop trying to build builders. 