### PR TITLE
Fix post process builder error handling.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.15.1-wip
+
+- Bug fix: handle errors from post process builders in previous runs without
+  crashing.
+
 ## 2.15.0
 
 - Remove `--low-resources-mode` as default memory usage has been improved. If

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -606,10 +606,14 @@ class AssetGraph implements GeneratedAssetHider {
 
   /// Returns outputs that were written to the source tree.
   Iterable<AssetId> outputsToDelete(BuildPackages buildPackages) {
-    // Checks if `id` is in a known package. If not, maybe the package was
-    // renamed: move it to the single package being built, if there is one,
-    // to delete for that case. If the ID is in an unknown package and can't
-    // be fixed, returns `null`.
+    // Checks if `id` is in a known package. If so, returns it.
+    //
+    // If not, and a single package is being built, returns `id` moved to that
+    // package. This allows old generated output to be deleted if the package
+    // was renamed since the last build.
+    //
+    // If `id` is not in a known package and a single package is not being
+    // built, returns `null`.
     AssetId? checkAndMoveId(AssetId id) {
       if (buildPackages[id.package] != null) {
         return id;

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -26,6 +26,7 @@ import 'exceptions.dart';
 import 'node.dart';
 import 'nodes.dart';
 import 'post_process_build_step_id.dart';
+import 'post_process_build_step_result.dart';
 import 'serializers.dart';
 
 part 'serialization.dart';
@@ -55,13 +56,13 @@ class AssetGraph implements GeneratedAssetHider {
 
   final BuiltMap<String, LanguageVersion?> packageLanguageVersions;
 
-  /// All post process build steps outputs, indexed by package then
+  /// All post process build steps results, indexed by package then
   /// [PostProcessBuildStepId].
   ///
   /// Created with empty outputs at the start of the build if it's a new build
-  /// step; or deserialized with previous build outputs if it has run before.
-  final Map<String, Map<PostProcessBuildStepId, Set<AssetId>>>
-  _postProcessBuildStepOutputs;
+  /// step; or deserialized with previous build results if it has run before.
+  final Map<String, Map<PostProcessBuildStepId, PostProcessBuildStepResult>>
+  _postProcessBuildStepResults;
 
   /// Digest of the previous build's `BuildTriggers`, or `null` if this is a
   /// clean build.
@@ -96,7 +97,7 @@ class AssetGraph implements GeneratedAssetHider {
       postBuildActionsOptionsDigests =
           buildPhases.postBuildActionsOptionsDigests,
       _nodes = Nodes(),
-      _postProcessBuildStepOutputs = {};
+      _postProcessBuildStepResults = {};
 
   /// An empty asset graph.
   @visibleForTesting
@@ -112,7 +113,7 @@ class AssetGraph implements GeneratedAssetHider {
     this.packageLanguageVersions,
     this.enabledExperiments,
   ) : _nodes = Nodes(),
-      _postProcessBuildStepOutputs = {};
+      _postProcessBuildStepResults = {};
 
   AssetGraph._with({
     required Nodes nodes,
@@ -121,8 +122,11 @@ class AssetGraph implements GeneratedAssetHider {
     required this.dartVersion,
     required this.enabledExperiments,
     required this.packageLanguageVersions,
-    required Map<String, Map<PostProcessBuildStepId, Set<AssetId>>>
-    postProcessBuildStepOutputs,
+    required Map<
+      String,
+      Map<PostProcessBuildStepId, PostProcessBuildStepResult>
+    >
+    postProcessBuildStepResults,
     required this.previousBuildTriggersDigest,
     required this.previousInBuildPhasesOptionsDigests,
     required this.inBuildPhasesOptionsDigests,
@@ -130,7 +134,7 @@ class AssetGraph implements GeneratedAssetHider {
     required this.postBuildActionsOptionsDigests,
     required this.previousPhasedAssetDeps,
   }) : _nodes = nodes,
-       _postProcessBuildStepOutputs = postProcessBuildStepOutputs;
+       _postProcessBuildStepResults = postProcessBuildStepResults;
 
   @visibleForTesting
   AssetGraph copyWith({String? dartVersion}) => AssetGraph._with(
@@ -140,7 +144,7 @@ class AssetGraph implements GeneratedAssetHider {
     dartVersion: dartVersion ?? this.dartVersion,
     enabledExperiments: enabledExperiments,
     packageLanguageVersions: packageLanguageVersions,
-    postProcessBuildStepOutputs: _postProcessBuildStepOutputs,
+    postProcessBuildStepResults: _postProcessBuildStepResults,
     previousBuildTriggersDigest: previousBuildTriggersDigest,
     previousInBuildPhasesOptionsDigests: previousInBuildPhasesOptionsDigests,
     inBuildPhasesOptionsDigests: inBuildPhasesOptionsDigests,
@@ -159,8 +163,8 @@ class AssetGraph implements GeneratedAssetHider {
       dartVersion: dartVersion,
       enabledExperiments: enabledExperiments,
       packageLanguageVersions: packageLanguageVersions,
-      postProcessBuildStepOutputs: {
-        for (final entry in _postProcessBuildStepOutputs.entries)
+      postProcessBuildStepResults: {
+        for (final entry in _postProcessBuildStepResults.entries)
           entry.key: Map.of(entry.value),
       },
       previousBuildTriggersDigest: previousBuildTriggersDigest,
@@ -204,9 +208,8 @@ class AssetGraph implements GeneratedAssetHider {
 
   List<int> serialize() => serializeAssetGraph(this);
 
-  @visibleForTesting
-  Map<String, Map<PostProcessBuildStepId, Set<AssetId>>>
-  get allPostProcessBuildStepOutputs => _postProcessBuildStepOutputs;
+  Map<String, Map<PostProcessBuildStepId, PostProcessBuildStepResult>>
+  get allPostProcessBuildStepResults => _postProcessBuildStepResults;
 
   /// Whether this is a clean build, meaning there was no previous build state
   /// loaded or it was discarded as incompatible.
@@ -256,8 +259,8 @@ class AssetGraph implements GeneratedAssetHider {
     });
 
     // Remove post build action applications with removed assets as inputs.
-    for (final packageOutputs in _postProcessBuildStepOutputs.values) {
-      packageOutputs.removeWhere((id, _) => removedIds!.contains(id.input));
+    for (final packageResults in _postProcessBuildStepResults.values) {
+      packageResults.removeWhere((id, _) => removedIds!.contains(id.input));
     }
   }
 
@@ -277,31 +280,35 @@ class AssetGraph implements GeneratedAssetHider {
   /// All the post process build steps for `package`.
   Iterable<PostProcessBuildStepId> postProcessBuildStepIds({
     required String package,
-  }) => _postProcessBuildStepOutputs[package]?.keys ?? const [];
+  }) => _postProcessBuildStepResults[package]?.keys ?? const [];
+
+  Iterable<AssetId> get allPostProcessOutputIds => _postProcessBuildStepResults
+      .values
+      .expand((entries) => entries.values.expand((v) => v.outputs));
 
   /// Creates or updates state for a [PostProcessBuildStepId].
-  void updatePostProcessBuildStep(
-    PostProcessBuildStepId buildStepId, {
-    required Set<AssetId> outputs,
-  }) {
-    _postProcessBuildStepOutputs.putIfAbsent(
+  void updatePostProcessBuildStepResult(
+    PostProcessBuildStepId buildStepId,
+    PostProcessBuildStepResult result,
+  ) {
+    _postProcessBuildStepResults.putIfAbsent(
           buildStepId.input.package,
           () => {},
         )[buildStepId] =
-        outputs;
+        result;
   }
 
-  /// Gets outputs of a [PostProcessBuildStepId].
+  /// Gets the result of a [PostProcessBuildStepId].
   ///
-  /// These are set using [updatePostProcessBuildStep] during the build, then
-  /// used to clean up prior outputs in the next build.
-  Iterable<AssetId> postProcessBuildStepOutputs(PostProcessBuildStepId action) {
-    return _postProcessBuildStepOutputs[action.input.package]![action]!;
-  }
+  /// These are set using [updatePostProcessBuildStepResult] during the build,
+  /// then used to clean up prior outputs in the next build.
+  PostProcessBuildStepResult? postProcessBuildStepResultFor(
+    PostProcessBuildStepId action,
+  ) => _postProcessBuildStepResults[action.input.package]?[action];
 
   /// All the generated outputs in the graph.
   Iterable<AssetId> get outputs =>
-      allNodes.where((n) => n.type == NodeType.generated).map((n) => n.id);
+      allNodes.where((n) => n.isGenerated).map((n) => n.id);
 
   /// All the generated outputs for a particular phase.
   Iterable<AssetNode> outputsForPhase(String package, int phase) =>
@@ -494,9 +501,9 @@ class AssetGraph implements GeneratedAssetHider {
     for (final action in phase.builderActions) {
       final inputs = allInputs.where((input) => _actionMatches(action, input));
       for (final input in inputs) {
-        updatePostProcessBuildStep(
+        updatePostProcessBuildStepResult(
           PostProcessBuildStepId(input: input, actionNumber: actionNumber),
-          outputs: {},
+          PostProcessBuildStepResult(hidden: action.hideOutput),
         );
       }
       actionNumber++;
@@ -599,22 +606,43 @@ class AssetGraph implements GeneratedAssetHider {
 
   /// Returns outputs that were written to the source tree.
   Iterable<AssetId> outputsToDelete(BuildPackages buildPackages) {
+    // Checks if `id` is in a known package. If not, maybe the package was
+    // renamed: move it to the single package being built, if there is one,
+    // to delete for that case. If the ID is in an unknown package and can't
+    // be fixed, returns `null`.
+    AssetId? checkAndMoveId(AssetId id) {
+      if (buildPackages[id.package] != null) {
+        return id;
+      }
+      final singleOutputPackage = buildPackages.singleOutputPackage;
+      if (singleOutputPackage == null) return null;
+      return AssetId(singleOutputPackage, id.path);
+    }
+
     final result = <AssetId>[];
     // Delete all the non-hidden outputs.
     for (final id in outputs) {
       final node = get(id)!;
+      if (node.type == NodeType.postGenerated) {
+        // Handled via post process build step results below so we know if the
+        // output is hidden.
+        continue;
+      }
       final nodeConfiguration = node.generatedNodeConfiguration!;
       if (node.wasOutput && !nodeConfiguration.isHidden) {
-        var idToDelete = id;
-        // If the package no longer exists, then the user might have renamed
-        // it. So move `idToDelete` to the single package being built, if there
-        // is one, to delete for that case.
-        if (buildPackages[id.package] == null) {
-          final singleOutputPackage = buildPackages.singleOutputPackage;
-          if (singleOutputPackage == null) continue;
-          idToDelete = AssetId(singleOutputPackage, id.path);
+        final idToDelete = checkAndMoveId(id);
+        if (idToDelete != null) result.add(idToDelete);
+      }
+    }
+    for (final packagePostProcessResults
+        in _postProcessBuildStepResults.values) {
+      for (final postProcessResults in packagePostProcessResults.values) {
+        if (!postProcessResults.hidden) {
+          for (final id in postProcessResults.outputs) {
+            final idToDelete = checkAndMoveId(id);
+            if (idToDelete != null) result.add(idToDelete);
+          }
         }
-        result.add(idToDelete);
       }
     }
     return result;

--- a/build_runner/lib/src/build/asset_graph/node.dart
+++ b/build_runner/lib/src/build/asset_graph/node.dart
@@ -19,6 +19,7 @@ class NodeType extends EnumClass {
   static Serializer<NodeType> get serializer => _$nodeTypeSerializer;
 
   static const NodeType generated = _$generated;
+  static const NodeType postGenerated = _$postGenerated;
   static const NodeType glob = _$glob;
   static const NodeType placeholder = _$placeholder;
   static const NodeType source = _$source;
@@ -78,7 +79,10 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
   /// Whether this asset is a normal, readable file.
   ///
   /// Does not guarantee that the file currently exists.
-  bool get isFile => type == NodeType.generated || type == NodeType.source;
+  bool get isFile =>
+      type == NodeType.generated ||
+      type == NodeType.postGenerated ||
+      type == NodeType.source;
 
   /// Whether this node is tracked as an input in the asset graph.
   bool get isTrackedInput =>
@@ -170,6 +174,12 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
   static AssetId createGlobNodeId(String package, String glob, int phaseNum) =>
       AssetId(package, 'glob.$phaseNum.${base64.encode(utf8.encode(glob))}');
 
+  /// A post-process generated node.
+  factory AssetNode.postGenerated(AssetId id) => AssetNode((b) {
+    b.id = id;
+    b.type = NodeType.postGenerated;
+  });
+
   AssetNode._() {
     // Check that configuration and state fields are non-null exactly when the
     // node is of the corresponding type.
@@ -210,11 +220,16 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
     }
   }
 
+  bool get isGenerated =>
+      type == NodeType.generated || type == NodeType.postGenerated;
+
   /// Whether this is a generated node that was written when the generator ran.
   ///
   /// A file can be output by a failing generator, check
   /// `generatedNodeState.result` for whether the generator succeeded.
-  bool get wasOutput => type == NodeType.generated && digest != null;
+  bool get wasOutput =>
+      type == NodeType.postGenerated ||
+      (type == NodeType.generated && digest != null);
 }
 
 /// Additional configuration for an [AssetNode.generated].

--- a/build_runner/lib/src/build/asset_graph/node.g.dart
+++ b/build_runner/lib/src/build/asset_graph/node.g.dart
@@ -7,6 +7,7 @@ part of 'node.dart';
 // **************************************************************************
 
 const NodeType _$generated = const NodeType._('generated');
+const NodeType _$postGenerated = const NodeType._('postGenerated');
 const NodeType _$glob = const NodeType._('glob');
 const NodeType _$placeholder = const NodeType._('placeholder');
 const NodeType _$source = const NodeType._('source');
@@ -16,6 +17,8 @@ NodeType _$nodeTypeValueOf(String name) {
   switch (name) {
     case 'generated':
       return _$generated;
+    case 'postGenerated':
+      return _$postGenerated;
     case 'glob':
       return _$glob;
     case 'placeholder':
@@ -31,6 +34,7 @@ NodeType _$nodeTypeValueOf(String name) {
 
 final BuiltSet<NodeType> _$nodeTypeValues = BuiltSet<NodeType>(const <NodeType>[
   _$generated,
+  _$postGenerated,
   _$glob,
   _$placeholder,
   _$source,

--- a/build_runner/lib/src/build/asset_graph/post_process_build_step_result.dart
+++ b/build_runner/lib/src/build/asset_graph/post_process_build_step_result.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart' hide Builder;
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'post_process_build_step_result.g.dart';
+
+/// The outputs and errors of a post process build step, and whether its
+/// output is hidden.
+abstract class PostProcessBuildStepResult
+    implements
+        Built<PostProcessBuildStepResult, PostProcessBuildStepResultBuilder> {
+  static Serializer<PostProcessBuildStepResult> get serializer =>
+      _$postProcessBuildStepResultSerializer;
+
+  bool get hidden;
+
+  BuiltSet<AssetId> get outputs;
+
+  BuiltList<String> get errors;
+
+  factory PostProcessBuildStepResult({
+    required bool hidden,
+    Iterable<AssetId> outputs = const [],
+    Iterable<String> errors = const [],
+  }) => _$PostProcessBuildStepResult._(
+    hidden: hidden,
+    outputs: outputs.toBuiltSet(),
+    errors: errors.toBuiltList(),
+  );
+
+  PostProcessBuildStepResult._();
+}

--- a/build_runner/lib/src/build/asset_graph/post_process_build_step_result.g.dart
+++ b/build_runner/lib/src/build/asset_graph/post_process_build_step_result.g.dart
@@ -1,0 +1,234 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'post_process_build_step_result.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<PostProcessBuildStepResult> _$postProcessBuildStepResultSerializer =
+    _$PostProcessBuildStepResultSerializer();
+
+class _$PostProcessBuildStepResultSerializer
+    implements StructuredSerializer<PostProcessBuildStepResult> {
+  @override
+  final Iterable<Type> types = const [
+    PostProcessBuildStepResult,
+    _$PostProcessBuildStepResult,
+  ];
+  @override
+  final String wireName = 'PostProcessBuildStepResult';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    PostProcessBuildStepResult object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'hidden',
+      serializers.serialize(object.hidden, specifiedType: const FullType(bool)),
+      'outputs',
+      serializers.serialize(
+        object.outputs,
+        specifiedType: const FullType(BuiltSet, const [
+          const FullType(AssetId),
+        ]),
+      ),
+      'errors',
+      serializers.serialize(
+        object.errors,
+        specifiedType: const FullType(BuiltList, const [
+          const FullType(String),
+        ]),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  PostProcessBuildStepResult deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = PostProcessBuildStepResultBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'hidden':
+          result.hidden =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(bool),
+                  )!
+                  as bool;
+          break;
+        case 'outputs':
+          result.outputs.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(BuiltSet, const [
+                    const FullType(AssetId),
+                  ]),
+                )!
+                as BuiltSet<Object?>,
+          );
+          break;
+        case 'errors':
+          result.errors.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(BuiltList, const [
+                    const FullType(String),
+                  ]),
+                )!
+                as BuiltList<Object?>,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PostProcessBuildStepResult extends PostProcessBuildStepResult {
+  @override
+  final bool hidden;
+  @override
+  final BuiltSet<AssetId> outputs;
+  @override
+  final BuiltList<String> errors;
+
+  factory _$PostProcessBuildStepResult([
+    void Function(PostProcessBuildStepResultBuilder)? updates,
+  ]) => (PostProcessBuildStepResultBuilder()..update(updates))._build();
+
+  _$PostProcessBuildStepResult._({
+    required this.hidden,
+    required this.outputs,
+    required this.errors,
+  }) : super._();
+  @override
+  PostProcessBuildStepResult rebuild(
+    void Function(PostProcessBuildStepResultBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  PostProcessBuildStepResultBuilder toBuilder() =>
+      PostProcessBuildStepResultBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PostProcessBuildStepResult &&
+        hidden == other.hidden &&
+        outputs == other.outputs &&
+        errors == other.errors;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, hidden.hashCode);
+    _$hash = $jc(_$hash, outputs.hashCode);
+    _$hash = $jc(_$hash, errors.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PostProcessBuildStepResult')
+          ..add('hidden', hidden)
+          ..add('outputs', outputs)
+          ..add('errors', errors))
+        .toString();
+  }
+}
+
+class PostProcessBuildStepResultBuilder
+    implements
+        Builder<PostProcessBuildStepResult, PostProcessBuildStepResultBuilder> {
+  _$PostProcessBuildStepResult? _$v;
+
+  bool? _hidden;
+  bool? get hidden => _$this._hidden;
+  set hidden(bool? hidden) => _$this._hidden = hidden;
+
+  SetBuilder<AssetId>? _outputs;
+  SetBuilder<AssetId> get outputs => _$this._outputs ??= SetBuilder<AssetId>();
+  set outputs(SetBuilder<AssetId>? outputs) => _$this._outputs = outputs;
+
+  ListBuilder<String>? _errors;
+  ListBuilder<String> get errors => _$this._errors ??= ListBuilder<String>();
+  set errors(ListBuilder<String>? errors) => _$this._errors = errors;
+
+  PostProcessBuildStepResultBuilder();
+
+  PostProcessBuildStepResultBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _hidden = $v.hidden;
+      _outputs = $v.outputs.toBuilder();
+      _errors = $v.errors.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PostProcessBuildStepResult other) {
+    _$v = other as _$PostProcessBuildStepResult;
+  }
+
+  @override
+  void update(void Function(PostProcessBuildStepResultBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PostProcessBuildStepResult build() => _build();
+
+  _$PostProcessBuildStepResult _build() {
+    _$PostProcessBuildStepResult _$result;
+    try {
+      _$result =
+          _$v ??
+          _$PostProcessBuildStepResult._(
+            hidden: BuiltValueNullFieldError.checkNotNull(
+              hidden,
+              r'PostProcessBuildStepResult',
+              'hidden',
+            ),
+            outputs: outputs.build(),
+            errors: errors.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'outputs';
+        outputs.build();
+        _$failedField = 'errors';
+        errors.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'PostProcessBuildStepResult',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/build_runner/lib/src/build/asset_graph/serialization.dart
+++ b/build_runner/lib/src/build/asset_graph/serialization.dart
@@ -8,7 +8,7 @@ part of 'graph.dart';
 ///
 /// This should be incremented any time the serialize/deserialize formats
 /// change.
-const _version = 32;
+const _version = 33;
 
 /// Deserializes an [AssetGraph] from a [Map].
 ///
@@ -66,16 +66,19 @@ AssetGraph? deserializeAssetGraph(List<int> bytes) {
     graph._nodes.add(_deserializeAssetNode(serializedItem as List));
   }
 
-  final postProcessOutputs =
+  final postProcessResults =
       serializers.deserialize(
-            serializedGraph['postProcessOutputs'],
-            specifiedType: postProcessBuildStepOutputsFullType,
+            serializedGraph['postProcessResults'],
+            specifiedType: postProcessBuildStepResultsFullType,
           )
-          as Map<String, Map<PostProcessBuildStepId, Set<AssetId>>>;
+          as Map<
+            String,
+            Map<PostProcessBuildStepId, PostProcessBuildStepResult>
+          >;
 
-  for (final postProcessOutputsForPackage in postProcessOutputs.values) {
-    for (final entry in postProcessOutputsForPackage.entries) {
-      graph.updatePostProcessBuildStep(entry.key, outputs: entry.value);
+  for (final postProcessResultsForPackage in postProcessResults.values) {
+    for (final entry in postProcessResultsForPackage.entries) {
+      graph.updatePostProcessBuildStepResult(entry.key, entry.value);
     }
   }
 
@@ -117,9 +120,9 @@ List<int> serializeAssetGraph(AssetGraph graph) {
             .map((pkg, version) => MapEntry(pkg, version?.toString()))
             .toMap(),
     'enabledExperiments': graph.enabledExperiments.toList(),
-    'postProcessOutputs': serializers.serialize(
-      graph._postProcessBuildStepOutputs,
-      specifiedType: postProcessBuildStepOutputsFullType,
+    'postProcessResults': serializers.serialize(
+      graph._postProcessBuildStepResults,
+      specifiedType: postProcessBuildStepResultsFullType,
     ),
     'inBuildPhasesOptionsDigests': serializers.serialize(
       graph.inBuildPhasesOptionsDigests,

--- a/build_runner/lib/src/build/asset_graph/serializers.dart
+++ b/build_runner/lib/src/build/asset_graph/serializers.dart
@@ -4,7 +4,7 @@
 
 import 'dart:convert';
 
-import 'package:build/build.dart' show AssetId, PostProcessBuildStep;
+import 'package:build/build.dart' show AssetId;
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 import 'package:crypto/crypto.dart';
@@ -15,17 +15,18 @@ import '../library_cycle_graph/phased_value.dart';
 import 'identity_serializer.dart';
 import 'node.dart';
 import 'post_process_build_step_id.dart';
+import 'post_process_build_step_result.dart';
 
 part 'serializers.g.dart';
 
-final postProcessBuildStepOutputsInnerFullType = const FullType(Map, [
-  FullType(PostProcessBuildStep),
-  FullType(Set, [FullType(AssetId)]),
+final postProcessBuildStepResultsInnerFullType = const FullType(Map, [
+  FullType(PostProcessBuildStepId),
+  FullType(PostProcessBuildStepResult),
 ]);
 
-final postProcessBuildStepOutputsFullType = FullType(Map, [
+final postProcessBuildStepResultsFullType = FullType(Map, [
   const FullType(String),
-  postProcessBuildStepOutputsInnerFullType,
+  postProcessBuildStepResultsInnerFullType,
 ]);
 
 final assetIdSerializer = AssetIdSerializer();
@@ -33,7 +34,12 @@ final identityAssetIdSerializer = IdentitySerializer<AssetId>(
   assetIdSerializer,
 );
 
-@SerializersFor([AssetNode, PhasedAssetDeps, AssetDeps])
+@SerializersFor([
+  AssetDeps,
+  AssetNode,
+  PhasedAssetDeps,
+  PostProcessBuildStepResult,
+])
 final Serializers serializers =
     (_$serializers.toBuilder()
           ..add(identityAssetIdSerializer)
@@ -43,12 +49,20 @@ final Serializers serializers =
             () => <AssetId>{},
           )
           ..addBuilderFactory(
-            postProcessBuildStepOutputsInnerFullType,
-            () => <PostProcessBuildStepId, Set<AssetId>>{},
+            postProcessBuildStepResultsInnerFullType,
+            () => <PostProcessBuildStepId, PostProcessBuildStepResult>{},
           )
           ..addBuilderFactory(
-            postProcessBuildStepOutputsFullType,
-            () => <String, Map<PostProcessBuildStepId, Set<AssetId>>>{},
+            postProcessBuildStepResultsFullType,
+            () =>
+                <
+                  String,
+                  Map<PostProcessBuildStepId, PostProcessBuildStepResult>
+                >{},
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltMap, [FullType(AssetId), FullType(Digest)]),
+            MapBuilder<AssetId, Digest>.new,
           )
           ..addBuilderFactory(
             const FullType(BuiltList, [FullType(Digest)]),

--- a/build_runner/lib/src/build/asset_graph/serializers.g.dart
+++ b/build_runner/lib/src/build/asset_graph/serializers.g.dart
@@ -19,6 +19,7 @@ Serializers _$serializers =
           ..add(PhasedAssetDeps.serializer)
           ..add(PhasedValue.serializer)
           ..add(PostProcessBuildStepId.serializer)
+          ..add(PostProcessBuildStepResult.serializer)
           ..addBuilderFactory(
             const FullType(BuiltMap, const [
               const FullType(AssetId),
@@ -37,6 +38,14 @@ Serializers _$serializers =
           ..addBuilderFactory(
             const FullType(BuiltList, const [const FullType(AssetId)]),
             () => ListBuilder<AssetId>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSet, const [const FullType(AssetId)]),
+            () => SetBuilder<AssetId>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(String)]),
+            () => ListBuilder<String>(),
           )
           ..addBuilderFactory(
             const FullType(BuiltSet, const [const FullType(AssetId)]),

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -29,6 +29,7 @@ import '../logging/timed_activities.dart';
 import 'asset_graph/graph.dart';
 import 'asset_graph/node.dart';
 import 'asset_graph/post_process_build_step_id.dart';
+import 'asset_graph/post_process_build_step_result.dart';
 import 'build_dirs.dart';
 import 'build_result.dart';
 import 'input_tracker.dart';
@@ -159,22 +160,49 @@ class Build {
         if (node.generatedNodeState!.result != false) continue;
         failures.add(node);
       }
+
       if (failures.isNotEmpty) {
         for (final failure in failures) {
           if (errorsShownOutputs.contains(failure.id)) continue;
-          final phase =
-              buildPhases.inBuildPhases[failure
-                  .generatedNodeConfiguration!
-                  .phaseNumber];
+          final config = failure.generatedNodeConfiguration!;
+          final phase = buildPhases.inBuildPhases[config.phaseNumber];
           final logger = buildLog.loggerFor(
             phase: phase,
-            primaryInput: failure.generatedNodeConfiguration!.primaryInput,
+            primaryInput: config.primaryInput,
             lazy: phase.isOptional,
           );
           for (final error in failure.generatedNodeState!.errors) {
             logger.severe(error);
           }
         }
+      }
+
+      final failedPostProcessSteps = <PostProcessBuildStepId>[];
+      for (final packageResults
+          in assetGraph.allPostProcessBuildStepResults.values) {
+        for (final entry in packageResults.entries) {
+          if (entry.value.errors.isNotEmpty) {
+            failedPostProcessSteps.add(entry.key);
+          }
+        }
+      }
+
+      if (failedPostProcessSteps.isNotEmpty) {
+        for (final id in failedPostProcessSteps) {
+          final action =
+              buildPhases.postBuildPhase.builderActions[id.actionNumber];
+          final logger = buildLog.loggerForOther(
+            action.builderLabel,
+            contextId: id.input,
+          );
+          final stepResult = assetGraph.postProcessBuildStepResultFor(id)!;
+          for (final error in stepResult.errors) {
+            logger.severe(error);
+          }
+        }
+      }
+
+      if (failures.isNotEmpty || failedPostProcessSteps.isNotEmpty) {
         result = result.copyWith(status: BuildStatus.failure);
       }
     }
@@ -736,9 +764,11 @@ class Build {
       assetsWritten: {},
     );
 
-    final existingOutputs = assetGraph.postProcessBuildStepOutputs(
-      postProcessBuildStepId,
-    );
+    final existingOutputs =
+        assetGraph
+            .postProcessBuildStepResultFor(postProcessBuildStepId)
+            ?.outputs ??
+        const <AssetId>{};
     if (!await _postProcessBuildStepShouldRun(
       postProcessBuildStepId,
       stepReaderWriter,
@@ -754,6 +784,10 @@ class Build {
     for (final output in existingOutputs) {
       assetGraph.removePostProcessOutput(output);
     }
+    assetGraph.updatePostProcessBuildStepResult(
+      postProcessBuildStepId,
+      PostProcessBuildStepResult(hidden: hideOutput),
+    );
     assetGraph.updateNode(inputNode.id, (nodeBuilder) {
       nodeBuilder.deletedBy.remove(postProcessBuildStepId);
     });
@@ -772,12 +806,7 @@ class Build {
         if (assetGraph.contains(assetId)) {
           throw InvalidOutputException(assetId, 'Asset already exists');
         }
-        final node = AssetNode.generated(
-          assetId,
-          primaryInput: input,
-          isHidden: hideOutput,
-          phaseNumber: phaseNumber,
-        );
+        final node = AssetNode.postGenerated(assetId);
         assetGraph.add(node);
         outputs.add(assetId);
       },
@@ -799,11 +828,6 @@ class Build {
       // Errors tracked through the logger
     });
 
-    assetGraph.updatePostProcessBuildStep(
-      postProcessBuildStepId,
-      outputs: outputs,
-    );
-
     final assetsWritten = stepReaderWriter.assetsWritten.toSet();
 
     // Reset the state for all the output nodes based on what was read and
@@ -812,11 +836,14 @@ class Build {
       nodeBuilder.primaryOutputs.addAll(assetsWritten);
     });
 
-    await _setOutputsState(
-      input,
-      assetsWritten,
-      stepReaderWriter,
-      logger.errors,
+    final stepResult = PostProcessBuildStepResult(
+      hidden: hideOutput,
+      outputs: assetsWritten,
+      errors: logger.errors,
+    );
+    assetGraph.updatePostProcessBuildStepResult(
+      postProcessBuildStepId,
+      stepResult,
     );
 
     return assetsWritten;
@@ -1112,7 +1139,7 @@ class Build {
   Future<void> _cleanUpStaleOutputs(Iterable<AssetId> outputs) async {
     for (final output in outputs) {
       final node = assetGraph.get(output)!;
-      if (node.type == NodeType.generated && node.wasOutput) {
+      if (node.isGenerated && node.wasOutput) {
         await _delete(output);
       }
     }

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -18,7 +18,6 @@ import '../io/generated_asset_hider.dart';
 import '../io/reader_writer.dart';
 import '../logging/build_log.dart';
 import 'asset_graph/graph.dart';
-import 'asset_graph/node.dart';
 import 'build.dart';
 import 'build_result.dart';
 
@@ -151,7 +150,7 @@ class BuildSeries {
       }
 
       // Ignore creation or modification of outputs.
-      if (node.type == NodeType.generated && change.type != ChangeType.REMOVE) {
+      if (node.isGenerated && change.type != ChangeType.REMOVE) {
         continue;
       }
 

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -79,6 +79,8 @@ class AnalysisDriverFilesystem
     _phaseByPath = <String, int>{};
     _pathByPhase = <int, List<String>>{};
     for (final node in generatedNodes) {
+      // Post process generated nodes are never analyzed.
+      if (node.type == NodeType.postGenerated) continue;
       final phase = node.generatedNodeConfiguration!.phaseNumber;
       final idAsPath = node.id.asPath;
       _phaseByPath[idAsPath] = phase;

--- a/build_runner/lib/src/build/single_step_reader_writer.dart
+++ b/build_runner/lib/src/build/single_step_reader_writer.dart
@@ -300,6 +300,10 @@ class SingleStepReaderWriter implements PhasedReader {
   ///
   /// If it's a generated node from an earlier phase, wait for it to be built.
   Future<Readability> _isReadableNode(AssetNode node) async {
+    if (node.type == NodeType.postGenerated) {
+      // Post process outputs are not readable until after the build.
+      return Readability.notReadable;
+    }
     if (node.type == NodeType.generated) {
       final nodeConfiguration = node.generatedNodeConfiguration!;
       if (nodeConfiguration.phaseNumber > _runningBuildStep!.phaseNumber) {

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -73,6 +73,9 @@ class BuildOutputReader {
     if (node.isDeleted) return UnreadableReason.deleted;
     if (!node.isFile) return UnreadableReason.assetType;
 
+    if (node.type == NodeType.postGenerated) {
+      return null;
+    }
     if (node.type == NodeType.generated) {
       if (_processedOutputs?.contains(node.id) == false) {
         // The generated output was not considered for building because its
@@ -164,6 +167,9 @@ class BuildOutputReader {
 
     if (node.type == NodeType.glob) {
       return true;
+    }
+    if (node.type == NodeType.postGenerated) {
+      return false;
     }
     if (node.type == NodeType.generated) {
       if (!node.wasOutput || node.generatedNodeState!.result == false) {

--- a/build_runner/lib/src/logging/build_log_configuration.g.dart
+++ b/build_runner/lib/src/logging/build_log_configuration.g.dart
@@ -53,15 +53,14 @@ class _$BuildLogConfiguration extends BuildLogConfiguration {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    final dynamic _$dynamicOther = other;
     return other is BuildLogConfiguration &&
         mode == other.mode &&
         verbose == other.verbose &&
         verboseDurations == other.verboseDurations &&
-        onLog == _$dynamicOther.onLog &&
+        onLog == other.onLog &&
         singleOutputPackage == other.singleOutputPackage &&
         throttleProgressUpdates == other.throttleProgressUpdates &&
-        printOnFailure == _$dynamicOther.printOnFailure &&
+        printOnFailure == other.printOnFailure &&
         forceAnsiConsoleForTesting == other.forceAnsiConsoleForTesting &&
         forceConsoleWidthForTesting == other.forceConsoleWidthForTesting;
   }

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.15.0
+version: 2.15.1-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/build/asset_graph/graph_test.dart
+++ b/build_runner/test/build/asset_graph/graph_test.dart
@@ -11,6 +11,7 @@ import 'package:build_runner/src/build/asset_graph/exceptions.dart';
 import 'package:build_runner/src/build/asset_graph/graph.dart';
 import 'package:build_runner/src/build/asset_graph/node.dart';
 import 'package:build_runner/src/build/asset_graph/post_process_build_step_id.dart';
+import 'package:build_runner/src/build/asset_graph/post_process_build_step_result.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
@@ -108,7 +109,10 @@ void main() {
             input: node.id,
             actionNumber: n,
           );
-          graph.updatePostProcessBuildStep(postProcessBuildStep, outputs: {});
+          graph.updatePostProcessBuildStepResult(
+            postProcessBuildStep,
+            PostProcessBuildStepResult(hidden: true),
+          );
           for (var g = 0; g < 5 - n; g++) {
             var generatedNode = AssetNode.generated(
               makeAssetId(),
@@ -146,8 +150,8 @@ void main() {
         final decoded = AssetGraph.deserialize(encoded)!;
         expect(decoded, equalsAssetGraph(graph));
         expect(
-          decoded.allPostProcessBuildStepOutputs,
-          graph.allPostProcessBuildStepOutputs,
+          decoded.allPostProcessBuildStepResults,
+          graph.allPostProcessBuildStepResults,
         );
       });
 

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -14,6 +14,7 @@ import 'package:build_config/build_config.dart'
 import 'package:build_runner/src/build/asset_graph/graph.dart';
 import 'package:build_runner/src/build/asset_graph/node.dart';
 import 'package:build_runner/src/build/asset_graph/post_process_build_step_id.dart';
+import 'package:build_runner/src/build/asset_graph/post_process_build_step_result.dart';
 import 'package:build_runner/src/build/build_result.dart';
 import 'package:build_runner/src/build_plan/build_configs.dart';
 import 'package:build_runner/src/build_plan/build_directory.dart';
@@ -1222,14 +1223,8 @@ targets:
       actionNumber: 0,
     );
 
-    final aPostCopyNode = AssetNode.generated(
+    final aPostCopyNode = AssetNode.postGenerated(
       makeAssetId('a|web/a.txt.post'),
-      phaseNumber: 1,
-      primaryInput: makeAssetId('a|web/a.txt'),
-      result: true,
-      digest: computeDigest(makeAssetId(r'$$a|web/a.txt.post'), 'a'),
-      inputs: [makeAssetId('a|web/a.txt')],
-      isHidden: true,
     );
     // Note we don't expect this node to get added to the builder options node
     // outputs.
@@ -1237,14 +1232,8 @@ targets:
       (b) => b..primaryOutputs.add(aPostCopyNode.id),
     );
 
-    final bPostCopyNode = AssetNode.generated(
+    final bPostCopyNode = AssetNode.postGenerated(
       makeAssetId('a|lib/b.txt.post'),
-      phaseNumber: 1,
-      primaryInput: makeAssetId('a|lib/b.txt'),
-      result: true,
-      digest: computeDigest(makeAssetId(r'$$a|lib/b.txt.post'), 'b'),
-      inputs: [makeAssetId('a|lib/b.txt')],
-      isHidden: true,
     );
     // Note we don't expect this node to get added to the builder options node
     // outputs.
@@ -1259,19 +1248,19 @@ targets:
       ..add(bCopyNode)
       ..add(aPostCopyNode)
       ..add(bPostCopyNode)
-      ..updatePostProcessBuildStep(
+      ..updatePostProcessBuildStepResult(
         aPostProcessBuildStepId,
-        outputs: {aPostCopyNode.id},
+        PostProcessBuildStepResult(hidden: true, outputs: [aPostCopyNode.id]),
       )
-      ..updatePostProcessBuildStep(
+      ..updatePostProcessBuildStepResult(
         bPostProcessBuildStepId,
-        outputs: {bPostCopyNode.id},
+        PostProcessBuildStepResult(hidden: true, outputs: [bPostCopyNode.id]),
       );
 
     expect(cachedGraph, equalsAssetGraph(expectedGraph));
     expect(
-      cachedGraph.allPostProcessBuildStepOutputs,
-      expectedGraph.allPostProcessBuildStepOutputs,
+      cachedGraph.allPostProcessBuildStepResults,
+      expectedGraph.allPostProcessBuildStepResults,
     );
   });
 
@@ -1968,7 +1957,7 @@ targets:
       // A build does not crash in `_cleanUpStaleOutputs`
       await testPhases(builderFactories, builderDefinitions, {
         'a|lib/a.txt': 'a',
-      });
+      }, status: BuildStatus.failure);
     });
 
     test('can have assets ending in a dot', () async {

--- a/build_runner/test/integration_tests/build_command_errors_test.dart
+++ b/build_runner/test/integration_tests/build_command_errors_test.dart
@@ -91,5 +91,92 @@ class TestBuilder implements Builder {
       output,
       contains('TestBuilder.build (package:builder_pkg/builder.dart'),
     );
+
+    // Now with post process builder errors.
+    tester.writePackage(
+      name: 'builder_pkg',
+      dependencies: ['build', 'build_runner'],
+      files: {
+        'build.yaml': '''
+builders:
+  test_builder:
+    import: "package:builder_pkg/builder.dart"
+    builder_factories: ["testBuilder"]
+    build_extensions: {".dart": [".unused"]}
+    auto_apply: all_packages
+    build_to: cache
+    applies_builders:
+      - builder_pkg:test_post_process_builder
+post_process_builders:
+  test_post_process_builder:
+    import: "package:builder_pkg/builder.dart"
+    builder_factory: "testPostProcessBuilder"
+    input_extensions: [".txt"]
+    build_to: cache
+    defaults:
+      options:
+        output_extension: ".post"
+''',
+        'lib/builder.dart': '''
+import 'package:build/build.dart';
+
+TestBuilder testBuilder(BuilderOptions options) => TestBuilder();
+TestPostProcessBuilder testPostProcessBuilder(BuilderOptions options)
+    => TestPostProcessBuilder(options.config['output_extension'] as String);
+
+class TestBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {'.dart': ['.unused']};
+
+  @override
+  Future<void> build(BuildStep buildStep) async {}
+}
+
+class TestPostProcessBuilder implements PostProcessBuilder {
+  final String outputExtension;
+  TestPostProcessBuilder(this.outputExtension);
+
+  @override
+  List<String> get inputExtensions => ['.txt'];
+
+  @override
+  Future<void> build(PostProcessBuildStep buildStep) async {
+    log.warning('post process builder ran');
+    log.severe('post process builder failed');
+    await buildStep.writeAsString(
+      buildStep.inputId.addExtension(outputExtension),
+      'failed output',
+    );
+  }
+}
+''',
+      },
+    );
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {'web/a.txt': 'a'},
+    );
+
+    // Initial build. It should fail because the post process builder logged a
+    // severe error.
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+      expectExitCode: 1,
+    );
+    expect(output, contains('post process builder ran'));
+    expect(output, contains('post process builder failed'));
+
+    // On rebuild: nothing changed, so the action does not run again.
+    // Errors are serialized so the error is reported again; the warning is not.
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+      expectExitCode: 1,
+    );
+    expect(output, isNot(contains('post process builder ran')));
+    expect(output, contains('post process builder failed'));
   });
 }

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.16-wip
+
+- Use `build_runner` 2.15.1.
+
 ## 3.5.15
 
 - Use `build_runner` 2.15.0.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.15
+version: 3.5.16-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.15.0'
+  build_runner: '2.15.1-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Both normal builders and post process builders store their build step results in a weird way right now: they are copied over all output nodes. I was in the middle of refactoring to store the build results in a better way when I discovered that post process errors aren't handled properly, there is a crash when deserializing them.

Add test coverage, fix it.

Prepare for the upcoming refactoring about build results by moving post process build results to be stored once per execution instead of on all the outputs. Introduce a new node type, postGenerated, for these generated nodes where the execution result is stored elsewhere. The ~next PR will do the same for normal builders.