### PR TITLE
Fix "Bad state: Sorted file IDs ... were already computed".

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Add `--workspace` flag. Use it with `dart run build_runner build`, `watch`
   or `serve` to build, watch or serve all packages in the current workspace.
+- Bug fix: fix crash in corner case with post process builder, optional builder
+  and output used for `--output`, `watch` or `serve`.
 
 ## 2.10.5
 

--- a/build_runner/test/integration_tests/build_command_output_only_required_test.dart
+++ b/build_runner/test/integration_tests/build_command_output_only_required_test.dart
@@ -13,8 +13,8 @@ void main() async {
   test('build command --output writes only required files', () async {
     final pubspecs = await Pubspecs.load();
     final tester = BuildRunnerTester(pubspecs);
-    tester.writeFixturePackage(FixturePackages.optionalCopyAndReadBuilders);
 
+    tester.writeFixturePackage(FixturePackages.optionalCopyAndReadBuilders);
     tester.writePackage(
       name: 'root_pkg',
       dependencies: ['build_runner'],
@@ -53,5 +53,23 @@ void main() async {
       'a.txt.copy': 'a',
       'b.txt': 'b',
     });
+
+    // Add a post process builder to regression test for the crash in
+    // https://github.com/dart-lang/build/issues/4341.
+    tester.writeFixturePackage(
+      FixturePackages.postProcessCopyBuilder(
+        packageName: 'post_process_builder_pkg',
+      ),
+    );
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg', 'post_process_builder_pkg'],
+      files: {'other/a.txt': 'a'},
+    );
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --output build --build-filter other/*',
+    );
   });
 }

--- a/build_runner/test/integration_tests/build_command_output_test.dart
+++ b/build_runner/test/integration_tests/build_command_output_test.dart
@@ -28,6 +28,16 @@ void main() async {
     expect(tester.read('root_pkg/build/web/a.txt.copy'), 'a');
     expect(tester.read('root_pkg/build/web/b.txt.copy'), 'b');
 
+    // No rebuild if nothing changed.
+    var output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --output build',
+    );
+    expect(output, contains('wrote 0 outputs'));
+    // Output is copied the same.
+    expect(tester.read('root_pkg/build/web/a.txt.copy'), 'a');
+    expect(tester.read('root_pkg/build/web/b.txt.copy'), 'b');
+
     // The --output option filters to --build-filter.
     await tester.run(
       'root_pkg',
@@ -55,7 +65,7 @@ void main() async {
     expect(tester.read('root_pkg/build2/web/b.txt.copy'), 'b');
 
     // Duplicate --output options are an error.
-    var output = await tester.run(
+    output = await tester.run(
       'root_pkg',
       'dart run build_runner build --output web:build --output test:build',
       expectExitCode: ExitCode.usage.code,

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -88,6 +88,7 @@ void main() {
         buildPlan: buildPlan,
         readerWriter: readerWriter,
         assetGraph: assetGraph,
+        processedOutputs: assetGraph.outputs.toSet(),
       );
       expect(await reader.canRead(notDeleted.id), true);
       expect(await reader.canRead(deleted.id), false);
@@ -131,6 +132,7 @@ void main() {
         buildPlan: buildPlan,
         readerWriter: readerWriter,
         assetGraph: assetGraph,
+        processedOutputs: assetGraph.outputs.toSet(),
       );
       expect(
         await reader.unreadableReason(id),
@@ -155,6 +157,8 @@ void main() {
         buildPlan: buildPlan,
         readerWriter: readerWriter,
         assetGraph: assetGraph,
+        // `a` does not match the build filter and is not processed.
+        processedOutputs: {},
       );
 
       expect(

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -103,6 +103,7 @@ void main() {
         buildPlan: buildPlan,
         readerWriter: readerWriter,
         assetGraph: graph,
+        processedOutputs: graph.outputs.toSet(),
       );
 
       for (final id in graph.outputs) {
@@ -388,6 +389,7 @@ void main() {
         ),
         readerWriter: readerWriter,
         assetGraph: graph,
+        processedOutputs: graph.outputs.toSet(),
       );
       final success = await createMergedOutputDirectories(
         buildDirs:


### PR DESCRIPTION
Fix #4341 

The crash is because the code assets that files per package are only computed once, when in this corner case it gets computed twice.

We could just allow doing the computation twice, but looking closely at where it's used: it's in code that checks whether an output "was required", to decide whether to serve it / copy it. This does a recursive check from outputs back to inputs to decide if something needed to be built. It seems like this is something we should know already. And indeed the "processedOutputs" set in the build looks like exactly what's needed.

So, stop doing the computation twice :)

Using `processedOutputs` was not 100% equivalent due to not being updated when post process builders do incremental builds: add test coverage for this and update it.