### PR TITLE
Add process lock.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -8,6 +8,17 @@
   write files unless the contents changed. These reduce unnecessary work by
   tools that watch the filesystem.
 - `--workspace` flag is no longer experimental, remove the warning.
+- Add `--workspace` flag to `clean` command, use it to clear the cache used for
+  a `--workspace` build.
+- Add new command `stop`: run `dart run build_runner stop` to terminate a
+  running `watch` or `serve` command in the current package or workspace. If
+  a build is in progress, the build will complete first.
+- Add locking: `build_runner` will wait for any already-running command before
+  running. If there is an already-running `watch` or `serve` command, it will be
+  closed after the currently-running build, as if you ran the new
+  `dart run build_runner stop`.
+- Note: the `daemon` command ignores `build_runner stop` and ignores the new
+  locking as it uses its own locking.
 - Bug fix: small correctness fix in input tracking.
 - Bug fix: fix corner case that caused missing outputs with `build_runner serve`
   when directories were specified with a port, for example 

--- a/build_runner/lib/src/bootstrap/bootstrapper.dart
+++ b/build_runner/lib/src/bootstrap/bootstrapper.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:built_collection/built_collection.dart';
 
+import '../build_plan/build_paths.dart';
 import '../exceptions.dart';
 import '../internal.dart';
 import 'aot_compiler.dart';
@@ -21,9 +22,9 @@ import 'processes.dart';
 /// that knows how to instantiate all the builders that will run during the
 /// build.
 ///
-/// If [workspace] the `BuilderFactories` contains builders applied to any
-/// package in the workspace. Otherwise, it only contains builders for the
-/// current directory package and its transitive dependencies.
+/// If `buildPaths.buildWorkspace` the `BuilderFactories` contains builders
+/// applied to any package in the workspace. Otherwise, it only contains
+/// builders for the current directory package and its transitive dependencies.
 ///
 /// When the entrypoint script is compiled a "depfile" is created listing all
 /// the sources it is compiled from. Then a digest is written based on the
