### PR TITLE
Check resolution API signatures for invalidation

### DIFF
--- a/build_runner/lib/src/build/asset_graph/node.dart
+++ b/build_runner/lib/src/build/asset_graph/node.dart
@@ -256,8 +256,9 @@ abstract class GeneratedNodeState
   /// to generate it.
   BuiltSet<AssetId> get inputs;
 
-  /// Entrypoints used for resolution with the analyzer.
-  BuiltSet<AssetId> get resolverEntrypoints;
+  /// Entrypoints used for resolution with the analyzer and their transitive API
+  /// signatures.
+  BuiltMap<AssetId, String> get resolverEntrypoints;
 
   /// Whether the generation succeded, or `null` if it did not run.
   ///

--- a/build_runner/lib/src/build/asset_graph/node.g.dart
+++ b/build_runner/lib/src/build/asset_graph/node.g.dart
@@ -369,8 +369,9 @@ class _$GeneratedNodeStateSerializer
       'resolverEntrypoints',
       serializers.serialize(
         object.resolverEntrypoints,
-        specifiedType: const FullType(BuiltSet, const [
+        specifiedType: const FullType(BuiltMap, const [
           const FullType(AssetId),
+          const FullType(String),
         ]),
       ),
       'errors',
@@ -422,11 +423,12 @@ class _$GeneratedNodeStateSerializer
           result.resolverEntrypoints.replace(
             serializers.deserialize(
                   value,
-                  specifiedType: const FullType(BuiltSet, const [
+                  specifiedType: const FullType(BuiltMap, const [
                     const FullType(AssetId),
+                    const FullType(String),
                   ]),
                 )!
-                as BuiltSet<Object?>,
+                as BuiltMap<Object?, Object?>,
           );
           break;
         case 'result':
@@ -948,7 +950,7 @@ class _$GeneratedNodeState extends GeneratedNodeState {
   @override
   final BuiltSet<AssetId> inputs;
   @override
-  final BuiltSet<AssetId> resolverEntrypoints;
+  final BuiltMap<AssetId, String> resolverEntrypoints;
   @override
   final bool? result;
   @override
@@ -1013,10 +1015,10 @@ class GeneratedNodeStateBuilder
   SetBuilder<AssetId> get inputs => _$this._inputs ??= SetBuilder<AssetId>();
   set inputs(SetBuilder<AssetId>? inputs) => _$this._inputs = inputs;
 
-  SetBuilder<AssetId>? _resolverEntrypoints;
-  SetBuilder<AssetId> get resolverEntrypoints =>
-      _$this._resolverEntrypoints ??= SetBuilder<AssetId>();
-  set resolverEntrypoints(SetBuilder<AssetId>? resolverEntrypoints) =>
+  MapBuilder<AssetId, String>? _resolverEntrypoints;
+  MapBuilder<AssetId, String> get resolverEntrypoints =>
+      _$this._resolverEntrypoints ??= MapBuilder<AssetId, String>();
+  set resolverEntrypoints(MapBuilder<AssetId, String>? resolverEntrypoints) =>
       _$this._resolverEntrypoints = resolverEntrypoints;
 
   bool? _result;

--- a/build_runner/lib/src/build/asset_graph/serialization.dart
+++ b/build_runner/lib/src/build/asset_graph/serialization.dart
@@ -8,7 +8,7 @@ part of 'graph.dart';
 ///
 /// This should be incremented any time the serialize/deserialize formats
 /// change.
-const _version = 32;
+const _version = 33;
 
 /// Deserializes an [AssetGraph] from a [Map].
 ///

--- a/build_runner/lib/src/build/asset_graph/serializers.g.dart
+++ b/build_runner/lib/src/build/asset_graph/serializers.g.dart
@@ -43,6 +43,13 @@ Serializers _$serializers =
             () => SetBuilder<AssetId>(),
           )
           ..addBuilderFactory(
+            const FullType(BuiltMap, const [
+              const FullType(AssetId),
+              const FullType(String),
+            ]),
+            () => MapBuilder<AssetId, String>(),
+          )
+          ..addBuilderFactory(
             const FullType(BuiltSet, const [const FullType(AssetId)]),
             () => SetBuilder<AssetId>(),
           )

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -54,6 +54,7 @@ class Build {
   final LibraryCycleGraphLoader previousLibraryCycleGraphLoader =
       LibraryCycleGraphLoader();
   final AssetDepsLoader? previousDepsLoader;
+  final ResolversImpl? _resolversImpl;
 
   // Logging.
   final BuildPerformanceTracker performanceTracker;
@@ -122,7 +123,11 @@ class Build {
        previousDepsLoader =
            assetGraph.previousPhasedAssetDeps == null
                ? null
-               : AssetDepsLoader.fromDeps(assetGraph.previousPhasedAssetDeps!);
+               : AssetDepsLoader.fromDeps(assetGraph.previousPhasedAssetDeps!),
+       _resolversImpl =
+           buildPlan.testingOverrides.resolvers == null
+               ? ResolversImpl.sharedInstance
+               : buildPlan.testingOverrides.resolversImpl;
 
   BuildOptions get buildOptions => buildPlan.buildOptions;
   TestingOverrides get testingOverrides => buildPlan.testingOverrides;
@@ -896,12 +901,28 @@ class Build {
         if (changed) return true;
       }
 
-      for (final graphId in firstOutputState.resolverEntrypoints) {
+      for (final graphId in firstOutputState.resolverEntrypoints.keys) {
         if (await _hasInputGraphChanged(
           phaseNumber: phaseNumber,
           entrypointId: graphId,
         )) {
-          return true;
+          // A file in the transitive deps changed.
+          if (_resolversImpl == null) {
+            // No way to check further, assume resolution changed. This can
+            // happen because `package:build_test` allows injection of
+            //`Resolvers` via `testingOverrides`.
+            return true;
+          } else {
+            // Check whether resolution of the entrypoint actually changed.
+            final oldSignature = firstOutputState.resolverEntrypoints[graphId];
+            final signature = await _resolversImpl.updateDriverForEntrypoint(
+              entrypoint: graphId,
+              phasedReader: readerWriter,
+            );
+            if (signature != oldSignature) {
+              return true;
+            }
+          }
         }
       }
 

--- a/build_runner/lib/src/build/input_tracker.dart
+++ b/build_runner/lib/src/build/input_tracker.dart
@@ -24,7 +24,8 @@ class InputTracker {
   final AssetId? primaryInput;
   final String? builderLabel;
   final HashSet<AssetId> _inputs = HashSet<AssetId>();
-  final HashSet<AssetId> _resolverEntrypoints = HashSet<AssetId>();
+  final HashMap<AssetId, String> _resolverEntrypoints =
+      HashMap<AssetId, String>();
 
   /// Creates an input tracker.
   ///
@@ -39,10 +40,13 @@ class InputTracker {
 
   void add(AssetId input) => _inputs.add(input);
 
-  void addResolverEntrypoint(AssetId graph) => _resolverEntrypoints.add(graph);
+  void addResolverEntrypoint({
+    required AssetId entrypoint,
+    required String apiSignature,
+  }) => _resolverEntrypoints[entrypoint] = apiSignature;
 
   Set<AssetId> get inputs => _inputs;
-  Set<AssetId> get resolverEntrypoints => _resolverEntrypoints;
+  Map<AssetId, String> get resolverEntrypoints => _resolverEntrypoints;
 
   void clear() {
     _inputs.clear();

--- a/build_runner/lib/src/build/resolver/analysis_driver.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver.dart
@@ -5,13 +5,12 @@
 import 'dart:io';
 
 import 'package:analyzer/file_system/file_system.dart' show ResourceProvider;
-// ignore: implementation_imports
-import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
 import 'package:package_config/package_config.dart' show PackageConfig;
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
 import 'analysis_driver_filesystem.dart';
+import 'analysis_driver_for_package_build.dart';
 import 'analysis_driver_model.dart';
 
 /// Builds an [AnalysisDriverForPackageBuild] backed by a summary SDK.

--- a/build_runner/lib/src/build/resolver/analysis_driver_for_package_build.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_for_package_build.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// FORK of package:analyzer//src/clients/build_resolvers/build_resolvers.dart.
+// Not intended for merging! Changes: add `libraryApiSignature` method.
+
+// ignore_for_file: combinators_ordering
+// ignore_for_file: implementation_imports
+// ignore_for_file: prefer_final_locals
+
+import 'dart:typed_data';
+
+import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
+import 'package:analyzer/dart/analysis/analysis_options.dart';
+import 'package:analyzer/dart/analysis/session.dart';
+import 'package:analyzer/file_system/file_system.dart';
+import 'package:analyzer/src/context/packages.dart';
+import 'package:analyzer/src/dart/analysis/analysis_options.dart';
+import 'package:analyzer/src/dart/analysis/analysis_options_map.dart';
+import 'package:analyzer/src/dart/analysis/byte_store.dart';
+import 'package:analyzer/src/dart/analysis/driver.dart';
+import 'package:analyzer/src/dart/analysis/file_content_cache.dart';
+import 'package:analyzer/src/dart/analysis/file_state.dart';
+import 'package:analyzer/src/dart/analysis/performance_logger.dart';
+import 'package:analyzer/src/dart/analysis/results.dart';
+import 'package:analyzer/src/generated/source.dart';
+import 'package:analyzer/src/summary/package_bundle_reader.dart';
+import 'package:analyzer/src/summary/summary_sdk.dart';
+import 'package:analyzer/src/summary2/package_bundle_format.dart';
+
+export 'package:analyzer/dart/analysis/analysis_options.dart'
+    show AnalysisOptions;
+export 'package:analyzer/source/source.dart' show Source;
+export 'package:analyzer/src/context/packages.dart' show Packages, Package;
+export 'package:analyzer/src/dart/analysis/analysis_options.dart'
+    show AnalysisOptionsImpl;
+export 'package:analyzer/src/dart/analysis/byte_store.dart' show ByteStore;
+export 'package:analyzer/src/dart/analysis/experiments.dart'
+    show ExperimentStatus;
+export 'package:analyzer/src/generated/source.dart' show UriResolver;
+
+/// A somewhat low level API to create [AnalysisSession].
+///
+/// Ideally we want clients to use [AnalysisContextCollection], which
+/// encapsulates any internals and is driven by `package_config.json` and
+/// `analysis_options.yaml` files. But so far it looks that `build_resolvers`
+/// wants to provide [UriResolver], and push [Packages] created by other means
+/// than parsing `package_config.json`.
+AnalysisDriverForPackageBuild createAnalysisDriver({
+  required ResourceProvider resourceProvider,
+  required Uint8List sdkSummaryBytes,
+  required AnalysisOptions analysisOptions,
+  FileContentCache? fileContentCache,
+  required List<UriResolver> uriResolvers,
+  required Packages packages,
+  ByteStore? byteStore,
+}) {
+  var sdkBundle = PackageBundleReader(sdkSummaryBytes);
+  var sdk = SummaryBasedDartSdk.forBundle(sdkBundle);
+
+  var sourceFactory = SourceFactory([DartUriResolver(sdk), ...uriResolvers]);
+
+  var dataStore = SummaryDataStore();
+  dataStore.addBundle('', sdkBundle);
+
+  var logger = PerformanceLog(null);
+  byteStore ??= MemoryByteStore();
+
+  var scheduler = AnalysisDriverScheduler(logger);
+  scheduler.events.drain<void>().ignore();
+
+  var sharedOptions = analysisOptions as AnalysisOptionsImpl;
+  var optionsMap = AnalysisOptionsMap.forSharedOptions(sharedOptions);
+  var driver = AnalysisDriver(
+    scheduler: scheduler,
+    logger: logger,
+    resourceProvider: resourceProvider,
+    byteStore: byteStore,
+    sourceFactory: sourceFactory,
+    analysisOptionsMap: optionsMap,
+    fileContentCache: fileContentCache,
+    externalSummaries: dataStore,
+    packages: packages,
+    withFineDependencies: false,
+    shouldReportInconsistentAnalysisException: false,
+  );
+
+  scheduler.start();
+
+  return AnalysisDriverForPackageBuild._(sdk.libraryUris, driver);
+}
+
+/// [AnalysisSession] plus a tiny bit more.
+class AnalysisDriverForPackageBuild {
+  final List<Uri> _sdkLibraryUris;
+  final AnalysisDriver _driver;
+
+  AnalysisDriverForPackageBuild._(this._sdkLibraryUris, this._driver);
+
+  /// Returns the transitive API signature of the library at [path].
+  ///
+  /// If it is not found or is not a library, returns `null`.
+  String? libraryApiSignature(String path) {
+    final fileResult = _driver.getFileSync(path);
+    if (fileResult is FileResultImpl) {
+      final kind = fileResult.fileState.kind;
+      if (kind is LibraryFileKind) {
+        return kind.libraryCycle.apiSignature;
+      }
+    }
+
+    // Failed. The resolve in the builder will also fail.
+    return '';
+  }
+
+  AnalysisSession get currentSession {
+    return _driver.currentSession;
+  }
+
+  /// Returns URIs of libraries in the given SDK.
+  List<Uri> get sdkLibraryUris {
+    return _sdkLibraryUris;
+  }
+
+  /// Return a [Future] that completes after pending file changes are applied,
+  /// so that [currentSession] can be used to compute results.
+  Future<void> applyPendingFileChanges() {
+    return _driver.applyPendingFileChanges();
+  }
+
+  /// The file with the given [path] might have changed - updated, added or
+  /// removed. Or not, we don't know. Or it might have, but then changed back.
+  ///
+  /// The [path] must be absolute and normalized.
+  ///
+  /// The [currentSession] most probably will be invalidated.
+  /// Note, is does NOT at the time of writing this comment.
+  /// But we are going to fix this.
+  void changeFile(String path) {
+    _driver.changeFile(path);
+  }
+
+  /// Return `true` if the [uri] can be resolved to an existing file.
+  bool isUriOfExistingFile(Uri uri) {
+    var source = _driver.sourceFactory.forUri2(uri);
+    return source != null && source.exists();
+  }
+}

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -4,8 +4,6 @@
 
 import 'dart:async';
 
-// ignore: implementation_imports
-import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
 import 'package:build/build.dart';
 
 import '../../logging/timed_activities.dart';
@@ -15,6 +13,7 @@ import '../library_cycle_graph/library_cycle_graph_loader.dart';
 import '../library_cycle_graph/phased_asset_deps.dart';
 import '../library_cycle_graph/phased_reader.dart';
 import 'analysis_driver_filesystem.dart';
+import 'analysis_driver_for_package_build.dart';
 
 /// Manages analysis driver and related build state.
 ///
@@ -75,16 +74,21 @@ class AnalysisDriverModel {
   /// If [transitive], then all the transitive imports from [entrypoint] are
   /// also updated.
   ///
-  /// Records what was read in [inputTracker].
-  Future<void> updateDriver({
+  /// Records what was read in [inputTracker], if any.
+  ///
+  /// If [transitive] returns the transitive API signature of the resolved
+  /// file, or the empty string if it is not a valid library.
+  ///
+  /// If not [transitive], returns `null`.
+  Future<String?> updateDriverForEntrypoint({
     required Future<void> Function(
       Future<void> Function(AnalysisDriverForPackageBuild),
     )
     withDriver,
     required AssetId entrypoint,
     required PhasedReader phasedReader,
-    required InputTracker inputTracker,
     required bool transitive,
+    InputTracker? inputTracker,
   }) async {
     Iterable<AssetId> idsToSyncOntoFilesystem;
 
@@ -95,15 +99,15 @@ class AnalysisDriverModel {
         // cause a recursive `_performResolve` on this same `AnalysisDriver`
         // instance.
         final nodeLoader = AssetDepsLoader(phasedReader);
-        inputTracker.addResolverEntrypoint(entrypoint);
         return await _graphLoader.transitiveDepsOf(nodeLoader, entrypoint);
       });
     } else {
       // Notify [buildStep] of its inputs.
-      inputTracker.add(entrypoint);
+      inputTracker?.add(entrypoint);
       idsToSyncOntoFilesystem = [entrypoint];
     }
 
+    String? apiSignature;
     await withDriver((driver) async {
       // Sync changes onto the "URI resolver", the in-memory filesystem.
       final phase = phasedReader.phase;
@@ -140,7 +144,21 @@ class AnalysisDriverModel {
       }
       filesystem.clearChangedPaths();
       await driver.applyPendingFileChanges();
+
+      if (transitive) {
+        apiSignature = driver.libraryApiSignature(entrypoint.asPath) ?? '';
+      }
     });
+
+    if (transitive) {
+      inputTracker?.addResolverEntrypoint(
+        entrypoint: entrypoint,
+        apiSignature: apiSignature!,
+      );
+      return apiSignature!;
+    } else {
+      return null;
+    }
   }
 }
 

--- a/build_runner/lib/src/build/resolver/build_resolver.dart
+++ b/build_runner/lib/src/build/resolver/build_resolver.dart
@@ -9,8 +9,6 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/diagnostic/diagnostic.dart';
 import 'package:analyzer/error/error.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
 import 'package:build/build.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:pool/pool.dart';
@@ -19,6 +17,7 @@ import '../../logging/timed_activities.dart';
 import '../input_tracker.dart';
 import '../library_cycle_graph/phased_reader.dart';
 import 'analysis_driver_filesystem.dart';
+import 'analysis_driver_for_package_build.dart';
 import 'analysis_driver_model.dart';
 import 'build_step_resolver.dart';
 
@@ -214,13 +213,18 @@ class BuildResolver {
   /// If [transitive], then all the transitive imports from [entrypoint] are
   /// also updated.
   ///
-  /// Records what was read in [inputTracker].
-  Future<void> updateDriverForEntrypoint({
+  /// Records what was read in [inputTracker], if any.
+  ///
+  /// If [transitive] returns the transitive API signature of the resolved
+  /// file, or the empty string if it is not a valid library.
+  ///
+  /// If not [transitive], returns `null`.
+  Future<String?> updateDriverForEntrypoint({
     required AssetId entrypoint,
     required PhasedReader phasedReader,
-    required InputTracker inputTracker,
     required bool transitive,
-  }) => _analysisDriverModel.updateDriver(
+    InputTracker? inputTracker,
+  }) => _analysisDriverModel.updateDriverForEntrypoint(
     withDriver:
         (withDriver) => _driverPool.withResource(() => withDriver(_driver)),
     phasedReader: phasedReader,

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -5,8 +5,6 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/analysis/features.dart';
-// ignore: implementation_imports
-import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
 import 'package:build/build.dart';
 import 'package:build/experiments.dart';
 import 'package:package_config/package_config.dart';
@@ -15,7 +13,9 @@ import 'package:pool/pool.dart';
 import '../../bootstrap/build_process_state.dart';
 import '../../logging/build_log.dart';
 import '../build_step_impl.dart';
+import '../library_cycle_graph/phased_reader.dart';
 import 'analysis_driver.dart';
+import 'analysis_driver_for_package_build.dart';
 import 'analysis_driver_model.dart';
 import 'build_resolver.dart';
 import 'build_step_resolver.dart';
@@ -68,8 +68,7 @@ class ResolversImpl implements Resolvers {
   }) : _packageConfig = packageConfig,
        _analysisDriverModel = analysisDriverModel;
 
-  @override
-  Future<BuildStepResolver> get(BuildStep buildStep) async {
+  Future<void> _initialize() async {
     await _initializationPool.withResource(() async {
       if (_buildResolver != null) return;
       _warnOnLanguageVersionMismatch();
@@ -89,7 +88,11 @@ class ResolversImpl implements Resolvers {
 
       _buildResolver = BuildResolver(driver, _driverPool, _analysisDriverModel);
     });
+  }
 
+  @override
+  Future<BuildStepResolver> get(BuildStep buildStep) async {
+    await _initialize();
     return BuildStepResolver(_buildResolver!, buildStep as BuildStepImpl);
   }
 
@@ -97,6 +100,18 @@ class ResolversImpl implements Resolvers {
   @override
   void reset() {
     _analysisDriverModel.reset();
+  }
+
+  Future<String> updateDriverForEntrypoint({
+    required AssetId entrypoint,
+    required PhasedReader phasedReader,
+  }) async {
+    await _initialize();
+    return (await _buildResolver!.updateDriverForEntrypoint(
+      entrypoint: entrypoint,
+      phasedReader: phasedReader,
+      transitive: true,
+    ))!;
   }
 }
 

--- a/build_runner/lib/src/build_plan/testing_overrides.dart
+++ b/build_runner/lib/src/build_plan/testing_overrides.dart
@@ -10,6 +10,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:logging/logging.dart';
 import 'package:watcher/watcher.dart';
 
+import '../build/resolver/resolvers_impl.dart';
 import '../io/reader_writer.dart';
 import 'build_packages.dart';
 import 'build_phases.dart';
@@ -46,6 +47,11 @@ class TestingOverrides {
     this.resolvers,
     this.terminateEventStream,
   });
+
+  /// If [resolvers] is a [ResolversImpl], [resolvers] cast to `ResolversImpl`.
+  /// Otherwise, `null`.
+  ResolversImpl? get resolversImpl =>
+      resolvers is ResolversImpl ? resolvers as ResolversImpl : null;
 
   TestingOverrides copyWith({
     BuiltList<BuilderDefinition>? builderDefinitions,

--- a/build_runner/test/common/fixture_packages.dart
+++ b/build_runner/test/common/fixture_packages.dart
@@ -122,6 +122,43 @@ class ReadBuilder implements Builder {
     },
   );
 
+  /// Resolves dart files and outputs the library name.
+  static final FixturePackage resolveBuilder = FixturePackage(
+    name: 'builder_pkg',
+    dependencies: ['build', 'build_runner'],
+    files: {
+      'build.yaml': '''
+builders:
+  test_builder:
+    import: 'package:builder_pkg/builder.dart'
+    builder_factories: ['testBuilderFactory']
+    build_extensions: {'.dart': ['.resolved']}
+    auto_apply: root_package
+    build_to: source
+''',
+      'lib/builder.dart': '''
+import 'package:build/build.dart';
+
+Builder testBuilderFactory(BuilderOptions options) => TestBuilder();
+
+class TestBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions
+      => {'.dart': ['.resolved']};
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    final library = await buildStep.inputLibrary;
+    buildStep.writeAsString(
+        buildStep.inputId.changeExtension('.resolved'),
+        library.name!,
+    );
+  }
+}
+''',
+    },
+  );
+
   /// A post process builder that copies .txt -> .post.
   ///
   /// Comes with a normal builder that does nothing but applies the post

--- a/build_runner/test/integration_tests/watch_command_skip_analysis_test.dart
+++ b/build_runner/test/integration_tests/watch_command_skip_analysis_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['integration3'])
+library;
+
+import 'package:build_runner/src/logging/build_log.dart';
+import 'package:test/test.dart';
+
+import '../common/common.dart';
+
+void main() async {
+  test('watch command skip analysis', () async {
+    final pubspecs = await Pubspecs.load();
+    final tester = BuildRunnerTester(pubspecs);
+
+    tester.writeFixturePackage(FixturePackages.resolveBuilder);
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {
+        'lib/a.dart': '''
+library a;
+import 'b.dart';
+int x = 3;
+''',
+        'lib/b.dart': '''
+import 'c.dart';
+
+int y = 4;
+''',
+        'lib/c.dart': '''
+''',
+      },
+    );
+
+    // Watch and initial build.
+    final watch = await tester.start('root_pkg', 'dart run build_runner watch');
+    await watch.expect(BuildLog.successPattern);
+    expect(tester.read('root_pkg/lib/a.resolved'), 'a');
+
+    // Updating `c.dart` with a change that does not affect its API should
+    // cause `c.resolved` to be rebuilt but not `a.resolved` or `b.resolved`.
+    tester.write('root_pkg/lib/c.dart', '// new comment');
+    var line = await watch.expectAndGetLine(BuildLog.successPattern);
+    expect(line, contains('wrote 1 output'));
+
+    // Updating `c.dart` with a change that does affect its API should
+    // cause all three to be rebuilt.
+    tester.write('root_pkg/lib/c.dart', 'int z = 3;');
+    line = await watch.expectAndGetLine(BuildLog.successPattern);
+    expect(line, contains('wrote 3 outputs'));
+
+    // Now try a code change that still doesn't affect the API.
+    tester.write('root_pkg/lib/c.dart', 'int z = 4;');
+    line = await watch.expectAndGetLine(BuildLog.successPattern);
+    expect(line, contains('wrote 1 output'));
+  });
+}

--- a/build_runner/test/invalidation/invalidation_tester.dart
+++ b/build_runner/test/invalidation/invalidation_tester.dart
@@ -8,8 +8,7 @@ import 'dart:math';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
-import 'package:build_runner/src/constants.dart';
-import 'package:build_runner/src/logging/build_log.dart';
+import 'package:build_runner/src/internal.dart';
 import 'package:build_test/build_test.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:crypto/crypto.dart';
@@ -203,7 +202,7 @@ class InvalidationTester {
         throw StateError('Do a build without change, delete or create first.');
       }
       for (final id in _sourceAssets) {
-        assets[id] = '${_imports(id)}// initial source';
+        assets[id] = '${_imports(id)}\nint? x; // initial source';
       }
       if (_buildYaml != null) {
         assets[AssetId('pkg', 'build.yaml')] = _buildYaml!;
@@ -218,7 +217,7 @@ class InvalidationTester {
     // Make the requested updates.
     if (change != null) {
       assets[change.assetId] =
-          '${_imports(change.assetId)}\n// ${++_outputNumber}';
+          '${_imports(change.assetId)}\nint? x${++_outputNumber};';
     }
     if (delete != null) {
       if (assets.containsKey(delete.assetId)) {
@@ -235,7 +234,8 @@ class InvalidationTester {
       if (assets.containsKey(create.assetId)) {
         throw StateError('Asset $create to create already exists in: $assets');
       }
-      assets[create.assetId] = '${_imports(create.assetId)}// initial source';
+      assets[create.assetId] =
+          '${_imports(create.assetId)}\nint? x; // initial source';
     }
     if (buildYaml != null) {
       assets[AssetId('pkg', 'build.yaml')] = buildYaml;
@@ -531,6 +531,18 @@ class TestBuilder implements Builder {
         recordInput(resolve.assetId, null);
       }
     }
+
+    String renderRecordedInput() {
+      final result = StringBuffer();
+      for (final input in recordedInput) {
+        final digest = md5.convert(utf8.encode(input)).bytes.join('_');
+        // Any change needs to be an API change, so name a variable using the
+        // digest. Also bring the long form version in a comment.
+        result.writeln('int? x$digest; // $input');
+      }
+      return result.toString();
+    }
+
     for (final write in writes) {
       final writeId = buildStep.inputId.replaceExtensions('$from.dart', write);
       final outputStrategy =
@@ -539,7 +551,7 @@ class TestBuilder implements Builder {
         OutputStrategy.fixed => _tester._imports(writeId),
         OutputStrategy.inputDigest =>
           '${_tester._imports(writeId)}\n'
-              '${recordedInput.map((l) => '// $l\n').join('')}',
+              '${renderRecordedInput()}',
         OutputStrategy.none => null,
       };
       if (output != null) {

--- a/build_test/lib/src/internal_test_reader_writer.dart
+++ b/build_test/lib/src/internal_test_reader_writer.dart
@@ -231,7 +231,7 @@ class _ReaderWriterTestingImpl implements ReaderWriterTesting {
   @override
   Iterable<AssetId> get resolverEntrypointsTracked =>
       InputTracker.inputTrackersForTesting[_readerWriter.filesystem]!
-          .expand((tracker) => tracker.resolverEntrypoints)
+          .expand((tracker) => tracker.resolverEntrypoints.keys)
           .toSet();
 
   @override
@@ -246,7 +246,7 @@ class _ReaderWriterTestingImpl implements ReaderWriterTesting {
                 (builderLabel == null ||
                     builderLabel == inputTracker.builderLabel);
           })
-          .expand((tracker) => tracker.resolverEntrypoints)
+          .expand((tracker) => tracker.resolverEntrypoints.keys)
           .toSet();
 
   @override


### PR DESCRIPTION
When a file is resolved, record the (transitive) API signature.

On the next build, when choosing whether to build: if the only thing that has changed is a transitive import of something that was resolved, check the API signature and only rebuild if the API signature changed.

Work in progress: not for merge due to fork of analyzer class into `analysis_driver_for_package_build`. The change to that file is small, only the new method `libraryApiSignature`.

