### PR TITLE
Fix build_daemon modify while building.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 2.10.3-wip
+## 2.10.2
 
+- Bug fix: fix issue with webdev failing due to a modification during a build.
 - In "serve" and "watch" modes, retry failed compiles instead of exiting.
 
 ## 2.10.1

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -162,8 +162,8 @@ class BuildSeries {
 
       // For modifications, confirm that the content actually changed.
       if (change.type == ChangeType.MODIFY) {
-        _readerWriter.cache.invalidate([id]);
-        final newDigest = await _readerWriter.digest(id);
+        // Use `_buildPlan.readerWriter` which has no cache to do a real read.
+        final newDigest = await _buildPlan.readerWriter.digest(id);
         if (node.digest != newDigest) {
           result.add(change);
         }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.10.3-wip
+version: 2.10.2
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,8 +1,4 @@
-## 3.5.3-wip
-
-- Use `build_runner` 2.10.3.
-
-## 3.5.2-wip
+## 3.5.2
 
 - Use `build_runner` 2.10.2.
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.3-wip
+version: 3.5.2
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.10.3-wip'
+  build_runner: '2.10.2'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Fix #4268 

This is a regression from a few versions back: the "was it actually modified" check was changed during the refactor to use the readerWriter in buildSeries which can have a cache, which fails because the cache refuses to invalidate a file while there are pending writes. (Which is good! It would have corrupted the build).

Revert to using the one without a cache instead.

I tried to come up with an e2e test for it but the timing is awkward, I didn't manage to repro in a test; it repros easily enough manually, so confirmed the fix that way.