### PR TITLE
Fix read of global options from wrong workspace package.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -6,6 +6,9 @@
   have performance measurement needs not covered by the newer `--dart-aot-perf`.
 - Removed options can still be passed, they will be ignored with a warning.
 - Bug fix: fix crash during logging if an asset path is an invalid URI.
+- Bug fix: with `--workspace` the global options affecting build order were read
+  from the wrong package. They are now read from `build.yaml` in the workspace
+  root, like other global options.
 - Allow `analyzer` 13.0.0.
 
 ## 2.14.1

--- a/build_runner/lib/src/build_plan/builder_definition.dart
+++ b/build_runner/lib/src/build_plan/builder_definition.dart
@@ -77,7 +77,9 @@ sealed class AbstractBuilderDefinition {
               c.package == buildPackages.outputRoot,
         );
 
-    final rootBuildConfig = orderedConfigs.last;
+    final rootBuildConfig = orderedConfigs.singleWhere(
+      (c) => c.packageName == buildPackages.outputRoot,
+    );
     final orderedBuilders =
         findBuilderOrder(
           builderDefinitions,

--- a/build_runner/test/integration_tests/build_command_define_test.dart
+++ b/build_runner/test/integration_tests/build_command_define_test.dart
@@ -162,5 +162,67 @@ global_options:
 ''');
     await tester.run('', 'dart run build_runner build --force-jit --workspace');
     expect(tester.read('root_pkg/web/a.txt.copy'), 'b(workspace global)');
+
+    // Global options `runs_before` from workspace root `build.yaml` are used.
+    tester.writePackage(
+      name: 'pkg_a',
+      files:
+          FixturePackages.copyBuilder(
+            packageName: 'pkg_a',
+            outputExtension: '.a',
+          ).files,
+      dependencies: ['build', 'build_runner'],
+      inWorkspace: true,
+    );
+    tester.writePackage(
+      name: 'pkg_b',
+      files:
+          FixturePackages.copyBuilder(
+            packageName: 'pkg_b',
+            outputExtension: '.b',
+          ).files,
+      dependencies: ['build', 'build_runner'],
+      inWorkspace: true,
+    );
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['pkg_a', 'pkg_b'],
+      files: {'web/a.txt': 'a'},
+      inWorkspace: true,
+    );
+    tester.writeWorkspacePubspec(packages: ['root_pkg', 'pkg_a', 'pkg_b']);
+
+    // `pkg_a:test_builder` runs first.
+    tester.write('build.yaml', r'''
+global_options:
+  pkg_a:test_builder:
+    runs_before: ['pkg_b:test_builder']
+''');
+    // Run order can be determined by which shows first in the log.
+    var output = await tester.run(
+      '',
+      'dart run build_runner build --force-jit --workspace',
+    );
+    expect(
+      output.indexOf('pkg_a:test_builder'),
+      lessThan(output.indexOf('pkg_b:test_builder')),
+    );
+
+    // `pkg_b:test_builder` runs first.
+    tester.write('build.yaml', r'''
+global_options:
+  pkg_b:test_builder:
+    runs_before: ['pkg_a:test_builder']
+''');
+    // Now they show in the reverse order in the log.
+    output = await tester.run(
+      '',
+      'dart run build_runner build --force-jit --workspace',
+    );
+    expect(
+      output.indexOf('pkg_a:test_builder'),
+      greaterThan(output.indexOf('pkg_b:test_builder')),
+    );
   });
 }


### PR DESCRIPTION
As reported here https://github.com/dart-lang/build/discussions/4349#discussioncomment-16759149

When calculating run order it was using global options from the "last" package, which only makes sense for a single package build. It should use the "output root" package instead.