### PR TITLE
fix dev bootstrap script on safari

### DIFF
--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -398,7 +398,7 @@ var _currentDirectory = (function () {
       if (match) return match[1];
     }
     // Safari.
-    return lines[0].match(/(.+):\d+:\d+$/)[1];
+    return lines[0].match(/[@](.+):\d+:\d+$/)[1];
   }
   _url = lookupUrl();
   var lastSlash = _url.lastIndexOf('/');


### PR DESCRIPTION
Fixes https://github.com/dart-lang/webdev/issues/1499 based on @eddyw 's solution.

I confirmed this works in Safari Version 26.2 (21623.1.14.11.9)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
