### PR TITLE
Fix out-of-sync pubspec+CHANGELOG.

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.4.7
+## 4.4.7-wip
 - Add support for DDC's Library Bundle module system, which is compatible with web hot reload. This is not yet enabled by default.
 
 ## 4.4.6

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.4.6
+version: 4.4.7-wip
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
4.4.7 has not been published, so it's -wip.