### PR TITLE
Fixing dart2js sourcemaps not being written when both dart2js and wasm are enabled.

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.1
+- Fix Dart2JS sourcemaps not being written when both wasm and js are enabled.
+
 ## 4.3.0
 
 - When both wasm and js builds are enabled you can now add force_js=true

--- a/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -20,16 +20,20 @@ import 'platforms.dart';
 import 'web_entrypoint_builder.dart';
 
 /// Compiles an the primary input of [buildStep] with dart2js.
+///
+/// [onlyCompiler] indicates that Dart2JS is the only compiler enabled.
 Future<void> bootstrapDart2Js(
   BuildStep buildStep,
   List<String> dart2JsArgs, {
   required bool? nativeNullAssertions,
+  required bool onlyCompiler,
   String entrypointExtension = jsEntrypointExtension,
 }) => _resourcePool.withResource(
   () => _bootstrapDart2Js(
     buildStep,
     dart2JsArgs,
     nativeNullAssertions: nativeNullAssertions,
+    onlyCompiler: onlyCompiler,
     entrypointExtension: entrypointExtension,
   ),
 );
@@ -38,6 +42,7 @@ Future<void> _bootstrapDart2Js(
   BuildStep buildStep,
   List<String> dart2JsArgs, {
   required bool? nativeNullAssertions,
+  required bool onlyCompiler,
   required String entrypointExtension,
 }) async {
   final dartEntrypointId = buildStep.inputId;
@@ -155,7 +160,11 @@ $librariesString
     // these as part of the archive because they already have asset nodes.
     await scratchSpace.copyOutput(jsOutputId, buildStep);
     await fixAndCopySourceMap(
-      dartEntrypointId.changeExtension(jsEntrypointSourceMapExtension),
+      dartEntrypointId.changeExtension(
+        onlyCompiler
+            ? jsEntrypointSourceMapExtension
+            : dart2jsEntrypointSourceMapExtension,
+      ),
       scratchSpace,
       buildStep,
     );

--- a/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -22,6 +22,7 @@ const wasmExtension = '.wasm';
 const wasmSourceMapExtension = '.wasm.map';
 const moduleJsExtension = '.mjs';
 const jsEntrypointSourceMapExtension = '.dart.js.map';
+const dart2jsEntrypointSourceMapExtension = '.dart2js.js.map';
 const jsEntrypointArchiveExtension = '.dart.js.tar.gz';
 const digestsEntrypointExtension = '.digests';
 const mergedMetadataExtension = '.dart.ddc_merged_metadata';
@@ -256,6 +257,7 @@ final class EntrypointBuilderOptions {
         if (optionsFor(WebCompiler.Dart2Js) case final dart2js?) ...[
           dart2js.extension,
           jsEntrypointSourceMapExtension,
+          dart2jsEntrypointSourceMapExtension,
           jsEntrypointArchiveExtension,
         ],
         if (optionsFor(WebCompiler.Dart2Wasm) case final dart2wasm?) ...[
@@ -331,6 +333,7 @@ class WebEntrypointBuilder implements Builder {
               buildStep,
               compiler.compilerArguments,
               nativeNullAssertions: options.nativeNullAssertions,
+              onlyCompiler: options.compilers.length == 1,
               entrypointExtension: compiler.extension,
             ),
           );

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.3.0
+version: 4.3.1
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace

--- a/build_web_compilers/test/dart2wasm_bootstrap_test.dart
+++ b/build_web_compilers/test/dart2wasm_bootstrap_test.dart
@@ -91,6 +91,7 @@ void main() {
         ),
         'a|web/index.dart.js.tar.gz': isNotNull,
         'a|web/index.dart2js.js': decodedMatches(contains('Hello world!')),
+        'a|web/index.dart2js.js.map': isNotNull,
         'a|web/index.mjs': isNotNull,
         'a|web/index.wasm.map': isNotNull,
         'a|web/index.wasm': isNotNull,
@@ -108,6 +109,7 @@ void main() {
     final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
       'a|web/index.dart.js.tar.gz': isNotNull,
       'a|web/index.dart2js.js': decodedMatches(contains('Hello world!')),
+      'a|web/index.dart2js.js.map': isNotNull,
       'a|web/index.mjs': isNotNull,
       'a|web/index.wasm.map': isNotNull,
       'a|web/index.wasm': isNotNull,


### PR DESCRIPTION
Dart2JS has two naming paths, using `dart2js.xxx` when `dart.xxx` might be conflicting. Our map files had been hardcoded to their `dart.xxx` counterparts in mixed-compiler builds.

See: https://github.com/dart-lang/build/issues/4230