### PR TITLE
Add support for deferred loading when compiling to wasm.

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.4.19-wip
 
 - Allow `analyzer` 13.0.0.
+- Add support for deferred loading when compiling to wasm. Users can enable this by adding `--enable-deferred-loading` to the `args` for the `build_web_compilers:dart2wasm` builder.
 
 ## 4.4.18
 

--- a/builder_pkgs/build_web_compilers/build.yaml
+++ b/builder_pkgs/build_web_compilers/build.yaml
@@ -118,6 +118,7 @@ builders:
         - .wasm
         - .wasm.map
         - .mjs
+        - .wasm.tar.gz
     required_inputs:
       - .dart
       - .ddc.js

--- a/builder_pkgs/build_web_compilers/lib/src/archive_extractor.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/archive_extractor.dart
@@ -22,14 +22,20 @@ class Dart2JsArchiveExtractor implements PostProcessBuilder {
     : filterOutputs = options.config['filter_outputs'] as bool? ?? false;
 
   @override
-  final inputExtensions = const [jsEntrypointArchiveExtension];
+  final inputExtensions = const [
+    jsEntrypointArchiveExtension,
+    wasmEntrypointArchiveExtension,
+  ];
 
   @override
   Future<void> build(PostProcessBuildStep buildStep) async {
     final bytes = await buildStep.readInputAsBytes();
     final archive = TarDecoder().decodeBytes(bytes);
     for (final file in archive.files) {
-      if (filterOutputs && !file.name.endsWith('.js')) continue;
+      if (filterOutputs &&
+          !(file.name.endsWith('.js') || file.name.endsWith('.wasm'))) {
+        continue;
+      }
       final inputId = buildStep.inputId;
       final id = AssetId(
         inputId.package,

--- a/builder_pkgs/build_web_compilers/lib/src/dart2wasm_bootstrap.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/dart2wasm_bootstrap.dart
@@ -5,9 +5,12 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:archive/archive.dart';
 import 'package:build/build.dart';
 import 'package:build/experiments.dart';
 import 'package:build_modules/build_modules.dart';
+import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 
@@ -151,6 +154,38 @@ $librariesString
       scratchSpace,
       buildStep,
     );
+
+    final rootDir = p.dirname(wasmOutputFile.path);
+    final baseInputName = p.basenameWithoutExtension(dartEntrypointId.path);
+    final archive = Archive();
+    final fileGlob = Glob('$baseInputName*$wasmExtension');
+    await for (final wasmFile in fileGlob.list(root: rootDir)) {
+      if (wasmFile is! File) continue;
+      if (wasmFile.path.endsWith(moduleJsExtension) ||
+          wasmFile.path.endsWith(wasmSourceMapExtension) ||
+          wasmFile.absolute.path == wasmOutputFile.absolute.path) {
+        // These are explicitly output, and are not part of the archive.
+        continue;
+      }
+      final fileName = p.relative(wasmFile.path, from: rootDir);
+      final fileStats = await wasmFile.stat();
+      archive.addFile(
+        ArchiveFile(
+            fileName,
+            fileStats.size,
+            await (wasmFile as File).readAsBytes(),
+          )
+          ..mode = fileStats.mode
+          ..lastModTime = fileStats.modified.millisecondsSinceEpoch,
+      );
+    }
+
+    if (archive.isNotEmpty) {
+      final archiveId = dartEntrypointId.changeExtension(
+        wasmEntrypointArchiveExtension,
+      );
+      await buildStep.writeAsBytes(archiveId, TarEncoder().encode(archive));
+    }
 
     final loaderContents =
         await scratchSpace

--- a/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -25,6 +25,7 @@ const moduleJsExtension = '.mjs';
 const jsEntrypointSourceMapExtension = '.dart.js.map';
 const dart2jsEntrypointSourceMapExtension = '.dart2js.js.map';
 const jsEntrypointArchiveExtension = '.dart.js.tar.gz';
+const wasmEntrypointArchiveExtension = '.wasm.tar.gz';
 const digestsEntrypointExtension = '.digests';
 const mergedMetadataExtension = '.dart.ddc_merged_metadata';
 
@@ -314,6 +315,7 @@ final class EntrypointBuilderOptions {
           dart2wasm.extension,
           wasmExtension,
           wasmSourceMapExtension,
+          wasmEntrypointArchiveExtension,
         ],
         if (loaderExtension case final loader?) loader,
       ],
@@ -493,10 +495,13 @@ if (!forceJS && $supportCheck) {
     }
 
     loaderResult.writeln('''
+function loadDeferredModules(modules, handleWasmBytes) {
+  return Promise.all(modules.map((m) => fetch(relativeURL(`./\${m}`)).then((b) => handleWasmBytes(m, b))));
+}
 let { compileStreaming } = await import(relativeURL("./$basename${wasmCompiler.extension}"));
 
 let app = await compileStreaming(fetch(relativeURL("$basename.wasm")));
-let module = await app.instantiate({});
+let module = await app.instantiate({}, {loadDeferredModules: loadDeferredModules});
 module.invokeMain();
 ''');
 

--- a/builder_pkgs/build_web_compilers/test/dart2wasm_bootstrap_test.dart
+++ b/builder_pkgs/build_web_compilers/test/dart2wasm_bootstrap_test.dart
@@ -12,8 +12,16 @@ void main() {
   initializePlatforms();
   final startingAssets = {
     'a|web/index.dart': '''
-        void main() {
+        import 'lib.dart' deferred as lib;
+        Future<void> main() async {
           print('Hello world!');
+          await lib.loadLibrary();
+          lib.foo();
+        }
+      ''',
+    'a|web/lib.dart': '''
+        void foo() {
+          print('Hello from foo!');
         }
       ''',
   };
@@ -34,6 +42,7 @@ void main() {
     'a|web/index.dart2js.module': isNotNull,
     'a|web/index.dart2wasm.module': isNotNull,
     'a|web/index.module.library': isNotNull,
+    'a|web/lib.module.library': isNotNull,
   };
 
   test('base build', () async {
@@ -177,6 +186,35 @@ void main() {
         'loader': null,
       }),
     );
+
+    await testBuilders(
+      [...startingBuilders, builder],
+      startingAssets,
+      outputs: expectedOutputs,
+    );
+  });
+
+  test('generates archive when deferred loading enabled', () async {
+    final builder = WebEntrypointBuilder.fromOptions(
+      const BuilderOptions({
+        'compilers': {
+          'dart2js': <String, Object?>{},
+          'dart2wasm': <String, Object?>{
+            'args': ['--enable-deferred-loading'],
+          },
+        },
+      }),
+    );
+    final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
+      'a|web/index.dart.js.tar.gz': isNotNull,
+      'a|web/index.dart2js.js': isNotNull,
+      'a|web/index.dart2js.js.map': isNotNull,
+      'a|web/index.dart.js': isNotNull,
+      'a|web/index.wasm.tar.gz': isNotNull,
+      'a|web/index.mjs': isNotNull,
+      'a|web/index.wasm.map': isNotNull,
+      'a|web/index.wasm': isNotNull,
+    });
 
     await testBuilders(
       [...startingBuilders, builder],


### PR DESCRIPTION
- Capture any additional '.wasm' outputs from the dart2wasm compiler into an .gz archive
- Add the archive as an additional (optional) expected output of the dart2wasm builder
- Update the entrypoint JS script to provide the deferred loading helper function.
- Add a test for the dart2wasm builder.