### PR TITLE
Added docs for accessing built `AssetId`s via `TestReaderWriter`

### DIFF
--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -4,6 +4,8 @@
   skip reading real `asset_graph.json` files. This prevents the test build from
   deleting, in RAM only, generated outputs of the real build.
 - Use `build_runner` 2.10.6.
+- Added documentation about reading generated assets as `String` using
+  `TestReaderWriter` and `testBuilder` with `flattenOutput`.
 
 ## 3.5.5
 

--- a/build_test/README.md
+++ b/build_test/README.md
@@ -55,43 +55,40 @@ test('should resolve a simple dart file', () async {
 ```
 
 ### Get generated source code as `String`
-You can use `TestReaderWriter` to read generated assets as `String`.
-Make sure to set `flattenOutput` to `true` in `testBuilder` to make sure the output assets are accessible:
+
+You can use `TestReaderWriter` to read generated assets as `String`. Read more about
+how this works in the [TestReaderWriter documentation][api:TestReaderWriter].
+
+Set `flattenOutput` to `true` in `testBuilder` to make the output assets accessible:
 
 ```dart
 final yourBuilder = ...;
 
-final rw = TestReaderWriter(rootPackage: 'test_package');
+final readerWriter = TestReaderWriter(rootPackage: 'test_package');
 
 final result = await testBuilder(
   yourBuilder,
   {...},
-  readerWriter: rw,
+  readerWriter: readerWriter,
   outputs: null,
   flattenOutput: true,
 );
 
 
-/// Map of output asset paths to their contents.
-Map<String, String> outputs = {};
-
+// You can read all of the generated assets like this...
 for (final AssetId asset in result.outputs) {
-  // print("reading generated asset: ${asset}");
-  // print("  can read ${asset}: ${await rw.canRead(asset)}");
-  // print("  exists ${asset}: ${await rw.testing.exists(asset)}");
-
-  final content = rw.testing.readString(asset);
-  outputs['${asset.package}|${asset.path}'] = content;
+  print('reading generated asset: ${asset}');
+  print('  can read: ${await readerWriter.canRead(asset)}');
+  print('  exists: ${await readerWriter.testing.exists(asset)}');
+  print('  content: \n${await readerWriter.testing.readString(asset)}');
 }
-```
 
-Now `outputs` contains all generated assets as strings. Access it like this:
-
-```dart
-final generatedCode = outputs['test_package|lib/source_file.g.dart'];
-
-// you can use it in tests like
-expect(generatedCode, contains('some expected content'));
+// ...or access a single generated asset directly, like this:
+final String generatedCode = await readerWriter.testing.readString(
+  AssetId('test_package', 'lib/source_file.g.dart')
+);
+// ...and, for example, use it in tests:
+expect(generatedCode, contains('callExpectedFunction();'));
 ```
 
 [api:PackageAssetReader]: https://pub.dev/documentation/build_test/latest/build_test/PackageAssetReader-class.html

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -174,7 +174,7 @@ Future<TestBuilderResult> testBuilder(
 ///
 /// To access the outputs via `testing.readString` using the same
 /// `AssetId`s as returned by the outputs of this method,
-/// make sure to set [flattenOutput] to `true`. See [TestReaderWriter] for details.
+/// set [flattenOutput] to `true`. See [TestReaderWriter] for details.
 Future<TestBuilderResult> testBuilders(
   Iterable<Builder> builders,
   Map<String, /*String|List<int>*/ Object> sourceAssets, {

--- a/build_test/lib/src/test_reader_writer.dart
+++ b/build_test/lib/src/test_reader_writer.dart
@@ -87,9 +87,8 @@ abstract interface class ReaderWriterTesting {
   ///
   /// [AssetId]s are from the point of view of the filesystem,
   /// so "hidden" assets are under .dart_tool.
-  /// Also see:
-  /// - [TestReaderWriter] class documentation.
-  /// - [testBuilders] `flattenOutput` parameter.
+  /// See also [TestReaderWriter] class documentation and
+  /// [testBuilders] `flattenOutput` parameter.
   bool exists(AssetId id);
 
   /// Writes [id] with [contents] to the [TestReaderWriter] in-memory
@@ -104,26 +103,21 @@ abstract interface class ReaderWriterTesting {
   ///
   /// [AssetId]s are from the point of view of the filesystem,
   /// so "hidden" assets are under .dart_tool.
-  /// Also see:
-  /// - [TestReaderWriter] class documentation.
-  /// - [testBuilders] `flattenOutput` parameter.
+  /// See also [TestReaderWriter] class documentation and
+  /// [testBuilders] `flattenOutput` parameter.
   Uint8List readBytes(AssetId id);
 
   /// Reads [id] from the [TestReaderWriter] in-memory filesystem.
   ///
   /// [AssetId]s are from the point of view of the filesystem,
   /// so "hidden" assets are under .dart_tool.
-  /// Also see:
-  /// - [TestReaderWriter] class documentation.
-  /// - [testBuilders] `flattenOutput` parameter.
+  /// /// See also [TestReaderWriter] class documentation and
   String readString(AssetId id);
 
   /// Deletes [id] from the [TestReaderWriter] in-memory filesystem.
   ///
   /// [AssetId]s are from the point of view of the filesystem,
   /// so "hidden" assets are under .dart_tool.
-  /// Also see:
-  /// - [TestReaderWriter] class documentation.
-  /// - [testBuilders] `flattenOutput` parameter.
+  /// /// [testBuilders] `flattenOutput` parameter.
   void delete(AssetId id);
 }


### PR DESCRIPTION
Adds docs on how to read built files via `TestReaderWriter` with flattened `AssetId`
For details see https://github.com/dart-lang/build/issues/4332#issuecomment-3785487983

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
