### PR TITLE
Show import path to libraries with disallowed deps.

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.8.0-wip
+
+- Improve error message when a transitive import uses a disallowed platform
+  library. Print an import path to the problem library.
+
 ## 4.7.0
 
 - Add support for proper reload-restarts after invalid hot reloads in DDC + Frontend Server builder.

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/errors.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/errors.dart
@@ -192,10 +192,7 @@ class UnsupportedModules implements Exception {
                 .toList();
         if (unsupportedSdkDeps.isEmpty) continue;
 
-        final targetAssetId = AssetId(
-          library.id.package,
-          library.id.path.replaceFirst(moduleLibraryExtension, '.dart'),
-        );
+        final targetAssetId = library.id.dartAssetId;
         final path = await _findImportPath(
           entrypoint,
           targetAssetId,
@@ -207,22 +204,9 @@ class UnsupportedModules implements Exception {
             '${unsupportedSdkDeps.map((d) => 'dart:$d').join(', ')}'
             ')';
         if (path != null) {
-          final pathString = path
-              .map((id) {
-                if (id.path.startsWith('lib/')) {
-                  return 'package:${id.package}/${id.path.substring(4)}';
-                }
-                return id.toString();
-              })
-              .join(' -> ');
-          buffer.writeln('$pathString$suffix');
+          buffer.writeln('${path.toDisplayString}$suffix');
         } else {
-          final libName =
-              targetAssetId.path.startsWith('lib/')
-                  ? 'package:${targetAssetId.package}/'
-                      '${targetAssetId.path.substring(4)}'
-                  : targetAssetId.toString();
-          buffer.writeln('$libName$suffix');
+          buffer.writeln('${targetAssetId.toDisplayString}$suffix');
         }
       }
     }
@@ -272,4 +256,20 @@ Future<List<AssetId>?> _findImportPath(
     }
   }
   return null;
+}
+
+extension on AssetId {
+  AssetId get dartAssetId =>
+      AssetId(package, path.replaceFirst(moduleLibraryExtension, '.dart'));
+
+  String get toDisplayString {
+    if (path.startsWith('lib/')) {
+      return 'package:$package/${path.substring(4)}';
+    }
+    return toString();
+  }
+}
+
+extension on Iterable<AssetId> {
+  String get toDisplayString => map((id) => id.toDisplayString).join(' -> ');
 }

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/errors.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/errors.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
@@ -12,6 +13,7 @@ import 'package:collection/collection.dart';
 import 'module_library.dart';
 import 'module_library_builder.dart';
 import 'modules.dart';
+import 'platform.dart';
 
 /// An [Exception] that is thrown when a worker returns an error.
 abstract class _WorkerException implements Exception {
@@ -163,8 +165,111 @@ class UnsupportedModules implements Exception {
     }
   }
 
+  Future<String> formattedUnsupportedMessage(
+    String compilerName,
+    AssetId entrypoint,
+    AssetReader reader,
+  ) async {
+    final buffer = StringBuffer(
+      'Skipping compiling $entrypoint with $compilerName '
+      'because some of its\n'
+      'transitive libraries have sdk dependencies that are not supported on '
+      'this platform:\n\n',
+    );
+
+    final platform = unsupportedModules.first.platform;
+    for (final module in unsupportedModules) {
+      for (final source in module.sources) {
+        final libraryId = source.changeExtension(moduleLibraryExtension);
+        if (!await reader.canRead(libraryId)) continue;
+        final library = ModuleLibrary.deserialize(
+          libraryId,
+          await reader.readAsString(libraryId),
+        );
+        final unsupportedSdkDeps =
+            library.sdkDeps
+                .where((lib) => !platform.supportsLibrary(lib))
+                .toList();
+        if (unsupportedSdkDeps.isEmpty) continue;
+
+        final targetAssetId = AssetId(
+          library.id.package,
+          library.id.path.replaceFirst(moduleLibraryExtension, '.dart'),
+        );
+        final path = await _findImportPath(
+          entrypoint,
+          targetAssetId,
+          platform,
+          reader,
+        );
+        final suffix =
+            ' (which imports '
+            '${unsupportedSdkDeps.map((d) => 'dart:$d').join(', ')}'
+            ')';
+        if (path != null) {
+          final pathString = path
+              .map((id) {
+                if (id.path.startsWith('lib/')) {
+                  return 'package:${id.package}/${id.path.substring(4)}';
+                }
+                return id.toString();
+              })
+              .join(' -> ');
+          buffer.writeln('$pathString$suffix');
+        } else {
+          final libName =
+              targetAssetId.path.startsWith('lib/')
+                  ? 'package:${targetAssetId.package}/'
+                      '${targetAssetId.path.substring(4)}'
+                  : targetAssetId.toString();
+          buffer.writeln('$libName$suffix');
+        }
+      }
+    }
+    return buffer.toString();
+  }
+
   @override
   String toString() =>
       'Some modules contained libraries that were incompatible '
       'with the current platform.';
