### PR TITLE
Fix build_daemon test.

### DIFF
--- a/build_daemon/test/daemon_test.dart
+++ b/build_daemon/test/daemon_test.dart
@@ -234,11 +234,7 @@ Future<Process> _runDaemon(
     }
       ''').create();
   final args = [
-    ...Platform.executableArguments,
-    if (!Platform.executableArguments.any(
-      (arg) => arg.startsWith('--packages'),
-    ))
-      '--packages=${(await Isolate.packageConfig)!.path}',
+    '--packages=${(await Isolate.packageConfig)!.path}',
     'test.dart',
   ];
   final process = await Process.start(


### PR DESCRIPTION
It's picking up a `--packages` arg that is relative so it doesn't work in the sandbox directory.

Not sure when this started failing, but there doesn't seem to be any need to pass through args at all, just use the package config from the current isolate.

"Publish" CI failure is unrelated, will address separately.