### PR TITLE
Improve build filters with `--workspace`. Support `asset:` URIs.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -7,6 +7,12 @@
   to JIT if the compile fails due to use of `dart:mirrors`. Use the
   `--force-jit` flag if you want the old default JIT builder compile. Use the
   `--force-aot` flag to turn off the fallback to JIT compile.
+- Add support for `asset:` scheme to the `--build-filter` flag. It is like
+  `package:` but for the whole package, not just `lib`. For example,
+  `package:a/b.dart` is the same as `asset:a/lib/b.dart`.
+- Paths specified using `--build-filter` when using the `--workspace` flag now
+  apply to the current package, not the workspace root. Other packages must
+  be referred to using `package:` or `asset:` schemes.
 - Add OSC 8 hyperlinks for logged input paths.
 - Better handling of deletions of files during the build: if the file is not
   needed ignore the deletion, if it's needed try to use the cached version,

--- a/build_runner/lib/src/build_plan/build_filter.dart
+++ b/build_runner/lib/src/build_plan/build_filter.dart
@@ -19,23 +19,25 @@ class BuildFilter {
   /// Builds a [BuildFilter] from a command line argument.
   ///
   /// Both relative paths and package: uris are supported. Relative
-  /// paths are treated as relative to the [currentPackage], if set.
+  /// paths are treated as relative to the [currentPackage].
   ///
   /// Globs are supported in package names and paths.
-  factory BuildFilter.fromArg(String arg, String? currentPackage) {
+  factory BuildFilter.fromArg({
+    required String arg,
+    required String currentPackage,
+  }) {
     final uri = Uri.parse(arg);
     if (uri.scheme == 'package') {
       final package = uri.pathSegments.first;
       final glob = Glob(p.url.joinAll(['lib', ...uri.pathSegments.skip(1)]));
       return BuildFilter(Glob(package), glob);
+    }
+    if (uri.scheme == 'asset') {
+      final package = uri.pathSegments.first;
+      final glob = Glob(p.url.joinAll(uri.pathSegments.skip(1)));
+      return BuildFilter(Glob(package), glob);
     } else if (uri.scheme.isEmpty) {
-      if (currentPackage == null) {
-        throw FormatException(
-          'No current package so relative path is not supported: $arg',
-        );
-      } else {
-        return BuildFilter(Glob(currentPackage), Glob(uri.path));
-      }
+      return BuildFilter(Glob(currentPackage), Glob(uri.path));
     } else {
       throw FormatException('Unsupported scheme ${uri.scheme}', uri);
     }

--- a/build_runner/lib/src/build_plan/build_options.dart
+++ b/build_runner/lib/src/build_plan/build_options.dart
@@ -99,8 +99,7 @@ class BuildOptions {
 
   /// Parses [commandLine].
   ///
-  /// Build config overrides use [rootPackage], the current package name, as the
-  /// default package name.
+  /// Build config overrides use [currentPackage] as the default package name.
   ///
   /// Set [restIsBuildDirs] to `true` if "rest" args specify build directories,
   /// as they do for the `build` command, or to false if they are used elsewhere
@@ -112,7 +111,7 @@ class BuildOptions {
   static BuildOptions parse(
     BuildRunnerCommandLine commandLine, {
     required BuildPaths buildPaths,
-    required String rootPackage,
+    required String currentPackage,
     required bool restIsBuildDirs,
     Iterable<String>? extraDirs,
   }) {
@@ -138,9 +137,12 @@ class BuildOptions {
       buildPaths: buildPaths,
       builderConfigOverrides: _parseBuilderConfigOverrides(
         commandLine,
-        rootPackage: rootPackage,
+        currentPackage: currentPackage,
       ),
-      buildFilters: _parseBuildFilters(commandLine, rootPackage: rootPackage),
+      buildFilters: _parseBuildFilters(
+        commandLine,
+        currentPackage: currentPackage,
+      ),
       configKey: commandLine.config,
       // Only available on Linux.
       dartAotPerf: commandLine.dartAotPerf ?? false,
@@ -258,7 +260,7 @@ String _checkTopLevel(BuildRunnerCommandLine commandLine, String arg) {
 
 BuiltMap<String, BuiltMap<String, dynamic>> _parseBuilderConfigOverrides(
   BuildRunnerCommandLine commandLine, {
-  required String rootPackage,
+  required String currentPackage,
 }) {
   if (commandLine.defines == null) return BuiltMap();
   final result = <String, Map<String, dynamic>>{};
@@ -278,7 +280,7 @@ BuiltMap<String, BuiltMap<String, dynamic>> _parseBuilderConfigOverrides(
         ..removeRange(2, parts.length)
         ..add(rest.join('='));
     }
-    final builderKey = normalizeBuilderKeyUsage(parts[0], rootPackage);
+    final builderKey = normalizeBuilderKeyUsage(parts[0], currentPackage);
     final option = parts[1];
     dynamic value;
     // Attempt to parse the value as JSON, and if that fails then treat it as
@@ -306,13 +308,14 @@ BuiltMap<String, BuiltMap<String, dynamic>> _parseBuilderConfigOverrides(
 /// with glob support for both package names and paths.
 BuiltSet<BuildFilter> _parseBuildFilters(
   BuildRunnerCommandLine commandLine, {
-  required String rootPackage,
+  required String currentPackage,
 }) {
   final filterArgs = commandLine.buildFilter;
   if (filterArgs == null || filterArgs.isEmpty) return BuiltSet();
   try {
     return {
-      for (final arg in filterArgs) BuildFilter.fromArg(arg, rootPackage),
+      for (final arg in filterArgs)
+        BuildFilter.fromArg(arg: arg, currentPackage: currentPackage),
     }.build();
   } on FormatException catch (e) {
     throw ArgumentError.value(

--- a/build_runner/lib/src/build_plan/build_packages.dart
+++ b/build_runner/lib/src/build_plan/build_packages.dart
@@ -33,8 +33,11 @@ class BuildPackages implements AssetPathProvider {
   /// cycles.
   final BuiltList<String> orderedPackages;
 
-  /// When building a single package: the package `build_runner` was launched
-  /// in, which is also the current directory package and the [outputRoot].
+  /// The package `build_runner` was launched in, which is also the current
+  /// directory package.
+  final String currentPackage;
+
+  /// When building a single package, [currentPackage].
   ///
   /// When building a workspace, `null`.
   final String? singleOutputPackage;
@@ -71,6 +74,7 @@ class BuildPackages implements AssetPathProvider {
   final BuiltSetMultimap<String, String> _peerPackages;
 
   BuildPackages({
+    required this.currentPackage,
     required this.singleOutputPackage,
     required this.outputRoot,
     required this.packages,
@@ -83,6 +87,7 @@ class BuildPackages implements AssetPathProvider {
        _peerPackages = buildPackages;
 
   factory BuildPackages.compute({
+    required String currentPackage,
     String? singlePackageToBuild,
     required String outputRoot,
     required BuiltMap<String, BuildPackage> packages,
@@ -124,6 +129,7 @@ class BuildPackages implements AssetPathProvider {
     final buildPackages = _computePeers(outputPackages, transitiveDependencies);
 
     return BuildPackages(
+      currentPackage: currentPackage,
       singleOutputPackage: singlePackageToBuild,
       outputRoot: outputRoot,
       packages: packages,
@@ -142,6 +148,7 @@ class BuildPackages implements AssetPathProvider {
     String package,
     Iterable<BuildPackage> packages,
   ) => BuildPackages.compute(
+    currentPackage: package,
     singlePackageToBuild: package,
     outputRoot: package,
     packages: {for (final package in packages) package.name: package}.build(),
@@ -150,10 +157,12 @@ class BuildPackages implements AssetPathProvider {
   /// Creates [BuildPackages] from [BuildPackage]s for a workspace build with
   /// workspace name [workspace].
   @visibleForTesting
-  factory BuildPackages.workspaceBuild(
-    String workspace,
-    Iterable<BuildPackage> packages,
-  ) => BuildPackages.compute(
+  factory BuildPackages.workspaceBuild({
+    required String currentPackage,
+    required String workspace,
+    required Iterable<BuildPackage> packages,
+  }) => BuildPackages.compute(
+    currentPackage: currentPackage,
     outputRoot: workspace,
     packages: {for (final package in packages) package.name: package}.build(),
   );

--- a/build_runner/lib/src/build_plan/build_packages_loader.dart
+++ b/build_runner/lib/src/build_plan/build_packages_loader.dart
@@ -54,6 +54,9 @@ class BuildPackagesLoader {
       );
     }
 
+    final currentPackagePubspec = _pubspecForPath(packagePath);
+    final currentPackage = currentPackagePubspec['name']! as String;
+
     String? singlePackageToBuild;
     String outputRootName;
     final packagesInBuild = <String>{};
@@ -62,10 +65,9 @@ class BuildPackagesLoader {
       packagesInBuild.addAll(workspacePackages!);
       outputRootName = workspaceName;
     } else {
-      final singlePackageToBuildPubspec = _pubspecForPath(packagePath);
-      singlePackageToBuild = singlePackageToBuildPubspec['name']! as String;
-      outputRootName = singlePackageToBuild;
-      packagesInBuild.add(singlePackageToBuild);
+      singlePackageToBuild = currentPackage;
+      outputRootName = currentPackage;
+      packagesInBuild.add(currentPackage);
     }
 
     // Read the lock file to find "fixed" packages that are hosted, on git
@@ -94,6 +96,7 @@ class BuildPackagesLoader {
     }
 
     return BuildPackages.compute(
+      currentPackage: currentPackage,
       singlePackageToBuild: singlePackageToBuild,
       outputRoot: outputRootName,
       packages: buildPackages.build(),

--- a/build_runner/lib/src/build_runner.dart
+++ b/build_runner/lib/src/build_runner.dart
@@ -82,7 +82,7 @@ class BuildRunner {
       }
       Directory.current = parent;
     }
-    final rootPackage =
+    final currentPackage =
         (loadYaml(File(p.join(p.current, 'pubspec.yaml')).readAsStringSync())
                 as YamlMap)['name']!
             as String;
@@ -120,7 +120,7 @@ class BuildRunner {
           buildOptions: BuildOptions.parse(
             commandLine,
             restIsBuildDirs: true,
-            rootPackage: rootPackage,
+            currentPackage: currentPackage,
             buildPaths: buildPaths,
           ),
         );
@@ -138,7 +138,7 @@ class BuildRunner {
           buildOptions: BuildOptions.parse(
             commandLine,
             restIsBuildDirs: false,
-            rootPackage: rootPackage,
+            currentPackage: currentPackage,
             buildPaths: buildPaths,
           ),
           daemonOptions: DaemonOptions.parse(commandLine),
@@ -150,7 +150,7 @@ class BuildRunner {
           buildOptions: BuildOptions.parse(
             commandLine,
             restIsBuildDirs: false,
-            rootPackage: rootPackage,
+            currentPackage: currentPackage,
             buildPaths: buildPaths,
           ),
           runOptions: RunOptions.parse(commandLine),
@@ -163,7 +163,7 @@ class BuildRunner {
           buildOptions: BuildOptions.parse(
             commandLine,
             restIsBuildDirs: false,
-            rootPackage: rootPackage,
+            currentPackage: currentPackage,
             buildPaths: buildPaths,
             extraDirs: serveOptions.serveTargets.map((t) => t.dir),
           ),
@@ -176,7 +176,7 @@ class BuildRunner {
           buildOptions: BuildOptions.parse(
             commandLine,
             restIsBuildDirs: false,
-            rootPackage: rootPackage,
+            currentPackage: currentPackage,
             buildPaths: buildPaths,
           ),
           testOptions: TestOptions.parse(commandLine),
@@ -188,7 +188,7 @@ class BuildRunner {
           buildOptions: BuildOptions.parse(
             commandLine,
             restIsBuildDirs: true,
-            rootPackage: rootPackage,
+            currentPackage: currentPackage,
             buildPaths: buildPaths,
           ),
         );

--- a/build_runner/lib/src/build_runner_command_line.dart
+++ b/build_runner/lib/src/build_runner_command_line.dart
@@ -300,11 +300,12 @@ class _Build extends _Command<BuildRunnerCommandLine> {
       ..addMultiOption(
         buildFilterOption,
         help:
-            'An explicit filter of files to build. Relative paths and '
-            '`package:` uris are supported, including glob syntax for paths '
-            'portions (but not package names). '
-            'If multiple filters are applied then outputs matching any '
-            'filter will be built (they do not need to match all filters).',
+            'Limits which files get built. Multiple filters are ORed together. '
+            'Specify a relative path, optionally with globs, to limit to '
+            'building matching paths in the current package. '
+            'Or, use a `package:` or `asset:` URI to refer to other packages. '
+            '`package:` URIs refer only to the `lib` folder of that package. '
+            '`asset:` URIs refer to the root of that package.',
       )
       ..addMultiOption(
         enableExperimentOption,

--- a/build_runner/lib/src/commands/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/commands/daemon/daemon_builder.dart
@@ -57,8 +57,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
   final _buildScriptUpdateCompleter = Completer<void>();
   Future<void> get buildScriptUpdated => _buildScriptUpdateCompleter.future;
 
-  String? get _singleOutputPackageName =>
-      _buildPlan.buildPackages.singleOutputPackage;
+  String get _currentPackageName => _buildPlan.buildPackages.currentPackage;
 
   @override
   Future<void> build(
@@ -91,15 +90,23 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
       if (target.buildFilters != null && target.buildFilters!.isNotEmpty) {
         buildFilters.addAll([
           for (final pattern in target.buildFilters!)
-            BuildFilter.fromArg(pattern, _singleOutputPackageName),
+            BuildFilter.fromArg(
+              arg: pattern,
+              currentPackage: _currentPackageName,
+            ),
         ]);
       } else {
         buildFilters
-          ..add(BuildFilter.fromArg('package:*/**', _singleOutputPackageName))
           ..add(
             BuildFilter.fromArg(
-              '${target.target}/**',
-              _singleOutputPackageName,
+              arg: 'package:*/**',
+              currentPackage: _currentPackageName,
+            ),
+          )
+          ..add(
+            BuildFilter.fromArg(
+              arg: '${target.target}/**',
+              currentPackage: _currentPackageName,
             ),
           );
       }

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -1083,9 +1083,15 @@ targets:
             r'$$b|lib/b.txt.copy': '',
           },
           buildFilters: {
-            BuildFilter.fromArg('web/a.txt.copy', 'a'),
-            BuildFilter.fromArg('package:a/a.txt.copy', 'a'),
-            BuildFilter.fromArg('package:b/b.txt.copy', 'a'),
+            BuildFilter.fromArg(arg: 'web/a.txt.copy', currentPackage: 'a'),
+            BuildFilter.fromArg(
+              arg: 'package:a/a.txt.copy',
+              currentPackage: 'a',
+            ),
+            BuildFilter.fromArg(
+              arg: 'package:b/b.txt.copy',
+              currentPackage: 'a',
+            ),
           },
           verbose: true,
           buildPackages: buildPackagesWithDep,
@@ -1106,7 +1112,12 @@ targets:
           ],
           {'a|lib/a.txt': '', 'b|lib/a.txt': ''},
           outputs: {r'$$a|lib/a.txt.copy': '', r'$$b|lib/a.txt.copy': ''},
-          buildFilters: {BuildFilter.fromArg('package:*/a.txt.copy', 'a')},
+          buildFilters: {
+            BuildFilter.fromArg(
+              arg: 'package:*/a.txt.copy',
+              currentPackage: 'a',
+            ),
+          },
           verbose: true,
           buildPackages: buildPackagesWithDep,
         );
@@ -1138,9 +1149,15 @@ targets:
             r'$$b|lib/b2.txt.copy': '',
           },
           buildFilters: {
-            BuildFilter.fromArg('package:a/*0.txt.copy', 'a'),
-            BuildFilter.fromArg('web/*1.txt.copy', 'a'),
-            BuildFilter.fromArg('package:b/*2.txt.copy', 'a'),
+            BuildFilter.fromArg(
+              arg: 'package:a/*0.txt.copy',
+              currentPackage: 'a',
+            ),
+            BuildFilter.fromArg(arg: 'web/*1.txt.copy', currentPackage: 'a'),
+            BuildFilter.fromArg(
+              arg: 'package:b/*2.txt.copy',
+              currentPackage: 'a',
+            ),
           },
           verbose: true,
           buildPackages: buildPackagesWithDep,
@@ -1161,7 +1178,12 @@ targets:
           ],
           {'a|lib/a.txt': '', 'b|lib/b.txt': ''},
           outputs: {r'$$a|lib/a.txt.copy': '', r'$$b|lib/b.txt.copy': ''},
-          buildFilters: {BuildFilter.fromArg('package:*/*.txt.copy', 'a')},
+          buildFilters: {
+            BuildFilter.fromArg(
+              arg: 'package:*/*.txt.copy',
+              currentPackage: 'a',
+            ),
+          },
           verbose: true,
           buildPackages: buildPackagesWithDep,
         );

--- a/build_runner/test/build_plan/build_packages_test.dart
+++ b/build_runner/test/build_plan/build_packages_test.dart
@@ -389,18 +389,22 @@ workspace:
   });
 
   test('calculates transitive dependencies', () {
-    final buildPackages = BuildPackages.workspaceBuild('workspace', [
-      BuildPackage.forTesting(name: 'a', dependencies: ['b']),
-      BuildPackage.forTesting(name: 'b', dependencies: ['d']),
-      BuildPackage.forTesting(name: 'c', dependencies: ['d']),
-      BuildPackage.forTesting(name: 'd', dependencies: ['e']),
-      BuildPackage.forTesting(name: 'e', dependencies: ['d']),
-      BuildPackage.forTesting(name: 'f', dependencies: ['g']),
-      BuildPackage.forTesting(name: 'g', dependencies: ['h']),
-      BuildPackage.forTesting(name: 'h', dependencies: ['g', 'i']),
-      BuildPackage.forTesting(name: 'i'),
-      BuildPackage.forTesting(name: 'workspace'),
-    ]);
+    final buildPackages = BuildPackages.workspaceBuild(
+      currentPackage: 'workspace',
+      workspace: 'workspace',
+      packages: [
+        BuildPackage.forTesting(name: 'a', dependencies: ['b']),
+        BuildPackage.forTesting(name: 'b', dependencies: ['d']),
+        BuildPackage.forTesting(name: 'c', dependencies: ['d']),
+        BuildPackage.forTesting(name: 'd', dependencies: ['e']),
+        BuildPackage.forTesting(name: 'e', dependencies: ['d']),
+        BuildPackage.forTesting(name: 'f', dependencies: ['g']),
+        BuildPackage.forTesting(name: 'g', dependencies: ['h']),
+        BuildPackage.forTesting(name: 'h', dependencies: ['g', 'i']),
+        BuildPackage.forTesting(name: 'i'),
+        BuildPackage.forTesting(name: 'workspace'),
+      ],
+    );
 
     expect(buildPackages.transitiveDepsOf('a'), {'a', 'b', 'd', 'e'});
     expect(buildPackages.transitiveDepsOf('d'), {'d', 'e'});
@@ -421,17 +425,21 @@ workspace:
   });
 
   test('calculates peer packages', () {
-    final buildPackages = BuildPackages.workspaceBuild('workspace', [
-      BuildPackage.forTesting(name: 'a', dependencies: ['b'], isOutput: true),
-      BuildPackage.forTesting(name: 'b', dependencies: ['d']),
-      BuildPackage.forTesting(name: 'c', dependencies: ['d'], isOutput: true),
-      BuildPackage.forTesting(name: 'd', dependencies: ['e']),
-      BuildPackage.forTesting(name: 'e', dependencies: ['d']),
-      BuildPackage.forTesting(name: 'f', dependencies: ['g'], isOutput: true),
-      BuildPackage.forTesting(name: 'g'),
-      BuildPackage.forTesting(name: 'h', dependencies: ['e'], isOutput: true),
-      BuildPackage.forTesting(name: 'workspace'),
-    ]);
+    final buildPackages = BuildPackages.workspaceBuild(
+      currentPackage: 'workspace',
+      workspace: 'workspace',
+      packages: [
+        BuildPackage.forTesting(name: 'a', dependencies: ['b'], isOutput: true),
+        BuildPackage.forTesting(name: 'b', dependencies: ['d']),
+        BuildPackage.forTesting(name: 'c', dependencies: ['d'], isOutput: true),
+        BuildPackage.forTesting(name: 'd', dependencies: ['e']),
+        BuildPackage.forTesting(name: 'e', dependencies: ['d']),
+        BuildPackage.forTesting(name: 'f', dependencies: ['g'], isOutput: true),
+        BuildPackage.forTesting(name: 'g'),
+        BuildPackage.forTesting(name: 'h', dependencies: ['e'], isOutput: true),
+        BuildPackage.forTesting(name: 'workspace'),
+      ],
+    );
 
     // Transitive deps of output package `a`.
     expect(buildPackages.peersOf('a'), {'a', 'b', 'd', 'e'});

--- a/build_runner/test/common/build_runner_tester.dart
+++ b/build_runner/test/common/build_runner_tester.dart
@@ -53,6 +53,7 @@ class BuildRunnerTester {
   /// A `pubspec.yaml` is also written, see [Pubspecs.pubspec].
   void writePackage({
     required String name,
+    String? path,
     required Map<String, String> files,
     List<String>? dependencies,
     List<String>? pathDependencies,
@@ -61,7 +62,7 @@ class BuildRunnerTester {
     bool inWorkspace = false,
   }) {
     _writeDirectory(
-      name: name,
+      name: path ?? name,
       files: {
         'pubspec.yaml': pubspecs.pubspec(
           name: name,
@@ -136,10 +137,17 @@ class BuildRunnerTester {
     file.writeAsStringSync(update(data));
   }
 
-  /// Deletes the workspace-relative [path].
+  /// Deletes the file or directory at workspace-relative [path].
   void delete(String path) {
-    final file = File(p.join(tempDirectory.path, path));
-    file.deleteSync(recursive: true);
+    final absolutePath = p.join(tempDirectory.path, path);
+    final type = FileSystemEntity.typeSync(absolutePath);
+    if (type == FileSystemEntityType.file) {
+      File(absolutePath).deleteSync(recursive: true);
+    } else if (type == FileSystemEntityType.directory) {
+      Directory(absolutePath).deleteSync(recursive: true);
+    } else {
+      throw UnsupportedError('File type: $type');
+    }
   }
 
   /// Reads the tree of files at the workspace-relative [path].

--- a/build_runner/test/integration_tests/build_command_build_filter_test.dart
+++ b/build_runner/test/integration_tests/build_command_build_filter_test.dart
@@ -14,6 +14,14 @@ void main() async {
     final pubspecs = await Pubspecs.load();
     final tester = BuildRunnerTester(pubspecs);
 
+    final testFiles = {
+      'lib/a.txt': 'a',
+      'lib/b.txt': 'b',
+      'web/a.txt': 'a',
+      'web/b.txt': 'b',
+    };
+
+    // Without `--workspace`.
     tester.writeFixturePackage(
       FixturePackages.copyBuilder(buildToCache: true, applyToAllPackages: true),
     );
@@ -21,28 +29,135 @@ void main() async {
       name: 'root_pkg',
       dependencies: ['build_runner'],
       pathDependencies: ['builder_pkg', 'other_pkg'],
-      files: {
-        'lib/a.txt': 'a',
-        'lib/b.txt': 'b',
-        'web/a.txt': 'a',
-        'web/b.txt': 'b',
-      },
+      files: testFiles,
     );
-    tester.writePackage(
-      name: 'other_pkg',
-      files: {'lib/a.txt': 'a', 'lib/b.txt': 'b'},
-    );
+    tester.writePackage(name: 'other_pkg', files: testFiles);
 
+    // Paths.
     await tester.run(
       'root_pkg',
       'dart run build_runner build --force-jit '
-          '--build-filter package:*/a.txt.copy '
-          '--build-filter web/a.txt.copy ',
+          '--build-filter */a*',
+    );
+    expect(tester.readFileTree('root_pkg/.dart_tool/build/generated'), {
+      'root_pkg/lib/a.txt.copy': 'a',
+      'root_pkg/web/a.txt.copy': 'a',
+    });
+    tester.delete('root_pkg/.dart_tool/build/generated');
+
+    // `package` scheme.
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit '
+          '--build-filter package:*/a*',
+    );
+    expect(tester.readFileTree('root_pkg/.dart_tool/build/generated'), {
+      'root_pkg/lib/a.txt.copy': 'a',
+      'other_pkg/lib/a.txt.copy': 'a',
+    });
+    tester.delete('root_pkg/.dart_tool/build/generated');
+
+    // `asset` scheme.
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit '
+          '--build-filter asset:*/*/a*',
     );
     expect(tester.readFileTree('root_pkg/.dart_tool/build/generated'), {
       'root_pkg/web/a.txt.copy': 'a',
       'root_pkg/lib/a.txt.copy': 'a',
       'other_pkg/lib/a.txt.copy': 'a',
+      // `other_pkg` `web` is not built because only public outputs of
+      // dependency packages are built.
     });
+    tester.delete('root_pkg/.dart_tool/build/generated');
+
+    // With `--workspace`.
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner', 'other_pkg'],
+      pathDependencies: ['builder_pkg'],
+      files: testFiles,
+      inWorkspace: true,
+    );
+    tester.writePackage(
+      name: 'other_pkg',
+      path: 'packages/other_pkg',
+      files: testFiles,
+      inWorkspace: true,
+    );
+    tester.writeWorkspacePubspec(packages: ['root_pkg', 'packages/other_pkg']);
+    // Apply builder to the workspace too.
+    tester.update('pubspec.yaml', (content) {
+      return '''
+$content
+dependencies:
+  builder_pkg: 
+    path: builder_pkg
+''';
+    });
+    // Put files in the workspace too.
+    tester.write('lib/a.txt', 'a');
+    tester.write('lib/b.txt', 'a');
+    tester.write('web/a.txt', 'a');
+    tester.write('web/b.txt', 'a');
+
+    // Paths.
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --workspace '
+          '--build-filter web/a*',
+    );
+    expect(tester.readFileTree('.dart_tool/build/generated'), {
+      'root_pkg/web/a.txt.copy': 'a',
+    });
+    tester.delete('.dart_tool/build/generated');
+    await tester.run(
+      'packages/other_pkg',
+      'dart run build_runner build --force-jit --workspace '
+          '--build-filter web/a*',
+    );
+    expect(tester.readFileTree('.dart_tool/build/generated'), {
+      'other_pkg/web/a.txt.copy': 'a',
+    });
+    tester.delete('.dart_tool/build/generated');
+    await tester.run(
+      '',
+      'dart run build_runner build --force-jit --workspace '
+          '--build-filter web/a*',
+    );
+    expect(tester.readFileTree('.dart_tool/build/generated'), {
+      'workspace/web/a.txt.copy': 'a',
+    });
+    tester.delete('.dart_tool/build/generated');
+
+    // `package` scheme.
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --workspace '
+          '--build-filter package:*/a*',
+    );
+    expect(tester.readFileTree('.dart_tool/build/generated'), {
+      'root_pkg/lib/a.txt.copy': 'a',
+      'other_pkg/lib/a.txt.copy': 'a',
+      'workspace/lib/a.txt.copy': 'a',
+    });
+    tester.delete('.dart_tool/build/generated');
+
+    // `asset` scheme.
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --workspace '
+          '--build-filter asset:*/*/a*',
+    );
+    expect(tester.readFileTree('.dart_tool/build/generated'), {
+      'root_pkg/web/a.txt.copy': 'a',
+      'root_pkg/lib/a.txt.copy': 'a',
+      'other_pkg/web/a.txt.copy': 'a',
+      'other_pkg/lib/a.txt.copy': 'a',
+      'workspace/web/a.txt.copy': 'a',
+      'workspace/lib/a.txt.copy': 'a',
+    });
+    tester.delete('.dart_tool/build/generated');
   });
 }


### PR DESCRIPTION
Fix #4882.

Make `--build-filter` paths with `--workspace` always refer to the _current_ package, so it closely matches the behavior without `--workspace`. Before this PR it was the workspace "package", which often has no files in it.

Support `asset:` URI scheme with `--build-filter` so it's possible to refer to files in any package but not under `lib`.