### PR TITLE
Remove `build_modules` from benchmark pubspec.yaml.

### DIFF
--- a/_benchmark/lib/config.dart
+++ b/_benchmark/lib/config.dart
@@ -87,8 +87,6 @@ class RunConfig {
     path: $buildRepoPath/build
   build_config:
     path: $buildRepoPath/build_config
-  build_modules:
-    path: $buildRepoPath/builder_pkgs/build_modules
   build_runner:
     path: $buildRepoPath/build_runner
   build_test:


### PR DESCRIPTION
It's no longer a dependency of the web compilers and it doesn't resolve.