### PR TITLE
Move phased asset deps out

### DIFF
--- a/build_runner/lib/src/build/asset_graph/asset_graph_json.dart
+++ b/build_runner/lib/src/build/asset_graph/asset_graph_json.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import '../../build_plan/build_plan_digest.dart';
+import '../library_cycle_graph/phased_asset_deps.dart';
 import 'graph.dart';
 import 'serializers.dart';
 
@@ -16,22 +17,39 @@ import 'serializers.dart';
 class AssetGraphJson {
   final BuildPlanDigest buildPlanDigest;
   final AssetGraph assetGraph;
+  final PhasedAssetDeps phasedAssetDeps;
 
-  AssetGraphJson({required this.buildPlanDigest, required this.assetGraph});
+  AssetGraphJson({
+    required this.buildPlanDigest,
+    required this.assetGraph,
+    required this.phasedAssetDeps,
+  });
 
   /// Serializes for `asset_graph.json`.
   static Uint8List serialize({
     required BuildPlanDigest buildPlanDigest,
     required AssetGraph assetGraph,
+    required PhasedAssetDeps phasedAssetDeps,
   }) {
+    // Serialize fields first so all `AssetId` instances are seen by
+    // `identityAssetIdSeralizer`.
+    final serializedAssetGraph = serializeAssetGraph(assetGraph);
+    final serializedBuildPlanDigest = serializers.serializeWith(
+      BuildPlanDigest.serializer,
+      buildPlanDigest,
+    );
+    final serializedPhasedAssetDeps = serializers.serializeWith(
+      PhasedAssetDeps.serializer,
+      phasedAssetDeps,
+    );
     final result = {
       'version': _version,
-      'assetGraph': serializeAssetGraph(assetGraph),
-      'buildPlanDigest': serializers.serializeWith(
-        BuildPlanDigest.serializer,
-        buildPlanDigest,
-      ),
+      'ids': identityAssetIdSerializer.serializedObjects,
+      'assetGraph': serializedAssetGraph,
+      'buildPlanDigest': serializedBuildPlanDigest,
+      'phasedAssetDeps': serializedPhasedAssetDeps,
     };
+    identityAssetIdSerializer.reset();
     return jsonUtf8.encode(result) as Uint8List;
   }
 
@@ -44,6 +62,12 @@ class AssetGraphJson {
       if (deserialized is! Map) return null;
       if (deserialized['version'] != _version) return null;
 
+      identityAssetIdSerializer.deserializeWithObjects(
+        (deserialized['ids'] as List).map(
+          (id) => assetIdSerializer.deserialize(serializers, id as Object),
+        ),
+      );
+
       final buildPlanDigest = serializers.deserializeWith(
         BuildPlanDigest.serializer,
         deserialized['buildPlanDigest'],
@@ -53,16 +77,24 @@ class AssetGraphJson {
         deserialized['assetGraph'] as Map,
       );
 
+      final phasedAssetDeps = serializers.deserializeWith(
+        PhasedAssetDeps.serializer,
+        deserialized['phasedAssetDeps'],
+      );
+
       return AssetGraphJson(
         assetGraph: assetGraph!,
         buildPlanDigest: buildPlanDigest!,
+        phasedAssetDeps: phasedAssetDeps!,
       );
     } catch (_) {
       return null;
+    } finally {
+      identityAssetIdSerializer.reset();
     }
   }
 }
 
 /// Increment whenever older `asset_graph.json` files should be rejected.
-const _version = 35;
+const _version = 36;
 final jsonUtf8 = json.fuse(utf8);

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -17,7 +17,6 @@ import '../../build_plan/build_phases.dart';
 import '../../build_plan/phase.dart';
 import '../../constants.dart';
 import '../../io/generated_asset_hider.dart';
-import '../library_cycle_graph/phased_asset_deps.dart';
 import 'build_step_id.dart';
 import 'build_step_result.dart';
 import 'exceptions.dart';
