### PR TITLE
Support globs in workspace pubspecs.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 2.11.2-wip
+## 2.12.0
 
+- Add support for globs in the package list of workspace `pubspec.yaml`,
+  matching the new feature in Dart SDK `3.11`.
 - Support the `build_to` key added to `post_process_builders` in
   `build_config 1.3.0`. Post process builders can use this to output files
   to the source tree.

--- a/build_runner/lib/src/build_plan/build_packages_loader.dart
+++ b/build_runner/lib/src/build_plan/build_packages_loader.dart
@@ -62,10 +62,14 @@ class BuildPackagesLoader {
           ..sort((a, b) => a.name.compareTo(b.name));
 
     String? workspaceName;
-    YamlMap? workspacePubspec;
+    List<String>? workspacePackages;
     if (buildType != BuildType.singlePackage) {
-      workspacePubspec = _pubspecForPath(workspacePath!);
+      final workspacePubspec = _pubspecForPath(workspacePath!);
       workspaceName = workspacePubspec['name']! as String;
+      final workspacePackageGraph = _packageGraphForPath(workspacePath);
+      workspacePackages = List.from(
+        workspacePackageGraph['roots'] as List<Object?>,
+      );
     }
 
     String? singlePackageToBuild;
@@ -73,14 +77,8 @@ class BuildPackagesLoader {
     final packagesInBuild = <String>{};
     if (buildType == BuildType.workspace) {
       packagesInBuild.add(workspaceName!);
+      packagesInBuild.addAll(workspacePackages!);
       outputRootName = workspaceName;
-      final workspacePackagePaths = workspacePubspec!['workspace'] as YamlList;
-      for (final path in workspacePackagePaths) {
-        packagesInBuild.add(
-          _pubspecForPath(p.join(workspacePath!, path as String))['name']
-              as String,
-        );
-      }
     } else {
       final singlePackageToBuildPubspec = _pubspecForPath(packagePath);
       singlePackageToBuild = singlePackageToBuildPubspec['name']! as String;
@@ -139,11 +137,25 @@ YamlMap _pubspecForPath(String absolutePath) {
   final pubspecPath = p.join(absolutePath, 'pubspec.yaml');
   final pubspec = File(pubspecPath);
   if (!pubspec.existsSync()) {
-    throw StateError(
-      'Unable to generate package graph, no `$pubspecPath` found.',
-    );
+    throw StateError('Unable to load packages, no `$pubspecPath` found.');
   }
   return loadYaml(pubspec.readAsStringSync()) as YamlMap;
+}
+
+/// Loads and returns `$absolutePath/.dart_tool/package_graph.json`.
+///
+/// Throws if it does not exist.
+Map<String, Object?> _packageGraphForPath(String absolutePath) {
+  final packageGraphPath = p.join(
+    absolutePath,
+    '.dart_tool',
+    'package_graph.json',
+  );
+  final packageGraph = File(packageGraphPath);
+  if (!packageGraph.existsSync()) {
+    throw StateError('Unable to load packages, no `$packageGraphPath` found.');
+  }
+  return json.decode(packageGraph.readAsStringSync()) as Map<String, Object?>;
 }
 
 /// Parses the `pubspec.lock` file and returns the names of packages that are

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.11.2-wip
+version: 2.12.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/common/build_runner_tester.dart
+++ b/build_runner/test/common/build_runner_tester.dart
@@ -80,8 +80,14 @@ class BuildRunnerTester {
   ///
   /// This includes `dependency_overrides` for `build`, `build_runner`, and
   /// `build_config` pointing to the local versions.
-  void writeWorkspacePubspec({required List<String> packages}) {
-    write('pubspec.yaml', pubspecs.workspacePubspec(packages: packages));
+  void writeWorkspacePubspec({
+    required List<String> packages,
+    String? sdkBound,
+  }) {
+    write(
+      'pubspec.yaml',
+      pubspecs.workspacePubspec(packages: packages, sdkBound: sdkBound),
+    );
   }
 
   /// Reads workspace-relative [path], or returns `null` if it does not exist.
@@ -504,11 +510,12 @@ dependencies:
   /// This includes `dependency_overrides` overriding packages to use the local
   /// versions depended on by the test itself, except for packages in the
   /// workspace.
-  String workspacePubspec({required List<String> packages}) {
+  String workspacePubspec({required List<String> packages, String? sdkBound}) {
+    sdkBound ??= '>=3.7.0 <4.0.0';
     final result = StringBuffer('''
 name: workspace
 environment:
-  sdk: '>=3.7.0 <4.0.0'
+  sdk: '$sdkBound'
 workspace: [${packages.join(', ')}]
 ''');
     result.writeln(

--- a/build_runner/test/integration_tests/build_command_workspace_test.dart
+++ b/build_runner/test/integration_tests/build_command_workspace_test.dart
@@ -152,5 +152,12 @@ void main() async {
     // being auto applied.
     await tester.run('', 'dart run build_runner build --workspace');
     expect(tester.read('p6/lib/p6.txt.copy'), '1');
+
+    // Support for globs in workspaces was added in 3.11.
+    tester.writeWorkspacePubspec(
+      packages: ["'p*'"],
+      sdkBound: '>=3.11.0 <4.0.0',
+    );
+    await tester.run('', 'dart run build_runner build --workspace');
   });
 }

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.5.8-wip
+## 3.5.8
 
-- Use `build_runner` 2.11.2-wip.
+- Use `build_runner` 2.12.0
 
 ## 3.5.7
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.8-wip
+version: 3.5.8
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.11.2-wip'
+  build_runner: '2.12.0'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Implement #4363, prepare release for that + post process builder output change + fix to use of `build_test` in a builder. 