### PR TITLE
Simplify build_runner instructions in README

### DIFF
--- a/builder_pkgs/mockito/README.md
+++ b/builder_pkgs/mockito/README.md
@@ -46,8 +46,6 @@ The next step is to run `build_runner` in order to generate this new library:
 
 ```shell
 dart run build_runner build
-# OR
-dart run build_runner build
 ```
 
 `build_runner` will generate a file with a name based on the file containing the


### PR DESCRIPTION
Removed redundant command from README for clarity.

Credits @sigurdm in https://github.com/dart-lang/build/commit/056424f57ceade852839cc9338fb5a8c0efb3b34 :rofl: 