### PR TITLE
Fix issue with `build_runner test` args after `--`.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -9,6 +9,8 @@
   build.
 - Bug fix: handle errors from post process builders in previous runs without
   crashing.
+- Bug fix: fix `dart run build_runner test` to correctly pass arguments after
+  `--` to the test process.
 
 ## 2.15.0
 

--- a/build_runner/lib/src/bootstrap/bootstrapper.dart
+++ b/build_runner/lib/src/bootstrap/bootstrapper.dart
@@ -137,7 +137,7 @@ class Bootstrapper {
                   buildPaths.outputRootPath,
                   entrypointAotPath,
                 ),
-                arguments: [...arguments, '--force-aot'],
+                arguments: _insertFlag(arguments, '--force-aot'),
                 message: buildProcessState.serialize(),
                 runUnderPerf: dartAotPerf,
               )
@@ -146,7 +146,7 @@ class Bootstrapper {
                 arguments:
                     compileStrategy == CompileStrategy.commandForcesJit
                         ? arguments.toList()
-                        : [...arguments, '--force-jit'],
+                        : _insertFlag(arguments, '--force-jit'),
                 message: buildProcessState.serialize(),
                 jitVmArgs: jitVmArgs,
               );
@@ -210,5 +210,18 @@ class Bootstrapper {
       return false;
     }
     return _compiler.isDependency(path);
+  }
+
+  /// Returns `args` with `flag` inserted before `--`, or at the end if there is
+  /// no `--`.
+  List<String> _insertFlag(Iterable<String> args, String flag) {
+    final result = args.toList();
+    final index = result.indexOf('--');
+    if (index == -1) {
+      result.add(flag);
+    } else {
+      result.insert(index, flag);
+    }
+    return result;
   }
 }

--- a/build_runner/test/integration_tests/test_command_test.dart
+++ b/build_runner/test/integration_tests/test_command_test.dart
@@ -22,21 +22,37 @@ void main() async {
     );
 
     // `test` does not support specifying directory to build.
-    await tester.run(
+    var output = await tester.run(
       'root_pkg',
       'dart run build_runner test --force-jit web',
       expectExitCode: ExitCode.usage.code,
     );
-    await tester.run(
+    expect(
+      output,
+      contains(
+        'The `test` command requires a `--` separator '
+        'before any test arguments.',
+      ),
+    );
+
+    output = await tester.run(
       'root_pkg',
       'dart run build_runner test --force-jit web -- -p chrome',
       expectExitCode: ExitCode.usage.code,
     );
+    expect(
+      output,
+      contains(
+        'The `test` command requires a `--` separator '
+        'before any test arguments.',
+      ),
+    );
 
-    // Requires `build_test` dependency.
-    final output = await tester.run(
+    // Corrected command instead fails with config error because `build_test`
+    // dependency is missing.
+    output = await tester.run(
       'root_pkg',
-      'dart run build_runner test --force-jit',
+      'dart run build_runner test --force-jit -- web',
       expectExitCode: ExitCode.config.code,
     );
     expect(
@@ -46,5 +62,26 @@ void main() async {
         'which is required to run tests.',
       ),
     );
+
+    // Add the `build_test` dependency, the argument is passed to `test` as
+    // expected.
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner', 'build_test'],
+      files: {
+        'test/passes_fails_test.dart': '''
+import 'package:test/test.dart';
+void main() {
+  test('passes', () {});
+  test('fails', () {
+    fail('should not run');
+  });
+}
+''',
+      },
+    );
+
+    // Succeds because only 'passes' runs.
+    await tester.run('root_pkg', 'dart run build_runner test -- -n passes');
   });
 }


### PR DESCRIPTION
Fix #4944 which was broken due to the `--force-jit` or `--force-aot` being inserted in the wrong place.

Improve the existing end to end test expectations so it's a bit clearer, and add a new case confirming args are now passed.