@@ -33,11 +34,11 @@ import 'processes.dart';
 /// or [ParentProcess.runAotSnapshotAndSend] which passes initial state to it
 /// and receives updated state when it exits.
 class Bootstrapper {
-  final bool workspace;
+  final BuildPaths buildPaths;
   final bool compileAot;
   final Compiler _compiler;
 
-  Bootstrapper({required this.workspace, required this.compileAot})
+  Bootstrapper({required this.buildPaths, required this.compileAot})
     : _compiler = compileAot ? AotCompiler() : KernelCompiler();
 
   /// Generates the entrypoint script, compiles it and runs it with [arguments].
@@ -149,7 +150,7 @@ class Bootstrapper {
   ///
   /// Reads before write so the file is not written if there is no change.
   Future<void> _writeBuildScript() async {
-    final buildScript = await generateBuildScript(workspace: workspace);
+    final buildScript = await generateBuildScript(buildPaths: buildPaths);
     final path = entrypointScriptPath;
     final existingBuildScript =
         File(path).existsSync() ? File(path).readAsStringSync() : null;

--- a/build_runner/lib/src/bootstrap/build_process_lock.dart
+++ b/build_runner/lib/src/bootstrap/build_process_lock.dart
@@ -1,0 +1,225 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:watcher/watcher.dart';
+
+import '../build_plan/build_paths.dart';
+import '../logging/build_log.dart';
+
+const _packageLockName = 'build_runner.lock';
+const _workspaceLockName = 'build_runner.workspace.lock';
+
+/// File lock to ensure only one `build_runner` command runs at a time on the
+/// same files.
+///
+/// Needs to know whether the build is a whole workspace or package build to
+/// use the correct lock granularity.
+///
+/// If a lock can't be taken, requests the lock. Notifies of requests for the
+/// lock from another process via [setLockRequestCallback].
+///
+/// Use via `BuildProcessState` which handles passing the configuration to the
+/// child process.
+class BuildProcessLock {
+  final BuildPaths paths;
+
+  BuildProcessLock(this.paths);
+
+  void Function()? _onLockRequested;
+  bool _lockWasRequested = false;
+
+  /// Takes the lock for this process.
+  ///
+  /// If building one package, a shared lock is taken on the workspace (if there
+  /// is one) and an exclusive lock on the package.
+  ///
+  /// If building the workspace, an exclusive lock is taken on the workspace.
+  ///
+  /// The lock is released when the process exits.
+  Future<void> takeLock() async {
+    Directory(p.dirname(_packageLockFile.path)).createSync(recursive: true);
+    if (_workspaceLockFile != null) {
+      Directory(
+        p.dirname(_workspaceLockFile!.path),
+      ).createSync(recursive: true);
+    }
+    var logged = false;
+    while (true) {
+      if (paths.buildWorkspace) {
+        // Workspace build needs exclusive lock on the workspace.
+        if (_workspaceLockFile!.tryLock(FileLock.exclusive) != null) {
+          // Success.
+          break;
+        }
+      } else {
+        // Package build needs shared lock on the workspace, if there is one.
+        final workspaceLock = _workspaceLockFile?.tryLock(FileLock.shared);
+
+        // If that succeeded, or was not needed, get the package lock.
+        if (paths.workspacePath == null || workspaceLock != null) {
+          if (_packageLockFile.tryLock(FileLock.exclusive) != null) {
+            // Success.
+            break;
+          }
+
+          // Release the workspace lock before retrying the package lock.
+          workspaceLock?.unlock();
+        }
+      }
+
+      if (!logged) {
+        buildLog.flushAndPrint('Waiting for already-running build_runner.');
+        logged = true;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+
+    /// Success: clear `.requested` files.
+    _clearRequested();
+  }
+
+  void setLockRequestCallback(void Function() callback) {
+    if (_onLockRequested != null) {
+      throw StateError('Lock request callback already set.');
+    }
+    _onLockRequested = callback;
+
+    // Check if already requested.
+    if (isLockRequested()) {
+      callback();
+      return;
+    }
+
+    _watchForLockRequests();
+  }
+
+  bool isLockRequested() {
+    if (_lockWasRequested) return true;
+    if (File('${_packageLockFile.path}.requested').existsSync()) return true;
+    if (_workspaceLockFile != null &&
+        File('${_workspaceLockFile!.path}.requested').existsSync()) {
+      _lockWasRequested = true;
+      return true;
+    }
+    return false;
+  }
+
+  void _watchForLockRequests() {
+    _watchDirectoryForLockRequests(p.dirname(_packageLockFile.path));
+    if (_workspaceLockFile != null) {
+      final workspaceDir = p.dirname(_workspaceLockFile!.path);
+      if (workspaceDir != p.dirname(_packageLockFile.path)) {
+        _watchDirectoryForLockRequests(workspaceDir);
+      }
+    }
+  }
+
+  void _watchDirectoryForLockRequests(String path) {
+    final dir = Directory(path);
+    if (!dir.existsSync()) {
+      dir.createSync(recursive: true);
+    }
+    final watcher = Watcher(dir.path);
+    watcher.events.listen((event) {
+      if (event.path.endsWith('.requested')) {
+        if (isLockRequested()) {
+          _onLockRequested?.call();
+        }
+      }
+    });
+  }
+
+  /// The lock file for [BuildPaths.packagePath].
+  File get _packageLockFile => File(
+    p.join(paths.packagePath, '.dart_tool/build/lock/$_packageLockName'),
+  );
+
+  /// The lock file for [BuildPaths.workspacePath].
+  File? get _workspaceLockFile =>
+      paths.workspacePath == null
+          ? null
+          : File(
+            p.join(
+              paths.workspacePath!,
+              '.dart_tool/build/lock/$_workspaceLockName',
+            ),
+          );
+
+  /// Deletes the lock request files.
+  void _clearRequested() {
+    _deleteFile(_packageLockFile);
+    _deleteFile(_workspaceLockFile);
+  }
+
+  void _deleteFile(File? lockFile) {
+    if (lockFile == null) return;
+    try {
+      final requestedFile = File('${lockFile.path}.requested');
+      if (requestedFile.existsSync()) {
+        requestedFile.deleteSync();
+      }
+    } catch (_) {}
+  }
+}
+
+extension _FileExtensions on File? {
+  /// Tries to open and lock `this`.
+  ///
+  /// If `this` is `null`, returns `null`.
+  ///
+  /// On failure, creates a `.requested` file to request that the lock is
+  /// released.
+  ///
+  /// Returns the [_Lock] on success, or `null` on failure.
+  _Lock? tryLock(FileLock mode) {
+    final lockFile = this;
+    if (lockFile == null) return null;
+    try {
+      return _Lock(lockFile, mode);
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+/// A lock file.
+class _Lock {
+  late RandomAccessFile _randomAccessFile;
+
+  /// Takes the lock on [file] or requests the lock and throws.
+  _Lock(File file, FileLock mode) {
+    try {
+      file.createSync(recursive: true);
+      _randomAccessFile = file.openSync(mode: FileMode.write);
+      _randomAccessFile.lockSync(mode);
+    } catch (_) {
+      _requestLock(file.path);
+      _randomAccessFile.closeSync();
+      rethrow;
+    }
+  }
+
+  /// Releases the lock and closes the file.
+  void unlock() {
+    try {
+      _randomAccessFile.unlockSync();
+      _randomAccessFile.closeSync();
+    } catch (_) {}
+  }
+
+  /// Creates `$path.requested` file.
+  static void _requestLock(String path) {
+    final requestedFile = File('$path.requested');
+    try {
+      requestedFile.parent.createSync(recursive: true);
+      // Write even if the file already exists to trigger a file watch event in
+      // the process that has the lock.
+      requestedFile.writeAsStringSync('');
+    } catch (_) {}
+  }
+}

--- a/build_runner/lib/src/bootstrap/build_process_lock.dart
+++ b/build_runner/lib/src/bootstrap/build_process_lock.dart
@@ -207,8 +207,10 @@ class _Lock {
   /// Releases the lock and closes the file.
   void unlock() {
     try {
-      _randomAccessFile.unlockSync();
       _randomAccessFile.closeSync();
+    } catch (_) {}
+    try {
+      _randomAccessFile.unlockSync();
     } catch (_) {}
   }
 
@@ -219,7 +221,7 @@ class _Lock {
       requestedFile.parent.createSync(recursive: true);
       // Write even if the file already exists to trigger a file watch event in
       // the process that has the lock.
-      requestedFile.writeAsStringSync('');
+      requestedFile.writeAsStringSync('', flush: true);
     } catch (_) {}
   }
 }

--- a/build_runner/lib/src/bootstrap/build_process_state.dart
+++ b/build_runner/lib/src/bootstrap/build_process_state.dart
@@ -7,6 +7,10 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
+import '../build_plan/build_paths.dart';
+
+import 'build_process_lock.dart';
+
 /// State for the whole build process.
 ///
 /// It's passed from the entrypoint to the spawned build script isolate, then
@@ -17,6 +21,45 @@ class BuildProcessState {
   final Map<String, Object?> _state = {};
   final List<void Function()> _beforeSends = [];
   final List<void Function()> _afterReceives = [];
+  BuildProcessLock? _lock;
+
+  BuildProcessState() {
+    _afterReceives.add(() {
+      // Initialize lock using state from parent process if it was set.
+      if (_buildPaths != null) {
+        _lock = BuildProcessLock(_buildPaths!);
+      }
+    });
+  }
+
+  /// Configures and takes the [BuildProcessLock].
+  ///
+  /// It will be released on process exit.
+  ///
+  /// If it can't be taken, notifies the lock holder and waits for it to become
+  /// available.
+  ///
+  /// Throws if called more than once.
+  Future<void> takeLock(BuildPaths buildPaths) {
+    if (_lock != null) throw StateError('Already took lock.');
+    _buildPaths = buildPaths;
+    _lock = BuildProcessLock(buildPaths);
+    return _lock!.takeLock();
+  }
+
+  /// Registers a callback to be called when a lock is requested.
+  ///
+  /// Setting the callback starts the watch for lock request files.
+  void setLockRequestCallback(void Function() callback) {
+    // _lock is null in unit tests, which never get lock requests.
+    _lock?.setLockRequestCallback(callback);
+  }
+
+  /// Whether another process has requested the [BuildProcessLock].
+  bool isLockRequested() {
+    // _lock is null in unit tests, which never get lock requests.
+    return _lock?.isLockRequested() ?? false;
+  }
 
   /// For `buildLog`, console output capabilities.
   ///
@@ -63,6 +106,21 @@ class BuildProcessState {
   String get packageConfigUri =>
       (_state['packageConfigUri'] ??= Isolate.packageConfigSync!.toString())
           as String;
+
+  /// The [BuildPaths] used for the process lock.
+  BuildPaths? get _buildPaths =>
+      _state.containsKey('packagePath')
+          ? BuildPaths(
+            packagePath: _state['packagePath'] as String,
+            workspacePath: _state['workspacePath'] as String?,
+            buildWorkspace: _state['buildWorkspace'] as bool,
+          )
+          : null;
+  set _buildPaths(BuildPaths? value) {
+    _state['packagePath'] = value?.packagePath;
+    _state['workspacePath'] = value?.workspacePath;
+    _state['buildWorkspace'] = value?.buildWorkspace;
+  }
 
   void resetForTests() {
     _state.clear();

--- a/build_runner/lib/src/bootstrap/build_script_generate.dart
+++ b/build_runner/lib/src/bootstrap/build_script_generate.dart
@@ -11,6 +11,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import '../build_plan/build_configs.dart';
 import '../build_plan/build_packages.dart';
+import '../build_plan/build_paths.dart';
 import '../constants.dart';
 import '../exceptions.dart';
 import '../io/reader_writer.dart';
@@ -18,8 +19,8 @@ import '../logging/build_log.dart';
 
 final _lastShortFormatDartVersion = Version(3, 6, 0);
 
-Future<String> generateBuildScript({required bool workspace}) async {
-  final builderFactories = await loadBuilderFactories(workspace: workspace);
+Future<String> generateBuildScript({required BuildPaths buildPaths}) async {
+  final builderFactories = await loadBuilderFactories(buildPaths: buildPaths);
 
   try {
     // The `build_runner` version number is included to force a rebuild if the
@@ -61,14 +62,13 @@ void main(List<String> args) async {
 /// Loads builder factories for the current package and its transitive
 /// dependencies.
 ///
-/// If [workspace], builder factories are also loaded for other packages in
-/// the current workspace, if any, and their transitive dependencies.
+/// If `buildPaths.buildWorkspace`, builder factories are also loaded for other
+/// packages in the current workspace, if any, and their transitive
+/// dependencies.
 Future<BuilderFactoriesExpressions> loadBuilderFactories({
-  required bool workspace,
+  required BuildPaths buildPaths,
 }) async {
-  final buildPackages = await BuildPackages.forThisPackage(
-    workspace: workspace,
-  );
+  final buildPackages = await BuildPackages.forPaths(buildPaths);
   final readerWriter = ReaderWriter(buildPackages);
   final overrides = await findBuildConfigOverrides(
     buildPackages: buildPackages,

--- a/build_runner/lib/src/build_plan/build_options.dart
+++ b/build_runner/lib/src/build_plan/build_options.dart
@@ -13,12 +13,14 @@ import 'package:path/path.dart' as p;
 import '../build_runner_command_line.dart';
 import 'build_directory.dart';
 import 'build_filter.dart';
+import 'build_paths.dart';
 
 /// The command line options common to all `build_runner` commands that do a
 /// build.
 class BuildOptions {
   final BuiltMap<String, BuiltMap<String, Object?>> builderConfigOverrides;
   final BuiltSet<BuildDirectory> buildDirs;
+  final BuildPaths buildPaths;
   final BuiltSet<BuildFilter> buildFilters;
   final String? configKey;
   final BuiltList<String> enableExperiments;
@@ -32,7 +34,6 @@ class BuildOptions {
   final bool trackPerformance;
   final bool verbose;
   final bool verboseDurations;
-  final bool workspace;
 
   late final bool anyMergedOutputDirectory = buildDirs.any(
     (target) => target.outputLocation?.path.isNotEmpty ?? false,
@@ -40,6 +41,7 @@ class BuildOptions {
 
   BuildOptions({
     required this.buildDirs,
+    required this.buildPaths,
     required this.builderConfigOverrides,
     required this.buildFilters,
     required this.configKey,
@@ -54,7 +56,6 @@ class BuildOptions {
     required this.trackPerformance,
     required this.verbose,
     required this.verboseDurations,
-    required this.workspace,
   });
 
   /// Creates with defaults that mostly match the real defaults.
@@ -65,6 +66,7 @@ class BuildOptions {
   factory BuildOptions.forTests({
     BuiltMap<String, BuiltMap<String, Object?>>? builderConfigOverrides,
     BuiltSet<BuildDirectory>? buildDirs,
+    BuildPaths? buildPaths,
     BuiltSet<BuildFilter>? buildFilters,
     String? configKey,
     bool? dartAotPerf,
@@ -78,10 +80,11 @@ class BuildOptions {
     bool? trackPerformance,
     bool? verbose,
     bool? verboseDurations,
-    bool? workspace,
   }) => BuildOptions(
     builderConfigOverrides: builderConfigOverrides ?? BuiltMap(),
     buildDirs: buildDirs ?? BuiltSet(),
+    buildPaths:
+        buildPaths ?? BuildPaths(packagePath: '.', buildWorkspace: false),
     buildFilters: buildFilters ?? BuiltSet(),
     configKey: configKey,
     dartAotPerf: dartAotPerf ?? false,
@@ -95,7 +98,6 @@ class BuildOptions {
     trackPerformance: trackPerformance ?? false,
     verbose: verbose ?? false,
     verboseDurations: verboseDurations ?? false,
-    workspace: workspace ?? false,
   );
 
   /// Parses [commandLine].
@@ -112,6 +114,7 @@ class BuildOptions {
   /// argument (like `serve`).
   static BuildOptions parse(
     BuildRunnerCommandLine commandLine, {
+    required BuildPaths buildPaths,
     required String rootPackage,
     required bool restIsBuildDirs,
     Iterable<String>? extraDirs,
@@ -125,6 +128,7 @@ class BuildOptions {
               for (final dir in extraDirs)
                 BuildDirectory(_checkTopLevel(commandLine, dir)),
           }.build(),
+      buildPaths: buildPaths,
       builderConfigOverrides: _parseBuilderConfigOverrides(
         commandLine,
         rootPackage: rootPackage,
@@ -144,7 +148,6 @@ class BuildOptions {
           commandLine.trackPerformance! || commandLine.logPerformance != null,
       verbose: commandLine.verbose!,
       verboseDurations: commandLine.verboseDurations!,
-      workspace: commandLine.workspace!,
     );
 
     if (result.forceAot && result.forceJit) {
@@ -162,6 +165,7 @@ class BuildOptions {
     BuiltSet<BuildFilter>? buildFilters,
   }) => BuildOptions(
     buildDirs: buildDirs ?? this.buildDirs,
+    buildPaths: buildPaths,
     builderConfigOverrides: builderConfigOverrides,
     buildFilters: buildFilters ?? this.buildFilters,
     configKey: configKey,
@@ -176,7 +180,6 @@ class BuildOptions {
     trackPerformance: trackPerformance,
     verbose: verbose,
     verboseDurations: verboseDurations,
-    workspace: workspace,
   );
 }
 

--- a/build_runner/lib/src/build_plan/build_packages.dart
+++ b/build_runner/lib/src/build_plan/build_packages.dart
@@ -15,6 +15,7 @@ import '../constants.dart';
 import '../io/asset_path_provider.dart';
 import 'build_package.dart';
 import 'build_packages_loader.dart';
+import 'build_paths.dart';
 
 /// The SDK package, we filter this to the core libs and dev compiler
 /// resources.
@@ -157,24 +158,16 @@ class BuildPackages implements AssetPathProvider {
     packages: {for (final package in packages) package.name: package}.build(),
   );
 
-  /// Loads the build packages for building the package at [packagePath].
+  /// Loads the build packages at [buildPaths].
   ///
   /// Assumes `pubspec.yaml` exists and has a name, as this is checked by
   /// `dart run`.
   ///
-  /// If [workspace], prepares to build the whole workspace, if any.
-  @visibleForTesting
-  static Future<BuildPackages> forPath(
-    String packagePath, {
-    bool workspace = false,
-  }) async => BuildPackagesLoader.forPath(packagePath, workspace: workspace);
-
-  /// Creates a [BuildPackages] for the package in which you are currently
-  /// running.
-  ///
-  /// If [workspace], prepares to build for the whole workspace, if any.
-  static Future<BuildPackages> forThisPackage({bool workspace = false}) =>
-      BuildPackages.forPath(p.current, workspace: workspace);
+  /// If `buildPaths.buildWorkspace`, prepares to build the whole workspace, if
+  /// any.
+  static Future<BuildPackages> forPaths(BuildPaths buildPaths) async {
+    return BuildPackagesLoader.forPaths(buildPaths);
+  }
 
   static PackageConfig _packagesToConfig(Iterable<BuildPackage> packages) {
     final relativeLib = Uri.parse('lib/');

--- a/build_runner/lib/src/build_plan/build_packages_loader.dart
+++ b/build_runner/lib/src/build_plan/build_packages_loader.dart
@@ -12,31 +12,18 @@ import 'package:yaml/yaml.dart';
 
 import 'build_package.dart';
 import 'build_packages.dart';
+import 'build_paths.dart';
 
 class BuildPackagesLoader {
-  /// Loads the build packages for building the package at [packagePath].
+  /// Loads the build packages for building [paths].
   ///
   /// Assumes `pubspec.yaml` exists and has a name, as this is checked by
   /// `dart run`.
-  ///
-  /// If [workspace], prepares to build the whole workspace, if any.
-  static Future<BuildPackages> forPath(
-    String packagePath, {
-    bool workspace = false,
-  }) async {
-    String? workspacePath;
-    final workspaceRefFile = File(
-      p.join(packagePath, '.dart_tool', 'pub', 'workspace_ref.json'),
-    );
+  static Future<BuildPackages> forPaths(BuildPaths paths) async {
+    final packagePath = paths.packagePath;
+    final workspacePath = paths.workspacePath;
     File packageConfigFile;
-    if (workspaceRefFile.existsSync()) {
-      final workspaceRef =
-          (json.decode(workspaceRefFile.readAsStringSync())
-                  as Map<String, Object?>)['workspaceRoot']
-              as String;
-      workspacePath = p.canonicalize(
-        p.join(p.dirname(workspaceRefFile.path), workspaceRef),
-      );
+    if (workspacePath != null) {
       packageConfigFile = File(
         p.join(workspacePath, '.dart_tool', 'package_config.json'),
       );
@@ -49,12 +36,7 @@ class BuildPackagesLoader {
       throw StateError('Failed to find package_config.json.');
     }
 
-    final buildType =
-        workspacePath == null
-            ? BuildType.singlePackage
-            : workspace
-            ? BuildType.workspace
-            : BuildType.singlePackageInWorkspace;
+    final buildType = paths.buildType;
 
     final packageConfig = await loadPackageConfig(packageConfigFile);
     final packageConfigs =
@@ -117,17 +99,6 @@ class BuildPackagesLoader {
       packages: buildPackages.build(),
     );
   }
-}
-
-enum BuildType {
-  /// Single package not in a workspace.
-  singlePackage,
-
-  /// Single package in a workspace, but the workspace is ignored.
-  singlePackageInWorkspace,
-
-  /// All packages in a workspace.
-  workspace,
 }
 
 /// Loads and returns `$absolutePath/pubspec.yaml`.

--- a/build_runner/lib/src/build_plan/build_paths.dart
+++ b/build_runner/lib/src/build_plan/build_paths.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// The current package path, workspace path, and whether to build the single
+/// package or the workspace.
+class BuildPaths {
+  /// The package in which `build_runner` was launched.
+  ///
+  /// Might be the root of a workspace, which can also be built like a package.
+  final String packagePath;
+
+  /// The workspace in which `build_runner` was launched, if any.
+  final String? workspacePath;
+
+  /// Whether this build should build the whole workspace.
+  ///
+  /// Otherwise, just build the package at [packagePath].
+  final bool buildWorkspace;
+
+  BuildType get buildType {
+    if (workspacePath == null) return BuildType.singlePackage;
+    if (buildWorkspace) return BuildType.workspace;
+    return BuildType.singlePackageInWorkspace;
+  }
+
+  BuildPaths({
+    required this.packagePath,
+    required this.buildWorkspace,
+    this.workspacePath,
+  });
+
+  /// Loads for [packagePath] and user input as to whether to [buildWorkspace].
+  ///
+  /// If not in a workspace, [buildWorkspace] is forced to `false`.
+  static BuildPaths load(String packagePath, {required bool buildWorkspace}) {
+    String? workspacePath;
+    final workspaceRefFile = File(
+      p.join(packagePath, '.dart_tool', 'pub', 'workspace_ref.json'),
+    );
+    if (workspaceRefFile.existsSync()) {
+      final workspaceRef =
+          (json.decode(workspaceRefFile.readAsStringSync())
+                  as Map<String, Object?>)['workspaceRoot']
+              as String;
+      workspacePath = p.canonicalize(
+        p.join(p.dirname(workspaceRefFile.path), workspaceRef),
+      );
+    }
+    return BuildPaths(
+      packagePath: packagePath,
+      buildWorkspace: buildWorkspace && workspacePath != null,
+      workspacePath: workspacePath,
+    );
+  }
+}
+
+/// The type of build: single package, single package in a workspace, or
+/// wole workspace build.
+enum BuildType { singlePackage, singlePackageInWorkspace, workspace }

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -109,7 +109,7 @@ class BuildPlan {
     bool recentlyBootstrapped = true,
   }) async {
     final bootstrapper = Bootstrapper(
-      workspace: buildOptions.workspace,
+      buildPaths: buildOptions.buildPaths,
       compileAot: buildOptions.forceAot,
     );
     var restartIsNeeded = false;
@@ -122,7 +122,7 @@ class BuildPlan {
 
     final buildPackages =
         testingOverrides.buildPackages ??
-        await BuildPackages.forThisPackage(workspace: buildOptions.workspace);
+        await BuildPackages.forPaths(buildOptions.buildPaths);
     final readerWriter =
         (testingOverrides.readerWriter ?? ReaderWriter(buildPackages)).copyWith(
           cache:
@@ -160,7 +160,7 @@ class BuildPlan {
           builderDefinitions: builderDefinitions,
           builderConfigOverrides: buildOptions.builderConfigOverrides,
           isReleaseBuild: buildOptions.isReleaseBuild,
-          workspace: buildOptions.workspace,
+          workspace: buildOptions.buildPaths.buildWorkspace,
         ).createBuildPhases();
     buildPhases.checkOutputLocations(buildPackages.outputPackages);
 

--- a/build_runner/lib/src/build_runner.dart
+++ b/build_runner/lib/src/build_runner.dart
@@ -12,7 +12,9 @@ import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
 import 'bootstrap/bootstrapper.dart';
+import 'bootstrap/build_process_state.dart';
 import 'build_plan/build_options.dart';
+import 'build_plan/build_paths.dart';
 import 'build_plan/builder_factories.dart';
 import 'build_runner_command_line.dart';
 import 'commands/build_command.dart';
@@ -24,6 +26,7 @@ import 'commands/run_command.dart';
 import 'commands/run_options.dart';
 import 'commands/serve_command.dart';
 import 'commands/serve_options.dart';
+import 'commands/stop_command.dart';
 import 'commands/test_command.dart';
 import 'commands/test_options.dart';
 import 'commands/watch_command.dart';
@@ -83,9 +86,19 @@ class BuildRunner {
                 as YamlMap)['name']!
             as String;
 
+    // Take the process lock if this is the outer process. All commands except
+    // `daemon` take the lock; `daemon` has its own locking.
+    final buildPaths = BuildPaths.load(
+      p.current,
+      buildWorkspace: commandLine.workspace ?? false,
+    );
+    if (builderFactories == null && commandLine.type != CommandType.daemon) {
+      await buildProcessState.takeLock(buildPaths);
+    }
+
     if (commandLine.type.requiresBuilders && builderFactories == null) {
       return await _runWithBuilders(
-        workspace: commandLine.workspace!,
+        buildPaths: buildPaths,
         compileAot: commandLine.forceAot!,
       );
     }
@@ -99,11 +112,15 @@ class BuildRunner {
             commandLine,
             restIsBuildDirs: true,
             rootPackage: rootPackage,
+            buildPaths: buildPaths,
           ),
         );
 
       case CommandType.clean:
-        command = CleanCommand();
+        command = CleanCommand(buildPaths);
+
+      case CommandType.stop:
+        command = StopCommand();
 
       case CommandType.daemon:
         command = DaemonCommand(
@@ -113,6 +130,7 @@ class BuildRunner {
             commandLine,
             restIsBuildDirs: false,
             rootPackage: rootPackage,
+            buildPaths: buildPaths,
           ),
           daemonOptions: DaemonOptions.parse(commandLine),
         );
@@ -124,6 +142,7 @@ class BuildRunner {
             commandLine,
             restIsBuildDirs: false,
             rootPackage: rootPackage,
+            buildPaths: buildPaths,
           ),
           runOptions: RunOptions.parse(commandLine),
         );
@@ -136,6 +155,7 @@ class BuildRunner {
             commandLine,
             restIsBuildDirs: false,
             rootPackage: rootPackage,
+            buildPaths: buildPaths,
             extraDirs: serveOptions.serveTargets.map((t) => t.dir),
           ),
           serveOptions: serveOptions,
@@ -148,6 +168,7 @@ class BuildRunner {
             commandLine,
             restIsBuildDirs: false,
             rootPackage: rootPackage,
+            buildPaths: buildPaths,
           ),
           testOptions: TestOptions.parse(commandLine),
         );
@@ -159,6 +180,7 @@ class BuildRunner {
             commandLine,
             restIsBuildDirs: true,
             rootPackage: rootPackage,
+            buildPaths: buildPaths,
           ),
         );
     }
@@ -171,7 +193,7 @@ class BuildRunner {
   /// The nested `build_runner` invocation reaches [run] with [builderFactories]
   /// set, so it runs the command instead of bootstrapping.
   Future<int> _runWithBuilders({
-    required bool workspace,
+    required BuildPaths buildPaths,
     required bool compileAot,
   }) async {
     buildLog.configuration = buildLog.configuration.rebuild((b) {
@@ -181,7 +203,7 @@ class BuildRunner {
     });
 
     final bootstrapper = Bootstrapper(
-      workspace: workspace,
+      buildPaths: buildPaths,
       compileAot: compileAot,
     );
     return await bootstrapper.run(

--- a/build_runner/lib/src/build_runner_command_line.dart
+++ b/build_runner/lib/src/build_runner_command_line.dart
@@ -17,6 +17,7 @@ enum CommandType {
   daemon,
   run,
   serve,
+  stop,
   test,
   watch;
 
@@ -28,7 +29,7 @@ enum CommandType {
 
   /// Whether the command must be launched as a nested `build_runner` binary
   /// built with configured builders.
-  bool get requiresBuilders => this != clean;
+  bool get requiresBuilders => this != clean && this != stop;
 }
 
 /// A `build_runner` command line with arguments parsed to primitive types.
@@ -106,6 +107,8 @@ class BuildRunnerCommandLine {
         return _run.usage;
       case CommandType.serve:
         return _serve.usage;
+      case CommandType.stop:
+        return _stop.usage;
       case CommandType.test:
         return _test.usage;
       case CommandType.watch:
@@ -166,6 +169,7 @@ class _CommandRunner extends CommandRunner<BuildRunnerCommandLine> {
     addCommand(_daemon);
     addCommand(_run);
     addCommand(_serve);
+    addCommand(_stop);
     addCommand(_test);
     addCommand(_watch);
   }
@@ -345,7 +349,17 @@ class _Clean extends _Command<BuildRunnerCommandLine> {
 
   @override
   String get description =>
-      'Deletes the build cache. The next build will be a full build.';
+      'Deletes the package or workspace build cache. '
+      'The next build will be a full build.';
+
+  _Clean() {
+    argParser.addFlag(
+      workspaceOption,
+      defaultsTo: false,
+      negatable: false,
+      help: 'Deletes the `--workspace` build cache.',
+    );
+  }
 
   @override
   Future<BuildRunnerCommandLine> run() async =>
@@ -510,4 +524,28 @@ class _Watch extends _Command<BuildRunnerCommandLine> {
   @override
   Future<BuildRunnerCommandLine> run() async =>
       BuildRunnerCommandLine(CommandType.watch, argResults!);
+}
+
+final _stop = _Stop();
+
+class _Stop extends _Command<BuildRunnerCommandLine> {
+  @override
+  String get name => 'stop';
+
+  @override
+  String get description =>
+      'Stops `watch` and `serve` commands in the same package or workspace.';
+
+  _Stop() {
+    argParser.addFlag(
+      workspaceOption,
+      defaultsTo: false,
+      negatable: false,
+      help: 'Stop `build_runner` in all packages in the current workspace.',
+    );
+  }
+
+  @override
+  Future<BuildRunnerCommandLine> run() async =>
+      BuildRunnerCommandLine(CommandType.stop, argResults!);
 }

--- a/build_runner/lib/src/commands/clean_command.dart
+++ b/build_runner/lib/src/commands/clean_command.dart
@@ -5,17 +5,42 @@
 import 'dart:io';
 
 import 'package:io/io.dart';
+import 'package:path/path.dart' as p;
 
+import '../build_plan/build_paths.dart';
 import '../constants.dart';
 import 'build_runner_command.dart';
 
 class CleanCommand implements BuildRunnerCommand {
+  final BuildPaths buildPaths;
+
+  CleanCommand(this.buildPaths);
+
   @override
   Future<int> run() async {
-    final generatedDir = Directory(cacheDirectoryPath);
+    // Delete specific directories and files instead of the whole cache
+    // directory, which can't be deleted on Windows due to the open lock file.
+
+    final basePath =
+        buildPaths.buildWorkspace
+            ? buildPaths.workspacePath!
+            : buildPaths.packagePath;
+
+    final entrypointDir = Directory(p.join(basePath, entrypointDirectoryPath));
+    if (entrypointDir.existsSync()) {
+      entrypointDir.deleteSync(recursive: true);
+    }
+
+    final assetGraph = File(p.join(basePath, assetGraphPath));
+    if (assetGraph.existsSync()) {
+      assetGraph.deleteSync();
+    }
+
+    final generatedDir = Directory(p.join(basePath, generatedOutputDirectory));
     if (generatedDir.existsSync()) {
       generatedDir.deleteSync(recursive: true);
     }
+
     return ExitCode.success.code;
   }
 }

--- a/build_runner/lib/src/commands/serve_command.dart
+++ b/build_runner/lib/src/commands/serve_command.dart
@@ -92,7 +92,9 @@ class ServeCommand implements BuildRunnerCommand {
       });
 
       // TODO(davidmorgan): reuse package graph.
-      _ensureBuildWebCompilersDependency(await BuildPackages.forThisPackage());
+      _ensureBuildWebCompilersDependency(
+        await BuildPackages.forPaths(buildOptions.buildPaths),
+      );
 
       final completer = Completer<int>();
       handleBuildResultsStream(watcher.buildResults, completer);

--- a/build_runner/lib/src/commands/stop_command.dart
+++ b/build_runner/lib/src/commands/stop_command.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:io/io.dart';
+
+import 'build_runner_command.dart';
+
+class StopCommand implements BuildRunnerCommand {
+  @override
+  Future<int> run() async {
+    // The lock is taken on startup in `build_runner.dart`, any other running
+    // `build_runner` was already notified and has closed.
+    return ExitCode.success.code;
+  }
+}

--- a/build_runner/lib/src/commands/test_command.dart
+++ b/build_runner/lib/src/commands/test_command.dart
@@ -54,7 +54,7 @@ class TestCommand implements BuildRunnerCommand {
     try {
       final buildPackages =
           testingOverrides.buildPackages ??
-          await BuildPackages.forThisPackage();
+          await BuildPackages.forPaths(buildOptions.buildPaths);
       if (!buildPackages.packages.containsKey('build_test')) {
         buildLog.error('''
 Missing dev dependency on package:build_test, which is required to run tests.

--- a/build_runner/lib/src/commands/watch/watcher.dart
+++ b/build_runner/lib/src/commands/watch/watcher.dart
@@ -7,10 +7,12 @@ import 'dart:async';
 import 'package:build/build.dart';
 import 'package:stream_transform/stream_transform.dart';
 
+import '../../bootstrap/build_process_state.dart';
 import '../../build/build_result.dart';
 import '../../build/build_series.dart';
 import '../../build_plan/build_packages.dart';
 import '../../build_plan/build_plan.dart';
+import '../../logging/build_log.dart';
 import 'asset_change.dart';
 import 'build_package_watcher.dart';
 import 'build_packages_watcher.dart';
@@ -50,6 +52,9 @@ class Watcher {
   /// File watchers are scheduled synchronously.
   void _run(Future<void> until) async {
     final terminate = Future.any([until, _buildSeries.closing]);
+    // If the BuildProcessLock is requested, finish the current build if there
+    // is one then exit.
+    buildProcessState.setLockRequestCallback(_buildSeries.close);
 
     // Start watching files immediately, before the first build is even started.
     final graphWatcher = BuildPackagesWatcher(
@@ -78,6 +83,13 @@ class Watcher {
         .takeUntil(terminate)
         .asyncMapBuffer(_doBuild)
         .drain<void>()
+        .then((_) async {
+          if (buildProcessState.isLockRequested()) {
+            buildLog.flushAndPrint(
+              'Exiting as requested by another build_runner process.',
+            );
+          }
+        })
         .ignore();
 
     await graphWatcher.ready;

--- a/build_runner/lib/src/logging/build_log.dart
+++ b/build_runner/lib/src/logging/build_log.dart
@@ -247,6 +247,10 @@ class BuildLog {
     _display.flushAndPrint('BuildLog.debug:$message');
   }
 
+  void flushAndPrint(String message) {
+    _display.flushAndPrint(message);
+  }
+
   _PhaseProgress _getProgress({
     required InBuildPhase phase,
     required bool lazy,

--- a/build_runner/test/build_plan/build_packages_test.dart
+++ b/build_runner/test/build_plan/build_packages_test.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
+import 'package:build_runner/src/build_plan/build_paths.dart';
 import 'package:package_config/package_config_types.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -22,7 +23,9 @@ void main() {
   group('BuildPackages', () {
     group('forThisPackage ', () {
       setUp(() async {
-        buildPackages = await BuildPackages.forThisPackage();
+        buildPackages = await BuildPackages.forPaths(
+          BuildPaths.load(p.current, buildWorkspace: false),
+        );
       });
 
       test('singleOutputPackage', () {
@@ -60,8 +63,11 @@ void main() {
         await tester.run('basic_pkg', 'dart pub get');
         fakeHostedPackages(tester.tempDirectory, ['a', 'b', 'c', 'd']);
 
-        buildPackages = await BuildPackages.forPath(
-          p.join(tempDirectory, 'basic_pkg'),
+        buildPackages = await BuildPackages.forPaths(
+          BuildPaths.load(
+            p.join(tempDirectory, 'basic_pkg'),
+            buildWorkspace: false,
+          ),
         );
       });
 
@@ -137,8 +143,11 @@ void main() {
         await tester.run('with_dev_deps', 'dart pub get');
         fakeHostedPackages(tester.tempDirectory, ['a', 'b', 'c']);
 
-        buildPackages = await BuildPackages.forPath(
-          p.join(tempDirectory, 'with_dev_deps'),
+        buildPackages = await BuildPackages.forPaths(
+          BuildPaths.load(
+            p.join(tempDirectory, 'with_dev_deps'),
+            buildWorkspace: false,
+          ),
         );
       });
 
@@ -196,7 +205,9 @@ void main() {
       final withFlutterDeps = p.absolute('test/fixtures/flutter_pkg');
 
       setUp(() async {
-        buildPackages = await BuildPackages.forPath(withFlutterDeps);
+        buildPackages = await BuildPackages.forPaths(
+          BuildPaths.load(withFlutterDeps, buildWorkspace: false),
+        );
       });
 
       test('allPackages resolved correctly with all packages', () {
@@ -243,8 +254,11 @@ void main() {
 
     test('missing pubspec throws on create', () {
       expect(
-        () => BuildPackages.forPath(
-          p.absolute(p.join('test', 'fixtures', 'no_pubspec')),
+        () => BuildPackages.forPaths(
+          BuildPaths.load(
+            p.absolute(p.join('test', 'fixtures', 'no_pubspec')),
+            buildWorkspace: false,
+          ),
         ),
         throwsA(anything),
       );
@@ -252,8 +266,11 @@ void main() {
 
     test('missing .dart_tool/package_config.json file throws on create', () {
       expect(
-        () => BuildPackages.forPath(
-          p.absolute(p.join('test', 'fixtures', 'no_packages_file')),
+        () => BuildPackages.forPaths(
+          BuildPaths.load(
+            p.absolute(p.join('test', 'fixtures', 'no_packages_file')),
+            buildWorkspace: false,
+          ),
         ),
         throwsA(anything),
       );
@@ -288,7 +305,9 @@ workspace:
     });
 
     test('without --workspace loads correctly', () async {
-      buildPackages = await BuildPackages.forPath(p.join(tempDirectory, 'a'));
+      buildPackages = await BuildPackages.forPaths(
+        BuildPaths.load(p.join(tempDirectory, 'a'), buildWorkspace: false),
+      );
 
       expect(buildPackages.packages.asMap(), {
         'a': BuildPackage(
@@ -346,9 +365,8 @@ workspace:
       test('for package', () async {
         // Load the workspace passing the directory of a package in the
         // workspace.
-        buildPackages = await BuildPackages.forPath(
-          p.join(tempDirectory, 'a'),
-          workspace: true,
+        buildPackages = await BuildPackages.forPaths(
+          BuildPaths.load(p.join(tempDirectory, 'a'), buildWorkspace: true),
         );
 
         expect(buildPackages.packages.asMap(), expectedPackages);
@@ -359,9 +377,8 @@ workspace:
       test('for workspace root', () async {
         // Load the workspace passing the directory of a package in the
         // workspace itself. The result should be identical.
-        buildPackages = await BuildPackages.forPath(
-          tempDirectory,
-          workspace: true,
+        buildPackages = await BuildPackages.forPaths(
+          BuildPaths.load(tempDirectory, buildWorkspace: true),
         );
 
         expect(buildPackages.packages.asMap(), expectedPackages);

--- a/build_runner/test/common/build_runner_tester.dart
+++ b/build_runner/test/common/build_runner_tester.dart
@@ -26,11 +26,24 @@ class BuildRunnerTester {
   final Pubspecs pubspecs;
   final Directory tempDirectory;
 
-  BuildRunnerTester(this.pubspecs)
-    : tempDirectory = Directory.systemTemp.createTempSync(
-        'BuildRunnerTester-',
-      ) {
+  BuildRunnerTester(Pubspecs pubspecs)
+    : this._(
+        pubspecs,
+        Directory.systemTemp.createTempSync('BuildRunnerTester-'),
+      );
+
+  BuildRunnerTester._(this.pubspecs, this.tempDirectory) {
     addTearDown(() => tempDirectory.deleteSync(recursive: true));
+  }
+
+  /// Copies the entire workspace, returns a new `BuildRunnerTester` using
+  /// the copy.
+  BuildRunnerTester copyWorkspace() {
+    final newTemp = Directory.systemTemp.createTempSync(
+      'BuildRunnerTester-copy-',
+    );
+    copyPathSync(tempDirectory.path, newTemp.path);
+    return BuildRunnerTester._(pubspecs, newTemp);
   }
 
   /// Writes a Dart package to the workspace.
@@ -244,7 +257,8 @@ class BuildRunnerProcess {
     final stopwatch = Stopwatch()..start();
     while (stopwatch.elapsed < duration) {
       try {
-        output.add(await _outputs.next.timeout(duration - stopwatch.elapsed));
+        output.add(await _outputs.peek.timeout(duration - stopwatch.elapsed));
+        await _outputs.next;
       } on TimeoutException catch (_) {
         // Expected.
       } catch (_) {

--- a/build_runner/test/integration_tests/build_process_lock_test.dart
+++ b/build_runner/test/integration_tests/build_process_lock_test.dart
@@ -1,0 +1,144 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['integration3'])
+library;
+
+import 'package:build_runner/src/logging/build_log.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../common/common.dart';
+
+void main() async {
+  test('build process lock', () async {
+    final pubspecs = await Pubspecs.load();
+    final tester = BuildRunnerTester(pubspecs);
+
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      files: {},
+    );
+
+    // One build blocks waiting for another.
+    final build1 = await tester.start(
+      'root_pkg',
+      'dart run build_runner build',
+    );
+    await build1.expect('compiling builders');
+    final build2 = await tester.start(
+      'root_pkg',
+      'dart run build_runner build',
+    );
+    await build2.expect('Waiting for already-running build_runner.');
+    await build1.exitCode;
+    await build2.exitCode;
+
+    // Lock waits for held lock to be released.
+    final rootPath = p.join(tester.tempDirectory.path, 'root_pkg');
+    tester.write('root_pkg/bin/take_until_killed.dart', '''
+import 'dart:io';
+import 'package:build_runner/src/bootstrap/build_process_lock.dart';
+import 'package:build_runner/src/build_plan/build_paths.dart';
+Future<void> main() async {
+  final lock = BuildProcessLock(BuildPaths(
+    packagePath: r'$rootPath',
+    buildWorkspace: false,
+    workspacePath: null,
+  ));
+  print('started');
+  await lock.takeLock();
+  print('got lock');
+  await Future.delayed(Duration(minutes: 5));
+}
+''');
+
+    final lock1 = await tester.start(
+      'root_pkg',
+      'dart run bin/take_until_killed.dart',
+    );
+    await lock1.expect('started');
+    final lock2 = await tester.start(
+      'root_pkg',
+      'dart run bin/take_until_killed.dart',
+    );
+    await lock2.expect('started');
+    await lock1.expect('got lock');
+    await lock2.expect('Waiting for already-running build_runner.');
+    await lock2.expectNoOutput(const Duration(milliseconds: 500));
+    await lock1.kill();
+    await lock2.expect('got lock');
+    await lock2.kill();
+
+    // Lock is requested when waiting for lock.
+    tester.write('root_pkg/bin/take_until_requested.dart', '''
+import 'dart:io';
+import 'package:build_runner/src/bootstrap/build_process_lock.dart';
+import 'package:build_runner/src/build_plan/build_paths.dart';
+Future<void> main() async {
+  final lock = BuildProcessLock(BuildPaths(
+    packagePath: r'$rootPath',
+    buildWorkspace: false,
+    workspacePath: null,
+  ));
+  print('started');
+  await lock.takeLock();
+  print('got lock');
+  while (!lock.isLockRequested()) {
+    await Future.delayed(Duration(milliseconds: 100));
+  }
+  print('lock requested');
+}
+''');
+
+    final lock3 = await tester.start(
+      'root_pkg',
+      'dart run bin/take_until_requested.dart',
+    );
+    await lock3.expect('started');
+    await lock3.expect('got lock');
+    final lock4 = await tester.start(
+      'root_pkg',
+      'dart run bin/take_until_requested.dart',
+    );
+    await lock4.expect('started');
+    await lock3.expect('lock requested');
+    await lock4.expect('got lock');
+
+    // Create the requested file to wake up lock4.
+    tester.write(
+      'root_pkg/.dart_tool/build/lock/build_runner.lock.requested',
+      '',
+    );
+    await lock4.expect('lock requested');
+
+    // Watch mode exits if requested during a build.
+    tester.writeFixturePackage(
+      FixturePackages.copyBuilder(
+        packageName: 'builder_pkg',
+        delayAtBuildStart: true,
+        applyToAllPackages: true,
+      ),
+    );
+    tester.writePackage(
+      name: 'p1',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {'lib/p1.txt': '1'},
+    );
+    var watch = await tester.start('p1', 'dart run build_runner watch');
+    await watch.expect('builder_pkg:test_builder on 1 input');
+    await tester.run('p1', 'dart run build_runner stop');
+    await watch.expect('Exiting as requested by another build_runner process.');
+    await watch.exitCode;
+
+    // Watch mode exits if requested while idle.
+    watch = await tester.start('p1', 'dart run build_runner watch');
+    await watch.expect(BuildLog.successPattern);
+    await tester.run('p1', 'dart run build_runner stop');
+    await watch.expect('Exiting as requested by another build_runner process.');
+    await watch.exitCode;
+  });
+}

--- a/build_runner/test/integration_tests/build_process_lock_workspace_test.dart
+++ b/build_runner/test/integration_tests/build_process_lock_workspace_test.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['integration3'])
+library;
+
+import 'package:build_runner/src/logging/build_log.dart';
+import 'package:test/test.dart';
+
+import '../common/common.dart';
+
+void main() async {
+  test('build process locks in workspace', () async {
+    final pubspecs = await Pubspecs.load();
+    final tester = BuildRunnerTester(pubspecs);
+
+    tester.writeFixturePackage(
+      FixturePackages.copyBuilder(
+        packageName: 'builder_pkg',
+        delayAtBuildStart: true,
+        applyToAllPackages: true,
+      ),
+    );
+
+    tester.writePackage(
+      name: 'p1',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {'lib/p1.txt': '1'},
+      inWorkspace: true,
+    );
+    tester.writePackage(
+      name: 'p2',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {'lib/p2.txt': '1'},
+      inWorkspace: true,
+    );
+    tester.writeWorkspacePubspec(packages: ['p1', 'p2']);
+
+    // Two single package builds can run concurrently.
+    final build1 = await tester.start('p1', 'dart run build_runner build');
+    final build2 = await tester.start('p2', 'dart run build_runner build');
+    final output1 = await build1.expectAndGetBlock(BuildLog.successPattern);
+    final output2 = await build2.expectAndGetBlock(BuildLog.successPattern);
+    expect(
+      output1,
+      isNot(contains('Waiting for already-running build_runner.')),
+    );
+    expect(
+      output2,
+      isNot(contains('Waiting for already-running build_runner.')),
+    );
+
+    // Workspace build blocks on single package build.
+    final build3 = await tester.start('p1', 'dart run build_runner build');
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    final build4 = await tester.start(
+      '',
+      'dart run build_runner build --workspace',
+    );
+    await build4.expect('Waiting for already-running build_runner.');
+    await build3.expect(BuildLog.successPattern);
+    await build4.expect(BuildLog.successPattern);
+
+    // Single package build blocks on workspace build.
+    final build5 = await tester.start(
+      '',
+      'dart run build_runner build --workspace',
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    final build6 = await tester.start('p1', 'dart run build_runner build');
+    await build6.expect('Waiting for already-running build_runner.');
+    await build5.expect(BuildLog.successPattern);
+    await build6.expect(BuildLog.successPattern);
+
+    // Watch mode in a package exits if requested via `stop --workspace`.
+    final watch = await tester.start('p1', 'dart run build_runner watch');
+    await watch.expect(BuildLog.successPattern);
+    await tester
+        .run('p1', 'dart run build_runner stop --workspace')
+        .timeout(const Duration(seconds: 5));
+    await watch.expect('Exiting as requested by another build_runner process.');
+    await watch.exitCode;
+
+    // Watch mode in a package exits if requested via `stop` (without
+    // --workspace).
+    final watch2 = await tester.start('p1', 'dart run build_runner watch');
+    await watch2.expect(BuildLog.successPattern);
+    await tester
+        .run('p1', 'dart run build_runner stop')
+        .timeout(const Duration(seconds: 5));
+    await watch2.expect(
+      'Exiting as requested by another build_runner process.',
+    );
+    await watch2.exitCode;
+
+    // Watch mode in a package exits if requested via `stop --workspace` from
+    // another package.
+    final watch3 = await tester.start('p1', 'dart run build_runner watch');
+    await watch3.expect(BuildLog.successPattern);
+    await tester
+        .run('p2', 'dart run build_runner stop --workspace')
+        .timeout(const Duration(seconds: 5));
+    await watch3.expect(
+      'Exiting as requested by another build_runner process.',
+    );
+    await watch3.exitCode;
+  });
+}

--- a/build_runner/test/integration_tests/clean_command_test.dart
+++ b/build_runner/test/integration_tests/clean_command_test.dart
@@ -24,6 +24,43 @@ void main() async {
     await tester.run('root_pkg', 'dart run build_runner build');
     expect(tester.read('root_pkg/$entrypointScriptPath'), isNotNull);
     await tester.run('root_pkg', 'dart run build_runner clean');
-    expect(tester.readFileTree('root_pkg/.dart_tool/build'), isNull);
+    expect(tester.readFileTree('root_pkg/.dart_tool/build'), {
+      'lock/build_runner.lock': '',
+    });
+
+    // Clean --workspace deletes files in the workspace root.
+    tester.writePackage(
+      name: 'p1',
+      dependencies: ['build_runner'],
+      files: {},
+      inWorkspace: true,
+    );
+    tester.writePackage(
+      name: 'p2',
+      dependencies: ['build_runner'],
+      files: {},
+      inWorkspace: true,
+    );
+    tester.writeWorkspacePubspec(packages: ['p1', 'p2']);
+
+    await tester.run('p1', 'dart run build_runner build --workspace');
+
+    // TODO(davidmorgan): `build --workspace` should put the entrypoint in the
+    // workspace root when run from a subpackage. Currently it puts it in the
+    // subpackage.
+    expect(tester.read('p1/$entrypointScriptPath'), isNotNull);
+
+    // Check if asset graph is created in the workspace root.
+    expect(tester.read(assetGraphPath), isNotNull);
+
+    await tester.run('p1', 'dart run build_runner clean --workspace');
+
+    // Verify that clean --workspace deletes the asset graph.
+    expect(tester.read(assetGraphPath), isNull);
+
+    // TODO(davidmorgan): `clean --workspace` should delete the entrypoint in
+    // the workspace root once it is moved there. Currently it does not delete
+    // it because it is in the subpackage.
+    expect(tester.read('p1/$entrypointScriptPath'), isNotNull);
   });
 }

--- a/build_runner/test/integration_tests/watch_command_test.dart
+++ b/build_runner/test/integration_tests/watch_command_test.dart
@@ -44,7 +44,10 @@ void main() async {
     await watch.expect('wrote 0 outputs');
 
     // State on disk is updated so `build` knows to do nothing.
-    var output = await tester.run('root_pkg', 'dart run build_runner build');
+    var output = await tester.copyWorkspace().run(
+      'root_pkg',
+      'dart run build_runner build',
+    );
     expect(output, contains('wrote 0 outputs'));
 
     // New file.
@@ -53,7 +56,10 @@ void main() async {
     expect(tester.read('root_pkg/web/b.txt.copy'), 'b');
 
     // State on disk is updated so `build` knows to do nothing.
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.copyWorkspace().run(
+      'root_pkg',
+      'dart run build_runner build',
+    );
     expect(output, contains('wrote 0 outputs'));
 
     // Deleted file.
@@ -97,7 +103,10 @@ class TestBuilder implements Builder {
     expect(tester.read('root_pkg/web/a.txt.copy'), 'hardcoded');
 
     // State on disk is updated so `build` knows to do nothing.
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.copyWorkspace().run(
+      'root_pkg',
+      'dart run build_runner build',
+    );
     expect(output, contains('wrote 0 outputs'));
 
     // Builder config change, add a file but it has no effect.
@@ -125,7 +134,10 @@ targets:
     await watch.expect('wrote 0 outputs');
 
     // State on disk is updated so `build` knows to do nothing.
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.copyWorkspace().run(
+      'root_pkg',
+      'dart run build_runner build',
+    );
     expect(output, contains('wrote 0 outputs'));
 
     // No-op change to `package_config.json` causes a build.

--- a/build_runner/test/io/reader_writer_test.dart
+++ b/build_runner/test/io/reader_writer_test.dart
@@ -7,6 +7,7 @@ library;
 import 'dart:io';
 
 import 'package:build_runner/src/build_plan/build_packages.dart';
+import 'package:build_runner/src/build_plan/build_paths.dart';
 import 'package:build_runner/src/io/reader_writer.dart';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' as path;
@@ -42,8 +43,11 @@ void main() async {
       );
       await tester.run('basic_pkg', 'dart pub get');
 
-      buildPackages = await BuildPackages.forPath(
-        p.join(tempDirectory, 'basic_pkg'),
+      buildPackages = await BuildPackages.forPaths(
+        BuildPaths.load(
+          p.join(tempDirectory, 'basic_pkg'),
+          buildWorkspace: false,
+        ),
       );
       readerWriter = ReaderWriter(buildPackages);
     });


### PR DESCRIPTION
Inspired by https://github.com/dart-lang/build/pull/4874.

Introduce `BuildPaths` which is the current package path, the workspace path (if there is one) and whether to build the single package or the workspace.

Add locking to the `build_runner` process so only one command can run at once.

If a `watch` or `serve` has the lock, notify it so it will exit: immediately if no build is running, or after the build completes.

In a workspace, lock the whole workspace for a workspace build or just the package for a single package build.

The `daemon` command does not take or check the lock.

Add `stop` command that just requests the lock then exits.

Add `--workspace` flag to `clean` command.

Update an end to end test that was using concurrent build during `watch` for checking state: copy the workspace to do the concurrent build.