### PR TITLE
Fix end to end test: allow build to complete before serving.

### DIFF
--- a/build_runner/test/integration_tests/serve_command_serve_only_required_test.dart
+++ b/build_runner/test/integration_tests/serve_command_serve_only_required_test.dart
@@ -29,8 +29,7 @@ void main() async {
     );
 
     // Initial build produces no output as the copy is not required.
-    await serve.expectServing();
-    await serve.expect(BuildLog.successPattern);
+    await serve.expectServingAndBuildSuccess();
     await serve.fetch('a.txt.copy', expectResponseCode: 404);
 
     // Read a copy so that it is now required.

--- a/build_runner/test/integration_tests/serve_command_test.dart
+++ b/build_runner/test/integration_tests/serve_command_test.dart
@@ -36,10 +36,7 @@ void main() async {
     tester.write('root_pkg/web/a.txt', 'a');
     tester.write('root_pkg/web/subdirectory/b.txt', 'b');
     serve = await tester.start('root_pkg', 'dart run build_runner serve web:0');
-    await serve.expectServing();
-
-    // Initial build.
-    await serve.expect(BuildLog.successPattern);
+    await serve.expectServingAndBuildSuccess();
 
     // Serves directory index as 404 for subdirectory without index.html.
     expect(


### PR DESCRIPTION
Using `watcher 1.2.0` changed the timing a bit, the no-op build done by the e2e tests now finishes before serving finishes starting, so the log order has changed. Just allow both.