### PR TITLE
Release `2.11.0` with `--workspace` documented and flagged as experimental.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 2.10.6-wip
+## 2.11.0
 
-- Add `--workspace` flag. Use it with `dart run build_runner build`, `watch`
-  or `serve` to build, watch or serve all packages in the current workspace.
+- Add `--workspace` flag. Use it with `dart run build_runner build` or `watch`
+  to build or watch or all packages in the current workspace. It is currently
+  experimental and subject to change based on feedback, please add feedback at
+  https://github.com/dart-lang/build/discussions/4349.
 - Bug fix: fix crash in corner case with post process builder, optional builder
   and output used for `--output`, `watch` or `serve`.
 - Bug fix: fix crash in corner case with `watch` or `serve` when builders depend

--- a/build_runner/README.md
+++ b/build_runner/README.md
@@ -134,9 +134,11 @@ class Person {
 }
 ```
 
-If you have multiple packages then you need to run `build` or `watch` in each
-package separately; there is an
-[open feature request for workspace support](https://github.com/dart-lang/build/issues/3804).
+You can build or watch more than one package together by putting them in a
+[workspace](https://dart.dev/tools/pub/workspaces) and passing the `--workspace`
+flag. This is still experimental and subject to change based on feedback, consider
+giving your own feedback in the
+[discussion forum](https://github.com/dart-lang/build/discussions/4349).
 
 ### Output files
 
@@ -159,6 +161,9 @@ So, tools such as `git` must be configured to ignore them. Make `git` ignore `.d
 ```bash
 .dart_tool
 ```
+
+With the `--workspace` flag the `.dart_tool` directory is written under the
+workspace root instead of under a package.
 
 ### Additional configuration
 
@@ -197,6 +202,10 @@ targets:
 ```
 
 —see each builder's documentation for details.
+
+With the `--workspace` flag package-specific options are read from each
+package's `build.yaml` file. Global options are read from the `build.yaml` in
+the workspace root, if there is one.
 
 ## Writing your own builder
 

--- a/build_runner/lib/src/build_runner_command_line.dart
+++ b/build_runner/lib/src/build_runner_command_line.dart
@@ -84,7 +84,9 @@ class BuildRunnerCommandLine {
       trackPerformance = argResults.boolNamed(trackPerformanceOption),
       symlink = argResults.boolNamed(symlinkOption),
       verbose = argResults.boolNamed(verboseOption),
-      workspace = argResults.boolNamed(workspaceOption);
+      // Only "build" and "watch" support --workspace, default to false for
+      // other commands.
+      workspace = argResults.boolNamed(workspaceOption) ?? false;
 
   String get usage {
     // Calling `usage` only works if the command has been added to a
@@ -170,13 +172,14 @@ final _build = _Build();
 
 class _Build extends Command<BuildRunnerCommandLine> {
   _Build() {
-    addBuildArgs(argParser, symlinksDefault: false);
+    addBuildArgs(argParser, symlinksDefault: false, supportWorkspace: true);
   }
 
   /// Adds args common to all build commands to [argParser].
   static void addBuildArgs(
     ArgParser argParser, {
     required bool symlinksDefault,
+    required bool supportWorkspace,
   }) {
     argParser
       // No longer does anything, but accept so old usage does not fail.
@@ -285,13 +288,15 @@ class _Build extends Command<BuildRunnerCommandLine> {
             'For example, `--dart-jit-vm-arg "--observe" '
             '--dart-jit-vm-arg "--pause-isolates-on-start"` would start the '
             'build script with a debugger attached to it.',
-      )
-      ..addFlag(
+      );
+    if (supportWorkspace) {
+      argParser.addFlag(
         workspaceOption,
         defaultsTo: false,
         negatable: true,
         help: 'Build all packages in the current workspace.',
       );
+    }
   }
 
   @override
