### PR TITLE
Retain generated analyzer filesystem contents across incremental builds

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.14.0-wip
 
+- Performance: further improvements to management of files for analysis
+  for 2x faster incremental builds.
 - Add OSC 8 hyperlinks for logged input paths.
 - Better handling of deletions of files during the build: if the file is not
   needed ignore the deletion, if it's needed try to use the cached version,

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -49,6 +49,23 @@ final ResolversImpl _defaultResolvers = ResolversImpl(
   analysisDriverModel: AnalysisDriverModel(),
 );
 
+class _AssetGraphSourceUpdates {
+  final bool isInitialBuild;
+  final Set<AssetId> changedSources;
+  final Set<AssetId> deletedSources;
+
+  const _AssetGraphSourceUpdates({
+    required this.isInitialBuild,
+    required this.changedSources,
+    required this.deletedSources,
+  });
+
+  const _AssetGraphSourceUpdates.initial()
+    : isInitialBuild = true,
+      changedSources = const {},
+      deletedSources = const {};
+}
+
 /// A single build.
 class Build {
   final BuildPlan buildPlan;
@@ -220,16 +237,23 @@ class Build {
     return result;
   }
 
-  Future<void> _updateAssetGraph(Set<AssetId> updates) async {
+  _AssetGraphSourceUpdates _initialSourceUpdates() =>
+      const _AssetGraphSourceUpdates.initial();
+
+  Future<_AssetGraphSourceUpdates> _updateAssetGraph(
+    Set<AssetId> updates,
+  ) async {
     changedInputs.clear();
     deletedAssets.clear();
 
     // Check what actually changed for each asset in `updates`.
     readerWriter.cache.invalidate(updates);
     final resolvedUpdates = <AssetId, ChangeType>{};
+    final previousSourceNodes = <AssetId, bool>{};
     final newDigests = <AssetId, Digest>{};
     for (final id in updates) {
       final oldNode = assetGraph.get(id);
+      previousSourceNodes[id] = oldNode?.type == NodeType.source;
       final oldExisted =
           oldNode != null && oldNode.type != NodeType.missingSource;
       final oldDigest = oldNode?.digest;
@@ -280,6 +304,29 @@ class Build {
         nodeBuilder.digest = entry.value;
       });
     }
+
+    final changedSources = <AssetId>{};
+    final deletedSources = <AssetId>{};
+    for (final entry in resolvedUpdates.entries) {
+      final id = entry.key;
+      final changeType = entry.value;
+      if (changeType == ChangeType.REMOVE) {
+        if (previousSourceNodes[id] == true) {
+          deletedSources.add(id);
+        }
+        continue;
+      }
+      final updatedNode = assetGraph.get(id);
+      if (updatedNode?.type == NodeType.source) {
+        changedSources.add(id);
+      }
+    }
+
+    return _AssetGraphSourceUpdates(
+      isInitialBuild: false,
+      changedSources: changedSources,
+      deletedSources: deletedSources,
+    );
   }
 
   /// Runs a build inside a zone with an error handler and stack chain
@@ -288,9 +335,10 @@ class Build {
     final done = Completer<BuildResult>();
     runZonedGuarded(
       () async {
-        if (!assetGraph.cleanBuild) {
-          await _updateAssetGraph(idsToCheck);
-        }
+        final sourceUpdates =
+            assetGraph.cleanBuild
+                ? _initialSourceUpdates()
+                : await _updateAssetGraph(idsToCheck);
         for (final id in assetGraph.sources) {
           final node = assetGraph.get(id)!;
           if (node.digest == null && node.primaryOutputs.isNotEmpty) {
@@ -300,7 +348,12 @@ class Build {
             });
           }
         }
-        await resolversImpl?.takeLockAndStartBuild(assetGraph);
+        await resolversImpl?.takeLockAndStartBuild(
+          assetGraph,
+          isInitialBuild: sourceUpdates.isInitialBuild,
+          changedSources: sourceUpdates.changedSources,
+          deletedSources: sourceUpdates.deletedSources,
+        );
         final result = await _runPhases();
 
         assetGraph.previousBuildTriggersDigest =

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -49,23 +49,6 @@ final ResolversImpl _defaultResolvers = ResolversImpl(
   analysisDriverModel: AnalysisDriverModel(),
 );
 
-class _AssetGraphSourceUpdates {
-  final bool isInitialBuild;
-  final Set<AssetId> changedSources;
-  final Set<AssetId> deletedSources;
-
-  const _AssetGraphSourceUpdates({
-    required this.isInitialBuild,
-    required this.changedSources,
-    required this.deletedSources,
-  });
-
-  const _AssetGraphSourceUpdates.initial()
-    : isInitialBuild = true,
-      changedSources = const {},
-      deletedSources = const {};
-}
-
 /// A single build.
 class Build {
   final BuildPlan buildPlan;
@@ -237,23 +220,20 @@ class Build {
     return result;
   }
 
-  _AssetGraphSourceUpdates _initialSourceUpdates() =>
-      const _AssetGraphSourceUpdates.initial();
-
-  Future<_AssetGraphSourceUpdates> _updateAssetGraph(
-    Set<AssetId> updates,
-  ) async {
+  Future<Set<AssetId>> _updateAssetGraph(Set<AssetId> updates) async {
     changedInputs.clear();
     deletedAssets.clear();
 
     // Check what actually changed for each asset in `updates`.
     readerWriter.cache.invalidate(updates);
     final resolvedUpdates = <AssetId, ChangeType>{};
-    final previousSourceNodes = <AssetId, bool>{};
+    final previousSourceNodes = <AssetId>{};
     final newDigests = <AssetId, Digest>{};
     for (final id in updates) {
       final oldNode = assetGraph.get(id);
-      previousSourceNodes[id] = oldNode?.type == NodeType.source;
+      if (oldNode?.type == NodeType.source) {
+        previousSourceNodes.add(id);
+      }
       final oldExisted =
           oldNode != null && oldNode.type != NodeType.missingSource;
       final oldDigest = oldNode?.digest;
@@ -305,28 +285,15 @@ class Build {
       });
     }
 
-    final changedSources = <AssetId>{};
-    final deletedSources = <AssetId>{};
+    final invalidatedSources = <AssetId>{};
     for (final entry in resolvedUpdates.entries) {
       final id = entry.key;
       final changeType = entry.value;
-      if (changeType == ChangeType.REMOVE) {
-        if (previousSourceNodes[id] == true) {
-          deletedSources.add(id);
-        }
-        continue;
-      }
-      final updatedNode = assetGraph.get(id);
-      if (updatedNode?.type == NodeType.source) {
-        changedSources.add(id);
+      if (changeType != ChangeType.ADD && previousSourceNodes.contains(id)) {
+        invalidatedSources.add(id);
       }
     }
-
-    return _AssetGraphSourceUpdates(
-      isInitialBuild: false,
-      changedSources: changedSources,
-      deletedSources: deletedSources,
-    );
+    return invalidatedSources;
   }
 
   /// Runs a build inside a zone with an error handler and stack chain
@@ -335,10 +302,8 @@ class Build {
     final done = Completer<BuildResult>();
     runZonedGuarded(
       () async {
-        final sourceUpdates =
-            assetGraph.cleanBuild
-                ? _initialSourceUpdates()
-                : await _updateAssetGraph(idsToCheck);
+        final invalidatedSources =
+            assetGraph.cleanBuild ? null : await _updateAssetGraph(idsToCheck);
         for (final id in assetGraph.sources) {
           final node = assetGraph.get(id)!;
           if (node.digest == null && node.primaryOutputs.isNotEmpty) {
@@ -350,9 +315,7 @@ class Build {
         }
         await resolversImpl?.takeLockAndStartBuild(
           assetGraph,
-          isInitialBuild: sourceUpdates.isInitialBuild,
-          changedSources: sourceUpdates.changedSources,
-          deletedSources: sourceUpdates.deletedSources,
+          invalidatedSources: invalidatedSources,
         );
         final result = await _runPhases();
 

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -31,6 +31,7 @@ class AnalysisDriverFilesystem
     implements UriResolver, ResourceProvider, FileContentCache {
   final Map<String, FileContent> _data = {};
   final Set<String> _changedPaths = {};
+  final Set<String> _writtenPathsThisBuild = {};
 
   // Path and phase information derived from the `Iterable<AssetNode>` for fast
   // lookup.
@@ -59,7 +60,11 @@ class AnalysisDriverFilesystem
       final isVisible = phase > entry.key;
 
       if (previouslyWasVisible != isVisible) {
-        _changedPaths.addAll(entry.value);
+        for (final path in entry.value) {
+          if (_data.containsKey(path)) {
+            _changedPaths.add(path);
+          }
+        }
       }
     }
   }
@@ -67,16 +72,58 @@ class AnalysisDriverFilesystem
   /// Initializes a new filesystem that will have files added due to the
   /// build described by [generatedNodes].
   void startBuild(Iterable<AssetNode> generatedNodes) {
-    _changedPaths.addAll(_data.keys);
-    _data.clear();
-    _phaseByPath.clear();
-    _pathByPhase.clear();
+    final previousPhaseByPath = Map<String, int>.from(_phaseByPath);
+    final previousGeneratedPaths = previousPhaseByPath.keys.toSet();
+    final nextPhaseByPath = <String, int>{};
+    final nextPathByPhase = <int, List<String>>{};
     for (final node in generatedNodes) {
       final phase = node.generatedNodeConfiguration!.phaseNumber;
       final idAsPath = node.id.asPath;
-      _phaseByPath[idAsPath] = phase;
-      _pathByPhase.putIfAbsent(phase, () => []).add(idAsPath);
+      nextPhaseByPath[idAsPath] = phase;
+      nextPathByPhase.putIfAbsent(phase, () => []).add(idAsPath);
     }
+
+    final sourcePathsToClear =
+        _data.keys
+            .where((path) => !previousGeneratedPaths.contains(path))
+            .toList();
+    for (final path in sourcePathsToClear) {
+      _changedPaths.add(path);
+      _data.remove(path);
+    }
+
+    final removedGeneratedPaths =
+        previousPhaseByPath.keys.toSet()..removeAll(nextPhaseByPath.keys);
+    for (final path in removedGeneratedPaths) {
+      final previousPhase = previousPhaseByPath[path]!;
+      final wasVisible = _phase > previousPhase;
+      if (_data.remove(path) != null && wasVisible) {
+        _changedPaths.add(path);
+      }
+    }
+
+    for (final entry in previousPhaseByPath.entries) {
+      final path = entry.key;
+      final nextPhase = nextPhaseByPath[path];
+      if (nextPhase == null ||
+          nextPhase == entry.value ||
+          !_data.containsKey(path)) {
+        continue;
+      }
+      final previouslyWasVisible = _phase > entry.value;
+      final isVisible = _phase > nextPhase;
+      if (previouslyWasVisible != isVisible) {
+        _changedPaths.add(path);
+      }
+    }
+
+    _phaseByPath
+      ..clear()
+      ..addAll(nextPhaseByPath);
+    _pathByPhase
+      ..clear()
+      ..addAll(nextPathByPhase);
+    _writtenPathsThisBuild.clear();
   }
 
   /// Returns the phase of the generated file at [path] or `-1` if it's not a
@@ -102,19 +149,30 @@ class AnalysisDriverFilesystem
   void writeContent(BuildRunnerFileContent content) {
     if (!content.exists) throw ArgumentError('content must exist');
     final path = content.path;
-    var wasAbsent = false;
-    final updatedContent = _data.putIfAbsent(path, () {
-      wasAbsent = true;
-      return content;
-    });
-    if (wasAbsent) {
-      if (_phase > _phaseOf(path)) {
+    final previousContent = _data[path];
+    final isVisible = _phase > _phaseOf(path);
+    if (previousContent == null) {
+      _data[path] = content;
+      _writtenPathsThisBuild.add(path);
+      if (isVisible) {
         _changedPaths.add(path);
       }
-    } else {
-      if (content.contentHash != updatedContent.contentHash) {
-        throw StateError('Different write to $path.');
-      }
+      return;
+    }
+
+    if (content.contentHash == previousContent.contentHash) {
+      _writtenPathsThisBuild.add(path);
+      return;
+    }
+
+    if (_writtenPathsThisBuild.contains(path)) {
+      throw StateError('Different write to $path.');
+    }
+
+    _data[path] = content;
+    _writtenPathsThisBuild.add(path);
+    if (isVisible) {
+      _changedPaths.add(path);
     }
   }
 

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -32,6 +32,7 @@ class AnalysisDriverFilesystem
   final Map<String, FileContent> _data = {};
   final Set<String> _changedPaths = {};
   final Set<String> _writtenPathsThisBuild = {};
+  bool _allCachedContentsAreFromCurrentBuild = false;
 
   // Path and phase information derived from the `Iterable<AssetNode>` for fast
   // lookup.
@@ -60,11 +61,7 @@ class AnalysisDriverFilesystem
       final isVisible = phase > entry.key;
 
       if (previouslyWasVisible != isVisible) {
-        for (final path in entry.value) {
-          if (_data.containsKey(path)) {
-            _changedPaths.add(path);
-          }
-        }
+        _changedPaths.addAll(entry.value);
       }
     }
   }
@@ -90,6 +87,7 @@ class AnalysisDriverFilesystem
     }
 
     _writtenPathsThisBuild.clear();
+    _allCachedContentsAreFromCurrentBuild = invalidatedSources == null;
 
     if (invalidatedSources == null) {
       _changedPaths.addAll(_data.keys);
@@ -152,7 +150,9 @@ class AnalysisDriverFilesystem
     final isVisible = _phase > _phaseOf(path);
     if (previousContent == null) {
       _data[path] = content;
-      _writtenPathsThisBuild.add(path);
+      if (!_allCachedContentsAreFromCurrentBuild) {
+        _writtenPathsThisBuild.add(path);
+      }
       if (isVisible) {
         _changedPaths.add(path);
       }
@@ -160,11 +160,14 @@ class AnalysisDriverFilesystem
     }
 
     if (content.contentHash == previousContent.contentHash) {
-      _writtenPathsThisBuild.add(path);
+      if (!_allCachedContentsAreFromCurrentBuild) {
+        _writtenPathsThisBuild.add(path);
+      }
       return;
     }
 
-    if (_writtenPathsThisBuild.contains(path)) {
+    if (_allCachedContentsAreFromCurrentBuild ||
+        _writtenPathsThisBuild.contains(path)) {
       throw StateError('Different write to $path.');
     }
 

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -25,8 +25,8 @@ import '../asset_graph/node.dart';
 /// During the build, set [phase] to change the phase that the files are viewed
 /// at.
 ///
-/// Source files are added as they're needed during a build and are managed by
-/// the analysis driver model. Generated files are tracked by [startBuild].
+/// Source files are added as they're needed during a build. [startBuild]
+/// manages how source and generated files are invalidated between builds.
 class AnalysisDriverFilesystem
     implements UriResolver, ResourceProvider, FileContentCache {
   final Map<String, FileContent> _data = {};
@@ -35,8 +35,8 @@ class AnalysisDriverFilesystem
 
   // Path and phase information derived from the `Iterable<AssetNode>` for fast
   // lookup.
-  final Map<String, int> _phaseByPath = {};
-  final Map<int, List<String>> _pathByPhase = {};
+  Map<String, int> _phaseByPath = {};
+  Map<int, List<String>> _pathByPhase = {};
 
   int _phase = 0;
 
@@ -71,68 +71,57 @@ class AnalysisDriverFilesystem
 
   /// Initializes a new filesystem that will have files added due to the
   /// build described by [generatedNodes].
-  void startBuild(Iterable<AssetNode> generatedNodes) {
-    final previousPhaseByPath = Map<String, int>.from(_phaseByPath);
-    final nextPhaseByPath = <String, int>{};
-    final nextPathByPhase = <int, List<String>>{};
+  ///
+  /// If [invalidatedSources] is `null`, this is an initial build and all
+  /// cached contents are cleared. Otherwise, only source files matching
+  /// [invalidatedSources] are removed.
+  void startBuild(
+    Iterable<AssetNode> generatedNodes, {
+    required Set<AssetId>? invalidatedSources,
+  }) {
+    final previousPhaseByPath = _phaseByPath;
+    _phaseByPath = <String, int>{};
+    _pathByPhase = <int, List<String>>{};
     for (final node in generatedNodes) {
       final phase = node.generatedNodeConfiguration!.phaseNumber;
       final idAsPath = node.id.asPath;
-      nextPhaseByPath[idAsPath] = phase;
-      nextPathByPhase.putIfAbsent(phase, () => []).add(idAsPath);
+      _phaseByPath[idAsPath] = phase;
+      _pathByPhase.putIfAbsent(phase, () => []).add(idAsPath);
     }
 
-    final removedGeneratedPaths =
-        previousPhaseByPath.keys.toSet()..removeAll(nextPhaseByPath.keys);
-    for (final path in removedGeneratedPaths) {
-      final previousPhase = previousPhaseByPath[path]!;
-      final wasVisible = _phase > previousPhase;
-      if (_data.remove(path) != null && wasVisible) {
+    _writtenPathsThisBuild.clear();
+
+    if (invalidatedSources == null) {
+      _changedPaths.addAll(_data.keys);
+      _data.clear();
+      return;
+    }
+
+    for (final id in invalidatedSources) {
+      final path = id.asPath;
+      if (_data.remove(path) != null) {
         _changedPaths.add(path);
       }
     }
 
     for (final entry in previousPhaseByPath.entries) {
       final path = entry.key;
-      final nextPhase = nextPhaseByPath[path];
-      if (nextPhase == null ||
-          nextPhase == entry.value ||
-          !_data.containsKey(path)) {
+      final previousPhase = entry.value;
+      final nextPhase = _phaseByPath[path];
+      if (nextPhase == null) {
+        if (_data.remove(path) != null && _phase > previousPhase) {
+          _changedPaths.add(path);
+        }
         continue;
       }
-      final previouslyWasVisible = _phase > entry.value;
+      if (nextPhase == previousPhase || !_data.containsKey(path)) {
+        continue;
+      }
+      final previouslyWasVisible = _phase > previousPhase;
       final isVisible = _phase > nextPhase;
       if (previouslyWasVisible != isVisible) {
         _changedPaths.add(path);
       }
-    }
-
-    _phaseByPath
-      ..clear()
-      ..addAll(nextPhaseByPath);
-    _pathByPhase
-      ..clear()
-      ..addAll(nextPathByPhase);
-    _writtenPathsThisBuild.clear();
-  }
-
-  /// Removes a source file from the in-memory filesystem.
-  void removeSourcePath(String path) {
-    if (_phaseByPath.containsKey(path)) {
-      throw ArgumentError.value(path, 'path', 'Must not be a generated path.');
-    }
-    if (_data.remove(path) != null) {
-      _changedPaths.add(path);
-    }
-  }
-
-  /// Clears all source file contents from the in-memory filesystem.
-  void clearSourcePaths() {
-    final sourcePaths =
-        _data.keys.where((path) => !_phaseByPath.containsKey(path)).toList();
-    for (final path in sourcePaths) {
-      _data.remove(path);
-      _changedPaths.add(path);
     }
   }
 

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -25,8 +25,8 @@ import '../asset_graph/node.dart';
 /// During the build, set [phase] to change the phase that the files are viewed
 /// at.
 ///
-/// Files are added as they're needed during one build and only removed when
-/// they are cleared by the next [startBuild].
+/// Source files are added as they're needed during a build and are managed by
+/// the analysis driver model. Generated files are tracked by [startBuild].
 class AnalysisDriverFilesystem
     implements UriResolver, ResourceProvider, FileContentCache {
   final Map<String, FileContent> _data = {};
@@ -71,12 +71,8 @@ class AnalysisDriverFilesystem
 
   /// Initializes a new filesystem that will have files added due to the
   /// build described by [generatedNodes].
-  void startBuild(
-    Iterable<AssetNode> generatedNodes, {
-    Iterable<AssetId> currentSources = const [],
-  }) {
+  void startBuild(Iterable<AssetNode> generatedNodes) {
     final previousPhaseByPath = Map<String, int>.from(_phaseByPath);
-    final currentSourcePaths = currentSources.map((id) => id.asPath).toSet();
     final nextPhaseByPath = <String, int>{};
     final nextPathByPhase = <int, List<String>>{};
     for (final node in generatedNodes) {
@@ -84,19 +80,6 @@ class AnalysisDriverFilesystem
       final idAsPath = node.id.asPath;
       nextPhaseByPath[idAsPath] = phase;
       nextPathByPhase.putIfAbsent(phase, () => []).add(idAsPath);
-    }
-
-    final removedSourcePaths =
-        _data.keys
-            .where(
-              (path) =>
-                  !previousPhaseByPath.containsKey(path) &&
-                  !currentSourcePaths.contains(path),
-            )
-            .toList();
-    for (final path in removedSourcePaths) {
-      _data.remove(path);
-      _changedPaths.add(path);
     }
 
     final removedGeneratedPaths =
@@ -131,6 +114,26 @@ class AnalysisDriverFilesystem
       ..clear()
       ..addAll(nextPathByPhase);
     _writtenPathsThisBuild.clear();
+  }
+
+  /// Removes a source file from the in-memory filesystem.
+  void removeSourcePath(String path) {
+    if (_phaseByPath.containsKey(path)) {
+      throw ArgumentError.value(path, 'path', 'Must not be a generated path.');
+    }
+    if (_data.remove(path) != null) {
+      _changedPaths.add(path);
+    }
+  }
+
+  /// Clears all source file contents from the in-memory filesystem.
+  void clearSourcePaths() {
+    final sourcePaths =
+        _data.keys.where((path) => !_phaseByPath.containsKey(path)).toList();
+    for (final path in sourcePaths) {
+      _data.remove(path);
+      _changedPaths.add(path);
+    }
   }
 
   /// Returns the phase of the generated file at [path] or `-1` if it's not a

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -31,8 +31,7 @@ class AnalysisDriverFilesystem
     implements UriResolver, ResourceProvider, FileContentCache {
   final Map<String, FileContent> _data = {};
   final Set<String> _changedPaths = {};
-  final Set<String> _writtenPathsThisBuild = {};
-  bool _allCachedContentsAreFromCurrentBuild = false;
+  final Set<String> _changedPathsThisBuild = {};
 
   // Path and phase information derived from the `Iterable<AssetNode>` for fast
   // lookup.
@@ -86,8 +85,7 @@ class AnalysisDriverFilesystem
       _pathByPhase.putIfAbsent(phase, () => []).add(idAsPath);
     }
 
-    _writtenPathsThisBuild.clear();
-    _allCachedContentsAreFromCurrentBuild = invalidatedSources == null;
+    _changedPathsThisBuild.clear();
 
     if (invalidatedSources == null) {
       _changedPaths.addAll(_data.keys);
@@ -140,42 +138,21 @@ class AnalysisDriverFilesystem
   }
 
   /// Writes [content].
-  ///
-  /// Throws if the file was already written with different content since the
-  /// most recent [startBuild].
   void writeContent(BuildRunnerFileContent content) {
     if (!content.exists) throw ArgumentError('content must exist');
     final path = content.path;
     final previousContent = _data[path];
     final isVisible = _phase > _phaseOf(path);
-    if (previousContent == null) {
-      _data[path] = content;
-      if (!_allCachedContentsAreFromCurrentBuild) {
-        _writtenPathsThisBuild.add(path);
-      }
-      if (isVisible) {
-        _changedPaths.add(path);
-      }
+    if (previousContent != null &&
+        content.contentHash == previousContent.contentHash) {
       return;
-    }
-
-    if (content.contentHash == previousContent.contentHash) {
-      if (!_allCachedContentsAreFromCurrentBuild) {
-        _writtenPathsThisBuild.add(path);
-      }
-      return;
-    }
-
-    if (_allCachedContentsAreFromCurrentBuild ||
-        _writtenPathsThisBuild.contains(path)) {
-      throw StateError('Different write to $path.');
     }
 
     _data[path] = content;
-    _writtenPathsThisBuild.add(path);
     if (isVisible) {
       _changedPaths.add(path);
     }
+    assert(_changedPathsThisBuild.add(path), path);
   }
 
   /// Paths that were modified by [writeContent] since the last

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -71,9 +71,12 @@ class AnalysisDriverFilesystem
 
   /// Initializes a new filesystem that will have files added due to the
   /// build described by [generatedNodes].
-  void startBuild(Iterable<AssetNode> generatedNodes) {
+  void startBuild(
+    Iterable<AssetNode> generatedNodes, {
+    Iterable<AssetId> currentSources = const [],
+  }) {
     final previousPhaseByPath = Map<String, int>.from(_phaseByPath);
-    final previousGeneratedPaths = previousPhaseByPath.keys.toSet();
+    final currentSourcePaths = currentSources.map((id) => id.asPath).toSet();
     final nextPhaseByPath = <String, int>{};
     final nextPathByPhase = <int, List<String>>{};
     for (final node in generatedNodes) {
@@ -83,13 +86,17 @@ class AnalysisDriverFilesystem
       nextPathByPhase.putIfAbsent(phase, () => []).add(idAsPath);
     }
 
-    final sourcePathsToClear =
+    final removedSourcePaths =
         _data.keys
-            .where((path) => !previousGeneratedPaths.contains(path))
+            .where(
+              (path) =>
+                  !previousPhaseByPath.containsKey(path) &&
+                  !currentSourcePaths.contains(path),
+            )
             .toList();
-    for (final path in sourcePathsToClear) {
-      _changedPaths.add(path);
+    for (final path in removedSourcePaths) {
       _data.remove(path);
+      _changedPaths.add(path);
     }
 
     final removedGeneratedPaths =

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -46,12 +46,21 @@ class AnalysisDriverModel {
   /// Starts a build with [assetGraph].
   ///
   /// If another build has the lock, waits for it to finish.
-  Future<void> takeLockAndStartBuild(AssetGraph assetGraph) async {
+  Future<void> takeLockAndStartBuild(
+    AssetGraph assetGraph, {
+    required bool isInitialBuild,
+    required Set<AssetId> changedSources,
+    required Set<AssetId> deletedSources,
+  }) async {
     _lock = await _pool.request();
-    filesystem.startBuild(
-      assetGraph.outputs.map((id) => assetGraph.get(id)!),
-      currentSources: assetGraph.sources,
-    );
+    if (isInitialBuild) {
+      filesystem.clearSourcePaths();
+    } else {
+      for (final id in deletedSources) {
+        filesystem.removeSourcePath(id.asPath);
+      }
+    }
+    filesystem.startBuild(assetGraph.outputs.map((id) => assetGraph.get(id)!));
   }
 
   /// Clears build state and frees the lock taken by [takeLockAndStartBuild].

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -48,7 +48,10 @@ class AnalysisDriverModel {
   /// If another build has the lock, waits for it to finish.
   Future<void> takeLockAndStartBuild(AssetGraph assetGraph) async {
     _lock = await _pool.request();
-    filesystem.startBuild(assetGraph.outputs.map((id) => assetGraph.get(id)!));
+    filesystem.startBuild(
+      assetGraph.outputs.map((id) => assetGraph.get(id)!),
+      currentSources: assetGraph.sources,
+    );
   }
 
   /// Clears build state and frees the lock taken by [takeLockAndStartBuild].

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -56,6 +56,9 @@ class AnalysisDriverModel {
     if (isInitialBuild) {
       filesystem.clearSourcePaths();
     } else {
+      for (final id in changedSources) {
+        filesystem.removeSourcePath(id.asPath);
+      }
       for (final id in deletedSources) {
         filesystem.removeSourcePath(id.asPath);
       }

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -48,22 +48,13 @@ class AnalysisDriverModel {
   /// If another build has the lock, waits for it to finish.
   Future<void> takeLockAndStartBuild(
     AssetGraph assetGraph, {
-    required bool isInitialBuild,
-    required Set<AssetId> changedSources,
-    required Set<AssetId> deletedSources,
+    required Set<AssetId>? invalidatedSources,
   }) async {
     _lock = await _pool.request();
-    if (isInitialBuild) {
-      filesystem.clearSourcePaths();
-    } else {
-      for (final id in changedSources) {
-        filesystem.removeSourcePath(id.asPath);
-      }
-      for (final id in deletedSources) {
-        filesystem.removeSourcePath(id.asPath);
-      }
-    }
-    filesystem.startBuild(assetGraph.outputs.map((id) => assetGraph.get(id)!));
+    filesystem.startBuild(
+      assetGraph.outputs.map((id) => assetGraph.get(id)!),
+      invalidatedSources: invalidatedSources,
+    );
   }
 
   /// Clears build state and frees the lock taken by [takeLockAndStartBuild].

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -102,8 +102,17 @@ class ResolversImpl implements Resolvers {
   /// implementation that needs locking. Find a way to do better. Fortunately,
   /// only two codepaths need to care about the lock: the main build in
   /// `build.dart` and test builds in `package:build_test` `test_builder.dart`.
-  Future<void> takeLockAndStartBuild(AssetGraph assetGraph) =>
-      _analysisDriverModel.takeLockAndStartBuild(assetGraph);
+  Future<void> takeLockAndStartBuild(
+    AssetGraph assetGraph, {
+    required bool isInitialBuild,
+    required Set<AssetId> changedSources,
+    required Set<AssetId> deletedSources,
+  }) => _analysisDriverModel.takeLockAndStartBuild(
+    assetGraph,
+    isInitialBuild: isInitialBuild,
+    changedSources: changedSources,
+    deletedSources: deletedSources,
+  );
 
   PhasedAssetDeps phasedAssetDeps() => _analysisDriverModel.phasedAssetDeps();
 

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -104,14 +104,10 @@ class ResolversImpl implements Resolvers {
   /// `build.dart` and test builds in `package:build_test` `test_builder.dart`.
   Future<void> takeLockAndStartBuild(
     AssetGraph assetGraph, {
-    required bool isInitialBuild,
-    required Set<AssetId> changedSources,
-    required Set<AssetId> deletedSources,
+    required Set<AssetId>? invalidatedSources,
   }) => _analysisDriverModel.takeLockAndStartBuild(
     assetGraph,
-    isInitialBuild: isInitialBuild,
-    changedSources: changedSources,
-    deletedSources: deletedSources,
+    invalidatedSources: invalidatedSources,
   );
 
   PhasedAssetDeps phasedAssetDeps() => _analysisDriverModel.phasedAssetDeps();

--- a/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
@@ -37,6 +37,14 @@ void main() {
       expect(filesystem.changedPaths, isEmpty);
     });
 
+    test('different write in the same build asserts', () {
+      filesystem.write('foo.txt', 'bar');
+      expect(
+        () => filesystem.write('foo.txt', 'baz'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
     test('write updates `exists`', () {
       expect(filesystem.exists('foo.txt'), false);
       filesystem.write('foo.txt', 'bar');

--- a/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
@@ -44,17 +44,14 @@ void main() {
     });
 
     test('startBuild removes disappeared generated files', () {
-      filesystem.startBuild(
-        [
-          AssetNode.generated(
-            AssetId.parse('a|lib/a.g.dart'),
-            primaryInput: AssetId.parse('a|lib/a.dart'),
-            phaseNumber: 1,
-            isHidden: false,
-          ),
-        ],
-        invalidatedSources: null,
-      );
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ], invalidatedSources: null);
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
@@ -66,32 +63,26 @@ void main() {
     });
 
     test('startBuild retains unchanged generated file contents', () {
-      filesystem.startBuild(
-        [
-          AssetNode.generated(
-            AssetId.parse('a|lib/a.g.dart'),
-            primaryInput: AssetId.parse('a|lib/a.dart'),
-            phaseNumber: 1,
-            isHidden: false,
-          ),
-        ],
-        invalidatedSources: null,
-      );
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ], invalidatedSources: null);
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild(
-        [
-          AssetNode.generated(
-            AssetId.parse('a|lib/a.g.dart'),
-            primaryInput: AssetId.parse('a|lib/a.dart'),
-            phaseNumber: 1,
-            isHidden: false,
-          ),
-        ],
-        invalidatedSources: const {},
-      );
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ], invalidatedSources: const {});
 
       expect(filesystem.read('/a/lib/a.g.dart'), 'a');
       expect(filesystem.changedPaths, isEmpty);
@@ -99,32 +90,26 @@ void main() {
 
     test('write with changed generated content across builds updates file and '
         'changedPaths', () {
-      filesystem.startBuild(
-        [
-          AssetNode.generated(
-            AssetId.parse('a|lib/a.g.dart'),
-            primaryInput: AssetId.parse('a|lib/a.dart'),
-            phaseNumber: 1,
-            isHidden: false,
-          ),
-        ],
-        invalidatedSources: null,
-      );
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ], invalidatedSources: null);
       filesystem.write('/a/lib/a.g.dart', 'before');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild(
-        [
-          AssetNode.generated(
-            AssetId.parse('a|lib/a.g.dart'),
-            primaryInput: AssetId.parse('a|lib/a.dart'),
-            phaseNumber: 1,
-            isHidden: false,
-          ),
-        ],
-        invalidatedSources: const {},
-      );
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ], invalidatedSources: const {});
       filesystem.write('/a/lib/a.g.dart', 'after');
 
       expect(filesystem.read('/a/lib/a.g.dart'), 'after');
@@ -132,40 +117,31 @@ void main() {
     });
 
     test('initial build clears all cached contents', () {
-      filesystem.startBuild(
-        [
-          AssetNode.generated(
-            AssetId.parse('a|lib/a.g.dart'),
-            primaryInput: AssetId.parse('a|lib/a.dart'),
-            phaseNumber: 1,
-            isHidden: false,
-          ),
-        ],
-        invalidatedSources: null,
-      );
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ], invalidatedSources: null);
       filesystem.write('/a/lib/a.dart', 'class A {}');
       filesystem.write('/a/lib/a.g.dart', 'generated');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild(
-        [
-          AssetNode.generated(
-            AssetId.parse('a|lib/a.g.dart'),
-            primaryInput: AssetId.parse('a|lib/a.dart'),
-            phaseNumber: 1,
-            isHidden: false,
-          ),
-        ],
-        invalidatedSources: null,
-      );
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ], invalidatedSources: null);
 
       expect(filesystem.exists('/a/lib/a.dart'), isFalse);
       expect(filesystem.exists('/a/lib/a.g.dart'), isFalse);
-      expect(filesystem.changedPaths, {
-        '/a/lib/a.dart',
-        '/a/lib/a.g.dart',
-      });
+      expect(filesystem.changedPaths, {'/a/lib/a.dart', '/a/lib/a.g.dart'});
     });
 
     test('incremental build removes only invalidated source contents', () {
@@ -185,55 +161,46 @@ void main() {
 
     test('startBuild reports visibility changes for retained generated '
         'files', () {
-      filesystem.startBuild(
-        [
-          AssetNode.generated(
-            AssetId.parse('a|lib/a.g.dart'),
-            primaryInput: AssetId.parse('a|lib/a.dart'),
-            phaseNumber: 1,
-            isHidden: false,
-          ),
-        ],
-        invalidatedSources: null,
-      );
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ], invalidatedSources: null);
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild(
-        [
-          AssetNode.generated(
-            AssetId.parse('a|lib/a.g.dart'),
-            primaryInput: AssetId.parse('a|lib/a.dart'),
-            phaseNumber: 3,
-            isHidden: false,
-          ),
-        ],
-        invalidatedSources: const {},
-      );
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 3,
+          isHidden: false,
+        ),
+      ], invalidatedSources: const {});
 
       expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
       expect(filesystem.exists('/a/lib/a.g.dart'), false);
     });
 
     test('files change by phases', () {
-      filesystem.startBuild(
-        [
-          AssetNode.generated(
-            AssetId.parse('a|lib/a.g.dart'),
-            primaryInput: AssetId.parse('a|lib/a.dart'),
-            phaseNumber: 1,
-            isHidden: false,
-          ),
-          AssetNode.generated(
-            AssetId.parse('b|lib/b.g.dart'),
-            primaryInput: AssetId.parse('b|lib/b.dart'),
-            phaseNumber: 2,
-            isHidden: false,
-          ),
-        ],
-        invalidatedSources: null,
-      );
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+        AssetNode.generated(
+          AssetId.parse('b|lib/b.g.dart'),
+          primaryInput: AssetId.parse('b|lib/b.dart'),
+          phaseNumber: 2,
+          isHidden: false,
+        ),
+      ], invalidatedSources: null);
 
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.write('/b/lib/b.g.dart', 'b');

--- a/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
@@ -43,14 +43,24 @@ void main() {
       expect(filesystem.exists('foo.txt'), true);
     });
 
-    test('startBuild clears non-generated file contents', () {
-      filesystem.write('foo.txt', 'bar');
+    test('startBuild retains unchanged non-generated file contents', () {
+      filesystem.write('/a/foo.txt', 'bar');
+      filesystem.clearChangedPaths();
+
+      filesystem.startBuild([], currentSources: [AssetId('a', 'foo.txt')]);
+
+      expect(filesystem.read('/a/foo.txt'), 'bar');
+      expect(filesystem.changedPaths, isEmpty);
+    });
+
+    test('startBuild removes disappeared non-generated file contents', () {
+      filesystem.write('/a/foo.txt', 'bar');
       filesystem.clearChangedPaths();
 
       filesystem.startBuild([]);
 
-      expect(filesystem.exists('foo.txt'), isFalse);
-      expect(filesystem.changedPaths, {'foo.txt'});
+      expect(filesystem.exists('/a/foo.txt'), isFalse);
+      expect(filesystem.changedPaths, {'/a/foo.txt'});
     });
 
     test('startBuild removes disappeared generated files', () {
@@ -108,22 +118,15 @@ void main() {
           isHidden: false,
         ),
       ]);
-      filesystem.write('/a/lib/a.g.dart', 'before');
+      filesystem.write('/a/foo.txt', 'before');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ]);
-      filesystem.write('/a/lib/a.g.dart', 'after');
+      filesystem.startBuild([], currentSources: [AssetId('a', 'foo.txt')]);
+      filesystem.write('/a/foo.txt', 'after');
 
-      expect(filesystem.read('/a/lib/a.g.dart'), 'after');
-      expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
+      expect(filesystem.read('/a/foo.txt'), 'after');
+      expect(filesystem.changedPaths, {'/a/foo.txt'});
     });
 
     test('startBuild reports visibility changes for retained generated '

--- a/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
@@ -44,45 +44,54 @@ void main() {
     });
 
     test('startBuild removes disappeared generated files', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ]);
+      filesystem.startBuild(
+        [
+          AssetNode.generated(
+            AssetId.parse('a|lib/a.g.dart'),
+            primaryInput: AssetId.parse('a|lib/a.dart'),
+            phaseNumber: 1,
+            isHidden: false,
+          ),
+        ],
+        invalidatedSources: null,
+      );
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild([]);
+      filesystem.startBuild([], invalidatedSources: const {});
 
       expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
       expect(filesystem.exists('/a/lib/a.g.dart'), false);
     });
 
     test('startBuild retains unchanged generated file contents', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ]);
+      filesystem.startBuild(
+        [
+          AssetNode.generated(
+            AssetId.parse('a|lib/a.g.dart'),
+            primaryInput: AssetId.parse('a|lib/a.dart'),
+            phaseNumber: 1,
+            isHidden: false,
+          ),
+        ],
+        invalidatedSources: null,
+      );
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ]);
+      filesystem.startBuild(
+        [
+          AssetNode.generated(
+            AssetId.parse('a|lib/a.g.dart'),
+            primaryInput: AssetId.parse('a|lib/a.dart'),
+            phaseNumber: 1,
+            isHidden: false,
+          ),
+        ],
+        invalidatedSources: const {},
+      );
 
       expect(filesystem.read('/a/lib/a.g.dart'), 'a');
       expect(filesystem.changedPaths, isEmpty);
@@ -90,110 +99,141 @@ void main() {
 
     test('write with changed generated content across builds updates file and '
         'changedPaths', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ]);
-      filesystem.write('/a/lib/a.g.dart', 'before');
-      filesystem.phase = 2;
-      filesystem.clearChangedPaths();
-
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ]);
-      filesystem.write('/a/lib/a.g.dart', 'after');
-
-      expect(filesystem.read('/a/lib/a.g.dart'), 'after');
-      expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
-    });
-
-    test('removeSourcePath removes source file contents and changedPaths', () {
-      filesystem.write('/a/foo.txt', 'bar');
-      filesystem.clearChangedPaths();
-
-      filesystem.removeSourcePath('/a/foo.txt');
-
-      expect(filesystem.exists('/a/foo.txt'), isFalse);
-      expect(filesystem.changedPaths, {'/a/foo.txt'});
-    });
-
-    test(
-      'clearSourcePaths removes all source file contents and changedPaths',
-      () {
-        filesystem.write('/a/foo.txt', 'bar');
-        filesystem.write('/b/bar.txt', 'baz');
-        filesystem.startBuild([
+      filesystem.startBuild(
+        [
           AssetNode.generated(
             AssetId.parse('a|lib/a.g.dart'),
             primaryInput: AssetId.parse('a|lib/a.dart'),
             phaseNumber: 1,
             isHidden: false,
           ),
-        ]);
-        filesystem.write('/a/lib/a.g.dart', 'generated');
-        filesystem.phase = 2;
-        filesystem.clearChangedPaths();
+        ],
+        invalidatedSources: null,
+      );
+      filesystem.write('/a/lib/a.g.dart', 'before');
+      filesystem.phase = 2;
+      filesystem.clearChangedPaths();
 
-        filesystem.clearSourcePaths();
+      filesystem.startBuild(
+        [
+          AssetNode.generated(
+            AssetId.parse('a|lib/a.g.dart'),
+            primaryInput: AssetId.parse('a|lib/a.dart'),
+            phaseNumber: 1,
+            isHidden: false,
+          ),
+        ],
+        invalidatedSources: const {},
+      );
+      filesystem.write('/a/lib/a.g.dart', 'after');
 
-        expect(filesystem.exists('/a/foo.txt'), isFalse);
-        expect(filesystem.exists('/b/bar.txt'), isFalse);
-        expect(filesystem.exists('/a/lib/a.g.dart'), isTrue);
-        expect(filesystem.changedPaths, {'/a/foo.txt', '/b/bar.txt'});
-      },
-    );
+      expect(filesystem.read('/a/lib/a.g.dart'), 'after');
+      expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
+    });
+
+    test('initial build clears all cached contents', () {
+      filesystem.startBuild(
+        [
+          AssetNode.generated(
+            AssetId.parse('a|lib/a.g.dart'),
+            primaryInput: AssetId.parse('a|lib/a.dart'),
+            phaseNumber: 1,
+            isHidden: false,
+          ),
+        ],
+        invalidatedSources: null,
+      );
+      filesystem.write('/a/lib/a.dart', 'class A {}');
+      filesystem.write('/a/lib/a.g.dart', 'generated');
+      filesystem.phase = 2;
+      filesystem.clearChangedPaths();
+
+      filesystem.startBuild(
+        [
+          AssetNode.generated(
+            AssetId.parse('a|lib/a.g.dart'),
+            primaryInput: AssetId.parse('a|lib/a.dart'),
+            phaseNumber: 1,
+            isHidden: false,
+          ),
+        ],
+        invalidatedSources: null,
+      );
+
+      expect(filesystem.exists('/a/lib/a.dart'), isFalse);
+      expect(filesystem.exists('/a/lib/a.g.dart'), isFalse);
+      expect(filesystem.changedPaths, {
+        '/a/lib/a.dart',
+        '/a/lib/a.g.dart',
+      });
+    });
+
+    test('incremental build removes only invalidated source contents', () {
+      filesystem.write('/a/foo.txt', 'bar');
+      filesystem.write('/b/bar.txt', 'baz');
+      filesystem.clearChangedPaths();
+
+      filesystem.startBuild(
+        const [],
+        invalidatedSources: {AssetId.parse('a|foo.txt')},
+      );
+
+      expect(filesystem.exists('/a/foo.txt'), isFalse);
+      expect(filesystem.exists('/b/bar.txt'), isTrue);
+      expect(filesystem.changedPaths, {'/a/foo.txt'});
+    });
 
     test('startBuild reports visibility changes for retained generated '
         'files', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ]);
+      filesystem.startBuild(
+        [
+          AssetNode.generated(
+            AssetId.parse('a|lib/a.g.dart'),
+            primaryInput: AssetId.parse('a|lib/a.dart'),
+            phaseNumber: 1,
+            isHidden: false,
+          ),
+        ],
+        invalidatedSources: null,
+      );
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 3,
-          isHidden: false,
-        ),
-      ]);
+      filesystem.startBuild(
+        [
+          AssetNode.generated(
+            AssetId.parse('a|lib/a.g.dart'),
+            primaryInput: AssetId.parse('a|lib/a.dart'),
+            phaseNumber: 3,
+            isHidden: false,
+          ),
+        ],
+        invalidatedSources: const {},
+      );
 
       expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
       expect(filesystem.exists('/a/lib/a.g.dart'), false);
     });
 
     test('files change by phases', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-        AssetNode.generated(
-          AssetId.parse('b|lib/b.g.dart'),
-          primaryInput: AssetId.parse('b|lib/b.dart'),
-          phaseNumber: 2,
-          isHidden: false,
-        ),
-      ]);
+      filesystem.startBuild(
+        [
+          AssetNode.generated(
+            AssetId.parse('a|lib/a.g.dart'),
+            primaryInput: AssetId.parse('a|lib/a.dart'),
+            phaseNumber: 1,
+            isHidden: false,
+          ),
+          AssetNode.generated(
+            AssetId.parse('b|lib/b.g.dart'),
+            primaryInput: AssetId.parse('b|lib/b.dart'),
+            phaseNumber: 2,
+            isHidden: false,
+          ),
+        ],
+        invalidatedSources: null,
+      );
 
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.write('/b/lib/b.g.dart', 'b');

