### PR TITLE
Release build_web_compilers 4.4.3.

### DIFF
--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.4.2
+version: 4.4.3
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
Missed one for the analyzer 9 bump.