### PR TITLE
Move generated output information out of nodes.

### DIFF
--- a/build_runner/lib/src/build/asset_graph/asset_graph_json.dart
+++ b/build_runner/lib/src/build/asset_graph/asset_graph_json.dart
@@ -96,5 +96,5 @@ class AssetGraphJson {
 }
 
 /// Increment whenever older `asset_graph.json` files should be rejected.
-const _version = 36;
+const _version = 37;
 final jsonUtf8 = json.fuse(utf8);

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -475,12 +475,7 @@ class AssetGraph implements GeneratedAssetHider {
         _removeRecursive(output, removedIds: removed);
       }
 
-      final newNode = AssetNode.generated(
-        output,
-        phaseNumber: phaseNumber,
-        primaryInput: primaryInput,
-        isHidden: isHidden,
-      );
+      final newNode = AssetNode.generated(output, isHidden: isHidden);
       _nodes.add(newNode);
       _generatedBy[output] = BuildStepId(
         primaryInput: primaryInput,

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -35,6 +35,15 @@ class AssetGraph implements GeneratedAssetHider {
   /// All the [AssetNode]s in the graph.
   final Nodes _nodes;
 
+  /// All standard build step execution results, indexed by [BuildStepId].
+  final Map<BuildStepId, BuildStepResult> _buildStepResults;
+
+  /// Declared generated outputs and their build steps.
+  final Map<AssetId, BuildStepId> _generatedBy;
+
+  /// Globs evaluated during the build.
+  final Map<GlobId, GlobResult> _globResults;
+
   /// All post process build steps results, indexed by package then
   /// [PostProcessBuildStepId].
   ///
@@ -43,16 +52,12 @@ class AssetGraph implements GeneratedAssetHider {
   final Map<String, Map<PostProcessBuildStepId, PostProcessBuildStepResult>>
   _postProcessBuildStepResults;
 
-  /// All standard build step execution results, indexed by [BuildStepId].
-  final Map<BuildStepId, BuildStepResult> _buildStepResults;
-
-  final Map<GlobId, GlobResult> _globResults;
-
   AssetGraph()
     : _nodes = Nodes(),
       _postProcessBuildStepResults = {},
       _buildStepResults = {},
-      _globResults = {};
+      _globResults = {},
+      _generatedBy = {};
 
   AssetGraph._with({
     required Nodes nodes,
@@ -63,10 +68,12 @@ class AssetGraph implements GeneratedAssetHider {
     postProcessBuildStepResults,
     required Map<BuildStepId, BuildStepResult> buildStepResults,
     required Map<GlobId, GlobResult> globResults,
+    required Map<AssetId, BuildStepId> generatedBy,
   }) : _nodes = nodes,
        _postProcessBuildStepResults = postProcessBuildStepResults,
        _buildStepResults = buildStepResults,
-       _globResults = globResults;
+       _globResults = globResults,
+       _generatedBy = generatedBy;
 
   /// Copies the graph prepared for the next build.
   AssetGraph copyForNextBuild() {
@@ -78,6 +85,7 @@ class AssetGraph implements GeneratedAssetHider {
       },
       buildStepResults: Map.of(_buildStepResults),
       globResults: Map.of(_globResults),
+      generatedBy: Map.of(_generatedBy),
     );
   }
 
@@ -129,6 +137,8 @@ class AssetGraph implements GeneratedAssetHider {
   }
 
   Map<BuildStepId, BuildStepResult> get buildStepResults => _buildStepResults;
+
+  Map<AssetId, BuildStepId> get generatedBy => _generatedBy;
 
   GlobResult? globResultFor(GlobId globId) => _globResults[globId];
   void updateGlobResult(GlobId globId, GlobResult result) {
@@ -190,6 +200,7 @@ class AssetGraph implements GeneratedAssetHider {
         _removeRecursive(output, removedIds: removedIds);
       }
       _nodes.remove(id);
+      _generatedBy.remove(id);
     }
   }
 
@@ -222,9 +233,14 @@ class AssetGraph implements GeneratedAssetHider {
     PostProcessBuildStepId action,
   ) => _postProcessBuildStepResults[action.input.package]?[action];
 
-  /// All the generated outputs in the graph.
+  /// All declared outputs in the graph.
   Iterable<AssetId> get outputs =>
       allNodes.where((n) => n.isGenerated).map((n) => n.id);
+
+  /// All declared outputs and the phases in which they are output.
+  Map<AssetId, int> get outputPhases => {
+    for (final entry in generatedBy.entries) entry.key: entry.value.phaseNumber,
+  };
 
   /// All the generated outputs for a particular phase.
   Iterable<AssetNode> outputsForPhase(String package, int phase) =>
@@ -233,7 +249,7 @@ class AssetGraph implements GeneratedAssetHider {
           .where(
             (n) =>
                 n.type == NodeType.generated &&
-                n.generatedNodeConfiguration!.phaseNumber == phase,
+                _generatedBy[n.id]?.phaseNumber == phase,
           );
 
   /// All the source files in the graph.
@@ -330,8 +346,7 @@ class AssetGraph implements GeneratedAssetHider {
 
     var inputNode = get(input)!;
     while (inputNode.type == NodeType.generated) {
-      final inputNodeConfiguration = inputNode.generatedNodeConfiguration!;
-      inputNode = get(inputNodeConfiguration.primaryInput)!;
+      inputNode = get(_generatedBy[inputNode.id]!.primaryInput)!;
     }
     return action.targetSources.matches(inputNode.id);
   }
@@ -450,12 +465,10 @@ class AssetGraph implements GeneratedAssetHider {
       if (contains(output)) {
         existing = get(output)!;
         if (existing.type == NodeType.generated) {
-          final existingConfiguration = existing.generatedNodeConfiguration!;
+          final existingPhase = _generatedBy[existing.id]!.phaseNumber;
           throw DuplicateAssetNodeException(
             existing.id,
-            buildPhases
-                .inBuildPhases[existingConfiguration.phaseNumber]
-                .displayName,
+            buildPhases.inBuildPhases[existingPhase].displayName,
             buildPhases.inBuildPhases[phaseNumber].displayName,
           );
         }
@@ -469,6 +482,10 @@ class AssetGraph implements GeneratedAssetHider {
         isHidden: isHidden,
       );
       _nodes.add(newNode);
+      _generatedBy[output] = BuildStepId(
+        primaryInput: primaryInput,
+        phaseNumber: phaseNumber,
+      );
     }
     return removed;
   }
@@ -476,10 +493,24 @@ class AssetGraph implements GeneratedAssetHider {
   @override
   String toString() => allNodes.toList().toString();
 
+  @visibleForTesting
   void add(AssetNode node) => _nodes.add(node);
 
+  @visibleForTesting
+  void addGeneratedForTest(AssetNode node, BuildStepId buildStepId) {
+    _nodes.add(node);
+    _generatedBy[node.id] = buildStepId;
+  }
+
+  /// Adds a source that a builder tried to access but was missing.
+  void addMissingSource(AssetId id) => _nodes.add(AssetNode.missingSource(id));
+
+  /// Adds a generated node that was output by a post process build step.
+  void addPostGenerated(AssetId id) {
+    _nodes.add(AssetNode.postGenerated(id));
+  }
+
   /// Removes a generated node that was output by a post process build step.
-  /// TODO(davidmorgan): look at removing them from the graph altogether.
   void removePostProcessOutput(AssetId id) => _nodes.remove(id);
 
   @override

--- a/build_runner/lib/src/build/asset_graph/node.dart
+++ b/build_runner/lib/src/build/asset_graph/node.dart
@@ -100,8 +100,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
   factory AssetNode.generated(
     AssetId id, {
     Digest? digest,
-    AssetId? primaryInput,
-    int? phaseNumber,
     required bool isHidden,
   }) => AssetNode((b) {
     b.id = id;

--- a/build_runner/lib/src/build/asset_graph/node.dart
+++ b/build_runner/lib/src/build/asset_graph/node.dart
@@ -8,8 +8,6 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:crypto/crypto.dart';
 
-import 'build_step_id.dart';
-
 part 'node.g.dart';
 
 /// Types of [AssetNode].
@@ -102,14 +100,12 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
   factory AssetNode.generated(
     AssetId id, {
     Digest? digest,
-    required AssetId primaryInput,
-    required int phaseNumber,
+    AssetId? primaryInput,
+    int? phaseNumber,
     required bool isHidden,
   }) => AssetNode((b) {
     b.id = id;
     b.type = NodeType.generated;
-    b.generatedNodeConfiguration.primaryInput = primaryInput;
-    b.generatedNodeConfiguration.phaseNumber = phaseNumber;
     b.generatedNodeConfiguration.isHidden = isHidden;
     b.digest = digest;
   });
@@ -145,23 +141,8 @@ abstract class GeneratedNodeConfiguration
   static Serializer<GeneratedNodeConfiguration> get serializer =>
       _$generatedNodeConfigurationSerializer;
 
-  /// The primary input which generated this node.
-  AssetId get primaryInput;
-
-  /// The phase in which this node is generated.
-  ///
-  /// The generator that produces this node can only read files from earlier
-  /// phases plus any files it writes itself.
-  ///
-  /// Other generators and globs can only read this node if they run in a
-  /// later phase.
-  int get phaseNumber;
-
   /// Whether the asset should be placed in the build cache.
   bool get isHidden;
-
-  BuildStepId get buildStepId =>
-      BuildStepId(primaryInput: primaryInput, phaseNumber: phaseNumber);
 
   factory GeneratedNodeConfiguration(
     void Function(GeneratedNodeConfigurationBuilder) updates,

--- a/build_runner/lib/src/build/asset_graph/node.g.dart
+++ b/build_runner/lib/src/build/asset_graph/node.g.dart
@@ -196,16 +196,6 @@ class _$GeneratedNodeConfigurationSerializer
     FullType specifiedType = FullType.unspecified,
   }) {
     final result = <Object?>[
-      'primaryInput',
-      serializers.serialize(
-        object.primaryInput,
-        specifiedType: const FullType(AssetId),
-      ),
-      'phaseNumber',
-      serializers.serialize(
-        object.phaseNumber,
-        specifiedType: const FullType(int),
-      ),
       'isHidden',
       serializers.serialize(
         object.isHidden,
@@ -230,22 +220,6 @@ class _$GeneratedNodeConfigurationSerializer
       iterator.moveNext();
       final Object? value = iterator.current;
       switch (key) {
-        case 'primaryInput':
-          result.primaryInput =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(AssetId),
-                  )!
-                  as AssetId;
-          break;
-        case 'phaseNumber':
-          result.phaseNumber =
-              serializers.deserialize(
-                    value,
-                    specifiedType: const FullType(int),
-                  )!
-                  as int;
-          break;
         case 'isHidden':
           result.isHidden =
               serializers.deserialize(
@@ -421,21 +395,13 @@ class AssetNodeBuilder implements Builder<AssetNode, AssetNodeBuilder> {
 
 class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
   @override
-  final AssetId primaryInput;
-  @override
-  final int phaseNumber;
-  @override
   final bool isHidden;
 
   factory _$GeneratedNodeConfiguration([
     void Function(GeneratedNodeConfigurationBuilder)? updates,
   ]) => (GeneratedNodeConfigurationBuilder()..update(updates))._build();
 
-  _$GeneratedNodeConfiguration._({
-    required this.primaryInput,
-    required this.phaseNumber,
-    required this.isHidden,
-  }) : super._();
+  _$GeneratedNodeConfiguration._({required this.isHidden}) : super._();
   @override
   GeneratedNodeConfiguration rebuild(
     void Function(GeneratedNodeConfigurationBuilder) updates,
@@ -448,17 +414,12 @@ class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is GeneratedNodeConfiguration &&
-        primaryInput == other.primaryInput &&
-        phaseNumber == other.phaseNumber &&
-        isHidden == other.isHidden;
+    return other is GeneratedNodeConfiguration && isHidden == other.isHidden;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, primaryInput.hashCode);
-    _$hash = $jc(_$hash, phaseNumber.hashCode);
     _$hash = $jc(_$hash, isHidden.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
@@ -467,10 +428,7 @@ class _$GeneratedNodeConfiguration extends GeneratedNodeConfiguration {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'GeneratedNodeConfiguration')
-          ..add('primaryInput', primaryInput)
-          ..add('phaseNumber', phaseNumber)
-          ..add('isHidden', isHidden))
-        .toString();
+      ..add('isHidden', isHidden)).toString();
   }
 }
 
@@ -478,15 +436,6 @@ class GeneratedNodeConfigurationBuilder
     implements
         Builder<GeneratedNodeConfiguration, GeneratedNodeConfigurationBuilder> {
   _$GeneratedNodeConfiguration? _$v;
-
-  AssetId? _primaryInput;
-  AssetId? get primaryInput => _$this._primaryInput;
-  set primaryInput(AssetId? primaryInput) =>
-      _$this._primaryInput = primaryInput;
-
-  int? _phaseNumber;
-  int? get phaseNumber => _$this._phaseNumber;
-  set phaseNumber(int? phaseNumber) => _$this._phaseNumber = phaseNumber;
 
   bool? _isHidden;
   bool? get isHidden => _$this._isHidden;
@@ -497,8 +446,6 @@ class GeneratedNodeConfigurationBuilder
   GeneratedNodeConfigurationBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _primaryInput = $v.primaryInput;
-      _phaseNumber = $v.phaseNumber;
       _isHidden = $v.isHidden;
       _$v = null;
     }
@@ -522,16 +469,6 @@ class GeneratedNodeConfigurationBuilder
     final _$result =
         _$v ??
         _$GeneratedNodeConfiguration._(
-          primaryInput: BuiltValueNullFieldError.checkNotNull(
-            primaryInput,
-            r'GeneratedNodeConfiguration',
-            'primaryInput',
-          ),
-          phaseNumber: BuiltValueNullFieldError.checkNotNull(
-            phaseNumber,
-            r'GeneratedNodeConfiguration',
-            'phaseNumber',
-          ),
           isHidden: BuiltValueNullFieldError.checkNotNull(
             isHidden,
             r'GeneratedNodeConfiguration',

--- a/build_runner/lib/src/build/asset_graph/serialization.dart
+++ b/build_runner/lib/src/build/asset_graph/serialization.dart
@@ -65,6 +65,19 @@ AssetGraph? deserializeAssetGraph(Map serializedGraph) {
     }
   }
 
+  if (serializedGraph.containsKey('generatedBy')) {
+    final deserializedGeneratedBy =
+        serializers.deserialize(
+              serializedGraph['generatedBy'],
+              specifiedType: const FullType(BuiltMap, [
+                FullType(AssetId),
+                FullType(BuildStepId),
+              ]),
+            )
+            as BuiltMap<AssetId, BuildStepId>;
+    graph._generatedBy.addAll(deserializedGeneratedBy.toMap());
+  }
+
   return graph;
 }
 
@@ -97,6 +110,13 @@ Map<String, Object?> serializeAssetGraph(AssetGraph graph) {
       specifiedType: const FullType(BuiltMap, [
         FullType(GlobId),
         FullType(GlobResult),
+      ]),
+    ),
+    'generatedBy': serializers.serialize(
+      BuiltMap<AssetId, BuildStepId>.of(graph._generatedBy),
+      specifiedType: const FullType(BuiltMap, [
+        FullType(AssetId),
+        FullType(BuildStepId),
       ]),
     ),
   };

--- a/build_runner/lib/src/build/asset_graph/serializers.dart
+++ b/build_runner/lib/src/build/asset_graph/serializers.dart
@@ -75,6 +75,13 @@ final Serializers serializers =
             MapBuilder<GlobId, GlobResult>.new,
           )
           ..addBuilderFactory(
+            const FullType(BuiltMap, [
+              FullType(AssetId),
+              FullType(BuildStepId),
+            ]),
+            MapBuilder<AssetId, BuildStepId>.new,
+          )
+          ..addBuilderFactory(
             const FullType(Set, [FullType(AssetId)]),
             () => <AssetId>{},
           )

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -165,8 +165,7 @@ class Build {
       for (final output in processedOutputs) {
         final node = assetGraph.get(output)!;
         if (node.type != NodeType.generated) continue;
-        final config = node.generatedNodeConfiguration!;
-        final buildStepId = config.buildStepId;
+        final buildStepId = assetGraph.generatedBy[output]!;
         final stepResult = assetGraph.buildStepResultFor(buildStepId);
         if (stepResult != null && stepResult.result == false) {
           failedSteps.add(buildStepId);
@@ -502,7 +501,7 @@ class Build {
       // since the test dir is not part of the build for non-root packages.
       if (!buildConfigs.isVisibleInBuild(node.id, packageNode)) continue;
 
-      ids.add(node.generatedNodeConfiguration!.primaryInput);
+      ids.add(assetGraph.generatedBy[node.id]!.primaryInput);
     }
     return ids.toList()..sort();
   }
@@ -517,8 +516,7 @@ class Build {
   Future<void> _buildOutput(AssetId id) async {
     final node = assetGraph.get(id)!;
     if (node.type == NodeType.generated && !processedOutputs.contains(id)) {
-      final nodeConfiguration = node.generatedNodeConfiguration!;
-      final buildStepId = nodeConfiguration.buildStepId;
+      final buildStepId = assetGraph.generatedBy[id]!;
       await lazyPhases.putIfAbsent(
         '${buildStepId.phaseNumber}|${buildStepId.primaryInput}',
         () async {
@@ -819,8 +817,7 @@ class Build {
         if (assetGraph.contains(assetId)) {
           throw InvalidOutputException(assetId, 'Asset already exists');
         }
-        final node = AssetNode.postGenerated(assetId);
-        assetGraph.add(node);
+        assetGraph.addPostGenerated(assetId);
         outputs.add(assetId);
       },
       deleteAsset: (assetId) {
@@ -922,9 +919,8 @@ class Build {
 
       // Propagate results for generated node inputs.
       if (primaryInputNode.type == NodeType.generated) {
-        final inputConfiguration = primaryInputNode.generatedNodeConfiguration!;
         final inputStepResult = assetGraph.buildStepResultFor(
-          inputConfiguration.buildStepId,
+          assetGraph.generatedBy[buildStepId.primaryInput]!,
         );
 
         // If the primary input's generating step failed, this build is also
@@ -1085,7 +1081,8 @@ class Build {
   }) async {
     final inputNode = assetGraph.get(input)!;
     if (inputNode.type == NodeType.generated) {
-      if (inputNode.generatedNodeConfiguration!.phaseNumber >= phaseNumber) {
+      final phase = assetGraph.generatedBy[input]!.phaseNumber;
+      if (phase >= phaseNumber) {
         // It's not readable in this phase.
         return false;
       }
@@ -1195,7 +1192,7 @@ class Build {
         // Generated nodes are only considered at all if they are output in
         // an earlier phase.
         if (node.type != NodeType.generated ||
-            node.generatedNodeConfiguration!.phaseNumber < globId.phaseNumber) {
+            assetGraph.generatedBy[id]!.phaseNumber < globId.phaseNumber) {
           if (node.type == NodeType.generated) {
             generatedFileInputs.add(node.id);
           } else {
@@ -1214,9 +1211,8 @@ class Build {
       final generatedFileResults = <AssetId>[];
       for (final id in generatedFileInputs) {
         final node = assetGraph.get(id)!;
-        final nodeConfig = node.generatedNodeConfiguration!;
         final stepResult = assetGraph.buildStepResultFor(
-          nodeConfig.buildStepId,
+          assetGraph.generatedBy[id]!,
         );
         if (node.wasOutput && stepResult != null && stepResult.result == true) {
           generatedFileResults.add(id);

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -14,8 +14,6 @@ import 'package:analyzer/src/dart/analysis/file_content_cache.dart';
 import 'package:build/build.dart' hide Resource;
 import 'package:path/path.dart' as p;
 
-import '../asset_graph/node.dart';
-
 /// The in-memory filesystem that is the analyzer's view of the build.
 ///
 /// Pass an `Iterable<AssetNode>` of generated file nodes to [startBuild] at the
@@ -66,23 +64,21 @@ class AnalysisDriverFilesystem
   }
 
   /// Initializes a new filesystem that will have files added due to the
-  /// build described by [generatedNodes].
+  /// build described by [generatedPhases].
   ///
   /// If [invalidatedSources] is `null`, this is an initial build and all
   /// cached contents are cleared. Otherwise, only source files matching
   /// [invalidatedSources] are removed.
   void startBuild(
-    Iterable<AssetNode> generatedNodes, {
+    Map<AssetId, int> generatedPhases, {
     required Set<AssetId>? invalidatedSources,
   }) {
     final previousPhaseByPath = _phaseByPath;
     _phaseByPath = <String, int>{};
     _pathByPhase = <int, List<String>>{};
-    for (final node in generatedNodes) {
-      // Post process generated nodes are never analyzed.
-      if (node.type == NodeType.postGenerated) continue;
-      final phase = node.generatedNodeConfiguration!.phaseNumber;
-      final idAsPath = node.id.asPath;
+    for (final entry in generatedPhases.entries) {
+      final phase = entry.value;
+      final idAsPath = entry.key.asPath;
       _phaseByPath[idAsPath] = phase;
       _pathByPhase.putIfAbsent(phase, () => []).add(idAsPath);
     }

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -52,7 +52,7 @@ class AnalysisDriverModel {
   }) async {
     _lock = await _pool.request();
     filesystem.startBuild(
-      assetGraph.outputs.map((id) => assetGraph.get(id)!),
+      assetGraph.outputPhases,
       invalidatedSources: invalidatedSources,
     );
   }

--- a/build_runner/lib/src/build/single_step_reader_writer.dart
+++ b/build_runner/lib/src/build/single_step_reader_writer.dart
@@ -16,7 +16,6 @@ import '../build_plan/build_packages.dart';
 import '../build_plan/phase.dart';
 import '../io/asset_finder.dart';
 import '../io/reader_writer.dart';
-import 'asset_graph/build_step_id.dart';
 import 'asset_graph/glob_id.dart';
 
 import 'asset_graph/graph.dart';
@@ -187,7 +186,7 @@ class SingleStepReaderWriter implements PhasedReader {
     final node = _runningBuild.assetGraph.get(id);
     if (node == null) {
       if (track) inputTracker.add(id);
-      _runningBuild.assetGraph.add(AssetNode.missingSource(id));
+      _runningBuild.assetGraph.addMissingSource(id);
       return false;
     }
 
@@ -304,11 +303,10 @@ class SingleStepReaderWriter implements PhasedReader {
       return Readability.notReadable;
     }
     if (node.type == NodeType.generated) {
-      final nodeConfiguration = node.generatedNodeConfiguration!;
-      if (nodeConfiguration.phaseNumber > _runningBuildStep!.phaseNumber) {
+      final stepId = _runningBuild!.assetGraph.generatedBy[node.id]!;
+      if (stepId.phaseNumber > _runningBuildStep!.phaseNumber) {
         return Readability.notReadable;
-      } else if (nodeConfiguration.phaseNumber ==
-          _runningBuildStep.phaseNumber) {
+      } else if (stepId.phaseNumber == _runningBuildStep.phaseNumber) {
         // allow a build step to read its outputs (contained in writtenAssets)
         final isInBuild =
             _runningBuildStep.buildPhase is InBuildPhase &&
@@ -317,13 +315,9 @@ class SingleStepReaderWriter implements PhasedReader {
         return isInBuild ? Readability.ownOutput : Readability.notReadable;
       }
 
-      await _runningBuild!.nodeBuilder(node.id);
+      await _runningBuild.nodeBuilder(node.id);
       node = _runningBuild.assetGraph.get(node.id)!;
-      final config = node.generatedNodeConfiguration!;
-      final buildStepId = BuildStepId(
-        primaryInput: config.primaryInput,
-        phaseNumber: config.phaseNumber,
-      );
+      final buildStepId = _runningBuild.assetGraph.generatedBy[node.id]!;
       final stepResult = _runningBuild.assetGraph.buildStepResultFor(
         buildStepId,
       );
@@ -389,14 +383,15 @@ class SingleStepReaderWriter implements PhasedReader {
     var node = _runningBuild.assetGraph.get(id);
     if (node == null) {
       // Add to the graph for input tracking.
-      _runningBuild.assetGraph.add(AssetNode.missingSource(id));
+      _runningBuild.assetGraph.addMissingSource(id);
       return PhasedValue.fixed('');
     } else if (node.type == NodeType.missingSource) {
       return PhasedValue.fixed('');
     }
 
     if (node.type == NodeType.generated) {
-      final nodePhase = node.generatedNodeConfiguration!.phaseNumber;
+      final buildStepId = _runningBuild.assetGraph.generatedBy[id]!;
+      final nodePhase = buildStepId.phaseNumber;
       if (nodePhase >= phase) {
         return PhasedValue.unavailable(before: '', expiresAfter: nodePhase);
       } else {
@@ -405,11 +400,6 @@ class SingleStepReaderWriter implements PhasedReader {
           await _runningBuild.nodeBuilder(id);
           node = _runningBuild.assetGraph.get(id)!;
         }
-        final config = node.generatedNodeConfiguration!;
-        final buildStepId = BuildStepId(
-          primaryInput: config.primaryInput,
-          phaseNumber: config.phaseNumber,
-        );
         final stepResult =
             _runningBuild.assetGraph.buildStepResultFor(buildStepId)!;
         final isSuccessOutput = node.wasOutput && stepResult.result == true;

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -102,8 +102,9 @@ class BuildOutputReader {
         // transitive input(s) did not match build dirs and/or build filters.
         return UnreadableReason.notOutput;
       }
-      final config = node.generatedNodeConfiguration!;
-      final stepResult = _assetGraph.buildStepResultFor(config.buildStepId);
+      final stepResult = _assetGraph.buildStepResultFor(
+        _assetGraph.generatedBy[id]!,
+      );
       if (stepResult != null && stepResult.result == false) {
         return UnreadableReason.failed;
       }
@@ -194,8 +195,9 @@ class BuildOutputReader {
       return false;
     }
     if (node.type == NodeType.generated) {
-      final config = node.generatedNodeConfiguration!;
-      final stepResult = _assetGraph!.buildStepResultFor(config.buildStepId);
+      final stepResult = _assetGraph!.buildStepResultFor(
+        _assetGraph.generatedBy[node.id]!,
+      );
       if (!node.wasOutput ||
           (stepResult == null || stepResult.result == false)) {
         return true;

--- a/build_runner/test/build/asset_graph/graph_test.dart
+++ b/build_runner/test/build/asset_graph/graph_test.dart
@@ -104,8 +104,6 @@ void main() {
             final generatedId = makeAssetId();
             final generatedNode = AssetNode.generated(
               generatedId,
-              phaseNumber: phaseNum,
-              primaryInput: node.id,
               digest: g.isEven ? Digest([]) : null,
               isHidden: g % 3 == 0,
             );

--- a/build_runner/test/build/asset_graph/graph_test.dart
+++ b/build_runner/test/build/asset_graph/graph_test.dart
@@ -133,9 +133,8 @@ void main() {
                     ..inputs.addAll([node.id, syntheticNode.id]),
             );
             graph.updateBuildStepResult(buildStepId, stepResult);
-            graph
-              ..add(generatedNode)
-              ..add(syntheticNode);
+            graph.addGeneratedForTest(generatedNode, buildStepId);
+            graph.add(syntheticNode);
           }
           graph.add(node);
         }
@@ -214,9 +213,8 @@ void main() {
           phaseNumber: 0,
         );
         expect(graph.buildStepResultFor(buildStepId), isNull);
-        final primaryOutputNode = graph.get(primaryOutputId)!;
         expect(
-          primaryOutputNode.generatedNodeConfiguration!.primaryInput,
+          graph.generatedBy[primaryOutputId]!.primaryInput,
           primaryInputId,
         );
 

--- a/build_runner/test/build/asset_graph/nodes_test.dart
+++ b/build_runner/test/build/asset_graph/nodes_test.dart
@@ -15,12 +15,7 @@ void main() {
       for (final node in [
         // Should match.
         AssetNode.source(AssetId('a', 'lib/a.dart')),
-        AssetNode.generated(
-          AssetId('a', 'lib/a.g.dart'),
-          primaryInput: AssetId('a', 'input'),
-          phaseNumber: 0,
-          isHidden: false,
-        ),
+        AssetNode.generated(AssetId('a', 'lib/a.g.dart'), isHidden: false),
         // Should not match.
         AssetNode.source(AssetId('b', 'lib/a.dart')),
         AssetNode.placeholder(AssetId('a', r'lib/$lib$')),

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -1192,8 +1192,6 @@ targets:
     final aCopyId = AssetId.parse('a|web/a.txt.copy');
     final aCopyNode = AssetNode.generated(
       aCopyId,
-      phaseNumber: 0,
-      primaryInput: makeAssetId('a|web/a.txt'),
       digest: computeDigest(aCopyId, 'a'),
       isHidden: false,
     );
@@ -1204,8 +1202,6 @@ targets:
     final bCopyId = makeAssetId('a|lib/b.txt.copy'); //;
     final bCopyNode = AssetNode.generated(
       bCopyId,
-      phaseNumber: 0,
-      primaryInput: makeAssetId('a|lib/b.txt'),
       digest: computeDigest(bCopyId, 'b'),
       isHidden: false,
     );

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -1911,24 +1911,30 @@ targets:
             result.readerWriter.testing.readBytes(AssetId('a', assetGraphPath)),
           )!.assetGraph;
 
-      final node1 = finalGraph.get(AssetId('a', 'web/a.g1'))!;
-      final config1 = node1.generatedNodeConfiguration!;
       expect(
-        finalGraph.buildStepResultFor(config1.buildStepId)!.result,
+        finalGraph
+            .buildStepResultFor(
+              finalGraph.generatedBy[AssetId('a', 'web/a.g1')]!,
+            )!
+            .result,
         isFalse,
       );
 
-      final node2 = finalGraph.get(AssetId('a', 'web/a.g2'))!;
-      final config2 = node2.generatedNodeConfiguration!;
       expect(
-        finalGraph.buildStepResultFor(config2.buildStepId)!.result,
+        finalGraph
+            .buildStepResultFor(
+              finalGraph.generatedBy[AssetId('a', 'web/a.g2')]!,
+            )!
+            .result,
         isFalse,
       );
 
-      final node3 = finalGraph.get(AssetId('a', 'web/a.g3'))!;
-      final config3 = node3.generatedNodeConfiguration!;
       expect(
-        finalGraph.buildStepResultFor(config3.buildStepId)!.result,
+        finalGraph
+            .buildStepResultFor(
+              finalGraph.generatedBy[AssetId('a', 'web/a.g3')]!,
+            )!
+            .result,
         isFalse,
       );
     });

--- a/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_filesystem_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
-import 'package:build_runner/src/build/asset_graph/node.dart';
 import 'package:build_runner/src/build/resolver/analysis_driver_filesystem.dart';
 import 'package:test/test.dart';
 
@@ -52,45 +51,30 @@ void main() {
     });
 
     test('startBuild removes disappeared generated files', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ], invalidatedSources: null);
+      filesystem.startBuild({
+        AssetId.parse('a|lib/a.g.dart'): 1,
+      }, invalidatedSources: null);
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild([], invalidatedSources: const {});
+      filesystem.startBuild({}, invalidatedSources: const {});
 
       expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
       expect(filesystem.exists('/a/lib/a.g.dart'), false);
     });
 
     test('startBuild retains unchanged generated file contents', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ], invalidatedSources: null);
+      filesystem.startBuild({
+        AssetId.parse('a|lib/a.g.dart'): 1,
+      }, invalidatedSources: null);
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ], invalidatedSources: const {});
+      filesystem.startBuild({
+        AssetId.parse('a|lib/a.g.dart'): 1,
+      }, invalidatedSources: const {});
 
       expect(filesystem.read('/a/lib/a.g.dart'), 'a');
       expect(filesystem.changedPaths, isEmpty);
@@ -98,26 +82,16 @@ void main() {
 
     test('write with changed generated content across builds updates file and '
         'changedPaths', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ], invalidatedSources: null);
+      filesystem.startBuild({
+        AssetId.parse('a|lib/a.g.dart'): 1,
+      }, invalidatedSources: null);
       filesystem.write('/a/lib/a.g.dart', 'before');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ], invalidatedSources: const {});
+      filesystem.startBuild({
+        AssetId.parse('a|lib/a.g.dart'): 1,
+      }, invalidatedSources: const {});
       filesystem.write('/a/lib/a.g.dart', 'after');
 
       expect(filesystem.read('/a/lib/a.g.dart'), 'after');
@@ -125,27 +99,17 @@ void main() {
     });
 
     test('initial build clears all cached contents', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ], invalidatedSources: null);
+      filesystem.startBuild({
+        AssetId.parse('a|lib/a.g.dart'): 1,
+      }, invalidatedSources: null);
       filesystem.write('/a/lib/a.dart', 'class A {}');
       filesystem.write('/a/lib/a.g.dart', 'generated');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ], invalidatedSources: null);
+      filesystem.startBuild({
+        AssetId.parse('a|lib/a.g.dart'): 1,
+      }, invalidatedSources: null);
 
       expect(filesystem.exists('/a/lib/a.dart'), isFalse);
       expect(filesystem.exists('/a/lib/a.g.dart'), isFalse);
@@ -158,7 +122,7 @@ void main() {
       filesystem.clearChangedPaths();
 
       filesystem.startBuild(
-        const [],
+        const {},
         invalidatedSources: {AssetId.parse('a|foo.txt')},
       );
 
@@ -169,46 +133,26 @@ void main() {
 
     test('startBuild reports visibility changes for retained generated '
         'files', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-      ], invalidatedSources: null);
+      filesystem.startBuild({
+        AssetId.parse('a|lib/a.g.dart'): 1,
+      }, invalidatedSources: null);
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.phase = 2;
       filesystem.clearChangedPaths();
 
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 3,
-          isHidden: false,
-        ),
-      ], invalidatedSources: const {});
+      filesystem.startBuild({
+        AssetId.parse('a|lib/a.g.dart'): 3,
+      }, invalidatedSources: const {});
 
       expect(filesystem.changedPaths, {'/a/lib/a.g.dart'});
       expect(filesystem.exists('/a/lib/a.g.dart'), false);
     });
 
     test('files change by phases', () {
-      filesystem.startBuild([
-        AssetNode.generated(
-          AssetId.parse('a|lib/a.g.dart'),
-          primaryInput: AssetId.parse('a|lib/a.dart'),
-          phaseNumber: 1,
-          isHidden: false,
-        ),
-        AssetNode.generated(
-          AssetId.parse('b|lib/b.g.dart'),
-          primaryInput: AssetId.parse('b|lib/b.dart'),
-          phaseNumber: 2,
-          isHidden: false,
-        ),
-      ], invalidatedSources: null);
+      filesystem.startBuild({
+        AssetId.parse('a|lib/a.g.dart'): 1,
+        AssetId.parse('b|lib/b.g.dart'): 2,
+      }, invalidatedSources: null);
 
       filesystem.write('/a/lib/a.g.dart', 'a');
       filesystem.write('/b/lib/b.g.dart', 'b');

--- a/build_runner/test/commands/serve/asset_handler_test.dart
+++ b/build_runner/test/commands/serve/asset_handler_test.dart
@@ -138,13 +138,7 @@ void main() {
     final outputId = AssetId('a', 'web/main.ddc.js');
     final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
     assetGraph.addGeneratedForTest(
-      AssetNode.generated(
-        outputId,
-        phaseNumber: 0,
-        isHidden: false,
-        digest: Digest([]),
-        primaryInput: primaryId,
-      ),
+      AssetNode.generated(outputId, isHidden: false, digest: Digest([])),
       buildStepId,
     );
     final stepResult = BuildStepResult((b) => b..result = false);

--- a/build_runner/test/commands/serve/asset_handler_test.dart
+++ b/build_runner/test/commands/serve/asset_handler_test.dart
@@ -136,7 +136,8 @@ void main() {
   test('Fails request for failed outputs', () async {
     final primaryId = AssetId('a', 'web/main.dart');
     final outputId = AssetId('a', 'web/main.ddc.js');
-    assetGraph.add(
+    final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
+    assetGraph.addGeneratedForTest(
       AssetNode.generated(
         outputId,
         phaseNumber: 0,
@@ -144,8 +145,8 @@ void main() {
         digest: Digest([]),
         primaryInput: primaryId,
       ),
+      buildStepId,
     );
-    final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
     final stepResult = BuildStepResult((b) => b..result = false);
     assetGraph.updateBuildStepResult(buildStepId, stepResult);
 

--- a/build_runner/test/commands/serve/serve_handler_test.dart
+++ b/build_runner/test/commands/serve/serve_handler_test.dart
@@ -259,7 +259,8 @@ void main() {
       addSource('a|web/index.html', '');
       final primaryId = AssetId('a', 'web/main.dart');
       final outputId = AssetId('a', 'web/main.ddc.js');
-      assetGraph.add(
+      final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
+      assetGraph.addGeneratedForTest(
         AssetNode.generated(
           outputId,
           phaseNumber: 0,
@@ -267,8 +268,8 @@ void main() {
           digest: Digest([]),
           primaryInput: primaryId,
         ),
+        buildStepId,
       );
-      final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
       final stepResult = BuildStepResult((b) => b..result = false);
       assetGraph.updateBuildStepResult(buildStepId, stepResult);
       watcher.addFutureResult(

--- a/build_runner/test/commands/serve/serve_handler_test.dart
+++ b/build_runner/test/commands/serve/serve_handler_test.dart
@@ -261,13 +261,7 @@ void main() {
       final outputId = AssetId('a', 'web/main.ddc.js');
       final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
       assetGraph.addGeneratedForTest(
-        AssetNode.generated(
-          outputId,
-          phaseNumber: 0,
-          isHidden: false,
-          digest: Digest([]),
-          primaryInput: primaryId,
-        ),
+        AssetNode.generated(outputId, isHidden: false, digest: Digest([])),
         buildStepId,
       );
       final stepResult = BuildStepResult((b) => b..result = false);

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -103,8 +103,8 @@ void main() {
         primaryInput: primaryId,
         isHidden: true,
       );
-      assetGraph.add(node);
       final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
+      assetGraph.addGeneratedForTest(node, buildStepId);
       final stepResult = BuildStepResult((b) => b..result = false);
       assetGraph.updateBuildStepResult(buildStepId, stepResult);
       readerWriter.testing.writeString(id, '');

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -96,13 +96,7 @@ void main() {
     test('Failure nodes interact well with build filters ', () async {
       final id = AssetId('a', 'web/a.txt');
       final primaryId = AssetId('a', 'web/a.dart');
-      final node = AssetNode.generated(
-        id,
-        phaseNumber: 0,
-        digest: Digest([]),
-        primaryInput: primaryId,
-        isHidden: true,
-      );
+      final node = AssetNode.generated(id, digest: Digest([]), isHidden: true);
       final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
       assetGraph.addGeneratedForTest(node, buildStepId);
       final stepResult = BuildStepResult((b) => b..result = false);

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -109,17 +109,15 @@ void main() {
       );
 
       for (final id in graph.outputs) {
-        final node = graph.get(id)!;
-        final config = node.generatedNodeConfiguration!;
         final stepResult = BuildStepResult((b) => b..result = true);
-        graph.updateBuildStepResult(config.buildStepId, stepResult);
+        graph.updateBuildStepResult(graph.generatedBy[id]!, stepResult);
 
         graph.updateNode(id, (nodeBuilder) {
           nodeBuilder.digest = Digest([]);
         });
         readerWriter.testing.writeString(
           id,
-          sources[graph.get(id)!.generatedNodeConfiguration!.primaryInput]!,
+          sources[graph.generatedBy[id]!.primaryInput]!,
         );
       }
       tmpDir = await Directory.systemTemp.createTemp('build_tests');
@@ -366,9 +364,8 @@ void main() {
 
     test('doesnt write files that werent output', () async {
       final node = graph.get(AssetId('b', 'lib/c.txt.copy'))!;
-      final config = node.generatedNodeConfiguration!;
       final stepResult = BuildStepResult((b) => b..result = null);
-      graph.updateBuildStepResult(config.buildStepId, stepResult);
+      graph.updateBuildStepResult(graph.generatedBy[node.id]!, stepResult);
 
       graph.updateNode(node.id, (nodeBuilder) {
         nodeBuilder.digest = null;


### PR DESCRIPTION
Continue chipping away at AssetNode. Remove the pointer back to the build step that generated a generated nodes; store it separately.

The end goal here is cleanly separate state accumulated during the build from state calculated before the build, so that the coming zero output builders change for enhanced parts doesn't get tangled up in the mix.