### PR TITLE
Bug fix: don't track files as inputs in `readAtPhase`.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.13.2-wip
+
+- Bug fix: small correctness fix in input tracking.
+
 ## 2.13.1
 
 - Allow `analyzer` 11.0.0 and 12.0.0.

--- a/build_runner/lib/src/build/single_step_reader_writer.dart
+++ b/build_runner/lib/src/build/single_step_reader_writer.dart
@@ -225,8 +225,8 @@ class SingleStepReaderWriter implements PhasedReader {
     return true;
   }
 
-  Future<Digest> digest(AssetId id) async {
-    final isReadable = await _isReadable(id);
+  Future<Digest> digest(AssetId id, {bool track = true}) async {
+    final isReadable = await _isReadable(id, track: track);
 
     if (!isReadable) {
       throw AssetNotFoundException(id);
@@ -423,7 +423,7 @@ class SingleStepReaderWriter implements PhasedReader {
     }
 
     final content = await readAsString(id, track: false);
-    final hash = base64.encode((await digest(id)).bytes);
+    final hash = base64.encode((await digest(id, track: false)).bytes);
     return BuildRunnerFileContent(id.asPath, true, content, hash);
   }
 }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.13.1
+version: 2.13.2-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.13-wip
+
+- Use `build_runner` 2.13.2-wip.
+
 ## 3.5.12
 
 - Use `build_runner` 2.13.1.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.12
+version: 3.5.13-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.13.1'
+  build_runner: '2.13.2-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Fix a recently-introduced bug in input tracking that causes transitive inputs to be recorded as direct inputs, but only once per file per build.

It wasn't detected by tests because:

 - it's functionally equivalent: transitive input graphs are an optimization vs direct inputs, they don't change invalidation behavior
 - it's limited to once per file per build so it doesn't particularly affect performance
 
The bug does cause a slight increase in the size of the serialized asset graph due to the explicit list of transitive deps, 0.2% for the 5000 file benchmark :)

Noticed while working on fine grained analysis integration because that optimization will only kick in for transitive input graphs, not for direct inputs. So that work will add test coverage that can tell the difference between the two.