### PR TITLE
Skip writing files if the contents are identical

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -4,8 +4,9 @@
 - Better handling of deletions of files during the build: if the file is not
   needed ignore the deletion, if it's needed try to use the cached version,
   as a last resort restart the build.
-- Defer deletions of files by `build_runner` until the build is complete to
-  avoid causing churn for tools that would notice the file deletion.
+- Defer deletions of files by `build_runner` until the build is complete. Don't
+  write files unless the contents changed. These reduce unnecessary work by
+  tools that watch the filesystem.
 - `--workspace` flag is no longer experimental, remove the warning.
 - Bug fix: small correctness fix in input tracking.
 - Bug fix: fix corner case that caused missing outputs with `build_runner serve`

--- a/build_runner/lib/src/io/filesystem.dart
+++ b/build_runner/lib/src/io/filesystem.dart
@@ -77,6 +77,28 @@ class IoFilesystem implements Filesystem {
   }) {
     final file = File(path);
     file.parent.createSync(recursive: true);
+
+    // Skip writing the file if it exists and the content is identical, in order
+    // to not cause tools that watch the filesystem to do work.
+    if (file.existsSync()) {
+      try {
+        final stat = file.statSync();
+        if (stat.size == contents.length) {
+          final existingContents = readAsBytesSync(path);
+          var different = false;
+          for (var i = 0; i != contents.length; ++i) {
+            if (contents[i] != existingContents[i]) {
+              different = true;
+              break;
+            }
+          }
+          if (!different) return;
+        }
+      } catch (_) {
+        // File disappearing after `existsSync`, continue to write.
+      }
+    }
+
     file.writeAsBytesSync(contents);
   }
 
@@ -88,6 +110,23 @@ class IoFilesystem implements Filesystem {
   }) {
     final file = File(path);
     file.parent.createSync(recursive: true);
+
+    // Skip writing the file if it exists and the content is identical, in order
+    // to not cause tools that watch the filesystem to do work.
+    if (file.existsSync()) {
+      try {
+        final stat = file.statSync();
+        if (stat.size == contents.length) {
+          String? existingContents;
+          existingContents = readAsStringSync(path, encoding: encoding);
+          if (existingContents == contents) return;
+        }
+      } catch (_) {
+        // File disappearing after `existsSync` or could not be decoded,
+        // continue to write.
+      }
+    }
+
     file.writeAsStringSync(contents, encoding: encoding);
   }
 }

--- a/build_runner/test/common/build_runner_tester.dart
+++ b/build_runner/test/common/build_runner_tester.dart
@@ -90,6 +90,12 @@ class BuildRunnerTester {
     );
   }
 
+  /// Stats workspace-relative [path], or returns `null` if it does not exist.
+  FileStat stat(String path) {
+    final file = File(p.join(tempDirectory.path, path));
+    return file.statSync();
+  }
+
   /// Reads workspace-relative [path], or returns `null` if it does not exist.
   String? read(String path) {
     final file = File(p.join(tempDirectory.path, path));

--- a/build_runner/test/integration_tests/build_command_write_batching_test.dart
+++ b/build_runner/test/integration_tests/build_command_write_batching_test.dart
@@ -37,5 +37,15 @@ void main() async {
     expect(tester.read('root_pkg/web/a.txt.copy'), 'old');
     await build.expect(BuildLog.successPattern);
     expect(tester.read('root_pkg/web/a.txt.copy'), 'a');
+
+    // Don't write identical files.
+    final stat1 = tester.stat('root_pkg/web/a.txt.copy');
+    tester.delete('root_pkg/.dart_tool/build/asset_graph.json');
+    await tester.run('root_pkg', 'dart run build_runner build');
+    final stat2 = tester.stat('root_pkg/web/a.txt.copy');
+    // The file should not have been rewritten. Confirm that `modified` is
+    // unchanged. The delay in the builder means it would change reliably
+    // if the file was rewritten.
+    expect(stat1.modified, stat2.modified);
   });
 }

--- a/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
+++ b/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
@@ -73,22 +73,14 @@ class TestBuilder implements Builder {
     );
     tester.writeWorkspacePubspec(packages: ['builder_pkg', 'root_pkg']);
 
-    // The first build runs and writes identical output for the generated file.
+    // The first build runs and produces identical output for the generated
+    // file. The identical output is not written due to the check on write
+    // by `Filesystem`.
     final watch = await tester.start(
       '',
       'dart run build_runner watch --workspace',
     );
     await watch.expect(BuildLog.successPattern);
-    expect(tester.read('builder_pkg/lib/builder.g.dart'), partContent);
-
-    // The write of the generated file causes a second build that does nothing
-    // because the build has already started before the lack of actual change
-    // can be detected in `BuildSeries.run`.
-    //
-    // Before the fix of https://github.com/dart-lang/build/issues/4348 this
-    // would cause a crash due to an "add" event for `builder.g.dart`.
-    var line = await watch.expectAndGetLine(BuildLog.successPattern);
-    expect(line, contains('wrote 0 outputs'));
     expect(tester.read('builder_pkg/lib/builder.g.dart'), partContent);
 
     // Update the generated file to something different that does build. The
@@ -103,16 +95,8 @@ part of 'builder.dart';
     expect(tester.read('builder_pkg/lib/builder.g.dart'), partContent);
 
     // The generated file content changed so the builders need recompiling.
-    // That happens, the build runs and the generated file is written again but
-    // this time with the same content.
-    await watch.expect('Starting build #4 with updated builders.');
-    line = await watch.expectAndGetLine(BuildLog.successPattern);
-    expect(line, contains('wrote 1 output'));
-
-    // Write of the generated file to the same content causes another build that
-    // does nothing because no input changed.
-    await watch.expect('Starting build #5.');
-    line = await watch.expectAndGetLine(BuildLog.successPattern);
-    expect(line, contains('wrote 0 outputs'));
+    // That happens, the build runs but the generated output is the same so it's
+    // not written and no new build starts.
+    await watch.expectNoOutput(const Duration(seconds: 1));
   });
 }


### PR DESCRIPTION
Fix #4113.

Before writing a file, check if it exists, if so "stat" it, if it's the same length as the intended write then read it before writing and only write if not identical.
