### PR TITLE
Lock resolvers for build.

### DIFF
--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -99,6 +99,11 @@ class AssetGraph implements GeneratedAssetHider {
       _nodes = Nodes(),
       _postProcessBuildStepOutputs = {};
 
+  /// An empty asset graph.
+  @visibleForTesting
+  AssetGraph.emptyForTesting()
+    : this._(null, BuildPhases([]), '', BuiltMap(), BuiltList());
+
   AssetGraph._fromSerialized(
     this.kernelDigest,
     this.buildPhasesDigest,

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -36,6 +36,7 @@ import 'input_tracker.dart';
 import 'library_cycle_graph/asset_deps_loader.dart';
 import 'library_cycle_graph/library_cycle_graph.dart';
 import 'library_cycle_graph/library_cycle_graph_loader.dart';
+import 'library_cycle_graph/phased_asset_deps.dart';
 import 'performance_tracker.dart';
 import 'performance_tracking_resolvers.dart';
 import 'resolver/analysis_driver_model.dart';
@@ -43,6 +44,10 @@ import 'resolver/resolvers_impl.dart';
 import 'run_builder.dart';
 import 'run_post_process_builder.dart';
 import 'single_step_reader_writer.dart';
+
+final ResolversImpl _defaultResolvers = ResolversImpl(
+  analysisDriverModel: AnalysisDriverModel(),
+);
 
 /// A single build.
 class Build {
@@ -130,10 +135,9 @@ class Build {
            assetGraph.previousPhasedAssetDeps == null
                ? null
                : AssetDepsLoader.fromDeps(assetGraph.previousPhasedAssetDeps!),
-       resolvers =
-           buildPlan.testingOverrides.resolvers ?? ResolversImpl.sharedInstance,
+       resolvers = buildPlan.testingOverrides.resolvers ?? _defaultResolvers,
        resolversImpl = switch (buildPlan.testingOverrides.resolvers ??
-           ResolversImpl.sharedInstance) {
+           _defaultResolvers) {
          ResolversImpl r => r,
          _ => null,
        };
@@ -248,8 +252,7 @@ class Build {
         if (!assetGraph.cleanBuild) {
           await _updateAssetGraph(updates);
         }
-        resolversImpl?.startBuild(assetGraph);
-
+        await resolversImpl?.takeLockAndStartBuild(assetGraph);
         final result = await _runPhases();
 
         assetGraph.previousBuildTriggersDigest =
@@ -257,11 +260,13 @@ class Build {
         // Combine previous phased asset deps, if any, with the newly loaded
         // deps. Because of skipped builds, the newly loaded deps might just
         // say "not generated yet", in which case the old value is retained.
+        final currentPhasedAssetDeps =
+            resolversImpl?.phasedAssetDeps() ?? PhasedAssetDeps();
         final updatedPhasedAssetDeps =
             assetGraph.previousPhasedAssetDeps == null
-                ? AnalysisDriverModel.sharedInstance.phasedAssetDeps()
+                ? currentPhasedAssetDeps
                 : assetGraph.previousPhasedAssetDeps!.update(
-                  AnalysisDriverModel.sharedInstance.phasedAssetDeps(),
+                  currentPhasedAssetDeps,
                 );
         assetGraph.previousPhasedAssetDeps = updatedPhasedAssetDeps;
         await readerWriter.writeAsBytes(

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 // ignore: implementation_imports
 import 'package:analyzer/src/clients/build_resolvers/build_resolvers.dart';
 import 'package:build/build.dart';
+import 'package:pool/pool.dart';
 
 import '../../logging/timed_activities.dart';
 import '../asset_graph/graph.dart';
@@ -29,8 +30,8 @@ import 'analysis_driver_filesystem.dart';
 ///   build.
 /// - Notifies the analyzer of changes to that in-memory filesystem.
 class AnalysisDriverModel {
-  /// The instance used by the shared `AnalyzerResolvers` instance.
-  static AnalysisDriverModel sharedInstance = AnalysisDriverModel();
+  final _pool = Pool(1);
+  PoolResource? _lock;
 
   /// In-memory filesystem for the analyzer.
   final AnalysisDriverFilesystem filesystem = AnalysisDriverFilesystem();
@@ -42,14 +43,22 @@ class AnalysisDriverModel {
   /// [filesystem].
   final Set<LibraryCycleGraph> _syncedLibraryCycleGraphs = Set.identity();
 
-  void startBuild(AssetGraph assetGraph) {
+  /// Starts a build with [assetGraph].
+  ///
+  /// If another build has the lock, waits for it to finish.
+  Future<void> takeLockAndStartBuild(AssetGraph assetGraph) async {
+    _lock = await _pool.request();
     filesystem.startBuild(assetGraph.outputs.map((id) => assetGraph.get(id)!));
   }
 
-  /// Clear cached information specific to an individual build.
-  void finishBuild() {
+  /// Clears build state and frees the lock taken by [takeLockAndStartBuild].
+  ///
+  /// If no lock was taken, just clears build state.
+  void endBuildAndUnlock() {
     _graphLoader.clear();
     _syncedLibraryCycleGraphs.clear();
+    _lock?.release();
+    _lock = null;
   }
 
   /// Serializable data from which the library cycle graphs can be

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -16,6 +16,7 @@ import '../../bootstrap/build_process_state.dart';
 import '../../logging/build_log.dart';
 import '../asset_graph/graph.dart';
 import '../build_step_impl.dart';
+import '../library_cycle_graph/phased_asset_deps.dart';
 import 'analysis_driver.dart';
 import 'analysis_driver_model.dart';
 import 'build_resolver.dart';
@@ -28,10 +29,6 @@ import 'sdk_summary.dart';
 /// build step. These provide access to a single underlying [BuildResolver]
 /// which has one analysis driver and manages it via one [AnalysisDriverModel].
 class ResolversImpl implements Resolvers {
-  static final ResolversImpl sharedInstance = ResolversImpl._(
-    analysisDriverModel: AnalysisDriverModel.sharedInstance,
-  );
-
   /// Guards initialization of this class.
   final _initializationPool = Pool(1);
 
@@ -47,7 +44,7 @@ class ResolversImpl implements Resolvers {
   /// Specifies the language version for each package during analysis.
   PackageConfig? _packageConfig;
 
-  /// Creates a separate resolvers instance to [sharedInstance].
+  /// Creates a new resolvers instance.
   ///
   /// Specify [packageConfig] to override package language versions for
   /// analysis. Otherwise, it will be created from
@@ -58,12 +55,12 @@ class ResolversImpl implements Resolvers {
   factory ResolversImpl.custom({
     PackageConfig? packageConfig,
     AnalysisDriverModel? analysisDriverModel,
-  }) => ResolversImpl._(
+  }) => ResolversImpl(
     packageConfig: packageConfig,
     analysisDriverModel: analysisDriverModel ?? AnalysisDriverModel(),
   );
 
-  ResolversImpl._({
+  ResolversImpl({
     PackageConfig? packageConfig,
     required AnalysisDriverModel analysisDriverModel,
   }) : _packageConfig = packageConfig,
@@ -94,13 +91,28 @@ class ResolversImpl implements Resolvers {
     return BuildStepResolver(_buildResolver!, buildStep as BuildStepImpl);
   }
 
-  void startBuild(AssetGraph assetGraph) {
-    _analysisDriverModel.startBuild(assetGraph);
-  }
+  /// Start a build with [assetGraph].
+  ///
+  /// If another build has the lock, waits for it to finish.
+  ///
+  /// The lock is released on [reset].
+  ///
+  /// TODO(davidmorgan): taking the lock is not enforced because `Resolvers` is
+  /// a public API that does not support locking and `ResolversImpl` is private
+  /// implementation that needs locking. Find a way to do better. Fortunately,
+  /// only two codepaths need to care about the lock: the main build in
+  /// `build.dart` and test builds in `package:build_test` `test_builder.dart`.
+  Future<void> takeLockAndStartBuild(AssetGraph assetGraph) =>
+      _analysisDriverModel.takeLockAndStartBuild(assetGraph);
 
+  PhasedAssetDeps phasedAssetDeps() => _analysisDriverModel.phasedAssetDeps();
+
+  /// Frees the lock taken by [takeLockAndStartBuild].
+  ///
+  /// Or if none was taken, does nothing.
   @override
   void reset() {
-    _analysisDriverModel.finishBuild();
+    _analysisDriverModel.endBuildAndUnlock();
   }
 }
 

--- a/build_runner/lib/src/internal.dart
+++ b/build_runner/lib/src/internal.dart
@@ -7,6 +7,7 @@ export 'bootstrap/build_script_generate.dart';
 export 'build/build_result.dart';
 export 'build/build_series.dart';
 export 'build/input_tracker.dart';
+export 'build/resolver/analysis_driver_model.dart';
 export 'build/resolver/resolvers_impl.dart';
 export 'build_plan/build_configs.dart';
 export 'build_plan/build_directory.dart';

--- a/build_runner/test/build/resolver/resolver_test.dart
+++ b/build_runner/test/build/resolver/resolver_test.dart
@@ -11,6 +11,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:build/experiments.dart';
+import 'package:build_runner/src/build/asset_graph/graph.dart';
 import 'package:build_runner/src/build/resolver/analysis_driver.dart';
 import 'package:build_runner/src/build/resolver/analysis_driver_model.dart';
 import 'package:build_runner/src/build/resolver/resolvers_impl.dart';
@@ -1102,7 +1103,7 @@ int? get x => 1;
     final readerWriter = InternalTestReaderWriter();
 
     readerWriter.testing.writeString(makeAssetId('a|lib/a.dart'), '');
-    await runBuilder(
+    await _runBuilder(
       builder,
       [makeAssetId('a|lib/a.dart')],
       SingleStepReaderWriter.fakeFor(readerWriter),
@@ -1110,7 +1111,7 @@ int? get x => 1;
     );
 
     readerWriter.testing.writeString(makeAssetId('a|lib/b.dart'), '');
-    await runBuilder(
+    await _runBuilder(
       builder,
       [makeAssetId('a|lib/b.dart')],
       SingleStepReaderWriter.fakeFor(readerWriter),
@@ -1179,14 +1180,14 @@ int? get x => 1;
       },
     );
     final resolvers = createResolvers();
-    await runBuilder(
+    await _runBuilder(
       builder,
       [input],
       SingleStepReaderWriter.fakeFor(readerWriter),
       resolvers,
     );
 
-    await runBuilder(
+    await _runBuilder(
       builder,
       [input.changeExtension('.a.dart')],
       SingleStepReaderWriter.fakeFor(readerWriter),
@@ -1213,7 +1214,7 @@ int? get x => 1;
       }),
     );
     final resolvers = createResolvers();
-    await runBuilder(
+    await _runBuilder(
       builder,
       [input],
       SingleStepReaderWriter.fakeFor(readerWriter),
@@ -1242,7 +1243,7 @@ int? get x => 1;
         }),
       );
       final resolvers = createResolvers();
-      await runBuilder(
+      await _runBuilder(
         builder,
         [input],
         SingleStepReaderWriter.fakeFor(readerWriter),
@@ -1334,6 +1335,41 @@ int? get x => 1;
       });
     });
   });
+
+  group('simultaneous build resolves', () {
+    test('succeed', () async {
+      final futures = <Future<void>>[];
+      for (var i = 0; i != 10; ++i) {
+        futures.add(
+          resolveSources(
+            {'a|web/main.dart': ' main() { /* $i */}'},
+            (resolver) async {
+              // await Future<void>.delayed(Duration(milliseconds: i * 100));
+              await resolver.compilationUnitFor(entryPoint);
+            },
+            resolvers: createResolvers(),
+          ),
+        );
+      }
+      await Future.wait(futures);
+    });
+  });
+}
+
+// Calls `runBuilder` after getting the resolvers lock.
+Future<void> _runBuilder(
+  TestBuilder builder,
+  List<AssetId> list,
+  SingleStepReaderWriter singleStepReaderWriter,
+  Resolvers resolvers,
+) async {
+  final resolversImpl = switch (resolvers) {
+    final ResolversImpl r => r,
+    _ => null,
+  };
+  await resolversImpl?.takeLockAndStartBuild(AssetGraph.emptyForTesting());
+  await runBuilder(builder, list, singleStepReaderWriter, resolvers);
+  resolversImpl?.reset();
 }
 
 final _skipOnPreRelease =

--- a/build_test/lib/src/resolve_source.dart
+++ b/build_test/lib/src/resolve_source.dart
@@ -6,9 +6,6 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:build/build.dart';
-import 'package:build/experiments.dart';
-// ignore: implementation_imports
-import 'package:build_runner/src/internal.dart';
 import 'package:glob/glob.dart';
 import 'package:package_config/package_config.dart';
 
@@ -202,13 +199,6 @@ Future<T> _resolveAssets<T>(
       }
     }
   }
-
-  // Use the default resolver if no experiments are enabled. This is much
-  // faster.
-  resolvers ??=
-      packageConfig == null && enabledExperiments.isEmpty
-          ? ResolversImpl.sharedInstance
-          : ResolversImpl.custom(packageConfig: resolvedConfig);
 
   await testBuilder(
     resolveBuilder,

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -380,7 +380,7 @@ Future<TestBuilderResult> testBuilderFactories(
   });
   resolvers ??=
       packageConfig == null && enabledExperiments.isEmpty
-          ? ResolversImpl.sharedInstance
+          ? _defaultResolvers
           : ResolversImpl.custom(packageConfig: packageConfig);
 
   // Build a `buildPackages` based on [sourceAssets].
@@ -623,3 +623,11 @@ String _firstNameNotIn(String name, Set<String> existingNames) {
     ++i;
   }
 }
+
+/// The default resolvers for tests.
+///
+/// Different from the default resolvers for real builds so that a real build
+/// can run `testBuilders`.
+final _defaultResolvers = ResolversImpl.custom(
+  analysisDriverModel: AnalysisDriverModel(),
+);


### PR DESCRIPTION
Since the optimization #4392 the `AnalysisDriverModel` now assumes that it's only used concurrently in one build. This allows it to accumulate writes instead of removing and re-adding files.

That means it breaks if used in multiple builds concurrently! This never happens in real builds and should be rare in tests, but I did see it a few times in CI runs.

Add unit test coverage that does reliably fail if there are simultaneous builds.

Add locking. Use a separate lock for real builds and test builds, because some users are doing test builds inside real builds(!).

The locking is not enforced because the APIs that would need to change are public, we do at least have test coverage for the previous failure mode and for the "real build runs test build" case.

Bug fix: `phasedAssetDeps` was always read from `AnalysisDriverModel.sharedInstance`, read it from the correct instance.