@@ -336,7 +341,11 @@ class _Daemon extends Command<BuildRunnerCommandLine> {
   String get name => 'daemon';
 
   _Daemon() {
-    _Build.addBuildArgs(argParser, symlinksDefault: false);
+    _Build.addBuildArgs(
+      argParser,
+      symlinksDefault: false,
+      supportWorkspace: false,
+    );
     argParser
       ..addOption(
         buildModeFlag,
@@ -360,7 +369,11 @@ final _run = _Run();
 
 class _Run extends Command<BuildRunnerCommandLine> {
   _Run() {
-    _Build.addBuildArgs(argParser, symlinksDefault: false);
+    _Build.addBuildArgs(
+      argParser,
+      symlinksDefault: false,
+      supportWorkspace: false,
+    );
   }
 
   @override
@@ -383,7 +396,11 @@ final _serve = _Serve();
 
 class _Serve extends Command<BuildRunnerCommandLine> {
   _Serve() {
-    _Build.addBuildArgs(argParser, symlinksDefault: false);
+    _Build.addBuildArgs(
+      argParser,
+      symlinksDefault: false,
+      supportWorkspace: false,
+    );
     argParser
       ..addOption(
         hostnameOption,
@@ -423,7 +440,11 @@ final _test = _Test();
 
 class _Test extends Command<BuildRunnerCommandLine> {
   _Test() {
-    _Build.addBuildArgs(argParser, symlinksDefault: !Platform.isWindows);
+    _Build.addBuildArgs(
+      argParser,
+      symlinksDefault: !Platform.isWindows,
+      supportWorkspace: false,
+    );
   }
 
   @override
@@ -446,7 +467,11 @@ final _watch = _Watch();
 
 class _Watch extends Command<BuildRunnerCommandLine> {
   _Watch() {
-    _Build.addBuildArgs(argParser, symlinksDefault: false);
+    _Build.addBuildArgs(
+      argParser,
+      symlinksDefault: false,
+      supportWorkspace: true,
+    );
   }
 
   @override

--- a/build_runner/lib/src/commands/build_command.dart
+++ b/build_runner/lib/src/commands/build_command.dart
@@ -46,6 +46,10 @@ class BuildCommand implements BuildRunnerCommand {
       b.onLog = testingOverrides.onLog;
     });
 
+    if (buildOptions.workspace) {
+      buildLog.warnAboutWorkspaceFlag();
+    }
+
     final buildPlan = await BuildPlan.load(
       builderFactories: builderFactories,
       buildOptions: buildOptions,

--- a/build_runner/lib/src/commands/watch_command.dart
+++ b/build_runner/lib/src/commands/watch_command.dart
@@ -50,6 +50,10 @@ class WatchCommand implements BuildRunnerCommand {
       b.onLog = testingOverrides.onLog;
     });
 
+    if (buildOptions.workspace) {
+      buildLog.warnAboutWorkspaceFlag();
+    }
+
     final buildPlan = await BuildPlan.load(
       builderFactories: builderFactories,
       buildOptions: buildOptions,

--- a/build_runner/lib/src/logging/build_log.dart
+++ b/build_runner/lib/src/logging/build_log.dart
@@ -638,6 +638,14 @@ class BuildLog {
     }
     return false;
   }
+
+  void warnAboutWorkspaceFlag() {
+    warning(
+      'The --workspace flag is experimental and subject to change based on '
+      'feedback. Consider adding your own feedback at: '
+      'https://github.com/dart-lang/build/discussions/4349',
+    );
+  }
 }
 
 extension _IntExtension on int {

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.10.6-wip
+version: 2.11.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
+++ b/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
@@ -22,6 +22,7 @@ void main() async {
     final pubspecs = await Pubspecs.load();
     final tester = BuildRunnerTester(pubspecs);
 
+    // The `builder.g.dart` content that the builder writes.
     final partContent = '''
 part of 'builder.dart';
 ''';
@@ -59,6 +60,7 @@ class TestBuilder implements Builder {
   }
 }
 ''',
+        // Start with the correct output.
         'lib/builder.g.dart': partContent,
       },
       inWorkspace: true,
@@ -76,6 +78,7 @@ environment:
 workspace: [builder_pkg, root_pkg]
 ''');
 
+    // The first build runs and writes identical output for the generated file.
     final watch = await tester.start(
       '',
       'dart run build_runner watch --workspace',

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,11 +1,11 @@
-## 3.5.6-wip
+## 3.5.6
 
+- Add documentation about reading generated assets as `String` using
+  `TestReaderWriter` and `testBuilder` with `flattenOutput`.
 - Bug fix: when using `resolveSources` with `readAllSourcesFromFilesystem`,
   skip reading real `asset_graph.json` files. This prevents the test build from
   deleting, in RAM only, generated outputs of the real build.
-- Use `build_runner` 2.10.6.
-- Added documentation about reading generated assets as `String` using
-  `TestReaderWriter` and `testBuilder` with `flattenOutput`.
+- Use `build_runner` 2.11.0.
 
 ## 3.5.5
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.6-wip
+version: 3.5.6
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.10.6-wip'
+  build_runner: '2.11.0'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Fix #3804

I considered doing a "dev" release to get the feature out and get some feedback on it, but that's not something we've done before ... the other option is to do a full release but mark the feature experimental, which is what this PR does. I also update README.md.

For now just prohibit "serve", "daemon", "run" and "test" with "--workspace". For "serve" it probably makes sense to also add an arg for one specific package to serve, the others I haven't looked at / thought about, they can be added based on feedback/demand.