### PR TITLE
Faster asset graph copying.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -7,6 +7,8 @@
   builds: 25% faster incremental build of the 5000 file "random" benchmark.
 - Avoid throwing and catching an exception during analysis of files that don't
   exist yet, for a small (2%) performance improvement.
+- Copy asset graph without a serialization round trip for a 5% performance
+  improvement.
 - Add `--dart-aot-perf` flag for profiling on Linux. Use it with `--force-aot`.
   It runs the builders under the `perf` profiling tool which writes to
   `perf.data`.

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -148,18 +148,25 @@ class AssetGraph implements GeneratedAssetHider {
 
   /// Copies the graph prepared for the next build with [buildPhases].
   AssetGraph copyForNextBuild(BuildPhases buildPhases) {
-    // TODO(davidmorgan): clean up so there is a way to copy safely without
-    // serializing then deserializing.
-    final result = AssetGraph.deserialize(serialize())!;
-    result.previousInBuildPhasesOptionsDigests =
-        result.inBuildPhasesOptionsDigests;
-    result.inBuildPhasesOptionsDigests =
-        buildPhases.inBuildPhasesOptionsDigests;
-    result.previousPostBuildActionsOptionsDigests =
-        result.postBuildActionsOptionsDigests;
-    result.postBuildActionsOptionsDigests =
-        buildPhases.postBuildActionsOptionsDigests;
-    return result;
+    return AssetGraph._with(
+      nodes: _nodes.clone(),
+      kernelDigest: kernelDigest,
+      buildPhasesDigest: buildPhasesDigest,
+      dartVersion: dartVersion,
+      enabledExperiments: enabledExperiments,
+      packageLanguageVersions: packageLanguageVersions,
+      postProcessBuildStepOutputs: {
+        for (final entry in _postProcessBuildStepOutputs.entries)
+          entry.key: Map.of(entry.value),
+      },
+      previousBuildTriggersDigest: previousBuildTriggersDigest,
+      previousInBuildPhasesOptionsDigests: inBuildPhasesOptionsDigests,
+      inBuildPhasesOptionsDigests: buildPhases.inBuildPhasesOptionsDigests,
+      previousPostBuildActionsOptionsDigests: postBuildActionsOptionsDigests,
+      postBuildActionsOptionsDigests:
+          buildPhases.postBuildActionsOptionsDigests,
+      previousPhasedAssetDeps: previousPhasedAssetDeps,
+    );
   }
 
   /// Deserializes an [AssetGraph] from a [Map].

--- a/build_runner/lib/src/build/asset_graph/nodes.dart
+++ b/build_runner/lib/src/build/asset_graph/nodes.dart
@@ -37,6 +37,12 @@ class Nodes {
 
   Nodes();
 
+  Nodes clone() {
+    final result = Nodes();
+    result._nodes.addAll(_nodes);
+    return result;
+  }
+
   /// Whether [id] is in the graph.
   bool contains(AssetId id) => _nodes.containsKey(id);
 


### PR DESCRIPTION
It was using a serialization round trip which is much more expensive than needed.

Saves 5% on the 5000 files "random" benchmark.