### PR TITLE
Improve AssetGraph API, rename to BuildState

### DIFF
--- a/build_runner/lib/src/build/asset_graph/asset_graph_json.dart
+++ b/build_runner/lib/src/build/asset_graph/asset_graph_json.dart
@@ -16,24 +16,24 @@ import 'serializers.dart';
 /// and if so exactly what should be rebuilt.
 class AssetGraphJson {
   final BuildPlanDigest buildPlanDigest;
-  final BuildState assetGraph;
+  final BuildState buildState;
   final PhasedAssetDeps phasedAssetDeps;
 
   AssetGraphJson({
     required this.buildPlanDigest,
-    required this.assetGraph,
+    required this.buildState,
     required this.phasedAssetDeps,
   });
 
   /// Serializes for `asset_graph.json`.
   static Uint8List serialize({
     required BuildPlanDigest buildPlanDigest,
-    required BuildState assetGraph,
+    required BuildState buildState,
     required PhasedAssetDeps phasedAssetDeps,
   }) {
     // Serialize fields first so all `AssetId` instances are seen by
     // `identityAssetIdSeralizer`.
-    final serializedAssetGraph = serializeAssetGraph(assetGraph);
+    final serializedBuildState = serializeBuildState(buildState);
     final serializedBuildPlanDigest = serializers.serializeWith(
       BuildPlanDigest.serializer,
       buildPlanDigest,
@@ -45,7 +45,7 @@ class AssetGraphJson {
     final result = {
       'version': _version,
       'ids': identityAssetIdSerializer.serializedObjects,
-      'assetGraph': serializedAssetGraph,
+      'buildState': serializedBuildState,
       'buildPlanDigest': serializedBuildPlanDigest,
       'phasedAssetDeps': serializedPhasedAssetDeps,
     };
@@ -73,8 +73,8 @@ class AssetGraphJson {
         deserialized['buildPlanDigest'],
       );
 
-      final assetGraph = deserializeAssetGraph(
-        deserialized['assetGraph'] as Map,
+      final buildState = deserializeBuildState(
+        deserialized['buildState'] as Map,
       );
 
       final phasedAssetDeps = serializers.deserializeWith(
@@ -83,7 +83,7 @@ class AssetGraphJson {
       );
 
       return AssetGraphJson(
-        assetGraph: assetGraph!,
+        buildState: buildState!,
         buildPlanDigest: buildPlanDigest!,
         phasedAssetDeps: phasedAssetDeps!,
       );
@@ -96,5 +96,5 @@ class AssetGraphJson {
 }
 
 /// Increment whenever older `asset_graph.json` files should be rejected.
-const _version = 40;
+const _version = 41;
 final jsonUtf8 = json.fuse(utf8);

--- a/build_runner/lib/src/build/asset_graph/asset_graph_json.dart
+++ b/build_runner/lib/src/build/asset_graph/asset_graph_json.dart
@@ -16,7 +16,7 @@ import 'serializers.dart';
 /// and if so exactly what should be rebuilt.
 class AssetGraphJson {
   final BuildPlanDigest buildPlanDigest;
-  final AssetGraph assetGraph;
+  final BuildState assetGraph;
   final PhasedAssetDeps phasedAssetDeps;
 
   AssetGraphJson({
@@ -28,7 +28,7 @@ class AssetGraphJson {
   /// Serializes for `asset_graph.json`.
   static Uint8List serialize({
     required BuildPlanDigest buildPlanDigest,
-    required AssetGraph assetGraph,
+    required BuildState assetGraph,
     required PhasedAssetDeps phasedAssetDeps,
   }) {
     // Serialize fields first so all `AssetId` instances are seen by

--- a/build_runner/lib/src/build/asset_graph/build_step_result.dart
+++ b/build_runner/lib/src/build/asset_graph/build_step_result.dart
@@ -43,4 +43,15 @@ abstract class BuildStepResult
   factory BuildStepResult([void Function(BuildStepResultBuilder)? updates]) =
       _$BuildStepResult;
   BuildStepResult._();
+
+  /// Whether the build step ran, either in the previous build or in this build.
+  bool get hasRun => result != null;
+
+  /// Whether the build step ran and succeeded, either in the previous build or
+  /// in this build.
+  bool get succeeded => result == true;
+
+  /// Whether the build step ran and failed, either in the previous build or in
+  /// this build.
+  bool get failed => result == false;
 }

--- a/build_runner/lib/src/build/asset_graph/exceptions.dart
+++ b/build_runner/lib/src/build/asset_graph/exceptions.dart
@@ -4,12 +4,12 @@
 
 import 'package:build/build.dart';
 
-class DuplicateAssetNodeException implements Exception {
+class DuplicateAssetIdException implements Exception {
   final AssetId assetId;
   final String builder1;
   final String builder2;
 
-  DuplicateAssetNodeException(this.assetId, this.builder1, this.builder2);
+  DuplicateAssetIdException(this.assetId, this.builder1, this.builder2);
   @override
   String toString() =>
       'Builders $builder1 and $builder2 outputs collide: ${assetId.uri}';

--- a/build_runner/lib/src/build/asset_graph/glob_result.dart
+++ b/build_runner/lib/src/build/asset_graph/glob_result.dart
@@ -14,12 +14,13 @@ part 'glob_result.g.dart';
 abstract class GlobResult implements Built<GlobResult, GlobResultBuilder> {
   static Serializer<GlobResult> get serializer => _$globResultSerializer;
 
-  /// The matching outputs that actually exist/were output in the graph.
+  /// The matching outputs that actually exist/were output in the build state.
   BuiltSet<AssetId> get results;
 
   /// All matching files checked as inputs.
   ///
-  /// This includes any missing or non-existent optional matching files.
+  /// This includes declared outputs that the build step did not output, so they
+  /// don't exist.
   BuiltSet<AssetId> get inputs;
 
   /// Content signature computed from the sorted list of matched

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:build/build.dart';
 import 'package:built_collection/built_collection.dart';
@@ -31,164 +30,251 @@ import 'sources.dart';
 
 part 'serialization.dart';
 
-/// All the [AssetId]s involved in a build, and all of their outputs.
-class AssetGraph implements GeneratedAssetHider {
+/// Build state that is updated during the build then serialized to allow a
+/// follow-on incremental build.
+///
+/// - Sources and their digests; missing sources.
+/// - Planned build steps, updated with results as the build progresses,
+///   including digests of outputs and error messages.
+/// - Glob results.
+/// - Post process build step results.
+class BuildState implements GeneratedAssetHider {
   /// Sources and missing sources.
   final Sources _sources;
 
   /// All standard build step execution results, indexed by [BuildStepId].
-  final Map<BuildStepId, BuildStepResult> buildStepResults;
+  final Map<BuildStepId, BuildStepResult> _buildStepResults;
 
   /// Declared outputs by primary input.
-  final Map<AssetId, Set<AssetId>> declaredOutputsByPrimaryInput;
+  final Map<AssetId, Set<AssetId>> _declaredOutputsByPrimaryInput;
 
   /// Build steps by primary output declared.
-  final Map<AssetId, BuildStepId> buildStepsByDeclaredOutput;
+  final Map<AssetId, BuildStepId> _buildStepsByDeclaredOutput;
 
   /// Globs evaluated during the build.
-  final Map<GlobId, GlobResult> globResults;
+  final Map<GlobId, GlobResult> _globResults;
 
   /// All post process build steps results, indexed by [PostProcessBuildStepId].
   final Map<PostProcessBuildStepId, PostProcessBuildStepResult>
-  postProcessBuildStepResults;
+  _postProcessBuildStepResults;
 
   /// All post process build step outputs.
-  final Set<AssetId> postProcessOutputs;
+  final Set<AssetId> _postProcessOutputs;
 
-  AssetGraph()
+  @visibleForTesting
+  BuildState.empty()
     : _sources = Sources(),
-      postProcessBuildStepResults = {},
-      postProcessOutputs = {},
-      buildStepResults = {},
-      declaredOutputsByPrimaryInput = {},
-      globResults = {},
-      buildStepsByDeclaredOutput = {};
+      _postProcessBuildStepResults = {},
+      _postProcessOutputs = {},
+      _buildStepResults = {},
+      _declaredOutputsByPrimaryInput = {},
+      _globResults = {},
+      _buildStepsByDeclaredOutput = {};
 
-  AssetGraph._with({
+  /// Creates from build phases, sources and packages.
+  factory BuildState.create({
+    required BuildPhases buildPhases,
+    required BuildPackages buildPackages,
+    required Set<AssetId> sources,
+  }) {
+    final result = BuildState.empty();
+    result._sources.addAll(sources);
+    result._addOutputsForSources(
+      buildPhases,
+      sources,
+      placeholders: buildPackages.placeholderIds,
+    );
+    return result;
+  }
+
+  BuildState._with({
     required Sources sources,
-    required this.postProcessBuildStepResults,
-    required this.postProcessOutputs,
-    required this.buildStepResults,
-    required this.globResults,
-    required this.buildStepsByDeclaredOutput,
-    required this.declaredOutputsByPrimaryInput,
-  }) : _sources = sources;
+    required Map<PostProcessBuildStepId, PostProcessBuildStepResult>
+    postProcessBuildStepResults,
+    required Set<AssetId> postProcessOutputs,
+    required Map<BuildStepId, BuildStepResult> buildStepResults,
+    required Map<GlobId, GlobResult> globResults,
+    required Map<AssetId, BuildStepId> buildStepsByDeclaredOutput,
+    required Map<AssetId, Set<AssetId>> declaredOutputsByPrimaryInput,
+  }) : _postProcessOutputs = postProcessOutputs,
+       _postProcessBuildStepResults = postProcessBuildStepResults,
+       _globResults = globResults,
+       _buildStepsByDeclaredOutput = buildStepsByDeclaredOutput,
+       _declaredOutputsByPrimaryInput = declaredOutputsByPrimaryInput,
+       _buildStepResults = buildStepResults,
+       _sources = sources;
 
   /// Copies the graph prepared for the next build.
-  AssetGraph copyForNextBuild() {
-    return AssetGraph._with(
+  BuildState copyForNextBuild() {
+    return BuildState._with(
       sources: _sources.clone(),
-      postProcessBuildStepResults: Map.of(postProcessBuildStepResults),
-      postProcessOutputs: Set.of(postProcessOutputs),
-      buildStepResults: Map.of(buildStepResults),
-      globResults: Map.of(globResults),
-      buildStepsByDeclaredOutput: Map.of(buildStepsByDeclaredOutput),
+      postProcessBuildStepResults: Map.of(_postProcessBuildStepResults),
+      postProcessOutputs: Set.of(_postProcessOutputs),
+      buildStepResults: Map.of(_buildStepResults),
+      globResults: Map.of(_globResults),
+      buildStepsByDeclaredOutput: Map.of(_buildStepsByDeclaredOutput),
       declaredOutputsByPrimaryInput: {
-        for (final entry in declaredOutputsByPrimaryInput.entries)
+        for (final entry in _declaredOutputsByPrimaryInput.entries)
           entry.key: Set.of(entry.value),
       },
     );
   }
 
-  /// Deserializes an [AssetGraph] from a [Map].
-  ///
-  /// Returns `null` if deserialization fails.
-  @visibleForTesting
-  static AssetGraph? deserialize(String serializedGraph) {
-    try {
-      final decodedMap = json.decode(serializedGraph);
-      if (decodedMap is! Map) return null;
-      return deserializeAssetGraph(decodedMap);
-    } catch (_) {
-      return null;
-    }
-  }
-
-  static Future<AssetGraph> build(
-    BuildPhases buildPhases,
-    Set<AssetId> sources,
-    BuildPackages buildPackages,
-  ) async {
-    final graph = AssetGraph();
-    graph._addSources(sources);
-    graph._addOutputsForSources(
-      buildPhases,
-      sources,
-      placeholders: buildPackages.placeholderIds,
-    );
-    return graph;
-  }
-
-  @visibleForTesting
-  String serialize() => json.encode(serializeAssetGraph(this));
+  // Predicates over IDs and iterables of IDs.
 
   /// Whether [id] is a placeholder.
+  ///
+  /// Placeholders are virtual files that exist in every package. They can't be
+  /// read, but they can be matched as inputs. This allows builders to generate
+  /// a fixed list of outputs for any package.
   bool isPlaceholder(AssetId id) => Placeholders.isPlaceholderPath(id.path);
 
-  /// Whether [id] is one of: source, output or post process output.
-  bool isKnownFile(AssetId id) =>
+  /// Whether [id] is one of: source, declared output or actual post process
+  /// output.
+  bool isFile(AssetId id) =>
       isSource(id) || isDeclaredOutput(id) || isActualPostOutput(id);
+
+  /// Files that are in [package] and match [glob].
+  ///
+  /// Checks sources and declared outputs. The declared outputs that match might
+  /// not exist yet if their build step hasn't run, or might never exist if it
+  /// runs but decides not to output them.
+  ///
+  /// Does not match post process outputs.
+  Iterable<AssetId> findFiles({required String package, Glob? glob}) =>
+      _sources.findFiles(package, declaredOutputs, glob: glob);
+
+  /// Sources.
+  ///
+  /// Files that were on disk in all packages in the build when the build
+  /// started, excluding any that were matched as prior `build_runner` outputs.
+  Iterable<AssetId> get sources => _sources.sourceIds;
 
   /// Whether [id] is a source file.
   bool isSource(AssetId id) => _sources.isSource(id);
 
-  /// Whether [id] is a source file.
+  /// Whether [id] is a source file that has never been read.
+  ///
+  /// That means it is not a primary input and has never been read by any
+  /// builder as an additional input.
   bool isUnreadSource(AssetId id) => _sources.isUnreadSource(id);
 
   /// Whether [id] is a source file that was accessed but did not exist.
   bool isMissingSource(AssetId id) => _sources.isMissingSource(id);
 
-  /// The digest of source [id], or `null` if it has not been read.
-  Digest? sourceDigest(AssetId id) => _sources.getDigest(id);
+  /// Declared build outputs.
+  Iterable<AssetId> get declaredOutputs => _buildStepsByDeclaredOutput.keys;
 
   /// Whether [id] is a declared build output.
   bool isDeclaredOutput(AssetId id) =>
-      buildStepsByDeclaredOutput.containsKey(id);
+      _buildStepsByDeclaredOutput.containsKey(id);
+
+  /// Declared outputs of [id].
+  Iterable<AssetId> declaredOutputsOf(AssetId id) =>
+      _declaredOutputsByPrimaryInput[id] ?? const [];
+
+  /// All the declared outputs for [phase].
+  Iterable<AssetId> declaredOutputsForPhase(String package, int phase) =>
+      findFiles(
+        package: package,
+      ).where((id) => _buildStepsByDeclaredOutput[id]?.phaseNumber == phase);
 
   /// Whether [id] is a declared build output that was actually generated.
   bool isActualOutput(AssetId id) {
-    final buildStepId = buildStepsByDeclaredOutput[id];
+    final buildStepId = _buildStepsByDeclaredOutput[id];
     if (buildStepId == null) return false;
-    return buildStepResultFor(buildStepId)!.outputs.containsKey(id);
+    return stepResult(buildStepId).outputs.containsKey(id);
   }
+
+  /// Whether [id] is a declared build output that was actually generated by
+  /// a build step that succeeded.
+  bool isActualSuccessfulOutput(AssetId id) {
+    final step = _buildStepsByDeclaredOutput[id];
+    if (step == null) return false;
+    final stepResult = this.stepResult(step);
+    return stepResult.succeeded && stepResult.outputs.containsKey(id);
+  }
+
+  /// All post process build outputs.
+  ///
+  /// Note that post process outputs happen after the main build, so during the
+  /// main build this is either empty or is the post process outputs from the
+  /// previous build.
+  Iterable<AssetId> get actualPostOutputs => _postProcessOutputs;
 
   /// Whether [id] is a post process build output that was actually generated.
-  bool isActualPostOutput(AssetId id) => postProcessOutputs.contains(id);
+  bool isActualPostOutput(AssetId id) => _postProcessOutputs.contains(id);
 
-  BuildStepResult? buildStepResultFor(BuildStepId buildStepId) =>
-      buildStepResults[buildStepId];
+  // Digests.
+
+  /// If [id] is a source or a declared output, returns the latest digest.
+  ///
+  /// Otherwise, returns `null`. In particular, post process outputs don't have
+  /// their digests stored.
+  Digest? digestOf(AssetId id) {
+    if (isSource(id)) return _sources.digestOfSource(id);
+    if (isDeclaredOutput(id)) {
+      return stepResult(stepForDeclaredOutput(id)).outputs[id];
+    }
+    return null;
+  }
+
+  /// The digest of source [id], or `null` if it has not been read.
+  ///
+  /// Throws if it is not a source.
+  Digest? digestOfSource(AssetId id) => _sources.digestOfSource(id);
+
+  // Build steps.
+
+  /// The build step that declared [id].
+  BuildStepId stepForDeclaredOutput(AssetId id) =>
+      _buildStepsByDeclaredOutput[id]!;
+
+  /// The result of [buildStep].
+  BuildStepResult stepResult(BuildStepId buildStep) =>
+      _buildStepResults[buildStep]!;
+
+  /// Updates a build step result after the step runs.
   void updateBuildStepResult(BuildStepId buildStepId, BuildStepResult result) {
-    buildStepResults[buildStepId] = result;
+    _buildStepResults[buildStepId] = result;
   }
 
-  GlobResult? globResultFor(GlobId globId) => globResults[globId];
+  // Globs.
+
+  GlobResult? globResultFor(GlobId globId) => _globResults[globId];
+
   void updateGlobResult(GlobId globId, GlobResult result) {
-    globResults[globId] = result;
+    _globResults[globId] = result;
   }
 
-  Iterable<AssetId> get sources => _sources.sourceIds;
-  Iterable<AssetId> packageFileIds(String package, {Glob? glob}) =>
-      _sources.packageFileIds(package, [
-        ...buildStepsByDeclaredOutput.keys,
-        ...allPostProcessOutputIds,
-      ], glob: glob);
-  void removeForTest(AssetId id) => _sources.remove(id);
+  // Post process build steps.
 
-  /// Adds [assetIds] to this graph.
-  void _addSources(Set<AssetId> assetIds) {
-    for (final id in assetIds) {
-      _sources.add(id);
+  void addPostProcessBuildStepResult(
+    PostProcessBuildStepId stepId,
+    PostProcessBuildStepResult result,
+  ) {
+    final updated = _postProcessBuildStepResults.putIfAbsent(
+      stepId,
+      () => result,
+    );
+    if (!identical(updated, result)) {
+      throw StateError('Already had post process result for $stepId.');
+    }
+    _postProcessOutputs.addAll(result.outputs);
+  }
+
+  void removePostProcessBuildResult(PostProcessBuildStepId buildStepId) {
+    final oldResult = _postProcessBuildStepResults.remove(buildStepId);
+    if (oldResult != null) {
+      _postProcessOutputs.removeAll(oldResult.outputs);
     }
   }
 
-  Iterable<AssetId> primaryOutputsOf(AssetId id) =>
-      declaredOutputsByPrimaryInput[id] ?? const [];
-
-  // For use by tests and `_addInBuildPhaseOutputs`.
-  @visibleForTesting
-  void declareOutputs(AssetId id, Iterable<AssetId> outputs) {
-    declaredOutputsByPrimaryInput.putIfAbsent(id, () => {}).addAll(outputs);
-  }
+  /// Gets the result for a [PostProcessBuildStepId], or `null` if there is
+  /// none.
+  PostProcessBuildStepResult? postProcessBuildStepResultFor(
+    PostProcessBuildStepId action,
+  ) => _postProcessBuildStepResults[action];
 
   /// Changes [id] and its transitive`primaryOutput`s to `missingSource` nodes.
   ///
@@ -196,17 +282,17 @@ class AssetGraph implements GeneratedAssetHider {
   void _setMissingRecursive(AssetId id, {Set<AssetId>? removedIds}) {
     removedIds ??= <AssetId>{};
     removedIds.add(id);
-    for (final output in primaryOutputsOf(id).toList()) {
+    for (final output in declaredOutputsOf(id).toList()) {
       _setMissingRecursive(output, removedIds: removedIds);
     }
-    buildStepsByDeclaredOutput.remove(id);
-    declaredOutputsByPrimaryInput.remove(id);
+    _buildStepsByDeclaredOutput.remove(id);
+    _declaredOutputsByPrimaryInput.remove(id);
     _sources.setMissing(id);
 
     // Remove post build action applications with removed assets as inputs.
-    postProcessBuildStepResults.removeWhere((id, result) {
+    _postProcessBuildStepResults.removeWhere((id, result) {
       if (removedIds!.contains(id.input)) {
-        postProcessOutputs.removeAll(result.outputs);
+        _postProcessOutputs.removeAll(result.outputs);
         return true;
       }
       return false;
@@ -217,59 +303,30 @@ class AssetGraph implements GeneratedAssetHider {
   void _removeRecursive(AssetId id, {Set<AssetId>? removedIds}) {
     removedIds ??= <AssetId>{};
     if (removedIds.add(id)) {
-      for (final output in primaryOutputsOf(id).toList()) {
+      for (final output in declaredOutputsOf(id).toList()) {
         _removeRecursive(output, removedIds: removedIds);
       }
       _sources.remove(id);
-      buildStepsByDeclaredOutput.remove(id);
-      declaredOutputsByPrimaryInput.remove(id);
+      _buildStepsByDeclaredOutput.remove(id);
+      _declaredOutputsByPrimaryInput.remove(id);
     }
   }
-
-  Iterable<AssetId> get allPostProcessOutputIds => postProcessOutputs;
-
-  /// Creates or updates state for a [PostProcessBuildStepId].
-  void updatePostProcessBuildStepResult(
-    PostProcessBuildStepId buildStepId,
-    PostProcessBuildStepResult result,
-  ) {
-    final oldResult = postProcessBuildStepResults[buildStepId];
-    if (oldResult != null) {
-      postProcessOutputs.removeAll(oldResult.outputs);
-    }
-    postProcessBuildStepResults[buildStepId] = result;
-    postProcessOutputs.addAll(result.outputs);
-  }
-
-  /// Gets the result of a [PostProcessBuildStepId].
-  ///
-  /// These are set using [updatePostProcessBuildStepResult] during the build,
-  /// then used to clean up prior outputs in the next build.
-  PostProcessBuildStepResult? postProcessBuildStepResultFor(
-    PostProcessBuildStepId action,
-  ) => postProcessBuildStepResults[action];
 
   /// All declared outputs in the graph.
   Iterable<AssetId> get outputs => [
-    ...buildStepsByDeclaredOutput.keys,
-    ...allPostProcessOutputIds,
+    ..._buildStepsByDeclaredOutput.keys,
+    ...actualPostOutputs,
   ];
 
   /// All declared outputs and the phases in which they are output.
   Map<AssetId, int> get outputPhases => {
-    for (final entry in buildStepsByDeclaredOutput.entries)
+    for (final entry in _buildStepsByDeclaredOutput.entries)
       entry.key: entry.value.phaseNumber,
   };
 
-  /// All the generated outputs for a particular phase.
-  Iterable<AssetId> outputsForPhase(String package, int phase) =>
-      packageFileIds(
-        package,
-      ).where((id) => buildStepsByDeclaredOutput[id]?.phaseNumber == phase);
-
   /// All actual outputs.
   Iterable<AssetId> get actualOutputs =>
-      buildStepResults.values.expand((result) => result.outputs.keys);
+      _buildStepResults.values.expand((result) => result.outputs.keys);
 
   /// Updates graph structure, invalidating and deleting any outputs that were
   /// affected.
@@ -301,14 +358,14 @@ class AssetGraph implements GeneratedAssetHider {
       }
     }
 
-    _addSources(newIds);
+    _sources.addAll(newIds);
 
     // Compute generated nodes that will no longer be output because their
     // primary input was deleted. Delete them.
     final transitiveRemovedIds = <AssetId>{};
     void addTransitivePrimaryOutputs(AssetId id) {
       if (transitiveRemovedIds.add(id)) {
-        primaryOutputsOf(id).forEach(addTransitivePrimaryOutputs);
+        declaredOutputsOf(id).forEach(addTransitivePrimaryOutputs);
       }
     }
 
@@ -353,7 +410,7 @@ class AssetGraph implements GeneratedAssetHider {
 
     var currentInput = input;
     while (true) {
-      final buildStep = buildStepsByDeclaredOutput[currentInput];
+      final buildStep = _buildStepsByDeclaredOutput[currentInput];
       if (buildStep == null) break;
       currentInput = buildStep.primaryInput;
     }
@@ -407,7 +464,9 @@ class AssetGraph implements GeneratedAssetHider {
       if (!allInputs.contains(input)) continue;
       final outputs = expectedOutputs(phase.builder, input);
       phaseOutputs.addAll(outputs);
-      declareOutputs(input, outputs);
+      _declaredOutputsByPrimaryInput
+          .putIfAbsent(input, () => {})
+          .addAll(outputs);
       final deleted = _addGeneratedOutputs(
         outputs,
         phaseNum,
@@ -447,7 +506,7 @@ class AssetGraph implements GeneratedAssetHider {
         _removeRecursive(output, removedIds: removed);
       } else if (isDeclaredOutput(output)) {
         // The output was already declared by another builder.
-        final buildStep = buildStepsByDeclaredOutput[output]!;
+        final buildStep = _buildStepsByDeclaredOutput[output]!;
         final existingPhase = buildStep.phaseNumber;
         throw DuplicateAssetNodeException(
           output,
@@ -460,12 +519,12 @@ class AssetGraph implements GeneratedAssetHider {
         primaryInput: primaryInput,
         phaseNumber: phaseNumber,
       );
-      buildStepsByDeclaredOutput[output] = buildStepId;
+      _buildStepsByDeclaredOutput[output] = buildStepId;
       final buildStepResultBuilder =
-          buildStepResults[buildStepId]?.toBuilder() ??
+          _buildStepResults[buildStepId]?.toBuilder() ??
           BuildStepResultBuilder();
       buildStepResultBuilder.isHidden = isHidden;
-      buildStepResults[buildStepId] = buildStepResultBuilder.build();
+      _buildStepResults[buildStepId] = buildStepResultBuilder.build();
     }
     return removed;
   }
@@ -481,10 +540,10 @@ class AssetGraph implements GeneratedAssetHider {
     bool isHidden = true,
     Digest? digest,
   }) {
-    buildStepsByDeclaredOutput[id] = buildStepId;
-    final existingResult = buildStepResults[buildStepId];
+    _buildStepsByDeclaredOutput[id] = buildStepId;
+    final existingResult = _buildStepResults[buildStepId];
     if (existingResult == null) {
-      buildStepResults[buildStepId] = BuildStepResult((b) {
+      _buildStepResults[buildStepId] = BuildStepResult((b) {
         b.isHidden = isHidden;
         if (digest != null) {
           b.outputs[id] = digest;
@@ -492,19 +551,11 @@ class AssetGraph implements GeneratedAssetHider {
       });
     } else {
       if (digest != null) {
-        buildStepResults[buildStepId] = existingResult.rebuild(
+        _buildStepResults[buildStepId] = existingResult.rebuild(
           (b) => b..outputs[id] = digest,
         );
       }
     }
-  }
-
-  Digest? digestFor(AssetId id) {
-    final buildStep = buildStepsByDeclaredOutput[id];
-    if (buildStep != null) {
-      return buildStepResultFor(buildStep)!.outputs[id];
-    }
-    return _sources.getDigest(id);
   }
 
   /// Updates a source file digest.
@@ -527,9 +578,9 @@ class AssetGraph implements GeneratedAssetHider {
     if (!isDeclaredOutput(id)) {
       return false;
     }
-    final buildStepId = buildStepsByDeclaredOutput[id];
+    final buildStepId = _buildStepsByDeclaredOutput[id];
     if (buildStepId != null) {
-      return buildStepResultFor(buildStepId)!.isHidden;
+      return stepResult(buildStepId).isHidden;
     }
     return false;
   }
@@ -561,7 +612,7 @@ class AssetGraph implements GeneratedAssetHider {
         if (idToDelete != null) result.add(idToDelete);
       }
     }
-    for (final postProcessResults in postProcessBuildStepResults.values) {
+    for (final postProcessResults in _postProcessBuildStepResults.values) {
       if (!postProcessResults.hidden) {
         for (final id in postProcessResults.outputs) {
           final idToDelete = checkAndMoveId(id);
@@ -571,4 +622,10 @@ class AssetGraph implements GeneratedAssetHider {
     }
     return result;
   }
+
+  // Post process.
+
+  /// All [PostProcessBuildStepResult] by [PostProcessBuildStepId].
+  Iterable<MapEntry<PostProcessBuildStepId, PostProcessBuildStepResult>>
+  get postProcessBuildStepResults => _postProcessBuildStepResults.entries;
 }

--- a/build_runner/lib/src/build/asset_graph/graph.dart
+++ b/build_runner/lib/src/build/asset_graph/graph.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:build/build.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
@@ -104,7 +102,7 @@ class BuildState implements GeneratedAssetHider {
        _buildStepResults = buildStepResults,
        _sources = sources;
 
-  /// Copies the graph prepared for the next build.
+  /// Copies the state and prepares it for the next build.
   BuildState copyForNextBuild() {
     return BuildState._with(
       sources: _sources.clone(),
@@ -120,7 +118,7 @@ class BuildState implements GeneratedAssetHider {
     );
   }
 
-  // Predicates over IDs and iterables of IDs.
+  // --  Predicates over IDs and iterables over IDs.
 
   /// Whether [id] is a placeholder.
   ///
@@ -179,6 +177,18 @@ class BuildState implements GeneratedAssetHider {
         package: package,
       ).where((id) => _buildStepsByDeclaredOutput[id]?.phaseNumber == phase);
 
+  /// Declared outputs and the phase in which they will be output.
+  Map<AssetId, int> get declaredOutputPhases => {
+    for (final entry in _buildStepsByDeclaredOutput.entries)
+      entry.key: entry.value.phaseNumber,
+  };
+
+  /// Actual build step outputs.
+  ///
+  /// A subset of [declaredOutputs].
+  Iterable<AssetId> get actualOutputs =>
+      _buildStepResults.values.expand((result) => result.outputs.keys);
+
   /// Whether [id] is a declared build output that was actually generated.
   bool isActualOutput(AssetId id) {
     final buildStepId = _buildStepsByDeclaredOutput[id];
@@ -195,7 +205,7 @@ class BuildState implements GeneratedAssetHider {
     return stepResult.succeeded && stepResult.outputs.containsKey(id);
   }
 
-  /// All post process build outputs.
+  /// Post process outputs.
   ///
   /// Note that post process outputs happen after the main build, so during the
   /// main build this is either empty or is the post process outputs from the
@@ -205,7 +215,21 @@ class BuildState implements GeneratedAssetHider {
   /// Whether [id] is a post process build output that was actually generated.
   bool isActualPostOutput(AssetId id) => _postProcessOutputs.contains(id);
 
-  // Digests.
+  /// All declared outputs and all post process outputs.
+  Iterable<AssetId> get declaredAndActualOutputs => [
+    ..._buildStepsByDeclaredOutput.keys,
+    ...actualPostOutputs,
+  ];
+
+  // -- Digests.
+
+  /// Updates a source file digest.
+  ///
+  /// Does nothing for generated files, their digest is set when the build step
+  /// result is written.
+  void updateSourceDigest(AssetId id, Digest? digest) {
+    _sources.updateDigestIfPresent(id, digest);
+  }
 
   /// If [id] is a source or a declared output, returns the latest digest.
   ///
@@ -224,7 +248,15 @@ class BuildState implements GeneratedAssetHider {
   /// Throws if it is not a source.
   Digest? digestOfSource(AssetId id) => _sources.digestOfSource(id);
 
-  // Build steps.
+  // -- Missing sources.
+
+  /// Adds a source that a builder tried to access but was missing.
+  ///
+  /// The builder must check and find there is no declared output or
+  /// source before calling this.
+  void addMissingSource(AssetId id) => _sources.addMissing(id);
+
+  // -- Build steps.
 
   /// The build step that declared [id].
   BuildStepId stepForDeclaredOutput(AssetId id) =>
@@ -239,7 +271,7 @@ class BuildState implements GeneratedAssetHider {
     _buildStepResults[buildStepId] = result;
   }
 
-  // Globs.
+  // -- Globs.
 
   GlobResult? globResultFor(GlobId globId) => _globResults[globId];
 
@@ -247,152 +279,40 @@ class BuildState implements GeneratedAssetHider {
     _globResults[globId] = result;
   }
 
-  // Post process build steps.
+  // -- Post process build steps.
 
   void addPostProcessBuildStepResult(
-    PostProcessBuildStepId stepId,
+    PostProcessBuildStepId step,
     PostProcessBuildStepResult result,
   ) {
     final updated = _postProcessBuildStepResults.putIfAbsent(
-      stepId,
+      step,
       () => result,
     );
     if (!identical(updated, result)) {
-      throw StateError('Already had post process result for $stepId.');
+      throw StateError('Already had post process result for $step.');
     }
     _postProcessOutputs.addAll(result.outputs);
   }
 
-  void removePostProcessBuildResult(PostProcessBuildStepId buildStepId) {
-    final oldResult = _postProcessBuildStepResults.remove(buildStepId);
+  void removePostProcessBuildResult(PostProcessBuildStepId step) {
+    final oldResult = _postProcessBuildStepResults.remove(step);
     if (oldResult != null) {
       _postProcessOutputs.removeAll(oldResult.outputs);
     }
   }
 
-  /// Gets the result for a [PostProcessBuildStepId], or `null` if there is
-  /// none.
   PostProcessBuildStepResult? postProcessBuildStepResultFor(
-    PostProcessBuildStepId action,
-  ) => _postProcessBuildStepResults[action];
+    PostProcessBuildStepId step,
+  ) => _postProcessBuildStepResults[step];
 
-  /// Changes [id] and its transitive`primaryOutput`s to `missingSource` nodes.
-  ///
-  /// Removes post build applications with removed assets as inputs.
-  void _setMissingRecursive(AssetId id, {Set<AssetId>? removedIds}) {
-    removedIds ??= <AssetId>{};
-    removedIds.add(id);
-    for (final output in declaredOutputsOf(id).toList()) {
-      _setMissingRecursive(output, removedIds: removedIds);
-    }
-    _buildStepsByDeclaredOutput.remove(id);
-    _declaredOutputsByPrimaryInput.remove(id);
-    _sources.setMissing(id);
+  /// All [PostProcessBuildStepResult] by [PostProcessBuildStepId].
+  Iterable<MapEntry<PostProcessBuildStepId, PostProcessBuildStepResult>>
+  get postProcessBuildStepResults => _postProcessBuildStepResults.entries;
 
-    // Remove post build action applications with removed assets as inputs.
-    _postProcessBuildStepResults.removeWhere((id, result) {
-      if (removedIds!.contains(id.input)) {
-        _postProcessOutputs.removeAll(result.outputs);
-        return true;
-      }
-      return false;
-    });
-  }
+  // -- Build planning.
 
-  /// Removes [id] and its transitive`primaryOutput`s from the graph.
-  void _removeRecursive(AssetId id, {Set<AssetId>? removedIds}) {
-    removedIds ??= <AssetId>{};
-    if (removedIds.add(id)) {
-      for (final output in declaredOutputsOf(id).toList()) {
-        _removeRecursive(output, removedIds: removedIds);
-      }
-      _sources.remove(id);
-      _buildStepsByDeclaredOutput.remove(id);
-      _declaredOutputsByPrimaryInput.remove(id);
-    }
-  }
-
-  /// All declared outputs in the graph.
-  Iterable<AssetId> get outputs => [
-    ..._buildStepsByDeclaredOutput.keys,
-    ...actualPostOutputs,
-  ];
-
-  /// All declared outputs and the phases in which they are output.
-  Map<AssetId, int> get outputPhases => {
-    for (final entry in _buildStepsByDeclaredOutput.entries)
-      entry.key: entry.value.phaseNumber,
-  };
-
-  /// All actual outputs.
-  Iterable<AssetId> get actualOutputs =>
-      _buildStepResults.values.expand((result) => result.outputs.keys);
-
-  /// Updates graph structure, invalidating and deleting any outputs that were
-  /// affected.
-  ///
-  /// Outputs that are deleted from the filesystem are retained in the graph as
-  /// `missingSource` nodes.
-  ///
-  /// Returns the set of [AssetId]s to delete.
-  Future<Set<AssetId>> updateAndInvalidate(
-    BuildPhases buildPhases,
-    Map<AssetId, ChangeType> updates,
-  ) async {
-    final newIds = <AssetId>{};
-    final modifyIds = <AssetId>{};
-    final removeIds = <AssetId>{};
-    for (final entry in updates.entries) {
-      final id = entry.key;
-      final changeType = entry.value;
-      switch (changeType) {
-        case ChangeType.ADD:
-        case ChangeType.MODIFY:
-          if (!isSource(id) || isMissingSource(id)) {
-            newIds.add(id);
-          } else {
-            modifyIds.add(id);
-          }
-        case ChangeType.REMOVE:
-          if (isSource(id)) removeIds.add(id);
-      }
-    }
-
-    _sources.addAll(newIds);
-
-    // Compute generated nodes that will no longer be output because their
-    // primary input was deleted. Delete them.
-    final transitiveRemovedIds = <AssetId>{};
-    void addTransitivePrimaryOutputs(AssetId id) {
-      if (transitiveRemovedIds.add(id)) {
-        declaredOutputsOf(id).forEach(addTransitivePrimaryOutputs);
-      }
-    }
-
-    for (final id in removeIds) {
-      if (isSource(id)) {
-        addTransitivePrimaryOutputs(id);
-      }
-    }
-
-    // Change deleted source assets and their transitive primary outputs to
-    // `missingSource` nodes, rather than deleting them. This allows them to
-    // remain referenced in `inputs` in order to trigger rebuilds if necessary.
-    for (final id in removeIds) {
-      if (isSource(id)) {
-        _setMissingRecursive(id);
-      }
-    }
-
-    _addOutputsForSources(buildPhases, newIds);
-
-    _sources.clearComputationResults();
-    transitiveRemovedIds.removeAll(removeIds);
-    return transitiveRemovedIds;
-  }
-
-  /// Crawl up primary inputs to see if the original Source file matches the
-  /// glob on [action].
+  /// Returns whether [action] should run for [input].
   bool actionMatches(BuildAction action, AssetId input) {
     if (input.package != action.package) return false;
     if (!action.generateFor.matches(input)) return false;
@@ -415,174 +335,6 @@ class BuildState implements GeneratedAssetHider {
       currentInput = buildStep.primaryInput;
     }
     return action.targetSources.matches(currentInput);
-  }
-
-  /// Adds outputs for [newSources] and optionally [placeholders].
-  ///
-  /// May remove nodes if sources overlap with generated outputs.
-  void _addOutputsForSources(
-    BuildPhases buildPhases,
-    Set<AssetId> newSources, {
-    Iterable<AssetId>? placeholders,
-  }) {
-    final allInputs = Set<AssetId>.from(newSources);
-    if (placeholders != null) allInputs.addAll(placeholders);
-    for (
-      var phaseNum = 0;
-      phaseNum < buildPhases.inBuildPhases.length;
-      phaseNum++
-    ) {
-      allInputs.addAll(
-        _addInBuildPhaseOutputs(
-          buildPhases.inBuildPhases[phaseNum],
-          phaseNum,
-          allInputs,
-          buildPhases,
-        ),
-      );
-    }
-  }
-
-  /// Adds all generated asset outputs for [phase] given [allInputs].
-  ///
-  /// May remove some items from [allInputs], if they are deemed to actually be
-  /// outputs of this phase and not original sources.
-  ///
-  /// Returns all newly created asset ids.
-  Set<AssetId> _addInBuildPhaseOutputs(
-    InBuildPhase phase,
-    int phaseNum,
-    Set<AssetId> allInputs,
-    BuildPhases buildPhases,
-  ) {
-    final phaseOutputs = <AssetId>{};
-    final inputs =
-        allInputs.where((input) => actionMatches(phase, input)).toList();
-    for (final input in inputs) {
-      // We might have deleted some inputs during this loop, if they turned
-      // out to be generated assets.
-      if (!allInputs.contains(input)) continue;
-      final outputs = expectedOutputs(phase.builder, input);
-      phaseOutputs.addAll(outputs);
-      _declaredOutputsByPrimaryInput
-          .putIfAbsent(input, () => {})
-          .addAll(outputs);
-      final deleted = _addGeneratedOutputs(
-        outputs,
-        phaseNum,
-        buildPhases,
-        primaryInput: input,
-        isHidden: phase.hideOutput,
-      );
-      allInputs.removeAll(deleted);
-      // We may delete source nodes that were producing outputs previously.
-      // Detect this by checking for deleted nodes that no longer exist in the
-      // graph at all, and remove them from `phaseOutputs`.
-      phaseOutputs.removeAll(deleted.where((id) => !isDeclaredOutput(id)));
-    }
-    return phaseOutputs;
-  }
-
-  /// Adds [outputs] to the graph.
-  ///
-  /// If there are existing source or missing source nodes
-  /// that overlap the outputs, then they will be replaced,
-  /// and their transitive `primaryOutputs` will be
-  /// removed from the graph.
-  ///
-  /// The return value is the set of assets that were removed from the graph.
-  Set<AssetId> _addGeneratedOutputs(
-    Iterable<AssetId> outputs,
-    int phaseNumber,
-    BuildPhases buildPhases, {
-    required AssetId primaryInput,
-    required bool isHidden,
-  }) {
-    final removed = <AssetId>{};
-    for (final output in outputs) {
-      if (isSource(output)) {
-        // An old generated source was picked up as a source file. Remove it and
-        // its outputs.
-        _removeRecursive(output, removedIds: removed);
-      } else if (isDeclaredOutput(output)) {
-        // The output was already declared by another builder.
-        final buildStep = _buildStepsByDeclaredOutput[output]!;
-        final existingPhase = buildStep.phaseNumber;
-        throw DuplicateAssetNodeException(
-          output,
-          buildPhases.inBuildPhases[existingPhase].displayName,
-          buildPhases.inBuildPhases[phaseNumber].displayName,
-        );
-      }
-
-      final buildStepId = BuildStepId(
-        primaryInput: primaryInput,
-        phaseNumber: phaseNumber,
-      );
-      _buildStepsByDeclaredOutput[output] = buildStepId;
-      final buildStepResultBuilder =
-          _buildStepResults[buildStepId]?.toBuilder() ??
-          BuildStepResultBuilder();
-      buildStepResultBuilder.isHidden = isHidden;
-      _buildStepResults[buildStepId] = buildStepResultBuilder.build();
-    }
-    return removed;
-  }
-
-  @visibleForTesting
-  void addSourceForTest(AssetId id, {Digest? digest}) =>
-      _sources.add(id, digest: digest);
-
-  @visibleForTesting
-  void addGeneratedForTest(
-    AssetId id,
-    BuildStepId buildStepId, {
-    bool isHidden = true,
-    Digest? digest,
-  }) {
-    _buildStepsByDeclaredOutput[id] = buildStepId;
-    final existingResult = _buildStepResults[buildStepId];
-    if (existingResult == null) {
-      _buildStepResults[buildStepId] = BuildStepResult((b) {
-        b.isHidden = isHidden;
-        if (digest != null) {
-          b.outputs[id] = digest;
-        }
-      });
-    } else {
-      if (digest != null) {
-        _buildStepResults[buildStepId] = existingResult.rebuild(
-          (b) => b..outputs[id] = digest,
-        );
-      }
-    }
-  }
-
-  /// Updates a source file digest.
-  ///
-  /// Does nothing for generated files, their digest is set when the build step
-  /// result is written.
-  void updateSourceDigest(AssetId id, Digest? digest) {
-    _sources.updateDigestIfPresent(id, digest);
-  }
-
-  /// Adds a source that a builder tried to access but was missing.
-  void addMissingSource(AssetId id) => _sources.addMissing(id);
-
-  @override
-  bool isHidden(AssetId id) {
-    if (id.path.startsWith(generatedOutputDirectory) ||
-        id.path.startsWith(cacheDirectoryPath)) {
-      return false;
-    }
-    if (!isDeclaredOutput(id)) {
-      return false;
-    }
-    final buildStepId = _buildStepsByDeclaredOutput[id];
-    if (buildStepId != null) {
-      return stepResult(buildStepId).isHidden;
-    }
-    return false;
   }
 
   /// Returns outputs that were written to the source tree.
@@ -623,9 +375,262 @@ class BuildState implements GeneratedAssetHider {
     return result;
   }
 
-  // Post process.
+  // -- Creation of the state and updates for incremental builds.
 
-  /// All [PostProcessBuildStepResult] by [PostProcessBuildStepId].
-  Iterable<MapEntry<PostProcessBuildStepId, PostProcessBuildStepResult>>
-  get postProcessBuildStepResults => _postProcessBuildStepResults.entries;
+  /// Updates for the next build.
+  ///
+  /// Returns the set of [AssetId]s to delete.
+  Set<AssetId> updateForNextBuild(
+    BuildPhases buildPhases,
+    Map<AssetId, ChangeType> updates,
+  ) {
+    final newIds = <AssetId>{};
+    final modifyIds = <AssetId>{};
+    final removeIds = <AssetId>{};
+    for (final entry in updates.entries) {
+      final id = entry.key;
+      final changeType = entry.value;
+      switch (changeType) {
+        case ChangeType.ADD:
+        case ChangeType.MODIFY:
+          if (!isSource(id) || isMissingSource(id)) {
+            newIds.add(id);
+          } else {
+            modifyIds.add(id);
+          }
+        case ChangeType.REMOVE:
+          if (isSource(id)) removeIds.add(id);
+      }
+    }
+
+    _sources.addAll(newIds);
+
+    // Compute declared outputs that will no longer be output because their
+    // primary input was deleted. Delete them.
+    final transitiveRemovedIds = <AssetId>{};
+    void addTransitivePrimaryOutputs(AssetId id) {
+      if (transitiveRemovedIds.add(id)) {
+        declaredOutputsOf(id).forEach(addTransitivePrimaryOutputs);
+      }
+    }
+
+    for (final id in removeIds) {
+      if (isSource(id)) {
+        addTransitivePrimaryOutputs(id);
+      }
+    }
+
+    // Change deleted source assets and their transitive declared outputs to
+    // missing sources, rather than deleting them. This allows them to remain
+    // referenced in `inputs` in order to trigger rebuilds if necessary.
+    for (final id in removeIds) {
+      if (isSource(id)) {
+        _setMissingRecursive(id);
+      }
+    }
+
+    _addOutputsForSources(buildPhases, newIds);
+
+    _sources.clearComputationResults();
+    transitiveRemovedIds.removeAll(removeIds);
+    return transitiveRemovedIds;
+  }
+
+  /// Changes [id] and its transitive primary outputs to missing sources.
+  ///
+  /// Removes post build applications with removed assets as inputs.
+  void _setMissingRecursive(AssetId id, {Set<AssetId>? removedIds}) {
+    removedIds ??= <AssetId>{};
+    removedIds.add(id);
+    for (final output in declaredOutputsOf(id).toList()) {
+      _setMissingRecursive(output, removedIds: removedIds);
+    }
+    _buildStepsByDeclaredOutput.remove(id);
+    _declaredOutputsByPrimaryInput.remove(id);
+    _sources.setMissing(id);
+
+    // Remove post build action applications with removed assets as inputs.
+    _postProcessBuildStepResults.removeWhere((id, result) {
+      if (removedIds!.contains(id.input)) {
+        _postProcessOutputs.removeAll(result.outputs);
+        return true;
+      }
+      return false;
+    });
+  }
+
+  /// Removes [id] and its transitive declared outputs.
+  void _removeRecursive(AssetId id, {Set<AssetId>? removedIds}) {
+    removedIds ??= <AssetId>{};
+    if (removedIds.add(id)) {
+      for (final output in declaredOutputsOf(id).toList()) {
+        _removeRecursive(output, removedIds: removedIds);
+      }
+      _sources.remove(id);
+      _buildStepsByDeclaredOutput.remove(id);
+      _declaredOutputsByPrimaryInput.remove(id);
+    }
+  }
+
+  /// Adds outputs for [newSources] and optionally [placeholders].
+  ///
+  /// If a source now clashes with an output, it means an old generated output
+  /// was incorrectly treated as a source. Clean that up: remove any outputs
+  /// that were added because the output was treated as a source.
+  void _addOutputsForSources(
+    BuildPhases buildPhases,
+    Set<AssetId> newSources, {
+    Iterable<AssetId>? placeholders,
+  }) {
+    final allInputs = Set<AssetId>.from(newSources);
+    if (placeholders != null) allInputs.addAll(placeholders);
+    for (
+      var phaseNum = 0;
+      phaseNum < buildPhases.inBuildPhases.length;
+      phaseNum++
+    ) {
+      allInputs.addAll(
+        _addInBuildPhaseOutputs(
+          buildPhases.inBuildPhases[phaseNum],
+          phaseNum,
+          allInputs,
+          buildPhases,
+        ),
+      );
+    }
+  }
+
+  /// Adds all generated asset outputs for [phase] given [allInputs].
+  ///
+  /// Removes ids from [allInputs] if they are recognized as outputs of the
+  /// phase.
+  ///
+  /// Returns all newly created asset ids.
+  Set<AssetId> _addInBuildPhaseOutputs(
+    InBuildPhase phase,
+    int phaseNum,
+    Set<AssetId> allInputs,
+    BuildPhases buildPhases,
+  ) {
+    final phaseOutputs = <AssetId>{};
+    final inputs =
+        allInputs.where((input) => actionMatches(phase, input)).toList();
+    for (final input in inputs) {
+      // We might have deleted some inputs during this loop, if they turned
+      // out to be generated assets.
+      if (!allInputs.contains(input)) continue;
+      final outputs = expectedOutputs(phase.builder, input);
+      phaseOutputs.addAll(outputs);
+      _declaredOutputsByPrimaryInput
+          .putIfAbsent(input, () => {})
+          .addAll(outputs);
+      final deleted = _addGeneratedOutputs(
+        outputs,
+        phaseNum,
+        buildPhases,
+        primaryInput: input,
+        isHidden: phase.hideOutput,
+      );
+      allInputs.removeAll(deleted);
+      // We may delete sources that were producing outputs previously.
+      // Detect this by checking for deleted files that are no longer declared
+      // outputs, and remove them from `phaseOutputs`.
+      phaseOutputs.removeAll(deleted.where((id) => !isDeclaredOutput(id)));
+    }
+    return phaseOutputs;
+  }
+
+  /// Adds [outputs] to the state.
+  ///
+  /// If there are existing source or missing sources that match outputs,
+  /// replace them with outputs and remove incorrect transitive outputs.
+  ///
+  /// The return value is the set of assets that were removed from the
+  /// build state.
+  Set<AssetId> _addGeneratedOutputs(
+    Iterable<AssetId> outputs,
+    int phaseNumber,
+    BuildPhases buildPhases, {
+    required AssetId primaryInput,
+    required bool isHidden,
+  }) {
+    final removed = <AssetId>{};
+    for (final output in outputs) {
+      if (isSource(output)) {
+        // An old generated source was picked up as a source file. Remove it and
+        // its outputs.
+        _removeRecursive(output, removedIds: removed);
+      } else if (isDeclaredOutput(output)) {
+        // The output was already declared by another builder.
+        final buildStep = _buildStepsByDeclaredOutput[output]!;
+        final existingPhase = buildStep.phaseNumber;
+        throw DuplicateAssetIdException(
+          output,
+          buildPhases.inBuildPhases[existingPhase].displayName,
+          buildPhases.inBuildPhases[phaseNumber].displayName,
+        );
+      }
+
+      final buildStepId = BuildStepId(
+        primaryInput: primaryInput,
+        phaseNumber: phaseNumber,
+      );
+      _buildStepsByDeclaredOutput[output] = buildStepId;
+      final buildStepResultBuilder =
+          _buildStepResults[buildStepId]?.toBuilder() ??
+          BuildStepResultBuilder();
+      buildStepResultBuilder.isHidden = isHidden;
+      _buildStepResults[buildStepId] = buildStepResultBuilder.build();
+    }
+    return removed;
+  }
+
+  // -- GeneratedAssetHider implementation.
+
+  @override
+  bool isHidden(AssetId id) {
+    if (id.path.startsWith(generatedOutputDirectory) ||
+        id.path.startsWith(cacheDirectoryPath)) {
+      return false;
+    }
+    if (!isDeclaredOutput(id)) {
+      return false;
+    }
+    final buildStepId = _buildStepsByDeclaredOutput[id];
+    if (buildStepId != null) {
+      return stepResult(buildStepId).isHidden;
+    }
+    return false;
+  }
+
+  // -- Testing.
+
+  @visibleForTesting
+  void addSourceForTest(AssetId id, {Digest? digest}) =>
+      _sources.add(id, digest: digest);
+
+  @visibleForTesting
+  void addGeneratedForTest(
+    AssetId id,
+    BuildStepId buildStepId, {
+    bool isHidden = true,
+    Digest? digest,
+  }) {
+    _buildStepsByDeclaredOutput[id] = buildStepId;
+    final existingResult = _buildStepResults[buildStepId];
+    if (existingResult == null) {
+      _buildStepResults[buildStepId] = BuildStepResult((b) {
+        b.isHidden = isHidden;
+        if (digest != null) {
+          b.outputs[id] = digest;
+        }
+      });
+    } else {
+      if (digest != null) {
+        _buildStepResults[buildStepId] = existingResult.rebuild(
+          (b) => b..outputs[id] = digest,
+        );
+      }
+    }
+  }
 }

--- a/build_runner/lib/src/build/asset_graph/serialization.dart
+++ b/build_runner/lib/src/build/asset_graph/serialization.dart
@@ -4,26 +4,21 @@
 
 part of 'graph.dart';
 
-/// Part of the serialized graph, used to ensure versioning constraints.
-///
-/// This should be incremented any time the serialize/deserialize formats
-/// change.
-
 /// Deserializes an [BuildState] from a [Map].
 ///
 /// Returns `null` if deserialization fails.
-BuildState? deserializeAssetGraph(Map serializedGraph) {
-  final graph = BuildState.empty();
+BuildState? deserializeBuildState(Map serializedBuildState) {
+  final buildState = BuildState.empty();
 
   final sourceIds =
       serializers.deserialize(
-            serializedGraph['sourceIds'],
+            serializedBuildState['sourceIds'],
             specifiedType: const FullType(BuiltSet, [FullType(AssetId)]),
           )
           as BuiltSet<AssetId>;
   final sourceDigests =
       serializers.deserialize(
-            serializedGraph['sourceDigests'],
+            serializedBuildState['sourceDigests'],
             specifiedType: const FullType(BuiltMap, [
               FullType(AssetId),
               FullType(Digest),
@@ -32,34 +27,34 @@ BuildState? deserializeAssetGraph(Map serializedGraph) {
           as BuiltMap<AssetId, Digest>;
 
   for (final id in sourceIds) {
-    graph.addSourceForTest(id, digest: sourceDigests[id]);
+    buildState._sources.add(id, digest: sourceDigests[id]);
   }
 
   final postProcessResults =
       serializers.deserialize(
-            serializedGraph['postProcessResults'],
+            serializedBuildState['postProcessResults'],
             specifiedType: postProcessBuildStepResultsFullType,
           )
           as BuiltMap<PostProcessBuildStepId, PostProcessBuildStepResult>;
 
   for (final entry in postProcessResults.entries) {
-    graph.addPostProcessBuildStepResult(entry.key, entry.value);
+    buildState.addPostProcessBuildStepResult(entry.key, entry.value);
   }
 
-  if (serializedGraph.containsKey('missingSources')) {
+  if (serializedBuildState.containsKey('missingSources')) {
     final deserialized =
         serializers.deserialize(
-              serializedGraph['missingSources'],
+              serializedBuildState['missingSources'],
               specifiedType: const FullType(BuiltSet, [FullType(AssetId)]),
             )
             as BuiltSet<AssetId>;
-    graph._sources.missingSources.addAll(deserialized.toSet());
+    buildState._sources.missingSources.addAll(deserialized.toSet());
   }
 
-  if (serializedGraph.containsKey('buildStepResults')) {
+  if (serializedBuildState.containsKey('buildStepResults')) {
     final deserialized =
         serializers.deserialize(
-              serializedGraph['buildStepResults'],
+              serializedBuildState['buildStepResults'],
               specifiedType: const FullType(BuiltMap, [
                 FullType(BuildStepId),
                 FullType(BuildStepResult),
@@ -67,14 +62,14 @@ BuildState? deserializeAssetGraph(Map serializedGraph) {
             )
             as BuiltMap<BuildStepId, BuildStepResult>;
     for (final entry in deserialized.entries) {
-      graph.updateBuildStepResult(entry.key, entry.value);
+      buildState.updateBuildStepResult(entry.key, entry.value);
     }
   }
 
-  if (serializedGraph.containsKey('globResults')) {
+  if (serializedBuildState.containsKey('globResults')) {
     final deserialized =
         serializers.deserialize(
-              serializedGraph['globResults'],
+              serializedBuildState['globResults'],
               specifiedType: const FullType(BuiltMap, [
                 FullType(GlobId),
                 FullType(GlobResult),
@@ -82,27 +77,29 @@ BuildState? deserializeAssetGraph(Map serializedGraph) {
             )
             as BuiltMap<GlobId, GlobResult>;
     for (final entry in deserialized.entries) {
-      graph.updateGlobResult(entry.key, entry.value);
+      buildState.updateGlobResult(entry.key, entry.value);
     }
   }
 
-  if (serializedGraph.containsKey('buildStepsByDeclaredOutput')) {
+  if (serializedBuildState.containsKey('buildStepsByDeclaredOutput')) {
     final deserialized =
         serializers.deserialize(
-              serializedGraph['buildStepsByDeclaredOutput'],
+              serializedBuildState['buildStepsByDeclaredOutput'],
               specifiedType: const FullType(BuiltMap, [
                 FullType(AssetId),
                 FullType(BuildStepId),
               ]),
             )
             as BuiltMap<AssetId, BuildStepId>;
-    graph._buildStepsByDeclaredOutput.addAll(deserialized.toMap());
+    buildState._buildStepsByDeclaredOutput.addAll(deserialized.toMap());
   }
 
-  if (serializedGraph.containsKey('declaredPrimaryOutputsByPrimaryInput')) {
+  if (serializedBuildState.containsKey(
+    'declaredPrimaryOutputsByPrimaryInput',
+  )) {
     final deserialized =
         serializers.deserialize(
-              serializedGraph['declaredPrimaryOutputsByPrimaryInput'],
+              serializedBuildState['declaredPrimaryOutputsByPrimaryInput'],
               specifiedType: const FullType(BuiltMap, [
                 FullType(AssetId),
                 FullType(BuiltSet, [FullType(AssetId)]),
@@ -110,23 +107,24 @@ BuildState? deserializeAssetGraph(Map serializedGraph) {
             )
             as BuiltMap<AssetId, BuiltSet<AssetId>>;
     for (final entry in deserialized.entries) {
-      graph._declaredOutputsByPrimaryInput[entry.key] = entry.value.toSet();
+      buildState._declaredOutputsByPrimaryInput[entry.key] =
+          entry.value.toSet();
     }
   }
 
-  return graph;
+  return buildState;
 }
 
 /// Serializes an [BuildState] into a [Map].
-Map<String, Object?> serializeAssetGraph(BuildState graph) {
+Map<String, Object?> serializeBuildState(BuildState buildState) {
   final result = <String, Object?>{
     'sourceIds': serializers.serialize(
-      BuiltSet<AssetId>.of(graph._sources.sources.keys),
+      BuiltSet<AssetId>.of(buildState._sources.sources.keys),
       specifiedType: const FullType(BuiltSet, [FullType(AssetId)]),
     ),
     'sourceDigests': serializers.serialize(
       BuiltMap<AssetId, Digest>.of({
-        for (final entry in graph._sources.sources.entries)
+        for (final entry in buildState._sources.sources.entries)
           if (entry.value != null) entry.key: entry.value!,
       }),
       specifiedType: const FullType(BuiltMap, [
@@ -136,30 +134,30 @@ Map<String, Object?> serializeAssetGraph(BuildState graph) {
     ),
     'postProcessResults': serializers.serialize(
       BuiltMap<PostProcessBuildStepId, PostProcessBuildStepResult>.of(
-        graph._postProcessBuildStepResults,
+        buildState._postProcessBuildStepResults,
       ),
       specifiedType: postProcessBuildStepResultsFullType,
     ),
     'missingSources': serializers.serialize(
-      BuiltSet<AssetId>.of(graph._sources.missingSources),
+      BuiltSet<AssetId>.of(buildState._sources.missingSources),
       specifiedType: const FullType(BuiltSet, [FullType(AssetId)]),
     ),
     'buildStepResults': serializers.serialize(
-      BuiltMap<BuildStepId, BuildStepResult>.of(graph._buildStepResults),
+      BuiltMap<BuildStepId, BuildStepResult>.of(buildState._buildStepResults),
       specifiedType: const FullType(BuiltMap, [
         FullType(BuildStepId),
         FullType(BuildStepResult),
       ]),
     ),
     'globResults': serializers.serialize(
-      BuiltMap<GlobId, GlobResult>.of(graph._globResults),
+      BuiltMap<GlobId, GlobResult>.of(buildState._globResults),
       specifiedType: const FullType(BuiltMap, [
         FullType(GlobId),
         FullType(GlobResult),
       ]),
     ),
     'buildStepsByDeclaredOutput': serializers.serialize(
-      BuiltMap<AssetId, BuildStepId>.of(graph._buildStepsByDeclaredOutput),
+      BuiltMap<AssetId, BuildStepId>.of(buildState._buildStepsByDeclaredOutput),
       specifiedType: const FullType(BuiltMap, [
         FullType(AssetId),
         FullType(BuildStepId),
@@ -167,7 +165,7 @@ Map<String, Object?> serializeAssetGraph(BuildState graph) {
     ),
     'declaredPrimaryOutputsByPrimaryInput': serializers.serialize(
       BuiltMap<AssetId, BuiltSet<AssetId>>.of({
-        for (final entry in graph._declaredOutputsByPrimaryInput.entries)
+        for (final entry in buildState._declaredOutputsByPrimaryInput.entries)
           entry.key: entry.value.toBuiltSet(),
       }),
       specifiedType: const FullType(BuiltMap, [

--- a/build_runner/lib/src/build/asset_graph/serialization.dart
+++ b/build_runner/lib/src/build/asset_graph/serialization.dart
@@ -9,11 +9,11 @@ part of 'graph.dart';
 /// This should be incremented any time the serialize/deserialize formats
 /// change.
 
-/// Deserializes an [AssetGraph] from a [Map].
+/// Deserializes an [BuildState] from a [Map].
 ///
 /// Returns `null` if deserialization fails.
-AssetGraph? deserializeAssetGraph(Map serializedGraph) {
-  final graph = AssetGraph();
+BuildState? deserializeAssetGraph(Map serializedGraph) {
+  final graph = BuildState.empty();
 
   final sourceIds =
       serializers.deserialize(
@@ -43,7 +43,7 @@ AssetGraph? deserializeAssetGraph(Map serializedGraph) {
           as BuiltMap<PostProcessBuildStepId, PostProcessBuildStepResult>;
 
   for (final entry in postProcessResults.entries) {
-    graph.updatePostProcessBuildStepResult(entry.key, entry.value);
+    graph.addPostProcessBuildStepResult(entry.key, entry.value);
   }
 
   if (serializedGraph.containsKey('missingSources')) {
@@ -96,7 +96,7 @@ AssetGraph? deserializeAssetGraph(Map serializedGraph) {
               ]),
             )
             as BuiltMap<AssetId, BuildStepId>;
-    graph.buildStepsByDeclaredOutput.addAll(deserialized.toMap());
+    graph._buildStepsByDeclaredOutput.addAll(deserialized.toMap());
   }
 
   if (serializedGraph.containsKey('declaredPrimaryOutputsByPrimaryInput')) {
@@ -110,15 +110,15 @@ AssetGraph? deserializeAssetGraph(Map serializedGraph) {
             )
             as BuiltMap<AssetId, BuiltSet<AssetId>>;
     for (final entry in deserialized.entries) {
-      graph.declaredOutputsByPrimaryInput[entry.key] = entry.value.toSet();
+      graph._declaredOutputsByPrimaryInput[entry.key] = entry.value.toSet();
     }
   }
 
   return graph;
 }
 
-/// Serializes an [AssetGraph] into a [Map].
-Map<String, Object?> serializeAssetGraph(AssetGraph graph) {
+/// Serializes an [BuildState] into a [Map].
+Map<String, Object?> serializeAssetGraph(BuildState graph) {
   final result = <String, Object?>{
     'sourceIds': serializers.serialize(
       BuiltSet<AssetId>.of(graph._sources.sources.keys),
@@ -136,7 +136,7 @@ Map<String, Object?> serializeAssetGraph(AssetGraph graph) {
     ),
     'postProcessResults': serializers.serialize(
       BuiltMap<PostProcessBuildStepId, PostProcessBuildStepResult>.of(
-        graph.postProcessBuildStepResults,
+        graph._postProcessBuildStepResults,
       ),
       specifiedType: postProcessBuildStepResultsFullType,
     ),
@@ -145,21 +145,21 @@ Map<String, Object?> serializeAssetGraph(AssetGraph graph) {
       specifiedType: const FullType(BuiltSet, [FullType(AssetId)]),
     ),
     'buildStepResults': serializers.serialize(
-      BuiltMap<BuildStepId, BuildStepResult>.of(graph.buildStepResults),
+      BuiltMap<BuildStepId, BuildStepResult>.of(graph._buildStepResults),
       specifiedType: const FullType(BuiltMap, [
         FullType(BuildStepId),
         FullType(BuildStepResult),
       ]),
     ),
     'globResults': serializers.serialize(
-      BuiltMap<GlobId, GlobResult>.of(graph.globResults),
+      BuiltMap<GlobId, GlobResult>.of(graph._globResults),
       specifiedType: const FullType(BuiltMap, [
         FullType(GlobId),
         FullType(GlobResult),
       ]),
     ),
     'buildStepsByDeclaredOutput': serializers.serialize(
-      BuiltMap<AssetId, BuildStepId>.of(graph.buildStepsByDeclaredOutput),
+      BuiltMap<AssetId, BuildStepId>.of(graph._buildStepsByDeclaredOutput),
       specifiedType: const FullType(BuiltMap, [
         FullType(AssetId),
         FullType(BuildStepId),
@@ -167,7 +167,7 @@ Map<String, Object?> serializeAssetGraph(AssetGraph graph) {
     ),
     'declaredPrimaryOutputsByPrimaryInput': serializers.serialize(
       BuiltMap<AssetId, BuiltSet<AssetId>>.of({
-        for (final entry in graph.declaredOutputsByPrimaryInput.entries)
+        for (final entry in graph._declaredOutputsByPrimaryInput.entries)
           entry.key: entry.value.toBuiltSet(),
       }),
       specifiedType: const FullType(BuiltMap, [

--- a/build_runner/lib/src/build/asset_graph/sources.dart
+++ b/build_runner/lib/src/build/asset_graph/sources.dart
@@ -31,10 +31,10 @@ class Sources {
     return result;
   }
 
-  /// Whether [id) is a source file.
+  /// Whether [id] is a source file.
   bool isSource(AssetId id) => sources.containsKey(id);
 
-  /// Whether [id) is a source file that has never been read.
+  /// Whether [id] is a source file that has never been read.
   bool isUnreadSource(AssetId id) =>
       sources[id] == null && sources.containsKey(id);
 

--- a/build_runner/lib/src/build/asset_graph/sources.dart
+++ b/build_runner/lib/src/build/asset_graph/sources.dart
@@ -31,19 +31,22 @@ class Sources {
     return result;
   }
 
-  /// Whether [id] is a known source on disk.
+  /// Whether [id) is a source file.
   bool isSource(AssetId id) => sources.containsKey(id);
 
-  /// Whether [id] is a known source on disk but has not been read.
+  /// Whether [id) is a source file that has never been read.
   bool isUnreadSource(AssetId id) =>
       sources[id] == null && sources.containsKey(id);
 
-  /// Whether [id] is a missing source: a builder tried to read it but it does
-  /// not exist.
-  bool isMissingSource(AssetId id) => missingSources.contains(id);
-
   /// The digest of source [id], or `null` if it has not been read.
-  Digest? getDigest(AssetId id) => sources[id];
+  ///
+  /// Throws if it is not a source.
+  Digest? digestOfSource(AssetId id) {
+    if (!sources.containsKey(id)) {
+      throw StateError('Tried to read digest of non-source $id.');
+    }
+    return sources[id];
+  }
 
   /// Updates the digest of [id] if it's a known source.
   void updateDigestIfPresent(AssetId id, Digest? digest) {
@@ -63,6 +66,19 @@ class Sources {
     sources[id] = digest;
     missingSources.remove(id);
   }
+
+  /// Adds [ids] as known sources.
+  ///
+  /// Throws a [StateError] if any ID was already known.
+  void addAll(Iterable<AssetId> ids) {
+    for (final id in ids) {
+      add(id);
+    }
+  }
+
+  /// Whether [id] is a missing source: a builder tried to read it but it does
+  /// not exist.
+  bool isMissingSource(AssetId id) => missingSources.contains(id);
 
   /// Adds [id] as a missing source.
   void addMissing(AssetId id) {
@@ -93,12 +109,12 @@ class Sources {
   /// All IDs in `package` that refer to files and match.
   ///
   /// If [glob] is passed, return only IDs for which the glob matches the path.
-  Iterable<AssetId> packageFileIds(
+  Iterable<AssetId> findFiles(
     String package,
-    Iterable<AssetId> generatedIds, {
+    Iterable<AssetId> declaredOutputs, {
     Glob? glob,
   }) {
-    _sortedFileIdsByPackage ??= _computeSortedFileIdsByPackage(generatedIds);
+    _sortedFileIdsByPackage ??= _computeSortedFileIdsByPackage(declaredOutputs);
     final list = _sortedFileIdsByPackage![package];
     if (list == null) return const [];
     if (glob == null) return list;

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -81,7 +81,7 @@ class Build {
   /// updated accordingly.
   final Set<AssetId> processedOutputs = {};
 
-  /// Glob nodes that have been processed.
+  /// Globs that have been processed.
   ///
   /// That means they have been checked to determine whether they
   /// need evaluating, and if so their state has been updated accordingly.
@@ -94,8 +94,8 @@ class Build {
 
   /// Assets that were deleted since the last build.
   ///
-  /// This is used to distinguish between `missingSource` nodes that were
-  /// already missing and `missingSource` nodes that are newly missing.
+  /// This is used to distinguish between missing sources that were
+  /// already known and missing sources that are newly known.
   final Set<AssetId> deletedAssets = {};
 
   /// Assets that might be new primary inputs since the previous build.
@@ -150,7 +150,7 @@ class Build {
       _buildOutputReader ??= BuildOutputReader(
         buildPlan: buildPlan,
         readerWriter: readerWriter,
-        assetGraph: buildState,
+        buildState: buildState,
         processedOutputs: processedOutputs,
       );
 
@@ -170,15 +170,15 @@ class Build {
         }
       }
       if (failedSteps.isNotEmpty) {
-        for (final buildStep in failedSteps) {
-          if (errorsShownSteps.contains(buildStep)) continue;
-          final phase = buildPhases.inBuildPhases[buildStep.phaseNumber];
+        for (final step in failedSteps) {
+          if (errorsShownSteps.contains(step)) continue;
+          final phase = buildPhases.inBuildPhases[step.phaseNumber];
           final logger = buildLog.loggerFor(
             phase: phase,
-            primaryInput: buildStep.primaryInput,
+            primaryInput: step.primaryInput,
             lazy: phase.isOptional,
           );
-          final stepResult = buildState.stepResult(buildStep);
+          final stepResult = buildState.stepResult(step);
           for (final error in stepResult.errors) {
             logger.severe(error);
           }
@@ -243,19 +243,19 @@ class Build {
     return result;
   }
 
-  Future<Set<AssetId>> _updateAssetGraph(Set<AssetId> updates) async {
+  Future<Set<AssetId>> _updateBuildState(Set<AssetId> updates) async {
     changedInputs.clear();
     deletedAssets.clear();
 
     // Check what actually changed for each asset in `updates`.
     readerWriter.cache.invalidate(updates);
     final resolvedUpdates = <AssetId, ChangeType>{};
-    final previousSourceNodes = <AssetId>{};
+    final previousSources = <AssetId>{};
     final newDigests = <AssetId, Digest>{};
     for (final id in updates) {
       final oldIsSource = buildState.isSource(id);
       if (oldIsSource) {
-        previousSourceNodes.add(id);
+        previousSources.add(id);
       }
       final oldExisted = buildState.isFile(id);
       final oldDigest = oldIsSource ? buildState.digestOfSource(id) : null;
@@ -293,10 +293,7 @@ class Build {
       }
     }
 
-    final deleted = await buildState.updateAndInvalidate(
-      buildPhases,
-      resolvedUpdates,
-    );
+    final deleted = buildState.updateForNextBuild(buildPhases, resolvedUpdates);
     for (final id in deleted) {
       await readerWriter.delete(id);
     }
@@ -309,7 +306,7 @@ class Build {
     for (final entry in resolvedUpdates.entries) {
       final id = entry.key;
       final changeType = entry.value;
-      if (changeType != ChangeType.ADD && previousSourceNodes.contains(id)) {
+      if (changeType != ChangeType.ADD && previousSources.contains(id)) {
         invalidatedSources.add(id);
       }
     }
@@ -323,7 +320,7 @@ class Build {
     runZonedGuarded(
       () async {
         final invalidatedSources =
-            buildPlan.cleanBuild ? null : await _updateAssetGraph(idsToCheck);
+            buildPlan.cleanBuild ? null : await _updateBuildState(idsToCheck);
         for (final id in buildState.sources) {
           if (buildState.isUnreadSource(id) &&
               buildState.declaredOutputsOf(id).isNotEmpty) {
@@ -349,10 +346,10 @@ class Build {
                   currentPhasedAssetDeps,
                 );
         await readerWriter.writeAsBytes(
-          AssetId(buildPackages.outputRoot, assetGraphPath),
+          AssetId(buildPackages.outputRoot, assetGraphJsonPath),
           AssetGraphJson.serialize(
             buildPlanDigest: buildPlan.buildPlanDigest,
-            assetGraph: buildState,
+            buildState: buildState,
             phasedAssetDeps: updatedPhasedAssetDeps,
           ),
         );
@@ -455,7 +452,7 @@ class Build {
       (Future<Iterable<AssetId>> lazyOuts) async =>
           outputs.addAll(await lazyOuts),
     );
-    // Assume success, `_assetGraph.failedOutputs` will be checked later.
+    // Assume success, failed outputs will be checked later.
     return BuildResult(
       status: BuildStatus.success,
       outputs: outputs.build(),
@@ -471,7 +468,7 @@ class Build {
     // Accumulate in a `Set` because inputs are found once per output.
     final ids = <AssetId>{};
     final phase = buildPhases[phaseNumber] as InBuildPhase;
-    final packageNode = buildPackages[package]!;
+    final buildPackage = buildPackages[package]!;
 
     for (final outputId in buildState
         .declaredOutputsForPhase(package, phaseNumber)
@@ -487,9 +484,9 @@ class Build {
       }
 
       // Don't build for inputs that aren't visible. This can happen for
-      // placeholder nodes like `test/$test$` that are added to each package,
+      // placeholders like `test/$test$` that are added to each package,
       // since the test dir is not part of the build for non-root packages.
-      if (!buildConfigs.isVisibleInBuild(outputId, packageNode)) continue;
+      if (!buildConfigs.isVisibleInBuild(outputId, buildPackage)) continue;
 
       ids.add(buildState.stepForDeclaredOutput(outputId).primaryInput);
     }
@@ -538,7 +535,7 @@ class Build {
         buildPackages: buildPackages,
         buildConfigs: buildConfigs,
         buildState: buildState,
-        nodeBuilder: _buildOutput,
+        assetBuilder: _buildOutput,
         assetIsProcessedOutput: processedOutputs.contains,
         globEvaluator: _evaluateGlob,
       ),
@@ -610,8 +607,8 @@ class Build {
       });
     }
 
-    // Update the state for all the `builderOutputs` nodes based on what was
-    // read and written.
+    // Update the state for the build step its outputs based on what was read
+    // and written.
     await TimedActivity.track.runAsync(
       () => _setOutputsState(
         buildStepId.primaryInput,
@@ -751,7 +748,7 @@ class Build {
         buildPackages: buildPackages,
         buildConfigs: buildConfigs,
         buildState: buildState,
-        nodeBuilder: _buildOutput,
+        assetBuilder: _buildOutput,
         assetIsProcessedOutput: processedOutputs.contains,
         globEvaluator: _evaluateGlob,
       ),
@@ -888,7 +885,7 @@ class Build {
         }
       }
 
-      // Propagate results for generated node inputs.
+      // Propagate results for declared output primary input.
       if (buildState.isDeclaredOutput(step.primaryInput)) {
         final inputStepResult = buildState.stepResult(
           buildState.stepForDeclaredOutput(step.primaryInput),
@@ -990,8 +987,8 @@ class Build {
     while (graphsToCheckStack.isNotEmpty) {
       final nextGraph = graphsToCheckStack.last;
 
-      // If there are multiple paths to a node, it might have been calculated
-      // for another path.
+      // If there are multiple paths to an entrypoint graph, it might have been
+      // calculated for another path.
       if (changedGraphs.containsKey(nextGraph)) {
         graphsToCheckStack.removeLast();
         continue;
@@ -1105,7 +1102,7 @@ class Build {
         return true;
       }
     } else {
-      throw StateError('Expected generated or source node: $input');
+      throw StateError('Expected declared output or source: $input');
     }
 
     return false;
@@ -1125,7 +1122,7 @@ class Build {
     }
   }
 
-  /// Builds the glob node with [globId].
+  /// Evaluates the glob for [globId].
   ///
   /// This means finding matches of the glob and building them if necessary.
   ///
@@ -1138,8 +1135,8 @@ class Build {
   /// Second, a generated file might not actually be generated: its builder
   /// might choose at runtime to output nothing. In this case, the non-existent
   /// generated file is still tracked as an input that matched the glob, but is
-  /// not useful to something that wants to read the file. On the glob node, it
-  /// ends up in `inputs` but not in `results`.
+  /// not useful to something that wants to read the file. In the glob result,
+  /// it ends up in `inputs` but not in `results`.
   ///
   ///
   Future<void> _evaluateGlob(GlobId globId) async {
@@ -1160,8 +1157,7 @@ class Build {
         glob: glob,
       )) {
         if (buildState.isDeclaredOutput(id)) {
-          // Generated nodes are only considered at all if they are output in
-          // an earlier phase.
+          // Only outputs from an earlier phase can match.
           if (buildState.stepForDeclaredOutput(id).phaseNumber <
               globId.phaseNumber) {
             generatedFileInputs.add(id);

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -1137,8 +1137,6 @@ class Build {
   /// generated file is still tracked as an input that matched the glob, but is
   /// not useful to something that wants to read the file. In the glob result,
   /// it ends up in `inputs` but not in `results`.
-  ///
-  ///
   Future<void> _evaluateGlob(GlobId globId) async {
     if (processedGlobs.contains(globId)) {
       return;
@@ -1179,7 +1177,7 @@ class Build {
         final stepResult = buildState.stepResult(
           buildState.stepForDeclaredOutput(id),
         );
-        if (buildState.isActualOutput(id) && stepResult.result == true) {
+        if (buildState.isActualOutput(id) && stepResult.succeeded) {
           generatedFileResults.add(id);
         }
       }

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -70,8 +70,8 @@ class Build {
   final ResolversImpl? resolversImpl;
 
   // State.
-  final AssetGraph assetGraph;
-  final lazyPhases = <String, Future<Iterable<AssetId>>>{};
+  final BuildState buildState;
+  final lazyPhases = <BuildStepId, Future<Iterable<AssetId>>>{};
   final lazyGlobs = <GlobId, Future<void>>{};
 
   /// Generated outputs that have been processed.
@@ -128,7 +128,7 @@ class Build {
     required this.buildPlan,
     required this.readerWriter,
     required this.resourceManager,
-    required this.assetGraph,
+    required this.buildState,
   }) : previousDepsLoader =
            buildPlan.previousPhasedAssetDeps == null
                ? null
@@ -150,7 +150,7 @@ class Build {
       _buildOutputReader ??= BuildOutputReader(
         buildPlan: buildPlan,
         readerWriter: readerWriter,
-        assetGraph: assetGraph,
+        assetGraph: buildState,
         processedOutputs: processedOutputs,
       );
 
@@ -162,23 +162,23 @@ class Build {
     if (result.status == BuildStatus.success) {
       final failedSteps = <BuildStepId>{};
       for (final output in processedOutputs) {
-        if (!assetGraph.isDeclaredOutput(output)) continue;
-        final buildStepId = assetGraph.buildStepsByDeclaredOutput[output]!;
-        final stepResult = assetGraph.buildStepResultFor(buildStepId);
-        if (stepResult != null && stepResult.result == false) {
-          failedSteps.add(buildStepId);
+        if (!buildState.isDeclaredOutput(output)) continue;
+        final step = buildState.stepForDeclaredOutput(output);
+        final stepResult = buildState.stepResult(step);
+        if (stepResult.failed) {
+          failedSteps.add(step);
         }
       }
       if (failedSteps.isNotEmpty) {
-        for (final buildStepId in failedSteps) {
-          if (errorsShownSteps.contains(buildStepId)) continue;
-          final phase = buildPhases.inBuildPhases[buildStepId.phaseNumber];
+        for (final buildStep in failedSteps) {
+          if (errorsShownSteps.contains(buildStep)) continue;
+          final phase = buildPhases.inBuildPhases[buildStep.phaseNumber];
           final logger = buildLog.loggerFor(
             phase: phase,
-            primaryInput: buildStepId.primaryInput,
+            primaryInput: buildStep.primaryInput,
             lazy: phase.isOptional,
           );
-          final stepResult = assetGraph.buildStepResultFor(buildStepId)!;
+          final stepResult = buildState.stepResult(buildStep);
           for (final error in stepResult.errors) {
             logger.severe(error);
           }
@@ -186,7 +186,7 @@ class Build {
       }
 
       final failedPostProcessSteps = <PostProcessBuildStepId>[];
-      for (final entry in assetGraph.postProcessBuildStepResults.entries) {
+      for (final entry in buildState.postProcessBuildStepResults) {
         if (entry.value.errors.isNotEmpty) {
           failedPostProcessSteps.add(entry.key);
         }
@@ -200,7 +200,7 @@ class Build {
             action.builderLabel,
             contextId: id.input,
           );
-          final stepResult = assetGraph.postProcessBuildStepResultFor(id)!;
+          final stepResult = buildState.postProcessBuildStepResultFor(id)!;
           for (final error in stepResult.errors) {
             logger.severe(error);
           }
@@ -253,12 +253,12 @@ class Build {
     final previousSourceNodes = <AssetId>{};
     final newDigests = <AssetId, Digest>{};
     for (final id in updates) {
-      final oldIsSource = assetGraph.isSource(id);
+      final oldIsSource = buildState.isSource(id);
       if (oldIsSource) {
         previousSourceNodes.add(id);
       }
-      final oldExisted = assetGraph.isKnownFile(id);
-      final oldDigest = oldIsSource ? assetGraph.sourceDigest(id) : null;
+      final oldExisted = buildState.isFile(id);
+      final oldDigest = oldIsSource ? buildState.digestOfSource(id) : null;
       var exists = false;
       Digest? newDigest;
       if (await readerWriter.canRead(id)) {
@@ -293,7 +293,7 @@ class Build {
       }
     }
 
-    final deleted = await assetGraph.updateAndInvalidate(
+    final deleted = await buildState.updateAndInvalidate(
       buildPhases,
       resolvedUpdates,
     );
@@ -302,7 +302,7 @@ class Build {
     }
     deletedAssets.addAll(deleted);
     for (final entry in newDigests.entries) {
-      assetGraph.updateSourceDigest(entry.key, entry.value);
+      buildState.updateSourceDigest(entry.key, entry.value);
     }
 
     final invalidatedSources = <AssetId>{};
@@ -324,15 +324,15 @@ class Build {
       () async {
         final invalidatedSources =
             buildPlan.cleanBuild ? null : await _updateAssetGraph(idsToCheck);
-        for (final id in assetGraph.sources) {
-          if (assetGraph.isUnreadSource(id) &&
-              assetGraph.primaryOutputsOf(id).isNotEmpty) {
+        for (final id in buildState.sources) {
+          if (buildState.isUnreadSource(id) &&
+              buildState.declaredOutputsOf(id).isNotEmpty) {
             final digest = await readerWriter.digest(id);
-            assetGraph.updateSourceDigest(id, digest);
+            buildState.updateSourceDigest(id, digest);
           }
         }
         await resolversImpl?.takeLockAndStartBuild(
-          assetGraph,
+          buildState,
           invalidatedSources: invalidatedSources,
         );
         final result = await _runPhases();
@@ -352,7 +352,7 @@ class Build {
           AssetId(buildPackages.outputRoot, assetGraphPath),
           AssetGraphJson.serialize(
             buildPlanDigest: buildPlan.buildPlanDigest,
-            assetGraph: assetGraph,
+            assetGraph: buildState,
             phasedAssetDeps: updatedPhasedAssetDeps,
           ),
         );
@@ -473,8 +473,8 @@ class Build {
     final phase = buildPhases[phaseNumber] as InBuildPhase;
     final packageNode = buildPackages[package]!;
 
-    for (final outputId in assetGraph
-        .outputsForPhase(package, phaseNumber)
+    for (final outputId in buildState
+        .declaredOutputsForPhase(package, phaseNumber)
         .toList(growable: false)) {
       if (!shouldBuildForDirs(
         outputId,
@@ -491,7 +491,7 @@ class Build {
       // since the test dir is not part of the build for non-root packages.
       if (!buildConfigs.isVisibleInBuild(outputId, packageNode)) continue;
 
-      ids.add(assetGraph.buildStepsByDeclaredOutput[outputId]!.primaryInput);
+      ids.add(buildState.stepForDeclaredOutput(outputId).primaryInput);
     }
     return ids.toList()..sort();
   }
@@ -504,19 +504,16 @@ class Build {
   /// If it is currently being built according to [lazyPhases], waits for it to
   /// be built.
   Future<void> _buildOutput(AssetId id) async {
-    if (assetGraph.isDeclaredOutput(id) && !processedOutputs.contains(id)) {
-      final buildStepId = assetGraph.buildStepsByDeclaredOutput[id]!;
-      await lazyPhases.putIfAbsent(
-        '${buildStepId.phaseNumber}|${buildStepId.primaryInput}',
-        () async {
-          final phase = buildPhases.inBuildPhases[buildStepId.phaseNumber];
-          return _buildForPrimaryInput(
-            buildStepId: buildStepId,
-            phase: phase,
-            lazy: true,
-          );
-        },
-      );
+    if (buildState.isDeclaredOutput(id) && !processedOutputs.contains(id)) {
+      final step = buildState.stepForDeclaredOutput(id);
+      await lazyPhases.putIfAbsent(step, () async {
+        final phase = buildPhases.inBuildPhases[step.phaseNumber];
+        return _buildForPrimaryInput(
+          buildStepId: step,
+          phase: phase,
+          lazy: true,
+        );
+      });
     }
   }
 
@@ -540,7 +537,7 @@ class Build {
       runningBuild: RunningBuild(
         buildPackages: buildPackages,
         buildConfigs: buildConfigs,
-        assetGraph: assetGraph,
+        buildState: buildState,
         nodeBuilder: _buildOutput,
         assetIsProcessedOutput: processedOutputs.contains,
         globEvaluator: _evaluateGlob,
@@ -722,10 +719,10 @@ class Build {
     PostBuildAction action,
   ) async {
     final outputs = <AssetId>[];
-    for (final input in assetGraph.sources.followedBy(
-      assetGraph.actualOutputs,
+    for (final input in buildState.sources.followedBy(
+      buildState.actualOutputs,
     )) {
-      if (!assetGraph.actionMatches(action, input)) continue;
+      if (!buildState.actionMatches(action, input)) continue;
       final buildStepId = PostProcessBuildStepId(
         input: input,
         actionNumber: actionNum,
@@ -753,7 +750,7 @@ class Build {
       runningBuild: RunningBuild(
         buildPackages: buildPackages,
         buildConfigs: buildConfigs,
-        assetGraph: assetGraph,
+        buildState: buildState,
         nodeBuilder: _buildOutput,
         assetIsProcessedOutput: processedOutputs.contains,
         globEvaluator: _evaluateGlob,
@@ -769,7 +766,7 @@ class Build {
     );
 
     final existingOutputs =
-        assetGraph
+        buildState
             .postProcessBuildStepResultFor(postProcessBuildStepId)
             ?.outputs ??
         const <AssetId>{};
@@ -785,10 +782,7 @@ class Build {
 
     // Clean out the impacts of the previous run.
     await _cleanUpStaleOutputs(existingOutputs);
-    assetGraph.updatePostProcessBuildStepResult(
-      postProcessBuildStepId,
-      PostProcessBuildStepResult(hidden: hideOutput),
-    );
+    buildState.removePostProcessBuildResult(postProcessBuildStepId);
 
     final logger = buildLog.loggerForOther(
       buildLog.renderId(input),
@@ -802,13 +796,13 @@ class Build {
       stepReaderWriter,
       logger,
       addAsset: (assetId) {
-        if (assetGraph.isKnownFile(assetId)) {
+        if (buildState.isFile(assetId)) {
           throw InvalidOutputException(assetId, 'Asset already exists');
         }
         outputs.add(assetId);
       },
       deleteAsset: (assetId) {
-        if (!assetGraph.isKnownFile(assetId)) {
+        if (!buildState.isFile(assetId)) {
           throw AssetNotFoundException(assetId);
         }
         if (assetId != input) {
@@ -831,7 +825,7 @@ class Build {
       errors: logger.errors,
       deletedPrimaryInput: deletedPrimaryInput,
     );
-    assetGraph.updatePostProcessBuildStepResult(
+    buildState.addPostProcessBuildStepResult(
       postProcessBuildStepId,
       stepResult,
     );
@@ -839,13 +833,9 @@ class Build {
     return assetsWritten;
   }
 
-  void _markBuildStepSkipped(
-    BuildStepId buildStepId,
-    Iterable<AssetId> outputs,
-  ) {
-    final isHidden =
-        assetGraph.buildStepResultFor(buildStepId)?.isHidden ?? true;
-    assetGraph.updateBuildStepResult(
+  void _markStepSkipped(BuildStepId buildStepId, Iterable<AssetId> outputs) {
+    final isHidden = buildState.stepResult(buildStepId).isHidden;
+    buildState.updateBuildStepResult(
       buildStepId,
       BuildStepResult((b) => b..isHidden = isHidden),
     );
@@ -855,13 +845,12 @@ class Build {
   }
 
   /// Marks the build step as failed and clears output digests.
-  Future<void> _markBuildStepFailed(
+  Future<void> _markStepFailed(
     BuildStepId buildStepId,
     Iterable<AssetId> outputs,
   ) async {
-    final isHidden =
-        assetGraph.buildStepResultFor(buildStepId)?.isHidden ?? true;
-    assetGraph.updateBuildStepResult(
+    final isHidden = buildState.stepResult(buildStepId).isHidden;
+    buildState.updateBuildStepResult(
       buildStepId,
       BuildStepResult((b) {
         b.result = false;
@@ -874,49 +863,49 @@ class Build {
   }
 
   /// Checks and returns whether any [outputs] need to be updated by
-  /// the build step [buildStepId].
+  /// the build step [step].
   ///
   /// As part of checking, builds any inputs that need building.
   Future<bool> _buildShouldRun(
-    BuildStepId buildStepId,
+    BuildStepId step,
     Iterable<AssetId> outputs,
     SingleStepReaderWriter readerWriter,
   ) async {
     return await TimedActivity.track.runAsync(() async {
       // Update state for primary input if needed.
-      if (assetGraph.isDeclaredOutput(buildStepId.primaryInput)) {
-        if (!processedOutputs.contains(buildStepId.primaryInput)) {
-          await _buildOutput(buildStepId.primaryInput);
+      if (buildState.isDeclaredOutput(step.primaryInput)) {
+        if (!processedOutputs.contains(step.primaryInput)) {
+          await _buildOutput(step.primaryInput);
         }
       }
 
       // If the primary input has been deleted, the build is skipped.
-      if (deletedAssets.contains(buildStepId.primaryInput)) {
-        if (assetGraph.isMissingSource(buildStepId.primaryInput)) {
+      if (deletedAssets.contains(step.primaryInput)) {
+        if (buildState.isMissingSource(step.primaryInput)) {
           await _cleanUpStaleOutputs(outputs);
-          _markBuildStepSkipped(buildStepId, outputs);
+          _markStepSkipped(step, outputs);
           return false;
         }
       }
 
       // Propagate results for generated node inputs.
-      if (assetGraph.isDeclaredOutput(buildStepId.primaryInput)) {
-        final inputStepResult = assetGraph.buildStepResultFor(
-          assetGraph.buildStepsByDeclaredOutput[buildStepId.primaryInput]!,
+      if (buildState.isDeclaredOutput(step.primaryInput)) {
+        final inputStepResult = buildState.stepResult(
+          buildState.stepForDeclaredOutput(step.primaryInput),
         );
 
         // If the primary input's generating step failed, this build is also
         // failed.
-        if (inputStepResult != null && inputStepResult.result == false) {
-          await _markBuildStepFailed(buildStepId, outputs);
+        if (inputStepResult.failed) {
+          await _markStepFailed(step, outputs);
           return false;
         }
 
         // If the primary input succeeded but was not output, this build is
         // skipped.
-        if (!assetGraph.isActualOutput(buildStepId.primaryInput)) {
+        if (!buildState.isActualOutput(step.primaryInput)) {
           await _cleanUpStaleOutputs(outputs);
-          _markBuildStepSkipped(buildStepId, outputs);
+          _markStepSkipped(step, outputs);
           return false;
         }
       }
@@ -925,24 +914,23 @@ class Build {
 
       if (buildPlan.triggersChanged) return true;
 
-      if (buildPlan.phaseOptionsChanged(buildStepId.phaseNumber)) {
+      if (buildPlan.phaseOptionsChanged(step.phaseNumber)) {
         return true;
       }
 
-      if (newPrimaryInputs.contains(buildStepId.primaryInput)) return true;
+      if (newPrimaryInputs.contains(step.primaryInput)) return true;
 
       for (final output in outputs) {
         if (deletedAssets.contains(output)) return true;
       }
 
-      final stepResult = assetGraph.buildStepResultFor(buildStepId);
-
-      if (stepResult == null || stepResult.result == null) return true;
+      final stepResult = buildState.stepResult(step);
+      if (!stepResult.hasRun) return true;
 
       // Check for changes to any secondary inputs.
       for (final input in stepResult.inputs) {
         final changed = await _hasInputChanged(
-          phaseNumber: buildStepId.phaseNumber,
+          phaseNumber: step.phaseNumber,
           input: input,
         );
 
@@ -959,7 +947,7 @@ class Build {
 
       for (final graphId in stepResult.resolverEntrypoints) {
         if (await _hasInputGraphChanged(
-          phaseNumber: buildStepId.phaseNumber,
+          phaseNumber: step.phaseNumber,
           entrypointId: graphId,
         )) {
           return true;
@@ -1061,8 +1049,8 @@ class Build {
     required AssetId input,
     required int phaseNumber,
   }) async {
-    if (assetGraph.isDeclaredOutput(input)) {
-      final phase = assetGraph.buildStepsByDeclaredOutput[input]!.phaseNumber;
+    if (buildState.isDeclaredOutput(input)) {
+      final phase = buildState.stepForDeclaredOutput(input).phaseNumber;
       if (phase >= phaseNumber) {
         // It's not readable in this phase.
         return false;
@@ -1074,11 +1062,11 @@ class Build {
       if (changedOutputs.contains(input)) {
         return true;
       }
-    } else if (assetGraph.isSource(input)) {
+    } else if (buildState.isSource(input)) {
       if (changedInputs.contains(input)) {
         return true;
       }
-    } else if (assetGraph.isMissingSource(input)) {
+    } else if (buildState.isMissingSource(input)) {
       // It's only a newly-deleted asset if it's also in [deletedAssets].
       if (deletedAssets.contains(input)) {
         return true;
@@ -1104,7 +1092,7 @@ class Build {
       return true;
     }
 
-    if (assetGraph.isDeclaredOutput(input)) {
+    if (buildState.isDeclaredOutput(input)) {
       // Check that the input was built, so [changedOutputs] is updated.
       if (!processedOutputs.contains(input)) {
         await _buildOutput(input);
@@ -1112,7 +1100,7 @@ class Build {
       if (changedOutputs.contains(input)) {
         return true;
       }
-    } else if (assetGraph.isSource(input)) {
+    } else if (buildState.isSource(input)) {
       if (changedInputs.contains(input)) {
         return true;
       }
@@ -1130,8 +1118,8 @@ class Build {
   /// must be generated assets.
   Future<void> _cleanUpStaleOutputs(Iterable<AssetId> outputs) async {
     for (final output in outputs) {
-      if (assetGraph.isActualOutput(output) ||
-          assetGraph.isActualPostOutput(output)) {
+      if (buildState.isActualOutput(output) ||
+          buildState.isActualPostOutput(output)) {
         await _delete(output);
       }
     }
@@ -1167,11 +1155,14 @@ class Build {
       // Other types of file that match the glob.
       final otherInputs = <AssetId>[];
 
-      for (final id in assetGraph.packageFileIds(globId.package, glob: glob)) {
-        if (assetGraph.isDeclaredOutput(id)) {
+      for (final id in buildState.findFiles(
+        package: globId.package,
+        glob: glob,
+      )) {
+        if (buildState.isDeclaredOutput(id)) {
           // Generated nodes are only considered at all if they are output in
           // an earlier phase.
-          if (assetGraph.buildStepsByDeclaredOutput[id]!.phaseNumber <
+          if (buildState.stepForDeclaredOutput(id).phaseNumber <
               globId.phaseNumber) {
             generatedFileInputs.add(id);
           }
@@ -1189,12 +1180,10 @@ class Build {
       // the glob.
       final generatedFileResults = <AssetId>[];
       for (final id in generatedFileInputs) {
-        final stepResult = assetGraph.buildStepResultFor(
-          assetGraph.buildStepsByDeclaredOutput[id]!,
+        final stepResult = buildState.stepResult(
+          buildState.stepForDeclaredOutput(id),
         );
-        if (assetGraph.isActualOutput(id) &&
-            stepResult != null &&
-            stepResult.result == true) {
+        if (buildState.isActualOutput(id) && stepResult.result == true) {
           generatedFileResults.add(id);
         }
       }
@@ -1202,7 +1191,7 @@ class Build {
       final results = [...otherInputs, ...generatedFileResults];
       final digest = md5.convert(utf8.encode(results.join(' ')));
 
-      final previousGlobResult = assetGraph.globResultFor(globId);
+      final previousGlobResult = buildState.globResultFor(globId);
       if (previousGlobResult == null || previousGlobResult.digest != digest) {
         changedGlobs.add(globId);
       }
@@ -1213,7 +1202,7 @@ class Build {
         b.inputs.addAll(generatedFileInputs.followedBy(otherInputs));
         b.digest = digest;
       });
-      assetGraph.updateGlobResult(globId, globResult);
+      buildState.updateGlobResult(globId, globResult);
 
       unawaited(lazyGlobs.remove(globId));
     });
@@ -1260,16 +1249,16 @@ class Build {
     final buildStepResult = buildStepResultBuilder.build();
 
     final buildStepId = BuildStepId(primaryInput: input, phaseNumber: phaseNum);
-    final previousBuildStepResult = assetGraph.buildStepResultFor(buildStepId);
-    final previousResult = previousBuildStepResult?.result;
-    assetGraph.updateBuildStepResult(buildStepId, buildStepResult);
+    final previousBuildStepResult = buildState.stepResult(buildStepId);
+    final previousResult = previousBuildStepResult.result;
+    buildState.updateBuildStepResult(buildStepId, buildStepResult);
 
     if (result == false) {
       errorsShownSteps.add(buildStepId);
     }
 
     for (final output in outputs) {
-      final oldDigest = previousBuildStepResult?.outputs[output];
+      final oldDigest = previousBuildStepResult.outputs[output];
       final newDigest = buildStepResult.outputs[output];
 
       // A transition from (missing or failed) to (written and not failed) is

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -29,13 +29,13 @@ import 'build_result.dart';
 /// This happens either across multiple invocations of `build_runner build` or
 /// within one long-running `build_runner watch` or `build_runner serve`.
 ///
-/// In both cases, the `AssetGraph` is serialized after the build, to give the
+/// In both cases, the `BuildState` is serialized after the build, to give the
 /// starting state for the next `build_runner build`. For `watch` and `serve`
-/// this serialized state is not actually used: the `AssetGraph` instance
+/// this serialized state is not actually used: the `BuildState` instance
 /// already in memory is used directly.
 class BuildSeries {
   BuildPlan _buildPlan;
-  BuildState _assetGraph;
+  BuildState _buildState;
   ReaderWriter _readerWriter;
 
   final ResourceManager _resourceManager = ResourceManager();
@@ -57,25 +57,25 @@ class BuildSeries {
 
   BuildSeries._({
     required BuildPlan buildPlan,
-    required BuildState assetGraph,
+    required BuildState buildState,
     required ReaderWriter readerWriter,
     required BuiltSet<AssetId>? updatesFromLoad,
   }) : _buildPlan = buildPlan,
-       _assetGraph = assetGraph,
+       _buildState = buildState,
        _readerWriter = readerWriter,
        _updatesFromLoad = updatesFromLoad;
 
   factory BuildSeries(BuildPlan buildPlan) {
-    final assetGraph = buildPlan.takeAssetGraph();
+    final buildState = buildPlan.takeBuildState();
     final readerWriter = buildPlan.readerWriter.copyWith(
       generatedAssetHider:
           buildPlan.testingOverrides.flattenOutput
               ? const NoopGeneratedAssetHider()
-              : assetGraph,
+              : buildState,
     );
     return BuildSeries._(
       buildPlan: buildPlan,
-      assetGraph: assetGraph,
+      buildState: buildState,
       readerWriter: readerWriter,
       updatesFromLoad: buildPlan.updates,
     );
@@ -123,7 +123,7 @@ class BuildSeries {
         continue;
       }
 
-      if (!_assetGraph.isFile(id)) {
+      if (!_buildState.isFile(id)) {
         // Ignore under `.dart_tool/build`.
         if (id.path.startsWith(cacheDirectoryPath)) continue;
 
@@ -142,18 +142,18 @@ class BuildSeries {
       // If not copying to a merged output directory, ignore changes to files
       // with no outputs.
       if (!_buildPlan.buildOptions.anyMergedOutputDirectory &&
-          !_assetGraph.isMissingSource(id) &&
-          _assetGraph.digestOf(id) == null) {
+          !_buildState.isMissingSource(id) &&
+          _buildState.digestOf(id) == null) {
         continue;
       }
 
       // Ignore creation or modification of outputs.
-      if (_assetGraph.isDeclaredOutput(id) &&
+      if (_buildState.isDeclaredOutput(id) &&
           change.type != ChangeType.REMOVE) {
         continue;
       }
 
-      // It's an add of "missing source" node or a deletion of an input.
+      // It's an add of a "missing source" or a deletion of an input.
       result.add(change);
     }
 
@@ -171,7 +171,7 @@ class BuildSeries {
       _buildPlan.readerWriter,
       _buildPlan.buildPackages,
       _buildPlan.buildConfigs,
-    ).collectChanges(_assetGraph);
+    ).collectChanges(_buildState);
     return List.of(
       updates.entries.map((entry) => WatchEvent(entry.value, '${entry.key}')),
     );
@@ -233,12 +233,12 @@ class BuildSeries {
         await close();
         return result;
       }
-      _assetGraph = _buildPlan.takeAssetGraph();
+      _buildState = _buildPlan.takeBuildState();
       _readerWriter = _buildPlan.readerWriter.copyWith(
         generatedAssetHider:
             _buildPlan.testingOverrides.flattenOutput
                 ? const NoopGeneratedAssetHider()
-                : _assetGraph,
+                : _buildState,
       );
     }
 
@@ -261,7 +261,7 @@ class BuildSeries {
         buildDirs: buildDirs,
         buildFilters: buildFilters,
       ),
-      buildState: _assetGraph,
+      buildState: _buildState,
       readerWriter: _readerWriter,
       resourceManager: _resourceManager,
     );

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -35,7 +35,7 @@ import 'build_result.dart';
 /// already in memory is used directly.
 class BuildSeries {
   BuildPlan _buildPlan;
-  AssetGraph _assetGraph;
+  BuildState _assetGraph;
   ReaderWriter _readerWriter;
 
   final ResourceManager _resourceManager = ResourceManager();
@@ -57,7 +57,7 @@ class BuildSeries {
 
   BuildSeries._({
     required BuildPlan buildPlan,
-    required AssetGraph assetGraph,
+    required BuildState assetGraph,
     required ReaderWriter readerWriter,
     required BuiltSet<AssetId>? updatesFromLoad,
   }) : _buildPlan = buildPlan,
@@ -123,7 +123,7 @@ class BuildSeries {
         continue;
       }
 
-      if (!_assetGraph.isKnownFile(id)) {
+      if (!_assetGraph.isFile(id)) {
         // Ignore under `.dart_tool/build`.
         if (id.path.startsWith(cacheDirectoryPath)) continue;
 
@@ -143,7 +143,7 @@ class BuildSeries {
       // with no outputs.
       if (!_buildPlan.buildOptions.anyMergedOutputDirectory &&
           !_assetGraph.isMissingSource(id) &&
-          _assetGraph.digestFor(id) == null) {
+          _assetGraph.digestOf(id) == null) {
         continue;
       }
 
@@ -261,7 +261,7 @@ class BuildSeries {
         buildDirs: buildDirs,
         buildFilters: buildFilters,
       ),
-      assetGraph: _assetGraph,
+      buildState: _assetGraph,
       readerWriter: _readerWriter,
       resourceManager: _resourceManager,
     );

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -47,7 +47,7 @@ class AnalysisDriverModel {
   ///
   /// If another build has the lock, waits for it to finish.
   Future<void> takeLockAndStartBuild(
-    AssetGraph assetGraph, {
+    BuildState assetGraph, {
     required Set<AssetId>? invalidatedSources,
   }) async {
     _lock = await _pool.request();

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -43,16 +43,16 @@ class AnalysisDriverModel {
   /// [filesystem].
   final Set<LibraryCycleGraph> _syncedLibraryCycleGraphs = Set.identity();
 
-  /// Starts a build with [assetGraph].
+  /// Starts a build with [buildState].
   ///
   /// If another build has the lock, waits for it to finish.
   Future<void> takeLockAndStartBuild(
-    BuildState assetGraph, {
+    BuildState buildState, {
     required Set<AssetId>? invalidatedSources,
   }) async {
     _lock = await _pool.request();
     filesystem.startBuild(
-      assetGraph.outputPhases,
+      buildState.declaredOutputPhases,
       invalidatedSources: invalidatedSources,
     );
   }

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -91,7 +91,7 @@ class ResolversImpl implements Resolvers {
     return BuildStepResolver(_buildResolver!, buildStep as BuildStepImpl);
   }
 
-  /// Start a build with [assetGraph].
+  /// Start a build with [buildState].
   ///
   /// If another build has the lock, waits for it to finish.
   ///
@@ -103,10 +103,10 @@ class ResolversImpl implements Resolvers {
   /// only two codepaths need to care about the lock: the main build in
   /// `build.dart` and test builds in `package:build_test` `test_builder.dart`.
   Future<void> takeLockAndStartBuild(
-    BuildState assetGraph, {
+    BuildState buildState, {
     required Set<AssetId>? invalidatedSources,
   }) => _analysisDriverModel.takeLockAndStartBuild(
-    assetGraph,
+    buildState,
     invalidatedSources: invalidatedSources,
   );
 

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -103,7 +103,7 @@ class ResolversImpl implements Resolvers {
   /// only two codepaths need to care about the lock: the main build in
   /// `build.dart` and test builds in `package:build_test` `test_builder.dart`.
   Future<void> takeLockAndStartBuild(
-    AssetGraph assetGraph, {
+    BuildState assetGraph, {
     required Set<AssetId>? invalidatedSources,
   }) => _analysisDriverModel.takeLockAndStartBuild(
     assetGraph,

--- a/build_runner/lib/src/build/single_step_reader_writer.dart
+++ b/build_runner/lib/src/build/single_step_reader_writer.dart
@@ -186,7 +186,7 @@ class SingleStepReaderWriter implements PhasedReader {
     if (buildState.isPlaceholder(id)) return false;
     if (!buildState.isFile(id)) {
       if (track) inputTracker.add(id);
-      _runningBuild.buildState.addMissingSource(id);
+      buildState.addMissingSource(id);
       return false;
     }
 
@@ -390,8 +390,7 @@ class SingleStepReaderWriter implements PhasedReader {
         }
         final stepResult = _runningBuild.buildState.stepResult(step);
         final isSuccessOutput =
-            _runningBuild.buildState.isActualOutput(id) &&
-            stepResult.result == true;
+            _runningBuild.buildState.isActualOutput(id) && stepResult.succeeded;
         return PhasedValue.generated(
           atPhase: stepPhase,
           before: '',

--- a/build_runner/lib/src/build/single_step_reader_writer.dart
+++ b/build_runner/lib/src/build/single_step_reader_writer.dart
@@ -42,8 +42,8 @@ class Readability {
 
   const Readability({required this.canRead, required this.inSamePhase});
 
-  /// Determines readability for a node written in a previous build phase, which
-  /// means that [ownOutput] is impossible.
+  /// Determines readability for an output written in a previous build phase,
+  /// which means that [ownOutput] is impossible.
   factory Readability.fromPreviousPhase(bool readable) =>
       readable ? Readability.readable : Readability.notReadable;
 
@@ -66,7 +66,7 @@ class RunningBuild {
   final BuildPackages buildPackages;
   final BuildConfigs buildConfigs;
   final BuildState buildState;
-  final AssetBuilder nodeBuilder;
+  final AssetBuilder assetBuilder;
   final AssetIsProcessedOutput assetIsProcessedOutput;
   final GlobEvaluator globEvaluator;
 
@@ -74,7 +74,7 @@ class RunningBuild {
     required this.buildPackages,
     required this.buildConfigs,
     required this.buildState,
-    required this.nodeBuilder,
+    required this.assetBuilder,
     required this.assetIsProcessedOutput,
     required this.globEvaluator,
   });
@@ -271,9 +271,9 @@ class SingleStepReaderWriter implements PhasedReader {
   /// necessary.
   ///
   /// This is called on any read or existence check. With filesystem caching
-  /// this ensures that the cached file content matches the asset graph hash.
+  /// this ensures that the cached file content matches the build state hash.
   ///
-  /// Note that [id] must exist in the asset graph.
+  /// Note that [id] must exist in the build state.
   Future<Digest> _ensureDigest(AssetId id) async {
     if (_runningBuild == null) return _delegate.digest(id);
     final knownDigest = _runningBuild.buildState.digestOf(id);
@@ -291,7 +291,7 @@ class SingleStepReaderWriter implements PhasedReader {
 
   /// Checks whether [id] can be read by this step.
   ///
-  /// If it's a generated node from an earlier phase, wait for it to be built.
+  /// If it's a declared output from an earlier phase, wait for it to be built.
   Future<Readability> _isReadableId(AssetId id) async {
     if (_runningBuild!.buildState.isActualPostOutput(id)) {
       // Post process outputs are not readable until after the build.
@@ -310,7 +310,7 @@ class SingleStepReaderWriter implements PhasedReader {
         return isInBuild ? Readability.ownOutput : Readability.notReadable;
       }
 
-      await _runningBuild.nodeBuilder(id);
+      await _runningBuild.assetBuilder(id);
       return Readability.fromPreviousPhase(
         _runningBuild.buildState.isActualSuccessfulOutput(id),
       );
@@ -321,14 +321,14 @@ class SingleStepReaderWriter implements PhasedReader {
   void _checkInvalidInput(AssetId id) {
     if (_runningBuild == null) return;
 
-    final packageNode = _runningBuild.buildPackages[id.package];
-    if (packageNode == null) {
+    final package = _runningBuild.buildPackages[id.package];
+    if (package == null) {
       throw PackageNotFoundException(id.package);
     }
 
     // The id is an invalid input if it's not part of the build.
-    if (!_runningBuild.buildConfigs.isVisibleInBuild(id, packageNode)) {
-      final allowed = _runningBuild.buildConfigs.validInputsFor(packageNode);
+    if (!_runningBuild.buildConfigs.isVisibleInBuild(id, package)) {
+      final allowed = _runningBuild.buildConfigs.validInputsFor(package);
 
       throw InvalidInputException(id, allowedGlobs: allowed);
     }
@@ -371,7 +371,7 @@ class SingleStepReaderWriter implements PhasedReader {
     }
 
     if (!_runningBuild.buildState.isFile(id)) {
-      // Add to the graph for input tracking.
+      // Add to the build state for input tracking.
       _runningBuild.buildState.addMissingSource(id);
       return PhasedValue.fixed('');
     } else if (_runningBuild.buildState.isMissingSource(id)) {
@@ -380,20 +380,20 @@ class SingleStepReaderWriter implements PhasedReader {
 
     if (_runningBuild.buildState.isDeclaredOutput(id)) {
       final step = _runningBuild.buildState.stepForDeclaredOutput(id);
-      final nodePhase = step.phaseNumber;
-      if (nodePhase >= phase) {
-        return PhasedValue.unavailable(before: '', expiresAfter: nodePhase);
+      final stepPhase = step.phaseNumber;
+      if (stepPhase >= phase) {
+        return PhasedValue.unavailable(before: '', expiresAfter: stepPhase);
       } else {
         // If needed, trigger a build at an earlier phase.
         if (!_runningBuild.assetIsProcessedOutput(id)) {
-          await _runningBuild.nodeBuilder(id);
+          await _runningBuild.assetBuilder(id);
         }
         final stepResult = _runningBuild.buildState.stepResult(step);
         final isSuccessOutput =
             _runningBuild.buildState.isActualOutput(id) &&
             stepResult.result == true;
         return PhasedValue.generated(
-          atPhase: nodePhase,
+          atPhase: stepPhase,
           before: '',
           isSuccessOutput ? await _delegate.readAsString(id) : '',
         );

--- a/build_runner/lib/src/build/single_step_reader_writer.dart
+++ b/build_runner/lib/src/build/single_step_reader_writer.dart
@@ -65,7 +65,7 @@ class Readability {
 class RunningBuild {
   final BuildPackages buildPackages;
   final BuildConfigs buildConfigs;
-  final AssetGraph assetGraph;
+  final BuildState buildState;
   final AssetBuilder nodeBuilder;
   final AssetIsProcessedOutput assetIsProcessedOutput;
   final GlobEvaluator globEvaluator;
@@ -73,7 +73,7 @@ class RunningBuild {
   RunningBuild({
     required this.buildPackages,
     required this.buildConfigs,
-    required this.assetGraph,
+    required this.buildState,
     required this.nodeBuilder,
     required this.assetIsProcessedOutput,
     required this.globEvaluator,
@@ -182,12 +182,11 @@ class SingleStepReaderWriter implements PhasedReader {
       return _delegate.canRead(id);
     }
 
-    if (_runningBuild.assetGraph.isPlaceholder(id)) {
-      return false;
-    }
-    if (!_runningBuild.assetGraph.isKnownFile(id)) {
+    final buildState = _runningBuild.buildState;
+    if (buildState.isPlaceholder(id)) return false;
+    if (!buildState.isFile(id)) {
       if (track) inputTracker.add(id);
-      _runningBuild.assetGraph.addMissingSource(id);
+      _runningBuild.buildState.addMissingSource(id);
       return false;
     }
 
@@ -213,7 +212,7 @@ class SingleStepReaderWriter implements PhasedReader {
     if (!isReadable) return false;
     if (_runningBuild == null) return true;
 
-    if (_runningBuild.assetGraph.buildStepsByDeclaredOutput.containsKey(id) &&
+    if (_runningBuild.buildState.isDeclaredOutput(id) &&
         !await _delegate.canRead(id)) {
       return false;
     }
@@ -262,7 +261,7 @@ class SingleStepReaderWriter implements PhasedReader {
 
     _evaluateGlob(glob.pattern).then((globId) {
       inputTracker.addGlob(globId);
-      final globResult = _runningBuild.assetGraph.globResultFor(globId)!;
+      final globResult = _runningBuild.buildState.globResultFor(globId)!;
       streamCompleter.setSourceStream(Stream.fromIterable(globResult.results));
     });
     return streamCompleter.stream;
@@ -277,7 +276,7 @@ class SingleStepReaderWriter implements PhasedReader {
   /// Note that [id] must exist in the asset graph.
   Future<Digest> _ensureDigest(AssetId id) async {
     if (_runningBuild == null) return _delegate.digest(id);
-    final knownDigest = _runningBuild.assetGraph.digestFor(id);
+    final knownDigest = _runningBuild.buildState.digestOf(id);
     if (knownDigest != null) return knownDigest;
 
     Digest digest;
@@ -286,7 +285,7 @@ class SingleStepReaderWriter implements PhasedReader {
     } on AssetNotFoundException {
       await ChildProcess.exitDueToAssetDeleted(id);
     }
-    _runningBuild.assetGraph.updateSourceDigest(id, digest);
+    _runningBuild.buildState.updateSourceDigest(id, digest);
     return digest;
   }
 
@@ -294,15 +293,15 @@ class SingleStepReaderWriter implements PhasedReader {
   ///
   /// If it's a generated node from an earlier phase, wait for it to be built.
   Future<Readability> _isReadableId(AssetId id) async {
-    if (_runningBuild!.assetGraph.isActualPostOutput(id)) {
+    if (_runningBuild!.buildState.isActualPostOutput(id)) {
       // Post process outputs are not readable until after the build.
       return Readability.notReadable;
     }
-    final buildStep = _runningBuild.assetGraph.buildStepsByDeclaredOutput[id];
-    if (buildStep != null) {
-      if (buildStep.phaseNumber > _runningBuildStep!.phaseNumber) {
+    if (_runningBuild.buildState.isDeclaredOutput(id)) {
+      final step = _runningBuild.buildState.stepForDeclaredOutput(id);
+      if (step.phaseNumber > _runningBuildStep!.phaseNumber) {
         return Readability.notReadable;
-      } else if (buildStep.phaseNumber == _runningBuildStep.phaseNumber) {
+      } else if (step.phaseNumber == _runningBuildStep.phaseNumber) {
         // allow a build step to read its outputs (contained in writtenAssets)
         final isInBuild =
             _runningBuildStep.buildPhase is InBuildPhase &&
@@ -312,13 +311,11 @@ class SingleStepReaderWriter implements PhasedReader {
       }
 
       await _runningBuild.nodeBuilder(id);
-      final stepResult = _runningBuild.assetGraph.buildStepResultFor(buildStep);
       return Readability.fromPreviousPhase(
-        _runningBuild.assetGraph.isActualOutput(id) &&
-            (stepResult == null || stepResult.result != false),
+        _runningBuild.buildState.isActualSuccessfulOutput(id),
       );
     }
-    return Readability.fromPreviousPhase(_runningBuild.assetGraph.isSource(id));
+    return Readability.fromPreviousPhase(_runningBuild.buildState.isSource(id));
   }
 
   void _checkInvalidInput(AssetId id) {
@@ -373,18 +370,17 @@ class SingleStepReaderWriter implements PhasedReader {
       }
     }
 
-    if (!_runningBuild.assetGraph.isKnownFile(id)) {
+    if (!_runningBuild.buildState.isFile(id)) {
       // Add to the graph for input tracking.
-      _runningBuild.assetGraph.addMissingSource(id);
+      _runningBuild.buildState.addMissingSource(id);
       return PhasedValue.fixed('');
-    } else if (_runningBuild.assetGraph.isMissingSource(id)) {
+    } else if (_runningBuild.buildState.isMissingSource(id)) {
       return PhasedValue.fixed('');
     }
 
-    if (_runningBuild.assetGraph.buildStepsByDeclaredOutput.containsKey(id)) {
-      final buildStepId =
-          _runningBuild.assetGraph.buildStepsByDeclaredOutput[id]!;
-      final nodePhase = buildStepId.phaseNumber;
+    if (_runningBuild.buildState.isDeclaredOutput(id)) {
+      final step = _runningBuild.buildState.stepForDeclaredOutput(id);
+      final nodePhase = step.phaseNumber;
       if (nodePhase >= phase) {
         return PhasedValue.unavailable(before: '', expiresAfter: nodePhase);
       } else {
@@ -392,10 +388,9 @@ class SingleStepReaderWriter implements PhasedReader {
         if (!_runningBuild.assetIsProcessedOutput(id)) {
           await _runningBuild.nodeBuilder(id);
         }
-        final stepResult =
-            _runningBuild.assetGraph.buildStepResultFor(buildStepId)!;
+        final stepResult = _runningBuild.buildState.stepResult(step);
         final isSuccessOutput =
-            _runningBuild.assetGraph.isActualOutput(id) &&
+            _runningBuild.buildState.isActualOutput(id) &&
             stepResult.result == true;
         return PhasedValue.generated(
           atPhase: nodePhase,

--- a/build_runner/lib/src/build_plan/build_packages.dart
+++ b/build_runner/lib/src/build_plan/build_packages.dart
@@ -56,7 +56,7 @@ class BuildPackages implements AssetPathProvider {
   /// workspace root.
   ///
   /// Output includes the `.dart_tool/build` folder with the build script,
-  /// compiled build script, generated output and serialized asset graph.
+  /// compiled build script, generated output and serialized build state.
   ///
   /// Also the root for output of performance logs.
   ///
@@ -65,7 +65,7 @@ class BuildPackages implements AssetPathProvider {
   /// options and package-specific overrides.
   final String outputRoot;
 
-  /// A [PackageConfig] representation of this package graph.
+  /// A [PackageConfig] representation of this `BuildPackages`.
   final PackageConfig asPackageConfig;
 
   /// Transitive dependencies by package name.

--- a/build_runner/lib/src/build_plan/build_packages_loader.dart
+++ b/build_runner/lib/src/build_plan/build_packages_loader.dart
@@ -51,7 +51,7 @@ class BuildPackagesLoader {
         p.join(workspacePath!, 'pubspec.yaml'),
       );
       workspaceName = workspacePubspec['name']! as String;
-      final workspacePackageGraph = _packageGraphForPath(workspacePath);
+      final workspacePackageGraph = _buildPackagesForPath(workspacePath);
       workspacePackages = List.from(
         workspacePackageGraph['roots'] as List<Object?>,
       );
@@ -118,7 +118,7 @@ class BuildPackagesLoader {
 /// Loads and returns `$absolutePath/.dart_tool/package_graph.json`.
 ///
 /// Throws if it does not exist.
-Map<String, Object?> _packageGraphForPath(String absolutePath) {
+Map<String, Object?> _buildPackagesForPath(String absolutePath) {
   final packageGraphPath = p.join(
     absolutePath,
     '.dart_tool',

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -46,13 +46,13 @@ class BuildPlan {
   final BuildConfigs buildConfigs;
   final BuildPhases buildPhases;
 
-  final AssetGraph? _previousAssetGraph;
+  final BuildState? _previousAssetGraph;
   bool _previousAssetGraphWasTaken;
   final PhasedAssetDeps? previousPhasedAssetDeps;
   final bool restartIsNeeded;
 
   final Bootstrapper bootstrapper;
-  final AssetGraph _assetGraph;
+  final BuildState _assetGraph;
   bool _assetGraphWasTaken;
   final BuiltSet<AssetId>? updates;
 
@@ -94,12 +94,12 @@ class BuildPlan {
     required this.readerWriter,
     required this.buildConfigs,
     required this.buildPhases,
-    required AssetGraph? previousAssetGraph,
+    required BuildState? previousAssetGraph,
     required bool previousAssetGraphWasTaken,
     required this.previousPhasedAssetDeps,
     required this.restartIsNeeded,
     required this.bootstrapper,
-    required AssetGraph assetGraph,
+    required BuildState assetGraph,
     required bool assetGraphWasTaken,
     required this.updates,
     required this.filesToDelete,
@@ -205,7 +205,7 @@ class BuildPlan {
       generatedOutputDirectory,
     );
     BuildPlanDigest? previousBuildPlanDigest;
-    AssetGraph? previousAssetGraph;
+    BuildState? previousAssetGraph;
     final filesToDelete = <AssetId>{};
     final foldersToDelete = <AssetId>{};
 
@@ -251,7 +251,7 @@ class BuildPlan {
     final inputSources = await assetTracker.findInputSources();
     final cacheDirSources = await assetTracker.findCacheDirSources();
 
-    AssetGraph? assetGraph;
+    BuildState? assetGraph;
     Set<AssetId>? updates;
     if (previousAssetGraph != null) {
       updates = {
@@ -283,10 +283,10 @@ class BuildPlan {
       inputSources.removeAll(filesToDelete);
 
       try {
-        assetGraph = await AssetGraph.build(
-          buildPhases,
-          inputSources,
-          buildPackages,
+        assetGraph = BuildState.create(
+          buildPhases: buildPhases,
+          buildPackages: buildPackages,
+          sources: inputSources,
         );
       } on DuplicateAssetNodeException catch (e) {
         buildLog.error(e.toString());
@@ -405,22 +405,22 @@ class BuildPlan {
         ),
       );
 
-  /// Takes the loaded [AssetGraph], which may be `null` if none could be
+  /// Takes the loaded [BuildState], which may be `null` if none could be
   /// loaded or if it was invalid.
   ///
-  /// Subsequent calls will throw. This is because [AssetGraph] is mutable, so
+  /// Subsequent calls will throw. This is because [BuildState] is mutable, so
   /// the initial loaded state is only available once.
-  AssetGraph? takePreviousAssetGraph() {
+  BuildState? takePreviousAssetGraph() {
     if (_previousAssetGraphWasTaken) throw StateError('Already taken.');
     _previousAssetGraphWasTaken = true;
     return _previousAssetGraph;
   }
 
-  /// Takes the [AssetGraph] for the build.
+  /// Takes the [BuildState] for the build.
   ///
-  /// Subsequent calls will throw. This is because [AssetGraph] is mutable, so
+  /// Subsequent calls will throw. This is because [BuildState] is mutable, so
   /// the initial state is only available once.
-  AssetGraph takeAssetGraph() {
+  BuildState takeAssetGraph() {
     if (_assetGraphWasTaken) throw StateError('Already taken.');
     _assetGraphWasTaken = true;
     return _assetGraph;

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -46,14 +46,14 @@ class BuildPlan {
   final BuildConfigs buildConfigs;
   final BuildPhases buildPhases;
 
-  final BuildState? _previousAssetGraph;
-  bool _previousAssetGraphWasTaken;
+  final BuildState? _previousBuildState;
+  bool _previousBuildStateWasTaken;
   final PhasedAssetDeps? previousPhasedAssetDeps;
   final bool restartIsNeeded;
 
   final Bootstrapper bootstrapper;
-  final BuildState _assetGraph;
-  bool _assetGraphWasTaken;
+  final BuildState _buildState;
+  bool _buildStateWasTaken;
   final BuiltSet<AssetId>? updates;
 
   /// Whether this is a clean build.
@@ -75,7 +75,7 @@ class BuildPlan {
   ///
   /// - Outputs from the previous build.
   /// - Files on disk that conflict with outputs of the current build.
-  /// - The asset graph, if it's invalid.
+  /// - The build state, if it's invalid.
   ///
   /// Call [deleteFilesAndFolders] to delete them.
   final BuiltList<AssetId> filesToDelete;
@@ -94,13 +94,13 @@ class BuildPlan {
     required this.readerWriter,
     required this.buildConfigs,
     required this.buildPhases,
-    required BuildState? previousAssetGraph,
-    required bool previousAssetGraphWasTaken,
+    required BuildState? previousBuildState,
+    required bool previousBuildStateWasTaken,
     required this.previousPhasedAssetDeps,
     required this.restartIsNeeded,
     required this.bootstrapper,
-    required BuildState assetGraph,
-    required bool assetGraphWasTaken,
+    required BuildState buildState,
+    required bool buildStateWasTaken,
     required this.updates,
     required this.filesToDelete,
     required this.foldersToDelete,
@@ -108,10 +108,10 @@ class BuildPlan {
     required this.triggersChanged,
     required BuiltList<bool> phaseOptionsChanged,
     required BuiltList<bool> postBuildOptionsChanged,
-  }) : _previousAssetGraph = previousAssetGraph,
-       _previousAssetGraphWasTaken = previousAssetGraphWasTaken,
-       _assetGraph = assetGraph,
-       _assetGraphWasTaken = assetGraphWasTaken,
+  }) : _previousBuildState = previousBuildState,
+       _previousBuildStateWasTaken = previousBuildStateWasTaken,
+       _buildState = buildState,
+       _buildStateWasTaken = buildStateWasTaken,
        _phaseOptionsChanged = phaseOptionsChanged,
        _postBuildOptionsChanged = postBuildOptionsChanged;
 
@@ -119,11 +119,11 @@ class BuildPlan {
   ///
   /// Loads the package strucure and build configuration; prepares
   /// [readerWriter], deduces the [buildPhases] that will run, deserializes and
-  /// checks the `AssetGraph`.
+  /// checks the `BuildState`.
   ///
-  /// If the asset graph indicates a restart is needed, [restartIsNeeded] will
-  /// be set. Otherwise, if it's valid, the deserialized asset graph is
-  /// available from [takePreviousAssetGraph].
+  /// If the build state indicates a restart is needed, [restartIsNeeded] will
+  /// be set. Otherwise, if it's valid, the deserialized build state is
+  /// available from [takePreviousBuildState].
   ///
   /// Files that should be deleted before restarting or building are accumulated
   /// in [filesToDelete] and [foldersToDelete]. Call [deleteFilesAndFolders] to
@@ -199,47 +199,50 @@ class BuildPlan {
       buildPackages: buildPackages,
     );
 
-    final assetGraphId = AssetId(buildPackages.outputRoot, assetGraphPath);
+    final assetGraphJsonId = AssetId(
+      buildPackages.outputRoot,
+      assetGraphJsonPath,
+    );
     final generatedOutputDirectoryId = AssetId(
       buildPackages.outputRoot,
       generatedOutputDirectory,
     );
     BuildPlanDigest? previousBuildPlanDigest;
-    BuildState? previousAssetGraph;
+    BuildState? previousBuildState;
     final filesToDelete = <AssetId>{};
     final foldersToDelete = <AssetId>{};
 
     PhasedAssetDeps? previousPhasedAssetDeps;
-    if (await readerWriter.canRead(assetGraphId)) {
+    if (await readerWriter.canRead(assetGraphJsonId)) {
       final assetGraphJson = AssetGraphJson.deserialize(
-        await readerWriter.readAsBytes(assetGraphId) as Uint8List,
+        await readerWriter.readAsBytes(assetGraphJsonId) as Uint8List,
       );
       if (assetGraphJson != null) {
-        previousAssetGraph = assetGraphJson.assetGraph;
+        previousBuildState = assetGraphJson.buildState;
         previousBuildPlanDigest = assetGraphJson.buildPlanDigest;
         previousPhasedAssetDeps = assetGraphJson.phasedAssetDeps;
       }
-      if (previousAssetGraph != null) {
+      if (previousBuildState != null) {
         if (restartIsNeeded ||
             !buildPlanDigest.canIncrementallyBuildFrom(
               previousBuildPlanDigest,
             )) {
           // Mark old outputs for deletion.
           filesToDelete.addAll(
-            previousAssetGraph.outputsToDelete(buildPackages),
+            previousBuildState.outputsToDelete(buildPackages),
           );
 
-          // Discard the invalid asset graph so that a new one will be created
+          // Discard the invalid build state so that a new one will be created
           // from scratch.
-          previousAssetGraph = null;
+          previousBuildState = null;
         }
       }
     }
 
-    // If there was no previous asset graph or it was invalid, start by deleting
-    // any invalid graph file and the generated output directory.
-    if (previousAssetGraph == null) {
-      filesToDelete.add(assetGraphId);
+    // If there was no previous build state or it was invalid, start by deleting
+    // any invalid asset graph json file and the generated output directory.
+    if (previousBuildState == null) {
+      filesToDelete.add(assetGraphJsonId);
       foldersToDelete.add(generatedOutputDirectoryId);
     }
 
@@ -251,49 +254,49 @@ class BuildPlan {
     final inputSources = await assetTracker.findInputSources();
     final cacheDirSources = await assetTracker.findCacheDirSources();
 
-    BuildState? assetGraph;
+    BuildState? buildState;
     Set<AssetId>? updates;
-    if (previousAssetGraph != null) {
+    if (previousBuildState != null) {
       updates = {
         ...inputSources,
         ...cacheDirSources,
-        ...previousAssetGraph.sources,
-        ...previousAssetGraph.actualOutputs,
+        ...previousBuildState.sources,
+        ...previousBuildState.actualOutputs,
       };
-      assetGraph = previousAssetGraph.copyForNextBuild();
+      buildState = previousBuildState.copyForNextBuild();
 
       if (restartIsNeeded) {
         // Mark old outputs for deletion.
-        filesToDelete.addAll(previousAssetGraph.outputsToDelete(buildPackages));
+        filesToDelete.addAll(previousBuildState.outputsToDelete(buildPackages));
         foldersToDelete.add(generatedOutputDirectoryId);
 
-        // Discard the invalid asset graph so that a new one will be created
+        // Discard the invalid AssetGraphJson so that a new one will be created
         // from scratch, and mark it for deletion so that the same will happen
         // if restarting.
-        previousAssetGraph = null;
-        filesToDelete.add(assetGraphId);
+        previousBuildState = null;
+        filesToDelete.add(assetGraphJsonId);
 
-        // Discard state tied to the invalid asset graph.
+        // Discard state tied to the invalid AssetGraphJson.
         updates = null;
       }
     }
 
-    if (assetGraph == null) {
+    if (buildState == null) {
       // Files marked for deletion are not inputs.
       inputSources.removeAll(filesToDelete);
 
       try {
-        assetGraph = BuildState.create(
+        buildState = BuildState.create(
           buildPhases: buildPhases,
           buildPackages: buildPackages,
           sources: inputSources,
         );
-      } on DuplicateAssetNodeException catch (e) {
+      } on DuplicateAssetIdException catch (e) {
         buildLog.error(e.toString());
         throw const CannotBuildException();
       }
       final conflictsInDeps =
-          assetGraph.outputs
+          buildState.declaredAndActualOutputs
               .where((n) => !buildPackages.outputPackages.contains(n.package))
               .where(inputSources.contains)
               .toSet();
@@ -308,7 +311,7 @@ class BuildPlan {
       }
 
       filesToDelete.addAll(
-        assetGraph.outputs
+        buildState.declaredAndActualOutputs
             .where((n) => buildPackages.outputPackages.contains(n.package))
             .where(inputSources.contains)
             .toSet(),
@@ -324,17 +327,17 @@ class BuildPlan {
       readerWriter: readerWriter,
       buildConfigs: buildConfigs,
       buildPhases: buildPhases,
-      previousAssetGraph: previousAssetGraph,
-      previousAssetGraphWasTaken: false,
+      previousBuildState: previousBuildState,
+      previousBuildStateWasTaken: false,
       previousPhasedAssetDeps: previousPhasedAssetDeps,
       restartIsNeeded: restartIsNeeded,
       bootstrapper: bootstrapper,
-      assetGraph: assetGraph,
-      assetGraphWasTaken: false,
+      buildState: buildState,
+      buildStateWasTaken: false,
       updates: updates?.build(),
       filesToDelete: filesToDelete.toBuiltList(),
       foldersToDelete: foldersToDelete.toBuiltList(),
-      cleanBuild: previousAssetGraph == null,
+      cleanBuild: previousBuildState == null,
       triggersChanged:
           !buildPlanDigest.hasSameTriggersAs(previousBuildPlanDigest),
       phaseOptionsChanged: buildPlanDigest.computeChangedPhaseOptions(
@@ -368,14 +371,14 @@ class BuildPlan {
     buildConfigs: buildConfigs,
     readerWriter: readerWriter ?? this.readerWriter,
     buildPhases: buildPhases,
-    previousAssetGraph: _previousAssetGraph,
-    previousAssetGraphWasTaken: _previousAssetGraphWasTaken,
+    previousBuildState: _previousBuildState,
+    previousBuildStateWasTaken: _previousBuildStateWasTaken,
     previousPhasedAssetDeps:
         previousPhasedAssetDeps ?? this.previousPhasedAssetDeps,
     restartIsNeeded: restartIsNeeded,
     bootstrapper: bootstrapper,
-    assetGraph: _assetGraph,
-    assetGraphWasTaken: _assetGraphWasTaken,
+    buildState: _buildState,
+    buildStateWasTaken: _buildStateWasTaken,
     updates: updates,
     filesToDelete: filesToDelete,
     foldersToDelete: foldersToDelete,
@@ -410,20 +413,20 @@ class BuildPlan {
   ///
   /// Subsequent calls will throw. This is because [BuildState] is mutable, so
   /// the initial loaded state is only available once.
-  BuildState? takePreviousAssetGraph() {
-    if (_previousAssetGraphWasTaken) throw StateError('Already taken.');
-    _previousAssetGraphWasTaken = true;
-    return _previousAssetGraph;
+  BuildState? takePreviousBuildState() {
+    if (_previousBuildStateWasTaken) throw StateError('Already taken.');
+    _previousBuildStateWasTaken = true;
+    return _previousBuildState;
   }
 
   /// Takes the [BuildState] for the build.
   ///
   /// Subsequent calls will throw. This is because [BuildState] is mutable, so
   /// the initial state is only available once.
-  BuildState takeAssetGraph() {
-    if (_assetGraphWasTaken) throw StateError('Already taken.');
-    _assetGraphWasTaken = true;
-    return _assetGraph;
+  BuildState takeBuildState() {
+    if (_buildStateWasTaken) throw StateError('Already taken.');
+    _buildStateWasTaken = true;
+    return _buildState;
   }
 
   /// Whether [phaseNumber] has different options to the previous build

--- a/build_runner/lib/src/commands/clean_command.dart
+++ b/build_runner/lib/src/commands/clean_command.dart
@@ -31,9 +31,9 @@ class CleanCommand implements BuildRunnerCommand {
       entrypointDir.deleteSync(recursive: true);
     }
 
-    final assetGraph = File(p.join(basePath, assetGraphPath));
-    if (assetGraph.existsSync()) {
-      assetGraph.deleteSync();
+    final assetGraphJsonFile = File(p.join(basePath, assetGraphJsonPath));
+    if (assetGraphJsonFile.existsSync()) {
+      assetGraphJsonFile.deleteSync();
     }
 
     final generatedDir = Directory(p.join(basePath, generatedOutputDirectory));

--- a/build_runner/lib/src/commands/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/commands/daemon/daemon_builder.dart
@@ -148,7 +148,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
               b.status = BuildStatus.failed;
               // TODO(grouma) - We should forward the error messages
               // instead.
-              // We can use the AssetGraph and FailureReporter to provide
+              // We can use the BuildState and FailureReporter to provide
               // a better error message.;
               b.error = 'FailureType: ${result.failureType?.exitCode}';
               b.target = target.target;

--- a/build_runner/lib/src/commands/serve_command.dart
+++ b/build_runner/lib/src/commands/serve_command.dart
@@ -91,7 +91,7 @@ class ServeCommand implements BuildRunnerCommand {
         );
       });
 
-      // TODO(davidmorgan): reuse package graph.
+      // TODO(davidmorgan): reuse build packages.
       _ensureBuildWebCompilersDependency(
         await BuildPackages.forPaths(buildOptions.buildPaths),
       );

--- a/build_runner/lib/src/commands/watch/build_packages_watcher.dart
+++ b/build_runner/lib/src/commands/watch/build_packages_watcher.dart
@@ -36,7 +36,7 @@ class BuildPackagesWatcher {
     BuildPackageWatcher Function(BuildPackage)? watch,
   }) : _strategy = watch ?? _default;
 
-  /// Returns a stream of records for assets that changed in the package graph.
+  /// Returns a stream of records for assets that changed in the build packages.
   Stream<AssetChange> watch() {
     assert(!_isWatching);
     _isWatching = true;

--- a/build_runner/lib/src/commands/watch/watcher.dart
+++ b/build_runner/lib/src/commands/watch/watcher.dart
@@ -62,7 +62,7 @@ class Watcher {
     final terminate = Future.any([until, closeController.future]);
 
     // Start watching files immediately, before the first build is even started.
-    final graphWatcher = BuildPackagesWatcher(
+    final packagesWatcher = BuildPackagesWatcher(
       _buildPlan.buildPackages,
       watch:
           (buildPackage) => BuildPackageWatcher(
@@ -70,7 +70,7 @@ class Watcher {
             watch: _buildPlan.testingOverrides.directoryWatcherFactory,
           ),
     );
-    graphWatcher
+    packagesWatcher
         .watch()
         .asyncMap<AssetChange>((change) async {
           // Delay any events until the current build is completed.
@@ -99,7 +99,7 @@ class Watcher {
         })
         .ignore();
 
-    await graphWatcher.ready;
+    await packagesWatcher.ready;
     await _buildSeries.run({}, recentlyBootstrapped: true);
   }
 

--- a/build_runner/lib/src/constants.dart
+++ b/build_runner/lib/src/constants.dart
@@ -13,8 +13,8 @@ const String cacheDirectoryPath = '.dart_tool/build';
 const entrypointDirectoryPath = '$cacheDirectoryPath/entrypoint';
 const entrypointScriptPath = '$entrypointDirectoryPath/build.dart';
 
-/// Relative path to the asset graph from the root package dir.
-final String assetGraphPath = '$cacheDirectoryPath/asset_graph.json';
+/// Relative path to the AssetGraphJson from the root package dir.
+final String assetGraphJsonPath = '$cacheDirectoryPath/asset_graph.json';
 
 /// The directory to which hidden assets will be written.
 String get generatedOutputDirectory => '$cacheDirectoryPath/generated';

--- a/build_runner/lib/src/io/asset_tracker.dart
+++ b/build_runner/lib/src/io/asset_tracker.dart
@@ -27,11 +27,11 @@ class AssetTracker {
   AssetTracker(this._readerWriter, this._buildPackages, this._buildConfigs);
 
   /// Checks for and returns any file system changes compared to the current
-  /// state of the asset graph.
-  Future<Map<AssetId, ChangeType>> collectChanges(BuildState assetGraph) async {
+  /// build state.
+  Future<Map<AssetId, ChangeType>> collectChanges(BuildState buildState) async {
     final inputSources = await findInputSources();
     final generatedSources = await findCacheDirSources();
-    return computeSourceUpdates(inputSources, generatedSources, assetGraph);
+    return computeSourceUpdates(inputSources, generatedSources, buildState);
   }
 
   /// Returns the all the sources found in the cache directory.
@@ -49,12 +49,12 @@ class AssetTracker {
   }
 
   /// Finds the asset changes which have happened while unwatched between builds
-  /// by taking a difference between the assets in the graph and the assets on
-  /// disk.
+  /// by taking a difference between the assets in the build state and the
+  /// assets on disk.
   Future<Map<AssetId, ChangeType>> computeSourceUpdates(
     Set<AssetId> inputSources,
     Set<AssetId> generatedSources,
-    BuildState assetGraph,
+    BuildState buildState,
   ) async {
     final allSources =
         <AssetId>{}
@@ -67,19 +67,21 @@ class AssetTracker {
       }
     }
 
-    final newSources = inputSources.difference(assetGraph.sources.toSet());
+    final newSources = inputSources.difference(buildState.sources.toSet());
     addUpdates(newSources, ChangeType.ADD);
     final removedAssets = [
-      for (final id in assetGraph.sources.followedBy(assetGraph.outputs))
+      for (final id in buildState.sources.followedBy(
+        buildState.declaredAndActualOutputs,
+      ))
         if (!allSources.contains(id)) id,
     ];
 
     addUpdates(removedAssets, ChangeType.REMOVE);
 
-    final originalGraphSources = assetGraph.sources.toSet();
+    final originalGraphSources = buildState.sources.toSet();
     final preExistingSources = originalGraphSources.intersection(inputSources);
     for (final id in preExistingSources) {
-      final originalDigest = assetGraph.digestOfSource(id);
+      final originalDigest = buildState.digestOfSource(id);
       if (originalDigest == null) continue;
       _readerWriter.cache.invalidate([id]);
       final currentDigest = await _readerWriter.digest(id);

--- a/build_runner/lib/src/io/asset_tracker.dart
+++ b/build_runner/lib/src/io/asset_tracker.dart
@@ -28,7 +28,7 @@ class AssetTracker {
 
   /// Checks for and returns any file system changes compared to the current
   /// state of the asset graph.
-  Future<Map<AssetId, ChangeType>> collectChanges(AssetGraph assetGraph) async {
+  Future<Map<AssetId, ChangeType>> collectChanges(BuildState assetGraph) async {
     final inputSources = await findInputSources();
     final generatedSources = await findCacheDirSources();
     return computeSourceUpdates(inputSources, generatedSources, assetGraph);
@@ -54,7 +54,7 @@ class AssetTracker {
   Future<Map<AssetId, ChangeType>> computeSourceUpdates(
     Set<AssetId> inputSources,
     Set<AssetId> generatedSources,
-    AssetGraph assetGraph,
+    BuildState assetGraph,
   ) async {
     final allSources =
         <AssetId>{}
@@ -79,7 +79,7 @@ class AssetTracker {
     final originalGraphSources = assetGraph.sources.toSet();
     final preExistingSources = originalGraphSources.intersection(inputSources);
     for (final id in preExistingSources) {
-      final originalDigest = assetGraph.sourceDigest(id);
+      final originalDigest = assetGraph.digestOfSource(id);
       if (originalDigest == null) continue;
       _readerWriter.cache.invalidate([id]);
       final currentDigest = await _readerWriter.digest(id);

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -23,7 +23,7 @@ import 'reader_writer.dart';
 /// they exist on disk from a previous build.
 class BuildOutputReader {
   final BuildPlan? _buildPlan;
-  final AssetGraph? _assetGraph;
+  final BuildState? _assetGraph;
   final Set<AssetId>? _processedOutputs;
   final ReaderWriter? _readerWriter;
 
@@ -42,7 +42,7 @@ class BuildOutputReader {
   @visibleForTesting
   BuildOutputReader.graphOnly({
     required ReaderWriter readerWriter,
-    required AssetGraph assetGraph,
+    required BuildState assetGraph,
   }) : _buildPlan = null,
        _assetGraph = assetGraph,
        _readerWriter = readerWriter,
@@ -56,7 +56,7 @@ class BuildOutputReader {
   BuildOutputReader({
     required BuildPlan buildPlan,
     required ReaderWriter readerWriter,
-    required AssetGraph assetGraph,
+    required BuildState assetGraph,
     required Set<AssetId> processedOutputs,
   }) : _readerWriter = readerWriter,
        _assetGraph = assetGraph,
@@ -67,7 +67,7 @@ class BuildOutputReader {
     final assetGraph = _assetGraph;
     if (assetGraph == null) return const {};
     final result = <AssetId>{};
-    for (final entry in assetGraph.postProcessBuildStepResults.entries) {
+    for (final entry in assetGraph.postProcessBuildStepResults) {
       if (entry.value.deletedPrimaryInput) {
         result.add(entry.key.input);
       }
@@ -80,26 +80,26 @@ class BuildOutputReader {
     if (_assetGraph == null || _readerWriter == null) {
       return UnreadableReason.notFound;
     }
-    if (!_assetGraph.isKnownFile(id)) {
+    if (!_assetGraph.isFile(id)) {
       return UnreadableReason.notFound;
     }
     if (_assetsDeletedByPostProcessBuilders.contains(id)) {
       return UnreadableReason.deleted;
     }
-    if (!_assetGraph.isKnownFile(id)) return UnreadableReason.assetType;
+    if (!_assetGraph.isFile(id)) return UnreadableReason.assetType;
 
     if (_assetGraph.isActualPostOutput(id)) {
       return null;
     }
-    final buildStep = _assetGraph.buildStepsByDeclaredOutput[id];
-    if (buildStep != null) {
+    if (_assetGraph.isDeclaredOutput(id)) {
+      final step = _assetGraph.stepForDeclaredOutput(id);
       if (_processedOutputs?.contains(id) == false) {
         // The generated output was not considered for building because its
         // transitive input(s) did not match build dirs and/or build filters.
         return UnreadableReason.notOutput;
       }
-      final stepResult = _assetGraph.buildStepResultFor(buildStep);
-      if (stepResult != null && stepResult.result == false) {
+      final stepResult = _assetGraph.stepResult(step);
+      if (stepResult.failed) {
         return UnreadableReason.failed;
       }
       if (!_assetGraph.isActualOutput(id)) return UnreadableReason.notOutput;
@@ -135,7 +135,7 @@ class BuildOutputReader {
 
   Stream<AssetId> findAssets(Glob glob, {required String package}) async* {
     if (_assetGraph == null || _readerWriter == null) return;
-    for (final id in _assetGraph.packageFileIds(package, glob: glob)) {
+    for (final id in _assetGraph.findFiles(package: package, glob: glob)) {
       if (await _readerWriter.canRead(id)) {
         yield id;
       }
@@ -147,7 +147,7 @@ class BuildOutputReader {
   ///
   /// Note that [id] must exist in the asset graph.
   FutureOr<Digest> _ensureDigest(AssetId id) {
-    final digest = _assetGraph!.digestFor(id);
+    final digest = _assetGraph!.digestOf(id);
     if (digest != null) return digest;
     return _readerWriter!.digest(id).then((digest) {
       _assetGraph.updateSourceDigest(id, digest);
@@ -165,18 +165,18 @@ class BuildOutputReader {
         result.add(id);
       }
     }
-    for (final id in assetGraph.buildStepsByDeclaredOutput.keys) {
+    for (final id in assetGraph.declaredOutputs) {
       if (!_shouldSkipId(assetGraph, id, rootDir)) {
         result.add(id);
       }
     }
-    result.addAll(assetGraph.allPostProcessOutputIds);
+    result.addAll(assetGraph.actualPostOutputs);
     return result;
   }
 
-  bool _shouldSkipId(AssetGraph assetGraph, AssetId id, String? rootDir) {
+  bool _shouldSkipId(BuildState buildState, AssetId id, String? rootDir) {
     if (_buildPlan == null) return false;
-    if (!assetGraph.isKnownFile(id)) return true;
+    if (!buildState.isFile(id)) return true;
     if (_assetsDeletedByPostProcessBuilders.contains(id)) return true;
 
     // Exclude non-lib assets if they're outside of the root directory or not
@@ -188,14 +188,13 @@ class BuildOutputReader {
       }
     }
 
-    if (assetGraph.isActualPostOutput(id)) {
+    if (buildState.isActualPostOutput(id)) {
       return false;
     }
-    final buildStep = assetGraph.buildStepsByDeclaredOutput[id];
-    if (buildStep != null) {
-      final stepResult = assetGraph.buildStepResultFor(buildStep);
-      if (!assetGraph.isActualOutput(id) ||
-          (stepResult == null || stepResult.result == false)) {
+    if (buildState.isDeclaredOutput(id)) {
+      final step = buildState.stepForDeclaredOutput(id);
+      final stepResult = buildState.stepResult(step);
+      if (!buildState.isActualOutput(id) || (stepResult.failed)) {
         return true;
       }
       return !_processedOutputs!.contains(id);

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -23,7 +23,7 @@ import 'reader_writer.dart';
 /// they exist on disk from a previous build.
 class BuildOutputReader {
   final BuildPlan? _buildPlan;
-  final BuildState? _assetGraph;
+  final BuildState? _buildState;
   final Set<AssetId>? _processedOutputs;
   final ReaderWriter? _readerWriter;
 
@@ -32,7 +32,7 @@ class BuildOutputReader {
 
   /// For an unexpected failure condition, a fully empty output.
   BuildOutputReader.empty()
-    : _assetGraph = null,
+    : _buildState = null,
       _buildPlan = null,
       _readerWriter = null,
       _processedOutputs = null;
@@ -42,9 +42,9 @@ class BuildOutputReader {
   @visibleForTesting
   BuildOutputReader.graphOnly({
     required ReaderWriter readerWriter,
-    required BuildState assetGraph,
+    required BuildState buildState,
   }) : _buildPlan = null,
-       _assetGraph = assetGraph,
+       _buildState = buildState,
        _readerWriter = readerWriter,
        _processedOutputs = null;
 
@@ -56,18 +56,18 @@ class BuildOutputReader {
   BuildOutputReader({
     required BuildPlan buildPlan,
     required ReaderWriter readerWriter,
-    required BuildState assetGraph,
+    required BuildState buildState,
     required Set<AssetId> processedOutputs,
   }) : _readerWriter = readerWriter,
-       _assetGraph = assetGraph,
+       _buildState = buildState,
        _buildPlan = buildPlan,
        _processedOutputs = processedOutputs;
 
   Set<AssetId> _collectAssetsDeletedByPostProcessBuilders() {
-    final assetGraph = _assetGraph;
-    if (assetGraph == null) return const {};
+    final buildState = _buildState;
+    if (buildState == null) return const {};
     final result = <AssetId>{};
-    for (final entry in assetGraph.postProcessBuildStepResults) {
+    for (final entry in buildState.postProcessBuildStepResults) {
       if (entry.value.deletedPrimaryInput) {
         result.add(entry.key.input);
       }
@@ -77,39 +77,39 @@ class BuildOutputReader {
 
   /// Returns a reason why [id] is not readable, or null if it is readable.
   Future<UnreadableReason?> unreadableReason(AssetId id) async {
-    if (_assetGraph == null || _readerWriter == null) {
+    if (_buildState == null || _readerWriter == null) {
       return UnreadableReason.notFound;
     }
-    if (!_assetGraph.isFile(id)) {
+    if (!_buildState.isFile(id)) {
       return UnreadableReason.notFound;
     }
     if (_assetsDeletedByPostProcessBuilders.contains(id)) {
       return UnreadableReason.deleted;
     }
-    if (!_assetGraph.isFile(id)) return UnreadableReason.assetType;
+    if (!_buildState.isFile(id)) return UnreadableReason.assetType;
 
-    if (_assetGraph.isActualPostOutput(id)) {
+    if (_buildState.isActualPostOutput(id)) {
       return null;
     }
-    if (_assetGraph.isDeclaredOutput(id)) {
-      final step = _assetGraph.stepForDeclaredOutput(id);
+    if (_buildState.isDeclaredOutput(id)) {
+      final step = _buildState.stepForDeclaredOutput(id);
       if (_processedOutputs?.contains(id) == false) {
         // The generated output was not considered for building because its
         // transitive input(s) did not match build dirs and/or build filters.
         return UnreadableReason.notOutput;
       }
-      final stepResult = _assetGraph.stepResult(step);
+      final stepResult = _buildState.stepResult(step);
       if (stepResult.failed) {
         return UnreadableReason.failed;
       }
-      if (!_assetGraph.isActualOutput(id)) return UnreadableReason.notOutput;
+      if (!_buildState.isActualOutput(id)) return UnreadableReason.notOutput;
 
       // No need to explicitly check readability for generated files, their
-      // readability is recorded in the node state.
+      // readability is recorded in the build state.
       return null;
     }
 
-    if (_assetGraph.isSource(id) && await _readerWriter.canRead(id)) {
+    if (_buildState.isSource(id) && await _readerWriter.canRead(id)) {
       return null;
     }
     return UnreadableReason.unknown;
@@ -134,8 +134,8 @@ class BuildOutputReader {
   Future<List<int>> readAsBytes(AssetId id) => _readerWriter!.readAsBytes(id);
 
   Stream<AssetId> findAssets(Glob glob, {required String package}) async* {
-    if (_assetGraph == null || _readerWriter == null) return;
-    for (final id in _assetGraph.findFiles(package: package, glob: glob)) {
+    if (_buildState == null || _readerWriter == null) return;
+    for (final id in _buildState.findFiles(package: package, glob: glob)) {
       if (await _readerWriter.canRead(id)) {
         yield id;
       }
@@ -147,30 +147,30 @@ class BuildOutputReader {
   ///
   /// Note that [id] must exist in the asset graph.
   FutureOr<Digest> _ensureDigest(AssetId id) {
-    final digest = _assetGraph!.digestOf(id);
+    final digest = _buildState!.digestOf(id);
     if (digest != null) return digest;
     return _readerWriter!.digest(id).then((digest) {
-      _assetGraph.updateSourceDigest(id, digest);
+      _buildState.updateSourceDigest(id, digest);
       return digest;
     });
   }
 
   /// A lazily computed view of all the assets available after a build.
   List<AssetId> allAssets({String? rootDir}) {
-    final assetGraph = _assetGraph;
-    if (assetGraph == null) return [];
+    final buildState = _buildState;
+    if (buildState == null) return [];
     final result = <AssetId>[];
-    for (final id in assetGraph.sources) {
-      if (!_shouldSkipId(assetGraph, id, rootDir)) {
+    for (final id in buildState.sources) {
+      if (!_shouldSkipId(buildState, id, rootDir)) {
         result.add(id);
       }
     }
-    for (final id in assetGraph.declaredOutputs) {
-      if (!_shouldSkipId(assetGraph, id, rootDir)) {
+    for (final id in buildState.declaredOutputs) {
+      if (!_shouldSkipId(buildState, id, rootDir)) {
         result.add(id);
       }
     }
-    result.addAll(assetGraph.actualPostOutputs);
+    result.addAll(buildState.actualPostOutputs);
     return result;
   }
 

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -194,7 +194,7 @@ class BuildOutputReader {
     if (buildState.isDeclaredOutput(id)) {
       final step = buildState.stepForDeclaredOutput(id);
       final stepResult = buildState.stepResult(step);
-      if (!buildState.isActualOutput(id) || (stepResult.failed)) {
+      if (!buildState.isActualOutput(id) || stepResult.failed) {
         return true;
       }
       return !_processedOutputs!.contains(id);

--- a/build_runner/test/build/asset_graph/asset_graph_json_test.dart
+++ b/build_runner/test/build/asset_graph/asset_graph_json_test.dart
@@ -13,7 +13,7 @@ void main() {
   group('AssetGraphJson', () {
     test('deserialize returns null on version mismatch', () async {
       final validBytes = AssetGraphJson.serialize(
-        assetGraph: AssetGraph(),
+        assetGraph: BuildState.empty(),
         buildPlanDigest: BuildPlanDigest.build((b) {
           b.compileDigest = '';
           b.buildTriggersDigest = '';
@@ -36,7 +36,7 @@ void main() {
 
     test('deserialize returns null on invalid json', () async {
       final validBytes = AssetGraphJson.serialize(
-        assetGraph: AssetGraph(),
+        assetGraph: BuildState.empty(),
         buildPlanDigest: BuildPlanDigest.build((b) {
           b.compileDigest = '';
           b.buildTriggersDigest = '';

--- a/build_runner/test/build/asset_graph/asset_graph_json_test.dart
+++ b/build_runner/test/build/asset_graph/asset_graph_json_test.dart
@@ -13,7 +13,7 @@ void main() {
   group('AssetGraphJson', () {
     test('deserialize returns null on version mismatch', () async {
       final validBytes = AssetGraphJson.serialize(
-        assetGraph: BuildState.empty(),
+        buildState: BuildState.empty(),
         buildPlanDigest: BuildPlanDigest.build((b) {
           b.compileDigest = '';
           b.buildTriggersDigest = '';
@@ -36,7 +36,7 @@ void main() {
 
     test('deserialize returns null on invalid json', () async {
       final validBytes = AssetGraphJson.serialize(
-        assetGraph: BuildState.empty(),
+        buildState: BuildState.empty(),
         buildPlanDigest: BuildPlanDigest.build((b) {
           b.compileDigest = '';
           b.buildTriggersDigest = '';

--- a/build_runner/test/build/asset_graph/graph_test.dart
+++ b/build_runner/test/build/asset_graph/graph_test.dart
@@ -23,15 +23,15 @@ void main() {
   });
 
   group('AssetGraph', () {
-    late AssetGraph graph;
+    late BuildState graph;
 
     void expectNodeDoesNotExist(AssetId id) {
-      expect(graph.isKnownFile(id), isFalse);
+      expect(graph.isFile(id), isFalse);
       expect(graph.isSource(id), isFalse);
     }
 
     void expectNodeExists(AssetId id) {
-      expect(graph.isKnownFile(id), isTrue);
+      expect(graph.isFile(id), isTrue);
       expect(graph.isSource(id), isTrue);
     }
 
@@ -45,39 +45,16 @@ void main() {
 
     group('simple graph', () {
       setUp(() async {
-        graph = await AssetGraph.build(
-          BuildPhases([]),
-          <AssetId>{},
-          fooPackageGraph,
+        graph = BuildState.create(
+          buildPhases: BuildPhases([]),
+          buildPackages: fooPackageGraph,
+          sources: <AssetId>{},
         );
       });
 
       test('add, contains, get, allNodes', () {
         final expectedNodes = [for (var i = 0; i < 5; i++) testAddNode(i)];
         expect(graph.sources, unorderedEquals(expectedNodes));
-      });
-
-      test('remove', () {
-        final nodes = <AssetId>[];
-        for (var i = 0; i < 5; i++) {
-          nodes.add(testAddNode(i));
-        }
-        graph
-          ..removeForTest(nodes[1])
-          ..removeForTest(nodes[4]);
-
-        expectNodeExists(nodes[0]);
-        expectNodeDoesNotExist(nodes[1]);
-        expectNodeExists(nodes[2]);
-        expectNodeDoesNotExist(nodes[4]);
-        expectNodeExists(nodes[3]);
-
-        graph
-          // Doesn't throw.
-          ..removeForTest(nodes[1])
-          // Can be added back
-          ..addSourceForTest(nodes[1]);
-        expectNodeExists(nodes[1]);
       });
     });
 
@@ -112,10 +89,11 @@ void main() {
       final syntheticOutputId = makeAssetId('foo|synthetic.txt.copy');
 
       setUp(() async {
-        graph = await AssetGraph.build(buildPhases, {
-          primaryInputId,
-          excludedInputId,
-        }, fooPackageGraph);
+        graph = BuildState.create(
+          buildPhases: buildPhases,
+          buildPackages: fooPackageGraph,
+          sources: {primaryInputId, excludedInputId},
+        );
       });
 
       test('build', () {
@@ -124,15 +102,15 @@ void main() {
           graph.sources,
           unorderedEquals([primaryInputId, excludedInputId]),
         );
-        expect(graph.primaryOutputsOf(primaryInputId), [primaryOutputId]);
+        expect(graph.declaredOutputsOf(primaryInputId), [primaryOutputId]);
 
         final buildStepId = BuildStepId(
           primaryInput: primaryInputId,
           phaseNumber: 0,
         );
-        expect(graph.buildStepResultFor(buildStepId)!.result, isNull);
+        expect(graph.stepResult(buildStepId).result, isNull);
         expect(
-          graph.buildStepsByDeclaredOutput[primaryOutputId]!.primaryInput,
+          graph.stepForDeclaredOutput(primaryOutputId).primaryInput,
           primaryInputId,
         );
       });
@@ -141,12 +119,12 @@ void main() {
         test('add new primary input', () async {
           final changes = {AssetId('foo', 'new.txt'): ChangeType.ADD};
           await graph.updateAndInvalidate(buildPhases, changes);
-          expect(graph.isKnownFile(AssetId('foo', 'new.txt.copy')), isTrue);
+          expect(graph.isFile(AssetId('foo', 'new.txt.copy')), isTrue);
         });
 
         test('modify primary input', () async {
           final changes = {primaryInputId: ChangeType.MODIFY};
-          expect(graph.isKnownFile(primaryOutputId), isTrue);
+          expect(graph.isFile(primaryOutputId), isTrue);
           final buildStepId = BuildStepId(
             primaryInput: primaryInputId,
             phaseNumber: 0,
@@ -158,8 +136,8 @@ void main() {
           });
           graph.updateBuildStepResult(buildStepId, stepResult);
           await graph.updateAndInvalidate(buildPhases, changes);
-          expect(graph.isKnownFile(primaryInputId), isTrue);
-          expect(graph.isKnownFile(primaryOutputId), isTrue);
+          expect(graph.isFile(primaryInputId), isTrue);
+          expect(graph.isFile(primaryOutputId), isTrue);
         });
 
         test('add new primary input which replaces a synthetic node', () async {
@@ -169,9 +147,9 @@ void main() {
           final changes = {syntheticId: ChangeType.ADD};
           await graph.updateAndInvalidate(buildPhases, changes);
 
-          expect(graph.isKnownFile(syntheticId), isTrue);
+          expect(graph.isFile(syntheticId), isTrue);
           expect(graph.isSource(syntheticId), isTrue);
-          expect(graph.isKnownFile(syntheticOutputId), isTrue);
+          expect(graph.isFile(syntheticOutputId), isTrue);
           expect(graph.isDeclaredOutput(syntheticOutputId), isTrue);
         });
 
@@ -184,9 +162,9 @@ void main() {
             final changes = {syntheticId: ChangeType.ADD};
             await graph.updateAndInvalidate(buildPhases, changes);
 
-            expect(graph.isKnownFile(syntheticOutputId), isTrue);
+            expect(graph.isFile(syntheticOutputId), isTrue);
             expect(graph.isDeclaredOutput(syntheticOutputId), isTrue);
-            expect(graph.isKnownFile(syntheticOutputId), isTrue);
+            expect(graph.isFile(syntheticOutputId), isTrue);
           },
         );
 
@@ -220,8 +198,8 @@ void main() {
 
       test('overlapping build phases cause an error', () async {
         expect(
-          () => AssetGraph.build(
-            BuildPhases(
+          () => BuildState.create(
+            buildPhases: BuildPhases(
               List.filled(
                 2,
                 InBuildPhase(
@@ -231,8 +209,8 @@ void main() {
                 ),
               ),
             ),
-            {makeAssetId('foo|file')},
-            fooPackageGraph,
+            buildPackages: fooPackageGraph,
+            sources: {makeAssetId('foo|file')},
           ),
           throwsA(isA<DuplicateAssetNodeException>()),
         );
@@ -251,8 +229,8 @@ void main() {
             makeAssetId('foo|lib/2.a.b.c.txt'),
           };
 
-          final graph = await AssetGraph.build(
-            BuildPhases([
+          final buildState = BuildState.create(
+            buildPhases: BuildPhases([
               InBuildPhase(
                 builder: TestBuilder(
                   buildExtensions: replaceExtension('.txt', '.a.txt'),
@@ -278,11 +256,11 @@ void main() {
                 hideOutput: false,
               ),
             ]),
-            sources,
-            fooPackageGraph,
+            buildPackages: fooPackageGraph,
+            sources: sources,
           );
           expect(
-            graph.outputs,
+            buildState.outputs,
             unorderedEquals([
               makeAssetId('foo|lib/1.a.txt'),
               makeAssetId('foo|lib/1.b.txt'),
@@ -295,7 +273,7 @@ void main() {
             ]),
           );
           expect(
-            graph.sources,
+            buildState.sources,
             unorderedEquals([
               makeAssetId('foo|lib/1.txt'),
               makeAssetId('foo|lib/2.txt'),
@@ -306,8 +284,8 @@ void main() {
         test('allows running on generated inputs that do not match target '
             'source globs', () async {
           final sources = {makeAssetId('foo|lib/1.txt')};
-          final graph = await AssetGraph.build(
-            BuildPhases([
+          final buildState = BuildState.create(
+            buildPhases: BuildPhases([
               InBuildPhase(
                 builder: TestBuilder(
                   buildExtensions: appendExtension('.1', from: '.txt'),
@@ -324,11 +302,11 @@ void main() {
                 targetSources: const InputSet(include: ['lib/*.txt']),
               ),
             ]),
-            sources,
-            fooPackageGraph,
+            buildPackages: fooPackageGraph,
+            sources: sources,
           );
           expect(
-            graph.outputs,
+            buildState.outputs,
             unorderedEquals([
               makeAssetId('foo|lib/1.txt.1'),
               makeAssetId('foo|lib/1.txt.1.2'),
@@ -360,12 +338,14 @@ void main() {
           final buildPackages = BuildPackages.singlePackageBuild('a', {
             BuildPackage.forTesting(name: 'a', isOutput: true),
           });
-          final graph = await AssetGraph.build(buildPhases, {
-            source,
-          }, buildPackages);
+          final buildState = BuildState.create(
+            buildPhases: buildPhases,
+            buildPackages: buildPackages,
+            sources: {source},
+          );
 
           // Pretend a build happened.
-          graph.addMissingSource(toBeGeneratedDart);
+          buildState.addMissingSource(toBeGeneratedDart);
           final buildStepId = BuildStepId(
             primaryInput: generatedPart,
             phaseNumber: 1,
@@ -375,17 +355,17 @@ void main() {
             b.isHidden = false;
             b.inputs.addAll([generatedPart, toBeGeneratedDart]);
           });
-          graph.updateBuildStepResult(buildStepId, stepResult);
+          buildState.updateBuildStepResult(buildStepId, stepResult);
 
-          expect(graph.isSource(source), isTrue);
+          expect(buildState.isSource(source), isTrue);
 
-          await graph.updateAndInvalidate(buildPhases, {
+          await buildState.updateAndInvalidate(buildPhases, {
             renamedSource: ChangeType.ADD,
             source: ChangeType.REMOVE,
           });
 
           // The old generated part file should be marked as missing.
-          expect(graph.isMissingSource(generatedPart), isTrue);
+          expect(buildState.isMissingSource(generatedPart), isTrue);
         });
       });
     });

--- a/build_runner/test/build/asset_graph/graph_test.dart
+++ b/build_runner/test/build/asset_graph/graph_test.dart
@@ -22,30 +22,20 @@ void main() {
     BuildPackage.forTesting(name: 'foo', isOutput: true),
   });
 
-  group('AssetGraph', () {
-    late BuildState graph;
+  group('BuildState', () {
+    late BuildState buildState;
 
-    void expectNodeDoesNotExist(AssetId id) {
-      expect(graph.isFile(id), isFalse);
-      expect(graph.isSource(id), isFalse);
-    }
-
-    void expectNodeExists(AssetId id) {
-      expect(graph.isFile(id), isTrue);
-      expect(graph.isSource(id), isTrue);
-    }
-
-    AssetId testAddNode(int number) {
+    AssetId testAddSource(int number) {
       final id = AssetId.parse('pkg|lib/a$number.dart');
-      expectNodeDoesNotExist(id);
-      graph.addSourceForTest(id);
-      expectNodeExists(id);
+      expect(buildState.isSource(id), false);
+      buildState.addSourceForTest(id);
+      expect(buildState.isSource(id), true);
       return id;
     }
 
-    group('simple graph', () {
+    group('simple build state', () {
       setUp(() async {
-        graph = BuildState.create(
+        buildState = BuildState.create(
           buildPhases: BuildPhases([]),
           buildPackages: fooPackageGraph,
           sources: <AssetId>{},
@@ -53,8 +43,8 @@ void main() {
       });
 
       test('add, contains, get, allNodes', () {
-        final expectedNodes = [for (var i = 0; i < 5; i++) testAddNode(i)];
-        expect(graph.sources, unorderedEquals(expectedNodes));
+        final expectedNodes = [for (var i = 0; i < 5; i++) testAddSource(i)];
+        expect(buildState.sources, unorderedEquals(expectedNodes));
       });
     });
 
@@ -89,7 +79,7 @@ void main() {
       final syntheticOutputId = makeAssetId('foo|synthetic.txt.copy');
 
       setUp(() async {
-        graph = BuildState.create(
+        buildState = BuildState.create(
           buildPhases: buildPhases,
           buildPackages: fooPackageGraph,
           sources: {primaryInputId, excludedInputId},
@@ -97,20 +87,23 @@ void main() {
       });
 
       test('build', () {
-        expect(graph.outputs, unorderedEquals([primaryOutputId]));
         expect(
-          graph.sources,
+          buildState.declaredAndActualOutputs,
+          unorderedEquals([primaryOutputId]),
+        );
+        expect(
+          buildState.sources,
           unorderedEquals([primaryInputId, excludedInputId]),
         );
-        expect(graph.declaredOutputsOf(primaryInputId), [primaryOutputId]);
+        expect(buildState.declaredOutputsOf(primaryInputId), [primaryOutputId]);
 
         final buildStepId = BuildStepId(
           primaryInput: primaryInputId,
           phaseNumber: 0,
         );
-        expect(graph.stepResult(buildStepId).result, isNull);
+        expect(buildState.stepResult(buildStepId).result, isNull);
         expect(
-          graph.stepForDeclaredOutput(primaryOutputId).primaryInput,
+          buildState.stepForDeclaredOutput(primaryOutputId).primaryInput,
           primaryInputId,
         );
       });
@@ -118,13 +111,13 @@ void main() {
       group('updateAndInvalidate', () {
         test('add new primary input', () async {
           final changes = {AssetId('foo', 'new.txt'): ChangeType.ADD};
-          await graph.updateAndInvalidate(buildPhases, changes);
-          expect(graph.isFile(AssetId('foo', 'new.txt.copy')), isTrue);
+          buildState.updateForNextBuild(buildPhases, changes);
+          expect(buildState.isFile(AssetId('foo', 'new.txt.copy')), isTrue);
         });
 
         test('modify primary input', () async {
           final changes = {primaryInputId: ChangeType.MODIFY};
-          expect(graph.isFile(primaryOutputId), isTrue);
+          expect(buildState.isFile(primaryOutputId), isTrue);
           final buildStepId = BuildStepId(
             primaryInput: primaryInputId,
             phaseNumber: 0,
@@ -134,37 +127,37 @@ void main() {
             b.isHidden = false;
             b.inputs.add(primaryInputId);
           });
-          graph.updateBuildStepResult(buildStepId, stepResult);
-          await graph.updateAndInvalidate(buildPhases, changes);
-          expect(graph.isFile(primaryInputId), isTrue);
-          expect(graph.isFile(primaryOutputId), isTrue);
+          buildState.updateBuildStepResult(buildStepId, stepResult);
+          buildState.updateForNextBuild(buildPhases, changes);
+          expect(buildState.isFile(primaryInputId), isTrue);
+          expect(buildState.isFile(primaryOutputId), isTrue);
         });
 
         test('add new primary input which replaces a synthetic node', () async {
-          graph.addMissingSource(syntheticId);
-          expect(graph.isMissingSource(syntheticId), isTrue);
+          buildState.addMissingSource(syntheticId);
+          expect(buildState.isMissingSource(syntheticId), isTrue);
 
           final changes = {syntheticId: ChangeType.ADD};
-          await graph.updateAndInvalidate(buildPhases, changes);
+          buildState.updateForNextBuild(buildPhases, changes);
 
-          expect(graph.isFile(syntheticId), isTrue);
-          expect(graph.isSource(syntheticId), isTrue);
-          expect(graph.isFile(syntheticOutputId), isTrue);
-          expect(graph.isDeclaredOutput(syntheticOutputId), isTrue);
+          expect(buildState.isFile(syntheticId), isTrue);
+          expect(buildState.isSource(syntheticId), isTrue);
+          expect(buildState.isFile(syntheticOutputId), isTrue);
+          expect(buildState.isDeclaredOutput(syntheticOutputId), isTrue);
         });
 
         test(
           'add new generated asset which replaces a synthetic node',
           () async {
-            graph.addMissingSource(syntheticOutputId);
-            expect(graph.isMissingSource(syntheticOutputId), isTrue);
+            buildState.addMissingSource(syntheticOutputId);
+            expect(buildState.isMissingSource(syntheticOutputId), isTrue);
 
             final changes = {syntheticId: ChangeType.ADD};
-            await graph.updateAndInvalidate(buildPhases, changes);
+            buildState.updateForNextBuild(buildPhases, changes);
 
-            expect(graph.isFile(syntheticOutputId), isTrue);
-            expect(graph.isDeclaredOutput(syntheticOutputId), isTrue);
-            expect(graph.isFile(syntheticOutputId), isTrue);
+            expect(buildState.isFile(syntheticOutputId), isTrue);
+            expect(buildState.isDeclaredOutput(syntheticOutputId), isTrue);
+            expect(buildState.isFile(syntheticOutputId), isTrue);
           },
         );
 
@@ -182,16 +175,16 @@ void main() {
               b.isHidden = false;
               b.inputs.add(secondaryId);
             });
-            graph.updateBuildStepResult(buildStepId, stepResult);
+            buildState.updateBuildStepResult(buildStepId, stepResult);
 
-            graph.addSourceForTest(secondaryId);
-            expect(graph.isSource(secondaryId), isTrue);
+            buildState.addSourceForTest(secondaryId);
+            expect(buildState.isSource(secondaryId), isTrue);
 
             final changes = {primaryInputId: ChangeType.REMOVE};
-            await graph.updateAndInvalidate(buildPhases, changes);
+            buildState.updateForNextBuild(buildPhases, changes);
 
-            expect(graph.isMissingSource(primaryInputId), isTrue);
-            expect(graph.isMissingSource(primaryOutputId), isTrue);
+            expect(buildState.isMissingSource(primaryInputId), isTrue);
+            expect(buildState.isMissingSource(primaryOutputId), isTrue);
           },
         );
       });
@@ -212,7 +205,7 @@ void main() {
             buildPackages: fooPackageGraph,
             sources: {makeAssetId('foo|file')},
           ),
-          throwsA(isA<DuplicateAssetNodeException>()),
+          throwsA(isA<DuplicateAssetIdException>()),
         );
       });
 
@@ -260,7 +253,7 @@ void main() {
             sources: sources,
           );
           expect(
-            buildState.outputs,
+            buildState.declaredAndActualOutputs,
             unorderedEquals([
               makeAssetId('foo|lib/1.a.txt'),
               makeAssetId('foo|lib/1.b.txt'),
@@ -306,7 +299,7 @@ void main() {
             sources: sources,
           );
           expect(
-            buildState.outputs,
+            buildState.declaredAndActualOutputs,
             unorderedEquals([
               makeAssetId('foo|lib/1.txt.1'),
               makeAssetId('foo|lib/1.txt.1.2'),
@@ -359,7 +352,7 @@ void main() {
 
           expect(buildState.isSource(source), isTrue);
 
-          await buildState.updateAndInvalidate(buildPhases, {
+          buildState.updateForNextBuild(buildPhases, {
             renamedSource: ChangeType.ADD,
             source: ChangeType.REMOVE,
           });

--- a/build_runner/test/build/asset_graph/sources_test.dart
+++ b/build_runner/test/build/asset_graph/sources_test.dart
@@ -18,7 +18,7 @@ void main() {
       ]) {
         sources.add(id);
       }
-      expect(sources.packageFileIds('a', [AssetId('a', 'lib/a.g.dart')]), [
+      expect(sources.findFiles('a', [AssetId('a', 'lib/a.g.dart')]), [
         AssetId('a', 'lib/a.dart'),
         AssetId('a', 'lib/a.g.dart'),
       ]);
@@ -36,20 +36,20 @@ void main() {
       ]) {
         sources.add(id);
       }
-      expect(sources.packageFileIds('a', [], glob: Glob('lib/a*.dart')), [
+      expect(sources.findFiles('a', [], glob: Glob('lib/a*.dart')), [
         AssetId('a', 'lib/aa.dart'),
         AssetId('a', 'lib/ab.dart'),
       ]);
-      expect(sources.packageFileIds('a', [], glob: Glob('lib/*a.dart')), [
+      expect(sources.findFiles('a', [], glob: Glob('lib/*a.dart')), [
         AssetId('a', 'lib/aa.dart'),
         AssetId('a', 'lib/ba.dart'),
       ]);
-      expect(sources.packageFileIds('a', [], glob: Glob('*/aa.dart')), [
+      expect(sources.findFiles('a', [], glob: Glob('*/aa.dart')), [
         AssetId('a', 'lib/aa.dart'),
       ]);
-      expect(sources.packageFileIds('a', [], glob: Glob('*')), isEmpty);
+      expect(sources.findFiles('a', [], glob: Glob('*')), isEmpty);
 
-      expect(sources.packageFileIds('a', [], glob: Glob('**')), [
+      expect(sources.findFiles('a', [], glob: Glob('**')), [
         // Matches are sorted.
         AssetId('a', 'lib/aa.dart'),
         AssetId('a', 'lib/aa/a.dart'),
@@ -58,7 +58,7 @@ void main() {
         AssetId('a', 'lib/bb.dart'),
         AssetId('a', 'lib/bb/b.dart'),
       ]);
-      expect(sources.packageFileIds('a', [], glob: Glob('**/a.dart')), [
+      expect(sources.findFiles('a', [], glob: Glob('**/a.dart')), [
         AssetId('a', 'lib/aa/a.dart'),
       ]);
     });

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -501,19 +501,19 @@ targets:
           outputs: {'a|web/a.txt.copy': 'a', 'a|web/a.txt.copy.clone': 'a'},
         );
 
-        final graphId = makeAssetId('a|$assetGraphPath');
-        expect(result.readerWriter.testing.exists(graphId), isTrue);
-        final cachedGraph =
+        final assetGraphJsonId = makeAssetId('a|$assetGraphJsonPath');
+        expect(result.readerWriter.testing.exists(assetGraphJsonId), isTrue);
+        final cachedBuildState =
             AssetGraphJson.deserialize(
-              result.readerWriter.testing.readBytes(graphId),
-            )!.assetGraph;
+              result.readerWriter.testing.readBytes(assetGraphJsonId),
+            )!.buildState;
         expect(
-          cachedGraph.sources,
+          cachedBuildState.sources,
           unorderedEquals([makeAssetId('a|web/a.txt')]),
         );
-        expect(cachedGraph.sources, [makeAssetId('a|web/a.txt')]);
+        expect(cachedBuildState.sources, [makeAssetId('a|web/a.txt')]);
         expect(
-          cachedGraph.outputs,
+          cachedBuildState.declaredAndActualOutputs,
           unorderedEquals([
             makeAssetId('a|web/a.txt.copy'),
             makeAssetId('a|web/a.txt.copy.clone'),
@@ -1133,39 +1133,36 @@ targets:
     });
   });
 
-  test(
-    "builders reading their output don't cause self-referential nodes",
-    () async {
-      final result = await testBuilders(
-        [
-          TestBuilder(
-            build: (step, _) async {
-              final output = step.inputId.addExtension('.out');
-              await step.writeAsString(output, 'a');
-              await step.readAsString(output);
-            },
-            buildExtensions: appendExtension('.out', from: '.txt'),
-          ),
-        ],
-        {'a|lib/a.txt': 'a'},
-        outputs: {'a|lib/a.txt.out': 'a'},
-      );
+  test("builders reading their output don't cause self reference", () async {
+    final result = await testBuilders(
+      [
+        TestBuilder(
+          build: (step, _) async {
+            final output = step.inputId.addExtension('.out');
+            await step.writeAsString(output, 'a');
+            await step.readAsString(output);
+          },
+          buildExtensions: appendExtension('.out', from: '.txt'),
+        ),
+      ],
+      {'a|lib/a.txt': 'a'},
+      outputs: {'a|lib/a.txt.out': 'a'},
+    );
 
-      final graphId = makeAssetId('a|$assetGraphPath');
-      final cachedGraph =
-          AssetGraphJson.deserialize(
-            result.readerWriter.testing.readBytes(graphId),
-          )!.assetGraph;
-      final outputId = AssetId('a', 'lib/a.txt.out');
+    final graphId = makeAssetId('a|$assetGraphJsonPath');
+    final cachedBuildState =
+        AssetGraphJson.deserialize(
+          result.readerWriter.testing.readBytes(graphId),
+        )!.buildState;
+    final outputId = AssetId('a', 'lib/a.txt.out');
 
-      final buildStepId = BuildStepId(
-        primaryInput: makeAssetId('a|lib/a.txt'),
-        phaseNumber: 0,
-      );
-      final stepResult = cachedGraph.stepResult(buildStepId);
-      expect(stepResult.inputs, isNot(contains(outputId)));
-    },
-  );
+    final buildStepId = BuildStepId(
+      primaryInput: makeAssetId('a|lib/a.txt'),
+      phaseNumber: 0,
+    );
+    final stepResult = cachedBuildState.stepResult(buildStepId);
+    expect(stepResult.inputs, isNot(contains(outputId)));
+  });
 
   test(
     'outputs from previous full builds shouldn\'t be inputs to later ones',
@@ -1181,7 +1178,7 @@ targets:
         inputs,
         outputs: outputs,
       );
-      // Second run, only output should be the asset graph.
+      // Second run, only output should be the asset graph JSON.
       for (final id in result.readerWriter.testing.assets) {
         inputs[id.toString()] = await result.readerWriter.readAsString(id);
       }
@@ -1207,7 +1204,7 @@ targets:
     );
 
     // Delete the `asset_graph.json` file!
-    final outputId = makeAssetId('a|$assetGraphPath');
+    final outputId = makeAssetId('a|$assetGraphJsonPath');
     await (result.readerWriter as ReaderWriter).delete(outputId);
 
     // Second run, should have no extra outputs.
@@ -1219,7 +1216,7 @@ targets:
     );
   });
 
-  group('incremental builds with cached graph', () {
+  group('incremental builds with cached build state', () {
     group('reportUnusedAssets', () {
       test('removes input dependencies', () async {
         final builderFactories = BuilderFactories({
@@ -1385,21 +1382,21 @@ targets:
             resumeFrom: result,
           );
 
-          final graph =
+          final buildState =
               AssetGraphJson.deserialize(
                 result.readerWriter.testing.readBytes(
-                  makeAssetId('a|$assetGraphPath'),
+                  makeAssetId('a|$assetGraphJsonPath'),
                 ),
-              )!.assetGraph;
+              )!.buildState;
           expect(
-            graph.isMissingSource(makeAssetId('a|lib/a.txt.copy')),
+            buildState.isMissingSource(makeAssetId('a|lib/a.txt.copy')),
             isTrue,
           );
         },
       );
     });
 
-    test('graph/file system get cleaned up for deleted inputs', () async {
+    test('build state/file system get cleaned up for deleted inputs', () async {
       final builderFactories = BuilderFactories({
         '': [(_) => TestBuilder()],
         'b2': [
@@ -1423,7 +1420,7 @@ targets:
         outputs: {'a|lib/a.txt.copy': 'a', 'a|lib/a.txt.clone': 'a'},
       );
 
-      // Followup build with deleted input + cached graph.
+      // Followup build with deleted input + cached build state.
       result.readerWriter.testing.delete(AssetId('a', 'lib/a.txt'));
       await testPhases(
         builderFactories,
@@ -1434,21 +1431,21 @@ targets:
       );
 
       /// Should be deleted using the writer, and converted to missingSource.
-      final newGraph =
+      final newBuildState =
           AssetGraphJson.deserialize(
             result.readerWriter.testing.readBytes(
-              makeAssetId('a|$assetGraphPath'),
+              makeAssetId('a|$assetGraphJsonPath'),
             ),
-          )!.assetGraph;
-      final aNodeId = makeAssetId('a|lib/a.txt');
-      final aCopyNodeId = makeAssetId('a|lib/a.txt.copy');
-      final aCloneNodeId = makeAssetId('a|lib/a.txt.copy.clone');
-      expect(newGraph.isMissingSource(aNodeId), isTrue);
-      expect(newGraph.isMissingSource(aCopyNodeId), isTrue);
-      expect(newGraph.isFile(aCloneNodeId), isFalse);
-      expect(result.readerWriter.testing.exists(aNodeId), isFalse);
-      expect(result.readerWriter.testing.exists(aCopyNodeId), isFalse);
-      expect(result.readerWriter.testing.exists(aCloneNodeId), isFalse);
+          )!.buildState;
+      final anId = makeAssetId('a|lib/a.txt');
+      final aCopyId = makeAssetId('a|lib/a.txt.copy');
+      final aCloneId = makeAssetId('a|lib/a.txt.copy.clone');
+      expect(newBuildState.isMissingSource(anId), isTrue);
+      expect(newBuildState.isMissingSource(aCopyId), isTrue);
+      expect(newBuildState.isFile(aCloneId), isFalse);
+      expect(result.readerWriter.testing.exists(anId), isFalse);
+      expect(result.readerWriter.testing.exists(aCopyId), isFalse);
+      expect(result.readerWriter.testing.exists(aCloneId), isFalse);
     });
 
     test('no outputs if no changed sources', () async {
@@ -1461,7 +1458,7 @@ targets:
         outputs: {'a|web/a.txt.copy': 'a'},
       );
 
-      // Followup build with same sources + cached graph.
+      // Followup build with same sources + cached build state.
       await testPhases(
         builderFactories,
         builderDefinitions,
@@ -1490,7 +1487,7 @@ targets:
         outputs: {r'$$a|web/a.txt.copy': 'a'},
       );
 
-      // Followup build with same sources + cached graph.
+      // Followup build with same sources + cached build state.
       await testPhases(
         builderFactories,
         builderDefinitions,
@@ -1517,8 +1514,8 @@ targets:
         outputs: {'a|lib/file.a.copy': 'b'},
       );
 
-      // Followup build with same sources + cached graph, but configure the
-      // builder to read a different file.
+      // Followup build with same sources + cached build state, but configure
+      // the builder to read a different file.
       await testPhases(
         BuilderFactories({
           '': [
@@ -1541,22 +1538,22 @@ targets:
         resumeFrom: result,
       );
 
-      // Read cached graph and validate.
-      final graph =
+      // Read cached build state and validate.
+      final buildState =
           AssetGraphJson.deserialize(
             result.readerWriter.testing.readBytes(
-              makeAssetId('a|$assetGraphPath'),
+              makeAssetId('a|$assetGraphJsonPath'),
             ),
-          )!.assetGraph;
+          )!.buildState;
       final fileAId = makeAssetId('a|lib/file.a');
       final fileCId = makeAssetId('a|lib/file.c');
-      expect(graph.isSource(fileAId), isTrue);
-      expect(graph.isSource(fileCId), isTrue);
+      expect(buildState.isSource(fileAId), isTrue);
+      expect(buildState.isSource(fileCId), isTrue);
       final buildStepId = BuildStepId(
         primaryInput: makeAssetId('a|lib/file.a'),
         phaseNumber: 0,
       );
-      final stepResult = graph.stepResult(buildStepId);
+      final stepResult = buildState.stepResult(buildStepId);
       expect(stepResult.inputs, unorderedEquals([fileAId, fileCId]));
     });
 
@@ -1617,8 +1614,8 @@ targets:
         outputs: {'a|web/a.txt.new': 'sibling'},
       );
 
-      // Followup build with cached graph and a changed primary input, but the
-      // actual file that was read has not changed.
+      // Followup build with cached build state and a changed primary input, but
+      // the actual file that was read has not changed.
       result = await testPhases(
         builderFactories,
         builderDefinitions,
@@ -1770,8 +1767,8 @@ targets:
         resumeFrom: result,
       );
 
-      // Make sure if we mark the original node as a failure again, that we
-      // also mark all its primary outputs as failures.
+      // Make sure if we mark the original step as a failure again, that we
+      // also mark all its primary output steps as failures.
       await testPhases(
         builderFactories,
         builderDefinitions,
@@ -1781,40 +1778,42 @@ targets:
         resumeFrom: result,
       );
 
-      final finalGraph =
+      final finalBuildState =
           AssetGraphJson.deserialize(
-            result.readerWriter.testing.readBytes(AssetId('a', assetGraphPath)),
-          )!.assetGraph;
+            result.readerWriter.testing.readBytes(
+              AssetId('a', assetGraphJsonPath),
+            ),
+          )!.buildState;
 
       expect(
-        finalGraph
+        finalBuildState
             .stepResult(
-              finalGraph.stepForDeclaredOutput(AssetId('a', 'web/a.g1')),
+              finalBuildState.stepForDeclaredOutput(AssetId('a', 'web/a.g1')),
             )
             .result,
         isFalse,
       );
 
       expect(
-        finalGraph
+        finalBuildState
             .stepResult(
-              finalGraph.stepForDeclaredOutput(AssetId('a', 'web/a.g2')),
+              finalBuildState.stepForDeclaredOutput(AssetId('a', 'web/a.g2')),
             )
             .result,
         isFalse,
       );
 
       expect(
-        finalGraph
+        finalBuildState
             .stepResult(
-              finalGraph.stepForDeclaredOutput(AssetId('a', 'web/a.g3')),
+              finalBuildState.stepForDeclaredOutput(AssetId('a', 'web/a.g3')),
             )
             .result,
         isFalse,
       );
     });
 
-    test('a glob should not be an output of an anchor node', () async {
+    test('a glob should not match a post process output', () async {
       // https://github.com/dart-lang/build/issues/2017
       final builderFactories = BuilderFactories(
         {

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -1162,7 +1162,7 @@ targets:
         primaryInput: makeAssetId('a|lib/a.txt'),
         phaseNumber: 0,
       );
-      final stepResult = cachedGraph.buildStepResultFor(buildStepId)!;
+      final stepResult = cachedGraph.stepResult(buildStepId);
       expect(stepResult.inputs, isNot(contains(outputId)));
     },
   );
@@ -1445,7 +1445,7 @@ targets:
       final aCloneNodeId = makeAssetId('a|lib/a.txt.copy.clone');
       expect(newGraph.isMissingSource(aNodeId), isTrue);
       expect(newGraph.isMissingSource(aCopyNodeId), isTrue);
-      expect(newGraph.isKnownFile(aCloneNodeId), isFalse);
+      expect(newGraph.isFile(aCloneNodeId), isFalse);
       expect(result.readerWriter.testing.exists(aNodeId), isFalse);
       expect(result.readerWriter.testing.exists(aCopyNodeId), isFalse);
       expect(result.readerWriter.testing.exists(aCloneNodeId), isFalse);
@@ -1556,7 +1556,7 @@ targets:
         primaryInput: makeAssetId('a|lib/file.a'),
         phaseNumber: 0,
       );
-      final stepResult = graph.buildStepResultFor(buildStepId)!;
+      final stepResult = graph.stepResult(buildStepId);
       expect(stepResult.inputs, unorderedEquals([fileAId, fileCId]));
     });
 
@@ -1788,27 +1788,27 @@ targets:
 
       expect(
         finalGraph
-            .buildStepResultFor(
-              finalGraph.buildStepsByDeclaredOutput[AssetId('a', 'web/a.g1')]!,
-            )!
+            .stepResult(
+              finalGraph.stepForDeclaredOutput(AssetId('a', 'web/a.g1')),
+            )
             .result,
         isFalse,
       );
 
       expect(
         finalGraph
-            .buildStepResultFor(
-              finalGraph.buildStepsByDeclaredOutput[AssetId('a', 'web/a.g2')]!,
-            )!
+            .stepResult(
+              finalGraph.stepForDeclaredOutput(AssetId('a', 'web/a.g2')),
+            )
             .result,
         isFalse,
       );
 
       expect(
         finalGraph
-            .buildStepResultFor(
-              finalGraph.buildStepsByDeclaredOutput[AssetId('a', 'web/a.g3')]!,
-            )!
+            .stepResult(
+              finalGraph.stepForDeclaredOutput(AssetId('a', 'web/a.g3')),
+            )
             .result,
         isFalse,
       );

--- a/build_runner/test/build/resolver/analysis_driver_model_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_model_test.dart
@@ -25,7 +25,10 @@ void main() {
       model.filesystem.write('/a/lib/b.dart', 'class B {}');
       model.filesystem.clearChangedPaths();
 
-      await model.takeLockAndStartBuild(AssetGraph(), invalidatedSources: null);
+      await model.takeLockAndStartBuild(
+        BuildState.empty(),
+        invalidatedSources: null,
+      );
 
       expect(model.filesystem.exists('/a/lib/a.dart'), isFalse);
       expect(model.filesystem.exists('/a/lib/b.dart'), isFalse);
@@ -37,7 +40,7 @@ void main() {
       model.filesystem.clearChangedPaths();
 
       await model.takeLockAndStartBuild(
-        AssetGraph(),
+        BuildState.empty(),
         invalidatedSources: const {},
       );
 
@@ -53,7 +56,7 @@ void main() {
       model.filesystem.clearChangedPaths();
 
       await model.takeLockAndStartBuild(
-        AssetGraph(),
+        BuildState.empty(),
         invalidatedSources: {
           AssetId.parse('a|lib/changed.dart'),
           AssetId.parse('a|lib/deleted.dart'),

--- a/build_runner/test/build/resolver/resolver_test.dart
+++ b/build_runner/test/build/resolver/resolver_test.dart
@@ -1356,7 +1356,7 @@ Future<void> _runBuilder(
     _ => null,
   };
   await resolversImpl?.takeLockAndStartBuild(
-    AssetGraph(),
+    BuildState.empty(),
     invalidatedSources: null,
   );
   await runBuilder(builder, list, singleStepReaderWriter, resolvers);

--- a/build_runner/test/build_plan/build_packages_test.dart
+++ b/build_runner/test/build_plan/build_packages_test.dart
@@ -244,10 +244,10 @@ void main() {
       );
       final c = BuildPackage(name: 'c', path: '/c', watch: true);
       final d = BuildPackage(name: 'd', path: '/d', watch: true);
-      final graph = BuildPackages.singlePackageBuild('a', [a, b, c, d]);
-      expect(graph.singleOutputPackage!, 'a');
+      buildPackages = BuildPackages.singlePackageBuild('a', [a, b, c, d]);
+      expect(buildPackages.singleOutputPackage!, 'a');
       expect(
-        graph.packages.asMap(),
+        buildPackages.packages.asMap(),
         equals({'a': a, 'b': b, 'c': c, 'd': d, r'$sdk': anything}),
       );
     });

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -69,7 +69,7 @@ void main() {
     });
 
     Future<void> writeGraphAndPlan(
-      AssetGraph assetGraph,
+      BuildState assetGraph,
       BuildPlan buildPlan,
     ) async {
       await readerWriter.writeAsBytes(
@@ -155,11 +155,11 @@ void main() {
 
       // Write an output and add it to the asset graph as if it was built.
       await readerWriter.writeAsString(outputId, '// output');
-      final stepId = assetGraph.buildStepsByDeclaredOutput[outputId]!;
+      final step = assetGraph.stepForDeclaredOutput(outputId);
       assetGraph.updateBuildStepResult(
-        stepId,
+        step,
         assetGraph
-            .buildStepResultFor(stepId)!
+            .stepResult(step)
             .rebuild((b) => b..outputs[outputId] = Digest([])),
       );
       await writeGraphAndPlan(assetGraph, buildPlan);
@@ -246,11 +246,11 @@ void main() {
 
       // Write an output and add it to the asset graph as if it was built.
       await readerWriter.writeAsString(outputId, '// output');
-      final stepId = assetGraph.buildStepsByDeclaredOutput[outputId]!;
+      final stepId = assetGraph.stepForDeclaredOutput(outputId);
       assetGraph.updateBuildStepResult(
         stepId,
         assetGraph
-            .buildStepResultFor(stepId)!
+            .stepResult(stepId)
             .rebuild((b) => b..outputs[outputId] = Digest([])),
       );
       // Give digests to inputs so they are monitored for modifications.

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -30,7 +30,7 @@ void main() {
     final assetId = AssetId('a', 'lib/a.dart');
     final outputId = AssetId('a', 'lib/a.dart.copy');
     final assetId2 = AssetId('a', 'lib/an.other');
-    final assetGraphId = AssetId('a', assetGraphPath);
+    final assetGraphJsonId = AssetId('a', assetGraphJsonPath);
 
     late BuildPackages buildPackages;
     late ReaderWriter readerWriter;
@@ -64,35 +64,35 @@ void main() {
       );
     });
 
-    test('loads with no asset graph', () async {
-      expect(buildPlan.takePreviousAssetGraph(), null);
+    test('loads with no previous build state', () async {
+      expect(buildPlan.takePreviousBuildState(), null);
     });
 
-    Future<void> writeGraphAndPlan(
-      BuildState assetGraph,
+    Future<void> writeBuildStateAndPlan(
+      BuildState buildState,
       BuildPlan buildPlan,
     ) async {
       await readerWriter.writeAsBytes(
-        assetGraphId,
+        assetGraphJsonId,
         AssetGraphJson.serialize(
           buildPlanDigest: buildPlan.buildPlanDigest,
-          assetGraph: assetGraph,
+          buildState: buildState,
           phasedAssetDeps: PhasedAssetDeps(),
         ),
       );
     }
 
-    test('loads previous asset graph', () async {
-      final assetGraph = buildPlan.takeAssetGraph();
-      await writeGraphAndPlan(assetGraph, buildPlan);
+    test('loads previous build state', () async {
+      final buildState = buildPlan.takeBuildState();
+      await writeBuildStateAndPlan(buildState, buildPlan);
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
         buildOptions: buildOptions,
         testingOverrides: testingOverrides,
       );
-      final loadedGraph = buildPlan.takePreviousAssetGraph();
+      final loadedState = buildPlan.takePreviousBuildState();
 
-      expect(loadedGraph.toString(), assetGraph.toString());
+      expect(loadedState.toString(), buildState.toString());
     });
 
     test('requires restart if a factory is missing', () async {
@@ -108,9 +108,9 @@ void main() {
       expect(buildPlan.restartIsNeeded, true);
     });
 
-    test('discards previous asset graph if build phases changed', () async {
-      final assetGraph = buildPlan.takeAssetGraph();
-      await writeGraphAndPlan(assetGraph, buildPlan);
+    test('discards previous build state if build phases changed', () async {
+      final buildState = buildPlan.takeBuildState();
+      await writeBuildStateAndPlan(buildState, buildPlan);
 
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
@@ -125,13 +125,14 @@ void main() {
         ),
       );
 
-      expect(buildPlan.takePreviousAssetGraph(), null);
+      expect(buildPlan.takePreviousBuildState(), null);
 
-      // The old graph is in [BuildPlan#filesToDelete] because it's invalid.
-      expect(await readerWriter.canRead(assetGraphId), true);
+      // The old state file is in [BuildPlan#filesToDelete] because it's
+      // invalid.
+      expect(await readerWriter.canRead(assetGraphJsonId), true);
       await buildPlan.deleteFilesAndFolders();
       buildPlan.readerWriter.cache.flush();
-      expect(await readerWriter.canRead(assetGraphId), false);
+      expect(await readerWriter.canRead(assetGraphJsonId), false);
     });
 
     test('tracks lost outputs if build phases changed', () async {
@@ -151,18 +152,18 @@ void main() {
               ].build(),
         ),
       );
-      final assetGraph = buildPlan.takeAssetGraph();
+      final buildState = buildPlan.takeBuildState();
 
-      // Write an output and add it to the asset graph as if it was built.
+      // Write an output and add it to the build state as if it was built.
       await readerWriter.writeAsString(outputId, '// output');
-      final step = assetGraph.stepForDeclaredOutput(outputId);
-      assetGraph.updateBuildStepResult(
+      final step = buildState.stepForDeclaredOutput(outputId);
+      buildState.updateBuildStepResult(
         step,
-        assetGraph
+        buildState
             .stepResult(step)
             .rebuild((b) => b..outputs[outputId] = Digest([])),
       );
-      await writeGraphAndPlan(assetGraph, buildPlan);
+      await writeBuildStateAndPlan(buildState, buildPlan);
 
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
@@ -177,7 +178,7 @@ void main() {
         ),
       );
 
-      expect(buildPlan.takePreviousAssetGraph(), null);
+      expect(buildPlan.takePreviousBuildState(), null);
       expect(buildPlan.filesToDelete, isNotEmpty);
 
       // `BuildPlan` can delete lost outputs.
@@ -187,9 +188,9 @@ void main() {
       expect(await readerWriter.canRead(outputId), false);
     });
 
-    test('discards previous asset graph if SDK version changed', () async {
-      final assetGraph = buildPlan.takeAssetGraph();
-      await writeGraphAndPlan(assetGraph, buildPlan);
+    test('discards previous build state if SDK version changed', () async {
+      final buildState = buildPlan.takeBuildState();
+      await writeBuildStateAndPlan(buildState, buildPlan);
 
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
@@ -200,12 +201,12 @@ void main() {
         ),
       );
 
-      expect(buildPlan.takePreviousAssetGraph(), null);
+      expect(buildPlan.takePreviousBuildState(), null);
     });
 
-    test('discards previous asset graph if packages changed', () async {
-      final assetGraph = buildPlan.takeAssetGraph();
-      await writeGraphAndPlan(assetGraph, buildPlan);
+    test('discards previous build state if packages changed', () async {
+      final buildState = buildPlan.takeBuildState();
+      await writeBuildStateAndPlan(buildState, buildPlan);
 
       final buildPackages2 = BuildPackages.singlePackageBuild('b', [
         BuildPackage.forTesting(name: 'b', watch: true, isOutput: true),
@@ -219,14 +220,14 @@ void main() {
         testingOverrides: testingOverrides2,
       );
 
-      expect(buildPlan.takePreviousAssetGraph(), null);
+      expect(buildPlan.takePreviousBuildState(), null);
     });
 
     test(
-      'discards previous asset graph if enabled experiments changed',
+      'discards previous build state if enabled experiments changed',
       () async {
-        final assetGraph = buildPlan.takeAssetGraph();
-        await writeGraphAndPlan(assetGraph, buildPlan);
+        final buildState = buildPlan.takeBuildState();
+        await writeBuildStateAndPlan(buildState, buildPlan);
 
         buildPlan = await withEnabledExperiments(
           () => BuildPlan.load(
@@ -237,26 +238,26 @@ void main() {
           ['an_experiment'],
         );
 
-        expect(buildPlan.takePreviousAssetGraph(), null);
+        expect(buildPlan.takePreviousBuildState(), null);
       },
     );
 
     test('reports updates', () async {
-      final assetGraph = buildPlan.takeAssetGraph();
+      final buildState = buildPlan.takeBuildState();
 
-      // Write an output and add it to the asset graph as if it was built.
+      // Write an output and add it to the build state as if it was built.
       await readerWriter.writeAsString(outputId, '// output');
-      final stepId = assetGraph.stepForDeclaredOutput(outputId);
-      assetGraph.updateBuildStepResult(
+      final stepId = buildState.stepForDeclaredOutput(outputId);
+      buildState.updateBuildStepResult(
         stepId,
-        assetGraph
+        buildState
             .stepResult(stepId)
             .rebuild((b) => b..outputs[outputId] = Digest([])),
       );
       // Give digests to inputs so they are monitored for modifications.
-      assetGraph.updateSourceDigest(assetId2, Digest([]));
+      buildState.updateSourceDigest(assetId2, Digest([]));
 
-      await writeGraphAndPlan(assetGraph, buildPlan);
+      await writeBuildStateAndPlan(buildState, buildPlan);
 
       // Remove source.
       await readerWriter.delete(assetId);
@@ -300,9 +301,9 @@ void main() {
           buildConfig: {'a': buildConfig1}.build(),
         ),
       );
-      final assetGraph1 = buildPlan1.takeAssetGraph();
+      final buildState1 = buildPlan1.takeBuildState();
       // Matches the only `*.dart` source.
-      expect(assetGraph1.sources, <AssetId>{assetId});
+      expect(buildState1.sources, <AssetId>{assetId});
 
       // Same again but now glob `*.other`.
       final buildConfig2 = runInBuildConfigZone(
@@ -326,9 +327,9 @@ void main() {
           buildConfig: {'a': buildConfig2}.build(),
         ),
       );
-      final assetGraph2 = buildPlan2.takeAssetGraph();
+      final buildState2 = buildPlan2.takeBuildState();
       // Matches the only `*.other` source.
-      expect(assetGraph2.sources, <AssetId>{assetId2});
+      expect(buildState2.sources, <AssetId>{assetId2});
     });
 
     test('tracks cleanBuild when build_plan.json does not exist', () async {
@@ -343,7 +344,7 @@ void main() {
     test(
       'tracks cleanBuild when build_plan.json compileDigest is fresh',
       () async {
-        await writeGraphAndPlan(buildPlan.takeAssetGraph(), buildPlan);
+        await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
         buildPlan = await BuildPlan.load(
           builderFactories: builderFactories,
           buildOptions: buildOptions,
@@ -361,7 +362,7 @@ void main() {
             (b) => b.compileDigest = 'stale_digest',
           ),
         );
-        await writeGraphAndPlan(buildPlan.takeAssetGraph(), buildPlan);
+        await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
 
         buildPlan = await BuildPlan.load(
           builderFactories: builderFactories,
@@ -378,7 +379,7 @@ void main() {
           (b) => b.buildTriggersDigest = 'triggers_1',
         ),
       );
-      await writeGraphAndPlan(buildPlan.takeAssetGraph(), buildPlan);
+      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
 
       final buildConfig2 = runInBuildConfigZone(
         () {
@@ -416,7 +417,7 @@ void main() {
           (b) => b.inBuildPhasesOptionsDigests[0] = 'dummy_digest_1',
         ),
       );
-      await writeGraphAndPlan(buildPlan.takeAssetGraph(), buildPlan);
+      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
 
       final buildConfig2 = runInBuildConfigZone(
         () {
@@ -454,7 +455,7 @@ void main() {
           (b) => b.buildPhasesDigest = 'stale_digest',
         ),
       );
-      await writeGraphAndPlan(buildPlan.takeAssetGraph(), buildPlan);
+      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
 
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
@@ -470,7 +471,7 @@ void main() {
           (b) => b.dartVersion = 'stale_version',
         ),
       );
-      await writeGraphAndPlan(buildPlan.takeAssetGraph(), buildPlan);
+      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
 
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
@@ -486,7 +487,7 @@ void main() {
           (b) => b.enabledExperiments.add('stale_experiment'),
         ),
       );
-      await writeGraphAndPlan(buildPlan.takeAssetGraph(), buildPlan);
+      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
 
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
@@ -504,7 +505,7 @@ void main() {
             (b) => b.packageLanguageVersions['a'] = '1.0',
           ),
         );
-        await writeGraphAndPlan(buildPlan.takeAssetGraph(), buildPlan);
+        await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
 
         buildPlan = await BuildPlan.load(
           builderFactories: builderFactories,
@@ -516,13 +517,19 @@ void main() {
     );
 
     test('tracks cleanBuild when asset_graph.json version is stale', () async {
-      final assetGraphId = AssetId(buildPackages.outputRoot, assetGraphPath);
-      await writeGraphAndPlan(buildPlan.takeAssetGraph(), buildPlan);
+      final assetGraphJsonId = AssetId(
+        buildPackages.outputRoot,
+        assetGraphJsonPath,
+      );
+      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
 
       final decodedMap =
-          json.decode(await readerWriter.readAsString(assetGraphId)) as Map;
+          json.decode(await readerWriter.readAsString(assetGraphJsonId)) as Map;
       decodedMap['version'] = 999;
-      await readerWriter.writeAsString(assetGraphId, json.encode(decodedMap));
+      await readerWriter.writeAsString(
+        assetGraphJsonId,
+        json.encode(decodedMap),
+      );
 
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,

--- a/build_runner/test/commands/serve/asset_handler_test.dart
+++ b/build_runner/test/commands/serve/asset_handler_test.dart
@@ -25,20 +25,20 @@ void main() {
   late AssetHandler handler;
   late BuildOutputReader reader;
   late InternalTestReaderWriter readerWriter;
-  late AssetGraph assetGraph;
+  late BuildState buildState;
 
   setUp(() async {
-    assetGraph = await AssetGraph.build(
-      BuildPhases([]),
-      <AssetId>{},
-      BuildPackages.singlePackageBuild('a', [
+    buildState = BuildState.create(
+      buildPhases: BuildPhases([]),
+      buildPackages: BuildPackages.singlePackageBuild('a', [
         BuildPackage.forTesting(name: 'a', isOutput: true),
       ]),
+      sources: <AssetId>{},
     );
     readerWriter = InternalTestReaderWriter();
     reader = BuildOutputReader.graphOnly(
       readerWriter: readerWriter,
-      assetGraph: assetGraph,
+      assetGraph: buildState,
     );
     handler = AssetHandler(() async => reader, 'a');
   });
@@ -46,12 +46,12 @@ void main() {
   void addAsset(String id, String content, {bool deleted = false}) {
     final parsedId = AssetId.parse(id);
     if (deleted) {
-      assetGraph.updatePostProcessBuildStepResult(
+      buildState.addPostProcessBuildStepResult(
         PostProcessBuildStepId(input: parsedId, actionNumber: 1),
         PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
       );
     }
-    assetGraph.addSourceForTest(parsedId, digest: computeDigest(parsedId, 'a'));
+    buildState.addSourceForTest(parsedId, digest: computeDigest(parsedId, 'a'));
     readerWriter.testing.writeString(parsedId, content);
   }
 
@@ -132,12 +132,12 @@ void main() {
     final primaryId = AssetId('a', 'web/main.dart');
     final outputId = AssetId('a', 'web/main.ddc.js');
     final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
-    assetGraph.addGeneratedForTest(outputId, buildStepId, digest: Digest([]));
+    buildState.addGeneratedForTest(outputId, buildStepId, digest: Digest([]));
     final stepResult = BuildStepResult((b) {
       b.result = false;
       b.isHidden = false;
     });
-    assetGraph.updateBuildStepResult(buildStepId, stepResult);
+    buildState.updateBuildStepResult(buildStepId, stepResult);
 
     final response = await handler.handle(
       Request('GET', Uri.parse('http://server.com/main.ddc.js')),

--- a/build_runner/test/commands/serve/asset_handler_test.dart
+++ b/build_runner/test/commands/serve/asset_handler_test.dart
@@ -38,7 +38,7 @@ void main() {
     readerWriter = InternalTestReaderWriter();
     reader = BuildOutputReader.graphOnly(
       readerWriter: readerWriter,
-      assetGraph: buildState,
+      buildState: buildState,
     );
     handler = AssetHandler(() async => reader, 'a');
   });
@@ -55,7 +55,7 @@ void main() {
     readerWriter.testing.writeString(parsedId, content);
   }
 
-  test('can not read deleted nodes', () async {
+  test('can not read deleted files', () async {
     addAsset('a|web/index.html', 'content', deleted: true);
     final response = await handler.handle(
       Request('GET', Uri.parse('http://server.com/index.html')),

--- a/build_runner/test/commands/serve/serve_handler_test.dart
+++ b/build_runner/test/commands/serve/serve_handler_test.dart
@@ -127,7 +127,7 @@ void main() {
     serveHandler = ServeHandler(watcher);
     finalizedReader = BuildOutputReader.graphOnly(
       readerWriter: readerWriter,
-      assetGraph: buildState,
+      buildState: buildState,
     );
     watcher.addFutureResult(
       Future.value(

--- a/build_runner/test/commands/serve/serve_handler_test.dart
+++ b/build_runner/test/commands/serve/serve_handler_test.dart
@@ -108,7 +108,7 @@ void main() {
   late InternalTestReaderWriter readerWriter;
   late FakeWatcher watcher;
   late BuildPackages buildPackages;
-  late AssetGraph assetGraph;
+  late BuildState buildState;
   late BuildOutputReader finalizedReader;
 
   setUp(() async {
@@ -118,16 +118,16 @@ void main() {
     readerWriter = InternalTestReaderWriter(
       outputRootPackage: buildPackages.outputRoot,
     );
-    assetGraph = await AssetGraph.build(
-      BuildPhases([]),
-      <AssetId>{},
-      buildPackages,
+    buildState = BuildState.create(
+      buildPhases: BuildPhases([]),
+      buildPackages: buildPackages,
+      sources: <AssetId>{},
     );
     watcher = FakeWatcher(buildPackages);
     serveHandler = ServeHandler(watcher);
     finalizedReader = BuildOutputReader.graphOnly(
       readerWriter: readerWriter,
-      assetGraph: assetGraph,
+      assetGraph: buildState,
     );
     watcher.addFutureResult(
       Future.value(
@@ -142,12 +142,12 @@ void main() {
   void addSource(String id, String content, {bool deleted = false}) {
     final parsedId = AssetId.parse(id);
     if (deleted) {
-      assetGraph.updatePostProcessBuildStepResult(
+      buildState.addPostProcessBuildStepResult(
         PostProcessBuildStepId(input: parsedId, actionNumber: 1),
         PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
       );
     }
-    assetGraph.addSourceForTest(
+    buildState.addSourceForTest(
       parsedId,
       digest: computeDigest(parsedId, content),
     );
@@ -258,12 +258,12 @@ void main() {
       final primaryId = AssetId('a', 'web/main.dart');
       final outputId = AssetId('a', 'web/main.ddc.js');
       final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
-      assetGraph.addGeneratedForTest(outputId, buildStepId, digest: Digest([]));
+      buildState.addGeneratedForTest(outputId, buildStepId, digest: Digest([]));
       final stepResult = BuildStepResult((b) {
         b.result = false;
         b.isHidden = false;
       });
-      assetGraph.updateBuildStepResult(buildStepId, stepResult);
+      buildState.updateBuildStepResult(buildStepId, stepResult);
       watcher.addFutureResult(
         Future.value(
           BuildResult(

--- a/build_runner/test/integration_tests/build_command_invalidation_test.dart
+++ b/build_runner/test/integration_tests/build_command_invalidation_test.dart
@@ -63,9 +63,9 @@ void main() async {
     expect(tester.read('root_pkg/web/a.txt.copy2'), 'a');
 
     // Asset graph version mismatch.
-    final assetGraphPath = 'root_pkg/${constants.assetGraphPath}';
+    final assetGraphJsonPath = 'root_pkg/${constants.assetGraphJsonPath}';
     tester.update(
-      assetGraphPath,
+      assetGraphJsonPath,
       (json) => json.replaceAll('"version":', '"version":1'),
     );
     tester.write(fakeGeneratedOutput, '');

--- a/build_runner/test/integration_tests/clean_command_test.dart
+++ b/build_runner/test/integration_tests/clean_command_test.dart
@@ -48,10 +48,10 @@ void main() async {
       'dart run build_runner build --force-jit --workspace',
     );
     expect(tester.read(entrypointScriptPath), isNotNull);
-    expect(tester.read(assetGraphPath), isNotNull);
+    expect(tester.read(assetGraphJsonPath), isNotNull);
 
     await tester.run('p1', 'dart run build_runner clean --workspace');
-    expect(tester.read(assetGraphPath), isNull);
+    expect(tester.read(assetGraphJsonPath), isNull);
     expect(tester.read(entrypointScriptPath), isNull);
   });
 }

--- a/build_runner/test/invalidation/huge_resolved_graph_invalidation_test.dart
+++ b/build_runner/test/invalidation/huge_resolved_graph_invalidation_test.dart
@@ -41,11 +41,11 @@ void main() {
       expect(await tester.build(change: 'z$size'), Result(written: ['a.2']));
     });
 
-    test('asset graph size', () async {
+    test('asset graph JSON size', () async {
       await tester.build();
       // Currently measured at 276k; doesn't need to be a precise check, this is
       // to guard against quadratic behaviour which would cause size >> 1Mb.
-      expect(tester.assetGraphSize, lessThan(300000));
+      expect(tester.assetGraphJsonSize, lessThan(300000));
     });
   });
 }

--- a/build_runner/test/invalidation/invalidation_tester.dart
+++ b/build_runner/test/invalidation/invalidation_tester.dart
@@ -277,8 +277,10 @@ class InvalidationTester {
   }
 
   /// The size of the asset graph that was written by [build], in bytes.
-  int get assetGraphSize =>
-      readerWriter!.testing.readBytes(AssetId('pkg', assetGraphPath)).length;
+  int get assetGraphJsonSize =>
+      readerWriter!.testing
+          .readBytes(AssetId('pkg', assetGraphJsonPath))
+          .length;
 }
 
 /// Strategy used by generators for outputting files.

--- a/build_runner/test/io/asset_tracker_test.dart
+++ b/build_runner/test/io/asset_tracker_test.dart
@@ -24,7 +24,7 @@ import 'package:watcher/watcher.dart';
 void main() {
   group('AssetTracker.collectChanges()', () {
     late AssetTracker assetTracker;
-    late AssetGraph assetGraph;
+    late BuildState assetGraph;
 
     setUp(() async {
       await d.dir('a', [
@@ -47,9 +47,11 @@ void main() {
       ]);
       final reader = ReaderWriter(buildPackages);
       final aId = AssetId('a', 'web/a.txt');
-      assetGraph = await AssetGraph.build(BuildPhases([]), {
-        aId,
-      }, buildPackages);
+      assetGraph = BuildState.create(
+        buildPhases: BuildPhases([]),
+        buildPackages: buildPackages,
+        sources: {aId},
+      );
       // We need to pre-emptively assign a digest so we determine that the
       // node is "interesting".
       final digest = await reader.digest(aId);

--- a/build_runner/test/io/asset_tracker_test.dart
+++ b/build_runner/test/io/asset_tracker_test.dart
@@ -24,7 +24,7 @@ import 'package:watcher/watcher.dart';
 void main() {
   group('AssetTracker.collectChanges()', () {
     late AssetTracker assetTracker;
-    late BuildState assetGraph;
+    late BuildState buildState;
 
     setUp(() async {
       await d.dir('a', [
@@ -47,15 +47,14 @@ void main() {
       ]);
       final reader = ReaderWriter(buildPackages);
       final aId = AssetId('a', 'web/a.txt');
-      assetGraph = BuildState.create(
+      buildState = BuildState.create(
         buildPhases: BuildPhases([]),
         buildPackages: buildPackages,
         sources: {aId},
       );
-      // We need to pre-emptively assign a digest so we determine that the
-      // node is "interesting".
+      // Assign a digest so the source is recognized as having been used.
       final digest = await reader.digest(aId);
-      assetGraph.updateSourceDigest(aId, digest);
+      buildState.updateSourceDigest(aId, digest);
 
       final buildConfigs = await BuildConfigs.load(
         buildPackages: buildPackages,
@@ -64,8 +63,8 @@ void main() {
         ),
       );
       assetTracker = AssetTracker(reader, buildPackages, buildConfigs);
-      final updates = await assetTracker.collectChanges(assetGraph);
-      await assetGraph.updateAndInvalidate(BuildPhases([]), updates);
+      final updates = await assetTracker.collectChanges(buildState);
+      buildState.updateForNextBuild(BuildPhases([]), updates);
       // We should see no changes initially other than new sdk sources
       expect(
         updates..removeWhere(
@@ -78,7 +77,7 @@ void main() {
     test('Collects file edits', () async {
       File(p.join(d.sandbox, 'a', 'web', 'a.txt')).writeAsStringSync('goodbye');
 
-      expect(await assetTracker.collectChanges(assetGraph), {
+      expect(await assetTracker.collectChanges(buildState), {
         AssetId('a', 'web/a.txt'): ChangeType.MODIFY,
       });
     });
@@ -86,7 +85,7 @@ void main() {
     test('Collects new files', () async {
       File(p.join(d.sandbox, 'a', 'web', 'b.txt')).writeAsStringSync('yo!');
 
-      expect(await assetTracker.collectChanges(assetGraph), {
+      expect(await assetTracker.collectChanges(buildState), {
         AssetId('a', 'web/b.txt'): ChangeType.ADD,
       });
     });
@@ -94,7 +93,7 @@ void main() {
     test('Collects deleted files', () async {
       File(p.join(d.sandbox, 'a', 'web', 'a.txt')).deleteSync();
 
-      expect(await assetTracker.collectChanges(assetGraph), {
+      expect(await assetTracker.collectChanges(buildState), {
         AssetId('a', 'web/a.txt'): ChangeType.REMOVE,
       });
     });

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -34,7 +34,7 @@ void main() {
   group('FinalizedReader', () {
     BuildOutputReader reader;
     late InternalTestReaderWriter readerWriter;
-    late BuildState assetGraph;
+    late BuildState buildState;
     late BuildPackages buildPackages;
     late BuildPhases buildPhases;
 
@@ -43,7 +43,7 @@ void main() {
       buildPackages = BuildPackages.singlePackageBuild('a', [
         BuildPackage.forTesting(name: 'a', isOutput: true),
       ]);
-      assetGraph = BuildState.create(
+      buildState = BuildState.create(
         buildPhases: BuildPhases([]),
         buildPackages: buildPackages,
         sources: <AssetId>{},
@@ -55,12 +55,12 @@ void main() {
       final notDeletedId = AssetId.parse('a|web/a.txt');
       final deletedId = AssetId.parse('a|lib/b.txt');
 
-      assetGraph.addPostProcessBuildStepResult(
+      buildState.addPostProcessBuildStepResult(
         PostProcessBuildStepId(input: deletedId, actionNumber: 0),
         PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
       );
 
-      assetGraph
+      buildState
         ..addSourceForTest(
           notDeletedId,
           digest: computeDigest(notDeletedId, 'a'),
@@ -82,23 +82,23 @@ void main() {
       reader = BuildOutputReader(
         buildPlan: buildPlan,
         readerWriter: readerWriter,
-        assetGraph: assetGraph,
-        processedOutputs: assetGraph.outputs.toSet(),
+        buildState: buildState,
+        processedOutputs: buildState.declaredAndActualOutputs.toSet(),
       );
       expect(await reader.canRead(notDeletedId), true);
       expect(await reader.canRead(deletedId), false);
     });
 
-    test('Failure nodes interact well with build filters ', () async {
+    test('Failed steps interact well with build filters ', () async {
       final id = AssetId('a', 'web/a.txt');
       final primaryId = AssetId('a', 'web/a.dart');
       final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
-      assetGraph.addGeneratedForTest(id, buildStepId, digest: Digest([]));
+      buildState.addGeneratedForTest(id, buildStepId, digest: Digest([]));
       final stepResult = BuildStepResult((b) {
         b.result = false;
         b.isHidden = false;
       });
-      assetGraph.updateBuildStepResult(buildStepId, stepResult);
+      buildState.updateBuildStepResult(buildStepId, stepResult);
       readerWriter.testing.writeString(id, '');
 
       buildPhases = BuildPhases([
@@ -125,8 +125,8 @@ void main() {
       reader = BuildOutputReader(
         buildPlan: buildPlan,
         readerWriter: readerWriter,
-        assetGraph: assetGraph,
-        processedOutputs: assetGraph.outputs.toSet(),
+        buildState: buildState,
+        processedOutputs: buildState.declaredAndActualOutputs.toSet(),
       );
       expect(
         await reader.unreadableReason(id),
@@ -150,7 +150,7 @@ void main() {
       reader = BuildOutputReader(
         buildPlan: buildPlan,
         readerWriter: readerWriter,
-        assetGraph: assetGraph,
+        buildState: buildState,
         // `a` does not match the build filter and is not processed.
         processedOutputs: {},
       );

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -34,7 +34,7 @@ void main() {
   group('FinalizedReader', () {
     BuildOutputReader reader;
     late InternalTestReaderWriter readerWriter;
-    late AssetGraph assetGraph;
+    late BuildState assetGraph;
     late BuildPackages buildPackages;
     late BuildPhases buildPhases;
 
@@ -43,10 +43,10 @@ void main() {
       buildPackages = BuildPackages.singlePackageBuild('a', [
         BuildPackage.forTesting(name: 'a', isOutput: true),
       ]);
-      assetGraph = await AssetGraph.build(
-        BuildPhases([]),
-        <AssetId>{},
-        buildPackages,
+      assetGraph = BuildState.create(
+        buildPhases: BuildPhases([]),
+        buildPackages: buildPackages,
+        sources: <AssetId>{},
       );
       buildPhases = BuildPhases([]);
     });
@@ -55,7 +55,7 @@ void main() {
       final notDeletedId = AssetId.parse('a|web/a.txt');
       final deletedId = AssetId.parse('a|lib/b.txt');
 
-      assetGraph.updatePostProcessBuildStepResult(
+      assetGraph.addPostProcessBuildStepResult(
         PostProcessBuildStepId(input: deletedId, actionNumber: 0),
         PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
       );

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -32,7 +32,7 @@ import '../common/common.dart';
 void main() {
   group('createMergedDir', () {
     late BuildPlan buildPlan;
-    late BuildState graph;
+    late BuildState buildState;
     final phases = BuildPhases([
       InBuildPhase(
         builder: TestBuilder(
@@ -100,27 +100,27 @@ void main() {
           buildPackages: buildPackages,
         ),
       );
-      graph = buildPlan.takeAssetGraph();
+      buildState = buildPlan.takeBuildState();
       buildOutputReader = BuildOutputReader(
         buildPlan: buildPlan,
         readerWriter: readerWriter,
-        assetGraph: graph,
-        processedOutputs: graph.outputs.toSet(),
+        buildState: buildState,
+        processedOutputs: buildState.declaredAndActualOutputs.toSet(),
       );
 
-      for (final id in graph.outputs) {
+      for (final id in buildState.declaredAndActualOutputs) {
         final stepResult = BuildStepResult((b) {
           b.result = true;
           b.isHidden = false;
           b.outputs[id] = Digest([]);
         });
-        graph.updateBuildStepResult(
-          graph.stepForDeclaredOutput(id),
+        buildState.updateBuildStepResult(
+          buildState.stepForDeclaredOutput(id),
           stepResult,
         );
         readerWriter.testing.writeString(
           id,
-          sources[graph.stepForDeclaredOutput(id).primaryInput]!,
+          sources[buildState.stepForDeclaredOutput(id).primaryInput]!,
         );
       }
       tmpDir = await Directory.systemTemp.createTemp('build_tests');
@@ -149,7 +149,7 @@ void main() {
 
     test('doesnt write deleted files', () async {
       final targetId = AssetId('b', 'lib/c.txt.copy');
-      graph.addPostProcessBuildStepResult(
+      buildState.addPostProcessBuildStepResult(
         PostProcessBuildStepId(input: targetId, actionNumber: 1),
         PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
       );
@@ -370,8 +370,8 @@ void main() {
       final stepResult = BuildStepResult((b) {
         b.isHidden = false;
       });
-      graph.updateBuildStepResult(
-        graph.stepForDeclaredOutput(targetId),
+      buildState.updateBuildStepResult(
+        buildState.stepForDeclaredOutput(targetId),
         stepResult,
       );
 
@@ -397,8 +397,8 @@ void main() {
           buildDirs: {BuildDirectory('foo')}.build(),
         ),
         readerWriter: readerWriter,
-        assetGraph: graph,
-        processedOutputs: graph.outputs.toSet(),
+        buildState: buildState,
+        processedOutputs: buildState.declaredAndActualOutputs.toSet(),
       );
       final success = await createMergedOutputDirectories(
         buildDirs:
@@ -476,7 +476,7 @@ void main() {
         final removes = ['a|lib/a.txt', 'a|lib/a.txt.copy'];
         for (final remove in removes) {
           final removeId = makeAssetId(remove);
-          graph.addPostProcessBuildStepResult(
+          buildState.addPostProcessBuildStepResult(
             PostProcessBuildStepId(input: removeId, actionNumber: 1),
             PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
           );
@@ -485,8 +485,8 @@ void main() {
         buildOutputReader = BuildOutputReader(
           buildPlan: buildPlan,
           readerWriter: readerWriter,
-          assetGraph: graph,
-          processedOutputs: graph.outputs.toSet(),
+          buildState: buildState,
+          processedOutputs: buildState.declaredAndActualOutputs.toSet(),
         );
         success = await createMergedOutputDirectories(
           buildDirs:

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -32,7 +32,7 @@ import '../common/common.dart';
 void main() {
   group('createMergedDir', () {
     late BuildPlan buildPlan;
-    late AssetGraph graph;
+    late BuildState graph;
     final phases = BuildPhases([
       InBuildPhase(
         builder: TestBuilder(
@@ -115,12 +115,12 @@ void main() {
           b.outputs[id] = Digest([]);
         });
         graph.updateBuildStepResult(
-          graph.buildStepsByDeclaredOutput[id]!,
+          graph.stepForDeclaredOutput(id),
           stepResult,
         );
         readerWriter.testing.writeString(
           id,
-          sources[graph.buildStepsByDeclaredOutput[id]!.primaryInput]!,
+          sources[graph.stepForDeclaredOutput(id).primaryInput]!,
         );
       }
       tmpDir = await Directory.systemTemp.createTemp('build_tests');
@@ -149,7 +149,7 @@ void main() {
 
     test('doesnt write deleted files', () async {
       final targetId = AssetId('b', 'lib/c.txt.copy');
-      graph.updatePostProcessBuildStepResult(
+      graph.addPostProcessBuildStepResult(
         PostProcessBuildStepId(input: targetId, actionNumber: 1),
         PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
       );
@@ -371,7 +371,7 @@ void main() {
         b.isHidden = false;
       });
       graph.updateBuildStepResult(
-        graph.buildStepsByDeclaredOutput[targetId]!,
+        graph.stepForDeclaredOutput(targetId),
         stepResult,
       );
 
@@ -476,7 +476,7 @@ void main() {
         final removes = ['a|lib/a.txt', 'a|lib/a.txt.copy'];
         for (final remove in removes) {
           final removeId = makeAssetId(remove);
-          graph.updatePostProcessBuildStepResult(
+          graph.addPostProcessBuildStepResult(
             PostProcessBuildStepId(input: removeId, actionNumber: 1),
             PostProcessBuildStepResult(hidden: true, deletedPrimaryInput: true),
           );

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -53,7 +53,9 @@ void checkOutputs(
   final modifiableActualAssets = Set.of(actualAssets);
 
   // Ignore asset graph.
-  modifiableActualAssets.removeWhere((id) => id.path.endsWith(assetGraphPath));
+  modifiableActualAssets.removeWhere(
+    (id) => id.path.endsWith(assetGraphJsonPath),
+  );
 
   if (outputs != null) {
     outputs.forEach((serializedId, contentsMatcher) {


### PR DESCRIPTION
AssetGraph improvements

 - rename to `BuildState`
 - `AssetGraph.build` -> `BuildState.create`, switch to named parameters
 - make fields private, add getters/methods as needed; except for serialization which is done by a part so it can access them directly
 - API comments :)
 - moved members into sections of related members
 - `updateAndInvalidate` -> `updateForNextBuild`
 - `packageFileIds` -> `findFiles`; clarified that it does not match post process outputs

and clean up naming+comments across the codebase

 - refer to "build state" instead of "asset graph"
 - refer to sources, outputs, etc, instead of "node"
 - `prefer step` instead of `buildStep` in local variable names and private method names
 - fix other outdated uses of "graph" and "node"

 Didn't rename files yet to make the diffs easier to deal with.