### PR TITLE
Workspace script path

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -27,6 +27,8 @@
   `build_runner serve web:0`. Before the fix, non-optional outputs to cache 
   under `web` would be skipped unless they were used by another build step. 
   With the fix, all non-optional outputs under `web` are built and served.
+- Bug fix: when building with `--workspace` generate the entrypoint and compiled
+  artifacts under the workspace root instead of the current package root.
 - Remove `code_builder` dependency so builders can use any version of it.
 
 ## 2.13.1

--- a/build_runner/lib/src/bootstrap/aot_compiler.dart
+++ b/build_runner/lib/src/bootstrap/aot_compiler.dart
@@ -4,6 +4,9 @@
 
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+
+import '../build_plan/build_paths.dart';
 import '../constants.dart';
 import 'compiler.dart';
 import 'depfile.dart';
@@ -15,11 +18,18 @@ const entrypointAotDigestPath = '$entrypointScriptPath.aot.digest';
 
 /// Compiles the build script to an AOT snapshot.
 class AotCompiler implements Compiler {
-  final Depfile _outputDepfile = Depfile(
-    outputPath: entrypointAotPath,
-    depfilePath: entrypointAotDepfilePath,
-    digestPath: entrypointAotDigestPath,
-  );
+  final BuildPaths buildPaths;
+  final Depfile _outputDepfile;
+
+  AotCompiler(this.buildPaths)
+    : _outputDepfile = Depfile(
+        outputPath: p.join(buildPaths.outputRootPath, entrypointAotPath),
+        depfilePath: p.join(
+          buildPaths.outputRootPath,
+          entrypointAotDepfilePath,
+        ),
+        digestPath: p.join(buildPaths.outputRootPath, entrypointAotDigestPath),
+      );
 
   @override
   FreshnessResult checkFreshness({required bool digestsAreFresh}) =>
@@ -34,11 +44,11 @@ class AotCompiler implements Compiler {
     final result = await ParentProcess.run(dart, [
       'compile',
       'aot-snapshot',
-      entrypointScriptPath,
+      p.join(buildPaths.outputRootPath, entrypointScriptPath),
       '--output',
-      entrypointAotPath,
+      p.join(buildPaths.outputRootPath, entrypointAotPath),
       '--depfile',
-      entrypointAotDepfilePath,
+      p.join(buildPaths.outputRootPath, entrypointAotDepfilePath),
       if (experiments != null)
         for (final experiment in experiments) '--enable-experiment=$experiment',
     ]);
@@ -48,8 +58,11 @@ class AotCompiler implements Compiler {
 
       // Convert "unknown experiment" warnings to errors.
       if (stdout.contains('Unknown experiment:')) {
-        if (File(entrypointAotPath).existsSync()) {
-          File(entrypointAotPath).deleteSync();
+        final aotFile = File(
+          p.join(buildPaths.outputRootPath, entrypointAotPath),
+        );
+        if (aotFile.existsSync()) {
+          aotFile.deleteSync();
         }
         final messages = stdout
             .split('\n')

--- a/build_runner/lib/src/bootstrap/bootstrapper.dart
+++ b/build_runner/lib/src/bootstrap/bootstrapper.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:built_collection/built_collection.dart';
+import 'package:path/path.dart' as p;
 
 import '../build_plan/build_paths.dart';
 import '../exceptions.dart';
@@ -39,7 +40,8 @@ class Bootstrapper {
   final Compiler _compiler;
 
   Bootstrapper({required this.buildPaths, required this.compileAot})
-    : _compiler = compileAot ? AotCompiler() : KernelCompiler();
+    : _compiler =
+          compileAot ? AotCompiler(buildPaths) : KernelCompiler(buildPaths);
 
   /// Generates the entrypoint script, compiles it and runs it with [arguments].
   ///
@@ -121,13 +123,16 @@ class Bootstrapper {
       final result =
           compileAot
               ? await ParentProcess.runAotSnapshotAndSend(
-                aotSnapshot: entrypointAotPath,
+                aotSnapshot: p.join(
+                  buildPaths.outputRootPath,
+                  entrypointAotPath,
+                ),
                 arguments: arguments,
                 message: buildProcessState.serialize(),
                 runUnderPerf: dartAotPerf,
               )
               : await ParentProcess.runAndSend(
-                script: entrypointDillPath,
+                script: p.join(buildPaths.outputRootPath, entrypointDillPath),
                 arguments: arguments,
                 message: buildProcessState.serialize(),
                 jitVmArgs: jitVmArgs,
@@ -151,7 +156,7 @@ class Bootstrapper {
   /// Reads before write so the file is not written if there is no change.
   Future<void> _writeBuildScript() async {
     final buildScript = await generateBuildScript(buildPaths: buildPaths);
-    final path = entrypointScriptPath;
+    final path = p.join(buildPaths.outputRootPath, entrypointScriptPath);
     final existingBuildScript =
         File(path).existsSync() ? File(path).readAsStringSync() : null;
     if (buildScript != existingBuildScript) {

--- a/build_runner/lib/src/bootstrap/kernel_compiler.dart
+++ b/build_runner/lib/src/bootstrap/kernel_compiler.dart
@@ -4,6 +4,9 @@
 
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+
+import '../build_plan/build_paths.dart';
 import '../constants.dart';
 import 'compiler.dart';
 import 'depfile.dart';
@@ -15,11 +18,18 @@ const entrypointDillDigestPath = '$entrypointScriptPath.dill.digest';
 
 /// Compiles the build script to kernel.
 class KernelCompiler implements Compiler {
-  final Depfile _outputDepfile = Depfile(
-    outputPath: entrypointDillPath,
-    depfilePath: entrypointDillDepfilePath,
-    digestPath: entrypointDillDigestPath,
-  );
+  final BuildPaths buildPaths;
+  final Depfile _outputDepfile;
+
+  KernelCompiler(this.buildPaths)
+    : _outputDepfile = Depfile(
+        outputPath: p.join(buildPaths.outputRootPath, entrypointDillPath),
+        depfilePath: p.join(
+          buildPaths.outputRootPath,
+          entrypointDillDepfilePath,
+        ),
+        digestPath: p.join(buildPaths.outputRootPath, entrypointDillDigestPath),
+      );
 
   @override
   FreshnessResult checkFreshness({required bool digestsAreFresh}) =>
@@ -34,11 +44,11 @@ class KernelCompiler implements Compiler {
     final result = await ParentProcess.run(dart, [
       'compile',
       'kernel',
-      entrypointScriptPath,
+      p.join(buildPaths.outputRootPath, entrypointScriptPath),
       '--output',
-      entrypointDillPath,
+      p.join(buildPaths.outputRootPath, entrypointDillPath),
       '--depfile',
-      entrypointDillDepfilePath,
+      p.join(buildPaths.outputRootPath, entrypointDillDepfilePath),
       if (experiments != null)
         for (final experiment in experiments) '--enable-experiment=$experiment',
     ]);
@@ -48,8 +58,11 @@ class KernelCompiler implements Compiler {
 
       // Convert "unknown experiment" warnings to errors.
       if (stdout.contains('Unknown experiment:')) {
-        if (File(entrypointDillPath).existsSync()) {
-          File(entrypointDillPath).deleteSync();
+        final dillFile = File(
+          p.join(buildPaths.outputRootPath, entrypointDillPath),
+        );
+        if (dillFile.existsSync()) {
+          dillFile.deleteSync();
         }
         final messages = stdout
             .split('\n')

--- a/build_runner/lib/src/build_plan/build_paths.dart
+++ b/build_runner/lib/src/build_plan/build_paths.dart
@@ -28,6 +28,11 @@ class BuildPaths {
     return BuildType.singlePackageInWorkspace;
   }
 
+  /// The path to the output root for this build.
+  ///
+  /// If [buildWorkspace] then [workspacePath], otherwise [packagePath].
+  String get outputRootPath => buildWorkspace ? workspacePath! : packagePath;
+
   BuildPaths({
     required this.packagePath,
     required this.buildWorkspace,

--- a/build_runner/test/integration_tests/aot_compiler_test.dart
+++ b/build_runner/test/integration_tests/aot_compiler_test.dart
@@ -25,8 +25,9 @@ void main() async {
         'bin/compile.dart': r'''
 import 'dart:io';
 import 'package:build_runner/src/bootstrap/aot_compiler.dart';
+import 'package:build_runner/src/build_plan/build_paths.dart';
 void main() async {
-  final compiler = AotCompiler();
+  final compiler = AotCompiler(BuildPaths(packagePath: '.', buildWorkspace: false));
   if (compiler.checkFreshness(digestsAreFresh: false).outputIsFresh) {
     stdout.write('fresh\n');
   } else {

--- a/build_runner/test/integration_tests/clean_command_test.dart
+++ b/build_runner/test/integration_tests/clean_command_test.dart
@@ -44,23 +44,11 @@ void main() async {
     tester.writeWorkspacePubspec(packages: ['p1', 'p2']);
 
     await tester.run('p1', 'dart run build_runner build --workspace');
-
-    // TODO(davidmorgan): `build --workspace` should put the entrypoint in the
-    // workspace root when run from a subpackage. Currently it puts it in the
-    // subpackage.
-    expect(tester.read('p1/$entrypointScriptPath'), isNotNull);
-
-    // Check if asset graph is created in the workspace root.
+    expect(tester.read(entrypointScriptPath), isNotNull);
     expect(tester.read(assetGraphPath), isNotNull);
 
     await tester.run('p1', 'dart run build_runner clean --workspace');
-
-    // Verify that clean --workspace deletes the asset graph.
     expect(tester.read(assetGraphPath), isNull);
-
-    // TODO(davidmorgan): `clean --workspace` should delete the entrypoint in
-    // the workspace root once it is moved there. Currently it does not delete
-    // it because it is in the subpackage.
-    expect(tester.read('p1/$entrypointScriptPath'), isNotNull);
+    expect(tester.read(entrypointScriptPath), isNull);
   });
 }

--- a/build_runner/test/integration_tests/kernel_compiler_test.dart
+++ b/build_runner/test/integration_tests/kernel_compiler_test.dart
@@ -25,8 +25,9 @@ void main() async {
         'bin/compile.dart': r'''
 import 'dart:io';
 import 'package:build_runner/src/bootstrap/kernel_compiler.dart';
+import 'package:build_runner/src/build_plan/build_paths.dart';
 void main() async {
-  final compiler = KernelCompiler();
+  final compiler = KernelCompiler(BuildPaths(packagePath: '.', buildWorkspace: false));
   if (compiler.checkFreshness(digestsAreFresh: false).outputIsFresh) {
     stdout.write('fresh\n');
   } else {


### PR DESCRIPTION
Test added in #4879 noticed that the entrypoint is always written in the "current" package, with the `--workspace` flag it should be written in the workspace root.

So, fix that :)