### PR TITLE
Allow post process builders to write non hidden files

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.0
+
+- Add `build_to` key to `post_process_builders`. Like the `builders` key, it
+  controls where the builder output is written: by default `cache`, the hidden
+  build cache, or `source` to write next to source files.
+
 ## 1.2.0
 
 - Add top level key `triggers`. See

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -182,10 +182,9 @@ builders:
 `PostProcessBuilder`s are configured similarly to normal `Builder`s, but they
 have some different/missing options.
 
-These builders can not be auto-applied on their own, and must always build to
-cache because their outputs are not declared ahead of time. To apply them a
-user will need to explicitly enable them on a target, or a `Builder` definition
-can add them to `apply_builders`.
+These builders can't be auto-applied. They are applied when explicitly
+applied to a target and when a `Builder` definition applies them using
+`apply_builders`.
 
 Exposed `PostProcessBuilder`s are configured in the `post_process_builders`
 section of the  `build.yaml`. This is a map of builder names to configuration.
@@ -199,6 +198,10 @@ Each post process builder config may contain the following keys:
 - **input_extensions**: Required. A list of input extensions that will be
   processed. This must match the `inputExtensions` from the `PostProcessBuilder`
   returned by the `builder_factory`.
+- **build_to**: Optional. The location that generated assets should be output
+  to. The possibilities are:
+  - `"source"`: Outputs go to the source tree next to their primary inputs.
+  - `"cache"`: Outputs go to a hidden build cache and won't be published.
 - **defaults**: Optional: Default values to apply when a user does not specify
   the corresponding key in their `builders` section. May contain the following
   keys:

