### PR TITLE
Reuse already-computed errors.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Improve management of files for analysis for faster initial builds and
   incremental builds of large projects: 8% faster on the 1000 file "random"
   benchmark, 30% faster on the 5000 file "random" benchmark.
+- Reuse computation of syntax errors for faster initial builds and incremental
+  builds: 25% faster incremental build of the 5000 file "random" benchmark.
 - Add `--dart-aot-perf` flag for profiling on Linux. Use it with `--force-aot`.
   It runs the builders under the `perf` profiling tool which writes to
   `perf.data`.

--- a/build_runner/lib/src/build/resolver/build_resolver.dart
+++ b/build_runner/lib/src/build/resolver/build_resolver.dart
@@ -136,34 +136,24 @@ class BuildResolver {
   /// Finds syntax errors in files related to the [element].
   ///
   /// This includes the main library and existing part files.
-  Future<List<ErrorsResult>> _syntacticErrorsFor(LibraryElement element) async {
-    final existingSources = <Source>[];
-
-    for (final fragment in element.fragments) {
-      existingSources.add(fragment.source);
+  Future<List<AnalysisResultWithDiagnostics>> _syntacticErrorsFor(
+    LibraryElement element,
+  ) async {
+    final parsedLibrary = _driver.currentSession.getParsedLibraryByElement(
+      element,
+    );
+    if (parsedLibrary is! ParsedLibraryResult) {
+      return const [];
     }
 
-    // Map from elements to absolute paths
-    final paths = existingSources
-        .map((source) => _analysisDriverModel.lookupCachedAsset(source.uri))
-        .whereType<AssetId>() // filter out nulls
-        .map(AnalysisDriverFilesystem.assetPath);
-
-    final relevantResults = <ErrorsResult>[];
-
-    await _driverPool.withResource(() async {
-      for (final path in paths) {
-        final result = await _driver.currentSession.getErrors(path);
-        if (result is ErrorsResult &&
-            result.diagnostics.any(
-              (error) =>
-                  error.diagnosticCode.type == DiagnosticType.SYNTACTIC_ERROR,
-            )) {
-          relevantResults.add(result);
-        }
+    final relevantResults = <AnalysisResultWithDiagnostics>[];
+    for (final unit in parsedLibrary.units) {
+      if (unit.diagnostics.any(
+        (error) => error.diagnosticCode.type == DiagnosticType.SYNTACTIC_ERROR,
+      )) {
+        relevantResults.add(unit);
       }
-    });
-
+    }
     return relevantResults;
   }
 


### PR DESCRIPTION
It turns out `build_runner` was causing the analyzer to do double work: analyze library, then compute the errors. The first analysis already has the errors.

Before

<img width="253" height="257" alt="image" src="https://github.com/user-attachments/assets/eac014db-9557-460a-998c-f409c2b9eeb9" />

After:

<img width="152" height="180" alt="image" src="https://github.com/user-attachments/assets/8b70ae39-2fce-449e-bb18-d3a6503dfe60" />
