### PR TITLE
Allow analyzer 13.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.6
+
+- Allow `analyzer` 13.0.0.
+
 ## 4.0.5
 
 - Allow `analyzer` 11.0.0 and 12.0.0.

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 4.0.5
+version: 4.0.6
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: '>=8.0.0 <13.0.0'
+  analyzer: '>=8.0.0 <14.0.0'
   crypto: ^3.0.0
   glob: ^2.0.0
   logging: ^1.0.0

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove `--log-performance` and `--track-performance`. File an issue if you
   have performance measurement needs not covered by the newer `--dart-aot-perf`.
 - Removed options can still be passed, they will be ignored with a warning.
+- Allow `analyzer` 13.0.0.
 
 ## 2.14.1
 

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -13,7 +13,7 @@ platforms:
   macos:
 
 dependencies:
-  analyzer: '>=8.0.0 <13.0.0'
+  analyzer: '>=8.0.0 <14.0.0'
   args: ^2.5.0
   async: ^2.5.0
   build: ^4.0.0

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Use `build_runner` 2.15.0.
 - Remove `enableLowResourceMode` parameters as there is no longer a low resource
   mode.
+- Allow `analyzer` 13.0.0.
 
 ## 3.5.14
 

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   watcher: ^1.0.0
 
 dev_dependencies:
-  analyzer: '>=8.0.0 <13.0.0'
+  analyzer: '>=8.0.0 <14.0.0'
 
 topics:
  - build-runner

--- a/builder_pkgs/build_modules/CHANGELOG.md
+++ b/builder_pkgs/build_modules/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.12-wip
+
+- Allow `analyzer` 13.0.0.
+
 ## 5.1.11
 
 - Allow Dart SDK 3.12.x and 3.13 prerelease.

--- a/builder_pkgs/build_modules/pubspec.yaml
+++ b/builder_pkgs/build_modules/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_modules
-version: 5.1.11
+version: 5.1.12-wip
 description: >-
   Builders to analyze and split Dart code into individually compilable modules
   based on imports.
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.7.0 <3.13.0-z'
 
 dependencies:
-  analyzer: '>=5.1.0 <13.0.0'
+  analyzer: '>=5.1.0 <14.0.0'
   async: ^2.5.0
   bazel_worker: ^1.0.0
   build: '>=2.0.0 <5.0.0'

--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.19-wip
+
+- Allow `analyzer` 13.0.0.
+
 ## 4.4.18
 
 - Fix DDC + Frontend Server not properly formatting sourcemaps.

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.4.18
+version: 4.4.19-wip
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace
@@ -8,7 +8,7 @@ environment:
   sdk: '>=3.7.0 <3.13.0-z'
 
 dependencies:
-  analyzer: '>=5.1.0 <13.0.0'
+  analyzer: '>=5.1.0 <14.0.0'
   archive: '>=3.0.0 <5.0.0'
   bazel_worker: ^1.0.0
   build: '>=2.0.0 <5.0.0'

--- a/builder_pkgs/mockito/CHANGELOG.md
+++ b/builder_pkgs/mockito/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 5.6.5-wip
+
+* Require `analyzer` 13.0.0.
+
 ## 5.6.4
 
 * Allow `analyzer` 11.0.0 and 12.0.0.

--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -29,9 +29,6 @@ import 'package:analyzer/src/dart/element/element.dart'
 import 'package:analyzer/src/dart/element/inheritance_manager3.dart'
     show InheritanceManager3, Name;
 // ignore: implementation_imports
-import 'package:analyzer/src/dart/element/member.dart'
-    show SubstitutedExecutableElementImpl;
-// ignore: implementation_imports
 import 'package:analyzer/src/dart/element/type_algebra.dart' show Substitution;
 import 'package:build/build.dart';
 // Do not expose [refer] in the default namespace.
@@ -562,10 +559,10 @@ class _MockTargetGatherer {
 
   static ast.ListLiteral? _customMocksAst(ast.Annotation annotation) =>
       (annotation.arguments!.arguments.firstWhereOrNull(
-                    (arg) => arg is ast.NamedExpression,
+                    (arg) => arg is ast.NamedArgument,
                   )
-                  as ast.NamedExpression?)
-              ?.expression
+                  as ast.NamedArgument?)
+              ?.argumentExpression
           as ast.ListLiteral?;
 
   static ast.ListLiteral _niceMocksAst(ast.Annotation annotation) =>
@@ -946,10 +943,7 @@ class _MockTargetGatherer {
         .map
         .values
         .where((m) => !m.isPrivate && !m.isStatic)
-        .map(
-          (member) =>
-              SubstitutedExecutableElementImpl.from(member, substitution),
-        );
+        .map((member) => member.substitute(substitution));
     final unstubbableErrorMessages =
         relevantMembers.expand((member) {
           final nameWithEquals =
@@ -1327,10 +1321,7 @@ class _MockClassInfo {
               .getInterface(classToMock)
               .map
               .values
-              .map(
-                (member) =>
-                    SubstitutedExecutableElementImpl.from(member, substitution),
-              );
+              .map((member) => member.substitute(substitution));
 
           // The test can be pre-null-safety but if the class
           // we want to mock is defined in a null safe library,

--- a/builder_pkgs/mockito/pubspec.yaml
+++ b/builder_pkgs/mockito/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: '>=8.1.1 <13.0.0'
+  analyzer: ^13.0.0
   build: '>=3.0.0 <5.0.0'
   code_builder: ^4.5.0
   collection: ^1.19.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ">=5.0.0 <13.0.0"
+  analyzer: ">=5.0.0 <14.0.0"
   build: ^4.0.0
   # Not imported in code, but used to constrain `build.yaml` requirements
   build_config: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,3 +22,23 @@ workspace:
 - builder_pkgs/scratch_space
 - example
 - tool
+
+# Dependency overrides needed to resolve analyzer 13 pending releases of
+# dart_style, source_gen, test_api and test_core.
+dependency_overrides:
+  analyzer: '13.0.0'
+  dart_style:
+    git:
+      url: https://github.com/dart-lang/dart_style.git
+      ref: c9975c66895011079bb3a98dc2271f4e038d45e8
+  source_gen: '4.2.2'
+  test_api:
+    git:
+      url: https://github.com/dart-lang/test.git
+      ref: d0d5ccd037cb0eaea8e4dad900946ac54a4286c6
+      path: pkgs/test_api
+  test_core:
+    git:
+      url: https://github.com/dart-lang/test.git
+      ref: d0d5ccd037cb0eaea8e4dad900946ac54a4286c6
+      path: pkgs/test_core


### PR DESCRIPTION
Analyzer 13 landed in google3 with changes to mockito; land them here in github so we're back in sync.

They're breaking, so require analyzer 13. Everything else can have a range. We need dependency overrides to solve for analyzer 13 until some packages are published. Prepare `build` for release with wider version range as that will help.