+}
+
+Future<List<AssetId>?> _findImportPath(
+  AssetId start,
+  AssetId target,
+  DartPlatform platform,
+  AssetReader reader,
+) async {
+  final queue = Queue<AssetId>()..add(start);
+  final visited = {start};
+  final parents = <AssetId, AssetId>{};
+
+  while (queue.isNotEmpty) {
+    final current = queue.removeFirst();
+    if (current == target) {
+      final path = <AssetId>[];
+      var curr = target;
+      while (curr != start) {
+        path.add(curr);
+        curr = parents[curr]!;
+      }
+      path.add(start);
+      return path.reversed.toList();
+    }
+
+    final libraryId = current.changeExtension(moduleLibraryExtension);
+    if (!await reader.canRead(libraryId)) continue;
+    final library = ModuleLibrary.deserialize(
+      libraryId,
+      await reader.readAsString(libraryId),
+    );
+    for (final dep in library.depsForPlatform(platform)) {
+      if (visited.add(dep)) {
+        parents[dep] = current;
+        queue.add(dep);
+      }
+    }
+  }
+  return null;
 }

--- a/builder_pkgs/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -68,20 +68,13 @@ Future<void> _bootstrapDart2Js(
         throwIfUnsupported: !unsafeAllowUnsupportedModules,
       ))..add(module);
     } on UnsupportedModules catch (e) {
-      final librariesString = (await e.exactLibraries(buildStep).toList())
-          .map(
-            (lib) => AssetId(
-              lib.id.package,
-              lib.id.path.replaceFirst(moduleLibraryExtension, '.dart'),
-            ),
-          )
-          .join('\n');
-      log.warning('''
-Skipping compiling ${buildStep.inputId} with dart2js because some of its
-transitive libraries have sdk dependencies that are not supported on this platform:
-
-$librariesString
-''');
+      log.warning(
+        await e.formattedUnsupportedMessage(
+          'dart2js',
+          buildStep.inputId,
+          buildStep,
+        ),
+      );
       return;
     }
 

--- a/builder_pkgs/build_web_compilers/lib/src/dart2wasm_bootstrap.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/dart2wasm_bootstrap.dart
@@ -84,20 +84,13 @@ Future<Dart2WasmBootstrapResult> _bootstrapDart2Wasm(
         throwIfUnsupported: !unsafeAllowUnsupportedModules,
       ))..add(module);
     } on UnsupportedModules catch (e) {
-      final librariesString = (await e.exactLibraries(buildStep).toList())
-          .map(
-            (lib) => AssetId(
-              lib.id.package,
-              lib.id.path.replaceFirst(moduleLibraryExtension, '.dart'),
-            ),
-          )
-          .join('\n');
-      log.warning('''
-Skipping compiling ${buildStep.inputId} with dart2wasm because some of its
-transitive libraries have sdk dependencies that are not supported on this platform:
-
-$librariesString
-''');
+      log.warning(
+        await e.formattedUnsupportedMessage(
+          'dart2wasm',
+          buildStep.inputId,
+          buildStep,
+        ),
+      );
       return const Dart2WasmBootstrapResult.didNotCompile();
     }
 

