### PR TITLE
Fix race in test.

### DIFF
--- a/build_runner/test/integration_tests/processes_test.dart
+++ b/build_runner/test/integration_tests/processes_test.dart
@@ -137,7 +137,7 @@ void main() async {
     );
     parentPid = int.parse(parentLine.split(' ').last);
 
-    while (tester.read('root_pkg/pid.txt') == null) {
+    while (tester.read('root_pkg/pid.txt')?.isEmpty ?? true) {
       await Future<void>.delayed(const Duration(milliseconds: 100));
     }
     childPid = int.parse(tester.read('root_pkg/pid.txt')!);


### PR DESCRIPTION
I've seen this fail a few times on CI, it looks like the pid file is read after it's created but while it's still empty.

So, wait for non-empty.