### PR TITLE
Emit better errors for builds with bad conditional imports

### DIFF
--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.9
+
+- Emit build errors for bad conditional imports.
+
 ## 5.1.8
 
 - Generate synthetic `package_config.json` in the root of its synthetic test directory. Fixes sources in `web/` and related directories not obeying version constraints.

--- a/build_modules/lib/src/errors.dart
+++ b/build_modules/lib/src/errors.dart
@@ -107,11 +107,26 @@ Future<String?> _missingImportMessage(
   final import = parsed.directives
       .whereType<UriBasedDirective>()
       .firstWhereOrNull((directive) {
-        final uriString = directive.uri.stringValue;
-        if (uriString == null) return false;
-        if (uriString.startsWith('dart:')) return false;
-        final id = AssetId.resolve(Uri.parse(uriString), from: sourceId);
-        return id == missingId;
+        final uris = <String?>[
+          directive.uri.stringValue,
+          // Conditional imports are represented as NamespaceDirectives.
+          if (directive is NamespaceDirective)
+            for (final config in directive.configurations)
+              config.uri.stringValue,
+        ];
+
+        for (final uriString in uris) {
+          if (uriString == null) continue;
+          if (uriString.startsWith('dart:')) continue;
+
+          try {
+            final id = AssetId.resolve(Uri.parse(uriString), from: sourceId);
+            if (id == missingId) return true;
+          } on FormatException {
+            // Ignore format exceptions since we're assembling an error string.
+          }
+        }
+        return false;
       });
   if (import == null) return null;
   final lineInfo = parsed.lineInfo.getLocation(import.offset);

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 5.1.8
+version: 5.1.9
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.

--- a/build_modules/test/modules_test.dart
+++ b/build_modules/test/modules_test.dart
@@ -132,6 +132,51 @@ Please check the following imports:
       );
     });
 
+    test('missing conditional imports yield helpful errors', () async {
+      await testBuilder(
+        TestBuilder(
+          buildExtensions: {
+            'lib/a${moduleExtension(platform)}': ['.transitive'],
+          },
+          build: expectAsync2((buildStep, _) async {
+            await expectLater(
+              () => rootModule.computeTransitiveDependencies(buildStep),
+              throwsA(
+                isA<MissingModulesException>().having(
+                  (e) => e.message,
+                  'message',
+                  contains('''
+Unable to find modules for some sources, this is usually the result of either a
+bad import, a missing dependency in a package (or possibly a dev_dependency
+needs to move to a real dependency), or a build failure (if importing a
+generated file).
+
+Please check the following imports:
+
+`import 'some_other_dep.dart' if (dart.library.js_interop) 'src/dep.dart';` from b|lib/b.dart at 1:1
+'''),
+                ),
+              ),
+            );
+          }),
+        ),
+        {
+          'a|lib/a${moduleExtension(platform)}': jsonEncode(
+            rootModule.toJson(),
+          ),
+          'a|lib/src/dep${moduleExtension(platform)}': jsonEncode(
+            directDepModule.toJson(),
+          ),
+          'b|lib/b${moduleExtension(platform)}': jsonEncode(
+            transitiveDepModule.toJson(),
+          ),
+          // No module for b|lib/src/dep.dart
+          'b|lib/b.dart':
+              'import \'some_other_dep.dart\' if (dart.library.js_interop) \'src/dep.dart\';',
+        },
+      );
+    });
+
     group('unsupported modules', () {
       test('are not allowed as the root', () async {
         final unsupportedRootModule = Module(


### PR DESCRIPTION
Conditional imports are represented as `NamespaceDirective` objects in the analyzer, but we weren't crawling those when generating error messages.

Fixes #4297