### PR TITLE
Bump analyzer.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.5
+
+- Allow `analyzer` 11.0.0 and 12.0.0.
+
 ## 4.0.4
 
 - Allow `analyzer` 10.0.0.

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 4.0.4
+version: 4.0.5
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: '>=8.0.0 <11.0.0'
+  analyzer: '>=8.0.0 <13.0.0'
   crypto: ^3.0.0
   glob: ^2.0.0
   logging: ^1.0.0

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -16,10 +16,11 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  # TODO(davidmorgan): add back when released for build 3.0.0.
-  # json_serializable: ^6.0.0
   term_glyph: ^1.2.0
   test: ^1.16.0
+  # Builders: these are only needed when rebuilding generated files. Otherwise,
+  # keep them commented out to avoid circular dependencies.
+  # json_serializable: ^6.0.0
 
 topics:
  - build-runner

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.2-wip
+
+- Internal: remove use of `package:mockito` in test.
+
 ## 4.1.1
 
 - Bug fix: daemon process shuts down on internal error.

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version:  4.1.1
+version:  4.1.2-wip
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 resolution: workspace
@@ -23,10 +23,11 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  built_value_generator: ^8.1.0
-  mockito: ^5.0.0
   test: ^1.25.5
   test_descriptor: ^2.0.0
+  # Builders: these are only needed when rebuilding generated files. Otherwise,    
+  # keep them commented out to avoid circular dependencies.
+  # built_value_generator: ^8.1.0
 
 topics:
  - build-runner

--- a/build_daemon/test/managers/build_target_manager_test.dart
+++ b/build_daemon/test/managers/build_target_manager_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:build_daemon/data/build_target.dart';
 import 'package:build_daemon/src/managers/build_target_manager.dart';
-import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -143,4 +142,7 @@ void main() {
   );
 }
 
-class DummyChannel extends Mock implements WebSocketChannel {}
+class DummyChannel implements WebSocketChannel {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/build_modules/CHANGELOG.md
+++ b/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.10
+
+- Allow `analyzer` 11.0.0 and 12.0.0.
+
 ## 5.1.9
 
 - Emit build errors for bad conditional imports.

--- a/build_modules/pubspec.yaml
+++ b/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 5.1.9
+version: 5.1.10
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <3.12.0-z'
 
 dependencies:
-  analyzer: '>=5.1.0 <11.0.0'
+  analyzer: '>=5.1.0 <13.0.0'
   async: ^2.5.0
   bazel_worker: ^1.0.0
   build: '>=2.0.0 <5.0.0'
@@ -33,8 +33,10 @@ dev_dependencies:
     path: test/fixtures/b
   build_runner: ^2.0.0
   build_test: ^3.1.0
-  json_serializable: ^6.9.1
   test: ^1.16.0
+  # Builders: these are only needed when rebuilding generated files. Otherwise,    
+  # keep them commented out to avoid circular dependencies.
+  # json_serializable: ^6.9.1
 
 topics:
  - build-runner

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.13.1
+
+- Allow `analyzer` 11.0.0 and 12.0.0.
+
 ## 2.13.0
 
 - Performance: speedup of between 1.4x for small initial builds to 4x for large

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.13.0
+version: 2.13.1
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace
@@ -13,7 +13,7 @@ platforms:
   macos:
 
 dependencies:
-  analyzer: '>=8.0.0 <11.0.0'
+  analyzer: '>=8.0.0 <13.0.0'
   args: ^2.5.0
   async: ^2.5.0
   build: ^4.0.0

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.12
+
+- Use `build_runner` 2.13.1.
+
 ## 3.5.11
 
 - Use `build_runner` 2.13.0.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.11
+version: 3.5.12
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.13.0'
+  build_runner: '2.13.1'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0
@@ -25,7 +25,7 @@ dependencies:
   watcher: ^1.0.0
 
 dev_dependencies:
-  analyzer: '>=8.0.0 <11.0.0'
+  analyzer: '>=8.0.0 <13.0.0'
 
 topics:
  - build-runner

--- a/build_web_compilers/CHANGELOG.md
+++ b/build_web_compilers/CHANGELOG.md
@@ -1,16 +1,24 @@
+## 4.4.16
+
+- Allow `analyzer` 11.0.0 and 12.0.0.
+
 ## 4.4.15
+
 - Normalize URIs in DDC's bootstrapper on Windows to always use forward slashes when running with the DDC Library Bundle module system.
 
 ## 4.4.14
+
 - Update DDC Library Bundle to use path-resolvable module names for sourcemap IDs.
 
 ## 4.4.13
+
 - Update sourcemap paths for DDC Library Bundle sources.
 - Update bootstrapper for DDC Library Bundle apps to auto-run main.
 - Fix generated entrypoint loader to work in Web Worker contexts by guarding DOM APIs and using `importScripts` as a fallback.
 - Support reading `force_js` parameter from the script's own URL in addition to the page's query string.
 
 ## 4.4.12
+
 - Remove `setStartAsyncSynchronously` in DDC's bootstrapper.
 
 ## 4.4.11

--- a/build_web_compilers/pubspec.yaml
+++ b/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.4.15
+version: 4.4.16
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/build_web_compilers
 resolution: workspace
@@ -8,7 +8,7 @@ environment:
   sdk: '>=3.7.0 <3.12.0-z'
 
 dependencies:
-  analyzer: '>=5.1.0 <11.0.0'
+  analyzer: '>=5.1.0 <13.0.0'
   archive: '>=3.0.0 <5.0.0'
   bazel_worker: ^1.0.0
   build: '>=2.0.0 <5.0.0'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ">=5.0.0 <11.0.0"
+  analyzer: ">=5.0.0 <13.0.0"
   build: ^4.0.0
   # Not imported in code, but used to constrain `build.yaml` requirements
   build_config: ^1.0.0


### PR DESCRIPTION
Allow analyzer 11 and 12.

Comment out dev dependencies that are builders and cause circular dependencies: they're only needed when regenerating files.

Stop using Mockito, it has one package that is both runtime+dev so can't be commented out. Fortunately replacing it is a one-liner.

Update pubspecs and CHANGELOGs for release.