### PR TITLE
fix: validate manifest paths stay within output directory

### DIFF
--- a/build_runner/lib/src/io/create_merged_dir.dart
+++ b/build_runner/lib/src/io/create_merged_dir.dart
@@ -323,8 +323,6 @@ Future<bool> _cleanUpOutputDir(Directory outputDir) async {
 
     for (final path in previousOutputs) {
       final file = File(p.join(outputPath, path));
-      // Reject manifest entries that resolve outside the output directory;
-      // a malicious package could write ../ sequences into asset paths.
       if (!p.isWithin(outputPath, file.path)) continue;
       if (file.existsSync()) file.deleteSync();
     }

--- a/build_runner/lib/src/io/create_merged_dir.dart
+++ b/build_runner/lib/src/io/create_merged_dir.dart
@@ -323,6 +323,9 @@ Future<bool> _cleanUpOutputDir(Directory outputDir) async {
 
     for (final path in previousOutputs) {
       final file = File(p.join(outputPath, path));
+      // Reject manifest entries that resolve outside the output directory;
+      // a malicious package could write ../ sequences into asset paths.
+      if (!p.isWithin(outputPath, file.path)) continue;
       if (file.existsSync()) file.deleteSync();
     }
     _cleanEmptyDirectories(outputPath, previousOutputs);


### PR DESCRIPTION
## Summary

`_cleanUpOutputDir` reads paths from `.build.manifest` and deletes them without
validating that the resolved path remains inside the output directory:

```dart
for (final path in previousOutputs) {
  final file = File(p.join(outputPath, path));  // no traversal check
  if (file.existsSync()) file.deleteSync();      // arbitrary file deletion
}
```

A malicious pub.dev package (or any code that influences build output asset
paths) could write `../../../important/file` sequences into manifest entries.
On the next build, `_cleanUpOutputDir` would delete files outside the intended
output directory.

## Fix

Add `p.isWithin(outputPath, file.path)` guard before deletion to skip any
manifest entry that escapes the output directory:

```dart
if (!p.isWithin(outputPath, file.path)) continue;
```

Note: `_deleteUp` already uses `p.isWithin` for directory cleanup (line 351),
so this fix brings file deletion in line with the existing directory deletion logic.

## Impact

- Arbitrary file deletion by a malicious build plugin or package
- Attack vector: `.build.manifest` written with crafted `../` paths
- No user interaction required beyond running `dart run build_runner build`
  against an untrusted package