--- a/build_config/lib/src/builder_definition.dart
+++ b/build_config/lib/src/builder_definition.dart
@@ -185,6 +185,9 @@ class PostProcessBuilderDefinition {
   @Deprecated('do not use')
   final String? target;
 
+  /// Where the outputs of this builder should be written.
+  final BuildTo buildTo;
+
   final TargetBuilderConfigDefaults defaults;
 
   PostProcessBuilderDefinition({
@@ -192,8 +195,10 @@ class PostProcessBuilderDefinition {
     required this.import,
     this.inputExtensions,
     this.target,
+    BuildTo? buildTo,
     TargetBuilderConfigDefaults? defaults,
-  }) : defaults = defaults ?? const TargetBuilderConfigDefaults();
+  }) : buildTo = buildTo ?? BuildTo.cache,
+       defaults = defaults ?? const TargetBuilderConfigDefaults();
 
   factory PostProcessBuilderDefinition.fromJson(Map json) {
     ArgumentError.checkNotNull(json);

--- a/build_config/lib/src/builder_definition.g.dart
+++ b/build_config/lib/src/builder_definition.g.dart
@@ -111,6 +111,7 @@ PostProcessBuilderDefinition _$PostProcessBuilderDefinitionFromJson(
         'import',
         'input_extensions',
         'target',
+        'build_to',
         'defaults',
       ],
       requiredKeys: const ['builder_factory', 'import'],
@@ -124,6 +125,10 @@ PostProcessBuilderDefinition _$PostProcessBuilderDefinitionFromJson(
         (v) => (v as List<dynamic>?)?.map((e) => e as String),
       ),
       target: $checkedConvert('target', (v) => v as String?),
+      buildTo: $checkedConvert(
+        'build_to',
+        (v) => $enumDecodeNullable(_$BuildToEnumMap, v),
+      ),
       defaults: $checkedConvert(
         'defaults',
         (v) =>
@@ -135,6 +140,7 @@ PostProcessBuilderDefinition _$PostProcessBuilderDefinitionFromJson(
   fieldKeyMap: const {
     'builderFactory': 'builder_factory',
     'inputExtensions': 'input_extensions',
+    'buildTo': 'build_to',
   },
 );
 

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 1.2.0
+version: 1.3.0
 description: >-
   Format definition and support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.11.2-wip
 
+- Support the `build_to` key added to `post_process_builders` in
+  `build_config 1.3.0`. Post process builders can use this to output files
+  to the source tree.
 - Bug fix: prevent logging crash when using `build_test` in a builder.
 
 ## 2.11.1

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -397,7 +397,7 @@ class Build {
   ) async {
     // Accumulate in a `Set` because inputs are found once per output.
     final ids = <AssetId>{};
-    final phase = buildPhases[phaseNumber];
+    final phase = buildPhases[phaseNumber] as InBuildPhase;
     final packageNode = buildPackages[package]!;
 
     for (final node in assetGraph
@@ -669,7 +669,12 @@ class Build {
       if (inputNode.type == NodeType.source ||
           inputNode.type == NodeType.generated && inputNode.wasOutput) {
         outputs.addAll(
-          await _runPostProcessBuildStep(phaseNum, action.builder, buildStepId),
+          await _runPostProcessBuildStep(
+            phaseNum,
+            action.builder,
+            buildStepId,
+            hideOutput: action.hideOutput,
+          ),
         );
       }
     }
@@ -679,8 +684,9 @@ class Build {
   Future<Iterable<AssetId>> _runPostProcessBuildStep(
     int phaseNumber,
     PostProcessBuilder builder,
-    PostProcessBuildStepId postProcessBuildStepId,
-  ) async {
+    PostProcessBuildStepId postProcessBuildStepId, {
+    required bool hideOutput,
+  }) async {
     final input = postProcessBuildStepId.input;
     final inputNode = assetGraph.get(input)!;
     final stepReaderWriter = SingleStepReaderWriter(
@@ -738,7 +744,7 @@ class Build {
         final node = AssetNode.generated(
           assetId,
           primaryInput: input,
-          isHidden: true,
+          isHidden: hideOutput,
           phaseNumber: phaseNumber,
         );
         assetGraph.add(node);

--- a/build_runner/lib/src/build/build_dirs.dart
+++ b/build_runner/lib/src/build/build_dirs.dart
@@ -25,7 +25,7 @@ import '../build_plan/phase.dart';
 bool shouldBuildForDirs(
   AssetId id, {
   required BuiltSet<BuildDirectory> buildDirs,
-  required BuildPhase phase,
+  required InBuildPhase phase,
   required BuildConfigs buildConfigs,
   BuiltSet<BuildFilter>? buildFilters,
 }) {

--- a/build_runner/lib/src/build_plan/build_phase_creator.dart
+++ b/build_runner/lib/src/build_plan/build_phase_creator.dart
@@ -31,8 +31,8 @@ class BuildPhaseCreator {
   /// package.
   final bool workspace;
 
-  /// Builder definitions by key, excluding post process builders.
-  final Map<String, BuilderDefinition> _builderDefinitionByKey = {};
+  /// Builder definitions by key.
+  final Map<String, AbstractBuilderDefinition> _builderDefinitionByKey = {};
 
   /// For each builder key, the builders that apply that builder.
   ///
@@ -52,8 +52,8 @@ class BuildPhaseCreator {
     this.workspace = false,
   }) : builderDefinitions = builderDefinitions.toBuiltList() {
     for (final builderDefinition in builderDefinitions) {
+      _builderDefinitionByKey[builderDefinition.key] = builderDefinition;
       if (builderDefinition is BuilderDefinition) {
-        _builderDefinitionByKey[builderDefinition.key] = builderDefinition;
         for (final alsoApply in builderDefinition.appliesBuilders) {
           _builderAppliersByKey
               .putIfAbsent(alsoApply, () => [])
@@ -231,6 +231,7 @@ class BuildPhaseCreator {
         package: buildTarget.package,
         options: options,
         generateFor: targetConfig?.generateFor ?? builderConfig.generateFor,
+        hideOutput: builderDefinition.hideOutput,
         targetSources: buildTarget.sources,
       );
       result.add(builderAction);
@@ -289,15 +290,13 @@ class BuildPhaseCreator {
   ) {
     // If the package is not root, only hidden output is allowed. Return
     // `false` if the builder or any builder it applies has non-hidden output.
-    // Post process builder output is always hidden, so skip the check.
-    if (builderDefinition is BuilderDefinition &&
-        !buildPackages[buildTarget.package]!.isOutput) {
-      if (!(builderDefinition.hideOutput &&
-          builderDefinition.appliesBuilders.every(
-            // Post process builders are not in the map, replace `null` with
-            // `true` because post process builders always hide their output.
-            (b) => _builderDefinitionByKey[b]?.hideOutput ?? true,
-          ))) {
+    if (!buildPackages[buildTarget.package]!.isOutput) {
+      if (!builderDefinition.hideOutput) return false;
+      if (builderDefinition is BuilderDefinition &&
+          !(builderDefinition.hideOutput &&
+              builderDefinition.appliesBuilders.every(
+                (b) => _builderDefinitionByKey[b]!.hideOutput,
+              ))) {
         return false;
       }
     }

--- a/build_runner/lib/src/build_plan/build_phases.dart
+++ b/build_runner/lib/src/build_plan/build_phases.dart
@@ -89,16 +89,20 @@ class BuildPhases {
   ///
   /// If the phases are not valid, logs then throws
   /// [CannotBuildException].
-  ///
-  ///  [PostBuildPhase]s are always hidden, so they are always valid.
   void checkOutputLocations(BuiltSet<String> packagesInBuild) {
-    for (final action in inBuildPhases) {
+    for (final action in inBuildPhases.cast<BuildAction>().followedBy(
+      postBuildPhase.builderActions,
+    )) {
       if (action.hideOutput) continue;
       if (packagesInBuild.contains(action.package)) continue;
       // This should happen only with a manual build script since the build
-      // script generation filters these out.
+      // phases generation filters these out.
+      final name =
+          action is InBuildPhase
+              ? action.displayName
+              : (action as PostBuildAction).builderLabel;
       buildLog.error(
-        'A build phase (${action.displayName}) is attempting '
+        'A build phase ($name) is attempting '
         'to operate on package "${action.package}" without "hideOutput". '
         'This is only allowed for packages in the build, not for dependency '
         'packages.',

--- a/build_runner/lib/src/build_plan/builder_definition.dart
+++ b/build_runner/lib/src/build_plan/builder_definition.dart
@@ -25,6 +25,9 @@ sealed class AbstractBuilderDefinition {
   /// The package the builder is in.
   String get package;
 
+  /// Whether generated assets should be placed in the build cache.
+  bool get hideOutput;
+
   /// The defaults specified in `build.yaml` for this builder.
   TargetBuilderConfigDefaults get targetBuilderConfigDefaults;
 
@@ -119,7 +122,7 @@ class BuilderDefinition implements AbstractBuilderDefinition {
   /// even if [autoApply] does not match.
   final BuiltList<String> appliesBuilders;
 
-  /// Whether generated assets should be placed in the build cache.
+  @override
   final bool hideOutput;
 
   /// Whether the builder is skipped if nothing uses its output.
@@ -195,12 +198,16 @@ class PostProcessBuilderDefinition implements AbstractBuilderDefinition {
   final String package;
 
   @override
+  final bool hideOutput;
+
+  @override
   final TargetBuilderConfigDefaults targetBuilderConfigDefaults;
 
   @visibleForTesting
   PostProcessBuilderDefinition(
     this.key, {
     String? package,
+    this.hideOutput = true,
     this.targetBuilderConfigDefaults = const TargetBuilderConfigDefaults(),
   }) : package = package ?? (key.contains(':') ? key.split(':').first : '');
 
@@ -208,5 +215,6 @@ class PostProcessBuilderDefinition implements AbstractBuilderDefinition {
     build_config.PostProcessBuilderDefinition builderDefinition,
   ) : package = builderDefinition.package,
       key = builderDefinition.key,
+      hideOutput = builderDefinition.buildTo == build_config.BuildTo.cache,
       targetBuilderConfigDefaults = builderDefinition.defaults;
 }

--- a/build_runner/lib/src/build_plan/phase.dart
+++ b/build_runner/lib/src/build_plan/phase.dart
@@ -20,12 +20,6 @@ abstract class BuildPhase {
   /// never run.
   bool get isOptional;
 
-  /// Whether generated assets should be placed in the build cache.
-  ///
-  /// When this is `false` the Builder may not run on any package other than
-  /// the root.
-  bool get hideOutput;
-
   /// The identity of this action in terms of a build graph. If the identity of
   /// any action changes the build will be invalidated.
   ///
@@ -42,6 +36,7 @@ abstract class BuildAction {
   InputMatcher get generateFor;
   String get package;
   InputMatcher get targetSources;
+  bool get hideOutput;
 }
 
 /// A [BuildPhase] that uses a single [Builder] to generate files.
@@ -148,8 +143,6 @@ class PostBuildPhase implements BuildPhase {
   final List<PostBuildAction> builderActions;
 
   @override
-  bool get hideOutput => true;
-  @override
   bool get isOptional => false;
 
   PostBuildPhase(this.builderActions);
@@ -159,8 +152,7 @@ class PostBuildPhase implements BuildPhase {
 
   @override
   int get identity => _deepEquals.hash(
-    builderActions.map<dynamic>((b) => b.identity).toList()
-      ..addAll([isOptional, hideOutput]),
+    builderActions.map<dynamic>((b) => b.identity).toList()..add(isOptional),
   );
 }
 
@@ -177,6 +169,8 @@ class PostBuildAction implements BuildAction {
   final String package;
   @override
   final InputMatcher targetSources;
+  @override
+  final bool hideOutput;
 
   PostBuildAction({
     required this.builder,
@@ -184,6 +178,7 @@ class PostBuildAction implements BuildAction {
     required this.options,
     required InputSet targetSources,
     required InputSet generateFor,
+    required this.hideOutput,
   }) : builderLabel = _builderLabel(builder),
        targetSources = InputMatcher(targetSources),
        generateFor = InputMatcher(generateFor);
@@ -194,6 +189,7 @@ class PostBuildAction implements BuildAction {
     generateFor,
     package,
     targetSources,
+    hideOutput,
   ]);
 }
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   args: ^2.5.0
   async: ^2.5.0
   build: ^4.0.0
-  build_config: ">=1.2.0 <1.3.0"
+  build_config: ">=1.2.0 <1.4.0"
   build_daemon: ^4.0.0
   built_collection: ^5.1.1
   built_value: ^8.10.1

--- a/build_runner/test/build/asset_graph/graph_test.dart
+++ b/build_runner/test/build/asset_graph/graph_test.dart
@@ -196,6 +196,7 @@ void main() {
             targetSources: targetSources,
             options: const BuilderOptions({}),
             generateFor: const InputSet(),
+            hideOutput: true,
           ),
         ]),
       );

--- a/build_runner/test/build_plan/build_phases_test.dart
+++ b/build_runner/test/build_plan/build_phases_test.dart
@@ -114,6 +114,7 @@ void main() {
             options: const BuilderOptions({}),
             targetSources: const InputSet(),
             generateFor: const InputSet(),
+            hideOutput: true,
           ),
         ]),
       );
@@ -126,6 +127,7 @@ void main() {
             options: const BuilderOptions({'a': 'b'}),
             targetSources: const InputSet(),
             generateFor: const InputSet(),
+            hideOutput: true,
           ),
         ]),
       );

--- a/build_runner/test/common/fixture_packages.dart
+++ b/build_runner/test/common/fixture_packages.dart
@@ -128,6 +128,7 @@ class ReadBuilder implements Builder {
   /// process builder.
   static FixturePackage postProcessCopyBuilder({
     String packageName = 'builder_pkg',
+    bool buildToCache = true,
   }) => FixturePackage(
     name: packageName,
     dependencies: ['build', 'build_runner'],
@@ -137,9 +138,9 @@ builders:
   test_builder:
     import: "package:$packageName/builder.dart"
     builder_factories: ["testBuilder"]
-    build_extensions: {".dart": [".g.dart"]}
-    auto_apply: root_package
-    build_to: source
+    build_extensions: {".dart": [".unused"]}
+    auto_apply: all_packages
+    build_to: cache
     applies_builders:
       - $packageName:test_post_process_builder
 post_process_builders:
@@ -147,6 +148,7 @@ post_process_builders:
     import: "package:$packageName/builder.dart"
     builder_factory: "testPostProcessBuilder"
     input_extensions: [".txt"]
+    build_to: ${buildToCache ? 'cache' : 'source'}
     defaults:
       options:
         output_extension: ".post"
@@ -167,7 +169,7 @@ TestPostProcessBuilder testPostProcessBuilder(BuilderOptions options)
 
 class TestBuilder implements Builder {
   @override
-  Map<String, List<String>> get buildExtensions => {'.dart': ['.g.dart']};
+  Map<String, List<String>> get buildExtensions => {'.dart': ['.unused']};
 
   @override
   Future<void> build(BuildStep buildStep) async {}

--- a/build_runner/test/integration_tests/build_command_post_process_builder_test.dart
+++ b/build_runner/test/integration_tests/build_command_post_process_builder_test.dart
@@ -104,5 +104,34 @@ targets:
       'a.txt': 'a',
       'a.txt.third_post': 'a(yaml release)',
     });
+
+    // Build to source.
+    tester.writeFixturePackage(
+      FixturePackages.postProcessCopyBuilder(buildToCache: false),
+    );
+    tester.delete('root_pkg/build.yaml');
+    await tester.run('root_pkg', 'dart run build_runner build');
+    expect(tester.read('root_pkg/lib/a.txt.post'), 'a(default dev)');
+    tester.write('root_pkg/lib/a.txt', 'b');
+    await tester.run('root_pkg', 'dart run build_runner build');
+    expect(tester.read('root_pkg/lib/a.txt.post'), 'b(default dev)');
+
+    // Build to source deletes old outputs.
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build '
+          '--define=builder_pkg:test_post_process_builder=output_extension='
+          '.more_post',
+    );
+    expect(tester.read('root_pkg/lib/a.txt.post'), null);
+    expect(tester.read('root_pkg/lib/a.txt.more_post'), 'b(default dev)');
+    tester.write('root_pkg/lib/a.txt', 'c');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build '
+          '--define=builder_pkg:test_post_process_builder=output_extension='
+          '.more_post',
+    );
+    expect(tester.read('root_pkg/lib/a.txt.more_post'), 'c(default dev)');
   });
 }


### PR DESCRIPTION
Fix #4364

`build_runner` was initially designed to be bazel compatible, so undeclared outputs from post process builders can't be written to the source tree.

Some builders do want undeclared outputs, particularly i18n which wants to read config to decide which set of files to output.

Currently they just use `dart:io`, which is unsupported and breaks with the `--workspace` flag.

Allow post process builders to write to the source tree for this use case. It would need extra work to work with bazel, but it's better than the `dart:io` workaround :)