### PR TITLE
Fix test setup to use workspace.

### DIFF
--- a/build_runner/test/common/build_runner_tester.dart
+++ b/build_runner/test/common/build_runner_tester.dart
@@ -76,6 +76,14 @@ class BuildRunnerTester {
     copyPathSync(sourcePath, destinationPath);
   }
 
+  /// Writes a `pubspec.yaml` for the workspace root.
+  ///
+  /// This includes `dependency_overrides` for `build`, `build_runner`, and
+  /// `build_config` pointing to the local versions.
+  void writeWorkspacePubspec({required List<String> packages}) {
+    write('pubspec.yaml', pubspecs.workspacePubspec(packages: packages));
+  }
+
   /// Reads workspace-relative [path], or returns `null` if it does not exist.
   String? read(String path) {
     final file = File(p.join(tempDirectory.path, path));
@@ -478,12 +486,68 @@ dependencies:
       }
     }
 
+    // If `inWorkspace`, the overrides will be written in the workspace pubspec
+    // instead.
+    if (!inWorkspace) {
+      result.writeln(
+        _localDependencyOverrides(
+          pathDependencies: {...pathDependencies, ...pathDevDependencies},
+          workspaceDependencies: workspaceDependencies.toSet(),
+        ),
+      );
+    }
+    return result.toString();
+  }
+
+  /// Returns `pubspec.yaml` content for the workspace root.
+  ///
+  /// This includes `dependency_overrides` overriding packages to use the local
+  /// versions depended on by the test itself, except for packages in the
+  /// workspace.
+  String workspacePubspec({required List<String> packages}) {
+    final result = StringBuffer('''
+name: workspace
+environment:
+  sdk: '>=3.7.0 <4.0.0'
+workspace: [${packages.join(', ')}]
+''');
+    result.writeln(
+      _localDependencyOverrides(
+        pathDependencies: {},
+        workspaceDependencies: packages.toSet(),
+      ),
+    );
+    return result.toString();
+  }
+
+  /// Returns `dependency_overrides` yaml that overrides packages to use the
+  /// local versions depended on by the test itself.
+  ///
+  /// Packages named in [pathDependencies] are instead overriden to the path in
+  /// the test sandox.
+  ///
+  /// Packages named in [workspaceDependencies] are not overriden.
+  String _localDependencyOverrides({
+    required Set<String> workspaceDependencies,
+    required Set<String> pathDependencies,
+  }) {
+    final result = StringBuffer();
     result.writeln('dependency_overrides:');
-    for (final package in dependencies) {
-      final path = packageConfig[package]!.root.toFilePath();
+    for (final package in packageConfig.packages) {
+      final name = package.name;
+      if (workspaceDependencies.contains(name) ||
+          pathDependencies.contains(name)) {
+        continue;
+      }
+      final path = packageConfig[name]!.root.toFilePath();
+      result
+        ..writeln('  $name:')
+        ..writeln('    path: $path');
+    }
+    for (final package in pathDependencies) {
       result
         ..writeln('  $package:')
-        ..writeln('    path: $path');
+        ..writeln('    path: ../$package');
     }
     return result.toString();
   }

--- a/build_runner/test/integration_tests/aot_compiler_test.dart
+++ b/build_runner/test/integration_tests/aot_compiler_test.dart
@@ -87,9 +87,11 @@ void main() {
       'root_pkg/pubspec.yaml',
       pubspecs.pubspec(
         name: 'root_pkg',
-        dependencies: ['build', 'build_runner'],
+        dependencies: ['build_runner'],
+        pathDependencies: ['other'],
       ),
     );
+    tester.writePackage(name: 'other', files: {});
     output = await tester.run('root_pkg', 'dart run root_pkg:compile');
     expect(output, contains('succeeded: true'));
 

--- a/build_runner/test/integration_tests/build_command_define_test.dart
+++ b/build_runner/test/integration_tests/build_command_define_test.dart
@@ -140,12 +140,7 @@ global_options:
       files: {},
       inWorkspace: true,
     );
-    tester.write('pubspec.yaml', '''
-name: workspace
-environment:
-  sdk: ^3.5.0
-workspace: [root_pkg]
-''');
+    tester.writeWorkspacePubspec(packages: ['root_pkg']);
 
     // Build with --workspace. Package options from `root_pkg/build.yaml`
     // still apply, but global options from `root_pkg/build.yaml` don't.

--- a/build_runner/test/integration_tests/build_command_packages_and_paths_test.dart
+++ b/build_runner/test/integration_tests/build_command_packages_and_paths_test.dart
@@ -58,14 +58,7 @@ void main() async {
       files: {'lib/b.txt': 'b'},
       inWorkspace: true,
     );
-    tester.write('pubspec.yaml', '''
-name: workspace
-environment:
-  sdk: ^3.5.0
-workspace:
-  - root_pkg
-  - other_pkg
-''');
+    tester.writeWorkspacePubspec(packages: ['root_pkg', 'other_pkg']);
 
     // Files still not generated for `other_pkg` as it's not a dep.
     _deletePubspecs(tester);

--- a/build_runner/test/integration_tests/build_command_workspace_root_test.dart
+++ b/build_runner/test/integration_tests/build_command_workspace_root_test.dart
@@ -33,14 +33,12 @@ void main() async {
       inWorkspace: true,
     );
     // Workspace package with direct dependency on builder_pkg.
