### PR TITLE
Add logging of the compile step.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 2.11.0-wip
+
+- Add logging of builder compilation so you can tell how much time is spent
+  on the JIT or AOT compile. Explicitly log restarts to recompile builders.
+
 ## 2.10.4
 
 - Allow `analyzer` 9.0.0.
+
 
 ## 2.10.3
 

--- a/build_runner/lib/src/bootstrap/bootstrapper.dart
+++ b/build_runner/lib/src/bootstrap/bootstrapper.dart
@@ -59,7 +59,10 @@ class Bootstrapper {
 
       // Compile if there was any change.
       if (!_compiler.checkFreshness(digestsAreFresh: false).outputIsFresh) {
-        final result = await _compiler.compile(experiments: experiments);
+        final result = await buildLog.logCompile(
+          isAot: compileAot,
+          function: () => _compiler.compile(experiments: experiments),
+        );
         if (!result.succeeded) {
           final bool failedDueToMirrors;
           if (result.messages == null) {
@@ -109,6 +112,8 @@ class Bootstrapper {
       if (exitCode != ExitCode.tempFail.code) {
         return exitCode;
       }
+
+      buildLog.nextBuild(recompilingBuilders: true);
     }
   }
 

--- a/build_runner/lib/src/bootstrap/build_process_state.dart
+++ b/build_runner/lib/src/bootstrap/build_process_state.dart
@@ -45,6 +45,20 @@ class BuildProcessState {
   set elapsedMillis(int elapsedMillis) =>
       _state['elapsedMillis'] = elapsedMillis;
 
+  // For `buildLog`, the JIT compile progress.
+  Object? get jitCompileProgress => _state['jitCompileProgress'];
+  set jitCompileProgress(Object? jitCompileProgress) =>
+      _state['jitCompileProgress'] = jitCompileProgress;
+
+  // For `buildLog`, the AOT compile progress.
+  Object? get aotCompileProgress => _state['aotCompileProgress'];
+  set aotCompileProgress(Object? aotCompileProgress) =>
+      _state['aotCompileProgress'] = aotCompileProgress;
+
+  // For `buildLog`, the build number.
+  int get buildNumber => _state['buildNumber'] as int? ?? 1;
+  set buildNumber(int buildNumber) => _state['buildNumber'] = buildNumber;
+
   /// The package config URI.
   String get packageConfigUri =>
       (_state['packageConfigUri'] ??= Isolate.packageConfigSync!.toString())

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.10.4
+version: 2.11.0-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/logging/build_log_console_mode_test.dart
+++ b/build_runner/test/logging/build_log_console_mode_test.dart
@@ -44,6 +44,22 @@ E An error.'''),
       );
     });
 
+    test('compile progress', () {
+      buildLog.logCompile(isAot: false, function: () async {});
+      expect(
+        render(),
+        padLinesRight('''
+0s compiling builders/jit'''),
+      );
+      buildLog.logCompile(isAot: true, function: () async {});
+      expect(
+        render(),
+        padLinesRight('''
+0s compiling builders/jit
+0s compiling builders/aot'''),
+      );
+    });
+
     test('phase progress', () {
       final phases = _createPhases({'builder1': 10, 'builder2': 15});
       buildLog.startPhases(phases);

--- a/build_runner/test/logging/build_log_line_mode_test.dart
+++ b/build_runner/test/logging/build_log_line_mode_test.dart
@@ -37,6 +37,16 @@ void main() {
       ]);
     });
 
+    test('compile progress', () {
+      buildLog.logCompile(isAot: false, function: () async {});
+      expect(lines, ['  0s compiling builders/jit']);
+      buildLog.logCompile(isAot: true, function: () async {});
+      expect(lines, [
+        '  0s compiling builders/jit',
+        '  0s compiling builders/aot',
+      ]);
+    });
+
     test('phase progress', () {
       final phases = _createPhases({'builder1': 10, 'builder2': 15});
       buildLog.startPhases(phases);

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.5-wip
+
+- Use `build_runner` 2.11.0.
+
 ## 3.5.4
 
 - Use `build_runner` 2.10.4.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.10.4'
+  build_runner: '2.11.0-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
It seems like we should show what is going on with the compile, before adding any complexity about choosing to do an AOT compile vs a JIT compile :)

So, log it and how long it's taking.

Also improve logging around restarts, so they show with the same headers as a series of builds in watch mode.