### PR TITLE
Don't read asset graph in `readAllSourcesFromFilesystem`.

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 3.5.6-wip
 
+- Bug fix: when using `resolveSources` with `readAllSourcesFromFilesystem`,
+  skip reading real `asset_graph.json` files. This prevents the test build from
+  deleting, in RAM only, generated outputs of the real build.
 - Use `build_runner` 2.10.6.
 
 ## 3.5.5

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -93,6 +93,10 @@ Future<T> resolveSource<T>(
 /// [readAllSourcesFromFilesystem] to read all sources available with
 /// [packageConfig].
 ///
+/// In packages read using `readAllSourcesFromFilesystem` the asset graph
+/// `.dart_tool/build/asset_graph.json` is not loaded as it would cause generated
+/// output from the real build to be deleted, in RAM only, by the test build.
+///
 /// [assetReaderChecks], if provided, runs after the action completes and can be
 /// used to add expectations on the reader state.
 Future<T> resolveSources<T>(
@@ -189,6 +193,11 @@ Future<T> _resolveAssets<T>(
         Glob('**'),
         package: package.name,
       )) {
+        // Don't read the asset graph from a real build, it would cause
+        // generated files from that build to be deleted, in RAM only, in the
+        // test build.
+        if (id.path.startsWith('.dart_tool/build/asset_graph.json')) continue;
+
         readerWriter.testing.writeBytes(id, await assetReader.readAsBytes(id));
       }
     }


### PR DESCRIPTION
Fix #4334 