### PR TITLE
Move declared outputs from BuildState to BuildStepPlan.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -9,6 +9,8 @@
   build.
 - Mention in command usage that `--define` values are parsed as JSON with a
   fallback.
+- Performance: reduce size of serialized build state when there are optional
+  outputs that are not written.
 - Bug fix: handle errors from post process builders in previous runs without
   crashing.
 - Bug fix: fix `dart run build_runner test` to correctly pass arguments after

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -18,11 +18,13 @@ import '../build_plan/build_options.dart';
 import '../build_plan/build_packages.dart';
 import '../build_plan/build_phases.dart';
 import '../build_plan/build_plan.dart';
+import '../build_plan/build_step_plan.dart';
 import '../build_plan/phase.dart';
 import '../build_plan/testing_overrides.dart';
 import '../constants.dart';
 import '../io/build_output_reader.dart';
 import '../io/create_merged_dir.dart';
+import '../io/generated_asset_hider.dart';
 import '../io/reader_writer.dart';
 import '../logging/build_log.dart';
 import '../logging/timed_activities.dart';
@@ -53,11 +55,11 @@ final ResolversImpl _defaultResolvers = ResolversImpl(
 
 /// A single build.
 class Build {
-  final BuildPlan buildPlan;
+  BuildPlan _buildPlan;
 
   // Collaborators.
   final ResourceManager resourceManager;
-  final ReaderWriter readerWriter;
+  ReaderWriter _readerWriter;
   final LibraryCycleGraphLoader previousLibraryCycleGraphLoader =
       LibraryCycleGraphLoader();
   final AssetDepsLoader? previousDepsLoader;
@@ -125,11 +127,13 @@ class Build {
   BuildOutputReader? _buildOutputReader;
 
   Build({
-    required this.buildPlan,
-    required this.readerWriter,
+    required BuildPlan buildPlan,
+    required ReaderWriter readerWriter,
     required this.resourceManager,
     required this.buildState,
-  }) : previousDepsLoader =
+  }) : _buildPlan = buildPlan,
+       _readerWriter = readerWriter,
+       previousDepsLoader =
            buildPlan.previousPhasedAssetDeps == null
                ? null
                : AssetDepsLoader.fromDeps(buildPlan.previousPhasedAssetDeps!),
@@ -140,11 +144,14 @@ class Build {
          _ => null,
        };
 
+  BuildPlan get buildPlan => _buildPlan;
+  ReaderWriter get readerWriter => _readerWriter;
   BuildOptions get buildOptions => buildPlan.buildOptions;
   TestingOverrides get testingOverrides => buildPlan.testingOverrides;
   BuildPackages get buildPackages => buildPlan.buildPackages;
   BuildConfigs get buildConfigs => buildPlan.buildConfigs;
-  BuildPhases get buildPhases => buildPlan.buildPhases;
+  BuildPhases get buildPhases => buildPlan.buildStepPlan.buildPhases;
+  BuildStepPlan get buildStepPlan => buildPlan.buildStepPlan;
 
   BuildOutputReader get buildOutputReader =>
       _buildOutputReader ??= BuildOutputReader(
@@ -162,8 +169,8 @@ class Build {
     if (result.status == BuildStatus.success) {
       final failedSteps = <BuildStepId>{};
       for (final output in processedOutputs) {
-        if (!buildState.isDeclaredOutput(output)) continue;
-        final step = buildState.stepForDeclaredOutput(output);
+        final step = buildStepPlan.stepForDeclaredOutputOrNull(output);
+        if (step == null) continue;
         final stepResult = buildState.stepResult(step);
         if (stepResult.failed) {
           failedSteps.add(step);
@@ -252,7 +259,7 @@ class Build {
       if (oldIsSource) {
         previousSources.add(id);
       }
-      final oldExisted = buildState.isFile(id);
+      final oldExisted = _isFile(id);
       final oldDigest = oldIsSource ? buildState.digestOfSource(id) : null;
       var exists = false;
       Digest? newDigest;
@@ -288,10 +295,20 @@ class Build {
       }
     }
 
-    final deleted = buildState.updateForNextBuild(buildPhases, resolvedUpdates);
+    final deleted = buildState.updateForNextBuild(
+      buildStepPlan,
+      resolvedUpdates,
+    );
     for (final id in deleted) {
       await readerWriter.delete(id);
     }
+    _buildPlan = _buildPlan.updateForSources(buildState.sources);
+    _readerWriter = _readerWriter.copyWith(
+      generatedAssetHider:
+          _buildPlan.testingOverrides.flattenOutput
+              ? const NoopGeneratedAssetHider()
+              : _buildPlan.buildStepPlan,
+    );
     deletedAssets.addAll(deleted);
     for (final entry in newDigests.entries) {
       buildState.updateSourceDigest(entry.key, entry.value);
@@ -318,13 +335,13 @@ class Build {
             buildPlan.cleanBuild ? null : await _updateBuildState(idsToCheck);
         for (final id in buildState.sources) {
           if (buildState.isUnreadSource(id) &&
-              buildState.declaredOutputsOf(id).isNotEmpty) {
+              buildStepPlan.declaredOutputsOf(id).isNotEmpty) {
             final digest = await readerWriter.digest(id);
             buildState.updateSourceDigest(id, digest);
           }
         }
         await resolversImpl?.takeLockAndStartBuild(
-          buildState,
+          buildPlan.buildStepPlan.declaredOutputPhases,
           invalidatedSources: invalidatedSources,
         );
         final result = await _runPhases();
@@ -448,6 +465,7 @@ class Build {
           outputs.addAll(await lazyOuts),
     );
     // Assume success, failed outputs will be checked later.
+
     return BuildResult(
       status: BuildStatus.success,
       outputs: outputs.build(),
@@ -464,7 +482,7 @@ class Build {
     final phase = buildPhases[phaseNumber] as InBuildPhase;
     final buildPackage = buildPackages[package]!;
 
-    for (final step in buildState.buildStepsForPhase(package, phaseNumber)) {
+    for (final step in buildStepPlan.buildStepsByPhase[phaseNumber]) {
       final primaryInput = step.primaryInput;
       final outputs = expectedOutputs(phase.builder, primaryInput);
 
@@ -505,8 +523,8 @@ class Build {
   /// If it is currently being built according to [lazyPhases], waits for it to
   /// be built.
   Future<void> _buildOutput(AssetId id) async {
-    if (buildState.isDeclaredOutput(id) && !processedOutputs.contains(id)) {
-      final step = buildState.stepForDeclaredOutput(id);
+    final step = buildStepPlan.stepForDeclaredOutputOrNull(id);
+    if (step != null && !processedOutputs.contains(id)) {
       await lazyPhases.putIfAbsent(step, () async {
         final phase = buildPhases.inBuildPhases[step.phaseNumber];
         return _buildForPrimaryInput(
@@ -538,6 +556,7 @@ class Build {
       runningBuild: RunningBuild(
         buildPackages: buildPackages,
         buildConfigs: buildConfigs,
+        buildStepPlan: buildStepPlan,
         buildState: buildState,
         assetBuilder: _buildOutput,
         assetIsProcessedOutput: processedOutputs.contains,
@@ -723,7 +742,7 @@ class Build {
     for (final input in buildState.sources.followedBy(
       buildState.actualOutputs,
     )) {
-      if (!buildState.actionMatches(action, input)) continue;
+      if (!buildStepPlan.actionMatches(action, input)) continue;
       final buildStepId = PostProcessBuildStepId(
         input: input,
         actionNumber: actionNum,
@@ -751,6 +770,7 @@ class Build {
       runningBuild: RunningBuild(
         buildPackages: buildPackages,
         buildConfigs: buildConfigs,
+        buildStepPlan: buildStepPlan,
         buildState: buildState,
         assetBuilder: _buildOutput,
         assetIsProcessedOutput: processedOutputs.contains,
@@ -797,13 +817,13 @@ class Build {
       stepReaderWriter,
       logger,
       addAsset: (assetId) {
-        if (buildState.isFile(assetId)) {
+        if (_isFile(assetId)) {
           throw InvalidOutputException(assetId, 'Asset already exists');
         }
         outputs.add(assetId);
       },
       deleteAsset: (assetId) {
-        if (!buildState.isFile(assetId)) {
+        if (!_isFile(assetId)) {
           throw AssetNotFoundException(assetId);
         }
         if (assetId != input) {
@@ -835,7 +855,8 @@ class Build {
   }
 
   void _markStepSkipped(BuildStepId buildStepId, Iterable<AssetId> outputs) {
-    final isHidden = buildState.stepResult(buildStepId).isHidden;
+    final isHidden =
+        buildPhases.inBuildPhases[buildStepId.phaseNumber].hideOutput;
     buildState.updateBuildStepResult(
       buildStepId,
       BuildStepResult((b) => b..isHidden = isHidden),
@@ -850,7 +871,8 @@ class Build {
     BuildStepId buildStepId,
     Iterable<AssetId> outputs,
   ) async {
-    final isHidden = buildState.stepResult(buildStepId).isHidden;
+    final isHidden =
+        buildPhases.inBuildPhases[buildStepId.phaseNumber].hideOutput;
     buildState.updateBuildStepResult(
       buildStepId,
       BuildStepResult((b) {
@@ -874,7 +896,7 @@ class Build {
   ) async {
     return await TimedActivity.track.runAsync(() async {
       // Update state for primary input if needed.
-      if (buildState.isDeclaredOutput(step.primaryInput)) {
+      if (buildStepPlan.isDeclaredOutput(step.primaryInput)) {
         if (!processedOutputs.contains(step.primaryInput)) {
           await _buildOutput(step.primaryInput);
         }
@@ -890,9 +912,9 @@ class Build {
       }
 
       // Propagate results for declared output primary input.
-      if (buildState.isDeclaredOutput(step.primaryInput)) {
+      if (buildStepPlan.isDeclaredOutput(step.primaryInput)) {
         final inputStepResult = buildState.stepResult(
-          buildState.stepForDeclaredOutput(step.primaryInput),
+          buildStepPlan.stepForDeclaredOutput(step.primaryInput),
         );
 
         // If the primary input's generating step failed, this build is also
@@ -904,7 +926,11 @@ class Build {
 
         // If the primary input succeeded but was not output, this build is
         // skipped.
-        if (!buildState.isActualOutput(step.primaryInput)) {
+
+        if (!buildState.isActualOutput(
+          buildStepPlan: buildStepPlan,
+          id: step.primaryInput,
+        )) {
           await _cleanUpStaleOutputs(outputs);
           _markStepSkipped(step, outputs);
           return false;
@@ -925,8 +951,8 @@ class Build {
         if (deletedAssets.contains(output)) return true;
       }
 
-      final stepResult = buildState.stepResult(step);
-      if (!stepResult.hasRun) return true;
+      final stepResult = buildState.stepResultOrNull(step);
+      if (stepResult == null || !stepResult.hasRun) return true;
 
       // Check for changes to any secondary inputs.
       for (final input in stepResult.inputs) {
@@ -1050,8 +1076,8 @@ class Build {
     required AssetId input,
     required int phaseNumber,
   }) async {
-    if (buildState.isDeclaredOutput(input)) {
-      final phase = buildState.stepForDeclaredOutput(input).phaseNumber;
+    if (buildStepPlan.isDeclaredOutput(input)) {
+      final phase = buildStepPlan.stepForDeclaredOutput(input).phaseNumber;
       if (phase >= phaseNumber) {
         // It's not readable in this phase.
         return false;
@@ -1093,7 +1119,7 @@ class Build {
       return true;
     }
 
-    if (buildState.isDeclaredOutput(input)) {
+    if (buildStepPlan.isDeclaredOutput(input)) {
       // Check that the input was built, so [changedOutputs] is updated.
       if (!processedOutputs.contains(input)) {
         await _buildOutput(input);
@@ -1119,7 +1145,7 @@ class Build {
   /// must be generated assets.
   Future<void> _cleanUpStaleOutputs(Iterable<AssetId> outputs) async {
     for (final output in outputs) {
-      if (buildState.isActualOutput(output) ||
+      if (buildState.isActualOutput(buildStepPlan: buildStepPlan, id: output) ||
           buildState.isActualPostOutput(output)) {
         await _delete(output);
       }
@@ -1156,11 +1182,12 @@ class Build {
 
       for (final id in buildState.findFiles(
         package: globId.package,
+        buildStepPlan: buildStepPlan,
         glob: glob,
       )) {
-        if (buildState.isDeclaredOutput(id)) {
+        if (buildStepPlan.isDeclaredOutput(id)) {
           // Only outputs from an earlier phase can match.
-          if (buildState.stepForDeclaredOutput(id).phaseNumber <
+          if (buildStepPlan.stepForDeclaredOutput(id).phaseNumber <
               globId.phaseNumber) {
             generatedFileInputs.add(id);
           }
@@ -1178,10 +1205,12 @@ class Build {
       // the glob.
       final generatedFileResults = <AssetId>[];
       for (final id in generatedFileInputs) {
-        final stepResult = buildState.stepResult(
-          buildState.stepForDeclaredOutput(id),
+        final stepResult = buildState.stepResultOrNull(
+          buildStepPlan.stepForDeclaredOutput(id),
         );
-        if (buildState.isActualOutput(id) && stepResult.succeeded) {
+        if (stepResult != null &&
+            stepResult.outputs.containsKey(id) &&
+            stepResult.succeeded) {
           generatedFileResults.add(id);
         }
       }
@@ -1246,8 +1275,8 @@ class Build {
     final buildStepResult = buildStepResultBuilder.build();
 
     final buildStepId = BuildStepId(primaryInput: input, phaseNumber: phaseNum);
-    final previousBuildStepResult = buildState.stepResult(buildStepId);
-    final previousResult = previousBuildStepResult.result;
+    final previousBuildStepResult = buildState.stepResultOrNull(buildStepId);
+    final previousResult = previousBuildStepResult?.result;
     buildState.updateBuildStepResult(buildStepId, buildStepResult);
 
     if (result == false) {
@@ -1255,7 +1284,7 @@ class Build {
     }
 
     for (final output in outputs) {
-      final oldDigest = previousBuildStepResult.outputs[output];
+      final oldDigest = previousBuildStepResult?.outputs[output];
       final newDigest = buildStepResult.outputs[output];
 
       // A transition from (missing or failed) to (written and not failed) is
@@ -1273,6 +1302,9 @@ class Build {
       processedOutputs.add(output);
     }
   }
+
+  bool _isFile(AssetId id) =>
+      buildState.isFile(buildStepPlan: buildStepPlan, id: id);
 
   Future _delete(AssetId id) => readerWriter.delete(id);
 }

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -71,7 +71,7 @@ class BuildSeries {
       generatedAssetHider:
           buildPlan.testingOverrides.flattenOutput
               ? const NoopGeneratedAssetHider()
-              : buildState,
+              : buildPlan.buildStepPlan,
     );
     return BuildSeries._(
       buildPlan: buildPlan,
@@ -123,7 +123,11 @@ class BuildSeries {
         continue;
       }
 
-      if (!_buildState.isFile(id)) {
+      final isFile = _buildState.isFile(
+        buildStepPlan: _buildPlan.buildStepPlan,
+        id: id,
+      );
+      if (!isFile) {
         // Ignore under `.dart_tool/build`.
         if (id.path.startsWith(cacheDirectoryPath)) continue;
 
@@ -143,12 +147,16 @@ class BuildSeries {
       // with no outputs.
       if (!_buildPlan.buildOptions.anyMergedOutputDirectory &&
           !_buildState.isMissingSource(id) &&
-          _buildState.digestOf(id) == null) {
+          _buildState.digestOf(
+                id: id,
+                buildStepPlan: _buildPlan.buildStepPlan,
+              ) ==
+              null) {
         continue;
       }
 
       // Ignore creation or modification of outputs.
-      if (_buildState.isDeclaredOutput(id) &&
+      if (_buildPlan.buildStepPlan.isDeclaredOutput(id) &&
           change.type != ChangeType.REMOVE) {
         continue;
       }
@@ -171,7 +179,10 @@ class BuildSeries {
       _buildPlan.readerWriter,
       _buildPlan.buildPackages,
       _buildPlan.buildConfigs,
-    ).collectChanges(_buildState);
+    ).collectChanges(
+      buildStepPlan: _buildPlan.buildStepPlan,
+      buildState: _buildState,
+    );
     return List.of(
       updates.entries.map((entry) => WatchEvent(entry.value, '${entry.key}')),
     );
@@ -238,7 +249,7 @@ class BuildSeries {
         generatedAssetHider:
             _buildPlan.testingOverrides.flattenOutput
                 ? const NoopGeneratedAssetHider()
-                : _buildState,
+                : _buildPlan.buildStepPlan,
       );
     }
 
@@ -269,9 +280,10 @@ class BuildSeries {
 
     _currentBuildResult = build.run(updates);
     final result = await _currentBuildResult!;
-    _buildPlan = _buildPlan.forNextBuild(
+    _buildPlan = build.buildPlan.updateForResult(
       previousPhasedAssetDeps: result.phasedAssetDeps,
     );
+    _readerWriter = build.readerWriter;
     _buildResultsController.add(result);
     return result;
   }

--- a/build_runner/lib/src/build/build_state/asset_graph_json.dart
+++ b/build_runner/lib/src/build/build_state/asset_graph_json.dart
@@ -96,5 +96,5 @@ class AssetGraphJson {
 }
 
 /// Increment whenever older `asset_graph.json` files should be rejected.
-const _version = 41;
+const _version = 42;
 final jsonUtf8 = json.fuse(utf8);

--- a/build_runner/lib/src/build/build_state/build_state.dart
+++ b/build_runner/lib/src/build/build_state/build_state.dart
@@ -11,14 +11,10 @@ import 'package:meta/meta.dart';
 import 'package:watcher/watcher.dart';
 
 import '../../build_plan/build_packages.dart';
-import '../../build_plan/build_phases.dart';
-import '../../build_plan/phase.dart';
+import '../../build_plan/build_step_plan.dart';
 import '../../build_plan/placeholders.dart';
-import '../../constants.dart';
-import '../../io/generated_asset_hider.dart';
 import 'build_step_id.dart';
 import 'build_step_result.dart';
-import 'exceptions.dart';
 import 'glob_id.dart';
 import 'glob_result.dart';
 import 'post_process_build_step_id.dart';
@@ -32,22 +28,14 @@ part 'serialization.dart';
 /// follow-on incremental build.
 ///
 /// - Sources and their digests; missing sources.
-/// - Planned build steps, updated with results as the build progresses,
-///   including digests of outputs and error messages.
 /// - Glob results.
 /// - Post process build step results.
-class BuildState implements GeneratedAssetHider {
+class BuildState {
   /// Sources and missing sources.
   final Sources _sources;
 
   /// All standard build step execution results by [AssetId] then phase number.
   final Map<AssetId, Map<int, BuildStepResult>> _buildStepResultsByPrimaryInput;
-
-  /// Declared outputs by primary input.
-  final Map<AssetId, Set<AssetId>> _declaredOutputsByPrimaryInput;
-
-  /// Build steps by primary output declared.
-  final Map<AssetId, BuildStepId> _buildStepsByDeclaredOutput;
 
   /// Globs evaluated during the build.
   final Map<GlobId, GlobResult> _globResults;
@@ -65,23 +53,12 @@ class BuildState implements GeneratedAssetHider {
       _postProcessResultsByInput = {},
       _postProcessOutputs = {},
       _buildStepResultsByPrimaryInput = {},
-      _declaredOutputsByPrimaryInput = {},
-      _globResults = {},
-      _buildStepsByDeclaredOutput = {};
+      _globResults = {};
 
-  /// Creates from build phases, sources and packages.
-  factory BuildState.create({
-    required BuildPhases buildPhases,
-    required BuildPackages buildPackages,
-    required Set<AssetId> sources,
-  }) {
+  /// Creates from sources.
+  factory BuildState.create({required Set<AssetId> sources}) {
     final result = BuildState.empty();
     result._sources.addAll(sources);
-    result._addOutputsForSources(
-      buildPhases,
-      sources,
-      placeholders: buildPackages.placeholderIds,
-    );
     return result;
   }
 
@@ -93,13 +70,9 @@ class BuildState implements GeneratedAssetHider {
     required Map<AssetId, Map<int, BuildStepResult>>
     buildStepResultsByPrimaryInput,
     required Map<GlobId, GlobResult> globResults,
-    required Map<AssetId, BuildStepId> buildStepsByDeclaredOutput,
-    required Map<AssetId, Set<AssetId>> declaredOutputsByPrimaryInput,
   }) : _postProcessOutputs = postProcessOutputs,
        _postProcessResultsByInput = postProcessResultsByInput,
        _globResults = globResults,
-       _buildStepsByDeclaredOutput = buildStepsByDeclaredOutput,
-       _declaredOutputsByPrimaryInput = declaredOutputsByPrimaryInput,
        _buildStepResultsByPrimaryInput = buildStepResultsByPrimaryInput,
        _sources = sources;
 
@@ -117,11 +90,6 @@ class BuildState implements GeneratedAssetHider {
           entry.key: Map.of(entry.value),
       },
       globResults: Map.of(_globResults),
-      buildStepsByDeclaredOutput: Map.of(_buildStepsByDeclaredOutput),
-      declaredOutputsByPrimaryInput: {
-        for (final entry in _declaredOutputsByPrimaryInput.entries)
-          entry.key: Set.of(entry.value),
-      },
     );
   }
 
@@ -136,18 +104,27 @@ class BuildState implements GeneratedAssetHider {
 
   /// Whether [id] is one of: source, declared output or actual post process
   /// output.
-  bool isFile(AssetId id) =>
-      isSource(id) || isDeclaredOutput(id) || isActualPostOutput(id);
+  bool isFile({required BuildStepPlan? buildStepPlan, required AssetId id}) =>
+      isSource(id) ||
+      buildStepPlan?.isDeclaredOutput(id) == true ||
+      isActualPostOutput(id);
 
   /// Files that are in [package] and match [glob].
   ///
-  /// Checks sources and declared outputs. The declared outputs that match might
-  /// not exist yet if their build step hasn't run, or might never exist if it
-  /// runs but decides not to output them.
+  /// To match declared outputs as well as sources, pass `buildStepPlan`. The
+  /// declared outputs that match might not exist yet if their build step hasn't
+  /// run, or might never exist if it runs but decides not to output them.
   ///
   /// Does not match post process outputs.
-  Iterable<AssetId> findFiles({required String package, Glob? glob}) =>
-      _sources.findFiles(package, declaredOutputs, glob: glob);
+  Iterable<AssetId> findFiles({
+    required String package,
+    required BuildStepPlan? buildStepPlan,
+    Glob? glob,
+  }) => _sources.findFiles(
+    package,
+    buildStepPlan?.declaredOutputs ?? const [],
+    glob: glob,
+  );
 
   /// Sources.
   ///
@@ -167,57 +144,32 @@ class BuildState implements GeneratedAssetHider {
   /// Whether [id] is a source file that was accessed but did not exist.
   bool isMissingSource(AssetId id) => _sources.isMissingSource(id);
 
-  /// Declared build outputs.
-  Iterable<AssetId> get declaredOutputs => _buildStepsByDeclaredOutput.keys;
-
-  /// Whether [id] is a declared build output.
-  bool isDeclaredOutput(AssetId id) =>
-      _buildStepsByDeclaredOutput.containsKey(id);
-
-  /// Declared outputs of [id].
-  Iterable<AssetId> declaredOutputsOf(AssetId id) =>
-      _declaredOutputsByPrimaryInput[id] ?? const [];
-
-  /// All the build steps for [phase].
-  Iterable<BuildStepId> buildStepsForPhase(String package, int phase) {
-    final results = <BuildStepId>[];
-    for (final entry in _buildStepResultsByPrimaryInput.entries) {
-      final primaryInput = entry.key;
-      if (primaryInput.package != package) continue;
-      if (entry.value.containsKey(phase)) {
-        results.add(
-          BuildStepId(primaryInput: primaryInput, phaseNumber: phase),
-        );
-      }
-    }
-    return results;
-  }
-
-  /// Declared outputs and the phase in which they will be output.
-  Map<AssetId, int> get declaredOutputPhases => {
-    for (final entry in _buildStepsByDeclaredOutput.entries)
-      entry.key: entry.value.phaseNumber,
-  };
-
   /// Actual build step outputs.
   ///
-  /// A subset of [declaredOutputs].
+  /// A subset of the declared outputs.
   Iterable<AssetId> get actualOutputs => _buildStepResultsByPrimaryInput.values
       .expand((map) => map.values.expand((result) => result.outputs.keys));
 
   /// Whether [id] is a declared build output that was actually generated.
-  bool isActualOutput(AssetId id) {
-    final buildStepId = _buildStepsByDeclaredOutput[id];
+  bool isActualOutput({
+    required BuildStepPlan buildStepPlan,
+    required AssetId id,
+  }) {
+    final buildStepId = buildStepPlan.stepForDeclaredOutputOrNull(id);
     if (buildStepId == null) return false;
-    return stepResult(buildStepId).outputs.containsKey(id);
+    return stepResultOrNull(buildStepId)?.outputs.containsKey(id) ?? false;
   }
 
   /// Whether [id] is a declared build output that was actually generated by
   /// a build step that succeeded.
-  bool isActualSuccessfulOutput(AssetId id) {
-    final step = _buildStepsByDeclaredOutput[id];
+  bool isActualSuccessfulOutput({
+    required BuildStepPlan buildStepPlan,
+    required AssetId id,
+  }) {
+    final step = buildStepPlan.stepForDeclaredOutputOrNull(id);
     if (step == null) return false;
-    final stepResult = this.stepResult(step);
+    final stepResult = stepResultOrNull(step);
+    if (stepResult == null) return false;
     return stepResult.succeeded && stepResult.outputs.containsKey(id);
   }
 
@@ -230,12 +182,6 @@ class BuildState implements GeneratedAssetHider {
 
   /// Whether [id] is a post process build output that was actually generated.
   bool isActualPostOutput(AssetId id) => _postProcessOutputs.contains(id);
-
-  /// All declared outputs and all post process outputs.
-  Iterable<AssetId> get declaredAndActualOutputs => [
-    ..._buildStepsByDeclaredOutput.keys,
-    ...actualPostOutputs,
-  ];
 
   // -- Digests.
 
@@ -251,12 +197,11 @@ class BuildState implements GeneratedAssetHider {
   ///
   /// Otherwise, returns `null`. In particular, post process outputs don't have
   /// their digests stored.
-  Digest? digestOf(AssetId id) {
+  Digest? digestOf({BuildStepPlan? buildStepPlan, required AssetId id}) {
     if (isSource(id)) return _sources.digestOfSource(id);
-    if (isDeclaredOutput(id)) {
-      return stepResult(stepForDeclaredOutput(id)).outputs[id];
-    }
-    return null;
+    final step = buildStepPlan?.stepForDeclaredOutputOrNull(id);
+    if (step == null) return null;
+    return stepResultOrNull(step)?.outputs[id];
   }
 
   /// The digest of source [id], or `null` if it has not been read.
@@ -274,14 +219,15 @@ class BuildState implements GeneratedAssetHider {
 
   // -- Build steps.
 
-  /// The build step that declared [id].
-  BuildStepId stepForDeclaredOutput(AssetId id) =>
-      _buildStepsByDeclaredOutput[id]!;
-
   /// The result of [buildStep].
   BuildStepResult stepResult(BuildStepId buildStep) =>
-      _buildStepResultsByPrimaryInput[buildStep.primaryInput]![buildStep
-          .phaseNumber]!;
+      stepResultOrNull(buildStep)!;
+
+  /// The result of [buildStep], or `null` if it is not a known step or there is
+  /// no result yet.
+  BuildStepResult? stepResultOrNull(BuildStepId buildStep) =>
+      _buildStepResultsByPrimaryInput[buildStep.primaryInput]?[buildStep
+          .phaseNumber];
 
   /// Updates a build step result after the step runs.
   void updateBuildStepResult(BuildStepId buildStepId, BuildStepResult result) {
@@ -362,33 +308,6 @@ class BuildState implements GeneratedAssetHider {
     return result;
   }
 
-  // -- Build planning.
-
-  /// Returns whether [action] should run for [input].
-  bool actionMatches(BuildAction action, AssetId input) {
-    if (input.package != action.package) return false;
-    if (!action.generateFor.matches(input)) return false;
-
-    if (action is InBuildPhase) {
-      if (!action.builder.matchesInput(input)) return false;
-    } else if (action is PostBuildAction) {
-      final inputExtensions = action.builder.inputExtensions;
-      if (!inputExtensions.any(input.path.endsWith)) {
-        return false;
-      }
-    } else {
-      throw StateError('Unrecognized action type $action');
-    }
-
-    var currentInput = input;
-    while (true) {
-      final buildStep = _buildStepsByDeclaredOutput[currentInput];
-      if (buildStep == null) break;
-      currentInput = buildStep.primaryInput;
-    }
-    return action.targetSources.matches(currentInput);
-  }
-
   /// Returns outputs that were written to the source tree.
   Iterable<AssetId> outputsToDelete(BuildPackages buildPackages) {
     // Checks if `id` is in a known package. If so, returns it.
@@ -410,10 +329,14 @@ class BuildState implements GeneratedAssetHider {
 
     final result = <AssetId>[];
     // Delete all the non-hidden outputs.
-    for (final id in actualOutputs) {
-      if (!isHidden(id)) {
-        final idToDelete = checkAndMoveId(id);
-        if (idToDelete != null) result.add(idToDelete);
+    for (final map in _buildStepResultsByPrimaryInput.values) {
+      for (final stepResult in map.values) {
+        if (!stepResult.isHidden) {
+          for (final id in stepResult.outputs.keys) {
+            final idToDelete = checkAndMoveId(id);
+            if (idToDelete != null) result.add(idToDelete);
+          }
+        }
       }
     }
     for (final results in _postProcessResultsByInput.values) {
@@ -435,7 +358,7 @@ class BuildState implements GeneratedAssetHider {
   ///
   /// Returns the set of [AssetId]s to delete.
   Set<AssetId> updateForNextBuild(
-    BuildPhases buildPhases,
+    BuildStepPlan buildStepPlan,
     Map<AssetId, ChangeType> updates,
   ) {
     final newIds = <AssetId>{};
@@ -460,207 +383,26 @@ class BuildState implements GeneratedAssetHider {
     _sources.addAll(newIds);
 
     // Compute declared outputs that will no longer be output because their
-    // primary input was deleted. Delete them.
-    final transitiveRemovedIds = <AssetId>{};
-    void addTransitivePrimaryOutputs(AssetId id) {
-      if (transitiveRemovedIds.add(id)) {
-        declaredOutputsOf(id).forEach(addTransitivePrimaryOutputs);
+    // primary input was deleted. Mark them as missing sources, allowing them
+    // to remain referenced in `inputs` in order to trigger rebuilds.
+    final sourcesToRemove = removeIds.where(isSource).toList();
+    final transitiveRemovedIds = buildStepPlan.transitiveDeclaredOutputsOf(
+      sourcesToRemove,
+    );
+
+    for (final id in transitiveRemovedIds) {
+      _sources.setMissing(id);
+      final postProcessResults = _postProcessResultsByInput.remove(id);
+      if (postProcessResults != null) {
+        for (final result in postProcessResults.values) {
+          _postProcessOutputs.removeAll(result.outputs);
+        }
       }
     }
-
-    for (final id in removeIds) {
-      if (isSource(id)) {
-        addTransitivePrimaryOutputs(id);
-      }
-    }
-
-    // Change deleted source assets and their transitive declared outputs to
-    // missing sources, rather than deleting them. This allows them to remain
-    // referenced in `inputs` in order to trigger rebuilds if necessary.
-    for (final id in removeIds) {
-      if (isSource(id)) {
-        _setMissingRecursive(id);
-      }
-    }
-
-    _addOutputsForSources(buildPhases, newIds);
 
     _sources.clearComputationResults();
     transitiveRemovedIds.removeAll(removeIds);
     return transitiveRemovedIds;
-  }
-
-  /// Changes [id] and its transitive primary outputs to missing sources.
-  ///
-  /// Removes post build applications with removed assets as inputs.
-  void _setMissingRecursive(AssetId id, {Set<AssetId>? removedIds}) {
-    removedIds ??= <AssetId>{};
-    removedIds.add(id);
-    for (final output in declaredOutputsOf(id).toList()) {
-      _setMissingRecursive(output, removedIds: removedIds);
-    }
-    _buildStepsByDeclaredOutput.remove(id);
-    _declaredOutputsByPrimaryInput.remove(id);
-    _sources.setMissing(id);
-
-    // Remove post build action applications with removed assets as inputs.
-    final postProcessResults = _postProcessResultsByInput.remove(id);
-    if (postProcessResults != null) {
-      for (final result in postProcessResults.values) {
-        _postProcessOutputs.removeAll(result.outputs);
-      }
-    }
-  }
-
-  /// Removes [id] and its transitive declared outputs.
-  void _removeRecursive(AssetId id, {Set<AssetId>? removedIds}) {
-    removedIds ??= <AssetId>{};
-    if (removedIds.add(id)) {
-      for (final output in declaredOutputsOf(id).toList()) {
-        _removeRecursive(output, removedIds: removedIds);
-      }
-      _sources.remove(id);
-      _buildStepsByDeclaredOutput.remove(id);
-      _declaredOutputsByPrimaryInput.remove(id);
-      _buildStepResultsByPrimaryInput.remove(id);
-    }
-  }
-
-  /// Adds outputs for [newSources] and optionally [placeholders].
-  ///
-  /// If a source now clashes with an output, it means an old generated output
-  /// was incorrectly treated as a source. Clean that up: remove any outputs
-  /// that were added because the output was treated as a source.
-  void _addOutputsForSources(
-    BuildPhases buildPhases,
-    Set<AssetId> newSources, {
-    Iterable<AssetId>? placeholders,
-  }) {
-    final allInputs = Set<AssetId>.from(newSources);
-    if (placeholders != null) allInputs.addAll(placeholders);
-    for (
-      var phaseNum = 0;
-      phaseNum < buildPhases.inBuildPhases.length;
-      phaseNum++
-    ) {
-      allInputs.addAll(
-        _addInBuildPhaseOutputs(
-          buildPhases.inBuildPhases[phaseNum],
-          phaseNum,
-          allInputs,
-          buildPhases,
-        ),
-      );
-    }
-  }
-
-  /// Adds all generated asset outputs for [phase] given [allInputs].
-  ///
-  /// Removes ids from [allInputs] if they are recognized as outputs of the
-  /// phase.
-  ///
-  /// Returns all newly created asset ids.
-  Set<AssetId> _addInBuildPhaseOutputs(
-    InBuildPhase phase,
-    int phaseNum,
-    Set<AssetId> allInputs,
-    BuildPhases buildPhases,
-  ) {
-    final phaseOutputs = <AssetId>{};
-    final inputs =
-        allInputs.where((input) => actionMatches(phase, input)).toList();
-    for (final input in inputs) {
-      // We might have deleted some inputs during this loop, if they turned
-      // out to be generated assets.
-      if (!allInputs.contains(input)) continue;
-      final outputs = expectedOutputs(phase.builder, input);
-      phaseOutputs.addAll(outputs);
-      _declaredOutputsByPrimaryInput
-          .putIfAbsent(input, () => {})
-          .addAll(outputs);
-      final deleted = _addGeneratedOutputs(
-        outputs,
-        phaseNum,
-        buildPhases,
-        primaryInput: input,
-        isHidden: phase.hideOutput,
-      );
-      allInputs.removeAll(deleted);
-      // We may delete sources that were producing outputs previously.
-      // Detect this by checking for deleted files that are no longer declared
-      // outputs, and remove them from `phaseOutputs`.
-      phaseOutputs.removeAll(deleted.where((id) => !isDeclaredOutput(id)));
-    }
-    return phaseOutputs;
-  }
-
-  /// Adds [outputs] to the state.
-  ///
-  /// If there are existing source or missing sources that match outputs,
-  /// replace them with outputs and remove incorrect transitive outputs.
-  ///
-  /// The return value is the set of assets that were removed from the
-  /// build state.
-  Set<AssetId> _addGeneratedOutputs(
-    Iterable<AssetId> outputs,
-    int phaseNumber,
-    BuildPhases buildPhases, {
-    required AssetId primaryInput,
-    required bool isHidden,
-  }) {
-    final buildStepId = BuildStepId(
-      primaryInput: primaryInput,
-      phaseNumber: phaseNumber,
-    );
-    final existingResults = _buildStepResultsByPrimaryInput[primaryInput];
-    final existingResult = existingResults?[phaseNumber];
-    final buildStepResultBuilder =
-        existingResult?.toBuilder() ?? BuildStepResultBuilder();
-    buildStepResultBuilder.isHidden = isHidden;
-    _buildStepResultsByPrimaryInput.putIfAbsent(
-          primaryInput,
-          () => {},
-        )[phaseNumber] =
-        buildStepResultBuilder.build();
-
-    final removed = <AssetId>{};
-    for (final output in outputs) {
-      if (isSource(output)) {
-        // An old generated source was picked up as a source file. Remove it and
-        // its outputs.
-        _removeRecursive(output, removedIds: removed);
-      } else if (isDeclaredOutput(output)) {
-        // The output was already declared by another builder.
-        final buildStep = _buildStepsByDeclaredOutput[output]!;
-        final existingPhase = buildStep.phaseNumber;
-        throw DuplicateAssetIdException(
-          output,
-          buildPhases.inBuildPhases[existingPhase].displayName,
-          buildPhases.inBuildPhases[phaseNumber].displayName,
-        );
-      }
-
-      _buildStepsByDeclaredOutput[output] = buildStepId;
-    }
-    return removed;
-  }
-
-  // -- GeneratedAssetHider implementation.
-
-  @override
-  bool isHidden(AssetId id) {
-    if (id.path.startsWith(generatedOutputDirectory) ||
-        id.path.startsWith(cacheDirectoryPath)) {
-      return false;
-    }
-    if (!isDeclaredOutput(id)) {
-      return false;
-    }
-    final buildStepId = _buildStepsByDeclaredOutput[id];
-    if (buildStepId != null) {
-      return stepResult(buildStepId).isHidden;
-    }
-    return false;
   }
 
   // -- Testing.
@@ -668,36 +410,4 @@ class BuildState implements GeneratedAssetHider {
   @visibleForTesting
   void addSourceForTest(AssetId id, {Digest? digest}) =>
       _sources.add(id, digest: digest);
-
-  @visibleForTesting
-  void addGeneratedForTest(
-    AssetId id,
-    BuildStepId buildStepId, {
-    bool isHidden = true,
-    Digest? digest,
-  }) {
-    _buildStepsByDeclaredOutput[id] = buildStepId;
-    final primaryInput = buildStepId.primaryInput;
-    final phaseNumber = buildStepId.phaseNumber;
-    final existingResults = _buildStepResultsByPrimaryInput[primaryInput];
-    final existingResult = existingResults?[phaseNumber];
-    if (existingResult == null) {
-      _buildStepResultsByPrimaryInput.putIfAbsent(
-        primaryInput,
-        () => {},
-      )[phaseNumber] = BuildStepResult((b) {
-        b.isHidden = isHidden;
-        if (digest != null) {
-          b.outputs[id] = digest;
-        }
-      });
-    } else {
-      if (digest != null) {
-        _buildStepResultsByPrimaryInput.putIfAbsent(
-          primaryInput,
-          () => {},
-        )[phaseNumber] = existingResult.rebuild((b) => b..outputs[id] = digest);
-      }
-    }
-  }
 }

--- a/build_runner/lib/src/build/build_state/serialization.dart
+++ b/build_runner/lib/src/build/build_state/serialization.dart
@@ -81,37 +81,6 @@ BuildState? deserializeBuildState(Map serializedBuildState) {
     }
   }
 
-  if (serializedBuildState.containsKey('buildStepsByDeclaredOutput')) {
-    final deserialized =
-        serializers.deserialize(
-              serializedBuildState['buildStepsByDeclaredOutput'],
-              specifiedType: const FullType(BuiltMap, [
-                FullType(AssetId),
-                FullType(BuildStepId),
-              ]),
-            )
-            as BuiltMap<AssetId, BuildStepId>;
-    buildState._buildStepsByDeclaredOutput.addAll(deserialized.toMap());
-  }
-
-  if (serializedBuildState.containsKey(
-    'declaredPrimaryOutputsByPrimaryInput',
-  )) {
-    final deserialized =
-        serializers.deserialize(
-              serializedBuildState['declaredPrimaryOutputsByPrimaryInput'],
-              specifiedType: const FullType(BuiltMap, [
-                FullType(AssetId),
-                FullType(BuiltSet, [FullType(AssetId)]),
-              ]),
-            )
-            as BuiltMap<AssetId, BuiltSet<AssetId>>;
-    for (final entry in deserialized.entries) {
-      buildState._declaredOutputsByPrimaryInput[entry.key] =
-          entry.value.toSet();
-    }
-  }
-
   return buildState;
 }
 
@@ -162,23 +131,6 @@ Map<String, Object?> serializeBuildState(BuildState buildState) {
       specifiedType: const FullType(BuiltMap, [
         FullType(GlobId),
         FullType(GlobResult),
-      ]),
-    ),
-    'buildStepsByDeclaredOutput': serializers.serialize(
-      BuiltMap<AssetId, BuildStepId>.of(buildState._buildStepsByDeclaredOutput),
-      specifiedType: const FullType(BuiltMap, [
-        FullType(AssetId),
-        FullType(BuildStepId),
-      ]),
-    ),
-    'declaredPrimaryOutputsByPrimaryInput': serializers.serialize(
-      BuiltMap<AssetId, BuiltSet<AssetId>>.of({
-        for (final entry in buildState._declaredOutputsByPrimaryInput.entries)
-          entry.key: entry.value.toBuiltSet(),
-      }),
-      specifiedType: const FullType(BuiltMap, [
-        FullType(AssetId),
-        FullType(BuiltSet, [FullType(AssetId)]),
       ]),
     ),
   };

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -10,7 +10,6 @@ import 'package:build/build.dart';
 import 'package:pool/pool.dart';
 
 import '../../logging/timed_activities.dart';
-import '../build_state/build_state.dart';
 import '../input_tracker.dart';
 import '../library_cycle_graph/asset_deps_loader.dart';
 import '../library_cycle_graph/library_cycle_graph.dart';
@@ -43,16 +42,16 @@ class AnalysisDriverModel {
   /// [filesystem].
   final Set<LibraryCycleGraph> _syncedLibraryCycleGraphs = Set.identity();
 
-  /// Starts a build with [buildState].
+  /// Starts a build with [declaredOutputPhases].
   ///
   /// If another build has the lock, waits for it to finish.
   Future<void> takeLockAndStartBuild(
-    BuildState buildState, {
+    Map<AssetId, int> declaredOutputPhases, {
     required Set<AssetId>? invalidatedSources,
   }) async {
     _lock = await _pool.request();
     filesystem.startBuild(
-      buildState.declaredOutputPhases,
+      declaredOutputPhases,
       invalidatedSources: invalidatedSources,
     );
   }

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -14,7 +14,6 @@ import 'package:pool/pool.dart';
 
 import '../../bootstrap/build_process_state.dart';
 import '../../logging/build_log.dart';
-import '../build_state/build_state.dart';
 import '../build_step_impl.dart';
 import '../library_cycle_graph/phased_asset_deps.dart';
 import 'analysis_driver.dart';
@@ -91,7 +90,7 @@ class ResolversImpl implements Resolvers {
     return BuildStepResolver(_buildResolver!, buildStep as BuildStepImpl);
   }
 
-  /// Start a build with [buildState].
+  /// Start a build with [declaredOutputPhases].
   ///
   /// If another build has the lock, waits for it to finish.
   ///
@@ -103,10 +102,10 @@ class ResolversImpl implements Resolvers {
   /// only two codepaths need to care about the lock: the main build in
   /// `build.dart` and test builds in `package:build_test` `test_builder.dart`.
   Future<void> takeLockAndStartBuild(
-    BuildState buildState, {
+    Map<AssetId, int> declaredOutputPhases, {
     required Set<AssetId>? invalidatedSources,
   }) => _analysisDriverModel.takeLockAndStartBuild(
-    buildState,
+    declaredOutputPhases,
     invalidatedSources: invalidatedSources,
   );
 

--- a/build_runner/lib/src/build/single_step_reader_writer.dart
+++ b/build_runner/lib/src/build/single_step_reader_writer.dart
@@ -13,6 +13,7 @@ import 'package:glob/glob.dart';
 import '../bootstrap/processes.dart';
 import '../build_plan/build_configs.dart';
 import '../build_plan/build_packages.dart';
+import '../build_plan/build_step_plan.dart';
 import '../build_plan/phase.dart';
 import '../io/asset_finder.dart';
 import '../io/reader_writer.dart';
@@ -64,6 +65,7 @@ class Readability {
 class RunningBuild {
   final BuildPackages buildPackages;
   final BuildConfigs buildConfigs;
+  final BuildStepPlan buildStepPlan;
   final BuildState buildState;
   final AssetBuilder assetBuilder;
   final AssetIsProcessedOutput assetIsProcessedOutput;
@@ -72,6 +74,7 @@ class RunningBuild {
   RunningBuild({
     required this.buildPackages,
     required this.buildConfigs,
+    required this.buildStepPlan,
     required this.buildState,
     required this.assetBuilder,
     required this.assetIsProcessedOutput,
@@ -183,7 +186,7 @@ class SingleStepReaderWriter implements PhasedReader {
 
     final buildState = _runningBuild.buildState;
     if (buildState.isPlaceholder(id)) return false;
-    if (!buildState.isFile(id)) {
+    if (!_isFile(id)) {
       if (track) inputTracker.add(id);
       buildState.addMissingSource(id);
       return false;
@@ -211,7 +214,7 @@ class SingleStepReaderWriter implements PhasedReader {
     if (!isReadable) return false;
     if (_runningBuild == null) return true;
 
-    if (_runningBuild.buildState.isDeclaredOutput(id) &&
+    if (_runningBuild.buildStepPlan.isDeclaredOutput(id) &&
         !await _delegate.canRead(id)) {
       return false;
     }
@@ -275,7 +278,10 @@ class SingleStepReaderWriter implements PhasedReader {
   /// Note that [id] must exist in the build state.
   Future<Digest> _ensureDigest(AssetId id) async {
     if (_runningBuild == null) return _delegate.digest(id);
-    final knownDigest = _runningBuild.buildState.digestOf(id);
+    final knownDigest = _runningBuild.buildState.digestOf(
+      id: id,
+      buildStepPlan: _runningBuild.buildStepPlan,
+    );
     if (knownDigest != null) return knownDigest;
 
     Digest digest;
@@ -296,8 +302,8 @@ class SingleStepReaderWriter implements PhasedReader {
       // Post process outputs are not readable until after the build.
       return Readability.notReadable;
     }
-    if (_runningBuild.buildState.isDeclaredOutput(id)) {
-      final step = _runningBuild.buildState.stepForDeclaredOutput(id);
+    if (_runningBuild.buildStepPlan.isDeclaredOutput(id)) {
+      final step = _runningBuild.buildStepPlan.stepForDeclaredOutput(id);
       if (step.phaseNumber > _runningBuildStep!.phaseNumber) {
         return Readability.notReadable;
       } else if (step.phaseNumber == _runningBuildStep.phaseNumber) {
@@ -311,7 +317,10 @@ class SingleStepReaderWriter implements PhasedReader {
 
       await _runningBuild.assetBuilder(id);
       return Readability.fromPreviousPhase(
-        _runningBuild.buildState.isActualSuccessfulOutput(id),
+        _runningBuild.buildState.isActualSuccessfulOutput(
+          buildStepPlan: _runningBuild.buildStepPlan,
+          id: id,
+        ),
       );
     }
     return Readability.fromPreviousPhase(_runningBuild.buildState.isSource(id));
@@ -369,7 +378,7 @@ class SingleStepReaderWriter implements PhasedReader {
       }
     }
 
-    if (!_runningBuild.buildState.isFile(id)) {
+    if (!_isFile(id)) {
       // Add to the build state for input tracking.
       _runningBuild.buildState.addMissingSource(id);
       return PhasedValue.fixed('');
@@ -377,8 +386,8 @@ class SingleStepReaderWriter implements PhasedReader {
       return PhasedValue.fixed('');
     }
 
-    if (_runningBuild.buildState.isDeclaredOutput(id)) {
-      final step = _runningBuild.buildState.stepForDeclaredOutput(id);
+    if (_runningBuild.buildStepPlan.isDeclaredOutput(id)) {
+      final step = _runningBuild.buildStepPlan.stepForDeclaredOutput(id);
       final stepPhase = step.phaseNumber;
       if (stepPhase >= phase) {
         return PhasedValue.unavailable(before: '', expiresAfter: stepPhase);
@@ -387,9 +396,11 @@ class SingleStepReaderWriter implements PhasedReader {
         if (!_runningBuild.assetIsProcessedOutput(id)) {
           await _runningBuild.assetBuilder(id);
         }
-        final stepResult = _runningBuild.buildState.stepResult(step);
-        final isSuccessOutput =
-            _runningBuild.buildState.isActualOutput(id) && stepResult.succeeded;
+        final isSuccessOutput = _runningBuild.buildState
+            .isActualSuccessfulOutput(
+              buildStepPlan: _runningBuild.buildStepPlan,
+              id: id,
+            );
         return PhasedValue.generated(
           atPhase: stepPhase,
           before: '',
@@ -413,4 +424,9 @@ class SingleStepReaderWriter implements PhasedReader {
     final hash = base64.encode((await digest(id, track: false)).bytes);
     return BuildRunnerFileContent(id.asPath, true, content, hash);
   }
+
+  bool _isFile(AssetId id) => _runningBuild!.buildState.isFile(
+    buildStepPlan: _runningBuild.buildStepPlan,
+    id: id,
+  );
 }

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -26,8 +26,9 @@ import 'build_filter.dart';
 import 'build_options.dart';
 import 'build_packages.dart';
 import 'build_phase_creator.dart';
-import 'build_phases.dart';
+
 import 'build_plan_digest.dart';
+import 'build_step_plan.dart';
 import 'builder_definition.dart';
 import 'builder_factories.dart';
 import 'testing_overrides.dart';
@@ -43,7 +44,7 @@ class BuildPlan {
   final BuildPackages buildPackages;
   final ReaderWriter readerWriter;
   final BuildConfigs buildConfigs;
-  final BuildPhases buildPhases;
+  final BuildStepPlan buildStepPlan;
 
   final BuildState? _previousBuildState;
   bool _previousBuildStateWasTaken;
@@ -92,7 +93,7 @@ class BuildPlan {
     required this.buildPackages,
     required this.readerWriter,
     required this.buildConfigs,
-    required this.buildPhases,
+    required this.buildStepPlan,
     required BuildState? previousBuildState,
     required bool previousBuildStateWasTaken,
     required this.previousPhasedAssetDeps,
@@ -117,7 +118,7 @@ class BuildPlan {
   /// Loads a build plan.
   ///
   /// Loads the package strucure and build configuration; prepares
-  /// [readerWriter], deduces the [buildPhases] that will run, deserializes and
+  /// [readerWriter], deduces the buildPhases that will run, deserializes and
   /// checks the `BuildState`.
   ///
   /// If the build state indicates a restart is needed, [restartIsNeeded] will
@@ -284,18 +285,40 @@ class BuildPlan {
       // Files marked for deletion are not inputs.
       inputSources.removeAll(filesToDelete);
 
+      // Build steps are computed twice: first to identify inputs that are
+      // actually outputs and remove them from the input set.
+      final declaredOutputs =
+          BuildStepPlan.compute(
+            buildPhases: buildPhases,
+            placeholderIds: buildPackages.placeholderIds,
+            sources: inputSources,
+          ).declaredOutputs;
+      final inputSourcesWithoutOutputs = Set<AssetId>.from(inputSources);
+      for (final output in declaredOutputs) {
+        inputSourcesWithoutOutputs.remove(output);
+      }
+
       try {
-        buildState = BuildState.create(
-          buildPhases: buildPhases,
-          buildPackages: buildPackages,
-          sources: inputSources,
-        );
+        buildState = BuildState.create(sources: inputSourcesWithoutOutputs);
       } on DuplicateAssetIdException catch (e) {
         buildLog.error(e.toString());
         throw const CannotBuildException();
       }
+    }
+
+    final buildStepPlan = BuildStepPlan.compute(
+      buildPhases: buildPhases,
+      placeholderIds: buildPackages.placeholderIds,
+      sources: buildState.sources,
+    );
+    final declaredAndActualOutputs = [
+      ...buildStepPlan.declaredOutputs,
+      ...buildState.actualPostOutputs,
+    ];
+
+    if (previousBuildState == null) {
       final conflictsInDeps =
-          buildState.declaredAndActualOutputs
+          declaredAndActualOutputs
               .where((n) => !buildPackages.outputPackages.contains(n.package))
               .where(inputSources.contains)
               .toSet();
@@ -310,7 +333,7 @@ class BuildPlan {
       }
 
       filesToDelete.addAll(
-        buildState.declaredAndActualOutputs
+        declaredAndActualOutputs
             .where((n) => buildPackages.outputPackages.contains(n.package))
             .where(inputSources.contains)
             .toSet(),
@@ -325,7 +348,7 @@ class BuildPlan {
       buildPackages: buildPackages,
       readerWriter: readerWriter,
       buildConfigs: buildConfigs,
-      buildPhases: buildPhases,
+      buildStepPlan: buildStepPlan,
       previousBuildState: previousBuildState,
       previousBuildStateWasTaken: false,
       previousPhasedAssetDeps: previousPhasedAssetDeps,
@@ -358,8 +381,10 @@ class BuildPlan {
     PhasedAssetDeps? previousPhasedAssetDeps,
     BuiltList<bool>? phaseOptionsChanged,
     BuiltList<bool>? postBuildOptionsChanged,
+    BuildStepPlan? buildStepPlan,
   }) => BuildPlan(
     buildPlanDigest: buildPlanDigest ?? this.buildPlanDigest,
+    buildStepPlan: buildStepPlan ?? this.buildStepPlan,
     builderFactories: builderFactories,
     buildOptions: buildOptions.copyWith(
       buildDirs: buildDirs,
@@ -369,7 +394,6 @@ class BuildPlan {
     buildPackages: buildPackages,
     buildConfigs: buildConfigs,
     readerWriter: readerWriter ?? this.readerWriter,
-    buildPhases: buildPhases,
     previousBuildState: _previousBuildState,
     previousBuildStateWasTaken: _previousBuildStateWasTaken,
     previousPhasedAssetDeps:
@@ -390,22 +414,40 @@ class BuildPlan {
 
   /// Returns a copy of the plan updated for the next incremental build.
   ///
-  /// Updates [previousPhasedAssetDeps].
+  /// Updates [previousPhasedAssetDeps] from the build result.
   ///
   /// Sets [cleanBuild], [triggersChanged], `phaseOptionsChanged` and
   /// `postBuildOptionsChanged` to `false`.
-  BuildPlan forNextBuild({PhasedAssetDeps? previousPhasedAssetDeps}) =>
+  BuildPlan updateForResult({PhasedAssetDeps? previousPhasedAssetDeps}) =>
       copyWith(
         cleanBuild: false,
         triggersChanged: false,
         previousPhasedAssetDeps: previousPhasedAssetDeps,
         phaseOptionsChanged: BuiltList<bool>.from(
-          List.filled(buildPhases.inBuildPhasesOptionsDigests.length, false),
+          List.filled(
+            buildStepPlan.buildPhases.inBuildPhasesOptionsDigests.length,
+            false,
+          ),
         ),
         postBuildOptionsChanged: BuiltList<bool>.from(
-          List.filled(buildPhases.postBuildActionsOptionsDigests.length, false),
+          List.filled(
+            buildStepPlan.buildPhases.postBuildActionsOptionsDigests.length,
+            false,
+          ),
         ),
       );
+
+  /// Returns a copy of the plan with [buildStepPlan] updated for changed input
+  /// sources.
+  BuildPlan updateForSources(Iterable<AssetId> sources) {
+    return copyWith(
+      buildStepPlan: BuildStepPlan.compute(
+        buildPhases: buildStepPlan.buildPhases,
+        placeholderIds: buildPackages.placeholderIds,
+        sources: sources,
+      ),
+    );
+  }
 
   /// Takes the loaded [BuildState], which may be `null` if none could be
   /// loaded or if it was invalid.

--- a/build_runner/lib/src/build_plan/build_step_plan.dart
+++ b/build_runner/lib/src/build_plan/build_step_plan.dart
@@ -1,0 +1,170 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart' hide Builder;
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+
+import '../build/build_state/build_step_id.dart';
+import '../build/build_state/exceptions.dart';
+import '../constants.dart';
+import '../io/generated_asset_hider.dart';
+import 'build_phases.dart';
+import 'phase.dart';
+
+part 'build_step_plan.g.dart';
+
+/// Planned build steps for one build and their declared outputs.
+abstract class BuildStepPlan
+    implements Built<BuildStepPlan, BuildStepPlanBuilder>, GeneratedAssetHider {
+  BuildPhases get buildPhases;
+
+  BuiltMap<AssetId, BuildStepId> get buildStepsByDeclaredOutput;
+
+  BuiltListMultimap<AssetId, AssetId> get declaredOutputsByPrimaryInput;
+
+  BuiltList<BuiltList<BuildStepId>> get buildStepsByPhase;
+
+  factory BuildStepPlan([void Function(BuildStepPlanBuilder)? updates]) =
+      _$BuildStepPlan;
+  BuildStepPlan._();
+
+  /// Plans build steps from [buildPhases], placeholder IDs and source IDs.
+  factory BuildStepPlan.compute({
+    required BuildPhases buildPhases,
+    required Iterable<AssetId> placeholderIds,
+    required Iterable<AssetId> sources,
+  }) {
+    final result = BuildStepPlanBuilder()..buildPhases = buildPhases;
+
+    final allInputs = sources.toSet();
+    allInputs.addAll(placeholderIds);
+
+    for (
+      var phaseNum = 0;
+      phaseNum < buildPhases.inBuildPhases.length;
+      phaseNum++
+    ) {
+      final phase = buildPhases.inBuildPhases[phaseNum];
+      final phaseOutputs = <AssetId>{};
+      final phaseSteps = ListBuilder<BuildStepId>();
+      for (final input in allInputs) {
+        if (!_actionMatches(
+          phase,
+          input,
+          (id) => result.buildStepsByDeclaredOutput[id],
+        )) {
+          continue;
+        }
+        final outputs = expectedOutputs(phase.builder, input);
+        phaseOutputs.addAll(outputs);
+        result.declaredOutputsByPrimaryInput.addValues(input, outputs);
+
+        final buildStepId = BuildStepId(
+          primaryInput: input,
+          phaseNumber: phaseNum,
+        );
+        phaseSteps.add(buildStepId);
+
+        for (final output in outputs) {
+          if (result.buildStepsByDeclaredOutput[output] != null) {
+            final existingPhase =
+                result.buildStepsByDeclaredOutput[output]!.phaseNumber;
+            throw DuplicateAssetIdException(
+              output,
+              buildPhases.inBuildPhases[existingPhase].displayName,
+              buildPhases.inBuildPhases[phaseNum].displayName,
+            );
+          }
+          result.buildStepsByDeclaredOutput[output] = buildStepId;
+        }
+      }
+      result.buildStepsByPhase.add(phaseSteps.build());
+      allInputs.addAll(phaseOutputs);
+    }
+
+    return result.build();
+  }
+
+  /// Checks if a builder action matches a primary input.
+  bool actionMatches(BuildAction action, AssetId input) =>
+      _actionMatches(action, input, (id) => buildStepsByDeclaredOutput[id]);
+
+  static bool _actionMatches(
+    BuildAction action,
+    AssetId input,
+    BuildStepId? Function(AssetId)? stepLookup,
+  ) {
+    if (input.package != action.package) return false;
+    if (!action.generateFor.matches(input)) return false;
+
+    if (action is InBuildPhase) {
+      if (!action.builder.matchesInput(input)) return false;
+    } else if (action is PostBuildAction) {
+      final inputExtensions = action.builder.inputExtensions;
+      if (!inputExtensions.any(input.path.endsWith)) {
+        return false;
+      }
+    } else {
+      throw StateError('Unrecognized action type $action');
+    }
+
+    var currentInput = input;
+    if (stepLookup != null) {
+      while (true) {
+        final buildStep = stepLookup(currentInput);
+        if (buildStep == null) break;
+        currentInput = buildStep.primaryInput;
+      }
+    }
+    return action.targetSources.matches(currentInput);
+  }
+
+  @override
+  bool isHidden(AssetId id) {
+    if (id.path.startsWith(generatedOutputDirectory) ||
+        id.path.startsWith(cacheDirectoryPath)) {
+      return false;
+    }
+    final step = stepForDeclaredOutputOrNull(id);
+    if (step == null) return false;
+    return buildPhases.inBuildPhases[step.phaseNumber].hideOutput;
+  }
+
+  Iterable<AssetId> get declaredOutputs => buildStepsByDeclaredOutput.keys;
+
+  bool isDeclaredOutput(AssetId id) =>
+      buildStepsByDeclaredOutput.containsKey(id);
+
+  BuildStepId stepForDeclaredOutput(AssetId id) =>
+      buildStepsByDeclaredOutput[id]!;
+
+  BuildStepId? stepForDeclaredOutputOrNull(AssetId id) =>
+      buildStepsByDeclaredOutput[id];
+
+  Iterable<AssetId> declaredOutputsOf(AssetId id) =>
+      declaredOutputsByPrimaryInput[id];
+
+  Set<AssetId> transitiveDeclaredOutputsOf(Iterable<AssetId> ids) {
+    final results = <AssetId>{};
+
+    void addTransitive(AssetId id) {
+      if (results.add(id)) {
+        for (final output in declaredOutputsOf(id)) {
+          addTransitive(output);
+        }
+      }
+    }
+
+    for (final id in ids) {
+      addTransitive(id);
+    }
+    return results;
+  }
+
+  Map<AssetId, int> get declaredOutputPhases => {
+    for (final entry in buildStepsByDeclaredOutput.entries)
+      entry.key: entry.value.phaseNumber,
+  };
+}

--- a/build_runner/lib/src/build_plan/build_step_plan.g.dart
+++ b/build_runner/lib/src/build_plan/build_step_plan.g.dart
@@ -1,0 +1,165 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'build_step_plan.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$BuildStepPlan extends BuildStepPlan {
+  @override
+  final BuildPhases buildPhases;
+  @override
+  final BuiltMap<AssetId, BuildStepId> buildStepsByDeclaredOutput;
+  @override
+  final BuiltListMultimap<AssetId, AssetId> declaredOutputsByPrimaryInput;
+  @override
+  final BuiltList<BuiltList<BuildStepId>> buildStepsByPhase;
+
+  factory _$BuildStepPlan([void Function(BuildStepPlanBuilder)? updates]) =>
+      (BuildStepPlanBuilder()..update(updates))._build();
+
+  _$BuildStepPlan._({
+    required this.buildPhases,
+    required this.buildStepsByDeclaredOutput,
+    required this.declaredOutputsByPrimaryInput,
+    required this.buildStepsByPhase,
+  }) : super._();
+  @override
+  BuildStepPlan rebuild(void Function(BuildStepPlanBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BuildStepPlanBuilder toBuilder() => BuildStepPlanBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BuildStepPlan &&
+        buildPhases == other.buildPhases &&
+        buildStepsByDeclaredOutput == other.buildStepsByDeclaredOutput &&
+        declaredOutputsByPrimaryInput == other.declaredOutputsByPrimaryInput &&
+        buildStepsByPhase == other.buildStepsByPhase;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, buildPhases.hashCode);
+    _$hash = $jc(_$hash, buildStepsByDeclaredOutput.hashCode);
+    _$hash = $jc(_$hash, declaredOutputsByPrimaryInput.hashCode);
+    _$hash = $jc(_$hash, buildStepsByPhase.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BuildStepPlan')
+          ..add('buildPhases', buildPhases)
+          ..add('buildStepsByDeclaredOutput', buildStepsByDeclaredOutput)
+          ..add('declaredOutputsByPrimaryInput', declaredOutputsByPrimaryInput)
+          ..add('buildStepsByPhase', buildStepsByPhase))
+        .toString();
+  }
+}
+
+class BuildStepPlanBuilder
+    implements Builder<BuildStepPlan, BuildStepPlanBuilder> {
+  _$BuildStepPlan? _$v;
+
+  BuildPhases? _buildPhases;
+  BuildPhases? get buildPhases => _$this._buildPhases;
+  set buildPhases(BuildPhases? buildPhases) =>
+      _$this._buildPhases = buildPhases;
+
+  MapBuilder<AssetId, BuildStepId>? _buildStepsByDeclaredOutput;
+  MapBuilder<AssetId, BuildStepId> get buildStepsByDeclaredOutput =>
+      _$this._buildStepsByDeclaredOutput ??= MapBuilder<AssetId, BuildStepId>();
+  set buildStepsByDeclaredOutput(
+    MapBuilder<AssetId, BuildStepId>? buildStepsByDeclaredOutput,
+  ) => _$this._buildStepsByDeclaredOutput = buildStepsByDeclaredOutput;
+
+  ListMultimapBuilder<AssetId, AssetId>? _declaredOutputsByPrimaryInput;
+  ListMultimapBuilder<AssetId, AssetId> get declaredOutputsByPrimaryInput =>
+      _$this._declaredOutputsByPrimaryInput ??=
+          ListMultimapBuilder<AssetId, AssetId>();
+  set declaredOutputsByPrimaryInput(
+    ListMultimapBuilder<AssetId, AssetId>? declaredOutputsByPrimaryInput,
+  ) => _$this._declaredOutputsByPrimaryInput = declaredOutputsByPrimaryInput;
+
+  ListBuilder<BuiltList<BuildStepId>>? _buildStepsByPhase;
+  ListBuilder<BuiltList<BuildStepId>> get buildStepsByPhase =>
+      _$this._buildStepsByPhase ??= ListBuilder<BuiltList<BuildStepId>>();
+  set buildStepsByPhase(
+    ListBuilder<BuiltList<BuildStepId>>? buildStepsByPhase,
+  ) => _$this._buildStepsByPhase = buildStepsByPhase;
+
+  BuildStepPlanBuilder();
+
+  BuildStepPlanBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _buildPhases = $v.buildPhases;
+      _buildStepsByDeclaredOutput = $v.buildStepsByDeclaredOutput.toBuilder();
+      _declaredOutputsByPrimaryInput =
+          $v.declaredOutputsByPrimaryInput.toBuilder();
+      _buildStepsByPhase = $v.buildStepsByPhase.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BuildStepPlan other) {
+    _$v = other as _$BuildStepPlan;
+  }
+
+  @override
+  void update(void Function(BuildStepPlanBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BuildStepPlan build() => _build();
+
+  _$BuildStepPlan _build() {
+    _$BuildStepPlan _$result;
+    try {
+      _$result =
+          _$v ??
+          _$BuildStepPlan._(
+            buildPhases: BuiltValueNullFieldError.checkNotNull(
+              buildPhases,
+              r'BuildStepPlan',
+              'buildPhases',
+            ),
+            buildStepsByDeclaredOutput: buildStepsByDeclaredOutput.build(),
+            declaredOutputsByPrimaryInput:
+                declaredOutputsByPrimaryInput.build(),
+            buildStepsByPhase: buildStepsByPhase.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'buildStepsByDeclaredOutput';
+        buildStepsByDeclaredOutput.build();
+        _$failedField = 'declaredOutputsByPrimaryInput';
+        declaredOutputsByPrimaryInput.build();
+        _$failedField = 'buildStepsByPhase';
+        buildStepsByPhase.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'BuildStepPlan',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/build_runner/lib/src/io/asset_tracker.dart
+++ b/build_runner/lib/src/io/asset_tracker.dart
@@ -13,6 +13,7 @@ import 'package:watcher/watcher.dart';
 import '../build/build_state/build_state.dart';
 import '../build_plan/build_configs.dart';
 import '../build_plan/build_packages.dart';
+import '../build_plan/build_step_plan.dart';
 import '../build_plan/build_target.dart';
 import '../constants.dart';
 import '../logging/timed_activities.dart';
@@ -27,11 +28,23 @@ class AssetTracker {
   AssetTracker(this._readerWriter, this._buildPackages, this._buildConfigs);
 
   /// Checks for and returns any file system changes compared to the current
-  /// build state.
-  Future<Map<AssetId, ChangeType>> collectChanges(BuildState buildState) async {
+  /// build step plan and build state.
+  Future<Map<AssetId, ChangeType>> collectChanges({
+    required BuildStepPlan buildStepPlan,
+    required BuildState buildState,
+  }) async {
     final inputSources = await findInputSources();
     final generatedSources = await findCacheDirSources();
-    return computeSourceUpdates(inputSources, generatedSources, buildState);
+    final declaredAndActualOutputs = [
+      ...buildStepPlan.declaredOutputs,
+      ...buildState.actualPostOutputs,
+    ];
+    return computeSourceUpdates(
+      inputSources,
+      generatedSources,
+      buildState,
+      declaredAndActualOutputs,
+    );
   }
 
   /// Returns the all the sources found in the cache directory.
@@ -55,6 +68,7 @@ class AssetTracker {
     Set<AssetId> inputSources,
     Set<AssetId> generatedSources,
     BuildState buildState,
+    Iterable<AssetId> declaredAndActualOutputs,
   ) async {
     final allSources =
         <AssetId>{}
@@ -70,9 +84,7 @@ class AssetTracker {
     final newSources = inputSources.difference(buildState.sources.toSet());
     addUpdates(newSources, ChangeType.ADD);
     final removedAssets = [
-      for (final id in buildState.sources.followedBy(
-        buildState.declaredAndActualOutputs,
-      ))
+      for (final id in buildState.sources.followedBy(declaredAndActualOutputs))
         if (!allSources.contains(id)) id,
     ];
 

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as p;
 
 import '../build/build_state/build_state.dart';
 import '../build_plan/build_plan.dart';
+import '../build_plan/build_step_plan.dart';
 import 'reader_writer.dart';
 
 /// A view of the build output.
@@ -23,6 +24,7 @@ import 'reader_writer.dart';
 /// they exist on disk from a previous build.
 class BuildOutputReader {
   final BuildPlan? _buildPlan;
+  final BuildStepPlan? _buildStepPlan;
   final BuildState? _buildState;
   final Set<AssetId>? _processedOutputs;
   final ReaderWriter? _readerWriter;
@@ -34,16 +36,19 @@ class BuildOutputReader {
   BuildOutputReader.empty()
     : _buildState = null,
       _buildPlan = null,
+      _buildStepPlan = null,
       _readerWriter = null,
       _processedOutputs = null;
 
   /// For testing: a build output that does not check build phases to determine
   /// whether outputs were required.
   @visibleForTesting
-  BuildOutputReader.graphOnly({
+  BuildOutputReader.buildStateOnly({
     required ReaderWriter readerWriter,
     required BuildState buildState,
+    BuildStepPlan? buildStepPlan,
   }) : _buildPlan = null,
+       _buildStepPlan = buildStepPlan,
        _buildState = buildState,
        _readerWriter = readerWriter,
        _processedOutputs = null;
@@ -61,6 +66,7 @@ class BuildOutputReader {
   }) : _readerWriter = readerWriter,
        _buildState = buildState,
        _buildPlan = buildPlan,
+       _buildStepPlan = buildPlan.buildStepPlan,
        _processedOutputs = processedOutputs;
 
   Set<AssetId> _collectAssetsDeletedByPostProcessBuilders() =>
@@ -71,19 +77,19 @@ class BuildOutputReader {
     if (_buildState == null || _readerWriter == null) {
       return UnreadableReason.notFound;
     }
-    if (!_buildState.isFile(id)) {
+    if (!_isFile(id)) {
       return UnreadableReason.notFound;
     }
     if (_assetsDeletedByPostProcessBuilders.contains(id)) {
       return UnreadableReason.deleted;
     }
-    if (!_buildState.isFile(id)) return UnreadableReason.assetType;
+    if (!_isFile(id)) return UnreadableReason.assetType;
 
     if (_buildState.isActualPostOutput(id)) {
       return null;
     }
-    if (_buildState.isDeclaredOutput(id)) {
-      final step = _buildState.stepForDeclaredOutput(id);
+    final step = _buildStepPlan?.stepForDeclaredOutputOrNull(id);
+    if (step != null) {
       if (_processedOutputs?.contains(id) == false) {
         // The generated output was not considered for building because its
         // transitive input(s) did not match build dirs and/or build filters.
@@ -93,7 +99,9 @@ class BuildOutputReader {
       if (stepResult.failed) {
         return UnreadableReason.failed;
       }
-      if (!_buildState.isActualOutput(id)) return UnreadableReason.notOutput;
+      if (!_buildState.isActualOutput(buildStepPlan: _buildStepPlan!, id: id)) {
+        return UnreadableReason.notOutput;
+      }
 
       // No need to explicitly check readability for generated files, their
       // readability is recorded in the build state.
@@ -126,7 +134,11 @@ class BuildOutputReader {
 
   Stream<AssetId> findAssets(Glob glob, {required String package}) async* {
     if (_buildState == null || _readerWriter == null) return;
-    for (final id in _buildState.findFiles(package: package, glob: glob)) {
+    for (final id in _buildState.findFiles(
+      package: package,
+      buildStepPlan: _buildStepPlan,
+      glob: glob,
+    )) {
       if (await _readerWriter.canRead(id)) {
         yield id;
       }
@@ -138,7 +150,7 @@ class BuildOutputReader {
   ///
   /// Note that [id] must exist in the asset graph.
   FutureOr<Digest> _ensureDigest(AssetId id) {
-    final digest = _buildState!.digestOf(id);
+    final digest = _buildState!.digestOf(buildStepPlan: _buildStepPlan, id: id);
     if (digest != null) return digest;
     return _readerWriter!.digest(id).then((digest) {
       _buildState.updateSourceDigest(id, digest);
@@ -156,9 +168,12 @@ class BuildOutputReader {
         result.add(id);
       }
     }
-    for (final id in buildState.declaredOutputs) {
-      if (!_shouldSkipId(buildState, id, rootDir)) {
-        result.add(id);
+    final buildStepPlan = _buildStepPlan;
+    if (buildStepPlan != null) {
+      for (final id in buildStepPlan.declaredOutputs) {
+        if (!_shouldSkipId(buildState, id, rootDir)) {
+          result.add(id);
+        }
       }
     }
     result.addAll(buildState.actualPostOutputs);
@@ -167,7 +182,7 @@ class BuildOutputReader {
 
   bool _shouldSkipId(BuildState buildState, AssetId id, String? rootDir) {
     if (_buildPlan == null) return false;
-    if (!buildState.isFile(id)) return true;
+    if (!_isFile(id)) return true;
     if (_assetsDeletedByPostProcessBuilders.contains(id)) return true;
 
     // Exclude non-lib assets if they're outside of the root directory or not
@@ -182,10 +197,12 @@ class BuildOutputReader {
     if (buildState.isActualPostOutput(id)) {
       return false;
     }
-    if (buildState.isDeclaredOutput(id)) {
-      final step = buildState.stepForDeclaredOutput(id);
-      final stepResult = buildState.stepResult(step);
-      if (!buildState.isActualOutput(id) || stepResult.failed) {
+    final step = _buildStepPlan?.stepForDeclaredOutputOrNull(id);
+    if (step != null) {
+      final stepResult = buildState.stepResultOrNull(step);
+      if (stepResult == null ||
+          !stepResult.outputs.containsKey(id) ||
+          stepResult.failed) {
         return true;
       }
       return !_processedOutputs!.contains(id);
@@ -194,6 +211,9 @@ class BuildOutputReader {
     if (id.path == '.dart_tool/package_config.json') return true;
     return false;
   }
+
+  bool _isFile(AssetId id) =>
+      _buildState!.isFile(buildStepPlan: _buildStepPlan, id: id);
 }
 
 enum UnreadableReason {

--- a/build_runner/test/build/build_state/build_state_test.dart
+++ b/build_runner/test/build/build_state/build_state_test.dart
@@ -8,22 +8,19 @@ import 'package:build_runner/src/build/build_state/build_state.dart';
 import 'package:build_runner/src/build/build_state/build_step_id.dart';
 import 'package:build_runner/src/build/build_state/build_step_result.dart';
 import 'package:build_runner/src/build/build_state/exceptions.dart';
-import 'package:build_runner/src/build_plan/build_package.dart';
-import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
+import 'package:build_runner/src/build_plan/build_step_plan.dart';
 import 'package:build_runner/src/build_plan/phase.dart';
+
 import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 
 import '../../common/common.dart';
 
 void main() {
-  final fooPackageGraph = BuildPackages.singlePackageBuild('foo', {
-    BuildPackage.forTesting(name: 'foo', isOutput: true),
-  });
-
   group('BuildState', () {
     late BuildState buildState;
+    late BuildStepPlan buildStepPlan;
 
     AssetId testAddSource(int number) {
       final id = AssetId.parse('pkg|lib/a$number.dart');
@@ -35,11 +32,7 @@ void main() {
 
     group('simple build state', () {
       setUp(() async {
-        buildState = BuildState.create(
-          buildPhases: BuildPhases([]),
-          buildPackages: fooPackageGraph,
-          sources: <AssetId>{},
-        );
+        buildState = BuildState.create(sources: <AssetId>{});
       });
 
       test('add, contains, get, allNodes', () {
@@ -48,7 +41,7 @@ void main() {
       });
     });
 
-    group('with buildPhases', () {
+    group('build state with declared outputs', () {
       final targetSources = const InputSet(exclude: ['excluded.txt']);
       final buildPhases = BuildPhases(
         [
@@ -80,30 +73,43 @@ void main() {
 
       setUp(() async {
         buildState = BuildState.create(
-          buildPhases: buildPhases,
-          buildPackages: fooPackageGraph,
           sources: {primaryInputId, excludedInputId},
+        );
+        buildStepPlan = BuildStepPlan.compute(
+          buildPhases: buildPhases,
+          placeholderIds: [],
+          sources: buildState.sources,
         );
       });
 
+      void recomputeBuildStepPlan() {
+        buildStepPlan = BuildStepPlan.compute(
+          buildPhases: buildPhases,
+          placeholderIds: [],
+          sources: buildState.sources,
+        );
+      }
+
       test('build', () {
         expect(
-          buildState.declaredAndActualOutputs,
+          buildStepPlan.declaredOutputs,
           unorderedEquals([primaryOutputId]),
         );
         expect(
           buildState.sources,
           unorderedEquals([primaryInputId, excludedInputId]),
         );
-        expect(buildState.declaredOutputsOf(primaryInputId), [primaryOutputId]);
+        expect(buildStepPlan.declaredOutputsOf(primaryInputId), [
+          primaryOutputId,
+        ]);
 
         final buildStepId = BuildStepId(
           primaryInput: primaryInputId,
           phaseNumber: 0,
         );
-        expect(buildState.stepResult(buildStepId).result, isNull);
+        expect(buildState.stepResultOrNull(buildStepId), isNull);
         expect(
-          buildState.stepForDeclaredOutput(primaryOutputId).primaryInput,
+          buildStepPlan.stepForDeclaredOutput(primaryOutputId).primaryInput,
           primaryInputId,
         );
       });
@@ -111,13 +117,17 @@ void main() {
       group('updateAndInvalidate', () {
         test('add new primary input', () async {
           final changes = {AssetId('foo', 'new.txt'): ChangeType.ADD};
-          buildState.updateForNextBuild(buildPhases, changes);
-          expect(buildState.isFile(AssetId('foo', 'new.txt.copy')), isTrue);
+          buildState.updateForNextBuild(buildStepPlan, changes);
+          recomputeBuildStepPlan();
+          expect(
+            buildStepPlan.isDeclaredOutput(AssetId('foo', 'new.txt.copy')),
+            isTrue,
+          );
         });
 
         test('modify primary input', () async {
           final changes = {primaryInputId: ChangeType.MODIFY};
-          expect(buildState.isFile(primaryOutputId), isTrue);
+          expect(buildStepPlan.isDeclaredOutput(primaryOutputId), isTrue);
           final buildStepId = BuildStepId(
             primaryInput: primaryInputId,
             phaseNumber: 0,
@@ -128,9 +138,10 @@ void main() {
             b.inputs.add(primaryInputId);
           });
           buildState.updateBuildStepResult(buildStepId, stepResult);
-          buildState.updateForNextBuild(buildPhases, changes);
-          expect(buildState.isFile(primaryInputId), isTrue);
-          expect(buildState.isFile(primaryOutputId), isTrue);
+          buildState.updateForNextBuild(buildStepPlan, changes);
+          recomputeBuildStepPlan();
+          expect(buildState.isSource(primaryInputId), isTrue);
+          expect(buildStepPlan.isDeclaredOutput(primaryOutputId), isTrue);
         });
 
         test('add new primary input which replaces a synthetic node', () async {
@@ -138,12 +149,11 @@ void main() {
           expect(buildState.isMissingSource(syntheticId), isTrue);
 
           final changes = {syntheticId: ChangeType.ADD};
-          buildState.updateForNextBuild(buildPhases, changes);
+          buildState.updateForNextBuild(buildStepPlan, changes);
+          recomputeBuildStepPlan();
 
-          expect(buildState.isFile(syntheticId), isTrue);
           expect(buildState.isSource(syntheticId), isTrue);
-          expect(buildState.isFile(syntheticOutputId), isTrue);
-          expect(buildState.isDeclaredOutput(syntheticOutputId), isTrue);
+          expect(buildStepPlan.isDeclaredOutput(syntheticOutputId), isTrue);
         });
 
         test(
@@ -153,11 +163,10 @@ void main() {
             expect(buildState.isMissingSource(syntheticOutputId), isTrue);
 
             final changes = {syntheticId: ChangeType.ADD};
-            buildState.updateForNextBuild(buildPhases, changes);
+            buildState.updateForNextBuild(buildStepPlan, changes);
+            recomputeBuildStepPlan();
 
-            expect(buildState.isFile(syntheticOutputId), isTrue);
-            expect(buildState.isDeclaredOutput(syntheticOutputId), isTrue);
-            expect(buildState.isFile(syntheticOutputId), isTrue);
+            expect(buildStepPlan.isDeclaredOutput(syntheticOutputId), isTrue);
           },
         );
 
@@ -181,7 +190,8 @@ void main() {
             expect(buildState.isSource(secondaryId), isTrue);
 
             final changes = {primaryInputId: ChangeType.REMOVE};
-            buildState.updateForNextBuild(buildPhases, changes);
+            buildState.updateForNextBuild(buildStepPlan, changes);
+            recomputeBuildStepPlan();
 
             expect(buildState.isMissingSource(primaryInputId), isTrue);
             expect(buildState.isMissingSource(primaryOutputId), isTrue);
@@ -190,8 +200,9 @@ void main() {
       });
 
       test('overlapping build phases cause an error', () async {
+        // Statically compute overlapping outputs to verify it throws
         expect(
-          () => BuildState.create(
+          () => BuildStepPlan.compute(
             buildPhases: BuildPhases(
               List.filled(
                 2,
@@ -202,7 +213,7 @@ void main() {
                 ),
               ),
             ),
-            buildPackages: fooPackageGraph,
+            placeholderIds: [],
             sources: {makeAssetId('foo|file')},
           ),
           throwsA(isA<DuplicateAssetIdException>()),
@@ -211,49 +222,44 @@ void main() {
 
       group('regression tests', () {
         test('build can chains of pre-existing to-source outputs', () async {
-          final sources = {
-            makeAssetId('foo|lib/1.txt'),
-            makeAssetId('foo|lib/2.txt'),
-            // All the following are actually old outputs.
-            makeAssetId('foo|lib/1.a.txt'),
-            makeAssetId('foo|lib/1.a.b.txt'),
-            makeAssetId('foo|lib/2.a.txt'),
-            makeAssetId('foo|lib/2.a.b.txt'),
-            makeAssetId('foo|lib/2.a.b.c.txt'),
-          };
+          final buildPhases = BuildPhases([
+            InBuildPhase(
+              builder: TestBuilder(
+                buildExtensions: replaceExtension('.txt', '.a.txt'),
+              ),
+              key: 'TestBuilder',
+              package: 'foo',
+              hideOutput: false,
+            ),
+            InBuildPhase(
+              builder: TestBuilder(
+                buildExtensions: replaceExtension('.txt', '.b.txt'),
+              ),
+              key: 'TestBuilder',
+              package: 'foo',
+              hideOutput: false,
+            ),
+            InBuildPhase(
+              builder: TestBuilder(
+                buildExtensions: replaceExtension('.a.b.txt', '.a.b.c.txt'),
+              ),
+              key: 'TestBuilder',
+              package: 'foo',
+              hideOutput: false,
+            ),
+          ]);
 
-          final buildState = BuildState.create(
-            buildPhases: BuildPhases([
-              InBuildPhase(
-                builder: TestBuilder(
-                  buildExtensions: replaceExtension('.txt', '.a.txt'),
-                ),
-                key: 'TestBuilder',
-                package: 'foo',
-                hideOutput: false,
-              ),
-              InBuildPhase(
-                builder: TestBuilder(
-                  buildExtensions: replaceExtension('.txt', '.b.txt'),
-                ),
-                key: 'TestBuilder',
-                package: 'foo',
-                hideOutput: false,
-              ),
-              InBuildPhase(
-                builder: TestBuilder(
-                  buildExtensions: replaceExtension('.a.b.txt', '.a.b.c.txt'),
-                ),
-                key: 'TestBuilder',
-                package: 'foo',
-                hideOutput: false,
-              ),
-            ]),
-            buildPackages: fooPackageGraph,
-            sources: sources,
+          final buildStepPlan = BuildStepPlan.compute(
+            buildPhases: buildPhases,
+            placeholderIds: [],
+            sources: {
+              makeAssetId('foo|lib/1.txt'),
+              makeAssetId('foo|lib/2.txt'),
+            },
           );
+
           expect(
-            buildState.declaredAndActualOutputs,
+            buildStepPlan.declaredOutputs,
             unorderedEquals([
               makeAssetId('foo|lib/1.a.txt'),
               makeAssetId('foo|lib/1.b.txt'),
@@ -265,41 +271,39 @@ void main() {
               makeAssetId('foo|lib/2.a.b.c.txt'),
             ]),
           );
-          expect(
-            buildState.sources,
-            unorderedEquals([
-              makeAssetId('foo|lib/1.txt'),
-              makeAssetId('foo|lib/2.txt'),
-            ]),
-          );
         });
 
         test('allows running on generated inputs that do not match target '
             'source globs', () async {
           final sources = {makeAssetId('foo|lib/1.txt')};
-          final buildState = BuildState.create(
-            buildPhases: BuildPhases([
-              InBuildPhase(
-                builder: TestBuilder(
-                  buildExtensions: appendExtension('.1', from: '.txt'),
-                ),
-                key: 'TestBuilder',
-                package: 'foo',
+          final buildPhases = BuildPhases([
+            InBuildPhase(
+              builder: TestBuilder(
+                buildExtensions: appendExtension('.1', from: '.txt'),
               ),
-              InBuildPhase(
-                builder: TestBuilder(
-                  buildExtensions: appendExtension('.2', from: '.1'),
-                ),
-                key: 'TestBuilder',
-                package: 'foo',
-                targetSources: const InputSet(include: ['lib/*.txt']),
+              key: 'TestBuilder',
+              package: 'foo',
+            ),
+            InBuildPhase(
+              builder: TestBuilder(
+                buildExtensions: appendExtension('.2', from: '.1'),
               ),
-            ]),
-            buildPackages: fooPackageGraph,
+              key: 'TestBuilder',
+              package: 'foo',
+              targetSources: const InputSet(include: ['lib/*.txt']),
+            ),
+          ]);
+
+          final computed = BuildStepPlan.compute(
+            buildPhases: buildPhases,
+            placeholderIds: [],
             sources: sources,
           );
+          final buildStepsByDeclaredOutput =
+              computed.buildStepsByDeclaredOutput;
+
           expect(
-            buildState.declaredAndActualOutputs,
+            buildStepsByDeclaredOutput.keys,
             unorderedEquals([
               makeAssetId('foo|lib/1.txt.1'),
               makeAssetId('foo|lib/1.txt.1.2'),
@@ -328,12 +332,11 @@ void main() {
               package: 'a',
             ),
           ]);
-          final buildPackages = BuildPackages.singlePackageBuild('a', {
-            BuildPackage.forTesting(name: 'a', isOutput: true),
-          });
-          final buildState = BuildState.create(
+          final buildState = BuildState.create(sources: {source});
+
+          final computed = BuildStepPlan.compute(
             buildPhases: buildPhases,
-            buildPackages: buildPackages,
+            placeholderIds: [],
             sources: {source},
           );
 
@@ -352,7 +355,7 @@ void main() {
 
           expect(buildState.isSource(source), isTrue);
 
-          buildState.updateForNextBuild(buildPhases, {
+          buildState.updateForNextBuild(computed, {
             renamedSource: ChangeType.ADD,
             source: ChangeType.REMOVE,
           });
@@ -361,6 +364,77 @@ void main() {
           expect(buildState.isMissingSource(generatedPart), isTrue);
         });
       });
+    });
+  });
+
+  group('BuildStepPlan.transitiveDeclaredOutputsOf', () {
+    late BuildStepPlan plan;
+
+    setUp(() {
+      plan = BuildStepPlan((builder) => builder..buildPhases = BuildPhases([]));
+    });
+
+    test('empty plan', () {
+      expect(plan.transitiveDeclaredOutputsOf([]), isEmpty);
+      expect(plan.transitiveDeclaredOutputsOf([makeAssetId('foo|a')]), {
+        makeAssetId('foo|a'),
+      });
+    });
+
+    test('chain: a -> b -> c', () {
+      final a = makeAssetId('foo|a');
+      final b = makeAssetId('foo|b');
+      final c = makeAssetId('foo|c');
+      plan = BuildStepPlan(
+        (builder) =>
+            builder
+              ..buildPhases = BuildPhases([])
+              ..declaredOutputsByPrimaryInput.addValues(a, [b])
+              ..declaredOutputsByPrimaryInput.addValues(b, [c]),
+      );
+
+      expect(plan.transitiveDeclaredOutputsOf([a]), unorderedEquals({a, b, c}));
+      expect(plan.transitiveDeclaredOutputsOf([b]), unorderedEquals({b, c}));
+      expect(plan.transitiveDeclaredOutputsOf([c]), unorderedEquals({c}));
+    });
+
+    test('diamond: a -> b, c; b -> d; c -> d', () {
+      final a = makeAssetId('foo|a');
+      final b = makeAssetId('foo|b');
+      final c = makeAssetId('foo|c');
+      final d = makeAssetId('foo|d');
+      plan = BuildStepPlan(
+        (builder) =>
+            builder
+              ..buildPhases = BuildPhases([])
+              ..declaredOutputsByPrimaryInput.addValues(a, [b, c])
+              ..declaredOutputsByPrimaryInput.addValues(b, [d])
+              ..declaredOutputsByPrimaryInput.addValues(c, [d]),
+      );
+
+      expect(
+        plan.transitiveDeclaredOutputsOf([a]),
+        unorderedEquals({a, b, c, d}),
+      );
+    });
+
+    test('multiple inputs', () {
+      final a = makeAssetId('foo|a');
+      final b = makeAssetId('foo|b');
+      final c = makeAssetId('foo|c');
+      final d = makeAssetId('foo|d');
+      plan = BuildStepPlan(
+        (builder) =>
+            builder
+              ..buildPhases = BuildPhases([])
+              ..declaredOutputsByPrimaryInput.addValues(a, [b])
+              ..declaredOutputsByPrimaryInput.addValues(c, [d]),
+      );
+
+      expect(
+        plan.transitiveDeclaredOutputsOf([a, c]),
+        unorderedEquals({a, b, c, d}),
+      );
     });
   });
 }

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -513,7 +513,10 @@ targets:
         );
         expect(cachedBuildState.sources, [makeAssetId('a|web/a.txt')]);
         expect(
-          cachedBuildState.declaredAndActualOutputs,
+          [
+            ...result.buildPlan.buildStepPlan.declaredOutputs,
+            ...cachedBuildState.actualPostOutputs,
+          ],
           unorderedEquals([
             makeAssetId('a|web/a.txt.copy'),
             makeAssetId('a|web/a.txt.copy.clone'),
@@ -1442,7 +1445,11 @@ targets:
       final aCloneId = makeAssetId('a|lib/a.txt.copy.clone');
       expect(newBuildState.isMissingSource(anId), isTrue);
       expect(newBuildState.isMissingSource(aCopyId), isTrue);
-      expect(newBuildState.isFile(aCloneId), isFalse);
+      expect(
+        newBuildState.isSource(aCloneId) ||
+            result.buildPlan.buildStepPlan.isDeclaredOutput(aCloneId),
+        isFalse,
+      );
       expect(result.readerWriter.testing.exists(anId), isFalse);
       expect(result.readerWriter.testing.exists(aCopyId), isFalse);
       expect(result.readerWriter.testing.exists(aCloneId), isFalse);
@@ -1788,7 +1795,9 @@ targets:
       expect(
         finalBuildState
             .stepResult(
-              finalBuildState.stepForDeclaredOutput(AssetId('a', 'web/a.g1')),
+              result.buildPlan.buildStepPlan.stepForDeclaredOutput(
+                AssetId('a', 'web/a.g1'),
+              ),
             )
             .result,
         isFalse,
@@ -1797,7 +1806,9 @@ targets:
       expect(
         finalBuildState
             .stepResult(
-              finalBuildState.stepForDeclaredOutput(AssetId('a', 'web/a.g2')),
+              result.buildPlan.buildStepPlan.stepForDeclaredOutput(
+                AssetId('a', 'web/a.g2'),
+              ),
             )
             .result,
         isFalse,
@@ -1806,7 +1817,9 @@ targets:
       expect(
         finalBuildState
             .stepResult(
-              finalBuildState.stepForDeclaredOutput(AssetId('a', 'web/a.g3')),
+              result.buildPlan.buildStepPlan.stepForDeclaredOutput(
+                AssetId('a', 'web/a.g3'),
+              ),
             )
             .result,
         isFalse,

--- a/build_runner/test/build/resolver/analysis_driver_model_test.dart
+++ b/build_runner/test/build/resolver/analysis_driver_model_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
-import 'package:build_runner/src/build/build_state/build_state.dart';
 import 'package:build_runner/src/build/resolver/analysis_driver_filesystem.dart';
 import 'package:build_runner/src/build/resolver/analysis_driver_model.dart';
 import 'package:test/test.dart';
@@ -25,10 +24,7 @@ void main() {
       model.filesystem.write('/a/lib/b.dart', 'class B {}');
       model.filesystem.clearChangedPaths();
 
-      await model.takeLockAndStartBuild(
-        BuildState.empty(),
-        invalidatedSources: null,
-      );
+      await model.takeLockAndStartBuild(const {}, invalidatedSources: null);
 
       expect(model.filesystem.exists('/a/lib/a.dart'), isFalse);
       expect(model.filesystem.exists('/a/lib/b.dart'), isFalse);
@@ -39,10 +35,7 @@ void main() {
       model.filesystem.write('/a/lib/a.dart', 'class A {}');
       model.filesystem.clearChangedPaths();
 
-      await model.takeLockAndStartBuild(
-        BuildState.empty(),
-        invalidatedSources: const {},
-      );
+      await model.takeLockAndStartBuild(const {}, invalidatedSources: const {});
 
       expect(model.filesystem.exists('/a/lib/a.dart'), isTrue);
       expect(model.filesystem.read('/a/lib/a.dart'), 'class A {}');
@@ -56,7 +49,7 @@ void main() {
       model.filesystem.clearChangedPaths();
 
       await model.takeLockAndStartBuild(
-        BuildState.empty(),
+        const {},
         invalidatedSources: {
           AssetId.parse('a|lib/changed.dart'),
           AssetId.parse('a|lib/deleted.dart'),

--- a/build_runner/test/build/resolver/resolver_test.dart
+++ b/build_runner/test/build/resolver/resolver_test.dart
@@ -11,7 +11,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:build/experiments.dart';
-import 'package:build_runner/src/build/build_state/build_state.dart';
 import 'package:build_runner/src/build/resolver/analysis_driver.dart';
 import 'package:build_runner/src/build/resolver/analysis_driver_model.dart';
 import 'package:build_runner/src/build/resolver/resolvers_impl.dart';
@@ -1356,7 +1355,7 @@ Future<void> _runBuilder(
     _ => null,
   };
   await resolversImpl?.takeLockAndStartBuild(
-    BuildState.empty(),
+    const {},
     invalidatedSources: null,
   );
   await runBuilder(builder, list, singleStepReaderWriter, resolvers);

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -9,6 +9,7 @@ import 'package:build/experiments.dart';
 import 'package:build_config/build_config.dart' hide BuilderDefinition;
 import 'package:build_runner/src/build/build_state/asset_graph_json.dart';
 import 'package:build_runner/src/build/build_state/build_state.dart';
+import 'package:build_runner/src/build/build_state/build_step_result.dart';
 import 'package:build_runner/src/build/library_cycle_graph/phased_asset_deps.dart';
 import 'package:build_runner/src/build_plan/build_options.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
@@ -104,7 +105,7 @@ void main() {
         ),
       );
 
-      expect(buildPlan.buildPhases.inBuildPhases.isEmpty, true);
+      expect(buildPlan.buildStepPlan.buildPhases.inBuildPhases.isEmpty, true);
       expect(buildPlan.restartIsNeeded, true);
     });
 
@@ -156,12 +157,13 @@ void main() {
 
       // Write an output and add it to the build state as if it was built.
       await readerWriter.writeAsString(outputId, '// output');
-      final step = buildState.stepForDeclaredOutput(outputId);
+      final step = buildPlan.buildStepPlan.stepForDeclaredOutput(outputId);
       buildState.updateBuildStepResult(
         step,
-        buildState
-            .stepResult(step)
-            .rebuild((b) => b..outputs[outputId] = Digest([])),
+        BuildStepResult((b) {
+          b.isHidden = false;
+          b.outputs[outputId] = Digest([]);
+        }),
       );
       await writeBuildStateAndPlan(buildState, buildPlan);
 
@@ -247,12 +249,13 @@ void main() {
 
       // Write an output and add it to the build state as if it was built.
       await readerWriter.writeAsString(outputId, '// output');
-      final stepId = buildState.stepForDeclaredOutput(outputId);
+      final stepId = buildPlan.buildStepPlan.stepForDeclaredOutput(outputId);
       buildState.updateBuildStepResult(
         stepId,
-        buildState
-            .stepResult(stepId)
-            .rebuild((b) => b..outputs[outputId] = Digest([])),
+        BuildStepResult((b) {
+          b.isHidden = false;
+          b.outputs[outputId] = Digest([]);
+        }),
       );
       // Give digests to inputs so they are monitored for modifications.
       buildState.updateSourceDigest(assetId2, Digest([]));

--- a/build_runner/test/commands/serve/asset_handler_test.dart
+++ b/build_runner/test/commands/serve/asset_handler_test.dart
@@ -10,12 +10,11 @@ import 'package:build_runner/src/build/build_state/build_step_id.dart';
 import 'package:build_runner/src/build/build_state/build_step_result.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_id.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_result.dart';
-import 'package:build_runner/src/build_plan/build_package.dart';
-import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
+import 'package:build_runner/src/build_plan/build_step_plan.dart';
+import 'package:build_runner/src/build_plan/phase.dart';
 import 'package:build_runner/src/commands/serve/server.dart';
 import 'package:build_runner/src/io/build_output_reader.dart';
-import 'package:crypto/crypto.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
@@ -26,19 +25,19 @@ void main() {
   late BuildOutputReader reader;
   late InternalTestReaderWriter readerWriter;
   late BuildState buildState;
+  late BuildStepPlan buildStepPlan;
 
   setUp(() async {
-    buildState = BuildState.create(
-      buildPhases: BuildPhases([]),
-      buildPackages: BuildPackages.singlePackageBuild('a', [
-        BuildPackage.forTesting(name: 'a', isOutput: true),
-      ]),
-      sources: <AssetId>{},
-    );
+    buildState = BuildState.create(sources: <AssetId>{});
     readerWriter = InternalTestReaderWriter();
-    reader = BuildOutputReader.graphOnly(
+    buildStepPlan = BuildStepPlan(
+      (BuildStepPlanBuilder b) =>
+          b..buildPhases = BuildPhases(const <InBuildPhase>[]),
+    );
+    reader = BuildOutputReader.buildStateOnly(
       readerWriter: readerWriter,
       buildState: buildState,
+      buildStepPlan: buildStepPlan,
     );
     handler = AssetHandler(() async => reader, 'a');
   });
@@ -132,7 +131,16 @@ void main() {
     final primaryId = AssetId('a', 'web/main.dart');
     final outputId = AssetId('a', 'web/main.ddc.js');
     final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
-    buildState.addGeneratedForTest(outputId, buildStepId, digest: Digest([]));
+    final buildStepPlan = BuildStepPlan((BuildStepPlanBuilder b) {
+      b.buildPhases = BuildPhases(const <InBuildPhase>[]);
+      b.buildStepsByDeclaredOutput.addAll({outputId: buildStepId});
+    });
+    reader = BuildOutputReader.buildStateOnly(
+      readerWriter: readerWriter,
+      buildState: buildState,
+      buildStepPlan: buildStepPlan,
+    );
+    handler = AssetHandler(() async => reader, 'a');
     final stepResult = BuildStepResult((b) {
       b.result = false;
       b.isHidden = false;

--- a/build_runner/test/commands/serve/serve_handler_test.dart
+++ b/build_runner/test/commands/serve/serve_handler_test.dart
@@ -17,11 +17,12 @@ import 'package:build_runner/src/build/build_state/post_process_build_step_resul
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
+import 'package:build_runner/src/build_plan/build_step_plan.dart';
+import 'package:build_runner/src/build_plan/phase.dart';
 import 'package:build_runner/src/commands/serve/server.dart';
 import 'package:build_runner/src/commands/watch/watcher.dart';
 import 'package:build_runner/src/io/build_output_reader.dart';
 import 'package:built_collection/built_collection.dart';
-import 'package:crypto/crypto.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -110,6 +111,7 @@ void main() {
   late BuildPackages buildPackages;
   late BuildState buildState;
   late BuildOutputReader finalizedReader;
+  late BuildStepPlan buildStepPlan;
 
   setUp(() async {
     buildPackages = BuildPackages.singlePackageBuild('a', [
@@ -118,16 +120,17 @@ void main() {
     readerWriter = InternalTestReaderWriter(
       outputRootPackage: buildPackages.outputRoot,
     );
-    buildState = BuildState.create(
-      buildPhases: BuildPhases([]),
-      buildPackages: buildPackages,
-      sources: <AssetId>{},
-    );
+    buildState = BuildState.create(sources: <AssetId>{});
     watcher = FakeWatcher(buildPackages);
     serveHandler = ServeHandler(watcher);
-    finalizedReader = BuildOutputReader.graphOnly(
+    buildStepPlan = BuildStepPlan(
+      (BuildStepPlanBuilder b) =>
+          b..buildPhases = BuildPhases(const <InBuildPhase>[]),
+    );
+    finalizedReader = BuildOutputReader.buildStateOnly(
       readerWriter: readerWriter,
       buildState: buildState,
+      buildStepPlan: buildStepPlan,
     );
     watcher.addFutureResult(
       Future.value(
@@ -258,7 +261,18 @@ void main() {
       final primaryId = AssetId('a', 'web/main.dart');
       final outputId = AssetId('a', 'web/main.ddc.js');
       final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
-      buildState.addGeneratedForTest(outputId, buildStepId, digest: Digest([]));
+
+      final buildStepPlan = BuildStepPlan((BuildStepPlanBuilder b) {
+        b.buildPhases = BuildPhases(const <InBuildPhase>[]);
+        b.buildStepsByDeclaredOutput.addAll({outputId: buildStepId});
+      });
+
+      finalizedReader = BuildOutputReader.buildStateOnly(
+        readerWriter: readerWriter,
+        buildState: buildState,
+        buildStepPlan: buildStepPlan,
+      );
+
       final stepResult = BuildStepResult((b) {
         b.result = false;
         b.isHidden = false;

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -165,7 +165,11 @@ Future<TestBuildersResult> testPhases(
     );
   }
 
-  return TestBuildersResult(buildResult: result, readerWriter: readerWriter);
+  return TestBuildersResult(
+    buildResult: result,
+    readerWriter: readerWriter,
+    buildPlan: buildPlan,
+  );
 }
 
 /// Translates expected outptus which start with `$$` to the build cache and
@@ -212,6 +216,11 @@ void checkBuild(
 class TestBuildersResult {
   final BuildResult buildResult;
   final InternalTestReaderWriter readerWriter;
+  final BuildPlan buildPlan;
 
-  TestBuildersResult({required this.buildResult, required this.readerWriter});
+  TestBuildersResult({
+    required this.buildResult,
+    required this.readerWriter,
+    required this.buildPlan,
+  });
 }

--- a/build_runner/test/io/asset_tracker_test.dart
+++ b/build_runner/test/io/asset_tracker_test.dart
@@ -7,10 +7,13 @@ import 'dart:io';
 
 import 'package:build/build.dart';
 import 'package:build_runner/src/build/build_state/build_state.dart';
+import 'package:build_runner/src/build/build_state/build_step_id.dart';
 import 'package:build_runner/src/build_plan/build_configs.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
+import 'package:build_runner/src/build_plan/build_step_plan.dart';
+import 'package:build_runner/src/build_plan/phase.dart';
 import 'package:build_runner/src/build_plan/testing_overrides.dart';
 import 'package:build_runner/src/io/asset_tracker.dart';
 import 'package:build_runner/src/io/reader_writer.dart';
@@ -25,8 +28,13 @@ void main() {
   group('AssetTracker.collectChanges()', () {
     late AssetTracker assetTracker;
     late BuildState buildState;
+    late BuildStepPlan buildStepPlan;
 
     setUp(() async {
+      buildStepPlan = BuildStepPlan(
+        (BuildStepPlanBuilder b) =>
+            b..buildPhases = BuildPhases(const <InBuildPhase>[]),
+      );
       await d.dir('a', [
         d.dir('web', [d.file('a.txt', 'hello')]),
         d.dir('.dart_tool', [
@@ -47,11 +55,7 @@ void main() {
       ]);
       final reader = ReaderWriter(buildPackages);
       final aId = AssetId('a', 'web/a.txt');
-      buildState = BuildState.create(
-        buildPhases: BuildPhases([]),
-        buildPackages: buildPackages,
-        sources: {aId},
-      );
+      buildState = BuildState.create(sources: {aId});
       // Assign a digest so the source is recognized as having been used.
       final digest = await reader.digest(aId);
       buildState.updateSourceDigest(aId, digest);
@@ -63,8 +67,11 @@ void main() {
         ),
       );
       assetTracker = AssetTracker(reader, buildPackages, buildConfigs);
-      final updates = await assetTracker.collectChanges(buildState);
-      buildState.updateForNextBuild(BuildPhases([]), updates);
+      final updates = await assetTracker.collectChanges(
+        buildState: buildState,
+        buildStepPlan: buildStepPlan,
+      );
+      buildState.updateForNextBuild(buildStepPlan, updates);
       // We should see no changes initially other than new sdk sources
       expect(
         updates..removeWhere(
@@ -77,25 +84,65 @@ void main() {
     test('Collects file edits', () async {
       File(p.join(d.sandbox, 'a', 'web', 'a.txt')).writeAsStringSync('goodbye');
 
-      expect(await assetTracker.collectChanges(buildState), {
-        AssetId('a', 'web/a.txt'): ChangeType.MODIFY,
-      });
+      expect(
+        await assetTracker.collectChanges(
+          buildState: buildState,
+          buildStepPlan: buildStepPlan,
+        ),
+        {AssetId('a', 'web/a.txt'): ChangeType.MODIFY},
+      );
     });
 
     test('Collects new files', () async {
       File(p.join(d.sandbox, 'a', 'web', 'b.txt')).writeAsStringSync('yo!');
 
-      expect(await assetTracker.collectChanges(buildState), {
-        AssetId('a', 'web/b.txt'): ChangeType.ADD,
-      });
+      expect(
+        await assetTracker.collectChanges(
+          buildState: buildState,
+          buildStepPlan: buildStepPlan,
+        ),
+        {AssetId('a', 'web/b.txt'): ChangeType.ADD},
+      );
     });
 
     test('Collects deleted files', () async {
       File(p.join(d.sandbox, 'a', 'web', 'a.txt')).deleteSync();
 
-      expect(await assetTracker.collectChanges(buildState), {
-        AssetId('a', 'web/a.txt'): ChangeType.REMOVE,
-      });
+      expect(
+        await assetTracker.collectChanges(
+          buildState: buildState,
+          buildStepPlan: buildStepPlan,
+        ),
+        {AssetId('a', 'web/a.txt'): ChangeType.REMOVE},
+      );
+    });
+
+    test('Collects deleted declared outputs', () async {
+      // Create a buildState with no sources (so web/a.txt is not in sources).
+      final emptyBuildState = BuildState.create(sources: const {});
+
+      // Delete the file from disk so it's actually missing.
+      File(p.join(d.sandbox, 'a', 'web', 'a.txt')).deleteSync();
+
+      final outputId = AssetId('a', 'web/a.txt');
+      final buildStepId = BuildStepId(
+        primaryInput: AssetId('a', 'web/a.dart'),
+        phaseNumber: 0,
+      );
+
+      final planWithOutput = BuildStepPlan(
+        (BuildStepPlanBuilder b) =>
+            b
+              ..buildPhases = BuildPhases(const <InBuildPhase>[])
+              ..buildStepsByDeclaredOutput.addAll({outputId: buildStepId}),
+      );
+
+      final changes = await assetTracker.collectChanges(
+        buildState: emptyBuildState,
+        buildStepPlan: planWithOutput,
+      );
+      changes.removeWhere((id, type) => id.package == r'$sdk');
+      expect(changes, {outputId: ChangeType.REMOVE});
     });
   });
 }

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -11,7 +11,6 @@ import 'package:build_runner/src/build/build_state/build_step_id.dart';
 import 'package:build_runner/src/build/build_state/build_step_result.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_id.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_result.dart';
-import 'package:build_runner/src/build_plan/build_configs.dart';
 import 'package:build_runner/src/build_plan/build_directory.dart';
 import 'package:build_runner/src/build_plan/build_filter.dart';
 import 'package:build_runner/src/build_plan/build_options.dart';
@@ -24,7 +23,6 @@ import 'package:build_runner/src/build_plan/phase.dart';
 import 'package:build_runner/src/build_plan/testing_overrides.dart';
 import 'package:build_runner/src/io/build_output_reader.dart';
 import 'package:built_collection/built_collection.dart';
-import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:test/test.dart';
 
@@ -43,11 +41,7 @@ void main() {
       buildPackages = BuildPackages.singlePackageBuild('a', [
         BuildPackage.forTesting(name: 'a', isOutput: true),
       ]);
-      buildState = BuildState.create(
-        buildPhases: BuildPhases([]),
-        buildPackages: buildPackages,
-        sources: <AssetId>{},
-      );
+      buildState = BuildState.create(sources: <AssetId>{});
       buildPhases = BuildPhases([]);
     });
 
@@ -83,7 +77,10 @@ void main() {
         buildPlan: buildPlan,
         readerWriter: readerWriter,
         buildState: buildState,
-        processedOutputs: buildState.declaredAndActualOutputs.toSet(),
+        processedOutputs: <AssetId>{
+          ...buildPlan.buildStepPlan.declaredOutputs,
+          ...buildState.actualPostOutputs,
+        },
       );
       expect(await reader.canRead(notDeletedId), true);
       expect(await reader.canRead(deletedId), false);
@@ -93,17 +90,19 @@ void main() {
       final id = AssetId('a', 'web/a.txt');
       final primaryId = AssetId('a', 'web/a.dart');
       final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
-      buildState.addGeneratedForTest(id, buildStepId, digest: Digest([]));
       final stepResult = BuildStepResult((b) {
         b.result = false;
         b.isHidden = false;
       });
       buildState.updateBuildStepResult(buildStepId, stepResult);
+      readerWriter.testing.writeString(primaryId, '');
       readerWriter.testing.writeString(id, '');
 
       buildPhases = BuildPhases([
         InBuildPhase(
-          builder: TestBuilder(),
+          builder: TestBuilder(
+            buildExtensions: replaceExtension('.dart', '.txt'),
+          ),
           key: 'TestBuilder',
           package: 'a',
           isOptional: false,
@@ -117,7 +116,6 @@ void main() {
         ),
         testingOverrides: TestingOverrides(
           buildPhases: buildPhases,
-          defaultRootPackageSources: defaultDependencyVisibleAssets,
           readerWriter: readerWriter,
           buildPackages: buildPackages,
         ),
@@ -126,7 +124,10 @@ void main() {
         buildPlan: buildPlan,
         readerWriter: readerWriter,
         buildState: buildState,
-        processedOutputs: buildState.declaredAndActualOutputs.toSet(),
+        processedOutputs: <AssetId>{
+          ...buildPlan.buildStepPlan.declaredOutputs,
+          ...buildState.actualPostOutputs,
+        },
       );
       expect(
         await reader.unreadableReason(id),
@@ -142,7 +143,6 @@ void main() {
         ),
         testingOverrides: TestingOverrides(
           buildPhases: buildPhases,
-          defaultRootPackageSources: defaultDependencyVisibleAssets,
           readerWriter: readerWriter,
           buildPackages: buildPackages,
         ),

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -105,22 +105,30 @@ void main() {
         buildPlan: buildPlan,
         readerWriter: readerWriter,
         buildState: buildState,
-        processedOutputs: buildState.declaredAndActualOutputs.toSet(),
+        processedOutputs: <AssetId>{
+          ...buildPlan.buildStepPlan.declaredOutputs,
+          ...buildState.actualPostOutputs,
+        },
       );
 
-      for (final id in buildState.declaredAndActualOutputs) {
+      for (final id in [
+        ...buildPlan.buildStepPlan.declaredOutputs,
+        ...buildState.actualPostOutputs,
+      ]) {
         final stepResult = BuildStepResult((b) {
           b.result = true;
           b.isHidden = false;
           b.outputs[id] = Digest([]);
         });
         buildState.updateBuildStepResult(
-          buildState.stepForDeclaredOutput(id),
+          buildPlan.buildStepPlan.stepForDeclaredOutput(id),
           stepResult,
         );
         readerWriter.testing.writeString(
           id,
-          sources[buildState.stepForDeclaredOutput(id).primaryInput]!,
+          sources[buildPlan.buildStepPlan
+              .stepForDeclaredOutput(id)
+              .primaryInput]!,
         );
       }
       tmpDir = await Directory.systemTemp.createTemp('build_tests');
@@ -371,7 +379,7 @@ void main() {
         b.isHidden = false;
       });
       buildState.updateBuildStepResult(
-        buildState.stepForDeclaredOutput(targetId),
+        buildPlan.buildStepPlan.stepForDeclaredOutput(targetId),
         stepResult,
       );
 
@@ -398,7 +406,10 @@ void main() {
         ),
         readerWriter: readerWriter,
         buildState: buildState,
-        processedOutputs: buildState.declaredAndActualOutputs.toSet(),
+        processedOutputs: <AssetId>{
+          ...buildPlan.buildStepPlan.declaredOutputs,
+          ...buildState.actualPostOutputs,
+        },
       );
       final success = await createMergedOutputDirectories(
         buildDirs:
@@ -486,7 +497,10 @@ void main() {
           buildPlan: buildPlan,
           readerWriter: readerWriter,
           buildState: buildState,
-          processedOutputs: buildState.declaredAndActualOutputs.toSet(),
+          processedOutputs: <AssetId>{
+            ...buildPlan.buildStepPlan.declaredOutputs,
+            ...buildState.actualPostOutputs,
+          },
         );
         success = await createMergedOutputDirectories(
           buildDirs:


### PR DESCRIPTION
While working on the benchmarks I noticed that the web build asset_graph.json is huge, this turns out to be because it has optional outputs for each compiler and right now optional-but-not-written outputs do get mentioned in the serialized BuildState.

Fortunately all the recent refactorings should make it easy to separate declared outputs from actual outputs: move them from `BuildState` to new `BuildStepPlan` in `BuildPlan` and stop serializing them, they can always be computed.

Note that a change to `BuildPhases` always causes the old build to be discarded, we can rely on `BuildPhases` being the same for an incremental build, allowing the declared outputs to be computed correctly.

 - `BuildStepPlan` takes over from `BuildState` as the `GeneratedAssetHider` that knows whether an asset is generated or not
 - A few different places in `BuildState` were computing transitive declared outputs, pull out one method and simplify

Cuts JSON size for a small web build from ~10MB to ~1MB.