### PR TITLE
Compile builders with AOT by default.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - Performance: further improvements to management of files for analysis
   for 2x faster incremental builds.
+- Performance: default to AOT compilation for commands other than `run`. This
+  costs more initial startup time but gives faster builds afterwards. Fall back
+  to JIT if the compile fails due to use of `dart:mirrors`. Use the
+  `--force-jit` flag if you want the old default JIT builder compile. Use the
+  `--force-aot` flag to turn off the fallback to JIT compile.
 - Add OSC 8 hyperlinks for logged input paths.
 - Better handling of deletions of files during the build: if the file is not
   needed ignore the deletion, if it's needed try to use the cached version,

--- a/build_runner/lib/src/bootstrap/aot_compiler.dart
+++ b/build_runner/lib/src/bootstrap/aot_compiler.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 
 import '../build_plan/build_paths.dart';
 import '../constants.dart';
+import 'compile_type.dart';
 import 'compiler.dart';
 import 'depfile.dart';
 import 'processes.dart';
@@ -30,6 +31,9 @@ class AotCompiler implements Compiler {
         ),
         digestPath: p.join(buildPaths.outputRootPath, entrypointAotDigestPath),
       );
+
+  @override
+  CompileType get compileType => CompileType.aot;
 
   @override
   FreshnessResult checkFreshness({required bool digestsAreFresh}) =>

--- a/build_runner/lib/src/bootstrap/bootstrapper.dart
+++ b/build_runner/lib/src/bootstrap/bootstrapper.dart
@@ -12,6 +12,7 @@ import '../build_plan/build_paths.dart';
 import '../exceptions.dart';
 import '../internal.dart';
 import 'aot_compiler.dart';
+import 'compile_type.dart';
 import 'compiler.dart';
 import 'depfile.dart';
 import 'kernel_compiler.dart';
