### PR TITLE
Moved `deletedBy` out.

### DIFF
--- a/build_config/lib/src/build_target.g.dart
+++ b/build_config/lib/src/build_target.g.dart
@@ -6,44 +6,40 @@ part of 'build_target.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-BuildTarget _$BuildTargetFromJson(Map json) => $checkedCreate(
-  'BuildTarget',
-  json,
-  ($checkedConvert) {
-    $checkKeys(
-      json,
-      allowedKeys: const [
-        'auto_apply_builders',
-        'builders',
-        'dependencies',
-        'sources',
-      ],
-    );
-    final val = BuildTarget(
-      autoApplyBuilders: $checkedConvert(
-        'auto_apply_builders',
-        (v) => v as bool?,
-      ),
-      sources: $checkedConvert(
-        'sources',
-        (v) => v == null ? null : InputSet.fromJson(v),
-      ),
-      dependencies: $checkedConvert(
-        'dependencies',
-        (v) => (v as List<dynamic>?)?.map((e) => e as String),
-      ),
-      builders: $checkedConvert(
-        'builders',
-        (v) => (v as Map?)?.map(
-          (k, e) =>
-              MapEntry(k as String, TargetBuilderConfig.fromJson(e as Map)),
+BuildTarget _$BuildTargetFromJson(Map json) =>
+    $checkedCreate('BuildTarget', json, ($checkedConvert) {
+      $checkKeys(
+        json,
+        allowedKeys: const [
+          'auto_apply_builders',
+          'builders',
+          'dependencies',
+          'sources',
+        ],
+      );
+      final val = BuildTarget(
+        autoApplyBuilders: $checkedConvert(
+          'auto_apply_builders',
+          (v) => v as bool?,
         ),
-      ),
-    );
-    return val;
-  },
-  fieldKeyMap: const {'autoApplyBuilders': 'auto_apply_builders'},
-);
+        sources: $checkedConvert(
+          'sources',
+          (v) => v == null ? null : InputSet.fromJson(v),
+        ),
+        dependencies: $checkedConvert(
+          'dependencies',
+          (v) => (v as List<dynamic>?)?.map((e) => e as String),
+        ),
+        builders: $checkedConvert(
+          'builders',
+          (v) => (v as Map?)?.map(
+            (k, e) =>
+                MapEntry(k as String, TargetBuilderConfig.fromJson(e as Map)),
+          ),
+        ),
+      );
+      return val;
+    }, fieldKeyMap: const {'autoApplyBuilders': 'auto_apply_builders'});
 
 TargetBuilderConfig _$TargetBuilderConfigFromJson(Map json) => $checkedCreate(
   'TargetBuilderConfig',

--- a/build_runner/lib/src/build/asset_graph/node.dart
+++ b/build_runner/lib/src/build/asset_graph/node.dart
@@ -9,7 +9,6 @@ import 'package:built_value/serializer.dart';
 import 'package:crypto/crypto.dart';
 
 import 'build_step_id.dart';
-import 'post_process_build_step_id.dart';
 
 part 'node.g.dart';
 
@@ -55,9 +54,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
   /// For other node types, `null`.
   Digest? get digest;
 
-  /// The `PostProcessBuildStep`s which requested to delete this asset.
-  BuiltSet<PostProcessBuildStepId> get deletedBy;
-
   /// Whether this asset is a normal, readable file.
   ///
   /// Does not guarantee that the file currently exists.
@@ -65,11 +61,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
       type == NodeType.generated ||
       type == NodeType.postGenerated ||
       type == NodeType.source;
-
-  /// Whether the node is deleted.
-  ///
-  /// Deleted nodes are ignored in the final merge step and watch handlers.
-  bool get isDeleted => deletedBy.isNotEmpty;
 
   factory AssetNode([void Function(AssetNodeBuilder) updates]) = _$AssetNode;
 

--- a/build_runner/lib/src/build/asset_graph/node.g.dart
+++ b/build_runner/lib/src/build/asset_graph/node.g.dart
@@ -90,13 +90,6 @@ class _$AssetNodeSerializer implements StructuredSerializer<AssetNode> {
           const FullType(AssetId),
         ]),
       ),
