### PR TITLE
Defer deletes until build completes

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Better handling of deletions of files during the build: if the file is not
   needed ignore the deletion, if it's needed try to use the cached version,
   as a last resort restart the build.
+- Defer deletions of files by `build_runner` until the build is complete to
+  avoid causing churn for tools that would notice the file deletion.
 - Bug fix: small correctness fix in input tracking.
 - Bug fix: fix corner case that caused missing outputs with `build_runner serve`
   when directories were specified with a port, for example 

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -14,7 +14,6 @@ import '../build_plan/build_plan.dart';
 import '../commands/watch/asset_change.dart';
 import '../constants.dart';
 import '../io/asset_tracker.dart';
-import '../io/filesystem_cache.dart';
 import '../io/generated_asset_hider.dart';
 import '../io/reader_writer.dart';
 import '../logging/build_log.dart';
@@ -74,10 +73,6 @@ class BuildSeries {
           buildPlan.testingOverrides.flattenOutput
               ? const NoopGeneratedAssetHider()
               : assetGraph,
-      cache:
-          buildPlan.buildOptions.enableLowResourcesMode
-              ? const PassthroughFilesystemCache()
-              : InMemoryFilesystemCache(),
     );
     return BuildSeries._(
       buildPlan: buildPlan,
@@ -246,10 +241,6 @@ class BuildSeries {
             _buildPlan.testingOverrides.flattenOutput
                 ? const NoopGeneratedAssetHider()
                 : _assetGraph,
-        cache:
-            _buildPlan.buildOptions.enableLowResourcesMode
-                ? const PassthroughFilesystemCache()
-                : InMemoryFilesystemCache(),
       );
     }
 

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -15,6 +15,7 @@ import '../build/asset_graph/node.dart';
 import '../constants.dart';
 import '../exceptions.dart';
 import '../io/asset_tracker.dart';
+import '../io/filesystem_cache.dart';
 import '../io/generated_asset_hider.dart';
 import '../io/reader_writer.dart';
 import '../logging/build_log.dart';
@@ -123,7 +124,12 @@ class BuildPlan {
         testingOverrides.buildPackages ??
         await BuildPackages.forThisPackage(workspace: buildOptions.workspace);
     final readerWriter =
-        testingOverrides.readerWriter ?? ReaderWriter(buildPackages);
+        (testingOverrides.readerWriter ?? ReaderWriter(buildPackages)).copyWith(
+          cache:
+              buildOptions.enableLowResourcesMode
+                  ? const PassthroughFilesystemCache()
+                  : InMemoryFilesystemCache(),
+        );
     final buildConfigs = await BuildConfigs.load(
       readerWriter: readerWriter,
       buildPackages: buildPackages,

--- a/build_runner/lib/src/io/filesystem_cache.dart
+++ b/build_runner/lib/src/io/filesystem_cache.dart
@@ -143,9 +143,6 @@ class InMemoryFilesystemCache implements FilesystemCache {
 
   @override
   Future<void> invalidate(Iterable<AssetId> ids) async {
-    if (_pendingWrites.isNotEmpty) {
-      throw StateError("Can't invalidate while there are pending writes.");
-    }
     for (final id in ids) {
       _existsCache.remove(id);
       _bytesContentCache.remove(id);

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -119,6 +119,7 @@ void main() {
       // The old graph is in [BuildPlan#filesToDelete] because it's invalid.
       expect(await readerWriter.canRead(assetGraphId), true);
       await buildPlan.deleteFilesAndFolders();
+      buildPlan.readerWriter.cache.flush();
       expect(await readerWriter.canRead(assetGraphId), false);
     });
 
@@ -167,6 +168,7 @@ void main() {
       // `BuildPlan` can delete lost outputs.
       expect(await readerWriter.canRead(outputId), true);
       await buildPlan.deleteFilesAndFolders();
+      buildPlan.readerWriter.cache.flush();
       expect(await readerWriter.canRead(outputId), false);
     });
 

--- a/build_runner/test/common/fixture_packages.dart
+++ b/build_runner/test/common/fixture_packages.dart
@@ -26,6 +26,7 @@ class FixturePackages {
     String outputExtension = '.copy',
     String appliesBuilders = '[]',
     List<String> pathDependencies = const [],
+    bool delayAtBuildStart = false,
   }) => FixturePackage(
     name: packageName,
     dependencies: ['build', 'build_runner'],
@@ -53,6 +54,7 @@ class TestBuilder implements Builder {
 
   @override
   Future<void> build(BuildStep buildStep) async {
+${delayAtBuildStart ? 'await Future.delayed(Duration(seconds: 1));' : ''}
     buildStep.writeAsString(
         buildStep.inputId.addExtension('$outputExtension'),
         await buildStep.readAsString(buildStep.inputId),

--- a/build_runner/test/integration_tests/build_command_write_batching_test.dart
+++ b/build_runner/test/integration_tests/build_command_write_batching_test.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['integration4'])
+library;
+
+import 'package:build_runner/src/logging/build_log.dart';
+import 'package:test/test.dart';
+
+import '../common/common.dart';
+
+void main() async {
+  test('build command write batching', () async {
+    final pubspecs = await Pubspecs.load();
+    final tester = BuildRunnerTester(pubspecs);
+
+    tester.writeFixturePackage(
+      FixturePackages.copyBuilder(delayAtBuildStart: true),
+    );
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {
+        'web/a.txt': 'a',
+        // Start with a pre-existing output but no asset graph, it will be
+        // noticed during build plan creation and marked for deletion.
+        'web/a.txt.copy': 'old',
+        'web/b.txt': 'b',
+      },
+    );
+
+    // The delete should be deferred until the new output is ready.
+    final build = await tester.start('root_pkg', 'dart run build_runner build');
+    await build.expect('builder_pkg:test_builder');
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'old');
+    await build.expect(BuildLog.successPattern);
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'a');
+  });
+}

--- a/build_runner/test/io/filesystem_cache_test.dart
+++ b/build_runner/test/io/filesystem_cache_test.dart
@@ -278,6 +278,39 @@ void main() {
       expect(deleted, isTrue);
     });
   });
+
+  test('invalidate preserves pending writes', () {
+    var written = false;
+    cache.writeAsBytes(
+      txt1,
+      txt1Bytes,
+      writer: () {
+        written = true;
+      },
+    );
+    cache.invalidate([txt1]);
+    expect(
+      cache.readAsBytes(txt1, ifAbsent: () => throw UnimplementedError()),
+      txt1Bytes,
+    );
+    expect(written, isFalse);
+  });
+
+  test('invalidate preserves pending delete', () {
+    var deleted = false;
+    cache.delete(
+      txt1,
+      deleter: () {
+        deleted = true;
+      },
+    );
+    cache.invalidate([txt1]);
+    expect(
+      cache.exists(txt1, ifAbsent: () => throw UnimplementedError()),
+      isFalse,
+    );
+    expect(deleted, isFalse);
+  });
 }
 
 /// An encoding that produces bytes that are not valid UTF-8.

--- a/build_test/test/test_builder_test.dart
+++ b/build_test/test/test_builder_test.dart
@@ -343,6 +343,7 @@ Future<void> main() async {
       ),
       {'a|foo.in': 'new input', 'a|foo.out': 'pre-existing output'},
       outputs: {'a|foo.out': 'new input'},
+      flattenOutput: true,
     );
   });
 


### PR DESCRIPTION
Fix #4018

Create the filesystem cache in build_plan instead of in build_series, so that deletes on startup go to the cache and are flushed at the end of the build.

Allow writes/deletes and invalidates without flush in the cache: writes/deletes take precedence over what's on disk.