@@ -49,10 +48,6 @@ class AssetGraph implements GeneratedAssetHider {
 
   final Map<GlobId, GlobResult> _globResults;
 
-  /// Imports of resolved assets in the previous build, or `null` if this is a
-  /// clean build.
-  PhasedAssetDeps? previousPhasedAssetDeps;
-
   AssetGraph()
     : _nodes = Nodes(),
       _postProcessBuildStepResults = {},
@@ -68,23 +63,13 @@ class AssetGraph implements GeneratedAssetHider {
     postProcessBuildStepResults,
     required Map<BuildStepId, BuildStepResult> buildStepResults,
     required Map<GlobId, GlobResult> globResults,
-    required this.previousPhasedAssetDeps,
   }) : _nodes = nodes,
        _postProcessBuildStepResults = postProcessBuildStepResults,
        _buildStepResults = buildStepResults,
        _globResults = globResults;
 
-  @visibleForTesting
-  AssetGraph copyWith() => AssetGraph._with(
-    nodes: _nodes,
-    postProcessBuildStepResults: _postProcessBuildStepResults,
-    buildStepResults: _buildStepResults,
-    globResults: _globResults,
-    previousPhasedAssetDeps: previousPhasedAssetDeps,
-  );
-
-  /// Copies the graph prepared for the next build with [buildPhases].
-  AssetGraph copyForNextBuild(BuildPhases buildPhases) {
+  /// Copies the graph prepared for the next build.
+  AssetGraph copyForNextBuild() {
     return AssetGraph._with(
       nodes: _nodes.clone(),
       postProcessBuildStepResults: {
@@ -93,7 +78,6 @@ class AssetGraph implements GeneratedAssetHider {
       },
       buildStepResults: Map.of(_buildStepResults),
       globResults: Map.of(_globResults),
-      previousPhasedAssetDeps: previousPhasedAssetDeps,
     );
   }
 

--- a/build_runner/lib/src/build/asset_graph/serialization.dart
+++ b/build_runner/lib/src/build/asset_graph/serialization.dart
@@ -13,12 +13,6 @@ part of 'graph.dart';
 ///
 /// Returns `null` if deserialization fails.
 AssetGraph? deserializeAssetGraph(Map serializedGraph) {
-  identityAssetIdSerializer.deserializeWithObjects(
-    (serializedGraph['ids'] as List).map(
-      (id) => assetIdSerializer.deserialize(serializers, id as Object),
-    ),
-  );
-
   final graph = AssetGraph();
 
   for (final serializedItem in serializedGraph['nodes'] as Iterable) {
@@ -40,11 +34,6 @@ AssetGraph? deserializeAssetGraph(Map serializedGraph) {
       graph.updatePostProcessBuildStepResult(entry.key, entry.value);
     }
   }
-
-  graph.previousPhasedAssetDeps = serializers.deserializeWith(
-    PhasedAssetDeps.serializer,
-    serializedGraph['phasedAssetDeps'],
-  );
 
   if (serializedGraph.containsKey('buildStepResults')) {
     final deserializedResults =
@@ -76,7 +65,6 @@ AssetGraph? deserializeAssetGraph(Map serializedGraph) {
     }
   }
 
-  identityAssetIdSerializer.reset();
   return graph;
 }
 
@@ -91,19 +79,12 @@ Map<String, Object?> serializeAssetGraph(AssetGraph graph) {
   final nodes = graph.allNodes
       .map((node) => serializers.serializeWith(AssetNode.serializer, node))
       .toList(growable: false);
-  final serializedPhasedAssetDeps = serializers.serializeWith(
-    PhasedAssetDeps.serializer,
-    graph.previousPhasedAssetDeps,
-  );
-
   final result = <String, Object?>{
-    'ids': identityAssetIdSerializer.serializedObjects,
     'nodes': nodes,
     'postProcessResults': serializers.serialize(
       graph._postProcessBuildStepResults,
       specifiedType: postProcessBuildStepResultsFullType,
     ),
-    'phasedAssetDeps': serializedPhasedAssetDeps,
     'buildStepResults': serializers.serialize(
       BuiltMap<BuildStepId, BuildStepResult>.of(graph.buildStepResults),
       specifiedType: const FullType(BuiltMap, [
@@ -120,6 +101,5 @@ Map<String, Object?> serializeAssetGraph(AssetGraph graph) {
     ),
   };
 
-  identityAssetIdSerializer.reset();
   return result;
 }

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -131,9 +131,9 @@ class Build {
     required this.resourceManager,
     required this.assetGraph,
   }) : previousDepsLoader =
-           assetGraph.previousPhasedAssetDeps == null
+           buildPlan.previousPhasedAssetDeps == null
                ? null
-               : AssetDepsLoader.fromDeps(assetGraph.previousPhasedAssetDeps!),
+               : AssetDepsLoader.fromDeps(buildPlan.previousPhasedAssetDeps!),
        resolvers = buildPlan.testingOverrides.resolvers ?? _defaultResolvers,
        resolversImpl = switch (buildPlan.testingOverrides.resolvers ??
            _defaultResolvers) {
@@ -354,21 +354,25 @@ class Build {
         final currentPhasedAssetDeps =
             resolversImpl?.phasedAssetDeps() ?? PhasedAssetDeps();
         final updatedPhasedAssetDeps =
-            assetGraph.previousPhasedAssetDeps == null
+            buildPlan.previousPhasedAssetDeps == null
                 ? currentPhasedAssetDeps
-                : assetGraph.previousPhasedAssetDeps!.update(
+                : buildPlan.previousPhasedAssetDeps!.update(
                   currentPhasedAssetDeps,
                 );
-        assetGraph.previousPhasedAssetDeps = updatedPhasedAssetDeps;
         await readerWriter.writeAsBytes(
           AssetId(buildPackages.outputRoot, assetGraphPath),
           AssetGraphJson.serialize(
             buildPlanDigest: buildPlan.buildPlanDigest,
             assetGraph: assetGraph,
+            phasedAssetDeps: updatedPhasedAssetDeps,
           ),
         );
 
-        if (!done.isCompleted) done.complete(result);
+        if (!done.isCompleted) {
+          done.complete(
+            result.copyWith(phasedAssetDeps: updatedPhasedAssetDeps),
+          );
+        }
       },
       (e, st) {
         if (!done.isCompleted) {

--- a/build_runner/lib/src/build/build_result.dart
+++ b/build_runner/lib/src/build/build_result.dart
@@ -6,6 +6,7 @@ import 'package:build/build.dart';
 import 'package:built_collection/built_collection.dart';
 
 import '../io/build_output_reader.dart';
+import 'library_cycle_graph/phased_asset_deps.dart';
 
 /// The result of an individual build, this may be an incremental build or
 /// a full build.
@@ -22,6 +23,9 @@ class BuildResult {
   /// All outputs created/updated during this build.
   final BuiltList<AssetId> outputs;
 
+  /// The imports graph for resolved sources.
+  final PhasedAssetDeps phasedAssetDeps;
+
   // The build output.
   final BuildOutputReader buildOutputReader;
 
@@ -29,6 +33,7 @@ class BuildResult {
     required this.status,
     BuiltList<String>? errors,
     BuiltList<AssetId>? outputs,
+    PhasedAssetDeps? phasedAssetDeps,
     required this.buildOutputReader,
     FailureType? failureType,
   }) : failureType =
@@ -36,16 +41,19 @@ class BuildResult {
                ? FailureType.general
                : failureType,
        errors = errors ?? BuiltList(),
-       outputs = outputs ?? BuiltList();
+       outputs = outputs ?? BuiltList(),
+       phasedAssetDeps = phasedAssetDeps ?? PhasedAssetDeps();
 
   BuildResult copyWith({
     BuildStatus? status,
     FailureType? failureType,
     BuiltList<String>? errors,
+    PhasedAssetDeps? phasedAssetDeps,
   }) => BuildResult(
     status: status ?? this.status,
     errors: errors ?? this.errors,
     outputs: outputs,
+    phasedAssetDeps: phasedAssetDeps ?? this.phasedAssetDeps,
     buildOutputReader: buildOutputReader,
     failureType: failureType ?? this.failureType,
   );

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -272,7 +272,9 @@ class BuildSeries {
 
     _currentBuildResult = build.run(updates);
     final result = await _currentBuildResult!;
-    _buildPlan = _buildPlan.forNextBuild();
+    _buildPlan = _buildPlan.forNextBuild(
+      previousPhasedAssetDeps: result.phasedAssetDeps,
+    );
     _buildResultsController.add(result);
     return result;
   }

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -13,6 +13,7 @@ import '../build/asset_graph/asset_graph_json.dart';
 import '../build/asset_graph/exceptions.dart';
 import '../build/asset_graph/graph.dart';
 import '../build/asset_graph/node.dart';
+import '../build/library_cycle_graph/phased_asset_deps.dart';
 
 import '../constants.dart';
 import '../exceptions.dart';
@@ -48,6 +49,7 @@ class BuildPlan {
 
   final AssetGraph? _previousAssetGraph;
   bool _previousAssetGraphWasTaken;
+  final PhasedAssetDeps? previousPhasedAssetDeps;
   final bool restartIsNeeded;
 
   final Bootstrapper bootstrapper;
@@ -95,6 +97,7 @@ class BuildPlan {
     required this.buildPhases,
     required AssetGraph? previousAssetGraph,
     required bool previousAssetGraphWasTaken,
+    required this.previousPhasedAssetDeps,
     required this.restartIsNeeded,
     required this.bootstrapper,
     required AssetGraph assetGraph,
@@ -207,6 +210,7 @@ class BuildPlan {
     final filesToDelete = <AssetId>{};
     final foldersToDelete = <AssetId>{};
 
+    PhasedAssetDeps? previousPhasedAssetDeps;
     if (await readerWriter.canRead(assetGraphId)) {
       final assetGraphJson = AssetGraphJson.deserialize(
         await readerWriter.readAsBytes(assetGraphId) as Uint8List,
@@ -214,6 +218,7 @@ class BuildPlan {
       if (assetGraphJson != null) {
         previousAssetGraph = assetGraphJson.assetGraph;
         previousBuildPlanDigest = assetGraphJson.buildPlanDigest;
+        previousPhasedAssetDeps = assetGraphJson.phasedAssetDeps;
       }
       if (previousAssetGraph != null) {
         if (restartIsNeeded ||
@@ -258,7 +263,7 @@ class BuildPlan {
               (node.type != NodeType.generated || node.wasOutput))
             node.id,
       };
-      assetGraph = previousAssetGraph.copyForNextBuild(buildPhases);
+      assetGraph = previousAssetGraph.copyForNextBuild();
 
       if (restartIsNeeded) {
         // Mark old outputs for deletion.
@@ -324,6 +329,7 @@ class BuildPlan {
       buildPhases: buildPhases,
       previousAssetGraph: previousAssetGraph,
       previousAssetGraphWasTaken: false,
+      previousPhasedAssetDeps: previousPhasedAssetDeps,
       restartIsNeeded: restartIsNeeded,
       bootstrapper: bootstrapper,
       assetGraph: assetGraph,
@@ -350,6 +356,7 @@ class BuildPlan {
     ReaderWriter? readerWriter,
     bool? cleanBuild,
     bool? triggersChanged,
+    PhasedAssetDeps? previousPhasedAssetDeps,
     BuiltList<bool>? phaseOptionsChanged,
     BuiltList<bool>? postBuildOptionsChanged,
   }) => BuildPlan(
@@ -366,6 +373,8 @@ class BuildPlan {
     buildPhases: buildPhases,
     previousAssetGraph: _previousAssetGraph,
     previousAssetGraphWasTaken: _previousAssetGraphWasTaken,
+    previousPhasedAssetDeps:
+        previousPhasedAssetDeps ?? this.previousPhasedAssetDeps,
     restartIsNeeded: restartIsNeeded,
     bootstrapper: bootstrapper,
     assetGraph: _assetGraph,
@@ -382,18 +391,22 @@ class BuildPlan {
 
   /// Returns a copy of the plan updated for the next incremental build.
   ///
+  /// Updates [previousPhasedAssetDeps].
+  ///
   /// Sets [cleanBuild], [triggersChanged], `phaseOptionsChanged` and
   /// `postBuildOptionsChanged` to `false`.
-  BuildPlan forNextBuild() => copyWith(
-    cleanBuild: false,
-    triggersChanged: false,
-    phaseOptionsChanged: BuiltList<bool>.from(
-      List.filled(buildPhases.inBuildPhasesOptionsDigests.length, false),
-    ),
-    postBuildOptionsChanged: BuiltList<bool>.from(
-      List.filled(buildPhases.postBuildActionsOptionsDigests.length, false),
-    ),
-  );
+  BuildPlan forNextBuild({PhasedAssetDeps? previousPhasedAssetDeps}) =>
+      copyWith(
+        cleanBuild: false,
+        triggersChanged: false,
+        previousPhasedAssetDeps: previousPhasedAssetDeps,
+        phaseOptionsChanged: BuiltList<bool>.from(
+          List.filled(buildPhases.inBuildPhasesOptionsDigests.length, false),
+        ),
+        postBuildOptionsChanged: BuiltList<bool>.from(
+          List.filled(buildPhases.postBuildActionsOptionsDigests.length, false),
+        ),
+      );
 
   /// Takes the loaded [AssetGraph], which may be `null` if none could be
   /// loaded or if it was invalid.

--- a/build_runner/test/build/asset_graph/asset_graph_json_test.dart
+++ b/build_runner/test/build/asset_graph/asset_graph_json_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'package:build_runner/src/build/asset_graph/asset_graph_json.dart';
 import 'package:build_runner/src/build/asset_graph/graph.dart';
+import 'package:build_runner/src/build/library_cycle_graph/phased_asset_deps.dart';
 import 'package:build_runner/src/build_plan/build_plan_digest.dart';
 import 'package:test/test.dart';
 
@@ -19,6 +20,7 @@ void main() {
           b.buildPhasesDigest = '';
           b.dartVersion = '';
         }),
+        phasedAssetDeps: PhasedAssetDeps(),
       );
       expect(AssetGraphJson.deserialize(validBytes), isNotNull);
 
@@ -41,6 +43,7 @@ void main() {
           b.buildPhasesDigest = '';
           b.dartVersion = '';
         }),
+        phasedAssetDeps: PhasedAssetDeps(),
       );
       final invalidBytes = validBytes.sublist(0, validBytes.length - 1);
       expect(AssetGraphJson.deserialize(invalidBytes), isNull);

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -9,6 +9,7 @@ import 'package:build/experiments.dart';
 import 'package:build_config/build_config.dart' hide BuilderDefinition;
 import 'package:build_runner/src/build/asset_graph/asset_graph_json.dart';
 import 'package:build_runner/src/build/asset_graph/graph.dart';
+import 'package:build_runner/src/build/library_cycle_graph/phased_asset_deps.dart';
 import 'package:build_runner/src/build_plan/build_options.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
@@ -76,6 +77,7 @@ void main() {
         AssetGraphJson.serialize(
           buildPlanDigest: buildPlan.buildPlanDigest,
           assetGraph: assetGraph,
+          phasedAssetDeps: PhasedAssetDeps(),
         ),
       );
     }


### PR DESCRIPTION
Move `PhasedAssetDeps` out of `AssetGraph` to `AssetGraphJson` as it's a result of the previous build used for invalidation, not an active part of the build.