+    tester.writeWorkspacePubspec(packages: ['p1']);
     tester.write('pubspec.yaml', '''
-name: workspace
-environment:
-  sdk: ^3.5.0
+${tester.read('pubspec.yaml')}
 dependencies:
   builder_pkg:
     path: builder_pkg
-workspace: [p1]
 ''');
     tester.write('lib/w.txt', '1');
 

--- a/build_runner/test/integration_tests/build_command_workspace_test.dart
+++ b/build_runner/test/integration_tests/build_command_workspace_test.dart
@@ -34,12 +34,7 @@ void main() async {
       files: {'lib/p1.txt': '1'},
       inWorkspace: true,
     );
-    tester.write('pubspec.yaml', '''
-name: workspace
-environment:
-  sdk: ^3.5.0
-workspace: [p1]
-''');
+    tester.writeWorkspacePubspec(packages: ['p1']);
 
     // Run without --workspace in p1, builders apply.
     await tester.run('p1', 'dart run build_runner build');
@@ -75,12 +70,7 @@ workspace: [p1]
       files: {'lib/p2.txt': '1'},
       inWorkspace: true,
     );
-    tester.write('pubspec.yaml', '''
-name: workspace
-environment:
-  sdk: ^3.5.0
-workspace: [p1, p2]
-''');
+    tester.writeWorkspacePubspec(packages: ['p1', 'p2']);
 
     // Builders do not apply.
     await tester.run('', 'dart run build_runner build --workspace');
@@ -98,12 +88,7 @@ workspace: [p1, p2]
       files: {'lib/p3.txt': '1'},
       inWorkspace: true,
     );
-    tester.write('pubspec.yaml', '''
-name: workspace
-environment:
-  sdk: ^3.5.0
-workspace: [p1, p2, p3]
-''');
+    tester.writeWorkspacePubspec(packages: ['p1', 'p2', 'p3']);
 
     // Builders run.
     await tester.run('p3', 'dart run build_runner build --workspace');
@@ -131,12 +116,7 @@ workspace: [p1, p2, p3]
       files: {'lib/p5.txt': '1'},
       inWorkspace: true,
     );
-    tester.write('pubspec.yaml', '''
-name: workspace
-environment:
-  sdk: ^3.5.0
-workspace: [p1, p2, p3, p4, p5]
-''');
+    tester.writeWorkspacePubspec(packages: ['p1', 'p2', 'p3', 'p4', 'p5']);
 
     // Builders can apply to `p4` and `p5` because they are (transitive) deps
     // of `p1`.
@@ -164,12 +144,9 @@ workspace: [p1, p2, p3, p4, p5]
       pathDependencies: ['second_copy_builder_pkg'],
       inWorkspace: true,
     );
-    tester.write('pubspec.yaml', '''
-name: workspace
-environment:
-  sdk: ^3.5.0
-workspace: [p1, p2, p3, p4, p5, p6]
-''');
+    tester.writeWorkspacePubspec(
+      packages: ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
+    );
 
     // The builder applied by second_copy_builder_pkg runs despite not
     // being auto applied.

--- a/build_runner/test/integration_tests/kernel_compiler_test.dart
+++ b/build_runner/test/integration_tests/kernel_compiler_test.dart
@@ -87,9 +87,12 @@ void main() {
       'root_pkg/pubspec.yaml',
       pubspecs.pubspec(
         name: 'root_pkg',
-        dependencies: ['build', 'build_runner'],
+        dependencies: ['build_runner'],
+        pathDependencies: ['other'],
       ),
     );
+    tester.writePackage(name: 'other', files: {});
+
     output = await tester.run('root_pkg', 'dart run root_pkg:compile');
     expect(output, contains('succeeded: true'));
 

--- a/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
+++ b/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
@@ -71,12 +71,7 @@ class TestBuilder implements Builder {
       files: {},
       inWorkspace: true,
     );
-    tester.write('pubspec.yaml', '''
-name: workspace
-environment:
-  sdk: ^3.5.0
-workspace: [builder_pkg, root_pkg]
-''');
+    tester.writeWorkspacePubspec(packages: ['builder_pkg', 'root_pkg']);
 
     // The first build runs and writes identical output for the generated file.
     final watch = await tester.start(

--- a/build_runner/test/integration_tests/watch_command_workspace_test.dart
+++ b/build_runner/test/integration_tests/watch_command_workspace_test.dart
@@ -73,12 +73,9 @@ void main() async {
       pathDependencies: ['second_copy_builder_pkg'],
       inWorkspace: true,
     );
-    tester.write('pubspec.yaml', '''
-name: workspace
-environment:
-  sdk: ^3.5.0
-workspace: [p1, p2, p3, p4, p5, p6]
-''');
+    tester.writeWorkspacePubspec(
+      packages: ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
+    );
 
     final watch = await tester.start(
       '',


### PR DESCRIPTION
Test setup has an awkward point related to workspaces: with standalone packages each package can specify overrides, but with a workspace multiple overrides across the workspace are not allowed, so this doesn't work.

This is problematic for build_runner's own packages: we almost always want to override them to use a path dependency on the local version, so that we actually _test_ the local version and not something from pub :)

So, move overrides for workspaces into just the workspace yaml, and add a method to help create it.