### PR TITLE
Use `AutoApply` enum instead of opaque function `PackageFilter`.

### DIFF
--- a/build_runner/lib/src/build_plan/build_phases.dart
+++ b/build_runner/lib/src/build_plan/build_phases.dart
@@ -287,7 +287,8 @@ bool _shouldApply(
     return builderConfig!.isEnabled;
   }
   final shouldAutoApply =
-      node.target.autoApplyBuilders && builderApplication.filter(node.package);
+      node.target.autoApplyBuilders &&
+      builderApplication.autoAppliesTo(node.package);
   return shouldAutoApply ||
       (applyWith[builderApplication.builderKey] ?? const []).any(
         (anchorBuilder) =>

--- a/build_runner/lib/src/build_plan/builder_application.dart
+++ b/build_runner/lib/src/build_plan/builder_application.dart
@@ -17,8 +17,6 @@ typedef BuildPhaseFactory =
       bool isReleaseBuild,
     );
 
-typedef PackageFilter = bool Function(PackageNode node);
-
 /// A description of which packages need a given [Builder] or
 /// [PostProcessBuilder] applied.
 class BuilderApplication {
@@ -26,12 +24,15 @@ class BuilderApplication {
   /// [PostProcessBuilder]s that should be applied.
   final List<BuildPhaseFactory> buildPhaseFactories;
 
-  /// Determines whether a given package needs builder applied.
-  final PackageFilter filter;
+  /// Determines which packages a builder is automatically applied to.
+  final AutoApply autoApply;
 
   /// Builder keys which, when applied to a target, will also apply this Builder
-  /// even if [filter] does not match.
+  /// even if [autoApply] does not match.
   final Iterable<String> appliesBuilders;
+
+  /// The package the builder is in.
+  final String builderPackage;
 
   /// A uniqe key for this builder.
   ///
@@ -41,11 +42,26 @@ class BuilderApplication {
   /// Whether generated assets should be placed in the build cache.
   final bool hideOutput;
 
-  const BuilderApplication(
+  BuilderApplication(
+    this.builderPackage,
     this.builderKey,
     this.buildPhaseFactories,
-    this.filter,
+    this.autoApply,
     this.hideOutput,
     this.appliesBuilders,
   );
+
+  /// Whether this builder application is auto applied to [package].
+  bool autoAppliesTo(PackageNode package) {
+    switch (autoApply) {
+      case AutoApply.none:
+        return false;
+      case AutoApply.allPackages:
+        return true;
+      case AutoApply.rootPackage:
+        return package.isRoot;
+      case AutoApply.dependents:
+        return package.dependencies.any((p) => p.name == builderPackage);
+    }
+  }
 }

--- a/build_runner/lib/src/build_plan/builder_factories.dart
+++ b/build_runner/lib/src/build_plan/builder_factories.dart
@@ -122,16 +122,11 @@ BuilderApplication _applyBuilder(
   BuilderDefinition definition,
   BuiltList<BuilderFactory> builderFactories,
 ) {
-  final filter = switch (definition.autoApply) {
-    AutoApply.none => toNoneByDefault(),
-    AutoApply.dependents => toDependentsOf(definition.package),
-    AutoApply.allPackages => toAllPackages(),
-    AutoApply.rootPackage => toRoot(),
-  };
   return apply(
+    definition.package,
     definition.key,
     builderFactories,
-    filter,
+    definition.autoApply,
     isOptional: definition.isOptional,
     hideOutput: definition.buildTo == BuildTo.cache,
     defaultGenerateFor: definition.defaults.generateFor,
@@ -147,6 +142,7 @@ BuilderApplication _applyPostProcessBuilder(
   PostProcessBuilderFactory postProcessBuilderFactory,
 ) {
   return applyPostProcess(
+    definition.package,
     definition.key,
     postProcessBuilderFactory,
     defaultGenerateFor: definition.defaults.generateFor,

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -34,13 +34,15 @@ void main() {
   );
   final copyABuilderApplication = applyToRoot(testBuilder);
   final requiresPostProcessBuilderApplication = apply(
+    '',
     'test_builder',
     [(_) => testBuilder],
-    toRoot(),
+    AutoApply.rootPackage,
     appliesBuilders: ['a:post_copy_builder'],
     hideOutput: false,
   );
   final postCopyABuilderApplication = applyPostProcess(
+    'a',
     'a:post_copy_builder',
     (options) => CopyingPostProcessBuilder(
       outputExtension: options.config['extension'] as String? ?? '.post',
@@ -76,7 +78,8 @@ void main() {
         {'a|lib/a.dart': '', 'b|lib/b.dart': ''},
       );
 
-      // Once per package, including the SDK.
+      // Once per package with inputs, once in `test_builder.dart` to get the
+      // builder name.
       expect(invokedCount, 3);
     });
 
@@ -333,21 +336,23 @@ void main() {
         final builders = [
           copyABuilderApplication,
           apply(
+            'a',
             'a:clone_txt',
             [(_) => TestBuilder(buildExtensions: appendExtension('.clone'))],
-            toRoot(),
+            AutoApply.rootPackage,
             isOptional: true,
             hideOutput: false,
             appliesBuilders: ['a:post_copy_builder'],
           ),
           apply(
+            'a',
             'a:copy_web_clones',
             [
               (_) => TestBuilder(
                 buildExtensions: appendExtension('.copy', numCopies: 2),
               ),
             ],
-            toRoot(),
+            AutoApply.rootPackage,
             hideOutput: false,
           ),
           postCopyABuilderApplication,
@@ -709,8 +714,9 @@ additional_public_assets:
           [
             apply(
               '',
+              '',
               [(_) => TestBuilder()],
-              toPackage('b'),
+              AutoApply.allPackages,
               hideOutput: true,
               appliesBuilders: ['a:post_copy_builder'],
             ),
@@ -787,7 +793,13 @@ additional_public_assets:
       test('Will not delete from non-root packages', () async {
         await testPhases(
           [
-            apply('', [(_) => TestBuilder()], toPackage('b'), hideOutput: true),
+            apply(
+              '',
+              '',
+              [(_) => TestBuilder()],
+              AutoApply.allPackages,
+              hideOutput: true,
+            ),
           ],
           {
             'b|lib/b.txt': 'b',
@@ -969,9 +981,10 @@ targets:
       final result = await testPhases(
         [
           apply(
+            '',
             'test_builder',
             [(_) => TestBuilder()],
-            toRoot(),
+            AutoApply.rootPackage,
             isOptional: false,
             hideOutput: false,
           ),
@@ -1002,8 +1015,9 @@ targets:
           [
             apply(
               '',
+              '',
               [(_) => TestBuilder()],
-              toAllPackages(),
+              AutoApply.allPackages,
               defaultGenerateFor: const InputSet(include: ['**/*.txt']),
             ),
           ],
@@ -1034,8 +1048,9 @@ targets:
           [
             apply(
               '',
+              '',
               [(_) => TestBuilder()],
-              toAllPackages(),
+              AutoApply.allPackages,
               defaultGenerateFor: const InputSet(include: ['**/*.txt']),
             ),
           ],
@@ -1052,8 +1067,9 @@ targets:
           [
             apply(
               '',
+              '',
               [(_) => TestBuilder()],
-              toAllPackages(),
+              AutoApply.allPackages,
               defaultGenerateFor: const InputSet(include: ['**/*.txt']),
             ),
           ],
@@ -1085,8 +1101,9 @@ targets:
           [
             apply(
               '',
+              '',
               [(_) => TestBuilder()],
-              toAllPackages(),
+              AutoApply.allPackages,
               defaultGenerateFor: const InputSet(include: ['**/*.txt']),
             ),
           ],
@@ -1522,7 +1539,13 @@ targets:
 
     test('no outputs if no changed sources using `hideOutput: true`', () async {
       final builders = [
-        apply('', [(_) => TestBuilder()], toRoot(), hideOutput: true),
+        apply(
+          '',
+          '',
+          [(_) => TestBuilder()],
+          AutoApply.rootPackage,
+          hideOutput: true,
+        ),
       ];
 
       // Initial build.
@@ -1819,6 +1842,7 @@ targets:
       // https://github.com/dart-lang/build/issues/2017
       final builders = [
         apply(
+          '',
           'test_builder',
           [
             (_) => TestBuilder(
@@ -1827,10 +1851,14 @@ targets:
               },
             ),
           ],
-          toRoot(),
+          AutoApply.rootPackage,
           appliesBuilders: ['a|copy_builder'],
         ),
-        applyPostProcess('a|copy_builder', (_) => CopyingPostProcessBuilder()),
+        applyPostProcess(
+          '',
+          'a|copy_builder',
+          (_) => CopyingPostProcessBuilder(),
+        ),
       ];
       // A build does not crash in `_cleanUpStaleOutputs`
       await testPhases(builders, {'a|lib/a.txt': 'a'});

--- a/build_runner/test/build_plan/apply_builders_test.dart
+++ b/build_runner/test/build_plan/apply_builders_test.dart
@@ -30,7 +30,7 @@ void main() {
         ),
       );
       final builderApplications = [
-        apply('b:cool_builder', [CoolBuilder.new], toAllPackages()),
+        apply('b', 'b:cool_builder', [CoolBuilder.new], AutoApply.allPackages),
       ];
       final phases = await createBuildPhases(
         targetGraph,
@@ -82,7 +82,9 @@ void main() {
               ),
             );
             final builderApplications = [
-              apply('b:cool_builder', [CoolBuilder.new], toAllPackages()),
+              apply('b', 'b:cool_builder', [
+                CoolBuilder.new,
+              ], AutoApply.allPackages),
             ];
             final phases = await createBuildPhases(
               targetGraph,
@@ -125,7 +127,7 @@ void main() {
         ),
       );
       final builderApplications = [
-        apply('b:cool_builder', [CoolBuilder.new], toDependentsOf('b')),
+        apply('b', 'b:cool_builder', [CoolBuilder.new], AutoApply.dependents),
       ];
       final phases = await createBuildPhases(
         targetGraph,
@@ -150,12 +152,13 @@ void main() {
       );
       final builderApplications = [
         apply(
+          'b',
           'b:cool_builder',
           [CoolBuilder.new],
-          toDependentsOf('b'),
+          AutoApply.dependents,
           appliesBuilders: ['b:not_by_default'],
         ),
-        apply('b:not_by_default', [(_) => TestBuilder()], toNoneByDefault()),
+        apply('b', 'b:not_by_default', [(_) => TestBuilder()], AutoApply.none),
       ];
       final phases = await createBuildPhases(
         targetGraph,
@@ -190,9 +193,10 @@ void main() {
       );
       final builderApplications = [
         apply(
+          'c',
           'c:cool_builder',
           [CoolBuilder.new],
-          toDependentsOf('c'),
+          AutoApply.dependents,
           hideOutput: false,
         ),
       ];
@@ -231,15 +235,17 @@ void main() {
         );
         final builderApplications = [
           apply(
+            'c',
             'c:cool_builder',
             [CoolBuilder.new],
-            toDependentsOf('c'),
+            AutoApply.dependents,
             appliesBuilders: ['c:not_by_default'],
           ),
           apply(
+            'c',
             'c:not_by_default',
             [(_) => TestBuilder()],
-            toNoneByDefault(),
+            AutoApply.none,
             hideOutput: false,
           ),
         ];
@@ -287,7 +293,9 @@ void main() {
             ),
           );
           final builderApplications = [
-            apply('b:cool_builder', [CoolBuilder.new], toAllPackages()),
+            apply('b', 'b:cool_builder', [
+              CoolBuilder.new,
+            ], AutoApply.allPackages),
           ];
           expect(
             () => createBuildPhases(
@@ -336,12 +344,15 @@ void main() {
         );
         final builderApplications = [
           apply(
+            'b',
             'b:cool_builder',
             [CoolBuilder.new],
-            toDependentsOf('b'),
+            AutoApply.dependents,
             appliesBuilders: ['b:cool_builder_2'],
           ),
-          apply('b:cool_builder_2', [CoolBuilder.new], toDependentsOf('b')),
+          apply('b', 'b:cool_builder_2', [
+            CoolBuilder.new,
+          ], AutoApply.dependents),
         ];
         return await createBuildPhases(
           targetGraph,
@@ -414,12 +425,13 @@ void main() {
     );
     final builderApplications = [
       apply(
+        'a',
         'a:regular',
         [(_) => TestBuilder()],
-        toAllPackages(),
+        AutoApply.allPackages,
         appliesBuilders: ['a:post'],
       ),
-      applyPostProcess('a:post', (_) => _InvalidPostProcessBuilder()),
+      applyPostProcess('a', 'a:post', (_) => _InvalidPostProcessBuilder()),
     ];
 
     expect(


### PR DESCRIPTION
Supporting workspaces means better management of build configuration, so doing a bit of refactoring.

Store enum instead of an opaque function.

Introduce a test-only subclass for a special case for testing.