### PR TITLE
Reduce watches for nested packages

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Pass Dart SDK `--packages` arg to builder compiles, so they can be compiled
   with different packages to the current version solve.
+- More efficient watching for file changes in workspaces and other setups with
+  nested packages.
 - Bug fix: handle errors from post process builders in previous runs without
   crashing.
 

--- a/build_runner/lib/src/commands/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/commands/daemon/daemon_builder.dart
@@ -22,7 +22,6 @@ import '../../build_plan/build_filter.dart';
 import '../../build_plan/build_plan.dart';
 import '../../logging/build_log.dart';
 import '../daemon_options.dart';
-import '../watch/build_package_watcher.dart';
 import '../watch/build_packages_watcher.dart';
 import 'change_providers.dart';
 
@@ -235,25 +234,23 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
     final buildSeries = BuildSeries(buildPlan);
 
     // Only actually used for the AutoChangeProvider.
-    Stream<List<WatchEvent>> graphEvents() => BuildPackagesWatcher(
-          buildPlan.buildPackages,
-          watch: BuildPackageWatcher.new,
-        )
-        .watch()
-        .debounceBuffer(
-          buildPlan.testingOverrides.debounceDelay ??
-              const Duration(milliseconds: 250),
-        )
-        .asyncMap(
-          (changes) => buildSeries.filterChanges(changes, expectedDeletes),
-        )
-        .where((changes) => changes.isNotEmpty)
-        .map(
-          (changes) =>
-              changes
-                  .map((change) => WatchEvent(change.type, '${change.id}'))
-                  .toList(),
-        );
+    Stream<List<WatchEvent>> graphEvents() =>
+        BuildPackagesWatcher(buildPlan.buildPackages)
+            .watch()
+            .debounceBuffer(
+              buildPlan.testingOverrides.debounceDelay ??
+                  const Duration(milliseconds: 250),
+            )
+            .asyncMap(
+              (changes) => buildSeries.filterChanges(changes, expectedDeletes),
+            )
+            .where((changes) => changes.isNotEmpty)
+            .map(
+              (changes) =>
+                  changes
+                      .map((change) => WatchEvent(change.type, '${change.id}'))
+                      .toList(),
+            );
 
     final changeProvider =
         daemonOptions.buildMode == BuildMode.Auto

--- a/build_runner/lib/src/commands/watch/build_packages_watcher.dart
+++ b/build_runner/lib/src/commands/watch/build_packages_watcher.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:async/async.dart';
+import 'package:build/build.dart';
+import 'package:path/path.dart' as p;
 
 import '../../build_plan/build_package.dart';
 import '../../build_plan/build_packages.dart';
@@ -16,7 +18,7 @@ import 'build_package_watcher.dart';
 BuildPackageWatcher _default(BuildPackage buildPackage) =>
     BuildPackageWatcher(buildPackage);
 
