### PR TITLE
Tweaks to `watch` mode lock handling.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Bug fix: fix crash if a package used to belong to a workspace but was removed
   from the workspace leaving a stale `workspace.ref` file.
+- Bug fix: the `watch` command now always does one build before exiting due to
+  a request from another `build_runner` process. Fix crashes related to request
+  before build start.
 
 ## 2.14.0
 

--- a/build_runner/lib/src/commands/watch/watcher.dart
+++ b/build_runner/lib/src/commands/watch/watcher.dart
@@ -51,10 +51,15 @@ class Watcher {
   ///
   /// File watchers are scheduled synchronously.
   void _run(Future<void> until) async {
-    final terminate = Future.any([until, _buildSeries.closing]);
     // If the BuildProcessLock is requested, finish the current build if there
     // is one then exit.
-    buildProcessState.setLockRequestCallback(_buildSeries.close);
+    final closeController = Completer<void>();
+    buildProcessState.setLockRequestCallback(() {
+      if (!closeController.isCompleted) {
+        closeController.complete();
+      }
+    });
+    final terminate = Future.any([until, closeController.future]);
 
     // Start watching files immediately, before the first build is even started.
     final graphWatcher = BuildPackagesWatcher(
@@ -84,6 +89,8 @@ class Watcher {
         .asyncMapBuffer(_doBuild)
         .drain<void>()
         .then((_) async {
+          await currentBuildResult;
+          await _buildSeries.close();
           if (buildProcessState.isLockRequested()) {
             buildLog.flushAndPrint(
               'Exiting as requested by another build_runner process.',


### PR DESCRIPTION
I noticed that a lock request to `watch` command would cause it to exit before starting the first build, with a stack trace.

Obviously, fix the stack trace :) I also think it's better to do at least one build before exiting, so the command makes some progress.

I checked this with four consoles running in loops getting the lock, it ran for a while with no crashes or surprises.