### PR TITLE
Update min build_modules constraint to 5.1.7

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.9
+
+- Update min build_modules constraint to 5.1.7.
+
 ## 4.4.8
 
 - Add support for non-web-dir entrypoints with DDC + FES.

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.4.8
+version: 4.4.9
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace
@@ -12,7 +12,7 @@ dependencies:
   archive: '>=3.0.0 <5.0.0'
   bazel_worker: ^1.0.0
   build: '>=2.0.0 <5.0.0'
-  build_modules: ^5.1.0
+  build_modules: ^5.1.7
   build_runner: ^2.0.0
   collection: ^1.15.0
   glob: ^2.0.0


### PR DESCRIPTION
`checkAndDeserializeState` was introduced to `build_modules` in 5.1.7, but `build_web_compilers` wasn't updated.

See: https://github.com/dart-lang/build/issues/4336