### PR TITLE
Mockito: fix accidental API change.

### DIFF
--- a/builder_pkgs/mockito/lib/src/mock.dart
+++ b/builder_pkgs/mockito/lib/src/mock.dart
@@ -546,13 +546,15 @@ T named<T extends Mock>(T mock, {String? name, int? hashCode}) =>
       .._givenHashCode = hashCode;
 
 /// Clear stubs of, and collected interactions with [mock].
-void reset(Mock mock) {
+void reset(Object? mock) {
+  mock as Mock;
   mock._realCalls.clear();
   mock._responses.clear();
 }
 
 /// Clear the collected interactions with [mock].
-void clearInteractions(Mock mock) {
+void clearInteractions(Object? mock) {
+  mock as Mock;
   mock._realCalls.clear();
 }
 


### PR DESCRIPTION
A recent cleanup to satisfy lints change the param type from "dynamic".

But we have tests in google3 that don't compile, adding the correct type is a breaking change even if the runtime behavior is unchanged. It'll need to be a breaking release if we do want to do it.