### PR TITLE
Release 2.13.0.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,15 +1,11 @@
-## 2.12.3-wip
+## 2.13.0
 
-- Improve management of files for analysis for faster initial builds and
-  incremental builds of large projects: 8% faster on the 1000 file "random"
-  benchmark, 30% faster on the 5000 file "random" benchmark.
-- Reuse computation of syntax errors for faster initial builds and incremental
-  builds: 25% faster incremental build of the 5000 file "random" benchmark.
-- Avoid throwing and catching an exception during analysis of files that don't
-  exist yet, for a small (2%) performance improvement.
-- Copy asset graph without a serialization round trip for a 5% performance
-  improvement.
-- Reuse trigger configuration digest for a small (0.5%) performance improvement.
+- Performance: speedup of between 1.4x for small initial builds to 4x for large
+  incremental builds. See https://github.com/dart-lang/build/pull/4405 for full
+  benchmark results. Optimizations included: faster management of files for
+  analysis, re-use syntax errors computation, avoid a throw/catch on "not yet
+  generated" source, copy asset graph without a serialization round trip,
+  re-use trigger configuration digest.
 - Add `--dart-aot-perf` flag for profiling on Linux. Use it with `--force-aot`.
   It runs the builders under the `perf` profiling tool which writes to
   `perf.data`.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.12.3-wip
+version: 2.13.0
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.5.11-wip
+## 3.5.11
 
-- Use `build_runner` 2.12.3-wip.
+- Use `build_runner` 2.13.0.
 
 ## 3.5.10
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.11-wip
+version: 3.5.11
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.12.3-wip'
+  build_runner: '2.13.0'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
I ran some careful benchmarks to verify the performance improvements; all AOT-compiled on a physical, fast single CPU, Linux machine.

Here are the speedup factors on the "random" built_value benchmarks. The number is the number of libraries in the package. `init` means initial build, `incr` means incremental build, and `web` means it compiles with DDC as well as applying built_value.

1000 init | 1000 incr | 5000 init | 5000 incr | 10000 init | 10000 incr | 1000 init web | 1000 incr web | 10000 init web | 10000 incr web
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1.4x | 1.5x | 2.2x | 2.6x | 3.0x | 3.9x | 1.1x | 1.5x | 2.1x | 3.1x

We made a couple of improvements to the analyzer, I also benchmarked with those, when `build_runner` is on the next analyzer release + with these improvements we'll see a total speedup of

1000 init | 1000 incr | 5000 init | 5000 incr | 10000 init | 10000 incr | 1000 init web | 1000 incr web | 10000 init web | 10000 incr web
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1.5x | 1.6x | 2.6x | 3.0x | 3.9x | 4.8x | 1.1x | 1.5x | 2.3x | 3.5x

and here are the commands used and the raw measured times in seconds.

```
dart run build_runner build --verbose-durations --force-aot --build-filter=bleh; for i in (seq 1 6); rm -rf .dart_tool/build/generated/ .dart_tool/build/asset_graph.json; dart run build_runner build --verbose-durations --force-aot; end
dart run build_runner build --verbose-durations --force-aot --build-filter=bleh; for i in (seq 1 6); edit-benchmark; dart run build_runner build --verbose-durations --force-aot; end
```

  | 1000 init | 1000 incr | 5000 init | 5000 incr | 10000 init | 10000 incr | 1000 init web | 1000 incr web | 10000 init web | 10000 incr web
 -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
v2.12 avg | 1.91 | 1.61 | 16.12 | 14.04 | 48.75 | 45.72 | 5.28 | 3.47 | 62.93 | 55.24
  |   |   |   |   |   |   |   |   |   |  
v2.12 samples  | 1.9 | 1.61 | 16.02 | 14.33 | 48.64 | 45.76 | 5.25 | 3.47 | 64.03 | 54.93
  | 1.92 | 1.61 | 16.09 | 14.18 | 48.72 | 45.29 | 5.29 | 3.45 | 62.44 | 55.1
  | 1.93 | 1.6 | 16.26 | 14.04 | 48.5 | 45.81 | 5.28 | 3.46 | 62.61 | 55.76
  | 1.91 | 1.6 | 16.19 | 13.55 | 48.88 | 45.63 | 5.27 | 3.48 | 62.87 | 55.16
  | 1.91 | 1.61 | 16.03 | 14.09 | 49 | 46.12 | 5.29 | 3.5 | 62.7 | 55.26
  |   |   |   |   |   |   |   |   |   |  
v2.13.0 avg | 1.36 | 1.06 | 7.30 | 5.37 | 16.12 | 11.80 | 4.85 | 2.38 | 30.45 | 18.11
  |   |   |   |   |   |   |   |   |   |  
v2.13.0 samples  | 1.37 | 1.05 | 7.21 | 5.39 | 16.11 | 11.74 | 4.86 | 2.37 | 30.3 | 18.21
  | 1.35 | 1.06 | 7.22 | 5.33 | 16.1 | 11.73 | 4.87 | 2.37 | 30.37 | 18.03
  | 1.35 | 1.05 | 7.28 | 5.35 | 16.14 | 11.87 | 4.83 | 2.4 | 30.6 | 18.1
  | 1.36 | 1.07 | 7.47 | 5.4 | 16.07 | 11.84 | 4.84 | 2.37 | 30.51 | 18.02
  | 1.36 | 1.08 | 7.33 | 5.37 | 16.13 | 11.93 | 4.84 | 2.36 | 30.48 | 18.2
  |   |   |   |   |   |   |   |   |   |  
and analyzer avg | 1.25 | 0.978 | 6.22 | 4.65 | 12.48 | 9.46 | 4.72 | 2.27 | 27.03 | 15.63
  |   |   |   |   |   |   |   |   |   |  
and analyzer samples  | 1.24 | 0.98 | 6.21 | 4.66 | 12.46 | 9.35 | 4.71 | 2.27 | 27.15 | 15.59
  | 1.25 | 0.97 | 6.22 | 4.62 | 12.45 | 9.49 | 4.7 | 2.26 | 27.07 | 15.64
  | 1.25 | 0.98 | 6.2 | 4.68 | 12.5 | 9.53 | 4.74 | 2.27 | 26.96 | 15.65
  | 1.24 | 0.98 | 6.26 | 4.64 | 12.5 | 9.46 | 4.72 | 2.26 | 26.92 | 15.63
  | 1.25 | 0.97 | 6.21 | 4.69 | 12.56 | 9.47 | 4.68 | 2.25 | 26.69 | 15.68