### PR TITLE
FES + Build Daemon: Allow Daemon Builder to handle expression eval requests

### DIFF
--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -114,6 +114,7 @@ class BuildDaemonClient {
   final _buildResults = StreamController<BuildResults>.broadcast();
   final _shutdownNotifications =
       StreamController<ShutdownNotification>.broadcast();
+  final _responses = StreamController<Map<String, dynamic>>.broadcast();
   final Serializers _serializers;
 
   final IOWebSocketChannel _channel;
@@ -125,7 +126,13 @@ class BuildDaemonClient {
   ) : _channel = IOWebSocketChannel.connect('ws://localhost:$port') {
     _channel.stream
         .listen((data) {
-          final message = _serializers.deserialize(jsonDecode(data as String));
+          final json = jsonDecode(data as String);
+          if (json is Map<String, dynamic> &&
+              json['type'] == 'EvaluateExpressionResponse') {
+            _responses.add(json);
+            return;
+          }
+          final message = _serializers.deserialize(json);
           if (message is ServerLog) {
             logHandler(message);
           } else if (message is BuildResults) {
@@ -148,6 +155,23 @@ class BuildDaemonClient {
   Stream<ShutdownNotification> get shutdownNotifications =>
       _shutdownNotifications.stream;
   Future<void> get finished async => await _channel.sink.done;
+
+  /// Sends a custom JSON request to the daemon and returns its response.
+  ///
+  /// Assumes a strictly sequential request-response flow, returning the next
+  /// JSON message with a supported 'type'.
+  ///
+  /// Warning: Concurrent requests may deliver responses to the wrong callers
+  /// since they aren't matched by ID.
+  Future<Map<String, dynamic>> sendRequest(Map<String, dynamic> request) async {
+    if (request['type'] != 'EvaluateExpressionRequest') {
+      throw ArgumentError(
+        'sendRequest currently only supports EvaluateExpressionRequest',
+      );
+    }
+    _channel.sink.add(jsonEncode(request));
+    return await _responses.stream.first;
+  }
 
   /// Registers a build target to be built upon any file change.
   void registerBuildTarget(BuildTarget target) => _channel.sink.add(

--- a/build_daemon/lib/daemon_builder.dart
+++ b/build_daemon/lib/daemon_builder.dart
@@ -8,6 +8,8 @@ import 'package:watcher/watcher.dart' show WatchEvent;
 
 import 'data/build_status.dart';
 import 'data/build_target.dart';
+import 'data/evaluate_expression_request.dart';
+import 'data/evaluate_expression_response.dart';
 import 'data/server_log.dart';
 
 /// A builder for the daemon.
@@ -22,4 +24,8 @@ abstract class DaemonBuilder {
   Future<void> build(Set<BuildTarget> targets, Iterable<WatchEvent> changes);
 
   Future<void> stop();
+
+  Future<EvaluateExpressionResponse> evaluateExpression(
+    EvaluateExpressionRequest request,
+  );
 }

--- a/build_daemon/lib/data/evaluate_expression_request.dart
+++ b/build_daemon/lib/data/evaluate_expression_request.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'evaluate_expression_response.dart';
+
+/// A request to evaluate a Dart expression from an app built with
+/// build daemon.
+///
+/// This request is sent by a debugger (via DWDS) to the build daemon. The
+/// daemon asks the Frontend Server to compile [expression] to JS,
+/// and returns the result in an [EvaluateExpressionResponse].
+///
+/// See `compileExpressionToJs` in DWDS's `expression_compiler.dart`.
+class EvaluateExpressionRequest {
+  final String isolateId;
+  final String libraryUri;
+  final String scriptUri;
+  final int line;
+  final int column;
+
+  /// A map from variable name to the module name, where variable name is the
+  /// name originally used in JS to contain the module object. For example:
+  /// {'dart': 'dart_sdk', 'main': '/packages/hello_world_main.dart'}.
+  final Map<String, String> jsModules;
+
+  /// A map from JS variable name to its primitive value or another
+  /// variable name. For example: {'x': '1', 'y': 'y', 'o': 'null'}.
+  final Map<String, String> jsFrameValues;
+
+  final String moduleName;
+  final String expression;
+
+  EvaluateExpressionRequest({
+    required this.isolateId,
+    required this.libraryUri,
+    required this.scriptUri,
+    required this.line,
+    required this.column,
+    required this.jsModules,
+    required this.jsFrameValues,
+    required this.moduleName,
+    required this.expression,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'type': 'EvaluateExpressionRequest',
+    'isolateId': isolateId,
+    'libraryUri': libraryUri,
+    'scriptUri': scriptUri,
+    'line': line,
+    'column': column,
+    'jsModules': jsModules,
+    'jsFrameValues': jsFrameValues,
+    'moduleName': moduleName,
+    'expression': expression,
+  };
+
+  factory EvaluateExpressionRequest.fromJson(Map<String, dynamic> json) =>
+      EvaluateExpressionRequest(
+        isolateId: json['isolateId']?.toString() ?? '',
+        libraryUri: json['libraryUri'] as String,
+        scriptUri: json['scriptUri'] as String,
+        line: (json['line'] as int?) ?? 0,
+        column: (json['column'] as int?) ?? 0,
+        jsModules: Map<String, String>.from(json['jsModules'] as Map),
+        jsFrameValues: Map<String, String>.from(json['jsFrameValues'] as Map),
+        moduleName: json['moduleName'] as String,
+        expression: json['expression'] as String,
+      );
+}

--- a/build_daemon/lib/data/evaluate_expression_response.dart
+++ b/build_daemon/lib/data/evaluate_expression_response.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'evaluate_expression_request.dart';
+
+/// The response to an [EvaluateExpressionRequest].
+class EvaluateExpressionResponse {
+  /// The compiled JS expression or an error message if `isError` is true.
+  final String result;
+  final bool isError;
+
+  EvaluateExpressionResponse({required this.result, required this.isError});
+
+  Map<String, dynamic> toJson() => {
+    'type': 'EvaluateExpressionResponse',
+    'result': result,
+    'isError': isError,
+  };
+
+  factory EvaluateExpressionResponse.fromJson(Map<String, dynamic> json) =>
+      EvaluateExpressionResponse(
+        result: json['result'] as String,
+        isError: json['isError'] as bool,
+      );
+}

--- a/build_daemon/lib/src/fakes/fake_builder.dart
+++ b/build_daemon/lib/src/fakes/fake_builder.dart
@@ -9,6 +9,8 @@ import 'package:watcher/watcher.dart' show WatchEvent;
 import '../../daemon_builder.dart';
 import '../../data/build_status.dart';
 import '../../data/build_target.dart';
+import '../../data/evaluate_expression_request.dart';
+import '../../data/evaluate_expression_response.dart';
 import '../../data/server_log.dart';
 
 class FakeDaemonBuilder implements DaemonBuilder {
@@ -26,4 +28,14 @@ class FakeDaemonBuilder implements DaemonBuilder {
 
   @override
   Future<void> stop() async {}
+
+  @override
+  Future<EvaluateExpressionResponse> evaluateExpression(
+    EvaluateExpressionRequest request,
+  ) async {
+    return EvaluateExpressionResponse(
+      result: 'Fake evaluation result',
+      isError: false,
+    );
+  }
 }

--- a/build_daemon/lib/src/fakes/fake_test_builder.dart
+++ b/build_daemon/lib/src/fakes/fake_test_builder.dart
@@ -9,6 +9,8 @@ import 'package:watcher/watcher.dart' show WatchEvent;
 import '../../daemon_builder.dart';
 import '../../data/build_status.dart';
 import '../../data/build_target.dart';
+import '../../data/evaluate_expression_request.dart';
+import '../../data/evaluate_expression_response.dart';
 import '../../data/server_log.dart';
 
 class FakeTestDaemonBuilder implements DaemonBuilder {
@@ -56,5 +58,15 @@ class FakeTestDaemonBuilder implements DaemonBuilder {
       _outputStreamController.close(),
       _buildsController.close(),
     ]);
+  }
+
+  @override
+  Future<EvaluateExpressionResponse> evaluateExpression(
+    EvaluateExpressionRequest request,
+  ) async {
+    return EvaluateExpressionResponse(
+      result: 'Result for ${request.expression}',
+      isError: false,
+    );
   }
 }

--- a/build_daemon/lib/src/server.dart
+++ b/build_daemon/lib/src/server.dart
@@ -21,6 +21,7 @@ import '../daemon_builder.dart';
 import '../data/build_request.dart';
 import '../data/build_target.dart';
 import '../data/build_target_request.dart';
+import '../data/evaluate_expression_request.dart';
 import '../data/serializers.dart';
 import '../data/server_log.dart';
 import '../data/shutdown_notification.dart';
@@ -77,13 +78,36 @@ class Server {
     final handler = webSocketHandler((WebSocketChannel channel, _) async {
       channel.stream.listen(
         (message) async {
-          dynamic request;
+          dynamic decoded;
           try {
-            request = _serializers.deserialize(jsonDecode(message as String));
+            decoded = jsonDecode(message as String);
           } catch (e, s) {
             _logMessage(
               Level.WARNING,
               'Unable to parse message: $message',
+              e,
+              s,
+            );
+            return;
+          }
+
+          // Handle expression evaluation requests separately.
+          if (decoded case {'type': 'EvaluateExpressionRequest'}) {
+            final request = EvaluateExpressionRequest.fromJson(
+              Map<String, dynamic>.from(decoded),
+            );
+            final response = await _builder.evaluateExpression(request);
+            channel.sink.add(jsonEncode(response.toJson()));
+            return;
+          }
+
+          dynamic request;
+          try {
+            request = _serializers.deserialize(decoded);
+          } catch (e, s) {
+            _logMessage(
+              Level.WARNING,
+              'Unable to deserialize message: $message',
               e,
               s,
             );

--- a/build_daemon/test/data/evaluate_expression_test.dart
+++ b/build_daemon/test/data/evaluate_expression_test.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build_daemon/data/evaluate_expression_request.dart';
+import 'package:build_daemon/data/evaluate_expression_response.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EvaluateExpressionRequest', () {
+    test('can be serialized and deserialized', () {
+      final request = EvaluateExpressionRequest(
+        isolateId: '1',
+        libraryUri: 'org-dartlang-app:///web/main.dart',
+        scriptUri: 'web/main.dart',
+        line: 10,
+        column: 1,
+        jsModules: {'dart': 'dart_sdk'},
+        jsFrameValues: {'x': '1'},
+        moduleName: 'web/main.dart',
+        expression: 'x + 1',
+      );
+
+      final json = request.toJson();
+      final deserialized = EvaluateExpressionRequest.fromJson(json);
+
+      expect(deserialized.isolateId, request.isolateId);
+      expect(deserialized.libraryUri, request.libraryUri);
+      expect(deserialized.scriptUri, request.scriptUri);
+      expect(deserialized.line, request.line);
+      expect(deserialized.column, request.column);
+      expect(deserialized.jsModules, request.jsModules);
+      expect(deserialized.jsFrameValues, request.jsFrameValues);
+      expect(deserialized.moduleName, request.moduleName);
+      expect(deserialized.expression, request.expression);
+    });
+
+    test('handles missing or null line and column', () {
+      final json = {
+        'isolateId': '1',
+        'libraryUri': 'org-dartlang-app:///web/main.dart',
+        'scriptUri': 'web/main.dart',
+        'jsModules': <String, String>{},
+        'jsFrameValues': <String, String>{},
+        'moduleName': 'web/main.dart',
+        'expression': 'x + 1',
+      };
+
+      final deserialized = EvaluateExpressionRequest.fromJson(json);
+
+      expect(deserialized.line, 0);
+      expect(deserialized.column, 0);
+    });
+
+    test('handles non-string isolateId', () {
+      final json = {
+        'isolateId': 1,
+        'libraryUri': 'org-dartlang-app:///web/main.dart',
+        'scriptUri': 'web/main.dart',
+        'line': 10,
+        'column': 1,
+        'jsModules': <String, String>{},
+        'jsFrameValues': <String, String>{},
+        'moduleName': 'web/main.dart',
+        'expression': 'x + 1',
+      };
+
+      final deserialized = EvaluateExpressionRequest.fromJson(json);
+
+      expect(deserialized.isolateId, '1');
+    });
+  });
+
+  group('EvaluateExpressionResponse', () {
+    test('can be serialized and deserialized', () {
+      final response = EvaluateExpressionResponse(result: '42', isError: false);
+
+      final json = response.toJson();
+      final deserialized = EvaluateExpressionResponse.fromJson(json);
+
+      expect(deserialized.result, response.result);
+      expect(deserialized.isError, response.isError);
+    });
+  });
+}

--- a/build_daemon/test/server_test.dart
+++ b/build_daemon/test/server_test.dart
@@ -14,6 +14,8 @@ import 'package:build_daemon/data/build_request.dart';
 import 'package:build_daemon/data/build_status.dart';
 import 'package:build_daemon/data/build_target.dart';
 import 'package:build_daemon/data/build_target_request.dart';
+import 'package:build_daemon/data/evaluate_expression_request.dart';
+import 'package:build_daemon/data/evaluate_expression_response.dart';
 import 'package:build_daemon/data/serializers.dart';
 import 'package:build_daemon/data/server_log.dart';
 import 'package:build_daemon/src/fakes/fake_change_provider.dart';
@@ -95,7 +97,7 @@ void main() {
       addTearDown(interstedClient.sink.close);
       addTearDown(interestedEvents.close);
 
-      // Register default client, not intersted in changes
+      // Register default client, not interested in changes
       client.sink.add(
         jsonEncode(
           serializers.serialize(
@@ -146,6 +148,32 @@ void main() {
         ),
       );
     });
+    test('can handle EvaluateExpressionRequests', () async {
+      final request = EvaluateExpressionRequest(
+        isolateId: '1',
+        libraryUri: 'org-dartlang-app:///web/main.dart',
+        scriptUri: 'web/main.dart',
+        line: 10,
+        column: 1,
+        jsModules: {},
+        jsFrameValues: {},
+        moduleName: 'web/main.dart',
+        expression: 'x + 1',
+      );
+
+      client.sink.add(jsonEncode(request.toJson()));
+
+      await expectLater(
+        controller.stream,
+        emitsThrough(
+          isA<EvaluateExpressionResponse>().having(
+            (e) => e.result,
+            'result',
+            'Result for x + 1',
+          ),
+        ),
+      );
+    });
   });
 }
 
@@ -163,7 +191,15 @@ IOWebSocketChannel _createClient(
 ) {
   final client = IOWebSocketChannel.connect('ws://localhost:$port');
   client.stream.listen((data) {
-    final message = serializers.deserialize(jsonDecode(data as String));
+    final json = jsonDecode(data as String);
+    if (json is Map<String, dynamic> &&
+        json.containsKey('result') &&
+        json.containsKey('isError')) {
+      final response = EvaluateExpressionResponse.fromJson(json);
+      controller.add(response);
+      return;
+    }
+    final message = serializers.deserialize(json);
     controller.add(message);
   });
   return client;


### PR DESCRIPTION
This is part 1 for a series of changes to support expression eval + hot reload in our FES-backed implementation.

Notable changes:
* Build Daemon can now accept JSON requests (only expression eval supported as of now).
* Created `EvaluateExpressionResponse` and `EvaluateExpressionRequest` for sending/receiving expression evals. These don't use built_value but instead encode their 'type' as a JSON field. 