### PR TITLE
Provide dummy values for Int32 and Int64

### DIFF
--- a/builder_pkgs/mockito/CHANGELOG.md
+++ b/builder_pkgs/mockito/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.8.0-wip
+
+* Provide dummy values for `Int32` and `Int64` from `package:fixnum`.
+
 ## 5.7.0
 
 * Handle JS interop extension types and provide dummy values for them.

--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -1786,11 +1786,26 @@ class _MockClassInfo {
       // used, that's `String` when compiling to JS and an internal wrapper type
       // when compiling to Wasm.
       return _dummyValueFallbackToRuntime(type, invocation);
+    } else if (_isFixnumType(type)) {
+      final library = type.element.library;
+      final importUrl =
+          mockLibraryInfo.assetUris[type.element] ?? library.uri.toString();
+      return referImported(type.element.name!, importUrl).property('ZERO');
     }
 
     // This class is unknown; we must likely generate a fake class, and return
     // an instance here.
     return _dummyValueImplementing(type, invocation);
+  }
+
+  bool _isFixnumType(analyzer.DartType type) {
+    if (type is! analyzer.InterfaceType) return false;
+    final name = type.element.name;
+    if (name != 'Int32' && name != 'Int64') return false;
+    final uri = type.element.library.uri;
+    return uri.scheme == 'package' &&
+        uri.pathSegments.isNotEmpty &&
+        uri.pathSegments.first == 'fixnum';
   }
 
   /// Returns a reference to [Future], optionally with a type argument for the

--- a/builder_pkgs/mockito/pubspec.yaml
+++ b/builder_pkgs/mockito/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.7.0
+version: 5.8.0-wip
 description: >-
   A mock framework inspired by Mockito with APIs for Fakes, Mocks,
   behavior verification, and stubbing.

--- a/builder_pkgs/mockito/test/builder/auto_mocks_test.dart
+++ b/builder_pkgs/mockito/test/builder/auto_mocks_test.dart
@@ -2610,6 +2610,42 @@ void main() {
   });
 
   test(
+    'creates dummy non-null Int64 and Int32 return values from package:fixnum',
+    () async {
+      await testWithNonNullable(
+        {
+          ...metaAssets,
+          ...annotationsAsset,
+          ...simpleTestAsset,
+          'fixnum|lib/fixnum.dart': dedent(r'''
+          final class Int64 {
+            static const ZERO = Int64._();
+            const Int64._();
+          }
+          final class Int32 {
+            static const ZERO = Int32._();
+            const Int32._();
+          }
+        '''),
+          'foo|lib/foo.dart': dedent(r'''
+          import 'package:fixnum/fixnum.dart';
+          class Foo {
+            Int64 m64() => Int64.ZERO;
+            Int32 m32() => Int32.ZERO;
+          }
+        '''),
+        },
+        outputs: {
+          'foo|test/foo_test.mocks.dart': _containsAllOf(
+            '.Int64.ZERO',
+            '.Int32.ZERO',
+          ),
+        },
+      );
+    },
+  );
+
+  test(
     'calls dummyValue to get a dummy non-null String return value',
     () async {
       await expectSingleNonNullableOutput(


### PR DESCRIPTION
These are value types that should not be faked. An upcoming change will
mark these classes as final. Since these are types from a core package
owned by the Dart team, centralize support for using the static `ZERO`
fields as the dummy values.

The implementation and test intentionally avoid a dependency on
`package:fixnum`.