@@ -36,12 +37,11 @@ import 'processes.dart';
 /// and receives updated state when it exits.
 class Bootstrapper {
   final BuildPaths buildPaths;
-  final bool compileAot;
-  final Compiler _compiler;
+  final CompileStrategy compileStrategy;
+  Compiler _compiler;
 
-  Bootstrapper({required this.buildPaths, required this.compileAot})
-    : _compiler =
-          compileAot ? AotCompiler(buildPaths) : KernelCompiler(buildPaths);
+  Bootstrapper({required this.buildPaths, required this.compileStrategy})
+    : _compiler = compileStrategy.initialCompileType.createCompiler(buildPaths);
 
   /// Generates the entrypoint script, compiles it and runs it with [arguments].
   ///
@@ -71,7 +71,7 @@ class Bootstrapper {
       // Compile if there was any change.
       if (!_compiler.checkFreshness(digestsAreFresh: false).outputIsFresh) {
         final result = await buildLog.logCompile(
-          isAot: compileAot,
+          compileType: _compiler.compileType,
           function: () => _compiler.compile(experiments: experiments),
         );
 
@@ -89,17 +89,24 @@ class Bootstrapper {
             failedDueToMirrors = false;
           } else {
             failedDueToMirrors =
-                compileAot && result.messages!.contains('dart:mirrors');
+                _compiler.compileType == CompileType.aot &&
+                result.messages!.contains('dart:mirrors');
           }
           if (failedDueToMirrors) {
-            // TODO(davidmorgan): when build_runner manages use of AOT compile
-            // this will be an automatic fallback to JIT instead of a message.
-            buildLog.error(result.messages!);
-            buildLog.error(
-              'Failed to compile build script. A configured builder '
-              'uses `dart:mirrors` and cannot be compiled AOT. Try again '
-              'without --force-aot to use a JIT compile.',
+            if (compileStrategy == CompileStrategy.forceAot) {
+              buildLog.error(result.messages!);
+              buildLog.info(
+                'AOT compilation failed due to dart:mirrors usage. '
+                'Not falling back to JIT compilation due to --force-aot.',
+              );
+              throw const CannotBuildException();
+            }
+            buildLog.info(
+              'AOT compilation failed due to dart:mirrors usage. '
+              'Falling back to JIT compilation.',
             );
+            _compiler = CompileType.jit.createCompiler(buildPaths);
+            continue;
           } else {
             if (!messagesMatchPreviousMessages) {
               buildLog.error(result.messages!);
@@ -120,20 +127,26 @@ class Bootstrapper {
         }
       }
 
+      // The child process needs to know how it was compiled to check its
+      // freshness, so pass `--force-aot` or `--force-jit`, except for when
+      // strategy is alwaysJit.
       final result =
-          compileAot
+          _compiler.compileType == CompileType.aot
               ? await ParentProcess.runAotSnapshotAndSend(
                 aotSnapshot: p.join(
                   buildPaths.outputRootPath,
                   entrypointAotPath,
                 ),
-                arguments: arguments,
+                arguments: [...arguments, '--force-aot'],
                 message: buildProcessState.serialize(),
                 runUnderPerf: dartAotPerf,
               )
               : await ParentProcess.runAndSend(
                 script: p.join(buildPaths.outputRootPath, entrypointDillPath),
-                arguments: arguments,
+                arguments:
+                    compileStrategy == CompileStrategy.alwaysJit
+                        ? arguments.toList()
+                        : [...arguments, '--force-jit'],
                 message: buildProcessState.serialize(),
                 jitVmArgs: jitVmArgs,
               );

--- a/build_runner/lib/src/bootstrap/bootstrapper.dart
+++ b/build_runner/lib/src/bootstrap/bootstrapper.dart
@@ -144,7 +144,7 @@ class Bootstrapper {
               : await ParentProcess.runAndSend(
                 script: p.join(buildPaths.outputRootPath, entrypointDillPath),
                 arguments:
-                    compileStrategy == CompileStrategy.alwaysJit
+                    compileStrategy == CompileStrategy.commandForcesJit
                         ? arguments.toList()
                         : [...arguments, '--force-jit'],
                 message: buildProcessState.serialize(),

--- a/build_runner/lib/src/bootstrap/build_process_state.dart
+++ b/build_runner/lib/src/bootstrap/build_process_state.dart
@@ -7,6 +7,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
+import 'package:path/path.dart' as p;
+
 import '../build_plan/build_paths.dart';
 
 import 'build_process_lock.dart';
@@ -63,7 +65,7 @@ class BuildProcessState {
 
   /// For `buildLog`, console output capabilities.
   ///
-  /// If not already set, sets from the current process stdio on get.
+  /// If not already set, sets from the current process stdio.
   StdioCapabilities get stdio {
     _state['stdioCapabilities'] ??= StdioCapabilities().serialize();
     return StdioCapabilities.deserialize(
@@ -103,6 +105,9 @@ class BuildProcessState {
   set buildNumber(int buildNumber) => _state['buildNumber'] = buildNumber;
 
   /// The package config URI.
+  ///
+  /// If not already set, sets from the current process
+  /// `Isolate.packageConfigSync`.
   String get packageConfigUri =>
       (_state['packageConfigUri'] ??= Isolate.packageConfigSync!.toString())
           as String;
@@ -122,6 +127,19 @@ class BuildProcessState {
     _state['buildWorkspace'] = value?.buildWorkspace;
   }
 
+  /// The path to the Dart SDK.
+  ///
+  /// If not already set, sets from the current process
+  /// `Platform.resolvedExecutable`.
+  String get dartSdkPath {
+    _state['dartSdkPath'] ??= p.dirname(p.dirname(Platform.resolvedExecutable));
+    return _state['dartSdkPath'] as String;
+  }
+
+  set dartSdkPath(String value) {
+    _state['dartSdkPath'] = value;
+  }
+
   void resetForTests() {
     _state.clear();
   }
@@ -132,9 +150,13 @@ class BuildProcessState {
   }
 
   String serialize() {
-    // Set any unset values that should be set by the parent process.
-    stdio;
+    // Set unset values that can be read reliably only in the parent process
+    // because it is always JIT compiled.
+    dartSdkPath;
     packageConfigUri;
+    // Set unset terminal details that can only be read correctly by the parent
+    // process.
+    stdio;
 
     for (final beforeSend in _beforeSends) {
       beforeSend();

--- a/build_runner/lib/src/bootstrap/compile_type.dart
+++ b/build_runner/lib/src/bootstrap/compile_type.dart
@@ -31,7 +31,10 @@ enum CompileStrategy {
   /// Try AOT compilation, fall back to JIT if it fails.
   tryAot,
 
-  alwaysJit;
+  /// For the `run` command: JIT is required, so there are no flags and
+  /// `build_runner` knows to always use JIT and to check the JIT compile for
+  /// freshness.
+  commandForcesJit;
 
   CompileType get initialCompileType {
     switch (this) {
@@ -39,7 +42,7 @@ enum CompileStrategy {
       case CompileStrategy.tryAot:
         return CompileType.aot;
       case CompileStrategy.forceJit:
-      case CompileStrategy.alwaysJit:
+      case CompileStrategy.commandForcesJit:
         return CompileType.jit;
     }
   }

--- a/build_runner/lib/src/bootstrap/compile_type.dart
+++ b/build_runner/lib/src/bootstrap/compile_type.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../build_plan/build_paths.dart';
+import 'aot_compiler.dart';
+import 'compiler.dart';
+import 'kernel_compiler.dart';
+
+enum CompileType {
+  jit,
+  aot;
+
+  Compiler createCompiler(BuildPaths buildPaths) {
+    switch (this) {
+      case CompileType.aot:
+        return AotCompiler(buildPaths);
+      case CompileType.jit:
+        return KernelCompiler(buildPaths);
+    }
+  }
+
+  String get displayName => this == CompileType.aot ? 'aot' : 'jit';
+}
+
+enum CompileStrategy {
+  forceJit,
+
+  forceAot,
+
+  /// Try AOT compilation, fall back to JIT if it fails.
+  tryAot,
+
+  alwaysJit;
+
+  CompileType get initialCompileType {
+    switch (this) {
+      case CompileStrategy.forceAot:
+      case CompileStrategy.tryAot:
+        return CompileType.aot;
+      case CompileStrategy.forceJit:
+      case CompileStrategy.alwaysJit:
+        return CompileType.jit;
+    }
+  }
+}

--- a/build_runner/lib/src/bootstrap/compiler.dart
+++ b/build_runner/lib/src/bootstrap/compiler.dart
@@ -2,10 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'compile_type.dart';
 import 'depfile.dart';
 
 /// Compiles the build script.
 abstract class Compiler {
+  CompileType get compileType;
+
   /// Checks freshness of the build script compile output.
   ///
   /// Set [digestsAreFresh] if digests were very recently updated. Then, they

--- a/build_runner/lib/src/bootstrap/kernel_compiler.dart
+++ b/build_runner/lib/src/bootstrap/kernel_compiler.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 
 import '../build_plan/build_paths.dart';
 import '../constants.dart';
+import 'compile_type.dart';
 import 'compiler.dart';
 import 'depfile.dart';
 import 'processes.dart';
@@ -30,6 +31,9 @@ class KernelCompiler implements Compiler {
         ),
         digestPath: p.join(buildPaths.outputRootPath, entrypointDillDigestPath),
       );
+
+  @override
+  CompileType get compileType => CompileType.jit;
 
   @override
   FreshnessResult checkFreshness({required bool digestsAreFresh}) =>

--- a/build_runner/lib/src/build_plan/build_options.dart
+++ b/build_runner/lib/src/build_plan/build_options.dart
@@ -10,6 +10,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
+import '../bootstrap/compile_type.dart';
 import '../build_runner_command_line.dart';
 import 'build_directory.dart';
 import 'build_filter.dart';
@@ -22,12 +23,11 @@ class BuildOptions {
   final BuiltSet<BuildDirectory> buildDirs;
   final BuildPaths buildPaths;
   final BuiltSet<BuildFilter> buildFilters;
+  final CompileStrategy compileStrategy;
   final String? configKey;
   final BuiltList<String> enableExperiments;
   final bool enableLowResourcesMode;
   final bool dartAotPerf;
-  final bool forceAot;
-  final bool forceJit;
   final bool isReleaseBuild;
   final String? logPerformanceDir;
   final bool outputSymlinksOnly;
@@ -44,12 +44,11 @@ class BuildOptions {
     required this.buildPaths,
     required this.builderConfigOverrides,
     required this.buildFilters,
+    required this.compileStrategy,
     required this.configKey,
     required this.dartAotPerf,
     required this.enableExperiments,
     required this.enableLowResourcesMode,
-    required this.forceAot,
-    required this.forceJit,
     required this.isReleaseBuild,
     required this.logPerformanceDir,
     required this.outputSymlinksOnly,
@@ -68,12 +67,11 @@ class BuildOptions {
     BuiltSet<BuildDirectory>? buildDirs,
     BuildPaths? buildPaths,
     BuiltSet<BuildFilter>? buildFilters,
+    CompileStrategy? compileStrategy,
     String? configKey,
     bool? dartAotPerf,
     BuiltList<String>? enableExperiments,
     bool? enableLowResourcesMode,
-    bool? forceAot,
-    bool? forceJit,
     bool? isReleaseBuild,
     String? logPerformanceDir,
     bool? outputSymlinksOnly,
@@ -86,12 +84,11 @@ class BuildOptions {
     buildPaths:
         buildPaths ?? BuildPaths(packagePath: '.', buildWorkspace: false),
     buildFilters: buildFilters ?? BuiltSet(),
+    compileStrategy: compileStrategy ?? CompileStrategy.tryAot,
     configKey: configKey,
     dartAotPerf: dartAotPerf ?? false,
     enableExperiments: enableExperiments ?? BuiltList(),
     enableLowResourcesMode: enableLowResourcesMode ?? false,
-    forceAot: forceAot ?? false,
-    forceJit: forceJit ?? false,
     isReleaseBuild: isReleaseBuild ?? false,
     logPerformanceDir: logPerformanceDir,
     outputSymlinksOnly: outputSymlinksOnly ?? false,
@@ -119,6 +116,26 @@ class BuildOptions {
     required bool restIsBuildDirs,
     Iterable<String>? extraDirs,
   }) {
+    final forceAot = commandLine.forceAot!;
+    final forceJit = commandLine.forceJit!;
+    if (forceAot && forceJit) {
+      throw UsageException(
+        'Only one compile mode can be used, '
+        'got --$forceAotOption and --$forceJitOption.',
+        commandLine.usage,
+      );
+    }
+    CompileStrategy compileStrategy;
+    if (commandLine.type == CommandType.run) {
+      compileStrategy = CompileStrategy.alwaysJit;
+    } else if (forceJit) {
+      compileStrategy = CompileStrategy.forceJit;
+    } else if (forceAot) {
+      compileStrategy = CompileStrategy.forceAot;
+    } else {
+      compileStrategy = CompileStrategy.tryAot;
+    }
+
     final result = BuildOptions(
       buildDirs:
           {
@@ -139,8 +156,6 @@ class BuildOptions {
       dartAotPerf: commandLine.dartAotPerf ?? false,
       enableExperiments: commandLine.enableExperiments!,
       enableLowResourcesMode: commandLine.lowResourcesMode!,
-      forceAot: commandLine.forceAot!,
-      forceJit: commandLine.forceJit!,
       isReleaseBuild: commandLine.release!,
       logPerformanceDir: _parseLogPerformance(commandLine),
       outputSymlinksOnly: commandLine.symlink!,
@@ -148,21 +163,15 @@ class BuildOptions {
           commandLine.trackPerformance! || commandLine.logPerformance != null,
       verbose: commandLine.verbose!,
       verboseDurations: commandLine.verboseDurations!,
+      compileStrategy: compileStrategy,
     );
-
-    if (result.forceAot && result.forceJit) {
-      throw UsageException(
-        'Only one compile mode can be used, '
-        'got --$forceAotOption and --$forceJitOption.',
-        commandLine.usage,
-      );
-    }
     return result;
   }
 
   BuildOptions copyWith({
     BuiltSet<BuildDirectory>? buildDirs,
     BuiltSet<BuildFilter>? buildFilters,
+    CompileStrategy? compileStrategy,
   }) => BuildOptions(
     buildDirs: buildDirs ?? this.buildDirs,
     buildPaths: buildPaths,
@@ -172,14 +181,13 @@ class BuildOptions {
     dartAotPerf: dartAotPerf,
     enableExperiments: enableExperiments,
     enableLowResourcesMode: enableLowResourcesMode,
-    forceAot: forceAot,
-    forceJit: forceJit,
     isReleaseBuild: isReleaseBuild,
     logPerformanceDir: logPerformanceDir,
     outputSymlinksOnly: outputSymlinksOnly,
     trackPerformance: trackPerformance,
     verbose: verbose,
     verboseDurations: verboseDurations,
+    compileStrategy: compileStrategy ?? this.compileStrategy,
   );
 }
 

--- a/build_runner/lib/src/build_plan/build_options.dart
+++ b/build_runner/lib/src/build_plan/build_options.dart
@@ -125,16 +125,6 @@ class BuildOptions {
         commandLine.usage,
       );
     }
-    CompileStrategy compileStrategy;
-    if (commandLine.type == CommandType.run) {
-      compileStrategy = CompileStrategy.alwaysJit;
-    } else if (forceJit) {
-      compileStrategy = CompileStrategy.forceJit;
-    } else if (forceAot) {
-      compileStrategy = CompileStrategy.forceAot;
-    } else {
-      compileStrategy = CompileStrategy.tryAot;
-    }
 
     final result = BuildOptions(
       buildDirs:
@@ -163,7 +153,7 @@ class BuildOptions {
           commandLine.trackPerformance! || commandLine.logPerformance != null,
       verbose: commandLine.verbose!,
       verboseDurations: commandLine.verboseDurations!,
-      compileStrategy: compileStrategy,
+      compileStrategy: commandLine.compileStrategy,
     );
     return result;
   }

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -9,6 +9,7 @@ import 'package:build/experiments.dart';
 import 'package:built_collection/built_collection.dart';
 
 import '../bootstrap/bootstrapper.dart';
+import '../bootstrap/depfile.dart';
 import '../build/asset_graph/exceptions.dart';
 import '../build/asset_graph/graph.dart';
 import '../build/asset_graph/node.dart';
@@ -110,12 +111,15 @@ class BuildPlan {
   }) async {
     final bootstrapper = Bootstrapper(
       buildPaths: buildOptions.buildPaths,
-      compileAot: buildOptions.forceAot,
+      compileStrategy: buildOptions.compileStrategy,
     );
     var restartIsNeeded = false;
-    final kernelFreshness = await bootstrapper.checkCompileFreshness(
-      digestsAreFresh: recentlyBootstrapped,
-    );
+    final kernelFreshness =
+        testingOverrides.checkBuilderFreshness
+            ? await bootstrapper.checkCompileFreshness(
+              digestsAreFresh: recentlyBootstrapped,
+            )
+            : FreshnessResult(outputIsFresh: true, digest: 'dummy_digest');
     if (!kernelFreshness.outputIsFresh) {
       restartIsNeeded = true;
     }

--- a/build_runner/lib/src/build_plan/testing_overrides.dart
+++ b/build_runner/lib/src/build_plan/testing_overrides.dart
@@ -30,6 +30,7 @@ class TestingOverrides {
   final Resolvers? resolvers;
   final Stream<ProcessSignal>? terminateEventStream;
   final bool flattenOutput;
+  final bool checkBuilderFreshness;
 
   const TestingOverrides({
     this.builderDefinitions,
@@ -40,6 +41,7 @@ class TestingOverrides {
     this.defaultRootPackageSources,
     this.directoryWatcherFactory,
     this.flattenOutput = false,
+    this.checkBuilderFreshness = true,
     this.onLog,
     this.readerWriter,
     this.reportUnusedAssetsForInput,
@@ -65,5 +67,6 @@ class TestingOverrides {
     resolvers: resolvers,
     terminateEventStream: terminateEventStream,
     flattenOutput: flattenOutput,
+    checkBuilderFreshness: checkBuilderFreshness,
   );
 }

--- a/build_runner/lib/src/build_runner.dart
+++ b/build_runner/lib/src/build_runner.dart
@@ -13,6 +13,7 @@ import 'package:yaml/yaml.dart';
 
 import 'bootstrap/bootstrapper.dart';
 import 'bootstrap/build_process_state.dart';
+import 'bootstrap/compile_type.dart';
 import 'build_plan/build_options.dart';
 import 'build_plan/build_paths.dart';
 import 'build_plan/builder_factories.dart';
@@ -96,10 +97,28 @@ class BuildRunner {
       await buildProcessState.takeLock(buildPaths);
     }
 
+    if ((commandLine.forceAot ?? false) && (commandLine.forceJit ?? false)) {
+      throw UsageException(
+        'Only one compile mode can be used, '
+        'got --force-aot and --force-jit.',
+        commandLine.usage,
+      );
+    }
+
     if (commandLine.type.requiresBuilders && builderFactories == null) {
+      CompileStrategy compileStrategy;
+      if (commandLine.type == CommandType.run) {
+        compileStrategy = CompileStrategy.alwaysJit;
+      } else if (commandLine.forceJit ?? false) {
+        compileStrategy = CompileStrategy.forceJit;
+      } else if (commandLine.forceAot ?? false) {
+        compileStrategy = CompileStrategy.forceAot;
+      } else {
+        compileStrategy = CompileStrategy.tryAot;
+      }
       return await _runWithBuilders(
         buildPaths: buildPaths,
-        compileAot: commandLine.forceAot!,
+        compileStrategy: compileStrategy,
       );
     }
 
@@ -194,7 +213,7 @@ class BuildRunner {
   /// set, so it runs the command instead of bootstrapping.
   Future<int> _runWithBuilders({
     required BuildPaths buildPaths,
-    required bool compileAot,
+    required CompileStrategy compileStrategy,
   }) async {
     buildLog.configuration = buildLog.configuration.rebuild((b) {
       b.mode = commandLine.type.buildLogMode;
@@ -204,7 +223,7 @@ class BuildRunner {
 
     final bootstrapper = Bootstrapper(
       buildPaths: buildPaths,
-      compileAot: compileAot,
+      compileStrategy: compileStrategy,
     );
     return await bootstrapper.run(
       arguments,

--- a/build_runner/lib/src/build_runner.dart
+++ b/build_runner/lib/src/build_runner.dart
@@ -106,19 +106,9 @@ class BuildRunner {
     }
 
     if (commandLine.type.requiresBuilders && builderFactories == null) {
-      CompileStrategy compileStrategy;
-      if (commandLine.type == CommandType.run) {
-        compileStrategy = CompileStrategy.alwaysJit;
-      } else if (commandLine.forceJit ?? false) {
-        compileStrategy = CompileStrategy.forceJit;
-      } else if (commandLine.forceAot ?? false) {
-        compileStrategy = CompileStrategy.forceAot;
-      } else {
-        compileStrategy = CompileStrategy.tryAot;
-      }
       return await _runWithBuilders(
         buildPaths: buildPaths,
-        compileStrategy: compileStrategy,
+        compileStrategy: commandLine.compileStrategy,
       );
     }
 

--- a/build_runner/lib/src/build_runner_command_line.dart
+++ b/build_runner/lib/src/build_runner_command_line.dart
@@ -9,6 +9,7 @@ import 'package:args/command_runner.dart';
 import 'package:build_daemon/constants.dart';
 import 'package:built_collection/built_collection.dart';
 
+import 'bootstrap/compile_type.dart';
 import 'internal.dart';
 
 enum CommandType {
@@ -62,6 +63,13 @@ class BuildRunnerCommandLine {
   final bool? verbose;
   final bool? verboseDurations;
   final bool? workspace;
+
+  CompileStrategy get compileStrategy {
+    if (type == CommandType.run) return CompileStrategy.alwaysJit;
+    if (forceJit ?? false) return CompileStrategy.forceJit;
+    if (forceAot ?? false) return CompileStrategy.forceAot;
+    return CompileStrategy.tryAot;
+  }
 
   static Future<BuildRunnerCommandLine?> parse(Iterable<String> arguments) =>
       _CommandRunner().run(arguments);
@@ -229,7 +237,9 @@ class _Build extends _Command<BuildRunnerCommandLine> {
         forceAotOption,
         defaultsTo: false,
         negatable: false,
-        help: 'Compiles builders with AOT mode for faster builds.',
+        help:
+            'Forces AOT compilation of builders: disables fallback to '
+            'JIT mode.',
       )
       ..addFlag(
         forceJitOption,

--- a/build_runner/lib/src/build_runner_command_line.dart
+++ b/build_runner/lib/src/build_runner_command_line.dart
@@ -65,7 +65,7 @@ class BuildRunnerCommandLine {
   final bool? workspace;
 
   CompileStrategy get compileStrategy {
-    if (type == CommandType.run) return CompileStrategy.alwaysJit;
+    if (type == CommandType.run) return CompileStrategy.commandForcesJit;
     if (forceJit ?? false) return CompileStrategy.forceJit;
     if (forceAot ?? false) return CompileStrategy.forceAot;
     return CompileStrategy.tryAot;

--- a/build_runner/lib/src/commands/run_command.dart
+++ b/build_runner/lib/src/commands/run_command.dart
@@ -11,6 +11,7 @@ import 'package:io/io.dart';
 import 'package:path/path.dart' as p;
 
 import '../bootstrap/build_process_state.dart';
+import '../bootstrap/compile_type.dart';
 import '../build_plan/build_directory.dart';
 import '../build_plan/build_options.dart';
 import '../build_plan/builder_factories.dart';
@@ -69,6 +70,7 @@ class RunCommand implements BuildRunnerCommand {
         await BuildCommand(
           builderFactories: builderFactories,
           buildOptions: buildOptions.copyWith(
+            compileStrategy: CompileStrategy.forceJit,
             buildDirs: buildOptions.buildDirs.rebuild((b) {
               b.add(
                 BuildDirectory(

--- a/build_runner/lib/src/constants.dart
+++ b/build_runner/lib/src/constants.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:path/path.dart' as p;
+
+import 'bootstrap/build_process_state.dart';
 
 /// Relative path to the cache directory from the root package dir.
 const String cacheDirectoryPath = '.dart_tool/build';
@@ -20,10 +20,10 @@ final String assetGraphPath = '$cacheDirectoryPath/asset_graph.json';
 String get generatedOutputDirectory => '$cacheDirectoryPath/generated';
 
 /// The dart binary from the current sdk.
-final dartBinary = p.join(sdkBin, 'dart');
+String get dartBinary => p.join(sdkBin, 'dart');
 
 /// The path to the sdk bin directory on the current platform.
-final sdkBin = p.join(sdkPath, 'bin');
+String get sdkBin => p.join(sdkPath, 'bin');
 
 /// The path to the sdk on the current platform.
-final sdkPath = p.dirname(p.dirname(Platform.resolvedExecutable));
+String get sdkPath => buildProcessState.dartSdkPath;

--- a/build_runner/lib/src/logging/build_log.dart
+++ b/build_runner/lib/src/logging/build_log.dart
@@ -11,6 +11,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:path/path.dart' as p;
 
 import '../bootstrap/build_process_state.dart';
+import '../bootstrap/compile_type.dart';
 import '../build_plan/build_packages.dart';
 import '../build_plan/phase.dart';
 import 'ansi_buffer.dart';
@@ -262,31 +263,35 @@ class BuildLog {
   }
 
   Future<T> logCompile<T>({
-    required bool isAot,
+    required CompileType compileType,
     required Future<T> Function() function,
   }) async {
     final progress = _CompileProgress();
-    if (isAot) {
+    if (compileType == CompileType.aot) {
       _aotCompileProgress = progress;
     } else {
       _jitCompileProgress = progress;
     }
-    _compileTick(isAot: isAot, firstTick: true, lastTick: false);
+    _compileTick(compileType: compileType, firstTick: true, lastTick: false);
 
     final timer = Timer.periodic(
       const Duration(milliseconds: 100),
-      (_) => _compileTick(isAot: isAot, firstTick: false, lastTick: false),
+      (_) => _compileTick(
+        compileType: compileType,
+        firstTick: false,
+        lastTick: false,
+      ),
     );
     try {
       return await function();
     } finally {
       timer.cancel();
-      _compileTick(isAot: isAot, firstTick: false, lastTick: true);
+      _compileTick(compileType: compileType, firstTick: false, lastTick: true);
     }
   }
 
   void _compileTick({
-    required bool isAot,
+    required CompileType compileType,
     required bool firstTick,
     required bool lastTick,
   }) {
@@ -295,7 +300,7 @@ class BuildLog {
     _processDuration += duration;
 
     if (!firstTick) {
-      if (isAot) {
+      if (compileType == CompileType.aot) {
         _aotCompileProgress!.duration += duration;
       } else {
         _jitCompileProgress!.duration += duration;
@@ -308,7 +313,7 @@ class BuildLog {
       } else {
         _display.message(
           Severity.info,
-          _renderCompiling(isAot: isAot).toString(),
+          _renderCompiling(compileType: compileType).toString(),
         );
       }
     }
@@ -576,10 +581,10 @@ class BuildLog {
     final result = AnsiBuffer();
 
     if (_jitCompileProgress != null) {
-      result.write(_renderCompiling(isAot: false));
+      result.write(_renderCompiling(compileType: CompileType.jit));
     }
     if (_aotCompileProgress != null) {
-      result.write(_renderCompiling(isAot: true));
+      result.write(_renderCompiling(compileType: CompileType.aot));
     }
 
     final displayedProgressEntries = _phaseProgress.entries.where(
@@ -624,15 +629,18 @@ class BuildLog {
     return result;
   }
 
-  AnsiBufferLine _renderCompiling({required bool isAot}) {
-    final progress = isAot ? _aotCompileProgress! : _jitCompileProgress!;
+  AnsiBufferLine _renderCompiling({required CompileType compileType}) {
+    final progress =
+        compileType == CompileType.aot
+            ? _aotCompileProgress!
+            : _jitCompileProgress!;
     return AnsiBufferLine([
       renderDuration(progress.duration),
       ' ',
       AnsiBuffer.bold,
       'compiling builders',
       AnsiBuffer.reset,
-      '/${isAot ? 'aot' : 'jit'}',
+      '/${compileType.displayName}',
     ]);
   }
 

--- a/build_runner/test/integration_tests/build_command_aot_test.dart
+++ b/build_runner/test/integration_tests/build_command_aot_test.dart
@@ -14,6 +14,7 @@ void main() async {
     final pubspecs = await Pubspecs.load();
     final tester = BuildRunnerTester(pubspecs);
 
+    // Basic AOT build and rebuild on change.
     tester.writeFixturePackage(FixturePackages.copyBuilder());
     tester.writePackage(
       name: 'root_pkg',
@@ -44,5 +45,63 @@ void main() async {
       'dart run build_runner build --force-aot',
     );
     expect(output, contains('wrote 1 output'));
+
+    // Builder using `dart:mirrors`.
+    tester.writePackage(
+      name: 'builder_pkg',
+      dependencies: ['build', 'build_runner'],
+      files: {
+        'build.yaml': '''
+builders:
+  test_builder:
+    import: 'package:builder_pkg/builder.dart'
+    builder_factories: ['testBuilderFactory']
+    build_extensions: {'.txt': ['.g.dart']}
+    auto_apply: root_package
+    build_to: source
+''',
+        'lib/builder.dart': '''
+import 'dart:mirrors';
+import 'package:build/build.dart';
+
+Builder testBuilderFactory(BuilderOptions options) => TestBuilder();
+
+class TestBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {'.txt': ['.g.dart']};
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    print(currentMirrorSystem());
+  }
+}
+''',
+      },
+    );
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {'lib/a.txt': 'a'},
+    );
+
+    // Fall back to JIT and succeeds.
+    output = await tester.run('root_pkg', 'dart run build_runner build');
+    expect(
+      output,
+      contains('AOT compilation failed due to dart:mirrors usage.'),
+    );
+    expect(output, contains('Built with build_runner/jit'));
+
+    // With `--force-aot`, fails.
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-aot',
+      expectExitCode: 78,
+    );
+    expect(
+      output,
+      contains('Not falling back to JIT compilation due to --force-aot'),
+    );
   });
 }

--- a/build_runner/test/integration_tests/build_command_build_filter_test.dart
+++ b/build_runner/test/integration_tests/build_command_build_filter_test.dart
@@ -35,7 +35,7 @@ void main() async {
 
     await tester.run(
       'root_pkg',
-      'dart run build_runner build '
+      'dart run build_runner build --force-jit '
           '--build-filter package:*/a.txt.copy '
           '--build-filter web/a.txt.copy ',
     );

--- a/build_runner/test/integration_tests/build_command_config_validation_test.dart
+++ b/build_runner/test/integration_tests/build_command_config_validation_test.dart
@@ -30,7 +30,10 @@ targets:
       },
     );
 
-    var output = await tester.run('root_pkg', 'dart run build_runner build');
+    var output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(
       output,
       contains(
@@ -44,7 +47,10 @@ global_options:
   bad:builder:
     options: {}
 ''');
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(
       output,
       contains('Ignoring `global_options` for unknown builder `bad:builder`.'),
@@ -53,7 +59,7 @@ global_options:
     tester.delete('root_pkg/build.yaml');
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --define=bad:key=foo=bar',
+      'dart run build_runner build --force-jit --define=bad:key=foo=bar',
     );
     expect(
       output,
@@ -72,7 +78,7 @@ builders:
 ''');
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
       expectExitCode: ExitCode.config.code,
     );
     expect(output, contains("Error when reading 'missing_builder.dart'"));
@@ -90,7 +96,7 @@ builders:
 ''');
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
       expectExitCode: ExitCode.config.code,
     );
     expect(

--- a/build_runner/test/integration_tests/build_command_define_test.dart
+++ b/build_runner/test/integration_tests/build_command_define_test.dart
@@ -69,11 +69,14 @@ class TestBuilder implements Builder {
     );
 
     // Default dev build.
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/web/a.txt.copy'), 'a(default dev)');
 
     // Default release build.
-    await tester.run('root_pkg', 'dart run build_runner build --release');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --release',
+    );
     expect(tester.read('root_pkg/web/a.txt.copy'), 'a(default release)');
 
     // Configure via `build.yaml`.
@@ -89,16 +92,19 @@ targets:
         release_options:
           extra_content: "(yaml release)"
 ''');
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/web/a.txt.copy'), 'b(yaml dev)');
 
-    await tester.run('root_pkg', 'dart run build_runner build --release');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --release',
+    );
     expect(tester.read('root_pkg/web/a.txt.copy'), 'b(yaml release)');
 
     // Override with `--define`.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build '
+      'dart run build_runner build --force-jit '
           '--define=builder_pkg:test_builder=copy_from=root_pkg|web/a.txt',
     );
     expect(tester.read('root_pkg/web/a.txt.copy'), 'a(yaml dev)');
@@ -106,7 +112,7 @@ targets:
     // Override with `--define` and `--release`.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --release '
+      'dart run build_runner build --force-jit --release '
           '--define=builder_pkg:test_builder=copy_from=root_pkg|web/a.txt',
     );
     expect(tester.read('root_pkg/web/a.txt.copy'), 'a(yaml release)');
@@ -129,7 +135,7 @@ global_options:
     options:
       extra_content: "(global)"
 ''');
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/web/a.txt.copy'), 'b(global)');
 
     // Change to a workspace.
@@ -144,7 +150,7 @@ global_options:
 
     // Build with --workspace. Package options from `root_pkg/build.yaml`
     // still apply, but global options from `root_pkg/build.yaml` don't.
-    await tester.run('', 'dart run build_runner build --workspace');
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
     expect(tester.read('root_pkg/web/a.txt.copy'), 'b(yaml dev)');
 
     // Global options from workspace root `build.yaml` are used.
@@ -154,7 +160,7 @@ global_options:
     options:
       extra_content: "(workspace global)"
 ''');
-    await tester.run('', 'dart run build_runner build --workspace');
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
     expect(tester.read('root_pkg/web/a.txt.copy'), 'b(workspace global)');
   });
 }

--- a/build_runner/test/integration_tests/build_command_errors_test.dart
+++ b/build_runner/test/integration_tests/build_command_errors_test.dart
@@ -55,7 +55,7 @@ class TestBuilder implements Builder {
 
     var output = await tester.run(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
       expectExitCode: 1,
     );
     expect(output, contains('builder ran'));
@@ -65,7 +65,7 @@ class TestBuilder implements Builder {
     // Errors are serialized so the error is reported again; the warning is not.
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
       expectExitCode: 1,
     );
     expect(output, isNot(contains('builder ran')));
@@ -81,7 +81,7 @@ class TestBuilder implements Builder {
     );
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
       expectExitCode: 1,
     );
     expect(output, contains('builder ran'));

--- a/build_runner/test/integration_tests/build_command_find_assets_test.dart
+++ b/build_runner/test/integration_tests/build_command_find_assets_test.dart
@@ -59,7 +59,7 @@ class GlobbingBuilder extends Builder {
     );
 
     // Glob matches the expected files.
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/web/a.matchingFiles')!.split('\n'), [
       'root_pkg|web/a.txt',
       'root_pkg|web/b.txt',
@@ -67,7 +67,7 @@ class GlobbingBuilder extends Builder {
 
     // On rebuild glob matches a new file.
     tester.write('root_pkg/web/c.txt', '');
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/web/a.matchingFiles')!.split('\n'), [
       'root_pkg|web/a.txt',
       'root_pkg|web/b.txt',
@@ -76,7 +76,7 @@ class GlobbingBuilder extends Builder {
 
     // On rebuild glob no longer matches a deleted file.
     tester.delete('root_pkg/web/c.txt');
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/web/a.matchingFiles')!.split('\n'), [
       'root_pkg|web/a.txt',
       'root_pkg|web/b.txt',
@@ -84,7 +84,10 @@ class GlobbingBuilder extends Builder {
 
     // No work on rebuild for a new non-matching file.
     tester.write('root_pkg/web/c.other', '');
-    var output = await tester.run('root_pkg', 'dart run build_runner build');
+    var output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(output, contains('wrote 0 outputs'));
     expect(tester.read('root_pkg/web/a.matchingFiles')!.split('\n'), [
       'root_pkg|web/a.txt',
@@ -94,7 +97,10 @@ class GlobbingBuilder extends Builder {
     // No work on rebuild for changed matching file: the builder does not read
     // the files so they are not inputs.
     tester.write('root_pkg/web/a.txt', 'changed');
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(output, contains('wrote 0 outputs'));
     expect(tester.read('root_pkg/web/a.matchingFiles')!.split('\n'), [
       'root_pkg|web/a.txt',

--- a/build_runner/test/integration_tests/build_command_invalidation_test.dart
+++ b/build_runner/test/integration_tests/build_command_invalidation_test.dart
@@ -28,18 +28,27 @@ void main() async {
         'root_pkg/.dart_tool/build/generated/fake_output';
 
     // First build.
-    var output = await tester.run('root_pkg', 'dart run build_runner build');
+    var output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(output, contains('build_runner/jit'));
     expect(tester.read('root_pkg/web/a.txt.copy'), 'a');
 
     // With no changes, no rebuild.
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(output, contains('wrote 0 outputs'));
 
     // Change the build script, rebuilds.
     tester.update('builder_pkg/lib/builder.dart', (script) => '$script\n');
     tester.write(fakeGeneratedOutput, '');
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(output, contains('wrote 1 output'));
     expect(tester.read(fakeGeneratedOutput), null);
 
@@ -49,7 +58,7 @@ void main() async {
       'builder_pkg/lib/builder.dart',
       (script) => script.replaceAll('.copy', '.copy2'),
     );
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/web/a.txt.copy'), null);
     expect(tester.read('root_pkg/web/a.txt.copy2'), 'a');
 
@@ -60,7 +69,10 @@ void main() async {
       (json) => json.replaceAll('"version":', '"version":1'),
     );
     tester.write(fakeGeneratedOutput, '');
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(output, contains('wrote 1 output'));
     expect(tester.read(fakeGeneratedOutput), null);
 
@@ -78,11 +90,17 @@ void main() async {
       pathDependencies: ['build_runner'],
       files: {},
     );
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(output, contains('wrote 1 output'));
 
     // No change, no rebuild.
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(output, contains('wrote 0 outputs'));
 
     // Change `build_runner` source, rebuilds.
@@ -90,7 +108,10 @@ void main() async {
       'build_runner/lib/src/build_runner.dart',
       (script) => '$script\n',
     );
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     expect(output, contains('wrote 1 output'));
   });
 }

--- a/build_runner/test/integration_tests/build_command_output_only_required_test.dart
+++ b/build_runner/test/integration_tests/build_command_output_only_required_test.dart
@@ -23,7 +23,10 @@ void main() async {
     );
 
     // Initial build produces no output as the copy is not required.
-    await tester.run('root_pkg', 'dart run build_runner build --output build');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --output build',
+    );
     expect(tester.readFileTree('root_pkg/build/packages/root_pkg'), {
       'a.txt': 'a',
       'b.txt': 'b',
@@ -31,7 +34,10 @@ void main() async {
 
     // Read a copy so that it is now required.
     tester.write('root_pkg/lib/new.read', 'root_pkg|lib/a.txt.copy');
-    await tester.run('root_pkg', 'dart run build_runner build --output build');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --output build',
+    );
     expect(tester.readFileTree('root_pkg/build/packages/root_pkg'), {
       'new.read': 'root_pkg|lib/a.txt.copy',
       'a.txt': 'a',
@@ -41,7 +47,10 @@ void main() async {
 
     // Stop requiring the copy and it is no longer output to `build`.
     tester.delete('root_pkg/lib/new.read');
-    await tester.run('root_pkg', 'dart run build_runner build --output build');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --output build',
+    );
     expect(tester.readFileTree('root_pkg/build/packages/root_pkg'), {
       'a.txt': 'a',
       'b.txt': 'b',
@@ -69,7 +78,7 @@ void main() async {
     );
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output build --build-filter other/*',
+      'dart run build_runner build --force-jit --output build --build-filter other/*',
     );
   });
 }

--- a/build_runner/test/integration_tests/build_command_output_test.dart
+++ b/build_runner/test/integration_tests/build_command_output_test.dart
@@ -24,14 +24,17 @@ void main() async {
     );
 
     // The --output option creates a merged output directory.
-    await tester.run('root_pkg', 'dart run build_runner build --output build');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --output build',
+    );
     expect(tester.read('root_pkg/build/web/a.txt.copy'), 'a');
     expect(tester.read('root_pkg/build/web/b.txt.copy'), 'b');
 
     // No rebuild if nothing changed.
     var output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --output build',
+      'dart run build_runner build --force-jit --output build',
     );
     expect(output, contains('wrote 0 outputs'));
     // Output is copied the same.
@@ -41,7 +44,7 @@ void main() async {
     // The --output option filters to --build-filter.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output build --build-filter web/b.txt.copy',
+      'dart run build_runner build --force-jit --output build --build-filter web/b.txt.copy',
     );
     expect(tester.read('root_pkg/build/web/a.txt.copy'), null);
     expect(tester.read('root_pkg/build/web/b.txt.copy'), 'b');
@@ -49,7 +52,7 @@ void main() async {
     // The --output option accepts a root.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build',
+      'dart run build_runner build --force-jit --output web:build',
     );
     expect(tester.read('root_pkg/build/a.txt.copy'), 'a');
     expect(tester.read('root_pkg/build/b.txt.copy'), 'b');
@@ -57,7 +60,7 @@ void main() async {
     // The --output option can be passed multiple times.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output build1 --output build2',
+      'dart run build_runner build --force-jit --output build1 --output build2',
     );
     expect(tester.read('root_pkg/build1/web/a.txt.copy'), 'a');
     expect(tester.read('root_pkg/build1/web/b.txt.copy'), 'b');
@@ -67,7 +70,8 @@ void main() async {
     // Duplicate --output options are an error.
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build --output test:build',
+      'dart run build_runner build --force-jit --output web:build '
+          '--output test:build',
       expectExitCode: ExitCode.usage.code,
     );
     expect(
@@ -81,7 +85,7 @@ void main() async {
     // Can only specify top level directories to build.
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --output lib/something:build',
+      'dart run build_runner build --force-jit --output lib/something:build',
       expectExitCode: ExitCode.usage.code,
     );
     expect(
@@ -95,7 +99,8 @@ void main() async {
     // Correct output with specified folder and --symlink.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build_web --symlink',
+      'dart run build_runner build --force-jit --output web:build_web '
+          '--symlink',
     );
     expect(tester.read('root_pkg/build_web/a.txt.copy'), 'a');
     expect(tester.read('root_pkg/build_web/b.txt.copy'), 'b');
@@ -105,7 +110,7 @@ void main() async {
     tester.delete('root_pkg/build/.build.manifest');
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --output build',
+      'dart run build_runner build --force-jit --output build',
       expectExitCode: ExitCode.cantCreate.code,
     );
     expect(

--- a/build_runner/test/integration_tests/build_command_packages_and_paths_test.dart
+++ b/build_runner/test/integration_tests/build_command_packages_and_paths_test.dart
@@ -26,7 +26,7 @@ void main() async {
     tester.writePackage(name: 'other_pkg', files: {'lib/b.txt': 'b'});
 
     // Runs in a subdirectory of the package.
-    await tester.run('root_pkg/lib', 'dart run build_runner build');
+    await tester.run('root_pkg/lib', 'dart run build_runner build --force-jit');
     expect(tester.readFileTree('root_pkg/.dart_tool/build/generated'), {
       'root_pkg/lib/a.txt.copy': 'a',
       'other_pkg/lib/b.txt.copy': 'b',
@@ -40,7 +40,7 @@ void main() async {
       files: {'lib/a.txt': 'a'},
     );
     _deletePubspecs(tester);
-    await tester.run('root_pkg/lib', 'dart run build_runner build');
+    await tester.run('root_pkg/lib', 'dart run build_runner build --force-jit');
     expect(tester.readFileTree('root_pkg/.dart_tool/build/generated'), {
       'root_pkg/lib/a.txt.copy': 'a',
     });
@@ -62,7 +62,7 @@ void main() async {
 
     // Files still not generated for `other_pkg` as it's not a dep.
     _deletePubspecs(tester);
-    await tester.run('root_pkg/lib', 'dart run build_runner build');
+    await tester.run('root_pkg/lib', 'dart run build_runner build --force-jit');
     expect(tester.readFileTree('root_pkg/.dart_tool/build/generated'), {
       'root_pkg/lib/a.txt.copy': 'a',
     });
@@ -79,7 +79,7 @@ void main() async {
 
     // Files generated for `other_pkg` now it's a dep.
     _deletePubspecs(tester);
-    await tester.run('root_pkg/lib', 'dart run build_runner build');
+    await tester.run('root_pkg/lib', 'dart run build_runner build --force-jit');
     expect(tester.readFileTree('root_pkg/.dart_tool/build/generated'), {
       'root_pkg/lib/a.txt.copy': 'a',
       'other_pkg/lib/b.txt.copy': 'b',

--- a/build_runner/test/integration_tests/build_command_post_process_builder_test.dart
+++ b/build_runner/test/integration_tests/build_command_post_process_builder_test.dart
@@ -23,7 +23,10 @@ void main() async {
     );
 
     // Initial build.
-    await tester.run('root_pkg', 'dart run build_runner build --output build');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --output build',
+    );
     expect(tester.readFileTree('root_pkg/build/packages/root_pkg'), {
       'a.txt': 'a',
       'a.txt.post': 'a(default dev)',
@@ -32,7 +35,7 @@ void main() async {
     // No rebuild if nothing changed.
     var output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --output build',
+      'dart run build_runner build --force-jit --output build',
     );
     expect(output, contains('wrote 0 outputs'));
     // Output is copied the same.
@@ -45,7 +48,7 @@ void main() async {
     tester.write('root_pkg/lib/a.txt', 'b');
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --output build',
+      'dart run build_runner build --force-jit --output build',
     );
     expect(output, contains('wrote 1 output'));
     // Restore the original input.
@@ -54,7 +57,7 @@ void main() async {
     // Release build.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build '
+      'dart run build_runner build --force-jit '
           '--output build --release',
     );
     expect(tester.readFileTree('root_pkg/build/packages/root_pkg'), {
@@ -75,7 +78,10 @@ targets:
         release_options:
           extra_content: "(yaml release)"
 ''');
-    await tester.run('root_pkg', 'dart run build_runner build --output build');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --output build',
+    );
     expect(tester.readFileTree('root_pkg/build/packages/root_pkg'), {
       'a.txt': 'a',
       'a.txt.other_post': 'a(yaml dev)',
@@ -84,7 +90,7 @@ targets:
     // Configure with `--define`.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output build '
+      'dart run build_runner build --force-jit --output build '
           '--define=builder_pkg:test_post_process_builder=output_extension='
           '.third_post',
     );
@@ -96,7 +102,7 @@ targets:
     // Configure with `--define` and `--release`.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output build '
+      'dart run build_runner build --force-jit --output build '
           '--define=builder_pkg:test_post_process_builder=output_extension='
           '.third_post --release',
     );
@@ -110,16 +116,16 @@ targets:
       FixturePackages.postProcessCopyBuilder(buildToCache: false),
     );
     tester.delete('root_pkg/build.yaml');
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/lib/a.txt.post'), 'a(default dev)');
     tester.write('root_pkg/lib/a.txt', 'b');
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/lib/a.txt.post'), 'b(default dev)');
 
     // Build to source deletes old outputs.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build '
+      'dart run build_runner build --force-jit '
           '--define=builder_pkg:test_post_process_builder=output_extension='
           '.more_post',
     );
@@ -128,7 +134,7 @@ targets:
     tester.write('root_pkg/lib/a.txt', 'c');
     await tester.run(
       'root_pkg',
-      'dart run build_runner build '
+      'dart run build_runner build --force-jit '
           '--define=builder_pkg:test_post_process_builder=output_extension='
           '.more_post',
     );

--- a/build_runner/test/integration_tests/build_command_resolve_test.dart
+++ b/build_runner/test/integration_tests/build_command_resolve_test.dart
@@ -59,7 +59,7 @@ syntax error
     // Syntax error.
     var output = await tester.run(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
       expectExitCode: 1,
     );
     expect(output, contains("Expected to find ';'"));
@@ -68,11 +68,17 @@ syntax error
     tester.write('root_pkg/lib/a.dart', '''
 import 'missing_import.dart';
 ''');
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
 
     // Unreadable inputs in previous build do not break incremental build.
     tester.update('root_pkg/lib/a.dart', (script) => '$script\n');
-    output = await tester.run('root_pkg', 'dart run build_runner build');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
 
     // Check that it's possible for a builder to resolve source in strings using
     // `build_test`.
@@ -122,7 +128,7 @@ class TestBuilder implements Builder {
       files: {'lib/a.dart': ''},
     );
 
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/lib/a.g.dart'), 'library x;');
   });
 }

--- a/build_runner/test/integration_tests/build_command_resolve_test.dart
+++ b/build_runner/test/integration_tests/build_command_resolve_test.dart
@@ -56,8 +56,20 @@ syntax error
       },
     );
 
-    // Syntax error.
+    // Syntax error in default, AOT and JIT compile modes.
     var output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build',
+      expectExitCode: 1,
+    );
+    expect(output, contains("Expected to find ';'"));
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-aot',
+      expectExitCode: 1,
+    );
+    expect(output, contains("Expected to find ';'"));
+    output = await tester.run(
       'root_pkg',
       'dart run build_runner build --force-jit',
       expectExitCode: 1,

--- a/build_runner/test/integration_tests/build_command_vm_arg_test.dart
+++ b/build_runner/test/integration_tests/build_command_vm_arg_test.dart
@@ -21,7 +21,7 @@ void main() {
     // check that help output is emitted to verify that the option is respected.
     final output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --dart-jit-vm-arg=--help',
+      'dart run build_runner build --force-jit --dart-jit-vm-arg=--help',
     );
 
     expect(output, contains('Run "dart help" to see global options.'));

--- a/build_runner/test/integration_tests/build_command_workspace_root_test.dart
+++ b/build_runner/test/integration_tests/build_command_workspace_root_test.dart
@@ -43,28 +43,28 @@ dependencies:
     tester.write('lib/w.txt', '1');
 
     // Build without --workspace then build with, no input change.
-    await tester.run('', 'dart run build_runner build');
+    await tester.run('', 'dart run build_runner build --force-jit');
     expect(tester.read('lib/w.txt.copy'), '1');
     expect(
       tester.read('p1/lib/p1.txt.copy'),
       null,
     ); // No build of nested package.
-    await tester.run('', 'dart run build_runner build --workspace');
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
     expect(tester.read('lib/w.txt.copy'), '1');
     expect(tester.read('p1/lib/p1.txt.copy'), '1');
 
     // Build without --workspace then build with, input change in between.
-    await tester.run('', 'dart run build_runner build');
+    await tester.run('', 'dart run build_runner build --force-jit');
     expect(tester.read('lib/w.txt.copy'), '1');
     tester.write('lib/w.txt', '2');
     tester.write('p1/lib/p1.txt', '2');
-    await tester.run('', 'dart run build_runner build --workspace');
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
     expect(tester.read('lib/w.txt.copy'), '2');
     expect(tester.read('p1/lib/p1.txt.copy'), '2');
 
     // Build without --workspace again, no input change.
     tester.write('p1/lib/p1.txt', '3');
-    await tester.run('', 'dart run build_runner build');
+    await tester.run('', 'dart run build_runner build --force-jit');
     expect(tester.read('lib/w.txt.copy'), '2');
     expect(
       tester.read('p1/lib/p1.txt.copy'),
@@ -72,12 +72,12 @@ dependencies:
     ); // No build of nested package.
 
     // Build with --workspace then without, input change in between.
-    await tester.run('', 'dart run build_runner build --workspace');
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
     expect(tester.read('lib/w.txt.copy'), '2');
     expect(tester.read('p1/lib/p1.txt.copy'), '3');
     tester.write('lib/w.txt', '3');
     tester.write('p1/lib/p1.txt', '4');
-    await tester.run('', 'dart run build_runner build');
+    await tester.run('', 'dart run build_runner build --force-jit');
     expect(tester.read('lib/w.txt.copy'), '3');
     expect(
       tester.read('p1/lib/p1.txt.copy'),

--- a/build_runner/test/integration_tests/build_command_workspace_test.dart
+++ b/build_runner/test/integration_tests/build_command_workspace_test.dart
@@ -37,7 +37,7 @@ void main() async {
     tester.writeWorkspacePubspec(packages: ['p1']);
 
     // Run without --workspace in p1, builders apply.
-    await tester.run('p1', 'dart run build_runner build');
+    await tester.run('p1', 'dart run build_runner build --force-jit');
     expect(tester.read('p1/lib/p1.txt.copy'), '1');
     expect(
       tester.read('p1/.dart_tool/build/generated/p1/lib/p1.txt.hidden'),
@@ -47,7 +47,10 @@ void main() async {
     // Run with --workspace in p1, builders apply, logs with package name.
     tester.write('p1/lib/p1.txt', '2');
     expect(
-      await tester.run('p1', 'dart run build_runner build --workspace'),
+      await tester.run(
+        'p1',
+        'dart run build_runner build --force-jit --workspace',
+      ),
       contains('on 1 input; p1|lib/p1.txt'),
     );
     expect(tester.read('p1/lib/p1.txt.copy'), '2');
@@ -57,7 +60,10 @@ void main() async {
     // Run with --workspace in workspace root, builders apply.
     tester.write('p1/lib/p1.txt', '3');
     expect(
-      await tester.run('', 'dart run build_runner build --workspace'),
+      await tester.run(
+        '',
+        'dart run build_runner build --force-jit --workspace',
+      ),
       contains('on 1 input; p1|lib/p1.txt'),
     );
     expect(tester.read('p1/lib/p1.txt.copy'), '3');
@@ -73,7 +79,7 @@ void main() async {
     tester.writeWorkspacePubspec(packages: ['p1', 'p2']);
 
     // Builders do not apply.
-    await tester.run('', 'dart run build_runner build --workspace');
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
     expect(tester.read('p2/lib/p2.txt.copy'), null);
     expect(
       tester.read('.dart_tool/build/generated/p2/lib/p2.txt.hidden'),
@@ -91,7 +97,10 @@ void main() async {
     tester.writeWorkspacePubspec(packages: ['p1', 'p2', 'p3']);
 
     // Builders run.
-    await tester.run('p3', 'dart run build_runner build --workspace');
+    await tester.run(
+      'p3',
+      'dart run build_runner build --force-jit --workspace',
+    );
     expect(tester.read('p3/lib/p3.txt.copy'), '1');
     expect(tester.read('.dart_tool/build/generated/p3/lib/p3.txt.hidden'), '1');
 
@@ -120,7 +129,7 @@ void main() async {
 
     // Builders can apply to `p4` and `p5` because they are (transitive) deps
     // of `p1`.
-    await tester.run('', 'dart run build_runner build --workspace');
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
     // `AutoApply.root` does not apply because the builder is not a transitive
     // dep of `p4` or `p5`.
     expect(tester.read('p4/lib/p4.txt.copy'), null);
@@ -150,7 +159,7 @@ void main() async {
 
     // The builder applied by second_copy_builder_pkg runs despite not
     // being auto applied.
-    await tester.run('', 'dart run build_runner build --workspace');
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
     expect(tester.read('p6/lib/p6.txt.copy'), '1');
 
     // Support for globs in workspaces was added in 3.11.
@@ -158,7 +167,7 @@ void main() async {
       packages: ["'p*'"],
       sdkBound: '>=3.11.0 <4.0.0',
     );
-    await tester.run('', 'dart run build_runner build --workspace');
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
 
     // Write a builder that applies an unknown builder in its build.yaml, the
     // unknown builder is ignored.
@@ -171,6 +180,6 @@ void main() async {
         pathDependencies: ['builder_pkg'],
       ),
     );
-    await tester.run('', 'dart run build_runner build --workspace');
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
   });
 }

--- a/build_runner/test/integration_tests/build_command_write_batching_test.dart
+++ b/build_runner/test/integration_tests/build_command_write_batching_test.dart
@@ -32,7 +32,10 @@ void main() async {
     );
 
     // The delete should be deferred until the new output is ready.
-    final build = await tester.start('root_pkg', 'dart run build_runner build');
+    final build = await tester.start(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
     await build.expect('builder_pkg:test_builder');
     expect(tester.read('root_pkg/web/a.txt.copy'), 'old');
     await build.expect(BuildLog.successPattern);
@@ -41,7 +44,7 @@ void main() async {
     // Don't write identical files.
     final stat1 = tester.stat('root_pkg/web/a.txt.copy');
     tester.delete('root_pkg/.dart_tool/build/asset_graph.json');
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     final stat2 = tester.stat('root_pkg/web/a.txt.copy');
     // The file should not have been rewritten. Confirm that `modified` is
     // unchanged. The delay in the builder means it would change reliably

--- a/build_runner/test/integration_tests/build_process_lock_test.dart
+++ b/build_runner/test/integration_tests/build_process_lock_test.dart
@@ -25,12 +25,12 @@ void main() async {
     // One build blocks waiting for another.
     final build1 = await tester.start(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
     );
     await build1.expect('compiling builders');
     final build2 = await tester.start(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
     );
     await build2.expect('Waiting for already-running build_runner.');
     await build1.exitCode;
@@ -128,14 +128,17 @@ Future<void> main() async {
       pathDependencies: ['builder_pkg'],
       files: {'lib/p1.txt': '1'},
     );
-    var watch = await tester.start('p1', 'dart run build_runner watch');
+    var watch = await tester.start(
+      'p1',
+      'dart run build_runner watch --force-jit',
+    );
     await watch.expect('builder_pkg:test_builder on 1 input');
     await tester.run('p1', 'dart run build_runner stop');
     await watch.expect('Exiting as requested by another build_runner process.');
     await watch.exitCode;
 
     // Watch mode exits if requested while idle.
-    watch = await tester.start('p1', 'dart run build_runner watch');
+    watch = await tester.start('p1', 'dart run build_runner watch --force-jit');
     await watch.expect(BuildLog.successPattern);
     await tester.run('p1', 'dart run build_runner stop');
     await watch.expect('Exiting as requested by another build_runner process.');

--- a/build_runner/test/integration_tests/build_process_lock_workspace_test.dart
+++ b/build_runner/test/integration_tests/build_process_lock_workspace_test.dart
@@ -40,8 +40,14 @@ void main() async {
     tester.writeWorkspacePubspec(packages: ['p1', 'p2']);
 
     // Two single package builds can run concurrently.
-    final build1 = await tester.start('p1', 'dart run build_runner build');
-    final build2 = await tester.start('p2', 'dart run build_runner build');
+    final build1 = await tester.start(
+      'p1',
+      'dart run build_runner build --force-jit',
+    );
+    final build2 = await tester.start(
+      'p2',
+      'dart run build_runner build --force-jit',
+    );
     final output1 = await build1.expectAndGetBlock(BuildLog.successPattern);
     final output2 = await build2.expectAndGetBlock(BuildLog.successPattern);
     expect(
@@ -54,11 +60,14 @@ void main() async {
     );
 
     // Workspace build blocks on single package build.
-    final build3 = await tester.start('p1', 'dart run build_runner build');
+    final build3 = await tester.start(
+      'p1',
+      'dart run build_runner build --force-jit',
+    );
     await Future<void>.delayed(const Duration(milliseconds: 500));
     final build4 = await tester.start(
       '',
-      'dart run build_runner build --workspace',
+      'dart run build_runner build --force-jit --workspace',
     );
     await build4.expect('Waiting for already-running build_runner.');
     await build3.expect(BuildLog.successPattern);
@@ -67,16 +76,22 @@ void main() async {
     // Single package build blocks on workspace build.
     final build5 = await tester.start(
       '',
-      'dart run build_runner build --workspace',
+      'dart run build_runner build --force-jit --workspace',
     );
     await Future<void>.delayed(const Duration(milliseconds: 500));
-    final build6 = await tester.start('p1', 'dart run build_runner build');
+    final build6 = await tester.start(
+      'p1',
+      'dart run build_runner build --force-jit',
+    );
     await build6.expect('Waiting for already-running build_runner.');
     await build5.expect(BuildLog.successPattern);
     await build6.expect(BuildLog.successPattern);
 
     // Watch mode in a package exits if requested via `stop --workspace`.
-    final watch = await tester.start('p1', 'dart run build_runner watch');
+    final watch = await tester.start(
+      'p1',
+      'dart run build_runner watch --force-jit',
+    );
     await watch.expect(BuildLog.successPattern);
     await tester
         .run('p1', 'dart run build_runner stop --workspace')
@@ -86,7 +101,10 @@ void main() async {
 
     // Watch mode in a package exits if requested via `stop` (without
     // --workspace).
-    final watch2 = await tester.start('p1', 'dart run build_runner watch');
+    final watch2 = await tester.start(
+      'p1',
+      'dart run build_runner watch --force-jit',
+    );
     await watch2.expect(BuildLog.successPattern);
     await tester
         .run('p1', 'dart run build_runner stop')
@@ -98,7 +116,10 @@ void main() async {
 
     // Watch mode in a package exits if requested via `stop --workspace` from
     // another package.
-    final watch3 = await tester.start('p1', 'dart run build_runner watch');
+    final watch3 = await tester.start(
+      'p1',
+      'dart run build_runner watch --force-jit',
+    );
     await watch3.expect(BuildLog.successPattern);
     await tester
         .run('p2', 'dart run build_runner stop --workspace')

--- a/build_runner/test/integration_tests/clean_command_test.dart
+++ b/build_runner/test/integration_tests/clean_command_test.dart
@@ -21,7 +21,7 @@ void main() async {
       files: {},
     );
 
-    await tester.run('root_pkg', 'dart run build_runner build');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/$entrypointScriptPath'), isNotNull);
     await tester.run('root_pkg', 'dart run build_runner clean');
     expect(tester.readFileTree('root_pkg/.dart_tool/build'), {
@@ -43,7 +43,10 @@ void main() async {
     );
     tester.writeWorkspacePubspec(packages: ['p1', 'p2']);
 
-    await tester.run('p1', 'dart run build_runner build --workspace');
+    await tester.run(
+      'p1',
+      'dart run build_runner build --force-jit --workspace',
+    );
     expect(tester.read(entrypointScriptPath), isNotNull);
     expect(tester.read(assetGraphPath), isNotNull);
 

--- a/build_runner/test/integration_tests/daemon_command_test.dart
+++ b/build_runner/test/integration_tests/daemon_command_test.dart
@@ -65,12 +65,16 @@ void main() {
     // Invalid options.
     var daemon = await tester.start(
       'root_pkg',
-      'dart run build_runner daemon --enable-experiment=bad-experiment',
+      'dart run build_runner daemon --force-jit '
+          '--enable-experiment=bad-experiment',
     );
     await daemon.expect('Failed to compile build script.');
 
     // Start daemon in default "auto" mode that watches files.
-    daemon = await tester.start('root_pkg', 'dart run build_runner daemon');
+    daemon = await tester.start(
+      'root_pkg',
+      'dart run build_runner daemon --force-jit',
+    );
     await daemon.expect(readyToConnectLog);
 
     // Writes the asset server port.
@@ -84,7 +88,7 @@ void main() {
     // Start with different option gives an error.
     final differentOptionsDaemon = await tester.start(
       'root_pkg',
-      'dart run build_runner daemon --build-mode=BuildMode.Manual',
+      'dart run build_runner daemon --force-jit --build-mode=BuildMode.Manual',
     );
     await differentOptionsDaemon.expect(optionsSkew);
 
@@ -131,7 +135,7 @@ void main() {
     await daemon.kill();
     daemon = await tester.start(
       'root_pkg',
-      'dart run build_runner daemon --build-mode=BuildMode.Manual',
+      'dart run build_runner daemon --force-jit --build-mode=BuildMode.Manual',
     );
     await daemon.expect(readyToConnectLog);
 
@@ -170,7 +174,7 @@ void main() {
     // Start a new daemon, connect to it.
     daemon = await tester.start(
       'root_pkg',
-      'dart run build_runner daemon --build-mode=BuildMode.Manual',
+      'dart run build_runner daemon --force-jit --build-mode=BuildMode.Manual',
     );
     await daemon.expect(readyToConnectLog);
     client = await BuildDaemonClient.connectUnchecked(

--- a/build_runner/test/integration_tests/serve_command_serve_only_required_test.dart
+++ b/build_runner/test/integration_tests/serve_command_serve_only_required_test.dart
@@ -25,7 +25,7 @@ void main() async {
 
     var serve = await tester.start(
       'root_pkg',
-      'dart run build_runner serve web:0',
+      'dart run build_runner serve --force-jit web:0',
     );
 
     // Initial build produces no output as the copy is not required.
@@ -63,7 +63,10 @@ void main() async {
       pathDependencies: ['builder_pkg', 'post_process_builder_pkg'],
       files: {},
     );
-    serve = await tester.start('root_pkg', 'dart run build_runner serve web:0');
+    serve = await tester.start(
+      'root_pkg',
+      'dart run build_runner serve --force-jit web:0',
+    );
 
     await serve.expectServingAndBuildSuccess();
     await serve.fetch('a.txt.copy', expectResponseCode: 404);
@@ -83,7 +86,10 @@ void main() async {
       pathDependencies: ['builder_pkg'],
       files: {'web/a.txt': 'a'},
     );
-    serve = await tester.start('root_pkg', 'dart run build_runner serve web:0');
+    serve = await tester.start(
+      'root_pkg',
+      'dart run build_runner serve --force-jit web:0',
+    );
     await serve.expectServingAndBuildSuccess();
     expect(await serve.fetchContent('a.txt.copy'), 'a');
     await serve.kill();

--- a/build_runner/test/integration_tests/serve_command_test.dart
+++ b/build_runner/test/integration_tests/serve_command_test.dart
@@ -24,7 +24,10 @@ void main() async {
       files: {},
     );
 
-    var serve = await tester.start('root_pkg', 'dart run build_runner serve');
+    var serve = await tester.start(
+      'root_pkg',
+      'dart run build_runner serve --force-jit',
+    );
     await serve.expect(
       'Missing dev dependency on package:build_web_compilers, '
       'which is required to serve Dart compiled to JavaScript.',
@@ -35,7 +38,10 @@ void main() async {
     // Create some source to serve, serve it.
     tester.write('root_pkg/web/a.txt', 'a');
     tester.write('root_pkg/web/subdirectory/b.txt', 'b');
-    serve = await tester.start('root_pkg', 'dart run build_runner serve web:0');
+    serve = await tester.start(
+      'root_pkg',
+      'dart run build_runner serve --force-jit web:0',
+    );
     await serve.expectServingAndBuildSuccess();
 
     // Serves directory index as 404 for subdirectory without index.html.
@@ -70,7 +76,7 @@ void main() async {
     addTearDown(server.close);
     final output = await tester.run(
       'root_pkg',
-      'dart run build_runner serve web:${server.port}',
+      'dart run build_runner serve --force-jit web:${server.port}',
       expectExitCode: ExitCode.osError.code,
     );
     expect(

--- a/build_runner/test/integration_tests/test_command_test.dart
+++ b/build_runner/test/integration_tests/test_command_test.dart
@@ -24,19 +24,19 @@ void main() async {
     // `test` does not support specifying directory to build.
     await tester.run(
       'root_pkg',
-      'dart run build_runner test web',
+      'dart run build_runner test --force-jit web',
       expectExitCode: ExitCode.usage.code,
     );
     await tester.run(
       'root_pkg',
-      'dart run build_runner test web -- -p chrome',
+      'dart run build_runner test --force-jit web -- -p chrome',
       expectExitCode: ExitCode.usage.code,
     );
 
     // Requires `build_test` dependency.
     final output = await tester.run(
       'root_pkg',
-      'dart run build_runner test',
+      'dart run build_runner test --force-jit',
       expectExitCode: ExitCode.config.code,
     );
     expect(

--- a/build_runner/test/integration_tests/watch_command_concurrent_changes_test.dart
+++ b/build_runner/test/integration_tests/watch_command_concurrent_changes_test.dart
@@ -61,7 +61,10 @@ class TestBuilder implements Builder {
 
     // Files with primary outputs are read at the start of the build. So a
     // delete during the build does not interrupt the build.
-    var watch = await tester.start('root_pkg', 'dart run build_runner watch');
+    var watch = await tester.start(
+      'root_pkg',
+      'dart run build_runner watch --force-jit',
+    );
     // Wait for the build to start then delete the input.
     await watch.expect('builder_pkg:test_builder');
     tester.delete('root_pkg/lib/a.txt');
@@ -71,9 +74,10 @@ class TestBuilder implements Builder {
     await watch.expect(BuildLog.successPattern);
     expect(tester.read('root_pkg/lib/a.txt.copy'), null);
 
-    // Files that are not primary inputs are not read at the start of the first
-    // build. If they are never actually used then deleting them during the
-    // build does not interrupt the build, nor does it trigger a new build.
+    // Files that are not primary inputs are not read at the start of the
+    // first build. If they are never actually used then deleting them during
+    // the build does not interrupt the build, nor does it trigger a new
+    // build.
     tester.write('root_pkg/lib/a.txt', 'a');
     tester.write('root_pkg/lib/a.other', 'a');
     // Wait for the build to start then delete the non-primary input.
@@ -113,7 +117,10 @@ class TestBuilder implements Builder {
     // The non-primary input is not read on startup, so the build needs
     // to restart to recover.
     tester.write('root_pkg/lib/a.other', 'a');
-    watch = await tester.start('root_pkg', 'dart run build_runner watch');
+    watch = await tester.start(
+      'root_pkg',
+      'dart run build_runner watch --force-jit',
+    );
     // Wait for the build to start then delete the non-primary input.
     await watch.expect('builder_pkg:test_builder');
     tester.delete('root_pkg/lib/a.other');

--- a/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
+++ b/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
@@ -78,7 +78,7 @@ class TestBuilder implements Builder {
     // by `Filesystem`.
     final watch = await tester.start(
       '',
-      'dart run build_runner watch --workspace',
+      'dart run build_runner watch --force-jit --workspace',
     );
     await watch.expect(BuildLog.successPattern);
     expect(tester.read('builder_pkg/lib/builder.g.dart'), partContent);

--- a/build_runner/test/integration_tests/watch_command_test.dart
+++ b/build_runner/test/integration_tests/watch_command_test.dart
@@ -30,7 +30,10 @@ void main() async {
     );
 
     // Watch and initial build.
-    var watch = await tester.start('root_pkg', 'dart run build_runner watch');
+    var watch = await tester.start(
+      'root_pkg',
+      'dart run build_runner watch --force-jit',
+    );
     await watch.expect(BuildLog.successPattern);
     expect(tester.read('root_pkg/web/a.txt.copy'), 'a');
 
@@ -46,7 +49,7 @@ void main() async {
     // State on disk is updated so `build` knows to do nothing.
     var output = await tester.copyWorkspace().run(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
     );
     expect(output, contains('wrote 0 outputs'));
 
@@ -58,7 +61,7 @@ void main() async {
     // State on disk is updated so `build` knows to do nothing.
     output = await tester.copyWorkspace().run(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
     );
     expect(output, contains('wrote 0 outputs'));
 
@@ -105,7 +108,7 @@ class TestBuilder implements Builder {
     // State on disk is updated so `build` knows to do nothing.
     output = await tester.copyWorkspace().run(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
     );
     expect(output, contains('wrote 0 outputs'));
 
@@ -136,7 +139,7 @@ targets:
     // State on disk is updated so `build` knows to do nothing.
     output = await tester.copyWorkspace().run(
       'root_pkg',
-      'dart run build_runner build',
+      'dart run build_runner build --force-jit',
     );
     expect(output, contains('wrote 0 outputs'));
 
@@ -151,7 +154,7 @@ targets:
     // Now with --output.
     watch = await tester.start(
       'root_pkg',
-      'dart run build_runner watch --output web:build',
+      'dart run build_runner watch --force-jit --output web:build',
     );
     await watch.expect(BuildLog.successPattern);
     expect(tester.read('root_pkg/build/a.txt'), 'updated');

--- a/build_runner/test/integration_tests/watch_command_workspace_test.dart
+++ b/build_runner/test/integration_tests/watch_command_workspace_test.dart
@@ -79,7 +79,7 @@ void main() async {
 
     final watch = await tester.start(
       '',
-      'dart run build_runner watch --workspace',
+      'dart run build_runner watch --force-jit --workspace',
     );
     await watch.expect(BuildLog.successPattern);
 

--- a/build_runner/test/integration_tests/web_compilers_ddc_test.dart
+++ b/build_runner/test/integration_tests/web_compilers_ddc_test.dart
@@ -75,7 +75,7 @@ void main() async {
     // Initial build.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build',
+      'dart run build_runner build --force-jit --output web:build',
     );
     expect(
       tester.readFileTree('root_pkg/build')!.keys,
@@ -107,7 +107,7 @@ void main() async {
     tester.write('root_pkg/lib/a.dart', 'error');
     var output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build',
+      'dart run build_runner build --force-jit --output web:build',
       expectExitCode: 1,
     );
     expect(output, contains(BuildLog.failurePattern));
@@ -116,7 +116,7 @@ void main() async {
     tester.write('root_pkg/web/main.dart', 'void main() {}');
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build',
+      'dart run build_runner build --force-jit --output web:build',
     );
     expect(output, contains(BuildLog.successPattern));
 
@@ -124,7 +124,7 @@ void main() async {
     expect(tester.read('root_pkg/build/unused.dart'), '');
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build '
+      'dart run build_runner build --force-jit --output web:build '
           '--define=build_web_compilers:dart_source_cleanup=enabled=true',
     );
     expect(tester.read('root_pkg/build/unused.dart'), null);

--- a/build_runner/test/integration_tests/web_compilers_incremental_test.dart
+++ b/build_runner/test/integration_tests/web_compilers_incremental_test.dart
@@ -76,7 +76,10 @@ void main() async {
       files: {'lib/a.dart': "String helloWorld = 'Hello World!';"},
     );
     final generatedDirRoot = 'root_pkg/.dart_tool/build/generated';
-    final watch = await tester.start('root_pkg', 'dart run build_runner watch');
+    final watch = await tester.start(
+      'root_pkg',
+      'dart run build_runner watch --force-jit',
+    );
     await watch.expect(BuildLog.successPattern);
     expect(
       tester.read('$generatedDirRoot/pkg_a/lib/a.ddc.js'),
@@ -175,7 +178,10 @@ void main() async {
       files: {'lib/a.dart': "String helloWorld = 'Hello World!';"},
     );
     final generatedDirRoot = 'root_pkg/.dart_tool/build/generated';
-    final watch = await tester.start('root_pkg', 'dart run build_runner watch');
+    final watch = await tester.start(
+      'root_pkg',
+      'dart run build_runner watch --force-jit',
+    );
     await watch.expect(BuildLog.successPattern);
     expect(
       tester.read('$generatedDirRoot/pkg_a/lib/a.ddc.js'),

--- a/build_runner/test/integration_tests/web_compilers_test.dart
+++ b/build_runner/test/integration_tests/web_compilers_test.dart
@@ -64,7 +64,7 @@ void main() {
     // Initial build.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build',
+      'dart run build_runner build --force-jit --output web:build',
     );
     expect(
       tester.readFileTree('root_pkg/build')!.keys,
@@ -96,7 +96,7 @@ void main() {
     // With dart2js. Does compile into a single file.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build '
+      'dart run build_runner build --force-jit --output web:build '
           '--define build_web_compilers:entrypoint=compiler=dart2js',
     );
     expect(
@@ -111,7 +111,7 @@ void main() {
     // With dart2js + minify.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build '
+      'dart run build_runner build --force-jit --output web:build '
           '--define build_web_compilers:entrypoint=compiler=dart2js '
           '--define build_web_compilers:entrypoint=dart2js_args=["--minify"]',
     );
@@ -127,7 +127,7 @@ void main() {
     // With dart2wasm.
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build '
+      'dart run build_runner build --force-jit --output web:build '
           '--define build_web_compilers:entrypoint=compiler=dart2wasm',
     );
     expect(tester.readBytes('root_pkg/build/main.wasm'), isNotNull);
@@ -136,7 +136,7 @@ void main() {
     tester.write('root_pkg/lib/a.dart', 'error');
     var output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build',
+      'dart run build_runner build --force-jit --output web:build',
       expectExitCode: 1,
     );
     expect(output, contains(BuildLog.failurePattern));
@@ -145,7 +145,7 @@ void main() {
     tester.write('root_pkg/web/main.dart', 'void main() {}');
     output = await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build',
+      'dart run build_runner build --force-jit --output web:build',
     );
     expect(output, contains(BuildLog.successPattern));
 
@@ -153,7 +153,7 @@ void main() {
     expect(tester.read('root_pkg/build/unused.dart'), '');
     await tester.run(
       'root_pkg',
-      'dart run build_runner build --output web:build '
+      'dart run build_runner build --force-jit --output web:build '
           '--define=build_web_compilers:dart_source_cleanup=enabled=true',
     );
     expect(tester.read('root_pkg/build/unused.dart'), null);

--- a/build_runner/test/logging/build_log_console_mode_test.dart
+++ b/build_runner/test/logging/build_log_console_mode_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:build/build.dart';
 import 'package:build_runner/src/bootstrap/build_process_state.dart';
+import 'package:build_runner/src/bootstrap/compile_type.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/phase.dart';
@@ -49,13 +50,13 @@ E An error.'''),
     });
 
     test('compile progress', () {
-      buildLog.logCompile(isAot: false, function: () async {});
+      buildLog.logCompile(compileType: CompileType.jit, function: () async {});
       expect(
         render(),
         padLinesRight('''
 0s compiling builders/jit'''),
       );
-      buildLog.logCompile(isAot: true, function: () async {});
+      buildLog.logCompile(compileType: CompileType.aot, function: () async {});
       expect(
         render(),
         padLinesRight('''

--- a/build_runner/test/logging/build_log_line_mode_test.dart
+++ b/build_runner/test/logging/build_log_line_mode_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:build/build.dart';
 import 'package:build_runner/src/bootstrap/build_process_state.dart';
+import 'package:build_runner/src/bootstrap/compile_type.dart';
 import 'package:build_runner/src/build_plan/phase.dart';
 import 'package:build_runner/src/logging/build_log.dart';
 import 'package:build_runner/src/logging/build_log_messages.dart';
@@ -38,9 +39,9 @@ void main() {
     });
 
     test('compile progress', () {
-      buildLog.logCompile(isAot: false, function: () async {});
+      buildLog.logCompile(compileType: CompileType.jit, function: () async {});
       expect(lines, ['  0s compiling builders/jit']);
-      buildLog.logCompile(isAot: true, function: () async {});
+      buildLog.logCompile(compileType: CompileType.aot, function: () async {});
       expect(lines, [
         '  0s compiling builders/jit',
         '  0s compiling builders/aot',

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -455,6 +455,7 @@ Future<TestBuilderResult> testBuilderFactories(
     buildPackages: buildPackages,
     readerWriter: readerWriter as InternalTestReaderWriter,
     resolvers: resolvers,
+    checkBuilderFreshness: false,
     buildConfig:
         // Override sources to defaults plus all explicitly passed inputs,
         // optionally restricted by [inputFilter] or [generateFor]. Or if


### PR DESCRIPTION
Fix #4386.

Compile with AOT first, fall back to JIT if there is a failure due to mirrors.

The `build_runner` child process sometimes needs `Platform.resolvedExecutable`, pass it in `build_process_state`.

The `run` command doesn't work with AOT mode, use JIT always and remove the --force-jit and --force-aot flag for that command.

`testBuilders` now explicitly turns off builder freshness checking, the builders are passed rather than compiled so it anyway didn't make sense; it was only passing by coincidence, now it can fail if the test code tries to check the wrong compile type.

Add `--force-jit` in most e2e tests as we want the faster compile time.

Add e2e test for the fallback to JIT.