### PR TITLE
Optimize library cycle loader.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.10.3-wip
 
+- Performance: improve scalability with the number of library cycles, making
+  builds much faster for some large codebases.
 - Bug fix: fix crash when you run `dart run build_runner build` in a
   subdirectory of a package.
 - Bug fix: in a workspace, generate for transitive dependencies of the current


### PR DESCRIPTION
The benchmark in https://github.com/dart-lang/build/pull/4280 shows another quadratic scaling problem: in the number of library cycles.

The code is currently doing work for every already-loaded library cycle for every library cycle.

A simple change only does the work for deps that are actually needed.

Edit+incremental build on "random" benchmark before this PR, aot
```
1000,2000,3000,4000,5000
5.17,24.8,83.22,217.17,424.04
```

Edit+incremental build on "random" benchmark after this PR, aot

```
1000,2000,3000,4000,5000
2.89,4.92,7.75,11.07,15.35
```

<img width="723" height="447" alt="8j9fSNjWcErkMTU" src="https://github.com/user-attachments/assets/df0569f5-767e-4907-94ea-a90ffaed3834" />