-/// Allows watching an entire graph of packages to schedule rebuilds.
+/// Watches the watchable packages in a [BuildPackages] for file changes.
 class BuildPackagesWatcher {
   final BuildPackageWatcher Function(BuildPackage) _strategy;
   final BuildPackages _buildPackages;
@@ -28,8 +30,7 @@ class BuildPackagesWatcher {
 
   /// Creates a new watcher for a [BuildPackages].
   ///
-  /// May optionally specify a [watch] strategy, otherwise will attempt a
-  /// reasonable default based on the current platform.
+  /// Optionally override watch strategy [watch] for testing.
   BuildPackagesWatcher(
     this._buildPackages, {
     BuildPackageWatcher Function(BuildPackage)? watch,
@@ -43,58 +44,128 @@ class BuildPackagesWatcher {
   }
 
   Stream<AssetChange> _watch() {
-    final allWatchers =
-        _buildPackages.packages.values
-            .where((buildPackage) => buildPackage.watch)
-            .map(_strategy)
-            .toList();
-    final filteredEvents =
-        allWatchers
-            .map(
-              (w) => w
-                  .watch()
-                  .where(_nestedPathFilter(w.buildPackage))
-                  .handleError((Object e, StackTrace s) {
-                    buildLog.error(
-                      buildLog.renderThrowable(
-                        'Failed to watch files in '
-                        'package:${w.buildPackage.name}.',
-                        e,
-                      ),
-                    );
-                  }),
-            )
-            .toList();
+    final forest = _buildPackageForest();
+    final watchers = <BuildPackageWatcher>[];
+    final events = <Stream<AssetChange>>[];
+
+    for (final tree in forest) {
+      final watcher = _strategy(tree.package);
+      watchers.add(watcher);
+
+      final stream = watcher.watch().map(tree.moveToDeepestPackage);
+      events.add(
+        stream.handleError((Object e, StackTrace s) {
+          buildLog.error(
+            buildLog.renderThrowable(
+              'Failed to watch files in '
+              'package:${watcher.buildPackage.name}.',
+              e,
+            ),
+          );
+        }),
+      );
+    }
+
     // Asynchronously complete the `_readyCompleter` once all the watchers
     // are done.
     () async {
-      await Future.wait(
-        allWatchers.map((packageWatcher) => packageWatcher.watcher.ready),
-      );
+      final readyFutures = <Future<void>>[];
+      for (final watcher in watchers) {
+        readyFutures.add(watcher.watcher.ready);
+      }
+      await Future.wait(readyFutures);
       _readyCompleter.complete();
     }();
-    return StreamGroup.merge(filteredEvents);
+    return StreamGroup.merge(events);
   }
 
-  bool Function(AssetChange) _nestedPathFilter(BuildPackage rootPackage) {
-    final ignorePaths = _nestedPaths(rootPackage);
-    return (change) => !ignorePaths.any(change.id.path.startsWith);
+  /// Builds a forest of [WatchablePackageTree] with all watchable packages.
+  List<WatchablePackageTree> _buildPackageForest() {
+    final watchablePackages = <BuildPackage>[];
+    for (final p in _buildPackages.packages.values) {
+      if (p.watch) watchablePackages.add(p);
+    }
+    watchablePackages.sort((a, b) => a.path.length.compareTo(b.path.length));
+    final result = <WatchablePackageTree>[];
+    for (final package in watchablePackages) {
+      var inserted = false;
+      for (final tree in result) {
+        if (tree.insert(package)) {
+          inserted = true;
+          break;
+        }
+      }
+      if (!inserted) {
+        result.add(WatchablePackageTree(package));
+      }
+    }
+    return result;
+  }
+}
+
+/// A tree of watchable packages that share a common prefix.
+class WatchablePackageTree {
+  final BuildPackage package;
+  final String packagePathWithSeparator;
+  final List<WatchablePackageTree> children = [];
+
+  WatchablePackageTree(this.package)
+    : packagePathWithSeparator = package.path + Platform.pathSeparator;
+
+  /// Recursively inserts [newPackage] as a child if it is nested under this
+  /// package.
+  ///
+  /// Returns `true` if [newPackage] belongs in this subtree.
+  bool insert(BuildPackage newPackage) {
+    if (!newPackage.path.startsWith(packagePathWithSeparator)) {
+      return false;
+    }
+
+    for (final child in children) {
+      if (child.insert(newPackage)) {
+        return true;
+      }
+    }
+
+    children.add(WatchablePackageTree(newPackage));
+    return true;
   }
 
-  // Returns a set of all package paths that are "nested" within a package.
-  //
-  // This allows the watcher to optimize and avoid duplicate events.
-  List<String> _nestedPaths(BuildPackage rootPackage) {
-    return _buildPackages.packages.values
-        .where((buildPackage) {
-          return buildPackage.path.length > rootPackage.path.length &&
-              buildPackage.path.startsWith(rootPackage.path);
-        })
-        .map(
-          (buildPackage) =>
-              buildPackage.path.substring(rootPackage.path.length + 1) +
-              Platform.pathSeparator,
-        )
-        .toList();
+  /// Finds the deepest nested package in this subtree that contains [path].
+  ///
+  /// Returns `null` if [path] does not belong to this package tree.
+  BuildPackage? deepestPackageForPath(String path) {
+    if (path != package.path && !path.startsWith(packagePathWithSeparator)) {
+      return null;
+    }
+
+    for (final child in children) {
+      final match = child.deepestPackageForPath(path);
+      if (match != null) return match;
+    }
+
+    return package;
   }
+
+  /// Moves [change] to the deepest matching package in the tree.
+  ///
+  /// Throws if it's not in the tree.
+  AssetChange moveToDeepestPackage(AssetChange change) {
+    final absolutePath = p.join(package.path, change.id.platformPath);
+    final deepestPackage = deepestPackageForPath(absolutePath);
+    if (deepestPackage == null) {
+      throw StateError('No package found for path: $absolutePath');
+    }
+    if (deepestPackage == package) {
+      return change;
+    }
+    final relativePath = p.relative(absolutePath, from: deepestPackage.path);
+    return AssetChange(AssetId(deepestPackage.name, relativePath), change.type);
+  }
+}
+
+extension _AssetIdExtension on AssetId {
+  // Returns [path] with platform separators.
+  String get platformPath =>
+      Platform.isWindows ? path.replaceAll('/', r'\') : path;
 }

--- a/build_runner/test/commands/watch/build_packages_watcher_test.dart
+++ b/build_runner/test/commands/watch/build_packages_watcher_test.dart
@@ -149,6 +149,119 @@ void main() {
       await Future<void>.value();
       expect(done, isTrue);
     });
+
+    test('only watches the root-most packages', () async {
+      final buildPackages = BuildPackages.singlePackageBuild('a', {
+        BuildPackage(
+          name: 'a',
+          path: '/g/a',
+          isOutput: true,
+          watch: true,
+          dependencies: ['b', 'c'],
+        ),
+        BuildPackage(name: 'b', path: '/g/a/b', watch: true),
+        BuildPackage(name: 'c', path: '/g/c', watch: true),
+      });
+
+      final watchedPackages = <String>[];
+      final nodes = {
+        'a': FakeNodeWatcher(buildPackages['a']!)..markReady(),
+        'b': FakeNodeWatcher(buildPackages['b']!)..markReady(),
+        'c': FakeNodeWatcher(buildPackages['c']!)..markReady(),
+      };
+
+      final watcher = BuildPackagesWatcher(
+        buildPackages,
+        watch: (node) {
+          watchedPackages.add(node.name);
+          return nodes[node.name]!;
+        },
+      );
+
+      unawaited(watcher.watch().drain());
+      await watcher.ready;
+
+      expect(watchedPackages, contains('a'));
+      expect(watchedPackages, contains('c'));
+      expect(watchedPackages, isNot(contains('b')));
+      expect(watchedPackages.length, 2);
+    });
+
+    test('handle 3-level nesting correctly', () async {
+      final buildPackages = BuildPackages.singlePackageBuild('root', {
+        BuildPackage(
+          name: 'root',
+          path: '/g',
+          isOutput: true,
+          watch: true,
+          dependencies: ['a', 'b'],
+        ),
+        BuildPackage(name: 'a', path: '/g/a', watch: true),
+        BuildPackage(name: 'b', path: '/g/a/b', watch: true),
+      });
+
+      final watchedPackages = <String>[];
+      final nodes = {
+        'root': FakeNodeWatcher(buildPackages['root']!)..markReady(),
+        'a': FakeNodeWatcher(buildPackages['a']!)..markReady(),
+        'b': FakeNodeWatcher(buildPackages['b']!)..markReady(),
+      };
+
+      final watcher = BuildPackagesWatcher(
+        buildPackages,
+        watch: (node) {
+          watchedPackages.add(node.name);
+          return nodes[node.name]!;
+        },
+      );
+
+      unawaited(watcher.watch().drain());
+      await watcher.ready;
+
+      expect(watchedPackages, contains('root'));
+      expect(watchedPackages, isNot(contains('a')));
+      expect(watchedPackages, isNot(contains('b')));
+      expect(watchedPackages.length, 1);
+    });
+
+    test('reports events on the deepest nested package', () async {
+      final buildPackages = BuildPackages.singlePackageBuild('a', {
+        BuildPackage(
+          name: 'a',
+          path: '/g/a',
+          isOutput: true,
+          watch: true,
+          dependencies: ['b'],
+        ),
+        BuildPackage(name: 'b', path: '/g/a/b', watch: true),
+      });
+
+      final nodes = {'a': FakeNodeWatcher(buildPackages['a']!)..markReady()};
+
+      final watcher = BuildPackagesWatcher(
+        buildPackages,
+        watch: (node) {
+          return nodes[node.name]!;
+        },
+      );
+
+      final events = <AssetChange>[];
+      unawaited(watcher.watch().forEach(events.add));
+      await watcher.ready;
+
+      nodes['a']!.emitAdd('b/lib/b.dart');
+      nodes['a']!.emitAdd('lib/a.dart');
+
+      await pumpEventQueue();
+
+      expect(
+        events,
+        unorderedEquals([
+          AssetChange(AssetId('b', 'lib/b.dart'), ChangeType.ADD),
+          AssetChange(AssetId('a', 'lib/a.dart'), ChangeType.ADD),
+        ]),
+      );
+    });
   });
 }
 


### PR DESCRIPTION
Fix #4346.

When packages are nested, watch only the outer level package and resolve events to the correct package from that.