### PR TITLE
Document JSON parsing of --define values.

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1-wip
+
+- Document that `--define` values are parsed as JSON with a fallback.
+
 ## 1.3.0
 
 - Add `build_to` key to `post_process_builders`. Like the `builders` key, it

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -413,9 +413,9 @@ And when running the build:
 dart run build_runner build --define=some_package:some_builder=some_option="Priority 6"
 ```
 
-If values are valid JSON they are parsed to objects, making them as expressive
-as YAML files. For example, it's possible to pass lists and maps. If values are
-not valid JSON they are used as exact strings.
+If values are valid JSON they are parsed to objects. For example, it's possible
+to pass lists and maps. If values are not valid JSON they are used as exact
+strings.
 
 ### How can I include additional sources in my build?
 

--- a/build_config/README.md
+++ b/build_config/README.md
@@ -413,6 +413,10 @@ And when running the build:
 dart run build_runner build --define=some_package:some_builder=some_option="Priority 6"
 ```
 
+If values are valid JSON they are parsed to objects, making them as expressive
+as YAML files. For example, it's possible to pass lists and maps. If values are
+not valid JSON they are used as exact strings.
+
 ### How can I include additional sources in my build?
 
 The `build_runner` package defaults the included source files to directories

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 1.3.0
+version: 1.3.1-wip
 description: >-
   Format definition and support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Support builders with no declared outputs. They can't output anything, but
   they can do processing, write log messages and choose whether to fail the
   build.
+- Mention in command usage that `--define` values are parsed as JSON with a
+  fallback.
 - Bug fix: handle errors from post process builders in previous runs without
   crashing.
 - Bug fix: fix `dart run build_runner test` to correctly pass arguments after

--- a/build_runner/lib/src/build_runner_command_line.dart
+++ b/build_runner/lib/src/build_runner_command_line.dart
@@ -268,7 +268,10 @@ class _Build extends _Command<BuildRunnerCommandLine> {
       ..addMultiOption(
         defineOption,
         splitCommas: false,
-        help: 'Sets the global `options` config for a builder by key.',
+        help:
+            'Sets the global `options` config for a builder by key. '
+            'If values are valid JSON they are parsed to objects. If not, they '
+            'are used as exact strings.',
       )
       ..addFlag(
         symlinkOption,

--- a/build_runner/test/integration_tests/build_command_define_test.dart
+++ b/build_runner/test/integration_tests/build_command_define_test.dart
@@ -40,11 +40,11 @@ import 'package:build/build.dart';
 Builder testBuilderFactory(BuilderOptions options) =>
     TestBuilder(
         AssetId.parse(options.config['copy_from'] as String),
-        options.config['extra_content'] as String? ?? '');
+        options.config['extra_content'] as Object? ?? '');
 
 class TestBuilder implements Builder {
   final AssetId copyFrom;
-  final String extraContent;
+  final Object extraContent;
 
   TestBuilder(this.copyFrom, this.extraContent);
 
@@ -55,7 +55,7 @@ class TestBuilder implements Builder {
   Future<void> build(BuildStep buildStep) async {
     buildStep.writeAsString(
         buildStep.inputId.addExtension('.copy'),
-        await buildStep.readAsString(copyFrom) + extraContent,
+        await buildStep.readAsString(copyFrom) + '\$extraContent',
     );
   }
 }''',
@@ -108,6 +108,14 @@ targets:
           '--define=builder_pkg:test_builder=copy_from=root_pkg|web/a.txt',
     );
     expect(tester.read('root_pkg/web/a.txt.copy'), 'a(yaml dev)');
+
+    // Override with `--define` JSON content.
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit '
+          '--define=builder_pkg:test_builder=extra_content=[1,2,3,{"a":4}]',
+    );
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'b[1, 2, 3, {a: 4}]');
 
     // Override with `--define` and `--release`.
     await tester.run(


### PR DESCRIPTION
Fix #4310, add test coverage.

The "parse as JSON, fall back to string" is quite surprising, I would prefer without the fallback. But at least now it's documented :)