### PR TITLE
Removing setStartAsyncSynchronously in DDC's bootstrap logic

### DIFF
--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.12
+- Remove `setStartAsyncSynchronously` in DDC's bootstrapper.
+
 ## 4.4.11
 
 - Fix entrypoints in nested directories not being properly resolved in DDC's Library Bundle module system.

--- a/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -307,7 +307,6 @@ String _appBootstrap({
           : 'dart_sdk.dart.nativeNonNullAsserts($nativeNullAssertions);';
   return '''
 define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_sdk) {
-  dart_sdk.dart.setStartAsyncSynchronously(true);
   $nativeAssertsCode
   dart_sdk._isolate_helper.startRootIsolate(() => {}, []);
   $_initializeTools

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.4.11
+version: 4.4.12
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
Related SDK change: https://github.com/dart-lang/sdk/commit/e134003905e8cd4c145cbecbc1eebdaab4cef065