### PR TITLE
Add random benchmark shape.

### DIFF
--- a/_benchmark/lib/shape.dart
+++ b/_benchmark/lib/shape.dart
@@ -73,7 +73,7 @@ enum Shape {
           if (_random.nextInt(libraryNumber + 1) == 0) 'app.dart',
           for (var i = 0; i != numberOfImports; ++i)
             Benchmarks.libraryName(
-              _random.nextInt(_random.nextInt(benchmarkSize + 1) + 1) + 1,
+              _random.nextInt(_random.nextInt(benchmarkSize) + 1),
               benchmarkSize: benchmarkSize,
             ),
         ];


### PR DESCRIPTION
Older build_runner versions stack overflow on very large max import "depth", so the other benchmark "shapes" don't work.

It would anyway be more realistic to have much more mixed imports.

So, add a "shape" with random imports. Use low-number-biased random numbers instead of flat random numbers as random flat imports are not realistic, either.