### PR TITLE
make DdcFrontendServerBuilder use custom sdk build options

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Prefer entrypoints closer to the root of a searched directory,
   and `main.dart` over other entrypoints alongside it.
 - Accept a list of directories for `web-assets-path`.
+- Fix `DdcFrontendServerBuilder` to support the same custom sdk build options as `DevCompilerBuilder`.
 
 ## 4.8.10
 

--- a/builder_pkgs/build_web_compilers/bin/fes_manager.dart
+++ b/builder_pkgs/build_web_compilers/bin/fes_manager.dart
@@ -135,12 +135,13 @@ class FesManager {
     required Uri packagesFile,
     Map<String, String> environment = const {},
   }) async {
-    final fes = await PersistentFrontendServer.start(
+    final fes = PersistentFrontendServer(
       sdkRoot: sdkRoot,
       fileSystemRoot: fileSystemRoot,
       packagesFile: packagesFile,
       environment: environment,
     );
+    await fes.ensureStarted();
     final driver = FrontendServerProxyDriver()..init(fes);
     final packageConfig = await PackageConfig.load(File.fromUri(packagesFile));
     return FesManager._(fes: fes, driver: driver, packageConfig: packageConfig);

--- a/builder_pkgs/build_web_compilers/bin/fes_manager.dart
+++ b/builder_pkgs/build_web_compilers/bin/fes_manager.dart
@@ -161,12 +161,13 @@ class FesManager {
     required Uri packagesFile,
     Map<String, String> environment = const {},
   }) async {
-    final fes = await PersistentFrontendServer.start(
+    final fes = PersistentFrontendServer(
       sdkRoot: sdkRoot,
       fileSystemRoot: fileSystemRoot,
       packagesFile: packagesFile,
       environment: environment,
     );
+    await fes.ensureStarted();
     final driver = FrontendServerProxyDriver()..init(fes);
     final packageConfig = await PackageConfig.load(File.fromUri(packagesFile));
     return FesManager._(fes: fes, driver: driver, packageConfig: packageConfig);

--- a/builder_pkgs/build_web_compilers/lib/builders.dart
+++ b/builder_pkgs/build_web_compilers/lib/builders.dart
@@ -61,6 +61,9 @@ Builder ddcBuilder(BuilderOptions options) {
     frontendServerEnvironment = _readEnvironmentOption(options);
     return DdcFrontendServerBuilder(
       scratchSpaceDir: _readScratchSpaceDirOption(options),
+      librariesPath: _readLibrariesPathOption(options),
+      platformSdk: _readPlatformSdkOption(options),
+      sdkKernelPath: _readDdcKernelPathOption(options),
     );
   }
 

--- a/builder_pkgs/build_web_compilers/lib/builders.dart
+++ b/builder_pkgs/build_web_compilers/lib/builders.dart
@@ -64,7 +64,11 @@ Builder ddcBuilder(BuilderOptions options) {
 
   if (_readWebHotReloadOption(options)) {
     frontendServerEnvironment = _readEnvironmentOption(options);
-    return DdcFrontendServerBuilder();
+    return DdcFrontendServerBuilder(
+      librariesPath: _readLibrariesPathOption(options),
+      platformSdk: _readPlatformSdkOption(options),
+      sdkKernelPath: _readDdcKernelPathOption(options),
+    );
   }
 
   return DevCompilerBuilder(

--- a/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_driver.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_driver.dart
@@ -267,37 +267,89 @@ class _CompileExpressionToJsRequest extends _CompilationRequest {
 /// A single instance of the Frontend Server that persists across
 /// compile/recompile requests.
 class PersistentFrontendServer {
-  final FrontendServerClient _client;
+  final String sdkRoot;
+  final Uri fileSystemRoot;
+  final Uri packagesFile;
+  final Map<String, String> environment;
   final Uri outputDillUri;
   final WebMemoryFilesystem _fileSystem;
 
-  PersistentFrontendServer._({
-    required FrontendServerClient client,
-    required this.outputDillUri,
-    required WebMemoryFilesystem fileSystem,
-  }) : _client = client,
-       _fileSystem = fileSystem;
+  FrontendServerClient? _client;
+  Future<void>? _startFuture;
+  String? _librariesPath;
+  String? _platformSdk;
+  String? _sdkKernelPath;
 
-  FrontendServerClient get client => _client;
+  PersistentFrontendServer({
+    required this.sdkRoot,
+    required this.fileSystemRoot,
+    required this.packagesFile,
+    this.environment = const {},
+  }) : outputDillUri = fileSystemRoot.resolve('output.dill'),
+       _fileSystem = WebMemoryFilesystem(fileSystemRoot, getRootPackageName());
+
+  FrontendServerClient get client {
+    if (_client == null) {
+      throw StateError(
+        'Frontend server must be started before accessing client. '
+        'See ensureStarted().',
+      );
+    }
+    return _client!;
+  }
+
   WebMemoryFilesystem get fileSystem => _fileSystem;
 
-  static Future<PersistentFrontendServer> start({
-    required String sdkRoot,
-    required Uri fileSystemRoot,
-    required Uri packagesFile,
-    Map<String, String> environment = const {},
+  /// Starts the persistent Frontend Server process if not already started.
+  ///
+  /// Must be called before accessing the server's [client].
+  ///
+  /// If the server has already been started or is in the process of starting,
+  /// this method returns immediately. If the provided options differ from those
+  /// used in a previous call to [ensureStarted], an [ArgumentError] is thrown.
+  Future<void> ensureStarted({
+    String? librariesPath,
+    String? platformSdk,
+    String? sdkKernelPath,
+  }) async {
+    if (_client != null || _startFuture != null) {
+      if (librariesPath != _librariesPath ||
+          platformSdk != _platformSdk ||
+          sdkKernelPath != _sdkKernelPath) {
+        throw ArgumentError(
+          'PersistentFrontendServer was already started or is starting with '
+          'different options.\n'
+          'Expected: librariesPath=$_librariesPath, platformSdk=$_platformSdk, '
+          'sdkKernelPath=$_sdkKernelPath\n'
+          'Actual: librariesPath=$librariesPath, platformSdk=$platformSdk, '
+          'sdkKernelPath=$sdkKernelPath',
+        );
+      }
+      return _startFuture;
+    }
+    _librariesPath = librariesPath;
+    _platformSdk = platformSdk;
+    _sdkKernelPath = sdkKernelPath;
+    return _startFuture ??= _doStart(
+      librariesPath: librariesPath,
+      platformSdk: platformSdk,
+      sdkKernelPath: sdkKernelPath,
+    );
+  }
+
+  Future<void> _doStart({
+    String? librariesPath,
+    String? platformSdk,
+    String? sdkKernelPath,
   }) async {
     final rootPackage = getRootPackageName();
-    final socketConnection = await _tryConnectToFESManager(fileSystemRoot);
+    final socketConnection = await _tryConnectToFESManager();
     if (socketConnection != null) {
-      return PersistentFrontendServer._(
-        client: SocketFrontendServerClient(
-          socketConnection.socket,
-          socketConnection.socketLines,
-        ),
-        outputDillUri: fileSystemRoot.resolve('output.dill'),
-        fileSystem: WebMemoryFilesystem(fileSystemRoot, rootPackage),
+      _client = SocketFrontendServerClient(
+        socketConnection.socket,
+        socketConnection.socketLines,
       );
+      return;
     }
 
     // ScratchSpace's generated 'package_config.json' uses absolute file URIs
@@ -312,15 +364,17 @@ class PersistentFrontendServer {
     }
     PackageConfig.rewriteToMultiRoot(file, multiRootScheme, rootPackage);
 
-    final outputDillUri = fileSystemRoot.resolve('output.dill');
     // [platformDill] must be passed to the Frontend Server with a 'file:'
     // prefix to pass schema checks for Windows drive letters.
     final platformDill = Uri.file(
-      p.join(sdkDir, 'lib', '_internal', 'ddc_outline.dill'),
+      p.join(
+        platformSdk ?? sdkRoot,
+        sdkKernelPath ?? 'lib/_internal/ddc_outline.dill',
+      ),
     );
     final args = [
       frontendServerSnapshotPath,
-      '--sdk-root=$sdkRoot',
+      '--sdk-root=${platformSdk ?? sdkRoot}',
       '--incremental',
       '--target=dartdevc',
       '--dartdevc-module-format=ddc',
@@ -331,6 +385,7 @@ class PersistentFrontendServer {
       '--filesystem-scheme=$multiRootScheme',
       '--filesystem-root=${fileSystemRoot.toFilePath()}',
       '--platform=$platformDill',
+      if (librariesPath != null) '--libraries-spec=$librariesPath',
       '--output-dill=${outputDillUri.toFilePath()}',
       '--output-incremental-dill=${outputDillUri.toFilePath()}',
       for (final define in environment.entries)
@@ -339,7 +394,6 @@ class PersistentFrontendServer {
         '--enable-experiment=$experiment',
     ];
     final process = await _startWithReaper(dartaotruntimePath, args);
-    final fileSystem = WebMemoryFilesystem(fileSystemRoot, rootPackage);
     final stdoutHandler = StdoutHandler(logger: _log);
     process.stdout
         .transform(utf8.decoder)
@@ -347,15 +401,11 @@ class PersistentFrontendServer {
         .listen(stdoutHandler.handler);
     process.stderr.transform(utf8.decoder).listen(_log.warning);
 
-    return PersistentFrontendServer._(
-      client: StdioFrontendServerClient(
-        process,
-        stdoutHandler,
-        fileSystem,
-        outputDillUri,
-      ),
-      outputDillUri: outputDillUri,
-      fileSystem: fileSystem,
+    _client = StdioFrontendServerClient(
+      process,
+      stdoutHandler,
+      _fileSystem,
+      outputDillUri,
     );
   }
 
@@ -365,8 +415,7 @@ class PersistentFrontendServer {
   /// port and attempts to connect.
   ///
   /// If a connection can't be made, returns `null` and deletes the config file.
-  static Future<_FesSocketConnection?> _tryConnectToFESManager(
-    Uri fileSystemRoot, {
+  Future<_FesSocketConnection?> _tryConnectToFESManager({
     int retries = 10,
   }) async {
     final configFile = File(
@@ -451,17 +500,17 @@ class PersistentFrontendServer {
   }
 
   Future<CompilerOutput?> compile(String entrypoint) =>
-      _client.compile(entrypoint);
+      client.compile(entrypoint);
 
   Future<CompilerOutput?> recompile(
     String entrypoint,
     List<Uri> invalidatedFiles,
-  ) => _client.recompile(entrypoint, invalidatedFiles);
+  ) => client.recompile(entrypoint, invalidatedFiles);
 
   Future<CompilerOutput?> recompileRestart(
     String entrypoint,
     List<Uri> invalidatedFiles,
-  ) => _client.recompileRestart(entrypoint, invalidatedFiles);
+  ) => client.recompileRestart(entrypoint, invalidatedFiles);
 
   Future<CompilerOutput?> compileExpressionToJs({
     required String libraryUri,
@@ -472,7 +521,7 @@ class PersistentFrontendServer {
     required Map<String, String> jsFrameValues,
     required String moduleName,
     required String expression,
-  }) => _client.compileExpressionToJs(
+  }) => client.compileExpressionToJs(
     libraryUri: libraryUri,
     scriptUri: scriptUri,
     line: line,
@@ -483,10 +532,10 @@ class PersistentFrontendServer {
     expression: expression,
   );
 
-  Future<void> accept() => _client.accept();
-  Future<String> readOutputFile(String path) => _client.readOutputFile(path);
-  Future<CompilerOutput?> reject() => _client.reject();
-  Future<void> reset() => _client.reset();
+  Future<void> accept() => client.accept();
+  Future<String> readOutputFile(String path) => client.readOutputFile(path);
+  Future<CompilerOutput?> reject() => client.reject();
+  Future<void> reset() => client.reset();
 
   /// Records all modified files into the in-memory filesystem.
   void recordFiles() {
@@ -506,7 +555,14 @@ class PersistentFrontendServer {
     _fileSystem.writeFileToDisk(_fileSystem.jsRootUri, fileName);
   }
 
-  Future<void> shutdown() => _client.shutdown();
+  Future<void> shutdown() async {
+    await _client?.shutdown();
+    _client = null;
+    _startFuture = null;
+    _librariesPath = null;
+    _platformSdk = null;
+    _sdkKernelPath = null;
+  }
 }
 
 class CompilerOutput {

--- a/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_driver.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_driver.dart
@@ -267,40 +267,91 @@ class _CompileExpressionToJsRequest extends _CompilationRequest {
 /// A single instance of the Frontend Server that persists across
 /// compile/recompile requests.
 class PersistentFrontendServer {
-  final FrontendServerClient _client;
+  final String sdkRoot;
+  final Uri fileSystemRoot;
+  final List<Uri>? fileSystemRoots;
+  final Uri packagesFile;
+  final Map<String, String> environment;
   final Uri outputDillUri;
   final WebMemoryFilesystem _fileSystem;
 
-  PersistentFrontendServer._({
-    required this._client,
-    required this.outputDillUri,
-    required this._fileSystem,
-  });
+  FrontendServerClient? _client;
+  Future<void>? _startFuture;
+  String? _librariesPath;
+  String? _platformSdk;
+  String? _sdkKernelPath;
 
-  FrontendServerClient get client => _client;
+  PersistentFrontendServer({
+    required this.sdkRoot,
+    required this.fileSystemRoot,
+    this.fileSystemRoots,
+    required this.packagesFile,
+    this.environment = const {},
+  }) : outputDillUri = fileSystemRoot.resolve('output.dill'),
+       _fileSystem = WebMemoryFilesystem(fileSystemRoot, getRootPackageName());
+
+  FrontendServerClient get client {
+    if (_client == null) {
+      throw StateError(
+        'Frontend server must be started before accessing client. '
+        'See ensureStarted().',
+      );
+    }
+    return _client!;
+  }
+
   WebMemoryFilesystem get fileSystem => _fileSystem;
 
-  static Future<PersistentFrontendServer> start({
-    required String sdkRoot,
-    required Uri fileSystemRoot,
-    List<Uri>? fileSystemRoots,
-    required Uri packagesFile,
-    Map<String, String> environment = const {},
+  /// Starts the persistent Frontend Server process if not already started.
+  ///
+  /// Must be called before accessing the server's [client].
+  ///
+  /// If the server has already been started or is in the process of starting,
+  /// this method returns immediately. If the provided options differ from those
+  /// used in a previous call to [ensureStarted], an [ArgumentError] is thrown.
+  Future<void> ensureStarted({
+    String? librariesPath,
+    String? platformSdk,
+    String? sdkKernelPath,
+  }) async {
+    if (_client != null || _startFuture != null) {
+      if (librariesPath != _librariesPath ||
+          platformSdk != _platformSdk ||
+          sdkKernelPath != _sdkKernelPath) {
+        throw ArgumentError(
+          'PersistentFrontendServer was already started or is starting with '
+          'different options.\n'
+          'Expected: librariesPath=$_librariesPath, platformSdk=$_platformSdk, '
+          'sdkKernelPath=$_sdkKernelPath\n'
+          'Actual: librariesPath=$librariesPath, platformSdk=$platformSdk, '
+          'sdkKernelPath=$sdkKernelPath',
+        );
+      }
+      return _startFuture;
+    }
+    _librariesPath = librariesPath;
+    _platformSdk = platformSdk;
+    _sdkKernelPath = sdkKernelPath;
+    return _startFuture ??= _doStart(
+      librariesPath: librariesPath,
+      platformSdk: platformSdk,
+      sdkKernelPath: sdkKernelPath,
+    );
+  }
+
+  Future<void> _doStart({
     String? librariesPath,
     String? platformSdk,
     String? sdkKernelPath,
   }) async {
     final rootPackage = getRootPackageName();
-    final socketConnection = await _tryConnectToFESManager(fileSystemRoot);
+    final socketConnection = await _tryConnectToFESManager();
     if (socketConnection != null) {
-      return PersistentFrontendServer._(
-        client: SocketFrontendServerClient(
-          socketConnection.socket,
-          socketConnection.socketLines,
-        ),
-        outputDillUri: fileSystemRoot.resolve('output.dill'),
-        fileSystem: WebMemoryFilesystem(fileSystemRoot, rootPackage),
+      _client = SocketFrontendServerClient(
+        socketConnection.socket,
+        socketConnection.socketLines,
       );
+      return;
     }
 
     // ScratchSpace's generated 'package_config.json' uses absolute file URIs
@@ -315,15 +366,18 @@ class PersistentFrontendServer {
     }
     PackageConfig.rewriteToMultiRoot(file, multiRootScheme, rootPackage);
 
-    final outputDillUri = fileSystemRoot.resolve('output.dill');
     // [platformDill] must be passed to the Frontend Server with a 'file:'
     // prefix to pass schema checks for Windows drive letters.
     final platformDill = Uri.file(
-      p.join(sdkDir, 'lib', '_internal', 'ddc_outline.dill'),
+      p.join(
+        platformSdk ?? sdkRoot,
+        sdkKernelPath ?? 'lib/_internal/ddc_outline.dill',
+      ),
     );
+    final roots = fileSystemRoots;
     final args = [
       frontendServerSnapshotPath,
-      '--sdk-root=$sdkRoot',
+      '--sdk-root=${platformSdk ?? sdkRoot}',
       '--incremental',
       '--target=dartdevc',
       '--dartdevc-module-format=ddc',
@@ -333,8 +387,8 @@ class PersistentFrontendServer {
       '--experimental-emit-debug-metadata',
       '--filesystem-scheme=$multiRootScheme',
       '--filesystem-root=${fileSystemRoot.toFilePath()}',
-      if (fileSystemRoots != null)
-        for (final root in fileSystemRoots)
+      if (roots != null)
+        for (final root in roots)
           '--filesystem-root=${root.toFilePath()}',
       if (librariesPath != null) '--libraries-spec=$librariesPath',
       if (platformSdk != null) '--platform-sdk=$platformSdk',
@@ -349,7 +403,6 @@ class PersistentFrontendServer {
     ];
     final dartaotruntime = p.join(sdkRoot, 'bin', 'dartaotruntime');
     final process = await _startWithReaper(dartaotruntime, args);
-    final fileSystem = WebMemoryFilesystem(fileSystemRoot, rootPackage);
     final stdoutHandler = StdoutHandler(logger: _log);
     process.stdout
         .transform(utf8.decoder)
@@ -357,15 +410,11 @@ class PersistentFrontendServer {
         .listen(stdoutHandler.handler);
     process.stderr.transform(utf8.decoder).listen(_log.warning);
 
-    return PersistentFrontendServer._(
-      client: StdioFrontendServerClient(
-        process,
-        stdoutHandler,
-        fileSystem,
-        outputDillUri,
-      ),
-      outputDillUri: outputDillUri,
-      fileSystem: fileSystem,
+    _client = StdioFrontendServerClient(
+      process,
+      stdoutHandler,
+      _fileSystem,
+      outputDillUri,
     );
   }
 
@@ -375,8 +424,7 @@ class PersistentFrontendServer {
   /// port and attempts to connect.
   ///
   /// If a connection can't be made, returns `null` and deletes the config file.
-  static Future<_FesSocketConnection?> _tryConnectToFESManager(
-    Uri fileSystemRoot, {
+  Future<_FesSocketConnection?> _tryConnectToFESManager({
     int retries = 10,
   }) async {
     final configFile = File(
@@ -474,17 +522,17 @@ class PersistentFrontendServer {
   }
 
   Future<CompilerOutput?> compile(String entrypoint) =>
-      _client.compile(entrypoint);
+      client.compile(entrypoint);
 
   Future<CompilerOutput?> recompile(
     String entrypoint,
     List<Uri> invalidatedFiles,
-  ) => _client.recompile(entrypoint, invalidatedFiles);
+  ) => client.recompile(entrypoint, invalidatedFiles);
 
   Future<CompilerOutput?> recompileRestart(
     String entrypoint,
     List<Uri> invalidatedFiles,
-  ) => _client.recompileRestart(entrypoint, invalidatedFiles);
+  ) => client.recompileRestart(entrypoint, invalidatedFiles);
 
   Future<CompilerOutput?> compileExpressionToJs({
     required String libraryUri,
@@ -495,7 +543,7 @@ class PersistentFrontendServer {
     required Map<String, String> jsFrameValues,
     required String moduleName,
     required String expression,
-  }) => _client.compileExpressionToJs(
+  }) => client.compileExpressionToJs(
     libraryUri: libraryUri,
     scriptUri: scriptUri,
     line: line,
@@ -506,10 +554,10 @@ class PersistentFrontendServer {
     expression: expression,
   );
 
-  Future<void> accept() => _client.accept();
-  Future<String> readOutputFile(String path) => _client.readOutputFile(path);
-  Future<CompilerOutput?> reject() => _client.reject();
-  Future<void> reset() => _client.reset();
+  Future<void> accept() => client.accept();
+  Future<String> readOutputFile(String path) => client.readOutputFile(path);
+  Future<CompilerOutput?> reject() => client.reject();
+  Future<void> reset() => client.reset();
 
   /// Records all modified files into the in-memory filesystem.
   void recordFiles() {
@@ -529,7 +577,14 @@ class PersistentFrontendServer {
     _fileSystem.writeFileToDisk(_fileSystem.jsRootUri, fileName);
   }
 
-  Future<void> shutdown() => _client.shutdown();
+  Future<void> shutdown() async {
+    await _client?.shutdown();
+    _client = null;
+    _startFuture = null;
+    _librariesPath = null;
+    _platformSdk = null;
+    _sdkKernelPath = null;
+  }
 }
 
 class CompilerOutput {

--- a/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_driver.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_driver.dart
@@ -388,8 +388,7 @@ class PersistentFrontendServer {
       '--filesystem-scheme=$multiRootScheme',
       '--filesystem-root=${fileSystemRoot.toFilePath()}',
       if (roots != null)
-        for (final root in roots)
-          '--filesystem-root=${root.toFilePath()}',
+        for (final root in roots) '--filesystem-root=${root.toFilePath()}',
       if (librariesPath != null) '--libraries-spec=$librariesPath',
       if (platformSdk != null) '--platform-sdk=$platformSdk',
       if (sdkKernelPath != null) '--sdk-kernel-path=$sdkKernelPath',

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/workers.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/workers.dart
@@ -156,7 +156,7 @@ Future<PersistentFrontendServer> startFrontendServerWorker() async {
   final customPath = frontendServerState.customScratchSpacePath;
   final fesRoot =
       customPath != null ? Directory(customPath).uri : scratchSpace.tempDir.uri;
-  final fes = await PersistentFrontendServer.start(
+  final fes = PersistentFrontendServer(
     sdkRoot: sdkDir,
     fileSystemRoot: fesRoot,
     packagesFile: fesRoot.resolve(packagesFilePath),

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/workers.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/workers.dart
@@ -147,7 +147,7 @@ Future<PersistentFrontendServer> startFrontendServerWorker() async {
   // We bind the Frontend Server worker's filesystem root to that of the scratch
   // space.
   final fesRoot = scratchSpace.tempDir.uri;
-  final fes = await PersistentFrontendServer.start(
+  final fes = PersistentFrontendServer(
     sdkRoot: sdkDir,
     fileSystemRoot: fesRoot,
     packagesFile: fesRoot.resolve(packagesFilePath),

--- a/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
@@ -21,7 +21,6 @@ class DdcFrontendServerBuilder implements Builder {
   /// Used to share the scratch space directory with the `fes_manager` process
   /// when it is initialized separately from the build daemon (like in tests).
   final String? scratchSpaceDir;
-
   /// A persistent scratch space instance used when a custom scratch space
   /// directory is provided.
   ///
@@ -29,7 +28,16 @@ class DdcFrontendServerBuilder implements Builder {
   /// for recompiles.
   ScratchSpace? _scratchSpace;
 
-  DdcFrontendServerBuilder({this.scratchSpaceDir});
+  final String? librariesPath;
+  final String? platformSdk;
+  final String? sdkKernelPath;
+
+  DdcFrontendServerBuilder({
+    this.scratchSpaceDir,
+    this.librariesPath,
+    this.platformSdk,
+    this.sdkKernelPath,
+  });
 
   @override
   Map<String, List<String>> get buildExtensions => {
@@ -84,10 +92,17 @@ class DdcFrontendServerBuilder implements Builder {
       ], buildStep),
     );
     final root = getRootPackageName();
+    final frontendServer = await buildStep.fetchResource(
+      persistentFrontendServerResource,
+    );
+    await frontendServer.ensureStarted(
+      librariesPath: librariesPath,
+      platformSdk: platformSdk,
+      sdkKernelPath: sdkKernelPath,
+    );
     final driver = await buildStep.fetchResource(
       frontendServerProxyDriverResource,
     );
-    await buildStep.fetchResource(persistentFrontendServerResource);
     final entrypointArg = sourceArg(frontendServerState.entrypointAssetId!);
     String assetPath(AssetId id) =>
         id.package == root

--- a/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
@@ -14,6 +14,15 @@ import 'platforms.dart';
 
 /// A builder that compiles DDC modules with the Frontend Server.
 class DdcFrontendServerBuilder implements Builder {
+  final String? librariesPath;
+  final String? platformSdk;
+  final String? sdkKernelPath;
+
+  DdcFrontendServerBuilder({
+    this.librariesPath,
+    this.platformSdk,
+    this.sdkKernelPath,
+  });
   @override
   Map<String, List<String>> get buildExtensions => {
     moduleExtension(ddcPlatform): [
@@ -50,10 +59,17 @@ class DdcFrontendServerBuilder implements Builder {
     ];
     final scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
     final root = getRootPackageName();
+    final frontendServer = await buildStep.fetchResource(
+      persistentFrontendServerResource,
+    );
+    await frontendServer.ensureStarted(
+      librariesPath: librariesPath,
+      platformSdk: platformSdk,
+      sdkKernelPath: sdkKernelPath,
+    );
     final driver = await buildStep.fetchResource(
       frontendServerProxyDriverResource,
     );
-    await buildStep.fetchResource(persistentFrontendServerResource);
     final entrypointArg = sourceArg(entrypointAssetId);
     // Translates an AssetId to its scratch space file path.
     //
@@ -63,7 +79,6 @@ class DdcFrontendServerBuilder implements Builder {
     String assetPath(AssetId id) => id.package == root
         ? id.path
         : 'packages/${id.package}/${id.path.replaceFirst('lib/', '')}';
-
     try {
       final changedAssetUris = <Uri>[];
       frontendServerState.triggerSharedCompilation(entrypointAssetId, () async {

--- a/builder_pkgs/build_web_compilers/test/build_frontend_server/frontend_server_driver_test.dart
+++ b/builder_pkgs/build_web_compilers/test/build_frontend_server/frontend_server_driver_test.dart
@@ -30,16 +30,42 @@ void main() {
         p.join(Directory.current.path, fesManagerConfigPath),
       );
       if (configFile.existsSync()) configFile.deleteSync();
-      server = await PersistentFrontendServer.start(
+      server = PersistentFrontendServer(
         sdkRoot: sdkDir,
         fileSystemRoot: tempDir.uri,
         packagesFile: packageConfig,
       );
+      await server.ensureStarted();
     });
 
     tearDown(() async {
       await server.shutdown();
       await tempDir.delete(recursive: true);
+    });
+
+    test('throws ArgumentError if ensureStarted is called with different options', () async {
+      final localTempDir = await Directory.systemTemp.createTemp('fes-test-local');
+      final packageConfig = localTempDir.uri.resolve('.dart_tool/package_config.json');
+      File(packageConfig.toFilePath())
+        ..createSync(recursive: true)
+        ..writeAsStringSync(jsonEncode({'configVersion': 2, 'packages': <String>[]}));
+      final localServer = PersistentFrontendServer(
+        sdkRoot: sdkDir,
+        fileSystemRoot: localTempDir.uri,
+        packagesFile: packageConfig,
+      );
+      try {
+        await localServer.ensureStarted(librariesPath: 'foo');
+        expect(
+          () => localServer.ensureStarted(librariesPath: 'bar'),
+          throwsArgumentError,
+        );
+        // Calling with the same options is fine
+        await localServer.ensureStarted(librariesPath: 'foo');
+      } finally {
+        await localServer.shutdown();
+        await localTempDir.delete(recursive: true);
+      }
     });
 
     test('can compile a simple dart file', () async {
@@ -116,11 +142,12 @@ void main() {
         p.join(Directory.current.path, fesManagerConfigPath),
       );
       if (configFile.existsSync()) configFile.deleteSync();
-      server = await PersistentFrontendServer.start(
+      server = PersistentFrontendServer(
         sdkRoot: sdkDir,
         fileSystemRoot: tempDir.uri,
         packagesFile: packageConfig,
       );
+      await server.ensureStarted();
       driver = FrontendServerProxyDriver();
       driver.init(server);
     });
@@ -186,12 +213,13 @@ void main() {
       final packageConfig = tempDir.uri.resolve(
         '.dart_tool/package_config.json',
       );
-      final envServer = await PersistentFrontendServer.start(
+      final envServer = PersistentFrontendServer(
         sdkRoot: sdkDir,
         fileSystemRoot: tempDir.uri,
         packagesFile: packageConfig,
-        environment: {'MY_DEFINE': 'hello_world'},
+        environment: const {'MY_DEFINE': 'hello_world'},
       );
+      await envServer.ensureStarted();
       addTearDown(envServer.shutdown);
 
       final envDriver = FrontendServerProxyDriver()..init(envServer);

--- a/builder_pkgs/build_web_compilers/test/build_frontend_server/frontend_server_driver_test.dart
+++ b/builder_pkgs/build_web_compilers/test/build_frontend_server/frontend_server_driver_test.dart
@@ -30,17 +30,52 @@ void main() {
         p.join(Directory.current.path, fesManagerConfigPath),
       );
       if (configFile.existsSync()) configFile.deleteSync();
-      server = await PersistentFrontendServer.start(
+      server = PersistentFrontendServer(
         sdkRoot: sdkDir,
         fileSystemRoot: tempDir.uri,
         packagesFile: packageConfig,
       );
+      await server.ensureStarted();
     });
 
     tearDown(() async {
       await server.shutdown();
       await tempDir.delete(recursive: true);
     });
+
+    test(
+      'throws ArgumentError if ensureStarted is called with different options',
+      () async {
+        final localTempDir = await Directory.systemTemp.createTemp(
+          'fes-test-local',
+        );
+        final packageConfig = localTempDir.uri.resolve(
+          '.dart_tool/package_config.json',
+        );
+        File(packageConfig.toFilePath())
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            jsonEncode({'configVersion': 2, 'packages': <String>[]}),
+          );
+        final localServer = PersistentFrontendServer(
+          sdkRoot: sdkDir,
+          fileSystemRoot: localTempDir.uri,
+          packagesFile: packageConfig,
+        );
+        try {
+          await localServer.ensureStarted(librariesPath: 'foo');
+          expect(
+            () => localServer.ensureStarted(librariesPath: 'bar'),
+            throwsArgumentError,
+          );
+          // Calling with the same options is fine
+          await localServer.ensureStarted(librariesPath: 'foo');
+        } finally {
+          await localServer.shutdown();
+          await localTempDir.delete(recursive: true);
+        }
+      },
+    );
 
     test('can compile a simple dart file', () async {
       final entrypoint = tempDir.uri.resolve('entry.dart');
@@ -115,11 +150,12 @@ void main() {
         p.join(Directory.current.path, fesManagerConfigPath),
       );
       if (configFile.existsSync()) configFile.deleteSync();
-      server = await PersistentFrontendServer.start(
+      server = PersistentFrontendServer(
         sdkRoot: sdkDir,
         fileSystemRoot: tempDir.uri,
         packagesFile: packageConfig,
       );
+      await server.ensureStarted();
       driver = FrontendServerProxyDriver();
       driver.init(server);
     });
@@ -183,12 +219,13 @@ void main() {
       final packageConfig = tempDir.uri.resolve(
         '.dart_tool/package_config.json',
       );
-      final envServer = await PersistentFrontendServer.start(
+      final envServer = PersistentFrontendServer(
         sdkRoot: sdkDir,
         fileSystemRoot: tempDir.uri,
         packagesFile: packageConfig,
-        environment: {'MY_DEFINE': 'hello_world'},
+        environment: const {'MY_DEFINE': 'hello_world'},
       );
+      await envServer.ensureStarted();
       addTearDown(envServer.shutdown);
 
       final envDriver = FrontendServerProxyDriver()..init(envServer);


### PR DESCRIPTION
This makes DdcFrontendServerBuilder use the same build options as `DevCompilerBuilder` for specifying a custom sdk for building.

This is needed for Jaspr to run in "flutter compatibility mode", as added in https://github.com/dart-lang/build/issues/4299

As these options are only available during the build phase, the `PersistentFrontendServer` is modified to not start immediately when it's created in the resource, but only when the builder calls `ensureStarted` with the respective options.

@Markzipan 

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