--- a/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
@@ -43,6 +43,116 @@ void main() {
       expect(filesystem.exists('foo.txt'), true);
     });
 
+    test('startBuild clears non-generated file contents', () {
+      filesystem.write('foo.txt', 'bar');
+      filesystem.clearChangedPaths();
+
+      filesystem.startBuild([]);
+
+      expect(filesystem.exists('foo.txt'), isFalse);
+      expect(filesystem.changedPaths, {'foo.txt'});
+    });
+
+    test('startBuild removes disappeared generated files', () {
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ]);
+      filesystem.write('/a/lib/a.g.dart', 'a');
+      filesystem.phase = 2;
+      filesystem.clearChangedPaths();
+
+      filesystem.startBuild([]);
+
+      expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
+      expect(filesystem.exists('/a/lib/a.g.dart'), false);
+    });
+
+    test('startBuild retains unchanged generated file contents', () {
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ]);
+      filesystem.write('/a/lib/a.g.dart', 'a');
+      filesystem.phase = 2;
+      filesystem.clearChangedPaths();
+
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ]);
+
+      expect(filesystem.read('/a/lib/a.g.dart'), 'a');
+      expect(filesystem.changedPaths, isEmpty);
+    });
+
+    test('write with changed generated content across builds updates file and '
+        'changedPaths', () {
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ]);
+      filesystem.write('/a/lib/a.g.dart', 'before');
+      filesystem.phase = 2;
+      filesystem.clearChangedPaths();
+
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ]);
+      filesystem.write('/a/lib/a.g.dart', 'after');
+
+      expect(filesystem.read('/a/lib/a.g.dart'), 'after');
+      expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
+    });
+
+    test('startBuild reports visibility changes for retained generated '
+        'files', () {
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ]);
+      filesystem.write('/a/lib/a.g.dart', 'a');
+      filesystem.phase = 2;
+      filesystem.clearChangedPaths();
+
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 3,
+          isHidden: false,
+        ),
+      ]);
+
+      expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
+      expect(filesystem.exists('/a/lib/a.g.dart'), false);
+    });
+
     test('files change by phases', () {
       filesystem.startBuild([
         AssetNode.generated(

--- a/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
@@ -43,26 +43,6 @@ void main() {
       expect(filesystem.exists('foo.txt'), true);
     });
 
-    test('startBuild retains unchanged non-generated file contents', () {
-      filesystem.write('/a/foo.txt', 'bar');
-      filesystem.clearChangedPaths();
-
-      filesystem.startBuild([], currentSources: [AssetId('a', 'foo.txt')]);
-
-      expect(filesystem.read('/a/foo.txt'), 'bar');
-      expect(filesystem.changedPaths, isEmpty);
-    });
-
-    test('startBuild removes disappeared non-generated file contents', () {
-      filesystem.write('/a/foo.txt', 'bar');
-      filesystem.clearChangedPaths();
-
-      filesystem.startBuild([]);
-
-      expect(filesystem.exists('/a/foo.txt'), isFalse);
-      expect(filesystem.changedPaths, {'/a/foo.txt'});
-    });
-
     test('startBuild removes disappeared generated files', () {
       filesystem.startBuild([
         AssetNode.generated(
@@ -118,16 +98,59 @@ void main() {
           isHidden: false,
         ),
       ]);
-      filesystem.write('/a/foo.txt', 'before');
+      filesystem.write('/a/lib/a.g.dart', 'before');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild([], currentSources: [AssetId('a', 'foo.txt')]);
-      filesystem.write('/a/foo.txt', 'after');
+      filesystem.startBuild([
+        AssetNode.generated(
+          AssetId.parse('a|lib/a.g.dart'),
+          primaryInput: AssetId.parse('a|lib/a.dart'),
+          phaseNumber: 1,
+          isHidden: false,
+        ),
+      ]);
+      filesystem.write('/a/lib/a.g.dart', 'after');
 
-      expect(filesystem.read('/a/foo.txt'), 'after');
+      expect(filesystem.read('/a/lib/a.g.dart'), 'after');
+      expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
+    });
+
+    test('removeSourcePath removes source file contents and changedPaths', () {
+      filesystem.write('/a/foo.txt', 'bar');
+      filesystem.clearChangedPaths();
+
+      filesystem.removeSourcePath('/a/foo.txt');
+
+      expect(filesystem.exists('/a/foo.txt'), isFalse);
       expect(filesystem.changedPaths, {'/a/foo.txt'});
     });
+
+    test(
+      'clearSourcePaths removes all source file contents and changedPaths',
+      () {
+        filesystem.write('/a/foo.txt', 'bar');
+        filesystem.write('/b/bar.txt', 'baz');
+        filesystem.startBuild([
+          AssetNode.generated(
+            AssetId.parse('a|lib/a.g.dart'),
+            primaryInput: AssetId.parse('a|lib/a.dart'),
+            phaseNumber: 1,
+            isHidden: false,
+          ),
+        ]);
+        filesystem.write('/a/lib/a.g.dart', 'generated');
+        filesystem.phase = 2;
+        filesystem.clearChangedPaths();
+
+        filesystem.clearSourcePaths();
+
+        expect(filesystem.exists('/a/foo.txt'), isFalse);
+        expect(filesystem.exists('/b/bar.txt'), isFalse);
+        expect(filesystem.exists('/a/lib/a.g.dart'), isTrue);
+        expect(filesystem.changedPaths, {'/a/foo.txt', '/b/bar.txt'});
+      },
+    );
 
     test('startBuild reports visibility changes for retained generated '
         'files', () {

--- a/build_runner/test/build/resolver/analysis_driver_model_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_model_test.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:build_runner/src/build/asset_graph/graph.dart';
+import 'package:build_runner/src/build/resolver/analysis_driver_filesystem.dart';
+import 'package:build_runner/src/build/resolver/analysis_driver_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late AnalysisDriverModel model;
+
+  setUp(() {
+    model = AnalysisDriverModel();
+  });
+
+  tearDown(() {
+    model.endBuildAndUnlock();
+  });
+
+  group('AnalysisDriverModel.takeLockAndStartBuild', () {
+    test('initial build clears all cached source paths', () async {
+      model.filesystem.write('/a/lib/a.dart', 'class A {}');
+      model.filesystem.write('/a/lib/b.dart', 'class B {}');
+      model.filesystem.clearChangedPaths();
+
+      await model.takeLockAndStartBuild(
+        AssetGraph.emptyForTesting(),
+        isInitialBuild: true,
+        changedSources: const {},
+        deletedSources: const {},
+      );
+
+      expect(model.filesystem.exists('/a/lib/a.dart'), isFalse);
+      expect(model.filesystem.exists('/a/lib/b.dart'), isFalse);
+      expect(model.filesystem.changedPaths, {
+        '/a/lib/a.dart',
+        '/a/lib/b.dart',
+      });
+    });
+
+    test('incremental build keeps unchanged sources cached', () async {
+      model.filesystem.write('/a/lib/a.dart', 'class A {}');
+      model.filesystem.clearChangedPaths();
+
+      await model.takeLockAndStartBuild(
+        AssetGraph.emptyForTesting(),
+        isInitialBuild: false,
+        changedSources: const {},
+        deletedSources: const {},
+      );
+
+      expect(model.filesystem.exists('/a/lib/a.dart'), isTrue);
+      expect(model.filesystem.read('/a/lib/a.dart'), 'class A {}');
+      expect(model.filesystem.changedPaths, isEmpty);
+    });
+
+    test(
+      'incremental build removes only changed and deleted sources',
+      () async {
+      model.filesystem.write('/a/lib/changed.dart', 'class Changed {}');
+      model.filesystem.write('/a/lib/deleted.dart', 'class Deleted {}');
+      model.filesystem.write('/a/lib/unchanged.dart', 'class Unchanged {}');
+      model.filesystem.clearChangedPaths();
+
+      await model.takeLockAndStartBuild(
+        AssetGraph.emptyForTesting(),
+        isInitialBuild: false,
+        changedSources: {AssetId.parse('a|lib/changed.dart')},
+        deletedSources: {AssetId.parse('a|lib/deleted.dart')},
+      );
+
+      expect(model.filesystem.exists('/a/lib/changed.dart'), isFalse);
+      expect(model.filesystem.exists('/a/lib/deleted.dart'), isFalse);
+      expect(model.filesystem.exists('/a/lib/unchanged.dart'), isTrue);
+      expect(model.filesystem.changedPaths, {
+        '/a/lib/changed.dart',
+        '/a/lib/deleted.dart',
+      });
+      },
+    );
+  });
+}
+
+extension _AnalysisDriverFilesystemExtensions on AnalysisDriverFilesystem {
+  void write(String path, String content) {
+    writeContent(
+      BuildRunnerFileContent(path, true, content, content.hashCode.toString()),
+    );
+  }
+}

--- a/build_runner/test/build/resolver/analysis_driver_model_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_model_test.dart
@@ -32,10 +32,7 @@ void main() {
 
       expect(model.filesystem.exists('/a/lib/a.dart'), isFalse);
       expect(model.filesystem.exists('/a/lib/b.dart'), isFalse);
-      expect(model.filesystem.changedPaths, {
-        '/a/lib/a.dart',
-        '/a/lib/b.dart',
-      });
+      expect(model.filesystem.changedPaths, {'/a/lib/a.dart', '/a/lib/b.dart'});
     });
 
     test('incremental build keeps unchanged sources cached', () async {

--- a/build_runner/test/build/resolver/analysis_driver_model_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_model_test.dart
@@ -27,9 +27,7 @@ void main() {
 
       await model.takeLockAndStartBuild(
         AssetGraph.emptyForTesting(),
-        isInitialBuild: true,
-        changedSources: const {},
-        deletedSources: const {},
+        invalidatedSources: null,
       );
 
       expect(model.filesystem.exists('/a/lib/a.dart'), isFalse);
@@ -46,9 +44,7 @@ void main() {
 
       await model.takeLockAndStartBuild(
         AssetGraph.emptyForTesting(),
-        isInitialBuild: false,
-        changedSources: const {},
-        deletedSources: const {},
+        invalidatedSources: const {},
       );
 
       expect(model.filesystem.exists('/a/lib/a.dart'), isTrue);
@@ -56,9 +52,7 @@ void main() {
       expect(model.filesystem.changedPaths, isEmpty);
     });
 
-    test(
-      'incremental build removes only changed and deleted sources',
-      () async {
+    test('incremental build removes only invalidated sources', () async {
       model.filesystem.write('/a/lib/changed.dart', 'class Changed {}');
       model.filesystem.write('/a/lib/deleted.dart', 'class Deleted {}');
       model.filesystem.write('/a/lib/unchanged.dart', 'class Unchanged {}');
@@ -66,9 +60,10 @@ void main() {
 
       await model.takeLockAndStartBuild(
         AssetGraph.emptyForTesting(),
-        isInitialBuild: false,
-        changedSources: {AssetId.parse('a|lib/changed.dart')},
-        deletedSources: {AssetId.parse('a|lib/deleted.dart')},
+        invalidatedSources: {
+          AssetId.parse('a|lib/changed.dart'),
+          AssetId.parse('a|lib/deleted.dart'),
+        },
       );
 
       expect(model.filesystem.exists('/a/lib/changed.dart'), isFalse);
@@ -78,8 +73,7 @@ void main() {
         '/a/lib/changed.dart',
         '/a/lib/deleted.dart',
       });
-      },
-    );
+    });
   });
 }
 

--- a/build_runner/test/build/resolver/resolver_test.dart
+++ b/build_runner/test/build/resolver/resolver_test.dart
@@ -1367,7 +1367,12 @@ Future<void> _runBuilder(
     final ResolversImpl r => r,
     _ => null,
   };
-  await resolversImpl?.takeLockAndStartBuild(AssetGraph.emptyForTesting());
+  await resolversImpl?.takeLockAndStartBuild(
+    AssetGraph.emptyForTesting(),
+    isInitialBuild: true,
+    changedSources: const {},
+    deletedSources: const {},
+  );
   await runBuilder(builder, list, singleStepReaderWriter, resolvers);
   resolversImpl?.reset();
 }

--- a/build_runner/test/build/resolver/resolver_test.dart
+++ b/build_runner/test/build/resolver/resolver_test.dart
@@ -1369,9 +1369,7 @@ Future<void> _runBuilder(
   };
   await resolversImpl?.takeLockAndStartBuild(
     AssetGraph.emptyForTesting(),
-    isInitialBuild: true,
-    changedSources: const {},
-    deletedSources: const {},
+    invalidatedSources: null,
   );
   await runBuilder(builder, list, singleStepReaderWriter, resolvers);
   resolversImpl?.reset();


### PR DESCRIPTION
This keeps generated file contents in `AnalysisDriverFilesystem` across incremental builds instead of clearing them unconditionally on every `startBuild()`.

Refs #4875.

Today `startBuild()` clears all cached file contents. In long-lived watch sessions that means generated files that still exist in the next asset graph are removed and then re-added to the analyzer-facing filesystem on every incremental build.

This patch narrows that behavior:

- generated files that are still present in the next asset graph are retained,
- generated files are removed only if they actually disappear,
- source file handling stays unchanged,
- generated paths are still reported as changed when:
  - file content changes,
  - visibility changes because of phase transitions,
  - a generated path disappears.

This is intended as a watch / incremental performance optimization only. It does not change the broader build planning model or generated output semantics.

Tests added:

- non-generated files are still cleared at `startBuild()`,
- disappeared generated files are removed and reported as changed,
- unchanged generated files survive `startBuild()`,
- rewriting a generated file with different content across builds reports the change,
- visibility changes for retained generated files are still reported correctly.
