### PR TITLE
Fix for undefined builders mentioned in `build.yaml`.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.12.2
+
+- Bug fix: don't crash if `applies_builders` in `build.yaml` mentions an
+  unknown builder.
+
 ## 2.12.1
 
 - Require `build_config` 1.3.0.

--- a/build_runner/lib/src/build_plan/build_phase_creator.dart
+++ b/build_runner/lib/src/build_plan/build_phase_creator.dart
@@ -295,7 +295,9 @@ class BuildPhaseCreator {
       if (builderDefinition is BuilderDefinition &&
           !(builderDefinition.hideOutput &&
               builderDefinition.appliesBuilders.every(
-                (b) => _builderDefinitionByKey[b]!.hideOutput,
+                // Missing builders won't be applied and so are counted as
+                // hidden.
+                (b) => _builderDefinitionByKey[b]?.hideOutput ?? true,
               ))) {
         return false;
       }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.12.1
+version: 2.12.2
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/integration_tests/build_command_workspace_test.dart
+++ b/build_runner/test/integration_tests/build_command_workspace_test.dart
@@ -159,5 +159,18 @@ void main() async {
       sdkBound: '>=3.11.0 <4.0.0',
     );
     await tester.run('', 'dart run build_runner build --workspace');
+
+    // Write a builder that applies an unknown builder in its build.yaml, the
+    // unknown builder is ignored.
+    tester.writeFixturePackage(
+      FixturePackages.copyBuilder(
+        packageName: 'second_copy_builder_pkg',
+        outputExtension: '.copy2',
+        buildToCache: true,
+        appliesBuilders: '["unknown|test_builder"]',
+        pathDependencies: ['builder_pkg'],
+      ),
+    );
+    await tester.run('', 'dart run build_runner build --workspace');
   });
 }

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.10
+
+- Use `build_runner` 2.12.2.
+
 ## 3.5.9
 
 - Use `build_runner` 2.12.1.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.9
+version: 3.5.10
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.12.1'
+  build_runner: '2.12.2'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Fix #4384 

Restore allowing null in a place where it turns out to have mattered: if a builder "applies" another builder that's undefined.