### PR TITLE
Build also in the workspace root.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.11.1-wip
 
+- Bug fix: with `--workspace` flag, correctly build for sources in the workspace
+  root instead of failing with "tried to delete from package not in the build".
+
 ## 2.11.0
 
 - Add `--workspace` flag. Use it with `dart run build_runner build` or `watch`

--- a/build_runner/lib/src/build_plan/build_package.dart
+++ b/build_runner/lib/src/build_plan/build_package.dart
@@ -17,9 +17,6 @@ class BuildPackage {
   /// Paths are platform dependent.
   final String path;
 
-  /// Whether the "package" is actually a workspace.
-  final bool isWorkspace;
-
   /// Whether the package contents should be watched in `watch` and `serve`
   /// modes.
   final bool watch;
@@ -37,7 +34,6 @@ class BuildPackage {
   BuildPackage({
     required this.name,
     required String path,
-    this.isWorkspace = false,
     this.watch = false,
     this.isOutput = false,
     this.languageVersion,
@@ -56,7 +52,6 @@ class BuildPackage {
   }) => BuildPackage(
     name: name,
     path: '/$name',
-    isWorkspace: isWorkspace,
     watch: watch,
     isOutput: isOutput,
     dependencies: dependencies,
@@ -68,7 +63,6 @@ class BuildPackage {
     return other is BuildPackage &&
         name == other.name &&
         path == other.path &&
-        isWorkspace == other.isWorkspace &&
         watch == other.watch &&
         isOutput == other.isOutput &&
         languageVersion == other.languageVersion &&
@@ -84,7 +78,6 @@ class BuildPackage {
 BuildPackage(
   name: $name,
   path: $path,
-  isWorkspace: $isWorkspace,
   watch: $watch,
   isOutput: $isOutput,
   languageVersion: $languageVersion,

--- a/build_runner/lib/src/build_plan/build_packages_loader.dart
+++ b/build_runner/lib/src/build_plan/build_packages_loader.dart
@@ -72,7 +72,8 @@ class BuildPackagesLoader {
     String outputRootName;
     final packagesInBuild = <String>{};
     if (buildType == BuildType.workspace) {
-      outputRootName = workspaceName!;
+      packagesInBuild.add(workspaceName!);
+      outputRootName = workspaceName;
       final workspacePackagePaths = workspacePubspec!['workspace'] as YamlList;
       for (final path in workspacePackagePaths) {
         packagesInBuild.add(
@@ -93,11 +94,6 @@ class BuildPackagesLoader {
       p.join(workspacePath ?? packagePath, 'pubspec.lock'),
     );
     final fixedPackages = _parseFixedPackages(pubspecLockFile);
-    // The workspace root is treated like a package, but does not contain
-    // sources so don't watch it for changes.
-    // TODO(davidmorgan): add test coverage for yaml files in the workspace
-    // root, do watch those for changes.
-    if (workspaceName != null) fixedPackages.add(workspaceName);
 
     final buildPackages = MapBuilder<String, BuildPackage>();
     for (final packageConfig in packageConfigs) {
@@ -110,7 +106,6 @@ class BuildPackagesLoader {
       buildPackages[packageConfig.name] = BuildPackage(
         name: packageConfig.name,
         path: packageConfig.root.toFilePath(),
-        isWorkspace: packageConfig.name == workspaceName,
         languageVersion: packageConfig.languageVersion,
         watch: !fixedPackages.contains(packageConfig.name),
         isOutput: isInBuild,

--- a/build_runner/lib/src/commands/watch/build_packages_watcher.dart
+++ b/build_runner/lib/src/commands/watch/build_packages_watcher.dart
@@ -45,9 +45,7 @@ class BuildPackagesWatcher {
   Stream<AssetChange> _watch() {
     final allWatchers =
         _buildPackages.packages.values
-            .where(
-              (buildPackage) => buildPackage.watch || buildPackage.isWorkspace,
-            )
+            .where((buildPackage) => buildPackage.watch)
             .map(_strategy)
             .toList();
     final filteredEvents =

--- a/build_runner/test/build_plan/build_packages_test.dart
+++ b/build_runner/test/build_plan/build_packages_test.dart
@@ -335,7 +335,8 @@ workspace:
           'some_workspace_name': BuildPackage(
             name: 'some_workspace_name',
             path: tempDirectory,
-            isWorkspace: true,
+            watch: true,
+            isOutput: true,
             languageVersion: LanguageVersion(3, 5),
           ),
           r'$sdk': anything,

--- a/build_runner/test/integration_tests/build_command_workspace_root_test.dart
+++ b/build_runner/test/integration_tests/build_command_workspace_root_test.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['integration4'])
+library;
+
+import 'package:test/test.dart';
+
+import '../common/common.dart';
+
+void main() async {
+  test('build command workspace root', () async {
+    final pubspecs = await Pubspecs.load();
+    final tester = BuildRunnerTester(pubspecs);
+
+    tester.writeFixturePackage(
+      FixturePackages.copyBuilder(packageName: 'builder_pkg'),
+    );
+    tester.writeFixturePackage(
+      FixturePackages.copyBuilder(
+        packageName: 'cache_builder_pkg',
+        buildToCache: true,
+        applyToAllPackages: true,
+        outputExtension: '.hidden',
+      ),
+    );
+    tester.writePackage(
+      name: 'p1',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {'lib/p1.txt': '1'},
+      inWorkspace: true,
+    );
+    // Workspace package with direct dependency on builder_pkg.
+    tester.write('pubspec.yaml', '''
+name: workspace
+environment:
+  sdk: ^3.5.0
+dependencies:
+  builder_pkg:
+    path: builder_pkg
+workspace: [p1]
+''');
+    tester.write('lib/w.txt', '1');
+
+    // Build without --workspace then build with, no input change.
+    await tester.run('', 'dart run build_runner build');
+    expect(tester.read('lib/w.txt.copy'), '1');
+    expect(
+      tester.read('p1/lib/p1.txt.copy'),
+      null,
+    ); // No build of nested package.
+    await tester.run('', 'dart run build_runner build --workspace');
+    expect(tester.read('lib/w.txt.copy'), '1');
+    expect(tester.read('p1/lib/p1.txt.copy'), '1');
+
+    // Build without --workspace then build with, input change in between.
+    await tester.run('', 'dart run build_runner build');
+    expect(tester.read('lib/w.txt.copy'), '1');
+    tester.write('lib/w.txt', '2');
+    tester.write('p1/lib/p1.txt', '2');
+    await tester.run('', 'dart run build_runner build --workspace');
+    expect(tester.read('lib/w.txt.copy'), '2');
+    expect(tester.read('p1/lib/p1.txt.copy'), '2');
+
+    // Build without --workspace again, no input change.
+    tester.write('p1/lib/p1.txt', '3');
+    await tester.run('', 'dart run build_runner build');
+    expect(tester.read('lib/w.txt.copy'), '2');
+    expect(
+      tester.read('p1/lib/p1.txt.copy'),
+      '2',
+    ); // No build of nested package.
+
+    // Build with --workspace then without, input change in between.
+    await tester.run('', 'dart run build_runner build --workspace');
+    expect(tester.read('lib/w.txt.copy'), '2');
+    expect(tester.read('p1/lib/p1.txt.copy'), '3');
+    tester.write('lib/w.txt', '3');
+    tester.write('p1/lib/p1.txt', '4');
+    await tester.run('', 'dart run build_runner build');
+    expect(tester.read('lib/w.txt.copy'), '3');
+    expect(
+      tester.read('p1/lib/p1.txt.copy'),
+      '3',
+    ); // No build of nested package.
+  });
+}


### PR DESCRIPTION
Fix #4359 

I had assumed there should be no source in the workspace root, but in fact there can be. With older build_runner versions it acts like a package: direct deps specified in the workspace root turn on builders. So, maintain that behavior with `--workspace`.