### PR TITLE
Stop running serve-related code in `watch` command

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.11.1-wip
+
 ## 2.11.0
 
 - Add `--workspace` flag. Use it with `dart run build_runner build` or `watch`

--- a/build_runner/lib/src/commands/serve/server.dart
+++ b/build_runner/lib/src/commands/serve/server.dart
@@ -36,17 +36,18 @@ enum PerfSortOrder {
 }
 
 class ServeHandler {
-  final String outputRootPackage;
   final Watcher _watcher;
 
   final BuildUpdatesWebSocketHandler _webSocketHandler;
 
-  ServeHandler(this.outputRootPackage, this._watcher)
+  ServeHandler(this._watcher)
     : _webSocketHandler = BuildUpdatesWebSocketHandler() {
     _watcher.buildResults
         .listen(_webSocketHandler.emitUpdateMessage)
         .onDone(_webSocketHandler.close);
   }
+
+  String get outputRootPackage => _watcher.buildPackages.outputRoot;
 
   Future<BuildResult>? get currentBuildResult => _watcher.currentBuildResult;
 

--- a/build_runner/lib/src/commands/watch/watcher.dart
+++ b/build_runner/lib/src/commands/watch/watcher.dart
@@ -9,6 +9,7 @@ import 'package:stream_transform/stream_transform.dart';
 
 import '../../build/build_result.dart';
 import '../../build/build_series.dart';
+import '../../build_plan/build_packages.dart';
 import '../../build_plan/build_plan.dart';
 import 'asset_change.dart';
 import 'build_package_watcher.dart';
@@ -23,6 +24,8 @@ class Watcher {
   final Set<AssetId> _expectedDeletes;
 
   Watcher._(this._buildPlan, this._buildSeries, this._expectedDeletes);
+
+  BuildPackages get buildPackages => _buildPlan.buildPackages;
 
   factory Watcher({required BuildPlan buildPlan, required Future<void> until}) {
     final expectedDeletes = <AssetId>{};

--- a/build_runner/lib/src/commands/watch_command.dart
+++ b/build_runner/lib/src/commands/watch_command.dart
@@ -16,7 +16,6 @@ import '../build_plan/builder_factories.dart';
 import '../build_plan/testing_overrides.dart';
 import '../logging/build_log.dart';
 import 'build_runner_command.dart';
-import 'serve/server.dart';
 import 'watch/watcher.dart';
 
 class WatchCommand implements BuildRunnerCommand {
@@ -35,15 +34,15 @@ class WatchCommand implements BuildRunnerCommand {
       withEnabledExperiments(_run, buildOptions.enableExperiments.asList());
 
   Future<int> _run() async {
-    final handler = await watch();
-    if (handler == null) return ExitCode.tempFail.code;
+    final watcher = await watch();
+    if (watcher == null) return ExitCode.tempFail.code;
     final completer = Completer<int>();
-    handleBuildResultsStream(handler.buildResults, completer);
+    handleBuildResultsStream(watcher.buildResults, completer);
     return completer.future;
   }
 
   /// Watches files, or returns `null` if a restart is required.
-  Future<ServeHandler?> watch() async {
+  Future<Watcher?> watch() async {
     buildLog.configuration = buildLog.configuration.rebuild((b) {
       b.mode = BuildLogMode.build;
       b.verbose = buildOptions.verbose;
@@ -75,7 +74,7 @@ class WatchCommand implements BuildRunnerCommand {
       }),
     );
 
-    return ServeHandler(buildPlan.buildPackages.outputRoot, watcher);
+    return watcher;
   }
 }
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.11.0
+version: 2.11.1-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/build/serve_test.dart
+++ b/build_runner/test/build/serve_test.dart
@@ -201,7 +201,7 @@ Future<ServeHandler> createHandler(
     ),
   );
 
-  return (await watchCommand.watch())!;
+  return ServeHandler((await watchCommand.watch())!);
 }
 
 /// Tells the program to terminate.

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.7-wip
+
+- Use `build_runner` 2.11.1-wip.
+
 ## 3.5.6
 
 - Add documentation about reading generated assets as `String` using

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.6
+version: 3.5.7-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.11.0'
+  build_runner: '2.11.1-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
With one of the recent fixes I noticed that the `watch` command is computing changes in case there is a websocket connection waiting for updates, which obviously there isn't :)