### PR TITLE
Re-adding `multiRootScheme` as an export

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.1
+
+- Fix re-add `multiRootScheme` to build_modules exports.
+
 ## 5.1.0
 
 - Add drivers and state resources required for DDC + Frontend Server compilation.

--- a/build_modules/lib/build_modules.dart
+++ b/build_modules/lib/build_modules.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/common.dart' show multiRootScheme;
 export 'src/ddc_names.dart';
 export 'src/errors.dart' show MissingModulesException, UnsupportedModules;
 export 'src/frontend_server_resources.dart'

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 5.1.0
+version: 5.1.1
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.1
+
+- Read `multiRootScheme` from `build_modules`.
+
 ## 4.4.0
 
 - Add DDC + Frontend Server compilation support to existing builders.

--- a/build_web_compilers/lib/src/common.dart
+++ b/build_web_compilers/lib/src/common.dart
@@ -6,10 +6,10 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:build/build.dart';
+import 'package:build_modules/build_modules.dart' show multiRootScheme;
 import 'package:path/path.dart' as p;
 import 'package:scratch_space/scratch_space.dart';
 
-final multiRootScheme = 'org-dartlang-app';
 final jsModuleErrorsExtension = '.ddc.js.errors';
 final jsModuleExtension = '.ddc.js';
 final jsSourceMapExtension = '.ddc.js.map';

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.4.0
+version: 4.4.1
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
This was mistakenly removed in https://github.com/dart-lang/build/pull/4240

Causing issues, such as in https://github.com/dart-lang/build/issues/4271