-      'deletedBy',
-      serializers.serialize(
-        object.deletedBy,
-        specifiedType: const FullType(BuiltSet, const [
-          const FullType(PostProcessBuildStepId),
-        ]),
-      ),
     ];
     Object? value;
     value = object.generatedNodeConfiguration;
@@ -178,17 +171,6 @@ class _$AssetNodeSerializer implements StructuredSerializer<AssetNode> {
                     specifiedType: const FullType(Digest),
                   )
                   as Digest?;
-          break;
-        case 'deletedBy':
-          result.deletedBy.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltSet, const [
-                    const FullType(PostProcessBuildStepId),
-                  ]),
-                )!
-                as BuiltSet<Object?>,
-          );
           break;
       }
     }
@@ -290,8 +272,6 @@ class _$AssetNode extends AssetNode {
   final BuiltSet<AssetId> primaryOutputs;
   @override
   final Digest? digest;
-  @override
-  final BuiltSet<PostProcessBuildStepId> deletedBy;
 
   factory _$AssetNode([void Function(AssetNodeBuilder)? updates]) =>
       (AssetNodeBuilder()..update(updates))._build();
@@ -302,7 +282,6 @@ class _$AssetNode extends AssetNode {
     this.generatedNodeConfiguration,
     required this.primaryOutputs,
     this.digest,
-    required this.deletedBy,
   }) : super._();
   @override
   AssetNode rebuild(void Function(AssetNodeBuilder) updates) =>
@@ -319,8 +298,7 @@ class _$AssetNode extends AssetNode {
         type == other.type &&
         generatedNodeConfiguration == other.generatedNodeConfiguration &&
         primaryOutputs == other.primaryOutputs &&
-        digest == other.digest &&
-        deletedBy == other.deletedBy;
+        digest == other.digest;
   }
 
   @override
@@ -331,7 +309,6 @@ class _$AssetNode extends AssetNode {
     _$hash = $jc(_$hash, generatedNodeConfiguration.hashCode);
     _$hash = $jc(_$hash, primaryOutputs.hashCode);
     _$hash = $jc(_$hash, digest.hashCode);
-    _$hash = $jc(_$hash, deletedBy.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -343,8 +320,7 @@ class _$AssetNode extends AssetNode {
           ..add('type', type)
           ..add('generatedNodeConfiguration', generatedNodeConfiguration)
           ..add('primaryOutputs', primaryOutputs)
-          ..add('digest', digest)
-          ..add('deletedBy', deletedBy))
+          ..add('digest', digest))
         .toString();
   }
 }
@@ -378,12 +354,6 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
   Digest? get digest => _$this._digest;
   set digest(Digest? digest) => _$this._digest = digest;
 
-  SetBuilder<PostProcessBuildStepId>? _deletedBy;
-  SetBuilder<PostProcessBuildStepId> get deletedBy =>
-      _$this._deletedBy ??= SetBuilder<PostProcessBuildStepId>();
-  set deletedBy(SetBuilder<PostProcessBuildStepId>? deletedBy) =>
-      _$this._deletedBy = deletedBy;
-
   AssetNodeBuilder();
 
   AssetNodeBuilder get _$this {
@@ -394,7 +364,6 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
       _generatedNodeConfiguration = $v.generatedNodeConfiguration?.toBuilder();
       _primaryOutputs = $v.primaryOutputs.toBuilder();
       _digest = $v.digest;
-      _deletedBy = $v.deletedBy.toBuilder();
       _$v = null;
     }
     return this;
@@ -428,7 +397,6 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
             generatedNodeConfiguration: _generatedNodeConfiguration?.build(),
             primaryOutputs: primaryOutputs.build(),
             digest: digest,