--- a/builder_pkgs/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -60,20 +60,9 @@ Future<void> bootstrapDdc(
       throwIfUnsupported: !unsafeAllowUnsupportedModules,
     );
   } on UnsupportedModules catch (e) {
-    final librariesString = (await e.exactLibraries(buildStep).toList())
-        .map(
-          (lib) => AssetId(
-            lib.id.package,
-            lib.id.path.replaceFirst(moduleLibraryExtension, '.dart'),
-          ),
-        )
-        .join('\n');
-    log.warning('''
-Skipping compiling ${buildStep.inputId} with ddc because some of its
-transitive libraries have sdk dependencies that not supported on this platform:
-
-$librariesString
-''');
+    log.warning(
+      await e.formattedUnsupportedMessage('ddc', buildStep.inputId, buildStep),
+    );
     return;
   }
   final jsId = module.primarySource.changeExtension(jsModuleExtension);

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.7.0
+version: 4.8.0-wip
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace

--- a/builder_pkgs/build_web_compilers/test/dart2js_bootstrap_test.dart
+++ b/builder_pkgs/build_web_compilers/test/dart2js_bootstrap_test.dart
@@ -186,7 +186,131 @@ void main() {
           contains(
             'Skipping compiling a|lib/index.dart with dart2js because some of '
             'its\ntransitive libraries have sdk dependencies that are not '
-            'supported on this platform:\n\na|lib/index.dart',
+            'supported on this platform:\n\n'
+            'package:a/index.dart (which imports dart:io)',
+          ),
+        ),
+      ),
+    );
+  });
+
+  test('throws on transitive unsupported platform library imports', () async {
+    final assets = {
+      'a|lib/index.dart': '''
+        import 'package:a/dependency.dart';
+        main() {
+          print('hello world');
+        }
+      ''',
+      'a|lib/dependency.dart': '''
+        import 'package:a/transitive_dependency.dart';
+      ''',
+      'a|lib/transitive_dependency.dart': '''
+        import 'dart:io';
+      ''',
+    };
+    final expectedOutputs = {
+      'a|lib/.dart2js.meta_module.clean': isNotNull,
+      'a|lib/.dart2js.meta_module.raw': isNotNull,
+      'a|lib/index.dart2js.module': isNotNull,
+      'a|lib/index.module.library': isNotNull,
+      'a|lib/dependency.dart2js.module': isNotNull,
+      'a|lib/dependency.module.library': isNotNull,
+      'a|lib/transitive_dependency.dart2js.module': isNotNull,
+      'a|lib/transitive_dependency.module.library': isNotNull,
+    };
+    final logs = <LogRecord>[];
+    await testBuilders(
+      [
+        const ModuleLibraryBuilder(),
+        MetaModuleBuilder(platform),
+        MetaModuleCleanBuilder(platform),
+        ModuleBuilder(platform),
+        WebEntrypointBuilder.fromOptions(
+          const BuilderOptions({
+            'compiler': 'dart2js',
+            'native_null_assertions': false,
+          }),
+        ),
+      ],
+      assets,
+      outputs: expectedOutputs,
+      onLog: logs.add,
+    );
+    expect(
+      logs,
+      contains(
+        isA<LogRecord>().having(
+          (r) => r.message,
+          'message',
+          contains(
+            'Skipping compiling a|lib/index.dart with dart2js because some of '
+            'its\ntransitive libraries have sdk dependencies that are not '
+            'supported on this platform:\n\n'
+            'package:a/index.dart -> package:a/dependency.dart -> '
+            'package:a/transitive_dependency.dart (which imports dart:io)',
+          ),
+        ),
+      ),
+    );
+  });
+
+  test('throws on multiple unsupported platform library imports', () async {
+    final assets = {
+      'a|lib/index.dart': '''
+        import 'package:a/dependency_a.dart';
+        import 'package:a/dependency_b.dart';
+        main() {
+          print('hello world');
+        }
+      ''',
+      'a|lib/dependency_a.dart': '''
+        import 'dart:io';
+      ''',
+      'a|lib/dependency_b.dart': '''
+        import 'dart:ffi';
+      ''',
+    };
+    final expectedOutputs = {
+      'a|lib/.dart2js.meta_module.clean': isNotNull,
+      'a|lib/.dart2js.meta_module.raw': isNotNull,
+      'a|lib/index.dart2js.module': isNotNull,
+      'a|lib/index.module.library': isNotNull,
+      'a|lib/dependency_a.dart2js.module': isNotNull,
+      'a|lib/dependency_a.module.library': isNotNull,
+      'a|lib/dependency_b.dart2js.module': isNotNull,
+      'a|lib/dependency_b.module.library': isNotNull,
+    };
+    final logs = <LogRecord>[];
+    await testBuilders(
+      [
+        const ModuleLibraryBuilder(),
+        MetaModuleBuilder(platform),
+        MetaModuleCleanBuilder(platform),
+        ModuleBuilder(platform),
+        WebEntrypointBuilder.fromOptions(
+          const BuilderOptions({
+            'compiler': 'dart2js',
+            'native_null_assertions': false,
+          }),
+        ),
+      ],
+      assets,
+      outputs: expectedOutputs,
+      onLog: logs.add,
+    );
+    expect(
+      logs,
+      contains(
+        isA<LogRecord>().having(
+          (r) => r.message,
+          'message',
+          contains(
+            'Skipping compiling a|lib/index.dart with dart2js because some of '
+            'its\ntransitive libraries have sdk dependencies that are not '
+            'supported on this platform:\n\n'
+            'package:a/index.dart -> package:a/dependency_a.dart (which imports dart:io)\n'
+            'package:a/index.dart -> package:a/dependency_b.dart (which imports dart:ffi)',
           ),
         ),
       ),

--- a/builder_pkgs/build_web_compilers/test/dart2js_bootstrap_test.dart
+++ b/builder_pkgs/build_web_compilers/test/dart2js_bootstrap_test.dart
@@ -197,67 +197,6 @@ void main() {
   test('throws on transitive unsupported platform library imports', () async {
     final assets = {
       'a|lib/index.dart': '''
-        import 'package:a/dependency.dart';
-        main() {
-          print('hello world');
-        }
-      ''',
-      'a|lib/dependency.dart': '''
-        import 'package:a/transitive_dependency.dart';
-      ''',
-      'a|lib/transitive_dependency.dart': '''
-        import 'dart:io';
-      ''',
-    };
-    final expectedOutputs = {
-      'a|lib/.dart2js.meta_module.clean': isNotNull,
-      'a|lib/.dart2js.meta_module.raw': isNotNull,
-      'a|lib/index.dart2js.module': isNotNull,
-      'a|lib/index.module.library': isNotNull,
-      'a|lib/dependency.dart2js.module': isNotNull,
-      'a|lib/dependency.module.library': isNotNull,
-      'a|lib/transitive_dependency.dart2js.module': isNotNull,
-      'a|lib/transitive_dependency.module.library': isNotNull,
-    };
-    final logs = <LogRecord>[];
-    await testBuilders(
-      [
-        const ModuleLibraryBuilder(),
-        MetaModuleBuilder(platform),
-        MetaModuleCleanBuilder(platform),
-        ModuleBuilder(platform),
-        WebEntrypointBuilder.fromOptions(
-          const BuilderOptions({
-            'compiler': 'dart2js',
-            'native_null_assertions': false,
-          }),
-        ),
-      ],
-      assets,
-      outputs: expectedOutputs,
-      onLog: logs.add,
-    );
-    expect(
-      logs,
-      contains(
-        isA<LogRecord>().having(
-          (r) => r.message,
-          'message',
-          contains(
-            'Skipping compiling a|lib/index.dart with dart2js because some of '
-            'its\ntransitive libraries have sdk dependencies that are not '
-            'supported on this platform:\n\n'
-            'package:a/index.dart -> package:a/dependency.dart -> '
-            'package:a/transitive_dependency.dart (which imports dart:io)',
-          ),
-        ),
-      ),
-    );
-  });
-
-  test('throws on multiple unsupported platform library imports', () async {
-    final assets = {
-      'a|lib/index.dart': '''
         import 'package:a/dependency_a.dart';
         import 'package:a/dependency_b.dart';
         main() {


### PR DESCRIPTION
Fix #4959.

This is AI generated. I'm not super familiar with the code, as far as I can tell the change makes sense.

Initial prompt: "Please fix https://github.com/dart-lang/build/issues/4959"

Then I asked "What does the output look like if there are multiple files with disallowed imports?" and it added a second test with multiple disallowed imports.

--> first commit.

Then I said "Hmm I think you could clean up that rendering code in errors.dart with a few extension methods on AssetId?" and it cleaned up; I manually removed the one-disallowed-import test case as I don't think it adds much. --> second commit.