### PR TITLE
Fix for build_config 1.2.0.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.12.1
+
+- Bug fix: allow compilation with older `build_config 1.2.0`.
+
 ## 2.12.0
 
 - Add support for globs in the package list of workspace `pubspec.yaml`,

--- a/build_runner/lib/src/build_plan/builder_definition.dart
+++ b/build_runner/lib/src/build_plan/builder_definition.dart
@@ -218,3 +218,11 @@ class PostProcessBuilderDefinition implements AbstractBuilderDefinition {
       hideOutput = builderDefinition.buildTo == build_config.BuildTo.cache,
       targetBuilderConfigDefaults = builderDefinition.defaults;
 }
+
+/// Stubs for new `build_config` methods to allow compiling with 1.2.0.
+extension _PostProcessBuilderDefinitionStubs
+    on build_config.PostProcessBuilderDefinition {
+  // Added in `1.3.0`.
+  // ignore: unused_element
+  build_config.BuildTo? get buildTo => null;
+}

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.12.0
+version: 2.12.1
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 3.5.9
+
+- Use `build_runner` 2.12.1.
+
 ## 3.5.8
 
-- Use `build_runner` 2.12.0
+- Use `build_runner` 2.12.0.
 
 ## 3.5.7
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.8
+version: 3.5.9
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.12.0'
+  build_runner: '2.12.1'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Fix #4380 

`build_config 1.3.0` added a field, `build_runner` uses it so can no longer compile with `1.2.0`.

I retracted that version of the package as it will break if there is an upper bound forcing build_config 1.2.0 somewhere.

One option would be to add a min version to `build_runner` for `build_config 1.3.0`, but I prefer to use an extension method stub to keep compatibility with both. Tested by forcing build_config version to 1.2.0 and 1.3.0 and running tests.

Longer term ... in particular, if we make any big changes to config ... I'd like something less brittle.