### PR TITLE
Remove NodeType.postGenerated nodes, use AssetGraph.

### DIFF
--- a/build_runner/lib/src/build/asset_graph/asset_graph_json.dart
+++ b/build_runner/lib/src/build/asset_graph/asset_graph_json.dart
@@ -96,5 +96,5 @@ class AssetGraphJson {
 }
 
 /// Increment whenever older `asset_graph.json` files should be rejected.
-const _version = 38;
+const _version = 39;
 final jsonUtf8 = json.fuse(utf8);

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -48,17 +48,17 @@ class AssetGraph implements GeneratedAssetHider {
   /// Globs evaluated during the build.
   final Map<GlobId, GlobResult> globResults;
 
-  /// All post process build steps results, indexed by package then
-  /// [PostProcessBuildStepId].
-  ///
-  /// Created with empty outputs at the start of the build if it's a new build
-  /// step; or deserialized with previous build results if it has run before.
-  final Map<String, Map<PostProcessBuildStepId, PostProcessBuildStepResult>>
+  /// All post process build steps results, indexed by [PostProcessBuildStepId].
+  final Map<PostProcessBuildStepId, PostProcessBuildStepResult>
   postProcessBuildStepResults;
+
+  /// All post process build step outputs.
+  final Set<AssetId> postProcessOutputs;
 
   AssetGraph()
     : _nodes = Nodes(),
       postProcessBuildStepResults = {},
+      postProcessOutputs = {},
       buildStepResults = {},
       declaredOutputsByPrimaryInput = {},
       globResults = {},
@@ -67,6 +67,7 @@ class AssetGraph implements GeneratedAssetHider {
   AssetGraph._with({
     required Nodes nodes,
     required this.postProcessBuildStepResults,
+    required this.postProcessOutputs,
     required this.buildStepResults,
     required this.globResults,
     required this.buildStepsByDeclaredOutput,
@@ -77,10 +78,8 @@ class AssetGraph implements GeneratedAssetHider {
   AssetGraph copyForNextBuild() {
     return AssetGraph._with(
       nodes: _nodes.clone(),
-      postProcessBuildStepResults: {
-        for (final entry in postProcessBuildStepResults.entries)
-          entry.key: Map.of(entry.value),
-      },
+      postProcessBuildStepResults: Map.of(postProcessBuildStepResults),
+      postProcessOutputs: Set.of(postProcessOutputs),
       buildStepResults: Map.of(buildStepResults),
       globResults: Map.of(globResults),
       buildStepsByDeclaredOutput: Map.of(buildStepsByDeclaredOutput),
@@ -124,11 +123,17 @@ class AssetGraph implements GeneratedAssetHider {
   @visibleForTesting
   String serialize() => json.encode(serializeAssetGraph(this));
 
-  bool contains(AssetId id) =>
-      _nodes.contains(id) || buildStepsByDeclaredOutput.containsKey(id);
   AssetNode? get(AssetId id) => _nodes.get(id);
   AssetNode updateNode(AssetId id, void Function(AssetNodeBuilder) updates) =>
       _nodes.updateNode(id, updates);
+
+  /// Whether [id) is a placeholder.
+  bool isPlaceholder(AssetId id) =>
+      _nodes.get(id)?.type == NodeType.placeholder;
+
+  /// Whether [id] is one of: source, output or post process output.
+  bool isKnownFile(AssetId id) =>
+      isSource(id) || isDeclaredOutput(id) || isActualPostOutput(id);
 
   /// Whether [id) is a source file.
   bool isSource(AssetId id) => _nodes.get(id)?.type == NodeType.source;
@@ -149,12 +154,7 @@ class AssetGraph implements GeneratedAssetHider {
   }
 
   /// Whether [id] is a post process build output that was actually generated.
-  bool isActualPostOutput(AssetId id) =>
-      _nodes.get(id)?.type == NodeType.postGenerated;
-
-  bool isFile(AssetId id) =>
-      buildStepsByDeclaredOutput.containsKey(id) ||
-      _nodes.get(id)?.isFile == true;
+  bool isActualPostOutput(AssetId id) => postProcessOutputs.contains(id);
 
   BuildStepResult? buildStepResultFor(BuildStepId buildStepId) =>
       buildStepResults[buildStepId];
@@ -168,8 +168,11 @@ class AssetGraph implements GeneratedAssetHider {
   }
 
   Iterable<AssetNode> get allNodes => _nodes.allNodes;
-  Iterable<AssetId> packageFileIds(String package, {Glob? glob}) => _nodes
-      .packageFileIds(package, buildStepsByDeclaredOutput.keys, glob: glob);
+  Iterable<AssetId> packageFileIds(String package, {Glob? glob}) =>
+      _nodes.packageFileIds(package, [
+        ...buildStepsByDeclaredOutput.keys,
+        ...allPostProcessOutputIds,
+      ], glob: glob);
   void removeForTest(AssetId id) => _nodes.remove(id);
 
   /// Adds [AssetNode.placeholder]s for every package in [buildPackages].
@@ -203,7 +206,6 @@ class AssetGraph implements GeneratedAssetHider {
   /// Removes post build applications with removed assets as inputs.
   void _setMissingRecursive(AssetId id, {Set<AssetId>? removedIds}) {
     removedIds ??= <AssetId>{};
-    if (!contains(id)) return;
     removedIds.add(id);
     for (final output in primaryOutputsOf(id).toList()) {
       _setMissingRecursive(output, removedIds: removedIds);
@@ -219,15 +221,18 @@ class AssetGraph implements GeneratedAssetHider {
     }
 
     // Remove post build action applications with removed assets as inputs.
-    for (final packageResults in postProcessBuildStepResults.values) {
-      packageResults.removeWhere((id, _) => removedIds!.contains(id.input));
-    }
+    postProcessBuildStepResults.removeWhere((id, result) {
+      if (removedIds!.contains(id.input)) {
+        postProcessOutputs.removeAll(result.outputs);
+        return true;
+      }
+      return false;
+    });
   }
 
   /// Removes [id] and its transitive`primaryOutput`s from the graph.
   void _removeRecursive(AssetId id, {Set<AssetId>? removedIds}) {
     removedIds ??= <AssetId>{};
-    if (!contains(id)) return;
     if (removedIds.add(id)) {
       for (final output in primaryOutputsOf(id).toList()) {
         _removeRecursive(output, removedIds: removedIds);
@@ -238,25 +243,19 @@ class AssetGraph implements GeneratedAssetHider {
     }
   }
 
-  /// All the post process build steps for `package`.
-  Iterable<PostProcessBuildStepId> postProcessBuildStepIds({
-    required String package,
-  }) => postProcessBuildStepResults[package]?.keys ?? const [];
-
-  Iterable<AssetId> get allPostProcessOutputIds => postProcessBuildStepResults
-      .values
-      .expand((entries) => entries.values.expand((v) => v.outputs));
+  Iterable<AssetId> get allPostProcessOutputIds => postProcessOutputs;
 
   /// Creates or updates state for a [PostProcessBuildStepId].
   void updatePostProcessBuildStepResult(
     PostProcessBuildStepId buildStepId,
     PostProcessBuildStepResult result,
   ) {
-    postProcessBuildStepResults.putIfAbsent(
-          buildStepId.input.package,
-          () => {},
-        )[buildStepId] =
-        result;
+    final oldResult = postProcessBuildStepResults[buildStepId];
+    if (oldResult != null) {
+      postProcessOutputs.removeAll(oldResult.outputs);
+    }
+    postProcessBuildStepResults[buildStepId] = result;
+    postProcessOutputs.addAll(result.outputs);
   }
 
   /// Gets the result of a [PostProcessBuildStepId].
@@ -265,13 +264,12 @@ class AssetGraph implements GeneratedAssetHider {
   /// then used to clean up prior outputs in the next build.
   PostProcessBuildStepResult? postProcessBuildStepResultFor(
     PostProcessBuildStepId action,
-  ) => postProcessBuildStepResults[action.input.package]?[action];
+  ) => postProcessBuildStepResults[action];
 
   /// All declared outputs in the graph.
   Iterable<AssetId> get outputs => [
     ...buildStepsByDeclaredOutput.keys,
-    for (final node in allNodes)
-      if (node.type == NodeType.postGenerated) node.id,
+    ...allPostProcessOutputIds,
   ];
 
   /// All declared outputs and the phases in which they are output.
@@ -286,9 +284,13 @@ class AssetGraph implements GeneratedAssetHider {
         package,
       ).where((id) => buildStepsByDeclaredOutput[id]?.phaseNumber == phase);
 
-  /// All the source files in the graph.
+  /// All source files.
   Iterable<AssetId> get sources =>
       allNodes.where((n) => n.type == NodeType.source).map((n) => n.id);
+
+  /// All actual outputs.
+  Iterable<AssetId> get actualOutputs =>
+      buildStepResults.values.expand((result) => result.outputs.keys);
 
   /// Updates graph structure, invalidating and deleting any outputs that were
   /// affected.
@@ -363,7 +365,7 @@ class AssetGraph implements GeneratedAssetHider {
 
   /// Crawl up primary inputs to see if the original Source file matches the
   /// glob on [action].
-  bool _actionMatches(BuildAction action, AssetId input) {
+  bool actionMatches(BuildAction action, AssetId input) {
     if (input.package != action.package) return false;
     if (!action.generateFor.matches(input)) return false;
 
@@ -416,7 +418,6 @@ class AssetGraph implements GeneratedAssetHider {
         ),
       );
     }
-    _addPostBuildActionApplications(buildPhases.postBuildPhase, allInputs);
   }
 
   /// Adds all generated asset outputs for [phase] given [allInputs].
@@ -433,7 +434,7 @@ class AssetGraph implements GeneratedAssetHider {
   ) {
     final phaseOutputs = <AssetId>{};
     final inputs =
-        allInputs.where((input) => _actionMatches(phase, input)).toList();
+        allInputs.where((input) => actionMatches(phase, input)).toList();
     for (final input in inputs) {
       // We might have deleted some inputs during this loop, if they turned
       // out to be generated assets.
@@ -452,27 +453,9 @@ class AssetGraph implements GeneratedAssetHider {
       // We may delete source nodes that were producing outputs previously.
       // Detect this by checking for deleted nodes that no longer exist in the
       // graph at all, and remove them from `phaseOutputs`.
-      phaseOutputs.removeAll(deleted.where((id) => !contains(id)));
+      phaseOutputs.removeAll(deleted.where((id) => !isDeclaredOutput(id)));
     }
     return phaseOutputs;
-  }
-
-  /// Adds all [PostProcessBuildStepId]s for [phase] given [allInputs];
-  void _addPostBuildActionApplications(
-    PostBuildPhase phase,
-    Set<AssetId> allInputs,
-  ) {
-    var actionNumber = 0;
-    for (final action in phase.builderActions) {
-      final inputs = allInputs.where((input) => _actionMatches(action, input));
-      for (final input in inputs) {
-        updatePostProcessBuildStepResult(
-          PostProcessBuildStepId(input: input, actionNumber: actionNumber),
-          PostProcessBuildStepResult(hidden: action.hideOutput),
-        );
-      }
-      actionNumber++;
-    }
   }
 
   /// Adds [outputs] to the graph.
@@ -492,20 +475,19 @@ class AssetGraph implements GeneratedAssetHider {
   }) {
     final removed = <AssetId>{};
     for (final output in outputs) {
-      // When any outputs aren't hidden we can pick up old generated outputs as
-      // regular `AssetNode`s, we need to delete them and all their primary
-      // outputs, and replace them with a `GeneratedAssetNode`.
-      if (contains(output)) {
-        final buildStep = buildStepsByDeclaredOutput[output];
-        if (buildStep != null) {
-          final existingPhase = buildStep.phaseNumber;
-          throw DuplicateAssetNodeException(
-            output,
-            buildPhases.inBuildPhases[existingPhase].displayName,
-            buildPhases.inBuildPhases[phaseNumber].displayName,
-          );
-        }
+      if (isSource(output)) {
+        // An old generated source was picked up as a source file. Remove it and
+        // its outputs.
         _removeRecursive(output, removedIds: removed);
+      } else if (isDeclaredOutput(output)) {
+        // The output was already declared by another builder.
+        final buildStep = buildStepsByDeclaredOutput[output]!;
+        final existingPhase = buildStep.phaseNumber;
+        throw DuplicateAssetNodeException(
+          output,
+          buildPhases.inBuildPhases[existingPhase].displayName,
+          buildPhases.inBuildPhases[phaseNumber].displayName,
+        );
       }
 
       final buildStepId = BuildStepId(
@@ -574,21 +556,13 @@ class AssetGraph implements GeneratedAssetHider {
   /// Adds a source that a builder tried to access but was missing.
   void addMissingSource(AssetId id) => _nodes.add(AssetNode.missingSource(id));
 
-  /// Adds a generated node that was output by a post process build step.
-  void addPostGenerated(AssetId id) {
-    _nodes.add(AssetNode.postGenerated(id));
-  }
-
-  /// Removes a generated node that was output by a post process build step.
-  void removePostProcessOutput(AssetId id) => _nodes.remove(id);
-
   @override
   bool isHidden(AssetId id) {
     if (id.path.startsWith(generatedOutputDirectory) ||
         id.path.startsWith(cacheDirectoryPath)) {
       return false;
     }
-    if (!contains(id)) {
+    if (!isDeclaredOutput(id)) {
       return false;
     }
     final buildStepId = buildStepsByDeclaredOutput[id];
@@ -619,25 +593,17 @@ class AssetGraph implements GeneratedAssetHider {
 
     final result = <AssetId>[];
     // Delete all the non-hidden outputs.
-    for (final id in outputs) {
-      if (isActualPostOutput(id)) {
-        // Handled via post process build step results below so we know if the
-        // output is hidden.
-        continue;
-      }
-      if (isActualOutput(id) && !isHidden(id)) {
+    for (final id in actualOutputs) {
+      if (!isHidden(id)) {
         final idToDelete = checkAndMoveId(id);
         if (idToDelete != null) result.add(idToDelete);
       }
     }
-    for (final packagePostProcessResults
-        in postProcessBuildStepResults.values) {
-      for (final postProcessResults in packagePostProcessResults.values) {
-        if (!postProcessResults.hidden) {
-          for (final id in postProcessResults.outputs) {
-            final idToDelete = checkAndMoveId(id);
-            if (idToDelete != null) result.add(idToDelete);
-          }
+    for (final postProcessResults in postProcessBuildStepResults.values) {
+      if (!postProcessResults.hidden) {
+        for (final id in postProcessResults.outputs) {
+          final idToDelete = checkAndMoveId(id);
+          if (idToDelete != null) result.add(idToDelete);
         }
       }
     }

--- a/build_runner/lib/src/build/asset_graph/node.dart
+++ b/build_runner/lib/src/build/asset_graph/node.dart
@@ -14,7 +14,6 @@ part 'node.g.dart';
 class NodeType extends EnumClass {
   static Serializer<NodeType> get serializer => _$nodeTypeSerializer;
 
-  static const NodeType postGenerated = _$postGenerated;
   static const NodeType placeholder = _$placeholder;
   static const NodeType source = _$source;
   static const NodeType missingSource = _$missingSource;
@@ -37,11 +36,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
   /// For source files, this is computed when the file is read so it can be used
   /// to check for changes in the next build.
   Digest? get digest;
-
-  /// Whether this asset is a normal, readable file.
-  ///
-  /// Does not guarantee that the file currently exists.
-  bool get isFile => type == NodeType.postGenerated || type == NodeType.source;
 
   factory AssetNode([void Function(AssetNodeBuilder) updates]) = _$AssetNode;
 
@@ -72,12 +66,6 @@ abstract class AssetNode implements Built<AssetNode, AssetNodeBuilder> {
   factory AssetNode.placeholder(AssetId id) => AssetNode((b) {
     b.id = id;
     b.type = NodeType.placeholder;
-  });
-
-  /// A post-process generated node.
-  factory AssetNode.postGenerated(AssetId id) => AssetNode((b) {
-    b.id = id;
-    b.type = NodeType.postGenerated;
   });
 
   AssetNode._();

--- a/build_runner/lib/src/build/asset_graph/nodes.dart
+++ b/build_runner/lib/src/build/asset_graph/nodes.dart
@@ -56,7 +56,7 @@ class Nodes {
     final updatedNode = node.rebuild(updates);
     _nodes[id] = updatedNode;
 
-    if (node.isFile != updatedNode.isFile) {
+    if (node.type != updatedNode.type) {
       _sortedFileIdsByPackage = null;
     }
 
@@ -77,7 +77,7 @@ class Nodes {
     final updatedNode = node.rebuild(updates);
     _nodes[id] = updatedNode;
 
-    if (node.isFile != updatedNode.isFile) {
+    if (node.type != updatedNode.type) {
       _sortedFileIdsByPackage = null;
     }
 
@@ -91,7 +91,7 @@ class Nodes {
   /// Returns the updated node: if it replaces an [AssetNode.missingSource] then
   /// `outputs` and `primaryOutputs` are copied to it from that.
   AssetNode add(AssetNode node) {
-    if (node.isFile) _sortedFileIdsByPackage = null;
+    if (node.type == NodeType.source) _sortedFileIdsByPackage = null;
     final existing = get(node.id);
     if (existing != null) {
       if (existing.type == NodeType.missingSource) {
@@ -111,7 +111,7 @@ class Nodes {
   /// Removes [id] from the graph, if present.
   void remove(AssetId id) {
     final removed = _nodes.remove(id);
-    if (removed != null && removed.isFile) {
+    if (removed != null && removed.type == NodeType.source) {
       _sortedFileIdsByPackage = null;
     }
   }
@@ -120,8 +120,6 @@ class Nodes {
   Iterable<AssetNode> get allNodes => _nodes.values;
 
   /// All IDs in `package` that refer to files and match.
-  ///
-  /// A node refers to a file if [AssetNode.isFile].
   ///
   /// If [glob] is passed, return only IDs for which the glob matches the path.
   Iterable<AssetId> packageFileIds(
@@ -144,8 +142,6 @@ class Nodes {
   }
 
   /// Computes a `Map` from package names to sorted IDs of files in the package.
-  ///
-  /// An asset ID is a file if [AssetNode.isFile].
   Map<String, List<AssetId>> _computeSortedFileIdsByPackage(
     Iterable<AssetId> generatedIds,
   ) {
@@ -157,7 +153,7 @@ class Nodes {
     _sortedFileIdsByPackageWasComputed = true;
     final result = <String, List<AssetId>>{};
     for (final value in _nodes.values) {
-      if (value.isFile) {
+      if (value.type == NodeType.source) {
         result.putIfAbsent(value.id.package, () => []).add(value.id);
       }
     }

--- a/build_runner/lib/src/build/asset_graph/serialization.dart
+++ b/build_runner/lib/src/build/asset_graph/serialization.dart
@@ -24,15 +24,10 @@ AssetGraph? deserializeAssetGraph(Map serializedGraph) {
             serializedGraph['postProcessResults'],
             specifiedType: postProcessBuildStepResultsFullType,
           )
-          as Map<
-            String,
-            Map<PostProcessBuildStepId, PostProcessBuildStepResult>
-          >;
+          as BuiltMap<PostProcessBuildStepId, PostProcessBuildStepResult>;
 
-  for (final postProcessResultsForPackage in postProcessResults.values) {
-    for (final entry in postProcessResultsForPackage.entries) {
-      graph.updatePostProcessBuildStepResult(entry.key, entry.value);
-    }
+  for (final entry in postProcessResults.entries) {
+    graph.updatePostProcessBuildStepResult(entry.key, entry.value);
   }
 
   if (serializedGraph.containsKey('buildStepResults')) {
@@ -110,7 +105,9 @@ Map<String, Object?> serializeAssetGraph(AssetGraph graph) {
   final result = <String, Object?>{
     'nodes': nodes,
     'postProcessResults': serializers.serialize(
-      graph.postProcessBuildStepResults,
+      BuiltMap<PostProcessBuildStepId, PostProcessBuildStepResult>.of(
+        graph.postProcessBuildStepResults,
+      ),
       specifiedType: postProcessBuildStepResultsFullType,
     ),
     'buildStepResults': serializers.serialize(

--- a/build_runner/lib/src/build/asset_graph/serializers.dart
+++ b/build_runner/lib/src/build/asset_graph/serializers.dart
@@ -24,14 +24,9 @@ import 'post_process_build_step_result.dart';
 
 part 'serializers.g.dart';
 
-final postProcessBuildStepResultsInnerFullType = const FullType(Map, [
+final postProcessBuildStepResultsFullType = const FullType(BuiltMap, [
   FullType(PostProcessBuildStepId),
   FullType(PostProcessBuildStepResult),
-]);
-
-final postProcessBuildStepResultsFullType = FullType(Map, [
-  const FullType(String),
-  postProcessBuildStepResultsInnerFullType,
 ]);
 
 final assetIdSerializer = AssetIdSerializer();
@@ -93,16 +88,8 @@ final Serializers serializers =
             () => <AssetId>{},
           )
           ..addBuilderFactory(
-            postProcessBuildStepResultsInnerFullType,
-            () => <PostProcessBuildStepId, PostProcessBuildStepResult>{},
-          )
-          ..addBuilderFactory(
             postProcessBuildStepResultsFullType,
-            () =>
-                <
-                  String,
-                  Map<PostProcessBuildStepId, PostProcessBuildStepResult>
-                >{},
+            MapBuilder<PostProcessBuildStepId, PostProcessBuildStepResult>.new,
           )
           ..addBuilderFactory(
             const FullType(BuiltMap, [FullType(AssetId), FullType(Digest)]),

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -187,12 +187,9 @@ class Build {
       }
 
       final failedPostProcessSteps = <PostProcessBuildStepId>[];
-      for (final packageResults
-          in assetGraph.postProcessBuildStepResults.values) {
-        for (final entry in packageResults.entries) {
-          if (entry.value.errors.isNotEmpty) {
-            failedPostProcessSteps.add(entry.key);
-          }
+      for (final entry in assetGraph.postProcessBuildStepResults.entries) {
+        if (entry.value.errors.isNotEmpty) {
+          failedPostProcessSteps.add(entry.key);
         }
       }
 
@@ -261,8 +258,7 @@ class Build {
       if (oldNode?.type == NodeType.source) {
         previousSourceNodes.add(id);
       }
-      final oldExisted =
-          assetGraph.contains(id) && !assetGraph.isMissingSource(id);
+      final oldExisted = assetGraph.isKnownFile(id);
       final oldDigest =
           oldNode?.type == NodeType.source ? oldNode?.digest : null;
       var exists = false;
@@ -731,22 +727,22 @@ class Build {
     PostBuildAction action,
   ) async {
     final outputs = <AssetId>[];
-    for (final buildStepId in assetGraph.postProcessBuildStepIds(
-      package: action.package,
+    for (final input in assetGraph.sources.followedBy(
+      assetGraph.actualOutputs,
     )) {
-      if (buildStepId.actionNumber != actionNum) continue;
-      if (assetGraph.isSource(buildStepId.input) ||
-          assetGraph.isDeclaredOutput(buildStepId.input) &&
-              assetGraph.isActualOutput(buildStepId.input)) {
-        outputs.addAll(
-          await _runPostProcessBuildStep(
-            phaseNum,
-            action.builder,
-            buildStepId,
-            hideOutput: action.hideOutput,
-          ),
-        );
-      }
+      if (!assetGraph.actionMatches(action, input)) continue;
+      final buildStepId = PostProcessBuildStepId(
+        input: input,
+        actionNumber: actionNum,
+      );
+      outputs.addAll(
+        await _runPostProcessBuildStep(
+          phaseNum,
+          action.builder,
+          buildStepId,
+          hideOutput: action.hideOutput,
+        ),
+      );
     }
     return outputs;
   }
@@ -794,9 +790,6 @@ class Build {
 
     // Clean out the impacts of the previous run.
     await _cleanUpStaleOutputs(existingOutputs);
-    for (final output in existingOutputs) {
-      assetGraph.removePostProcessOutput(output);
-    }
     assetGraph.updatePostProcessBuildStepResult(
       postProcessBuildStepId,
       PostProcessBuildStepResult(hidden: hideOutput),
@@ -814,14 +807,13 @@ class Build {
       stepReaderWriter,
       logger,
       addAsset: (assetId) {
-        if (assetGraph.contains(assetId)) {
+        if (assetGraph.isKnownFile(assetId)) {
           throw InvalidOutputException(assetId, 'Asset already exists');
         }
-        assetGraph.addPostGenerated(assetId);
         outputs.add(assetId);
       },
       deleteAsset: (assetId) {
-        if (!assetGraph.contains(assetId)) {
+        if (!assetGraph.isKnownFile(assetId)) {
           throw AssetNotFoundException(assetId);
         }
         if (assetId != input) {

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -123,7 +123,7 @@ class BuildSeries {
         continue;
       }
 
-      if (!_assetGraph.contains(id)) {
+      if (!_assetGraph.isKnownFile(id)) {
         // Ignore under `.dart_tool/build`.
         if (id.path.startsWith(cacheDirectoryPath)) continue;
 

--- a/build_runner/lib/src/build/single_step_reader_writer.dart
+++ b/build_runner/lib/src/build/single_step_reader_writer.dart
@@ -182,7 +182,10 @@ class SingleStepReaderWriter implements PhasedReader {
       return _delegate.canRead(id);
     }
 
-    if (!_runningBuild.assetGraph.contains(id)) {
+    if (_runningBuild.assetGraph.isPlaceholder(id)) {
+      return false;
+    }
+    if (!_runningBuild.assetGraph.isKnownFile(id)) {
       if (track) inputTracker.add(id);
       _runningBuild.assetGraph.addMissingSource(id);
       return false;
@@ -370,7 +373,7 @@ class SingleStepReaderWriter implements PhasedReader {
       }
     }
 
-    if (!_runningBuild.assetGraph.contains(id)) {
+    if (!_runningBuild.assetGraph.isKnownFile(id)) {
       // Add to the graph for input tracking.
       _runningBuild.assetGraph.addMissingSource(id);
       return PhasedValue.fixed('');

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -257,10 +257,8 @@ class BuildPlan {
       updates = {
         ...inputSources,
         ...cacheDirSources,
-        for (final node in previousAssetGraph.allNodes)
-          if (node.isFile) node.id,
-        for (final id in previousAssetGraph.buildStepsByDeclaredOutput.keys)
-          if (previousAssetGraph.isActualOutput(id)) id,
+        ...previousAssetGraph.sources,
+        ...previousAssetGraph.actualOutputs,
       };
       assetGraph = previousAssetGraph.copyForNextBuild();
 

--- a/build_runner/lib/src/io/asset_tracker.dart
+++ b/build_runner/lib/src/io/asset_tracker.dart
@@ -70,10 +70,8 @@ class AssetTracker {
     final newSources = inputSources.difference(assetGraph.sources.toSet());
     addUpdates(newSources, ChangeType.ADD);
     final removedAssets = [
-      for (final node in assetGraph.allNodes)
-        if (node.isFile && !allSources.contains(node.id)) node.id,
-      for (final id in assetGraph.buildStepsByDeclaredOutput.keys)
-        if (assetGraph.isActualOutput(id) && !allSources.contains(id)) id,
+      for (final id in assetGraph.sources.followedBy(assetGraph.outputs))
+        if (!allSources.contains(id)) id,
     ];
 
     addUpdates(removedAssets, ChangeType.REMOVE);

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -67,12 +67,9 @@ class BuildOutputReader {
     final assetGraph = _assetGraph;
     if (assetGraph == null) return const {};
     final result = <AssetId>{};
-    for (final packageResults
-        in assetGraph.postProcessBuildStepResults.values) {
-      for (final entry in packageResults.entries) {
-        if (entry.value.deletedPrimaryInput) {
-          result.add(entry.key.input);
-        }
+    for (final entry in assetGraph.postProcessBuildStepResults.entries) {
+      if (entry.value.deletedPrimaryInput) {
+        result.add(entry.key.input);
       }
     }
     return result;
@@ -83,13 +80,13 @@ class BuildOutputReader {
     if (_assetGraph == null || _readerWriter == null) {
       return UnreadableReason.notFound;
     }
-    if (!_assetGraph.contains(id)) {
+    if (!_assetGraph.isKnownFile(id)) {
       return UnreadableReason.notFound;
     }
     if (_assetsDeletedByPostProcessBuilders.contains(id)) {
       return UnreadableReason.deleted;
     }
-    if (!_assetGraph.isFile(id)) return UnreadableReason.assetType;
+    if (!_assetGraph.isKnownFile(id)) return UnreadableReason.assetType;
 
     if (_assetGraph.isActualPostOutput(id)) {
       return null;
@@ -173,12 +170,13 @@ class BuildOutputReader {
         result.add(id);
       }
     }
+    result.addAll(assetGraph.allPostProcessOutputIds);
     return result;
   }
 
   bool _shouldSkipId(AssetGraph assetGraph, AssetId id, String? rootDir) {
     if (_buildPlan == null) return false;
-    if (!assetGraph.isFile(id)) return true;
+    if (!assetGraph.isKnownFile(id)) return true;
     if (_assetsDeletedByPostProcessBuilders.contains(id)) return true;
 
     // Exclude non-lib assets if they're outside of the root directory or not

--- a/build_runner/test/build/asset_graph/graph_test.dart
+++ b/build_runner/test/build/asset_graph/graph_test.dart
@@ -30,12 +30,12 @@ void main() {
     late AssetGraph graph;
 
     void expectNodeDoesNotExist(AssetNode node) {
-      expect(graph.contains(node.id), isFalse);
+      expect(graph.isKnownFile(node.id), isFalse);
       expect(graph.get(node.id), isNull);
     }
 
     void expectNodeExists(AssetNode node) {
-      expect(graph.contains(node.id), isTrue);
+      expect(graph.isKnownFile(node.id), isTrue);
       expect(graph.get(node.id), node);
     }
 
@@ -175,10 +175,6 @@ void main() {
       final syntheticId = makeAssetId('foo|synthetic.txt');
       final syntheticOutputId = makeAssetId('foo|synthetic.txt.copy');
       final placeholders = placeholderIdsFor(fooPackageGraph);
-      final expectedBuildStepId = PostProcessBuildStepId(
-        input: primaryInputId,
-        actionNumber: 0,
-      );
 
       setUp(() async {
         graph = await AssetGraph.build(buildPhases, {
@@ -193,9 +189,6 @@ void main() {
           graph.allNodes.map((n) => n.id),
           unorderedEquals([primaryInputId, excludedInputId, ...placeholders]),
         );
-        expect(graph.postProcessBuildStepIds(package: 'foo'), {
-          expectedBuildStepId,
-        });
         expect(graph.primaryOutputsOf(primaryInputId), [primaryOutputId]);
 
         final buildStepId = BuildStepId(
@@ -207,30 +200,18 @@ void main() {
           graph.buildStepsByDeclaredOutput[primaryOutputId]!.primaryInput,
           primaryInputId,
         );
-
-        expect(graph.postProcessBuildStepIds(package: 'foo'), {
-          expectedBuildStepId,
-        });
       });
 
       group('updateAndInvalidate', () {
         test('add new primary input', () async {
           final changes = {AssetId('foo', 'new.txt'): ChangeType.ADD};
           await graph.updateAndInvalidate(buildPhases, changes);
-          expect(graph.contains(AssetId('foo', 'new.txt.copy')), isTrue);
-          final newBuildStepId = PostProcessBuildStepId(
-            input: primaryInputId,
-            actionNumber: 0,
-          );
-          expect(
-            graph.postProcessBuildStepIds(package: 'foo'),
-            contains(newBuildStepId),
-          );
+          expect(graph.isKnownFile(AssetId('foo', 'new.txt.copy')), isTrue);
         });
 
         test('modify primary input', () async {
           final changes = {primaryInputId: ChangeType.MODIFY};
-          expect(graph.contains(primaryOutputId), isTrue);
+          expect(graph.isKnownFile(primaryOutputId), isTrue);
           final buildStepId = BuildStepId(
             primaryInput: primaryInputId,
             phaseNumber: 0,
@@ -242,8 +223,8 @@ void main() {
           });
           graph.updateBuildStepResult(buildStepId, stepResult);
           await graph.updateAndInvalidate(buildPhases, changes);
-          expect(graph.contains(primaryInputId), isTrue);
-          expect(graph.contains(primaryOutputId), isTrue);
+          expect(graph.isKnownFile(primaryInputId), isTrue);
+          expect(graph.isKnownFile(primaryOutputId), isTrue);
         });
 
         test('add new primary input which replaces a synthetic node', () async {
@@ -254,19 +235,10 @@ void main() {
           final changes = {syntheticId: ChangeType.ADD};
           await graph.updateAndInvalidate(buildPhases, changes);
 
-          expect(graph.contains(syntheticId), isTrue);
+          expect(graph.isKnownFile(syntheticId), isTrue);
           expect(graph.get(syntheticId)?.type, NodeType.source);
-          expect(graph.contains(syntheticOutputId), isTrue);
+          expect(graph.isKnownFile(syntheticOutputId), isTrue);
           expect(graph.isDeclaredOutput(syntheticOutputId), isTrue);
-
-          final newAnchor = PostProcessBuildStepId(
-            input: syntheticId,
-            actionNumber: 0,
-          );
-          expect(
-            graph.postProcessBuildStepIds(package: 'foo'),
-            contains(newAnchor),
-          );
         });
 
         test(
@@ -279,9 +251,9 @@ void main() {
             final changes = {syntheticId: ChangeType.ADD};
             await graph.updateAndInvalidate(buildPhases, changes);
 
-            expect(graph.contains(syntheticOutputId), isTrue);
+            expect(graph.isKnownFile(syntheticOutputId), isTrue);
             expect(graph.isDeclaredOutput(syntheticOutputId), isTrue);
-            expect(graph.contains(syntheticOutputId), isTrue);
+            expect(graph.isKnownFile(syntheticOutputId), isTrue);
           },
         );
 

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -1197,19 +1197,15 @@ targets:
       actionNumber: 0,
     );
 
-    final aPostCopyNode = AssetNode.postGenerated(
-      makeAssetId('a|web/a.txt.post'),
-    );
+    final aPostCopyId = makeAssetId('a|web/a.txt.post');
 
-    final bPostCopyNode = AssetNode.postGenerated(
-      makeAssetId('a|lib/b.txt.post'),
-    );
+    final bPostCopyId = makeAssetId('a|lib/b.txt.post');
 
     expectedGraph
       ..add(aSourceNode)
       ..add(bSourceNode)
-      ..declareOutputs(aId, [aCopyId, aPostCopyNode.id])
-      ..declareOutputs(bId, [bCopyId, bPostCopyNode.id])
+      ..declareOutputs(aId, [aCopyId, aPostCopyId])
+      ..declareOutputs(bId, [bCopyId, bPostCopyId])
       ..addGeneratedForTest(
         aCopyId,
         BuildStepId(primaryInput: aId, phaseNumber: 0),
@@ -1220,15 +1216,13 @@ targets:
         BuildStepId(primaryInput: bId, phaseNumber: 0),
         digest: computeDigest(bCopyId, 'b'),
       )
-      ..add(aPostCopyNode)
-      ..add(bPostCopyNode)
       ..updatePostProcessBuildStepResult(
         aPostProcessBuildStepId,
-        PostProcessBuildStepResult(hidden: true, outputs: [aPostCopyNode.id]),
+        PostProcessBuildStepResult(hidden: true, outputs: [aPostCopyId]),
       )
       ..updatePostProcessBuildStepResult(
         bPostProcessBuildStepId,
-        PostProcessBuildStepResult(hidden: true, outputs: [bPostCopyNode.id]),
+        PostProcessBuildStepResult(hidden: true, outputs: [bPostCopyId]),
       );
 
     expect(cachedGraph, equalsAssetGraph(expectedGraph));
@@ -1550,7 +1544,7 @@ targets:
       final aCloneNodeId = makeAssetId('a|lib/a.txt.copy.clone');
       expect(newGraph.get(aNodeId)!.type, NodeType.missingSource);
       expect(newGraph.get(aCopyNodeId)!.type, NodeType.missingSource);
-      expect(newGraph.contains(aCloneNodeId), isFalse);
+      expect(newGraph.isKnownFile(aCloneNodeId), isFalse);
       expect(result.readerWriter.testing.exists(aNodeId), isFalse);
       expect(result.readerWriter.testing.exists(aCopyNodeId), isFalse);
       expect(result.readerWriter.testing.exists(aCloneNodeId), isFalse);


### PR DESCRIPTION
Separate postGenerated nodes from sources, they are mostly not available at the same point in the build.

Various cleanup around AssetGraph getters, hopefully making everything clearer.

Stop "seeding" the AssetGraph with empty post build step action results, just compute them directly in `build.dart` where they are needed in `_runPostBuildPhase`. This allows to stop keeping them indexed by package in `AssetGraph`.