### PR TITLE
Watch for workspace yaml changes, add test coverage

### DIFF
--- a/build_runner/lib/src/build_plan/build_package.dart
+++ b/build_runner/lib/src/build_plan/build_package.dart
@@ -17,6 +17,9 @@ class BuildPackage {
   /// Paths are platform dependent.
   final String path;
 
+  /// Whether the "package" is actually a workspace.
+  final bool isWorkspace;
+
   /// Whether the package contents should be watched in `watch` and `serve`
   /// modes.
   final bool watch;
@@ -34,6 +37,7 @@ class BuildPackage {
   BuildPackage({
     required this.name,
     required String path,
+    this.isWorkspace = false,
     this.watch = false,
     this.isOutput = false,
     this.languageVersion,
@@ -45,12 +49,14 @@ class BuildPackage {
   @visibleForTesting
   factory BuildPackage.forTesting({
     required String name,
+    bool isWorkspace = false,
     bool watch = false,
     bool isOutput = false,
     Iterable<String> dependencies = const [],
   }) => BuildPackage(
     name: name,
     path: '/$name',
+    isWorkspace: isWorkspace,
     watch: watch,
     isOutput: isOutput,
     dependencies: dependencies,
@@ -62,6 +68,7 @@ class BuildPackage {
     return other is BuildPackage &&
         name == other.name &&
         path == other.path &&
+        isWorkspace == other.isWorkspace &&
         watch == other.watch &&
         isOutput == other.isOutput &&
         languageVersion == other.languageVersion &&
@@ -77,6 +84,7 @@ class BuildPackage {
 BuildPackage(
   name: $name,
   path: $path,
+  isWorkspace: $isWorkspace,
   watch: $watch,
   isOutput: $isOutput,
   languageVersion: $languageVersion,

--- a/build_runner/lib/src/build_plan/build_packages_loader.dart
+++ b/build_runner/lib/src/build_plan/build_packages_loader.dart
@@ -110,6 +110,7 @@ class BuildPackagesLoader {
       buildPackages[packageConfig.name] = BuildPackage(
         name: packageConfig.name,
         path: packageConfig.root.toFilePath(),
+        isWorkspace: packageConfig.name == workspaceName,
         languageVersion: packageConfig.languageVersion,
         watch: !fixedPackages.contains(packageConfig.name),
         isOutput: isInBuild,

--- a/build_runner/lib/src/commands/watch/build_packages_watcher.dart
+++ b/build_runner/lib/src/commands/watch/build_packages_watcher.dart
@@ -45,7 +45,9 @@ class BuildPackagesWatcher {
   Stream<AssetChange> _watch() {
     final allWatchers =
         _buildPackages.packages.values
-            .where((buildPackage) => buildPackage.watch)
+            .where(
+              (buildPackage) => buildPackage.watch || buildPackage.isWorkspace,
+            )
             .map(_strategy)
             .toList();
     final filteredEvents =

--- a/build_runner/test/build_plan/build_packages_test.dart
+++ b/build_runner/test/build_plan/build_packages_test.dart
@@ -335,6 +335,7 @@ workspace:
           'some_workspace_name': BuildPackage(
             name: 'some_workspace_name',
             path: tempDirectory,
+            isWorkspace: true,
             languageVersion: LanguageVersion(3, 5),
           ),
           r'$sdk': anything,

--- a/build_runner/test/integration_tests/watch_command_workspace_test.dart
+++ b/build_runner/test/integration_tests/watch_command_workspace_test.dart
@@ -126,5 +126,14 @@ workspace: [p1, p2, p3, p4, p5, p6]
     tester.write('p6/lib/p6.txt', '2');
     await watch.expect(BuildLog.successPattern);
     expect(tester.read('p6/lib/p6.txt.copy'), '2');
+
+    // Change workspace build.yaml, check that a build takes place.
+    tester.write('build.yaml', '''
+global_options:
+  builder_pkg|test_builder:
+    options:
+      some_option: some_value
+''');
+    await watch.expect(BuildLog.successPattern);
   });
 }


### PR DESCRIPTION
Also watch the workspace root to catch changes to build.yaml.

Add test coverage.

Filed #4346 for a possible optimization that watches _only_ the workspace root.