### PR TITLE
Remove use of Expression.expression getter

### DIFF
--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -1453,7 +1453,7 @@ class _MockClassInfo {
             referImported(
               'throwOnMissingStub',
               'package:mockito/mockito.dart',
-            ).call([refer('this').expression]).statement,
+            ).call([refer('this')]).statement,
   );
 
   /// Build a method which overrides [method], with all non-nullable


### PR DESCRIPTION
See https://github.com/dart-lang/tools/issues/2371

This `.expression` call was likely always unnecessary and unnoticed. The
`Expression.expression` API is marked with `@visibleForOverriding` and
is not intended for use from other packages, but the diagnostics are
suppressed because of some overrides that are not annotated.

Remove the call to `.expression` in preparation for it to be deprecated
and eventually removed.
