### PR TITLE
Provide a custom FileContentCache to the analyzer.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -5,6 +5,8 @@
   benchmark, 30% faster on the 5000 file "random" benchmark.
 - Reuse computation of syntax errors for faster initial builds and incremental
   builds: 25% faster incremental build of the 5000 file "random" benchmark.
+- Avoid throwing and catching an exception during analysis of files that don't
+  exist yet, for a small (2%) performance improvement.
 - Add `--dart-aot-perf` flag for profiling on Linux. Use it with `--force-aot`.
   It runs the builders under the `perf` profiling tool which writes to
   `perf.data`.

--- a/build_runner/lib/src/build/library_cycle_graph/phased_reader.dart
+++ b/build_runner/lib/src/build/library_cycle_graph/phased_reader.dart
@@ -4,6 +4,7 @@
 
 import 'package:build/build.dart';
 
+import '../resolver/analysis_driver_filesystem.dart';
 import 'phased_value.dart';
 
 /// Asset reader that views the build at one specific phase.
@@ -31,7 +32,6 @@ abstract class PhasedReader {
   /// empty string is returned for its content.
   Future<PhasedValue<String>> readPhased(AssetId id);
 
-  /// The contents at the current phase, or `null` if the file is missing at the
-  /// current phase.
-  Future<String?> readAtPhase(AssetId id);
+  /// The contents at the current phase.
+  Future<BuildRunnerFileContent> readAtPhase(AssetId id);
 }

--- a/build_runner/lib/src/build/resolver/analysis_driver.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver.dart
@@ -30,6 +30,7 @@ AnalysisDriverForPackageBuild analysisDriver(
       analysisDriverModel.filesystem,
     ),
     resourceProvider: analysisDriverModel.filesystem,
+    fileContentCache: analysisDriverModel.filesystem,
     sdkSummaryBytes: File(sdkSummaryPath).readAsBytesSync(),
     uriResolvers: [analysisDriverModel.filesystem],
   );

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -9,6 +9,8 @@ import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/source/file_source.dart';
 // ignore: implementation_imports
 import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
+// ignore: implementation_imports
+import 'package:analyzer/src/dart/analysis/file_content_cache.dart';
 import 'package:build/build.dart' hide Resource;
 import 'package:path/path.dart' as p;
 
@@ -25,8 +27,9 @@ import '../asset_graph/node.dart';
 ///
 /// Files are added as they're needed during one build and only removed when
 /// they are cleared by the next [startBuild].
