### PR TITLE
Simpler timeouts, fix flake.

### DIFF
--- a/build_runner/dart_test.yaml
+++ b/build_runner/dart_test.yaml
@@ -1,9 +1,9 @@
 tags:
   integration1:
-    timeout: 4x
+    timeout: 3m
   integration2:
-    timeout: 4x
+    timeout: 3m
   integration3:
-    timeout: 4x
+    timeout: 3m
   integration4:
-    timeout: 4x
+    timeout: 3m

--- a/build_runner/test/integration_tests/build_command_other_args_test.dart
+++ b/build_runner/test/integration_tests/build_command_other_args_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Tags(['integration1'])
+library;
+
 import 'package:test/test.dart';
 
 import '../common/common.dart';

--- a/build_runner/test/integration_tests/daemon_command_test.dart
+++ b/build_runner/test/integration_tests/daemon_command_test.dart
@@ -18,8 +18,6 @@ import 'package:test/test.dart';
 
 import '../common/common.dart';
 
-const defaultTimeout = Timeout(Duration(seconds: 120));
-
 void main() async {
   final webTarget = DefaultBuildTarget((b) {
     b.target = 'web';
@@ -219,5 +217,5 @@ void main() {
     // Check the second client was notified too.
     expect((await results2.next).results.single.status, BuildStatus.started);
     expect((await results2.next).results.single.status, BuildStatus.succeeded);
-  }, timeout: defaultTimeout);
+  });
 }

--- a/build_runner/test/integration_tests/watch_command_concurrent_changes_test.dart
+++ b/build_runner/test/integration_tests/watch_command_concurrent_changes_test.dart
@@ -101,10 +101,11 @@ class TestBuilder implements Builder {
   @override
   Future<void> build(BuildStep buildStep) async {
     final id = AssetId('root_pkg', 'lib/a.other');
-    final canRead = await buildStep.canRead(id);
     await Future.delayed(Duration(seconds: 1));
-    if (canRead) {
+    try {
       await buildStep.readAsString(id);
+    } catch (_) {
+      print('file was not present');
     }
     buildStep.writeAsString(
         buildStep.inputId.addExtension('.copy'),
@@ -128,6 +129,7 @@ class TestBuilder implements Builder {
       'root_pkg|lib/a.other was unexpectedly deleted, restarting the build.',
     );
     await watch.expect('Starting build #2.');
+    await watch.expect('file was not present');
     await watch.expect(BuildLog.successPattern);
 
     // If there was a succesful build using the non-primary input then it's

--- a/build_runner/test/integration_tests/watch_command_test.dart
+++ b/build_runner/test/integration_tests/watch_command_test.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 import '../common/common.dart';
 
 void main() async {
-  test('watch command', timeout: const Timeout.factor(4), () async {
+  test('watch command', () async {
     final pubspecs = await Pubspecs.load();
     final tester = BuildRunnerTester(pubspecs);
 

--- a/build_runner/test/integration_tests/web_compilers_ddc_test.dart
+++ b/build_runner/test/integration_tests/web_compilers_ddc_test.dart
@@ -10,8 +10,6 @@ import 'package:test/test.dart';
 
 import '../common/common.dart';
 
-const defaultTimeout = Timeout(Duration(minutes: 3));
-
 void main() async {
   // TODO(davidmorgan): this is an integration test of the web compilers,
   // support testing like this outside the `build_runner` package.
@@ -128,5 +126,5 @@ void main() async {
           '--define=build_web_compilers:dart_source_cleanup=enabled=true',
     );
     expect(tester.read('root_pkg/build/unused.dart'), null);
-  }, timeout: defaultTimeout);
+  });
 }

--- a/build_runner/test/integration_tests/web_compilers_incremental_test.dart
+++ b/build_runner/test/integration_tests/web_compilers_incremental_test.dart
@@ -10,8 +10,6 @@ import 'package:test/test.dart';
 
 import '../common/common.dart';
 
-const defaultTimeout = Timeout(Duration(minutes: 3));
-
 void main() async {
   // TODO(davidmorgan): this is an integration test of the web compilers,
   // support testing like this outside the `build_runner` package.
@@ -113,7 +111,7 @@ void main() async {
       tester.read('$generatedDirRoot/root_pkg/web/main.ddc.js'),
       isNot(contains('Hello')),
     );
-  }, timeout: defaultTimeout);
+  });
 
   // TODO(davidmorgan): this is an integration test of the web compilers,
   // support testing like this outside the `build_runner` package.
@@ -233,5 +231,5 @@ String helloWorld = 'Hello Dash!';
       tester.read('$generatedDirRoot/root_pkg/web/main.ddc.js'),
       isNot(contains('Hello')),
     );
-  }, timeout: defaultTimeout);
+  });
 }

--- a/build_runner/test/integration_tests/web_compilers_test.dart
+++ b/build_runner/test/integration_tests/web_compilers_test.dart
@@ -10,8 +10,6 @@ import 'package:test/test.dart';
 
 import '../common/common.dart';
 
-const defaultTimeout = Timeout(Duration(minutes: 3));
-
 void main() async {
   test('web compilers', () async {
     final pubspecs = await Pubspecs.load();
@@ -157,5 +155,5 @@ void main() {
           '--define=build_web_compilers:dart_source_cleanup=enabled=true',
     );
     expect(tester.read('root_pkg/build/unused.dart'), null);
-  }, timeout: defaultTimeout);
+  });
 }


### PR DESCRIPTION
Stop setting timeouts in individual integration tests, just set all to 3m.

Fix a test that was flaky: it was trying to guard the read of a file with `canRead`, but `canRead` causes reading the content to cache, missing the later delete.

Add a missing integration test tag.