### PR TITLE
Fix build_runner_build.dart.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.15.1-wip
 
+- Pass Dart SDK `--packages` arg to builder compiles, so they can be compiled
+  with different packages to the current version solve.
 - Bug fix: handle errors from post process builders in previous runs without
   crashing.
 

--- a/build_runner/lib/src/bootstrap/aot_compiler.dart
+++ b/build_runner/lib/src/bootstrap/aot_compiler.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:path/path.dart' as p;
 
@@ -48,6 +49,10 @@ class AotCompiler implements Compiler {
     final result = await ParentProcess.run(dart, [
       'compile',
       'aot-snapshot',
+      if (Isolate.packageConfigSync != null) ...[
+        '--packages',
+        Isolate.packageConfigSync!.toFilePath(),
+      ],
       p.join(buildPaths.outputRootPath, entrypointScriptPath),
       '--output',
       p.join(buildPaths.outputRootPath, entrypointAotPath),

--- a/build_runner/lib/src/bootstrap/kernel_compiler.dart
+++ b/build_runner/lib/src/bootstrap/kernel_compiler.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:path/path.dart' as p;
 
@@ -48,6 +49,10 @@ class KernelCompiler implements Compiler {
     final result = await ParentProcess.run(dart, [
       'compile',
       'kernel',
+      if (Isolate.packageConfigSync != null) ...[
+        '--packages',
+        Isolate.packageConfigSync!.toFilePath(),
+      ],
       p.join(buildPaths.outputRootPath, entrypointScriptPath),
       '--output',
       p.join(buildPaths.outputRootPath, entrypointDillPath),

--- a/build_runner/lib/src/build/asset_graph/serializers.dart
+++ b/build_runner/lib/src/build/asset_graph/serializers.dart
@@ -46,6 +46,7 @@ final identityAssetIdSerializer = IdentitySerializer<AssetId>(
   BuildStepResult,
   GlobId,
   GlobResult,
+  PostProcessBuildStepId,
   PostProcessBuildStepResult,
 ])
 final Serializers serializers =

--- a/tool/build_runner_build.dart
+++ b/tool/build_runner_build.dart
@@ -11,11 +11,20 @@ import 'dart:io';
 ///
 /// Usage: in one of the `build` repo packages, instead of running
 /// `dart run build_runner build`, run `dart ../tool/build_runner_build.dart`.
-void main() {
+void main(List<String> arguments) {
   final pathSegments = Directory.current.uri.pathSegments;
-  if (pathSegments[pathSegments.length - 3] != 'build') {
-    print('Current directly should be a package inside the build repo.');
+  if (pathSegments[pathSegments.length - 2] != 'build_runner') {
+    print('Current directory should be a package inside the build repo.');
     exit(1);
+  }
+
+  String? buildRunnerOverride;
+  if (arguments.length == 1) {
+    buildRunnerOverride = arguments[0];
+  } else if (arguments.length > 1) {
+    print(
+      'Usage: build_runner_build.dart [optional build_runner package path]',
+    );
   }
 
   // Run `pub get` in a temp folder to get paths for published versions of
@@ -24,13 +33,22 @@ void main() {
     'build_runner_build',
   );
   tempDirectory.createSync(recursive: true);
+  final maybeOverride =
+      buildRunnerOverride == null
+          ? ''
+          : '''
+dependency_overrides:
+  build_runner:
+    path: $buildRunnerOverride
+''';
   File.fromUri(tempDirectory.uri.resolve('pubspec.yaml')).writeAsStringSync('''
 name: none
 environment:
   sdk: ^3.7.0
 dependencies:
-  build_runner: '2.4.15'
+  build_runner: 2.15.0
   build_test: any
+$maybeOverride
 ''');
   Process.runSync('dart', ['pub', 'get'], workingDirectory: tempDirectory.path);
   final pubConfig = PackageConfig(
@@ -64,9 +82,7 @@ dependencies:
     'build',
     'build_config',
     'build_daemon',
-    'build_resolvers',
     'build_runner',
-    'build_runner_core',
     'build_test',
   ]) {
     final packageConfig = pubConfig.packageNamed(package);
@@ -85,7 +101,7 @@ dependencies:
     'run',
     '$buildRunnerPath/bin/build_runner.dart',
     'build',
-    '-d',
+    '--force-jit',
   ], workingDirectory: Directory.current.path);
 
   stdout.write(buildResult.stdout);


### PR DESCRIPTION
The "run build_runner in build_runner" script has been broken for a while, the bootstrapping changes meant the builders are no longer compiled with the current `--packages` so you can't use a different+working build_runner to build the current one.

Pass `--packages` to the compile so it works.

This still doesn't fix build_runner_build.dart until this version is published, so add a way to pass in an override path so I can use a local version until then.

Minor updates to the script: remove deleted packages and args, bump the build_runner version used, pass `--force-jit` for the faster iteration time. Remove the check that the workspace root folder is called `build` as I have multiple with different names right now :)

Fix a missing annotation in `serializers.dart` that causes wrong serializer generation if you actually manage to run it :)