### PR TITLE
Limit log repeats on failed builder script builds.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.11.1-wip
 
+- Improve logging on build script build failures, don't repeatedly log an
+  identical failure.
 - Bug fix: with `--workspace` flag, correctly build for sources in the workspace
   root instead of failing with "tried to delete from package not in the build".
 

--- a/build_runner/test/integration_tests/watch_command_test.dart
+++ b/build_runner/test/integration_tests/watch_command_test.dart
@@ -177,12 +177,19 @@ $yaml
     build_extensions: {'.txt': ['']}
 ''',
     );
+    await watch.expect('missingBuilderFactory');
     await watch.expect(
       'Failed to compile build script. '
       'Check builder definitions and generated script '
       '.dart_tool/build/entrypoint/build.dart. '
       'Retrying.',
     );
+
+    // The first build after retry is marked as a new build.
+    await watch.expect('Starting build #5');
+    // But the next identical build failure is not logged as a new build.
+    final block = await watch.expectAndGetBlock('0s compiling builders');
+    expect(block, isNot(contains('Starting build')));
 
     // Restore the correct build script and it gets compiled and runs.
     tester.write('builder_pkg/build.yaml', '''


### PR DESCRIPTION
Fix #4353 

Reduce the log noise when repeatedly retrying builder script compiles.

Also: don't retry if the failure is due to `dart:mirrors` as that's unlikely to be a recoverable/temporary failure. Just exit.