### PR TITLE
Support builders with no outputs.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.7-wip
+
+- Replace `Builder` extension method `hasOutputFor` with `matchesInput`.
+  Deprecate `hasOutputFor`. The new `matchesInput` is identical, but now that
+  zero-output builders are supported the old name is misleading.
+
 ## 4.0.6
 
 - Allow `analyzer` 13.0.0.

--- a/build/lib/src/expected_outputs.dart
+++ b/build/lib/src/expected_outputs.dart
@@ -31,13 +31,14 @@ final _parsedInputs = Expando<List<_ParsedBuildOutputs>>();
 
 /// Extensions on [Builder] describing expected outputs.
 extension BuildOutputExtensions on Builder {
-  /// Whether this builder is expected to output assets when running on [input].
-  ///
-  /// This will be `true` iff its [expectedOutputs] is not empty, but may be
-  /// more efficient to compute.
-  bool hasOutputFor(AssetId input) {
-    return _parsedExtensions.any((e) => e.hasAnyOutputFor(input));
-  }
+  // With zero output builders the name no longer makes sense, renamed to
+  // `matchesInput`.
+  @Deprecated('Use matchesInput')
+  bool hasOutputFor(AssetId input) => matchesInput(input);
+
+  /// Whether this builder runs on [input].
+  bool matchesInput(AssetId input) =>
+      _parsedExtensions.any((e) => e.matchesInput(input));
 
   List<_ParsedBuildOutputs> get _parsedExtensions {
     return _parsedInputs[this] ??= [
@@ -89,7 +90,8 @@ abstract class _ParsedBuildOutputs {
     }
   }
 
-  bool hasAnyOutputFor(AssetId input);
+  /// Whether this builder runs on [input].
+  bool matchesInput(AssetId input);
   Iterable<AssetId> matchingOutputsFor(AssetId input);
 }
 
@@ -102,11 +104,11 @@ class _FullMatchBuildOutputs extends _ParsedBuildOutputs {
   _FullMatchBuildOutputs(this.inputExtension, this.outputExtensions);
 
   @override
-  bool hasAnyOutputFor(AssetId input) => input.path == inputExtension;
+  bool matchesInput(AssetId input) => input.path == inputExtension;
 
   @override
   Iterable<AssetId> matchingOutputsFor(AssetId input) {
-    if (!hasAnyOutputFor(input)) return const Iterable.empty();
+    if (!matchesInput(input)) return const Iterable.empty();
 
     // If we expect an output, the asset's path ends with the input extension.
     // Expected outputs just replace the matched suffix in the path.
@@ -125,11 +127,11 @@ class _SuffixBuildOutputs extends _ParsedBuildOutputs {
   _SuffixBuildOutputs(this.inputExtension, this.outputExtensions);
 
   @override
-  bool hasAnyOutputFor(AssetId input) => input.path.endsWith(inputExtension);
+  bool matchesInput(AssetId input) => input.path.endsWith(inputExtension);
 
   @override
   Iterable<AssetId> matchingOutputsFor(AssetId input) {
-    if (!hasAnyOutputFor(input)) return const Iterable.empty();
+    if (!matchesInput(input)) return const Iterable.empty();
 
     // If we expect an output, the asset's path ends with the input extension.
     // Expected outputs just replace the matched suffix in the path.
@@ -236,7 +238,7 @@ class _CapturingBuildOutputs extends _ParsedBuildOutputs {
   }
 
   @override
-  bool hasAnyOutputFor(AssetId input) => _pathMatcher.hasMatch(input.path);
+  bool matchesInput(AssetId input) => _pathMatcher.hasMatch(input.path);
 
   @override
   Iterable<AssetId> matchingOutputsFor(AssetId input) {

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 4.0.6
+version: 4.0.7-wip
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -4,6 +4,9 @@
   with different packages to the current version solve.
 - More efficient watching for file changes in workspaces and other setups with
   nested packages.
+- Support builders with no declared outputs. They can't output anything, but
+  they can do processing, write log messages and choose whether to fail the
+  build.
 - Bug fix: handle errors from post process builders in previous runs without
   crashing.
 

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -185,12 +185,7 @@ class Build {
         }
       }
 
-      final failedPostProcessSteps = <PostProcessBuildStepId>[];
-      for (final entry in buildState.postProcessBuildStepResults) {
-        if (entry.value.errors.isNotEmpty) {
-          failedPostProcessSteps.add(entry.key);
-        }
-      }
+      final failedPostProcessSteps = buildState.failedPostProcessSteps;
 
       if (failedPostProcessSteps.isNotEmpty) {
         for (final id in failedPostProcessSteps) {
@@ -465,32 +460,41 @@ class Build {
     String package,
     int phaseNumber,
   ) async {
-    // Accumulate in a `Set` because inputs are found once per output.
-    final ids = <AssetId>{};
+    final ids = <AssetId>[];
     final phase = buildPhases[phaseNumber] as InBuildPhase;
     final buildPackage = buildPackages[package]!;
 
-    for (final outputId in buildState
-        .declaredOutputsForPhase(package, phaseNumber)
-        .toList(growable: false)) {
-      if (!shouldBuildForDirs(
-        outputId,
-        buildDirs: buildPlan.buildOptions.buildDirs,
-        buildFilters: buildPlan.buildOptions.buildFilters,
-        phase: phase,
-        buildConfigs: buildConfigs,
-      )) {
-        continue;
+    for (final step in buildState.buildStepsForPhase(package, phaseNumber)) {
+      final primaryInput = step.primaryInput;
+      final outputs = expectedOutputs(phase.builder, primaryInput);
+
+      final assetsToCheck = outputs.isEmpty ? [primaryInput] : outputs;
+      var shouldBuild = false;
+      for (final id in assetsToCheck) {
+        if (!shouldBuildForDirs(
+          id,
+          buildDirs: buildPlan.buildOptions.buildDirs,
+          buildFilters: buildPlan.buildOptions.buildFilters,
+          phase: phase,
+          buildConfigs: buildConfigs,
+        )) {
+          continue;
+        }
+
+        // Don't build for inputs that aren't visible. This can happen for
+        // placeholders like `test/$test$` that are added to each package,
+        // since the test dir is not part of the build for non-root packages.
+        if (!buildConfigs.isVisibleInBuild(id, buildPackage)) continue;
+
+        shouldBuild = true;
+        break;
       }
 
-      // Don't build for inputs that aren't visible. This can happen for
-      // placeholders like `test/$test$` that are added to each package,
-      // since the test dir is not part of the build for non-root packages.
-      if (!buildConfigs.isVisibleInBuild(outputId, buildPackage)) continue;
-
-      ids.add(buildState.stepForDeclaredOutput(outputId).primaryInput);
+      if (shouldBuild) {
+        ids.add(primaryInput);
+      }
     }
-    return ids.toList()..sort();
+    return ids..sort();
   }
 
   /// If [id] is a generated asset, ensures that it has been built.
@@ -1216,7 +1220,6 @@ class Build {
     Iterable<String> errors, {
     Set<AssetId>? unusedAssets,
   }) async {
-    if (outputs.isEmpty) return;
     final inputTracker = stepReaderWriter.inputTracker;
     final usedInputs =
         unusedAssets != null && unusedAssets.isNotEmpty

--- a/build_runner/lib/src/build/build_state/build_state.dart
+++ b/build_runner/lib/src/build/build_state/build_state.dart
@@ -40,8 +40,8 @@ class BuildState implements GeneratedAssetHider {
   /// Sources and missing sources.
   final Sources _sources;
 
-  /// All standard build step execution results, indexed by [BuildStepId].
-  final Map<BuildStepId, BuildStepResult> _buildStepResults;
+  /// All standard build step execution results by [AssetId] then phase number.
+  final Map<AssetId, Map<int, BuildStepResult>> _buildStepResultsByPrimaryInput;
 
   /// Declared outputs by primary input.
   final Map<AssetId, Set<AssetId>> _declaredOutputsByPrimaryInput;
@@ -52,9 +52,9 @@ class BuildState implements GeneratedAssetHider {
   /// Globs evaluated during the build.
   final Map<GlobId, GlobResult> _globResults;
 
-  /// All post process build steps results, indexed by [PostProcessBuildStepId].
-  final Map<PostProcessBuildStepId, PostProcessBuildStepResult>
-  _postProcessBuildStepResults;
+  /// All post process build steps results by [AssetId] then action number.
+  final Map<AssetId, Map<int, PostProcessBuildStepResult>>
+  _postProcessResultsByInput;
 
   /// All post process build step outputs.
   final Set<AssetId> _postProcessOutputs;
@@ -62,9 +62,9 @@ class BuildState implements GeneratedAssetHider {
   @visibleForTesting
   BuildState.empty()
     : _sources = Sources(),
-      _postProcessBuildStepResults = {},
+      _postProcessResultsByInput = {},
       _postProcessOutputs = {},
-      _buildStepResults = {},
+      _buildStepResultsByPrimaryInput = {},
       _declaredOutputsByPrimaryInput = {},
       _globResults = {},
       _buildStepsByDeclaredOutput = {};
@@ -87,28 +87,35 @@ class BuildState implements GeneratedAssetHider {
 
   BuildState._with({
     required Sources sources,
-    required Map<PostProcessBuildStepId, PostProcessBuildStepResult>
-    postProcessBuildStepResults,
+    required Map<AssetId, Map<int, PostProcessBuildStepResult>>
+    postProcessResultsByInput,
     required Set<AssetId> postProcessOutputs,
-    required Map<BuildStepId, BuildStepResult> buildStepResults,
+    required Map<AssetId, Map<int, BuildStepResult>>
+    buildStepResultsByPrimaryInput,
     required Map<GlobId, GlobResult> globResults,
     required Map<AssetId, BuildStepId> buildStepsByDeclaredOutput,
     required Map<AssetId, Set<AssetId>> declaredOutputsByPrimaryInput,
   }) : _postProcessOutputs = postProcessOutputs,
-       _postProcessBuildStepResults = postProcessBuildStepResults,
+       _postProcessResultsByInput = postProcessResultsByInput,
        _globResults = globResults,
        _buildStepsByDeclaredOutput = buildStepsByDeclaredOutput,
        _declaredOutputsByPrimaryInput = declaredOutputsByPrimaryInput,
-       _buildStepResults = buildStepResults,
+       _buildStepResultsByPrimaryInput = buildStepResultsByPrimaryInput,
        _sources = sources;
 
   /// Copies the state and prepares it for the next build.
   BuildState copyForNextBuild() {
     return BuildState._with(
       sources: _sources.clone(),
-      postProcessBuildStepResults: Map.of(_postProcessBuildStepResults),
+      postProcessResultsByInput: {
+        for (final entry in _postProcessResultsByInput.entries)
+          entry.key: Map.of(entry.value),
+      },
       postProcessOutputs: Set.of(_postProcessOutputs),
-      buildStepResults: Map.of(_buildStepResults),
+      buildStepResultsByPrimaryInput: {
+        for (final entry in _buildStepResultsByPrimaryInput.entries)
+          entry.key: Map.of(entry.value),
+      },
       globResults: Map.of(_globResults),
       buildStepsByDeclaredOutput: Map.of(_buildStepsByDeclaredOutput),
       declaredOutputsByPrimaryInput: {
@@ -171,11 +178,20 @@ class BuildState implements GeneratedAssetHider {
   Iterable<AssetId> declaredOutputsOf(AssetId id) =>
       _declaredOutputsByPrimaryInput[id] ?? const [];
 
-  /// All the declared outputs for [phase].
-  Iterable<AssetId> declaredOutputsForPhase(String package, int phase) =>
-      findFiles(
-        package: package,
-      ).where((id) => _buildStepsByDeclaredOutput[id]?.phaseNumber == phase);
+  /// All the build steps for [phase].
+  Iterable<BuildStepId> buildStepsForPhase(String package, int phase) {
+    final results = <BuildStepId>[];
+    for (final entry in _buildStepResultsByPrimaryInput.entries) {
+      final primaryInput = entry.key;
+      if (primaryInput.package != package) continue;
+      if (entry.value.containsKey(phase)) {
+        results.add(
+          BuildStepId(primaryInput: primaryInput, phaseNumber: phase),
+        );
+      }
+    }
+    return results;
+  }
 
   /// Declared outputs and the phase in which they will be output.
   Map<AssetId, int> get declaredOutputPhases => {
@@ -186,8 +202,8 @@ class BuildState implements GeneratedAssetHider {
   /// Actual build step outputs.
   ///
   /// A subset of [declaredOutputs].
-  Iterable<AssetId> get actualOutputs =>
-      _buildStepResults.values.expand((result) => result.outputs.keys);
+  Iterable<AssetId> get actualOutputs => _buildStepResultsByPrimaryInput.values
+      .expand((map) => map.values.expand((result) => result.outputs.keys));
 
   /// Whether [id] is a declared build output that was actually generated.
   bool isActualOutput(AssetId id) {
@@ -264,11 +280,16 @@ class BuildState implements GeneratedAssetHider {
 
   /// The result of [buildStep].
   BuildStepResult stepResult(BuildStepId buildStep) =>
-      _buildStepResults[buildStep]!;
+      _buildStepResultsByPrimaryInput[buildStep.primaryInput]![buildStep
+          .phaseNumber]!;
 
   /// Updates a build step result after the step runs.
   void updateBuildStepResult(BuildStepId buildStepId, BuildStepResult result) {
-    _buildStepResults[buildStepId] = result;
+    _buildStepResultsByPrimaryInput.putIfAbsent(
+          buildStepId.primaryInput,
+          () => {},
+        )[buildStepId.phaseNumber] =
+        result;
   }
 
   // -- Globs.
@@ -285,30 +306,61 @@ class BuildState implements GeneratedAssetHider {
     PostProcessBuildStepId step,
     PostProcessBuildStepResult result,
   ) {
-    final updated = _postProcessBuildStepResults.putIfAbsent(
-      step,
-      () => result,
+    final results = _postProcessResultsByInput.putIfAbsent(
+      step.input,
+      () => {},
     );
-    if (!identical(updated, result)) {
+    if (results.containsKey(step.actionNumber)) {
       throw StateError('Already had post process result for $step.');
     }
+    results[step.actionNumber] = result;
     _postProcessOutputs.addAll(result.outputs);
   }
 
   void removePostProcessBuildResult(PostProcessBuildStepId step) {
-    final oldResult = _postProcessBuildStepResults.remove(step);
+    final results = _postProcessResultsByInput[step.input];
+    if (results == null) return;
+    final oldResult = results.remove(step.actionNumber);
     if (oldResult != null) {
       _postProcessOutputs.removeAll(oldResult.outputs);
+    }
+    if (results.isEmpty) {
+      _postProcessResultsByInput.remove(step.input);
     }
   }
 
   PostProcessBuildStepResult? postProcessBuildStepResultFor(
     PostProcessBuildStepId step,
-  ) => _postProcessBuildStepResults[step];
+  ) => _postProcessResultsByInput[step.input]?[step.actionNumber];
 
-  /// All [PostProcessBuildStepResult] by [PostProcessBuildStepId].
-  Iterable<MapEntry<PostProcessBuildStepId, PostProcessBuildStepResult>>
-  get postProcessBuildStepResults => _postProcessBuildStepResults.entries;
+  Iterable<PostProcessBuildStepId> get failedPostProcessSteps {
+    final results = <PostProcessBuildStepId>[];
+    for (final outer in _postProcessResultsByInput.entries) {
+      final input = outer.key;
+      for (final inner in outer.value.entries) {
+        if (inner.value.errors.isNotEmpty) {
+          results.add(
+            PostProcessBuildStepId(input: input, actionNumber: inner.key),
+          );
+        }
+      }
+    }
+    return results;
+  }
+
+  Set<AssetId> get assetsDeletedByPostProcess {
+    final result = <AssetId>{};
+    for (final outer in _postProcessResultsByInput.entries) {
+      final input = outer.key;
+      for (final inner in outer.value.values) {
+        if (inner.deletedPrimaryInput) {
+          result.add(input);
+          break;
+        }
+      }
+    }
+    return result;
+  }
 
   // -- Build planning.
 
@@ -318,7 +370,7 @@ class BuildState implements GeneratedAssetHider {
     if (!action.generateFor.matches(input)) return false;
 
     if (action is InBuildPhase) {
-      if (!action.builder.hasOutputFor(input)) return false;
+      if (!action.builder.matchesInput(input)) return false;
     } else if (action is PostBuildAction) {
       final inputExtensions = action.builder.inputExtensions;
       if (!inputExtensions.any(input.path.endsWith)) {
@@ -364,11 +416,13 @@ class BuildState implements GeneratedAssetHider {
         if (idToDelete != null) result.add(idToDelete);
       }
     }
-    for (final postProcessResults in _postProcessBuildStepResults.values) {
-      if (!postProcessResults.hidden) {
-        for (final id in postProcessResults.outputs) {
-          final idToDelete = checkAndMoveId(id);
-          if (idToDelete != null) result.add(idToDelete);
+    for (final results in _postProcessResultsByInput.values) {
+      for (final postProcessResults in results.values) {
+        if (!postProcessResults.hidden) {
+          for (final id in postProcessResults.outputs) {
+            final idToDelete = checkAndMoveId(id);
+            if (idToDelete != null) result.add(idToDelete);
+          }
         }
       }
     }
@@ -450,13 +504,12 @@ class BuildState implements GeneratedAssetHider {
     _sources.setMissing(id);
 
     // Remove post build action applications with removed assets as inputs.
-    _postProcessBuildStepResults.removeWhere((id, result) {
-      if (removedIds!.contains(id.input)) {
+    final postProcessResults = _postProcessResultsByInput.remove(id);
+    if (postProcessResults != null) {
+      for (final result in postProcessResults.values) {
         _postProcessOutputs.removeAll(result.outputs);
-        return true;
       }
-      return false;
-    });
+    }
   }
 
   /// Removes [id] and its transitive declared outputs.
@@ -469,6 +522,7 @@ class BuildState implements GeneratedAssetHider {
       _sources.remove(id);
       _buildStepsByDeclaredOutput.remove(id);
       _declaredOutputsByPrimaryInput.remove(id);
+      _buildStepResultsByPrimaryInput.remove(id);
     }
   }
 
@@ -554,6 +608,21 @@ class BuildState implements GeneratedAssetHider {
     required AssetId primaryInput,
     required bool isHidden,
   }) {
+    final buildStepId = BuildStepId(
+      primaryInput: primaryInput,
+      phaseNumber: phaseNumber,
+    );
+    final existingResults = _buildStepResultsByPrimaryInput[primaryInput];
+    final existingResult = existingResults?[phaseNumber];
+    final buildStepResultBuilder =
+        existingResult?.toBuilder() ?? BuildStepResultBuilder();
+    buildStepResultBuilder.isHidden = isHidden;
+    _buildStepResultsByPrimaryInput.putIfAbsent(
+          primaryInput,
+          () => {},
+        )[phaseNumber] =
+        buildStepResultBuilder.build();
+
     final removed = <AssetId>{};
     for (final output in outputs) {
       if (isSource(output)) {
@@ -571,16 +640,7 @@ class BuildState implements GeneratedAssetHider {
         );
       }
 
-      final buildStepId = BuildStepId(
-        primaryInput: primaryInput,
-        phaseNumber: phaseNumber,
-      );
       _buildStepsByDeclaredOutput[output] = buildStepId;
-      final buildStepResultBuilder =
-          _buildStepResults[buildStepId]?.toBuilder() ??
-          BuildStepResultBuilder();
-      buildStepResultBuilder.isHidden = isHidden;
-      _buildStepResults[buildStepId] = buildStepResultBuilder.build();
     }
     return removed;
   }
@@ -617,9 +677,15 @@ class BuildState implements GeneratedAssetHider {
     Digest? digest,
   }) {
     _buildStepsByDeclaredOutput[id] = buildStepId;
-    final existingResult = _buildStepResults[buildStepId];
+    final primaryInput = buildStepId.primaryInput;
+    final phaseNumber = buildStepId.phaseNumber;
+    final existingResults = _buildStepResultsByPrimaryInput[primaryInput];
+    final existingResult = existingResults?[phaseNumber];
     if (existingResult == null) {
-      _buildStepResults[buildStepId] = BuildStepResult((b) {
+      _buildStepResultsByPrimaryInput.putIfAbsent(
+        primaryInput,
+        () => {},
+      )[phaseNumber] = BuildStepResult((b) {
         b.isHidden = isHidden;
         if (digest != null) {
           b.outputs[id] = digest;
@@ -627,9 +693,10 @@ class BuildState implements GeneratedAssetHider {
       });
     } else {
       if (digest != null) {
-        _buildStepResults[buildStepId] = existingResult.rebuild(
-          (b) => b..outputs[id] = digest,
-        );
+        _buildStepResultsByPrimaryInput.putIfAbsent(
+          primaryInput,
+          () => {},
+        )[phaseNumber] = existingResult.rebuild((b) => b..outputs[id] = digest);
       }
     }
   }

--- a/build_runner/lib/src/build/build_state/serialization.dart
+++ b/build_runner/lib/src/build/build_state/serialization.dart
@@ -133,9 +133,12 @@ Map<String, Object?> serializeBuildState(BuildState buildState) {
       ]),
     ),
     'postProcessResults': serializers.serialize(
-      BuiltMap<PostProcessBuildStepId, PostProcessBuildStepResult>.of(
-        buildState._postProcessBuildStepResults,
-      ),
+      BuiltMap<PostProcessBuildStepId, PostProcessBuildStepResult>.of({
+        for (final outer in buildState._postProcessResultsByInput.entries)
+          for (final inner in outer.value.entries)
+            PostProcessBuildStepId(input: outer.key, actionNumber: inner.key):
+                inner.value,
+      }),
       specifiedType: postProcessBuildStepResultsFullType,
     ),
     'missingSources': serializers.serialize(
@@ -143,7 +146,12 @@ Map<String, Object?> serializeBuildState(BuildState buildState) {
       specifiedType: const FullType(BuiltSet, [FullType(AssetId)]),
     ),
     'buildStepResults': serializers.serialize(
-      BuiltMap<BuildStepId, BuildStepResult>.of(buildState._buildStepResults),
+      BuiltMap<BuildStepId, BuildStepResult>.of({
+        for (final outer in buildState._buildStepResultsByPrimaryInput.entries)
+          for (final inner in outer.value.entries)
+            BuildStepId(primaryInput: outer.key, phaseNumber: inner.key):
+                inner.value,
+      }),
       specifiedType: const FullType(BuiltMap, [
         FullType(BuildStepId),
         FullType(BuildStepResult),

--- a/build_runner/lib/src/build/run_builder.dart
+++ b/build_runner/lib/src/build/run_builder.dart
@@ -64,7 +64,6 @@ Future<void> runBuilder(
 
   Future<void> buildForInput(AssetId input) async {
     final outputs = expectedOutputs(builder, input);
-    if (outputs.isEmpty) return;
     final buildStep = BuildStepImpl(
       input,
       outputs,

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -63,17 +63,8 @@ class BuildOutputReader {
        _buildPlan = buildPlan,
        _processedOutputs = processedOutputs;
 
-  Set<AssetId> _collectAssetsDeletedByPostProcessBuilders() {
-    final buildState = _buildState;
-    if (buildState == null) return const {};
-    final result = <AssetId>{};
-    for (final entry in buildState.postProcessBuildStepResults) {
-      if (entry.value.deletedPrimaryInput) {
-        result.add(entry.key.input);
-      }
-    }
-    return result;
-  }
+  Set<AssetId> _collectAssetsDeletedByPostProcessBuilders() =>
+      _buildState?.assetsDeletedByPostProcess ?? const {};
 
   /// Returns a reason why [id] is not readable, or null if it is readable.
   Future<UnreadableReason?> unreadableReason(AssetId id) async {

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   analyzer: '>=8.0.0 <14.0.0'
   args: ^2.5.0
   async: ^2.5.0
-  build: ^4.0.0
+  build: ^4.0.7-wip
   build_config: ">=1.3.0 <1.4.0"
   build_daemon: ^4.0.0
   built_collection: ^5.1.1

--- a/build_runner/test/integration_tests/build_command_zero_output_builder_test.dart
+++ b/build_runner/test/integration_tests/build_command_zero_output_builder_test.dart
@@ -1,0 +1,154 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['integration4'])
+library;
+
+import 'package:build_runner/src/logging/build_log.dart';
+import 'package:test/test.dart';
+
+import '../common/common.dart';
+
+void main() async {
+  test('build command with zero output builder', () async {
+    final pubspecs = await Pubspecs.load();
+    final tester = BuildRunnerTester(pubspecs);
+
+    tester.writePackage(
+      name: 'builder_pkg',
+      dependencies: ['build', 'build_runner'],
+      files: {
+        'build.yaml': '''
+builders:
+  zero_output_builder:
+    import: 'package:builder_pkg/builder.dart'
+    builder_factories: ['zeroOutputBuilderFactory']
+    build_extensions: {'.txt': []} # Declares no outputs.
+    auto_apply: 'root_package'
+    build_to: 'cache'
+    is_optional: false # Required to run.
+''',
+        'lib/builder.dart': '''
+import 'package:build/build.dart';
+
+Builder zeroOutputBuilderFactory(BuilderOptions options) => ZeroOutputBuilder();
+
+class ZeroOutputBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {'.txt': []};
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    // Create an input dependency, notify that the builder ran.
+    final otherId = AssetId(buildStep.inputId.package, 'lib/dep.other');
+    await buildStep.canRead(otherId);
+    log.warning('ZeroOutputBuilder ran on \${buildStep.inputId.path}');
+  }
+}
+''',
+      },
+    );
+
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {
+        'lib/a.txt': 'primary content',
+        'lib/dep.other': 'dependency content',
+      },
+    );
+
+    // Runs despite having no outputs.
+    var output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
+    expect(output, contains(BuildLog.successPattern));
+    expect(output, contains('ZeroOutputBuilder ran on lib/a.txt'));
+
+    // Does not rerun if nothing changed.
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
+    expect(output, contains(BuildLog.successPattern));
+    expect(output, isNot(contains('ZeroOutputBuilder ran on lib/a.txt')));
+
+    // Runs if something changes.
+    tester.write('root_pkg/lib/dep.other', 'modified dependency content');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
+    expect(output, contains(BuildLog.successPattern));
+    expect(output, contains('ZeroOutputBuilder ran on lib/a.txt')); // Rerun!
+
+    // Now with a mix of zero-output and non-zero-output extensions.
+    tester.writePackage(
+      name: 'builder_pkg',
+      dependencies: ['build', 'build_runner'],
+      files: {
+        'build.yaml': '''
+builders:
+  mixed_builder:
+    import: 'package:builder_pkg/builder.dart'
+    builder_factories: ['mixedBuilderFactory']
+    build_extensions: {'.txt': [], '.dart': ['.g.dart']}
+    auto_apply: 'root_package'
+    build_to: 'cache'
+    is_optional: false
+''',
+        'lib/builder.dart': '''
+import 'package:build/build.dart';
+
+Builder mixedBuilderFactory(BuilderOptions options) => MixedBuilder();
+
+class MixedBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {'.txt': [], '.dart': ['.g.dart']};
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    log.warning('MixedBuilder ran on \${buildStep.inputId.path}');
+    if (buildStep.inputId.path.endsWith('.dart')) {
+      await buildStep.writeAsString(
+        buildStep.inputId.changeExtension('.g.dart'), '',
+      );
+    }
+  }
+}
+''',
+      },
+    );
+
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {'lib/a.txt': 'primary content', 'lib/b.dart': 'class B {}'},
+    );
+
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
+    expect(output, contains(BuildLog.successPattern));
+    expect(output, contains('MixedBuilder ran on lib/a.txt'));
+    expect(output, contains('MixedBuilder ran on lib/b.dart'));
+    expect(
+      tester.read('root_pkg/.dart_tool/build/generated/root_pkg/lib/b.g.dart'),
+      isNotNull,
+    );
+
+    // Does not rerun if nothing changed.
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
+    expect(output, contains(BuildLog.successPattern));
+    expect(output, isNot(contains('MixedBuilder ran on lib/a.txt')));
+    expect(output, isNot(contains('MixedBuilder ran on lib/b.dart')));
+  });
+}


### PR DESCRIPTION
Allow builders with no outputs.

They can write log messages and, if they like, fail the build.

Next after this will be a new type of output that doesn't count as a normal output, for part files.

Also

 - rename methods that talk about `hasOutputs`, we now care instead whether the input is matched, as it might match with zero outputs
 -  change `Map<(ID, action number>, result` into `Map<ID, Map<action number, result>>` for both normal and post process actions as this saves scanning the whole map in a few cases