-            deletedBy: deletedBy.build(),
           );
     } catch (_) {
       late String _$failedField;
@@ -437,9 +405,6 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
         _generatedNodeConfiguration?.build();
         _$failedField = 'primaryOutputs';
         primaryOutputs.build();
-
-        _$failedField = 'deletedBy';
-        deletedBy.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(
           r'AssetNode',

--- a/build_runner/lib/src/build/asset_graph/post_process_build_step_result.dart
+++ b/build_runner/lib/src/build/asset_graph/post_process_build_step_result.dart
@@ -19,6 +19,8 @@ abstract class PostProcessBuildStepResult
 
   bool get hidden;
 
+  bool get deletedPrimaryInput;
+
   BuiltSet<AssetId> get outputs;
 
   BuiltList<String> get errors;
@@ -27,8 +29,10 @@ abstract class PostProcessBuildStepResult
     required bool hidden,
     Iterable<AssetId> outputs = const [],
     Iterable<String> errors = const [],
+    bool deletedPrimaryInput = false,
   }) => _$PostProcessBuildStepResult._(
     hidden: hidden,
+    deletedPrimaryInput: deletedPrimaryInput,
     outputs: outputs.toBuiltSet(),
     errors: errors.toBuiltList(),
   );

--- a/build_runner/lib/src/build/asset_graph/post_process_build_step_result.g.dart
+++ b/build_runner/lib/src/build/asset_graph/post_process_build_step_result.g.dart
@@ -28,6 +28,11 @@ class _$PostProcessBuildStepResultSerializer
     final result = <Object?>[
       'hidden',
       serializers.serialize(object.hidden, specifiedType: const FullType(bool)),
+      'deletedPrimaryInput',
+      serializers.serialize(
+        object.deletedPrimaryInput,
+        specifiedType: const FullType(bool),
+      ),
       'outputs',
       serializers.serialize(
         object.outputs,
@@ -69,6 +74,14 @@ class _$PostProcessBuildStepResultSerializer
                   )!
                   as bool;
           break;
+        case 'deletedPrimaryInput':
+          result.deletedPrimaryInput =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(bool),
+                  )!
+                  as bool;
+          break;
         case 'outputs':
           result.outputs.replace(
             serializers.deserialize(
@@ -102,6 +115,8 @@ class _$PostProcessBuildStepResult extends PostProcessBuildStepResult {
   @override
   final bool hidden;
   @override
+  final bool deletedPrimaryInput;
+  @override
   final BuiltSet<AssetId> outputs;
   @override
   final BuiltList<String> errors;
@@ -112,6 +127,7 @@ class _$PostProcessBuildStepResult extends PostProcessBuildStepResult {
 
   _$PostProcessBuildStepResult._({
     required this.hidden,
+    required this.deletedPrimaryInput,
     required this.outputs,
     required this.errors,
   }) : super._();
@@ -129,6 +145,7 @@ class _$PostProcessBuildStepResult extends PostProcessBuildStepResult {
     if (identical(other, this)) return true;
     return other is PostProcessBuildStepResult &&
         hidden == other.hidden &&
+        deletedPrimaryInput == other.deletedPrimaryInput &&
         outputs == other.outputs &&
         errors == other.errors;
   }
@@ -137,6 +154,7 @@ class _$PostProcessBuildStepResult extends PostProcessBuildStepResult {
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, hidden.hashCode);
+    _$hash = $jc(_$hash, deletedPrimaryInput.hashCode);
     _$hash = $jc(_$hash, outputs.hashCode);
     _$hash = $jc(_$hash, errors.hashCode);
     _$hash = $jf(_$hash);
@@ -147,6 +165,7 @@ class _$PostProcessBuildStepResult extends PostProcessBuildStepResult {
   String toString() {
     return (newBuiltValueToStringHelper(r'PostProcessBuildStepResult')
           ..add('hidden', hidden)
+          ..add('deletedPrimaryInput', deletedPrimaryInput)
           ..add('outputs', outputs)
           ..add('errors', errors))
         .toString();
@@ -162,6 +181,11 @@ class PostProcessBuildStepResultBuilder
   bool? get hidden => _$this._hidden;
   set hidden(bool? hidden) => _$this._hidden = hidden;
 
+  bool? _deletedPrimaryInput;
+  bool? get deletedPrimaryInput => _$this._deletedPrimaryInput;
+  set deletedPrimaryInput(bool? deletedPrimaryInput) =>
+      _$this._deletedPrimaryInput = deletedPrimaryInput;
+
   SetBuilder<AssetId>? _outputs;
   SetBuilder<AssetId> get outputs => _$this._outputs ??= SetBuilder<AssetId>();
   set outputs(SetBuilder<AssetId>? outputs) => _$this._outputs = outputs;
@@ -176,6 +200,7 @@ class PostProcessBuildStepResultBuilder
     final $v = _$v;
     if ($v != null) {
       _hidden = $v.hidden;
+      _deletedPrimaryInput = $v.deletedPrimaryInput;
       _outputs = $v.outputs.toBuilder();
       _errors = $v.errors.toBuilder();
       _$v = null;
@@ -206,6 +231,11 @@ class PostProcessBuildStepResultBuilder
               hidden,
               r'PostProcessBuildStepResult',
               'hidden',
+            ),
+            deletedPrimaryInput: BuiltValueNullFieldError.checkNotNull(
+              deletedPrimaryInput,
+              r'PostProcessBuildStepResult',
+              'deletedPrimaryInput',
             ),
             outputs: outputs.build(),
             errors: errors.build(),

--- a/build_runner/lib/src/build/asset_graph/serializers.g.dart
+++ b/build_runner/lib/src/build/asset_graph/serializers.g.dart
@@ -37,6 +37,10 @@ Serializers _$serializers =
             () => SetBuilder<AssetId>(),
           )
           ..addBuilderFactory(
+            const FullType(BuiltSet, const [const FullType(AssetId)]),
+            () => SetBuilder<AssetId>(),
+          )
+          ..addBuilderFactory(
             const FullType(BuiltList, const [const FullType(String)]),
             () => ListBuilder<String>(),
           )
@@ -63,16 +67,6 @@ Serializers _$serializers =
           ..addBuilderFactory(
             const FullType(BuiltList, const [const FullType(String)]),
             () => ListBuilder<String>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltSet, const [const FullType(AssetId)]),
-            () => SetBuilder<AssetId>(),
-          )
-          ..addBuilderFactory(
-            const FullType(BuiltSet, const [
-              const FullType(PostProcessBuildStepId),
-            ]),
-            () => SetBuilder<PostProcessBuildStepId>(),
           ))
         .build();
 

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -804,15 +804,13 @@ class Build {
       postProcessBuildStepId,
       PostProcessBuildStepResult(hidden: hideOutput),
     );
-    assetGraph.updateNode(inputNode.id, (nodeBuilder) {
-      nodeBuilder.deletedBy.remove(postProcessBuildStepId);
-    });
 
     final logger = buildLog.loggerForOther(
       buildLog.renderId(input),
       contextId: input,
     );
     final outputs = <AssetId>{};
+    var deletedPrimaryInput = false;
     await runPostProcessBuilder(
       builder,
       input,
@@ -836,9 +834,7 @@ class Build {
             'Can only delete primary input',
           );
         }
-        assetGraph.updateNode(assetId, (nodeBuilder) {
-          nodeBuilder.deletedBy.add(postProcessBuildStepId);
-        });
+        deletedPrimaryInput = true;
       },
     ).catchError((void _) {
       // Errors tracked through the logger
@@ -856,6 +852,7 @@ class Build {
       hidden: hideOutput,
       outputs: assetsWritten,
       errors: logger.errors,
+      deletedPrimaryInput: deletedPrimaryInput,
     );
     assetGraph.updatePostProcessBuildStepResult(
       postProcessBuildStepId,

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -28,6 +28,9 @@ class BuildOutputReader {
   final Set<AssetId>? _processedOutputs;
   final ReaderWriter? _readerWriter;
 
+  late final Set<AssetId> _assetsDeletedByPostProcessBuilders =
+      _collectAssetsDeletedByPostProcessBuilders();
+
   /// For an unexpected failure condition, a fully empty output.
   BuildOutputReader.empty()
     : _assetGraph = null,
@@ -61,6 +64,21 @@ class BuildOutputReader {
        _buildPlan = buildPlan,
        _processedOutputs = processedOutputs;
 
+  Set<AssetId> _collectAssetsDeletedByPostProcessBuilders() {
+    final assetGraph = _assetGraph;
+    if (assetGraph == null) return const {};
+    final result = <AssetId>{};
+    for (final packageResults
+        in assetGraph.allPostProcessBuildStepResults.values) {
+      for (final entry in packageResults.entries) {
+        if (entry.value.deletedPrimaryInput) {
+          result.add(entry.key.input);
+        }
+      }
+    }
+    return result;
+  }
+
   /// Returns a reason why [id] is not readable, or null if it is readable.
   Future<UnreadableReason?> unreadableReason(AssetId id) async {
     if (_assetGraph == null || _readerWriter == null) {
@@ -69,8 +87,10 @@ class BuildOutputReader {
     if (!_assetGraph.contains(id)) {
       return UnreadableReason.notFound;
     }
+    if (_assetsDeletedByPostProcessBuilders.contains(id)) {
+      return UnreadableReason.deleted;
+    }
     final node = _assetGraph.get(id)!;
-    if (node.isDeleted) return UnreadableReason.deleted;
     if (!node.isFile) return UnreadableReason.assetType;
 
     if (node.type == NodeType.postGenerated) {
@@ -159,7 +179,7 @@ class BuildOutputReader {
   bool _shouldSkipNode(AssetNode node, String? rootDir) {
     if (_buildPlan == null) return false;
     if (!node.isFile) return true;
-    if (node.isDeleted) return true;
+    if (_assetsDeletedByPostProcessBuilders.contains(node.id)) return true;
 
     // Exclude non-lib assets if they're outside of the root directory or not
     // an output package of the build.

--- a/build_runner/test/build/asset_graph/graph_test.dart
+++ b/build_runner/test/build/asset_graph/graph_test.dart
@@ -113,8 +113,12 @@ void main() {
             );
             node = node.rebuild((b) => b..primaryOutputs.add(generatedNode.id));
             if (g.isEven) {
-              node = node.rebuild(
-                (b) => b..deletedBy.add(postProcessBuildStep),
+              graph.updatePostProcessBuildStepResult(
+                postProcessBuildStep,
+                PostProcessBuildStepResult(
+                  hidden: true,
+                  deletedPrimaryInput: true,
+                ),
               );
             }
 

--- a/build_runner/test/build/resolver/resolver_test.dart
+++ b/build_runner/test/build/resolver/resolver_test.dart
@@ -329,15 +329,13 @@ void runTests(ResolversFactory resolversFactory) {
 
   group('language versioning', () {
     test('gives a correct languageVersion based on comments', () async {
-      await resolveSources(
-        {'a|web/main.dart': '// @dart=3.1\n\nmain() {}'},
-        (resolver) async {
-          final lib = await resolver.libraryFor(entryPoint);
-          expect(lib.languageVersion.effective.major, 3);
-          expect(lib.languageVersion.effective.minor, 1);
-        },
-        resolvers: createResolvers(),
-      );
+      await resolveSources({'a|web/main.dart': '// @dart=3.1\n\nmain() {}'}, (
+        resolver,
+      ) async {
+        final lib = await resolver.libraryFor(entryPoint);
+        expect(lib.languageVersion.effective.major, 3);
+        expect(lib.languageVersion.effective.minor, 1);
+      }, resolvers: createResolvers());
     });
 
     test('defaults to the current isolate package config', () async {
@@ -376,15 +374,11 @@ void runTests(ResolversFactory resolversFactory) {
           languageVersion: customVersion,
         ),
       ]);
-      await resolveSources(
-        {'a|web/main.dart': 'main() {}'},
-        (resolver) async {
-          final lib = await resolver.libraryFor(entryPoint);
-          expect(lib.languageVersion.effective.major, customVersion.major);
-          expect(lib.languageVersion.effective.minor, customVersion.minor);
-        },
-        resolvers: createResolvers(packageConfig: customPackageConfig),
-      );
+      await resolveSources({'a|web/main.dart': 'main() {}'}, (resolver) async {
+        final lib = await resolver.libraryFor(entryPoint);
+        expect(lib.languageVersion.effective.major, customVersion.major);
+        expect(lib.languageVersion.effective.minor, customVersion.minor);
+      }, resolvers: createResolvers(packageConfig: customPackageConfig));
     });
 
     test('gives the current language version if not provided', () async {
@@ -396,15 +390,11 @@ void runTests(ResolversFactory resolversFactory) {
           languageVersion: null,
         ),
       ]);
-      await resolveSources(
-        {'a|web/main.dart': 'main() {}'},
-        (resolver) async {
-          final lib = await resolver.libraryFor(entryPoint);
-          expect(lib.languageVersion.effective.major, sdkLanguageVersion.major);
-          expect(lib.languageVersion.effective.minor, sdkLanguageVersion.minor);
-        },
-        resolvers: createResolvers(packageConfig: customPackageConfig),
-      );
+      await resolveSources({'a|web/main.dart': 'main() {}'}, (resolver) async {
+        final lib = await resolver.libraryFor(entryPoint);
+        expect(lib.languageVersion.effective.major, sdkLanguageVersion.major);
+        expect(lib.languageVersion.effective.minor, sdkLanguageVersion.minor);
+      }, resolvers: createResolvers(packageConfig: customPackageConfig));
     });
 
     test(
@@ -1341,14 +1331,12 @@ int? get x => 1;
       final futures = <Future<void>>[];
       for (var i = 0; i != 10; ++i) {
         futures.add(
-          resolveSources(
-            {'a|web/main.dart': ' main() { /* $i */}'},
-            (resolver) async {
-              // await Future<void>.delayed(Duration(milliseconds: i * 100));
-              await resolver.compilationUnitFor(entryPoint);
-            },
-            resolvers: createResolvers(),
-          ),
+          resolveSources({'a|web/main.dart': ' main() { /* $i */}'}, (
+            resolver,
+          ) async {
+            // await Future<void>.delayed(Duration(milliseconds: i * 100));
+            await resolver.compilationUnitFor(entryPoint);
+          }, resolvers: createResolvers()),
         );
       }
       await Future.wait(futures);

--- a/build_runner/test/commands/serve/asset_handler_test.dart
+++ b/build_runner/test/commands/serve/asset_handler_test.dart
@@ -10,6 +10,7 @@ import 'package:build_runner/src/build/asset_graph/build_step_result.dart';
 import 'package:build_runner/src/build/asset_graph/graph.dart';
 import 'package:build_runner/src/build/asset_graph/node.dart';
 import 'package:build_runner/src/build/asset_graph/post_process_build_step_id.dart';
+import 'package:build_runner/src/build/asset_graph/post_process_build_step_result.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
@@ -45,13 +46,15 @@ void main() {
 
   void addAsset(String id, String content, {bool deleted = false}) {
     final parsedId = AssetId.parse(id);
-    var node = AssetNode.source(parsedId, digest: computeDigest(parsedId, 'a'));
+    final node = AssetNode.source(
+      parsedId,
+      digest: computeDigest(parsedId, 'a'),
+    );
     if (deleted) {
-      node = node.rebuild((b) {
-        b.deletedBy.add(
-          PostProcessBuildStepId(input: node.id, actionNumber: 1),
-        );
-      });
+      assetGraph.updatePostProcessBuildStepResult(
+        PostProcessBuildStepId(input: parsedId, actionNumber: 1),
+        PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
+      );
     }
     assetGraph.add(node);
     readerWriter.testing.writeString(node.id, content);

--- a/build_runner/test/commands/serve/serve_handler_test.dart
+++ b/build_runner/test/commands/serve/serve_handler_test.dart
@@ -13,6 +13,7 @@ import 'package:build_runner/src/build/asset_graph/build_step_result.dart';
 import 'package:build_runner/src/build/asset_graph/graph.dart';
 import 'package:build_runner/src/build/asset_graph/node.dart';
 import 'package:build_runner/src/build/asset_graph/post_process_build_step_id.dart';
+import 'package:build_runner/src/build/asset_graph/post_process_build_step_result.dart';
 import 'package:build_runner/src/build/build_result.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
@@ -141,16 +142,15 @@ void main() {
 
   void addSource(String id, String content, {bool deleted = false}) {
     final parsedId = AssetId.parse(id);
-    var node = AssetNode.source(
+    final node = AssetNode.source(
       parsedId,
       digest: computeDigest(parsedId, content),
     );
     if (deleted) {
-      node = node.rebuild((b) {
-        b.deletedBy.add(
-          PostProcessBuildStepId(input: node.id, actionNumber: 1),
-        );
-      });
+      assetGraph.updatePostProcessBuildStepResult(
+        PostProcessBuildStepId(input: parsedId, actionNumber: 1),
+        PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
+      );
     }
     assetGraph.add(node);
     readerWriter.testing.writeString(node.id, content);

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -11,6 +11,7 @@ import 'package:build_runner/src/build/asset_graph/build_step_result.dart';
 import 'package:build_runner/src/build/asset_graph/graph.dart';
 import 'package:build_runner/src/build/asset_graph/node.dart';
 import 'package:build_runner/src/build/asset_graph/post_process_build_step_id.dart';
+import 'package:build_runner/src/build/asset_graph/post_process_build_step_result.dart';
 import 'package:build_runner/src/build_plan/build_configs.dart';
 import 'package:build_runner/src/build_plan/build_directory.dart';
 import 'package:build_runner/src/build_plan/build_filter.dart';
@@ -56,17 +57,14 @@ void main() {
         AssetId.parse('a|web/a.txt'),
         digest: computeDigest(AssetId('a', 'web/a.txt'), 'a'),
       );
-      var deleted = AssetNode.source(
+      final deleted = AssetNode.source(
         AssetId.parse('a|lib/b.txt'),
         digest: computeDigest(AssetId('a', 'lib/b.txt'), 'b'),
       );
 
-      deleted = deleted.rebuild(
-        (b) =>
-            b
-              ..deletedBy.add(
-                PostProcessBuildStepId(input: notDeleted.id, actionNumber: 0),
-              ),
+      assetGraph.updatePostProcessBuildStepResult(
+        PostProcessBuildStepId(input: deleted.id, actionNumber: 0),
+        PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
       );
 
       assetGraph

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -9,6 +9,7 @@ import 'package:build/build.dart';
 import 'package:build_runner/src/build/asset_graph/build_step_result.dart';
 import 'package:build_runner/src/build/asset_graph/graph.dart';
 import 'package:build_runner/src/build/asset_graph/post_process_build_step_id.dart';
+import 'package:build_runner/src/build/asset_graph/post_process_build_step_result.dart';
 import 'package:build_runner/src/build_plan/build_configs.dart';
 import 'package:build_runner/src/build_plan/build_directory.dart';
 import 'package:build_runner/src/build_plan/build_options.dart';
@@ -147,11 +148,10 @@ void main() {
 
     test('doesnt write deleted files', () async {
       final node = graph.get(AssetId('b', 'lib/c.txt.copy'))!;
-      graph.updateNode(node.id, (nodeBuilder) {
-        nodeBuilder.deletedBy.add(
-          PostProcessBuildStepId(input: node.id, actionNumber: 1),
-        );
-      });
+      graph.updatePostProcessBuildStepResult(
+        PostProcessBuildStepId(input: node.id, actionNumber: 1),
+        PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
+      );
 
       final success = await createMergedOutputDirectories(
         buildDirs:
@@ -474,15 +474,19 @@ void main() {
         expect(success, isTrue);
         final removes = ['a|lib/a.txt', 'a|lib/a.txt.copy'];
         for (final remove in removes) {
-          graph.updateNode(makeAssetId(remove), (nodeBuilder) {
-            nodeBuilder.deletedBy.add(
-              PostProcessBuildStepId(
-                input: makeAssetId(remove),
-                actionNumber: 1,
-              ),
-            );
-          });
+          final removeId = makeAssetId(remove);
+          graph.updatePostProcessBuildStepResult(
+            PostProcessBuildStepId(input: removeId, actionNumber: 1),
+            PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
+          );
         }
+        // Recreate buildOutputReader so it notices the delete.
+        buildOutputReader = BuildOutputReader(
+          buildPlan: buildPlan,
+          readerWriter: readerWriter,
+          assetGraph: graph,
+          processedOutputs: graph.outputs.toSet(),
+        );
         success = await createMergedOutputDirectories(
           buildDirs:
               {


### PR DESCRIPTION
A bit more cleanup. The fact that a file was deleted by a post process builder is not used during the build, only when copying/serving the output. Move it to post process build results and use it from there.

A formatter change in the latest `dev` release means I have to format one test and one generated file to keep CI happy.