### PR TITLE
Fix workspace handling for stale workspace.ref.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.14.1-wip
+
+- Bug fix: fix crash if a package used to belong to a workspace but was removed
+  from the workspace leaving a stale `workspace.ref` file.
+
 ## 2.14.0
 
 - Performance: further improvements to management of files for analysis

--- a/build_runner/lib/src/build_plan/build_packages_loader.dart
+++ b/build_runner/lib/src/build_plan/build_packages_loader.dart
@@ -13,6 +13,7 @@ import 'package:yaml/yaml.dart';
 import 'build_package.dart';
 import 'build_packages.dart';
 import 'build_paths.dart';
+import 'pubspecs.dart';
 
 class BuildPackagesLoader {
   /// Loads the build packages for building [paths].
@@ -46,7 +47,9 @@ class BuildPackagesLoader {
     String? workspaceName;
     List<String>? workspacePackages;
     if (buildType != BuildType.singlePackage) {
-      final workspacePubspec = _pubspecForPath(workspacePath!);
+      final workspacePubspec = Pubspecs.load(
+        p.join(workspacePath!, 'pubspec.yaml'),
+      );
       workspaceName = workspacePubspec['name']! as String;
       final workspacePackageGraph = _packageGraphForPath(workspacePath);
       workspacePackages = List.from(
@@ -54,7 +57,9 @@ class BuildPackagesLoader {
       );
     }
 
-    final currentPackagePubspec = _pubspecForPath(packagePath);
+    final currentPackagePubspec = Pubspecs.load(
+      p.join(packagePath, 'pubspec.yaml'),
+    );
     final currentPackage = currentPackagePubspec['name']! as String;
 
     String? singlePackageToBuild;
@@ -80,7 +85,9 @@ class BuildPackagesLoader {
     final buildPackages = MapBuilder<String, BuildPackage>();
     for (final packageConfig in packageConfigs) {
       final isInBuild = packagesInBuild.contains(packageConfig.name);
-      final packagePubspec = _pubspecForPath(packageConfig.root.toFilePath());
+      final packagePubspec = Pubspecs.load(
+        p.join(packageConfig.root.toFilePath(), 'pubspec.yaml'),
+      );
       final dependencies = _depsFromYaml(
         packagePubspec,
         loadDevDependencies: isInBuild,
@@ -107,14 +114,6 @@ class BuildPackagesLoader {
 /// Loads and returns `$absolutePath/pubspec.yaml`.
 ///
 /// Throws if it does not exist.
-YamlMap _pubspecForPath(String absolutePath) {
-  final pubspecPath = p.join(absolutePath, 'pubspec.yaml');
-  final pubspec = File(pubspecPath);
-  if (!pubspec.existsSync()) {
-    throw StateError('Unable to load packages, no `$pubspecPath` found.');
-  }
-  return loadYaml(pubspec.readAsStringSync()) as YamlMap;
-}
 
 /// Loads and returns `$absolutePath/.dart_tool/package_graph.json`.
 ///

--- a/build_runner/lib/src/build_plan/build_paths.dart
+++ b/build_runner/lib/src/build_plan/build_paths.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:path/path.dart' as p;
+import 'pubspecs.dart';
 
 /// The current package path, workspace path, and whether to build the single
 /// package or the workspace.
@@ -48,13 +49,21 @@ class BuildPaths {
       p.join(packagePath, '.dart_tool', 'pub', 'workspace_ref.json'),
     );
     if (workspaceRefFile.existsSync()) {
-      final workspaceRef =
-          (json.decode(workspaceRefFile.readAsStringSync())
-                  as Map<String, Object?>)['workspaceRoot']
-              as String;
-      workspacePath = p.canonicalize(
-        p.join(p.dirname(workspaceRefFile.path), workspaceRef),
-      );
+      // The `workspace_ref.json` might be stale. Confirm by checking the
+      // current package `pubspec.yaml`. If it's a package in the workspace then
+      // it has `resolution: workspace`, if it is the workspace root then it has
+      // `workspace:`.
+      final pubspec = Pubspecs.load(p.join(packagePath, 'pubspec.yaml'));
+      if (pubspec['resolution'] == 'workspace' ||
+          pubspec['workspace'] != null) {
+        final workspaceRef =
+            (json.decode(workspaceRefFile.readAsStringSync())
+                    as Map<String, Object?>)['workspaceRoot']
+                as String;
+        workspacePath = p.canonicalize(
+          p.join(p.dirname(workspaceRefFile.path), workspaceRef),
+        );
+      }
     }
     return BuildPaths(
       packagePath: packagePath,

--- a/build_runner/lib/src/build_plan/pubspecs.dart
+++ b/build_runner/lib/src/build_plan/pubspecs.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'package:yaml/yaml.dart';
+
+class Pubspecs {
+  static YamlMap load(String path) {
+    final pubspec = File(path);
+    if (!pubspec.existsSync()) {
+      throw StateError('Unable to load packages, no `$path` found.');
+    }
+    return loadYaml(pubspec.readAsStringSync()) as YamlMap;
+  }
+}

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.14.0
+version: 2.14.1-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/integration_tests/build_command_workspace_test.dart
+++ b/build_runner/test/integration_tests/build_command_workspace_test.dart
@@ -181,5 +181,22 @@ void main() async {
       ),
     );
     await tester.run('', 'dart run build_runner build --force-jit --workspace');
+
+    // Rewrite p1 to not be in a workspace.
+    tester.writePackage(
+      name: 'p1',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg', 'cache_builder_pkg'],
+      files: {'lib/p1.txt': '4'},
+    );
+    // Explicitly write a stale workspace_ref.json pointing to a non-existent
+    // directory.
+    tester.write(
+      'p1/.dart_tool/pub/workspace_ref.json',
+      '{"workspaceRoot": "../../../non_existent"}',
+    );
+    // Run build in p1. It should succeed as a single package build,
+    // ignoring the stale workspace_ref.json.
+    await tester.run('p1', 'dart run build_runner build --force-jit');
   });
 }

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.14-wip
+
+- Use `build_runner` 2.14.1.
+
 ## 3.5.13
 
 - Use `build_runner` 2.14.0.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.13
+version: 3.5.14-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.14.0'
+  build_runner: '2.14.1-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Fix #4888.

Check pubspecs to be sure that a `workspace.ref` is not stale, before concluding there is a workspace.