### PR TITLE
fix ddc builder for generated entrypoint

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.20-wip
+
+- Fixed `DdcFrontendServerBuilder` to correctly work with generated entrypoints.
+
 ## 4.4.19
 
 - Allow `analyzer` 13.0.0.

--- a/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
@@ -96,7 +96,10 @@ class DdcFrontendServerBuilder implements Builder {
     await buildStep.trackStage(
       'EnsureAssets',
       () => scratchSpace.ensureAssets([
-        webEntrypointAsset,
+        // It is only safe to include the entrypoint here for the same package,
+        // as for other packages it might be generated in a later build phase.
+        if (webEntrypointAsset.package == buildStep.inputId.package)
+          webEntrypointAsset,
         ...transitiveAssets,
       ], buildStep),
     );

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.4.19
+version: 4.4.20-wip
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
Trying to fix https://github.com/schultek/jaspr/pull/799

In Jaspr, the client entrypoint (`web/main.client.dart`) is generated by another builder, which causes the `DdcFrontendServerBuilder` to throw at `scratchSpace.ensureAssets`.

@Markzipan 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