-class AnalysisDriverFilesystem implements UriResolver, ResourceProvider {
-  final Map<String, String> _data = {};
+class AnalysisDriverFilesystem
+    implements UriResolver, ResourceProvider, FileContentCache {
+  final Map<String, FileContent> _data = {};
   final Set<String> _changedPaths = {};
 
   // Path and phase information derived from the `Iterable<AssetNode>` for fast
@@ -89,14 +92,16 @@ class AnalysisDriverFilesystem implements UriResolver, ResourceProvider {
   /// Throws if ![exists].
   String read(String path) {
     if (!exists(path)) throw StateError('Read of non-existent file.');
-    return _data[path]!;
+    return _data[path]!.content;
   }
 
-  /// Writes [content] to [path].
+  /// Writes [content].
   ///
   /// Throws if the file was already written with different content since the
   /// most recent [startBuild].
-  void writeFile(String path, String content) {
+  void writeContent(BuildRunnerFileContent content) {
+    if (!content.exists) throw ArgumentError('content must exist');
+    final path = content.path;
     var wasAbsent = false;
     final updatedContent = _data.putIfAbsent(path, () {
       wasAbsent = true;
@@ -107,18 +112,36 @@ class AnalysisDriverFilesystem implements UriResolver, ResourceProvider {
         _changedPaths.add(path);
       }
     } else {
-      if (content != updatedContent) {
+      if (content.contentHash != updatedContent.contentHash) {
         throw StateError('Different write to $path.');
       }
     }
   }
 
-  /// Paths that were modified by [writeFile] since the last
+  /// Paths that were modified by [writeContent] since the last
   /// call to [clearChangedPaths].
   Iterable<String> get changedPaths => _changedPaths;
 
   /// Clears [changedPaths].
   void clearChangedPaths() => _changedPaths.clear();
+
+  // `FileContentCache` methods.
+
+  @override
+  FileContent get(String path) =>
+      exists(path) ? _data[path]! : BuildRunnerFileContent.missing(path);
+
+  @override
+  void invalidate(String path) {
+    // build_runner handles invalidation, ignore request to invalidate from the
+    // analyzer.
+  }
+
+  @override
+  void invalidateAll() {
+    // build_runner handles invalidation, ignore request to invalidate from the
+    // analyzer.
+  }
 
   // `UriResolver` methods.
 
@@ -217,6 +240,27 @@ class AnalysisDriverFilesystem implements UriResolver, ResourceProvider {
   Folder? getStateLocation(String pluginId) => throw UnimplementedError();
 }
 
+class BuildRunnerFileContent implements FileContent {
+  @override
+  final String path;
+  @override
+  final bool exists;
+  @override
+  final String content;
+  @override
+  final String contentHash;
+
+  BuildRunnerFileContent(
+    this.path,
+    this.exists,
+    this.content,
+    this.contentHash,
+  );
+
+  static BuildRunnerFileContent missing(String path) =>
+      BuildRunnerFileContent(path, false, '', '');
+}
+
 /// Minimal implementation of [File] and [Folder].
 ///
 /// Provides only what the analyzer actually uses during analysis.
@@ -235,14 +279,10 @@ class _Resource implements File, Folder {
   @override
   String get shortName => filesystem.pathContext.basename(path);
 
-  // `File` methods.
+  // `File` methods. These are mostly not used as reads for analysis are via
+  // the `FileContentCache` API.
   @override
-  Uint8List readAsBytesSync() {
-    // TODO(davidmorgan): the analyzer reads as bytes in `FileContentCache`
-    // then converts back to `String` and hashes. It should be possible to save
-    // that work, for example by injecting a custom `FileContentCache`.
-    return utf8.encode(filesystem.read(path));
-  }
+  Uint8List readAsBytesSync() => utf8.encode(filesystem.read(path));
 
   @override
   String readAsStringSync() => filesystem.read(path);

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -127,8 +127,8 @@ class AnalysisDriverModel {
 
         Future<void> writeToFilesystem(AssetId id) async {
           final content = await phasedReader.readAtPhase(id);
-          if (content != null) {
-            filesystem.writeFile(id.asPath, content);
+          if (content.exists) {
+            filesystem.writeContent(content);
           }
         }
 

--- a/build_runner/lib/src/build/single_step_reader_writer.dart
+++ b/build_runner/lib/src/build/single_step_reader_writer.dart
@@ -20,6 +20,7 @@ import 'asset_graph/node.dart';
 import 'input_tracker.dart';
 import 'library_cycle_graph/phased_reader.dart';
 import 'library_cycle_graph/phased_value.dart';
+import 'resolver/analysis_driver_filesystem.dart';
 
 /// Builds an asset.
 typedef AssetBuilder = Future<void> Function(AssetId);
@@ -416,9 +417,13 @@ class SingleStepReaderWriter implements PhasedReader {
   }
 
   @override
-  Future<String?> readAtPhase(AssetId id) async {
-    return await canRead(id, track: false)
-        ? await readAsString(id, track: false)
-        : null;
+  Future<BuildRunnerFileContent> readAtPhase(AssetId id) async {
+    if (!await canRead(id, track: false)) {
+      return BuildRunnerFileContent.missing(id.path);
+    }
+
+    final content = await readAsString(id, track: false);
+    final hash = base64.encode((await digest(id)).bytes);
+    return BuildRunnerFileContent(id.asPath, true, content, hash);
   }
 }

--- a/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
@@ -16,7 +16,7 @@ void main() {
 
   group('AnalysisDriverFilesystem', () {
     test('write then read', () {
-      filesystem.writeFile('foo.txt', 'bar');
+      filesystem.write('foo.txt', 'bar');
       expect(filesystem.read('foo.txt'), 'bar');
     });
 
@@ -25,21 +25,21 @@ void main() {
     });
 
     test('write adds to changedPaths', () {
-      filesystem.writeFile('foo.txt', 'bar');
+      filesystem.write('foo.txt', 'bar');
       expect(filesystem.changedPaths, ['foo.txt']);
     });
 
     test('identical write does not add to changedPaths', () {
-      filesystem.writeFile('foo.txt', 'bar');
+      filesystem.write('foo.txt', 'bar');
       filesystem.clearChangedPaths();
       expect(filesystem.changedPaths, isEmpty);
-      filesystem.writeFile('foo.txt', 'bar');
+      filesystem.write('foo.txt', 'bar');
       expect(filesystem.changedPaths, isEmpty);
     });
 
     test('write updates `exists`', () {
       expect(filesystem.exists('foo.txt'), false);
-      filesystem.writeFile('foo.txt', 'bar');
+      filesystem.write('foo.txt', 'bar');
       expect(filesystem.exists('foo.txt'), true);
     });
 
@@ -59,8 +59,8 @@ void main() {
         ),
       ]);
 
-      filesystem.writeFile('/a/lib/a.g.dart', 'a');
-      filesystem.writeFile('/b/lib/b.g.dart', 'b');
+      filesystem.write('/a/lib/a.g.dart', 'a');
+      filesystem.write('/b/lib/b.g.dart', 'b');
       filesystem.clearChangedPaths();
 
       expect(filesystem.exists('/a/lib/a.g.dart'), false);
@@ -84,4 +84,12 @@ void main() {
       expect(filesystem.exists('/b/lib/b.g.dart'), false);
     });
   });
+}
+
+extension _AnalysisDriverFilesystemExtensions on AnalysisDriverFilesystem {
+  void write(String path, String content) {
+    writeContent(
+      BuildRunnerFileContent(path, true, content, content.hashCode.toString()),
+    );
+  }
 }


### PR DESCRIPTION
This is a slightly tighter integration to how the analyzer reads files.

The original idea for this tighter integration was to save time because it saves a String -> bytes -> String conversion, but that turns out to not really save any time. It might reduce GC pressure.

But it turns out it is useful: the analyzer implementation tries to read files without first calling "exists", in a `try`/`catch`. Because build_runner starts with generated files not existing, this try/catch is hit a lot: the 5000 file benchmark spends 2% of its time on that try/catch.

So we can inject an implementation that calls "exists" first, and save 2%: `DependencyWalker.walk.strongConnect` in `_fe_analyzer_shared` drops from 5% to 3%.

