### PR TITLE
Stop directly reusing old build state

### DIFF
--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -11,9 +11,9 @@ import 'package:build/build.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
-import 'package:watcher/watcher.dart';
 
 import '../build_plan/build_configs.dart';
+import '../build_plan/build_inputs.dart';
 import '../build_plan/build_options.dart';
 import '../build_plan/build_packages.dart';
 import '../build_plan/build_phases.dart';
@@ -24,7 +24,6 @@ import '../build_plan/testing_overrides.dart';
 import '../constants.dart';
 import '../io/build_output_reader.dart';
 import '../io/create_merged_dir.dart';
-import '../io/generated_asset_hider.dart';
 import '../io/reader_writer.dart';
 import '../logging/build_log.dart';
 import '../logging/timed_activities.dart';
@@ -55,11 +54,11 @@ final ResolversImpl _defaultResolvers = ResolversImpl(
 
 /// A single build.
 class Build {
-  BuildPlan _buildPlan;
+  final BuildPlan buildPlan;
 
   // Collaborators.
   final ResourceManager resourceManager;
-  ReaderWriter _readerWriter;
+  final ReaderWriter readerWriter;
   final LibraryCycleGraphLoader previousLibraryCycleGraphLoader =
       LibraryCycleGraphLoader();
   final AssetDepsLoader? previousDepsLoader;
@@ -76,49 +75,6 @@ class Build {
   final lazyPhases = <BuildStepId, Future<Iterable<AssetId>>>{};
   final lazyGlobs = <GlobId, Future<void>>{};
 
-  /// Generated outputs that have been processed.
-  ///
-  /// That means they have been checked to determine whether they
-  /// need building; if so, those have been built, and state has been
-  /// updated accordingly.
-  final Set<AssetId> processedOutputs = {};
-
-  /// Globs that have been processed.
-  ///
-  /// That means they have been checked to determine whether they
-  /// need evaluating, and if so their state has been updated accordingly.
-  final Set<GlobId> processedGlobs = {};
-
-  /// Inputs that changed since the last build.
-  ///
-  /// Filled from the `updates` passed in to the build.
-  final Set<AssetId> changedInputs = {};
-
-  /// Assets that were deleted since the last build.
-  ///
-  /// This is used to distinguish between missing sources that were
-  /// already known and missing sources that are newly known.
-  final Set<AssetId> deletedAssets = {};
-
-  /// Assets that might be new primary inputs since the previous build.
-  ///
-  /// This means: new inputs, new generated outputs, or generated outputs
-  /// from generators that failed in the previous build and succeed in this
-  /// build.
-  final Set<AssetId> newPrimaryInputs = {};
-
-  /// Outputs that changed since the last build.
-  ///
-  /// Filled during the build as each output is produced and its digest is
-  /// checked against the digest from the previous build.
-  final Set<AssetId> changedOutputs = {};
-
-  /// Glob queries that changed since the last build.
-  final Set<GlobId> changedGlobs = {};
-
-  /// Build steps for which errors have been shown.
-  final Set<BuildStepId> errorsShownSteps = {};
-
   /// Whether a graph from [previousLibraryCycleGraphLoader] has any changed
   /// transitive source.
   final Map<LibraryCycleGraph, bool> changedGraphs = Map.identity();
@@ -126,66 +82,63 @@ class Build {
   /// The build output.
   BuildOutputReader? _buildOutputReader;
 
-  Build({
-    required BuildPlan buildPlan,
-    required ReaderWriter readerWriter,
-    required this.resourceManager,
-    required this.buildState,
-  }) : _buildPlan = buildPlan,
-       _readerWriter = readerWriter,
-       previousDepsLoader =
-           buildPlan.previousPhasedAssetDeps == null
-               ? null
-               : AssetDepsLoader.fromDeps(buildPlan.previousPhasedAssetDeps!),
-       resolvers = buildPlan.testingOverrides.resolvers ?? _defaultResolvers,
-       resolversImpl = switch (buildPlan.testingOverrides.resolvers ??
-           _defaultResolvers) {
-         ResolversImpl r => r,
-         _ => null,
-       };
+  Build({required this.buildPlan, required this.resourceManager})
+    : readerWriter = buildPlan.readerWriter,
+      previousDepsLoader =
+          buildPlan.previousPhasedAssetDeps == null
+              ? null
+              : AssetDepsLoader.fromDeps(buildPlan.previousPhasedAssetDeps!),
+      resolvers = buildPlan.testingOverrides.resolvers ?? _defaultResolvers,
+      resolversImpl = switch (buildPlan.testingOverrides.resolvers ??
+          _defaultResolvers) {
+        ResolversImpl r => r,
+        _ => null,
+      },
+      buildState = BuildState(buildPlan.buildInputs.sources) {
+    for (final entry in buildPlan.buildInputs.digests.entries) {
+      buildState.updateSourceDigest(entry.key, entry.value);
+    }
+  }
 
-  BuildPlan get buildPlan => _buildPlan;
-  ReaderWriter get readerWriter => _readerWriter;
   BuildOptions get buildOptions => buildPlan.buildOptions;
   TestingOverrides get testingOverrides => buildPlan.testingOverrides;
   BuildPackages get buildPackages => buildPlan.buildPackages;
   BuildConfigs get buildConfigs => buildPlan.buildConfigs;
   BuildPhases get buildPhases => buildPlan.buildStepPlan.buildPhases;
+  BuildState? get previousBuildState => buildPlan.previousBuildState;
+  BuildInputs get buildInputs => buildPlan.buildInputs;
   BuildStepPlan get buildStepPlan => buildPlan.buildStepPlan;
 
   BuildOutputReader get buildOutputReader =>
       _buildOutputReader ??= BuildOutputReader(
         buildPlan: buildPlan,
-        readerWriter: readerWriter,
         buildState: buildState,
-        processedOutputs: processedOutputs,
       );
 
-  Future<BuildResult> run(Set<AssetId> updates) async {
+  Future<BuildResult> run() async {
     buildLog.configuration = buildLog.configuration.rebuild(
       (b) => b..singleOutputPackage = buildPackages.singleOutputPackage,
     );
-    var result = await _safeBuild(updates);
+    var result = await _safeBuild();
     if (result.status == BuildStatus.success) {
-      final failedSteps = <BuildStepId>{};
-      for (final output in processedOutputs) {
-        final step = buildStepPlan.stepForDeclaredOutputOrNull(output);
-        if (step == null) continue;
-        final stepResult = buildState.stepResult(step);
-        if (stepResult.failed) {
-          failedSteps.add(step);
-        }
-      }
+      final failedSteps = buildState.failedSteps;
       if (failedSteps.isNotEmpty) {
         for (final step in failedSteps) {
-          if (errorsShownSteps.contains(step)) continue;
+          final stepResult = buildState.stepResult(step);
+          if (!identical(
+            stepResult,
+            previousBuildState?.stepResultOrNull(step),
+          )) {
+            // It was run in this build, so the errors were already logged
+            // by the builder itself.
+            continue;
+          }
           final phase = buildPhases.inBuildPhases[step.phaseNumber];
           final logger = buildLog.loggerFor(
             phase: phase,
             primaryInput: step.primaryInput,
             lazy: phase.isOptional,
           );
-          final stepResult = buildState.stepResult(step);
           for (final error in stepResult.errors) {
             logger.severe(error);
           }
@@ -245,106 +198,13 @@ class Build {
     return result;
   }
 
-  Future<Set<AssetId>> _updateBuildState(Set<AssetId> updates) async {
-    changedInputs.clear();
-    deletedAssets.clear();
-
-    // Check what actually changed for each asset in `updates`.
-    readerWriter.cache.invalidate(updates);
-    final resolvedUpdates = <AssetId, ChangeType>{};
-    final previousSources = <AssetId>{};
-    final newDigests = <AssetId, Digest>{};
-    for (final id in updates) {
-      final oldIsSource = buildState.isSource(id);
-      if (oldIsSource) {
-        previousSources.add(id);
-      }
-      final oldExisted = _isFile(id);
-      final oldDigest = oldIsSource ? buildState.digestOfSource(id) : null;
-      var exists = false;
-      Digest? newDigest;
-      if (await readerWriter.canRead(id)) {
-        exists = true;
-        // Assets are only eagerly read if they were an input in the previous
-        // build. In that case, they have a digest. Compute the new digest to
-        // check if the file changed.
-        if (oldDigest != null) {
-          try {
-            newDigest = await readerWriter.digest(id);
-            newDigests[id] = newDigest;
-          } catch (_) {
-            // Was deleted after `canRead`.
-            exists = false;
-          }
-        }
-      }
-
-      if (oldExisted && !exists) {
-        resolvedUpdates[id] = ChangeType.REMOVE;
-        deletedAssets.add(id);
-      } else if (!oldExisted && exists) {
-        changedInputs.add(id);
-        newPrimaryInputs.add(id);
-        resolvedUpdates[id] = ChangeType.ADD;
-      } else if (oldExisted &&
-          oldDigest != null &&
-          exists &&
-          oldDigest != newDigest) {
-        changedInputs.add(id);
-        resolvedUpdates[id] = ChangeType.MODIFY;
-      }
-    }
-
-    final deleted = buildState.updateForNextBuild(
-      buildStepPlan,
-      resolvedUpdates,
-    );
-    for (final id in deleted) {
-      await readerWriter.delete(id);
-    }
-    _buildPlan = _buildPlan.updateForSources(buildState.sources);
-    deletedAssets.addAll(deleted);
-    for (final entry in newDigests.entries) {
-      buildState.updateSourceDigest(entry.key, entry.value);
-    }
-
-    final invalidatedSources = <AssetId>{};
-    for (final entry in resolvedUpdates.entries) {
-      final id = entry.key;
-      final changeType = entry.value;
-      if (changeType != ChangeType.ADD && previousSources.contains(id)) {
-        invalidatedSources.add(id);
-      }
-    }
-    return invalidatedSources;
-  }
-
-  /// Runs a build inside a zone with an error handler and stack chain
-  /// capturing.
-  Future<BuildResult> _safeBuild(Set<AssetId> idsToCheck) {
+  Future<BuildResult> _safeBuild() {
     final done = Completer<BuildResult>();
     runZonedGuarded(
       () async {
-        final invalidatedSources =
-            buildPlan.cleanBuild ? null : await _updateBuildState(idsToCheck);
-        // _updateBuildState can change the buildStepPlan, give _readerWriter
-        // the latest plan.
-        _readerWriter = _readerWriter.copyWith(
-          generatedAssetHider:
-              _buildPlan.testingOverrides.flattenOutput
-                  ? const NoopGeneratedAssetHider()
-                  : _buildPlan.buildStepPlan,
-        );
-        for (final id in buildState.sources) {
-          if (buildState.isUnreadSource(id) &&
-              buildStepPlan.declaredOutputsOf(id).isNotEmpty) {
-            final digest = await readerWriter.digest(id);
-            buildState.updateSourceDigest(id, digest);
-          }
-        }
         await resolversImpl?.takeLockAndStartBuild(
           buildPlan.buildStepPlan.declaredOutputPhases,
-          invalidatedSources: invalidatedSources,
+          invalidatedSources: buildInputs.invalidatedSources,
         );
         final result = await _runPhases();
 
@@ -519,14 +379,15 @@ class Build {
 
   /// If [id] is a generated asset, ensures that it has been built.
   ///
-  /// If has already been built according to [processedOutputs], returns
+  /// If has already been built according to [buildState], returns
   /// immediately.
   ///
   /// If it is currently being built according to [lazyPhases], waits for it to
   /// be built.
   Future<void> _buildOutput(AssetId id) async {
     final step = buildStepPlan.stepForDeclaredOutputOrNull(id);
-    if (step != null && !processedOutputs.contains(id)) {
+    if (step != null &&
+        !buildState.isProcessedOutput(buildStepPlan: buildStepPlan, id: id)) {
       await lazyPhases.putIfAbsent(step, () async {
         final phase = buildPhases.inBuildPhases[step.phaseNumber];
         return _buildForPrimaryInput(
@@ -561,7 +422,11 @@ class Build {
         buildStepPlan: buildStepPlan,
         buildState: buildState,
         assetBuilder: _buildOutput,
-        assetIsProcessedOutput: processedOutputs.contains,
+        assetIsProcessedOutput:
+            (id) => buildState.isProcessedOutput(
+              buildStepPlan: buildStepPlan,
+              id: id,
+            ),
         globEvaluator: _evaluateGlob,
       ),
       runningBuildStep: RunningBuildStep(
@@ -580,19 +445,28 @@ class Build {
     );
 
     final builderOutputs = expectedOutputs(builder, buildStepId.primaryInput);
-    if (!await _buildShouldRun(
+    final stepAction = await _computeStepAction(
       buildStepId,
       builderOutputs,
       singleStepReaderWriter,
-    )) {
+    );
+    if (stepAction.isSkip) {
       buildLog.skipStep(phase: phase, lazy: lazy);
-      for (final output in builderOutputs) {
-        processedOutputs.add(output);
+      if (stepAction == StepAction.skipMissingPrimaryInput) {
+        await _deletePreviousOutputs(builderOutputs);
+        _markStepSkipped(buildStepId, builderOutputs);
+      } else if (stepAction == StepAction.skipFailedPrimaryInput) {
+        await _markStepFailed(buildStepId, builderOutputs);
+      } else if (stepAction == StepAction.skipReuse) {
+        buildState.updateBuildStepResult(
+          buildStepId,
+          previousBuildState!.stepResult(buildStepId),
+        );
       }
       return <AssetId>[];
     }
 
-    await _cleanUpStaleOutputs(builderOutputs);
+    await _deletePreviousOutputs(builderOutputs);
 
     // Clear input tracking accumulated during `_buildShouldRun`.
     singleStepReaderWriter.inputTracker.clear();
@@ -649,7 +523,7 @@ class Build {
         phase: phase,
         anyOutputs: singleStepReaderWriter.assetsWritten.isNotEmpty,
         anyChangedOutputs: singleStepReaderWriter.assetsWritten.any(
-          changedOutputs.contains,
+          _isChangedOutput,
         ),
         lazy: lazy,
       );
@@ -775,7 +649,11 @@ class Build {
         buildStepPlan: buildStepPlan,
         buildState: buildState,
         assetBuilder: _buildOutput,
-        assetIsProcessedOutput: processedOutputs.contains,
+        assetIsProcessedOutput:
+            (id) => buildState.isProcessedOutput(
+              buildStepPlan: buildStepPlan,
+              id: id,
+            ),
         globEvaluator: _evaluateGlob,
       ),
       runningBuildStep: RunningBuildStep(
@@ -789,22 +667,30 @@ class Build {
     );
 
     final existingOutputs =
-        buildState
-            .postProcessBuildStepResultFor(postProcessBuildStepId)
+        previousBuildState
+            ?.postProcessBuildStepResultFor(postProcessBuildStepId)
             ?.outputs ??
         const <AssetId>{};
     if (!await _postProcessBuildStepShouldRun(
       postProcessBuildStepId,
       stepReaderWriter,
     )) {
-      processedOutputs.addAll(existingOutputs);
+      final oldResult = previousBuildState?.postProcessBuildStepResultFor(
+        postProcessBuildStepId,
+      );
+      if (oldResult != null) {
+        buildState.addPostProcessBuildStepResult(
+          postProcessBuildStepId,
+          oldResult,
+        );
+      }
       return <AssetId>[];
     }
     // Clear input tracking accumulated during `_buildShouldRun`.
     stepReaderWriter.inputTracker.clear();
 
     // Clean out the impacts of the previous run.
-    await _cleanUpStaleOutputs(existingOutputs);
+    await _deletePreviousOutputs(existingOutputs);
     buildState.removePostProcessBuildResult(postProcessBuildStepId);
 
     final logger = buildLog.loggerForOther(
@@ -863,12 +749,8 @@ class Build {
       buildStepId,
       BuildStepResult((b) => b..isHidden = isHidden),
     );
-    for (final output in outputs) {
-      processedOutputs.add(output);
-    }
   }
 
-  /// Marks the build step as failed and clears output digests.
   Future<void> _markStepFailed(
     BuildStepId buildStepId,
     Iterable<AssetId> outputs,
@@ -882,16 +764,14 @@ class Build {
         b.isHidden = isHidden;
       }),
     );
-    for (final output in outputs) {
-      processedOutputs.add(output);
-    }
+    await _deletePreviousOutputs(outputs);
   }
 
   /// Checks and returns whether any [outputs] need to be updated by
   /// the build step [step].
   ///
   /// As part of checking, builds any inputs that need building.
-  Future<bool> _buildShouldRun(
+  Future<StepAction> _computeStepAction(
     BuildStepId step,
     Iterable<AssetId> outputs,
     SingleStepReaderWriter readerWriter,
@@ -899,18 +779,19 @@ class Build {
     return await TimedActivity.track.runAsync(() async {
       // Update state for primary input if needed.
       if (buildStepPlan.isDeclaredOutput(step.primaryInput)) {
-        if (!processedOutputs.contains(step.primaryInput)) {
+        if (!buildState.isProcessedOutput(
+          buildStepPlan: buildStepPlan,
+          id: step.primaryInput,
+        )) {
           await _buildOutput(step.primaryInput);
         }
       }
 
-      // If the primary input has been deleted, the build is skipped.
-      if (deletedAssets.contains(step.primaryInput)) {
-        if (buildState.isMissingSource(step.primaryInput)) {
-          await _cleanUpStaleOutputs(outputs);
-          _markStepSkipped(step, outputs);
-          return false;
-        }
+      // If a primary input source file has been deleted, the build is skipped.
+      if (!buildStepPlan.isDeclaredOutput(step.primaryInput) &&
+          (buildInputs.deletedSources.contains(step.primaryInput) ||
+              buildInputs.deletedOutputs.contains(step.primaryInput))) {
+        return StepAction.skipMissingPrimaryInput;
       }
 
       // Propagate results for declared output primary input.
@@ -922,8 +803,7 @@ class Build {
         // If the primary input's generating step failed, this build is also
         // failed.
         if (inputStepResult.failed) {
-          await _markStepFailed(step, outputs);
-          return false;
+          return StepAction.skipFailedPrimaryInput;
         }
 
         // If the primary input succeeded but was not output, this build is
@@ -932,28 +812,48 @@ class Build {
           buildStepPlan: buildStepPlan,
           id: step.primaryInput,
         )) {
-          await _cleanUpStaleOutputs(outputs);
-          _markStepSkipped(step, outputs);
-          return false;
+          return StepAction.skipMissingPrimaryInput;
         }
       }
 
-      if (buildPlan.cleanBuild) return true;
+      if (buildInputs.cleanBuild) return StepAction.run;
 
-      if (buildPlan.triggersChanged) return true;
+      if (buildPlan.triggersChanged) return StepAction.run;
 
       if (buildPlan.phaseOptionsChanged(step.phaseNumber)) {
-        return true;
+        return StepAction.run;
       }
 
-      if (newPrimaryInputs.contains(step.primaryInput)) return true;
+      final primaryInput = step.primaryInput;
+      if (buildInputs.addedSources.contains(primaryInput)) {
+        return StepAction.run;
+      }
+
+      if (buildStepPlan.isDeclaredOutput(primaryInput)) {
+        final inputStep = buildStepPlan.stepForDeclaredOutput(primaryInput);
+        final oldResult = previousBuildState?.stepResultOrNull(inputStep);
+        final newResult = buildState.stepResult(inputStep);
+        final oldWasOutput =
+            oldResult?.result == true &&
+            oldResult!.outputs.containsKey(primaryInput);
+        final newWasOutput =
+            newResult.result == true &&
+            newResult.outputs.containsKey(primaryInput);
+
+        if (!oldWasOutput && newWasOutput) {
+          return StepAction.run;
+        }
+      }
 
       for (final output in outputs) {
-        if (deletedAssets.contains(output)) return true;
+        if (buildInputs.deletedSources.contains(output) ||
+            buildInputs.deletedOutputs.contains(output)) {
+          return StepAction.run;
+        }
       }
 
-      final stepResult = buildState.stepResultOrNull(step);
-      if (stepResult == null || !stepResult.hasRun) return true;
+      final stepResult = previousBuildState?.stepResultOrNull(step);
+      if (stepResult == null || !stepResult.hasRun) return StepAction.run;
 
       // Check for changes to any secondary inputs.
       for (final input in stepResult.inputs) {
@@ -962,15 +862,20 @@ class Build {
           input: input,
         );
 
-        if (changed) return true;
+        if (changed) return StepAction.run;
       }
 
       // Check for changes to any glob inputs.
       for (final globId in stepResult.globsEvaluated) {
-        if (!processedGlobs.contains(globId)) {
+        var currentGlobResult = buildState.globResultFor(globId);
+        if (currentGlobResult == null) {
           await _evaluateGlob(globId);
+          currentGlobResult = buildState.globResultFor(globId);
         }
-        if (changedGlobs.contains(globId)) return true;
+        if (previousBuildState?.globResultFor(globId)?.digest !=
+            currentGlobResult?.digest) {
+          return StepAction.run;
+        }
       }
 
       for (final graphId in stepResult.resolverEntrypoints) {
@@ -978,16 +883,12 @@ class Build {
           phaseNumber: step.phaseNumber,
           entrypointId: graphId,
         )) {
-          return true;
+          return StepAction.run;
         }
       }
 
       // No input changes: build is not needed, and outputs state is up to date.
-      for (final output in outputs) {
-        processedOutputs.add(output);
-      }
-
-      return false;
+      return StepAction.skipReuse;
     });
   }
 
@@ -1083,22 +984,24 @@ class Build {
         // It's not readable in this phase.
         return false;
       }
-      // Ensure that the input was built, so [changedOutputs] is updated.
-      if (!processedOutputs.contains(input)) {
+      // Ensure that the input was built.
+      if (!buildState.isProcessedOutput(
+        buildStepPlan: buildStepPlan,
+        id: input,
+      )) {
         await _buildOutput(input);
       }
-      if (changedOutputs.contains(input)) {
+      if (_isChangedOutput(input)) {
         return true;
       }
     } else if (buildState.isSource(input)) {
-      if (changedInputs.contains(input)) {
+      if (buildInputs.modifiedSources.contains(input) ||
+          buildInputs.addedSources.contains(input)) {
         return true;
       }
-    } else if (buildState.isMissingSource(input)) {
-      // It's only a newly-deleted asset if it's also in [deletedAssets].
-      if (deletedAssets.contains(input)) {
-        return true;
-      }
+    } else if (buildInputs.deletedSources.contains(input) ||
+        buildInputs.deletedOutputs.contains(input)) {
+      return true;
     }
     return false;
   }
@@ -1112,7 +1015,7 @@ class Build {
   ) async {
     final input = buildStepId.input;
 
-    if (buildPlan.cleanBuild) {
+    if (buildInputs.cleanBuild) {
       return true;
     }
 
@@ -1121,15 +1024,19 @@ class Build {
     }
 
     if (buildStepPlan.isDeclaredOutput(input)) {
-      // Check that the input was built, so [changedOutputs] is updated.
-      if (!processedOutputs.contains(input)) {
+      // Check that the input was built.
+      if (!buildState.isProcessedOutput(
+        buildStepPlan: buildStepPlan,
+        id: input,
+      )) {
         await _buildOutput(input);
       }
-      if (changedOutputs.contains(input)) {
+      if (_isChangedOutput(input)) {
         return true;
       }
     } else if (buildState.isSource(input)) {
-      if (changedInputs.contains(input)) {
+      if (buildInputs.modifiedSources.contains(input) ||
+          buildInputs.addedSources.contains(input)) {
         return true;
       }
     } else {
@@ -1140,15 +1047,16 @@ class Build {
   }
 
   /// Deletes any of [outputs] which previously were output.
-  ///
-  /// This should be called after deciding that an asset really needs to be
-  /// regenerated based on its inputs hash changing. All assets in [outputs]
-  /// must be generated assets.
-  Future<void> _cleanUpStaleOutputs(Iterable<AssetId> outputs) async {
+  Future<void> _deletePreviousOutputs(Iterable<AssetId> outputs) async {
+    final previousBuildState = this.previousBuildState;
+    if (previousBuildState == null) return;
     for (final output in outputs) {
-      if (buildState.isActualOutput(buildStepPlan: buildStepPlan, id: output) ||
-          buildState.isActualPostOutput(output)) {
-        await _delete(output);
+      if (previousBuildState.isActualOutput(
+            buildStepPlan: buildStepPlan,
+            id: output,
+          ) ||
+          previousBuildState.isActualPostOutput(output)) {
+        await readerWriter.delete(output);
       }
     }
   }
@@ -1169,7 +1077,7 @@ class Build {
   /// not useful to something that wants to read the file. In the glob result,
   /// it ends up in `inputs` but not in `results`.
   Future<void> _evaluateGlob(GlobId globId) async {
-    if (processedGlobs.contains(globId)) {
+    if (buildState.hasGlobResult(globId)) {
       return;
     }
 
@@ -1218,12 +1126,6 @@ class Build {
 
       final results = [...otherInputs, ...generatedFileResults];
       final digest = md5.convert(utf8.encode(results.join(' ')));
-
-      final previousGlobResult = buildState.globResultFor(globId);
-      if (previousGlobResult == null || previousGlobResult.digest != digest) {
-        changedGlobs.add(globId);
-      }
-      processedGlobs.add(globId);
 
       final globResult = GlobResult((b) {
         b.results.addAll(results);
@@ -1276,36 +1178,26 @@ class Build {
     final buildStepResult = buildStepResultBuilder.build();
 
     final buildStepId = BuildStepId(primaryInput: input, phaseNumber: phaseNum);
-    final previousBuildStepResult = buildState.stepResultOrNull(buildStepId);
-    final previousResult = previousBuildStepResult?.result;
     buildState.updateBuildStepResult(buildStepId, buildStepResult);
-
-    if (result == false) {
-      errorsShownSteps.add(buildStepId);
-    }
-
-    for (final output in outputs) {
-      final oldDigest = previousBuildStepResult?.outputs[output];
-      final newDigest = buildStepResult.outputs[output];
-
-      // A transition from (missing or failed) to (written and not failed) is
-      // a new primary input that triggers generation even if no content
-      // changed.
-      if ((oldDigest == null || previousResult == false) &&
-          (newDigest != null && result)) {
-        newPrimaryInputs.add(output);
-      }
-      // Only a change to content matters for non-primary inputs.
-      if (oldDigest != newDigest) {
-        changedOutputs.add(output);
-      }
-
-      processedOutputs.add(output);
-    }
   }
 
   bool _isFile(AssetId id) =>
       buildState.isFile(buildStepPlan: buildStepPlan, id: id);
 
-  Future _delete(AssetId id) => readerWriter.delete(id);
+  bool _isChangedOutput(AssetId output) {
+    final generatingStep = buildStepPlan.stepForDeclaredOutput(output);
+    final oldDigest =
+        previousBuildState?.stepResultOrNull(generatingStep)?.outputs[output];
+    final newDigest = buildState.stepResult(generatingStep).outputs[output];
+    return oldDigest != newDigest;
+  }
+}
+
+enum StepAction {
+  run,
+  skipReuse,
+  skipMissingPrimaryInput,
+  skipFailedPrimaryInput;
+
+  bool get isSkip => this != run;
 }

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -14,8 +14,7 @@ import '../build_plan/build_plan.dart';
 import '../commands/watch/asset_change.dart';
 import '../constants.dart';
 import '../io/asset_tracker.dart';
-import '../io/generated_asset_hider.dart';
-import '../io/reader_writer.dart';
+
 import '../logging/build_log.dart';
 import 'build.dart';
 import 'build_result.dart';
@@ -35,17 +34,7 @@ import 'build_state/build_state.dart';
 /// already in memory is used directly.
 class BuildSeries {
   final ResourceManager _resourceManager = ResourceManager();
-  final ReaderWriter _readerWriter;
-
   BuildPlan _buildPlan;
-  BuildState _buildState;
-
-  /// For the first build only, assets that were updated since the previous
-  /// serialized build state.
-  ///
-  /// Null after the first build, or if there was no serialized build state, or
-  /// if the serialized build state was discarded.
-  BuiltSet<AssetId>? _updatesFromLoad;
 
   final StreamController<BuildResult> _buildResultsController =
       StreamController.broadcast();
@@ -55,30 +44,10 @@ class BuildSeries {
   /// Whether the next build is the first build.
   bool firstBuild = true;
 
-  BuildSeries._({
-    required BuildPlan buildPlan,
-    required BuildState buildState,
-    required ReaderWriter readerWriter,
-    required BuiltSet<AssetId>? updatesFromLoad,
-  }) : _buildPlan = buildPlan,
-       _buildState = buildState,
-       _readerWriter = readerWriter,
-       _updatesFromLoad = updatesFromLoad;
+  BuildSeries._({required BuildPlan buildPlan}) : _buildPlan = buildPlan;
 
   factory BuildSeries(BuildPlan buildPlan) {
-    final buildState = buildPlan.takeBuildState();
-    final readerWriter = buildPlan.readerWriter.copyWith(
-      generatedAssetHider:
-          buildPlan.testingOverrides.flattenOutput
-              ? const NoopGeneratedAssetHider()
-              : buildPlan.buildStepPlan,
-    );
-    return BuildSeries._(
-      buildPlan: buildPlan,
-      buildState: buildState,
-      readerWriter: readerWriter,
-      updatesFromLoad: buildPlan.updates,
-    );
+    return BuildSeries._(buildPlan: buildPlan);
   }
 
   /// Broadcast stream of build results.
@@ -123,10 +92,12 @@ class BuildSeries {
         continue;
       }
 
-      final isFile = _buildState.isFile(
-        buildStepPlan: _buildPlan.buildStepPlan,
-        id: id,
-      );
+      final isFile =
+          _buildPlan.previousBuildState?.isFile(
+            buildStepPlan: _buildPlan.buildStepPlan,
+            id: id,
+          ) ??
+          false;
       if (!isFile) {
         // Ignore under `.dart_tool/build`.
         if (id.path.startsWith(cacheDirectoryPath)) continue;
@@ -146,8 +117,8 @@ class BuildSeries {
       // If not copying to a merged output directory, ignore changes to files
       // with no outputs.
       if (!_buildPlan.buildOptions.anyMergedOutputDirectory &&
-          !_buildState.isMissingSource(id) &&
-          _buildState.digestOf(
+          !(_buildPlan.previousBuildState?.isMissingSource(id) ?? false) &&
+          _buildPlan.previousBuildState?.digestOf(
                 id: id,
                 buildStepPlan: _buildPlan.buildStepPlan,
               ) ==
@@ -181,7 +152,7 @@ class BuildSeries {
       _buildPlan.buildConfigs,
     ).collectChanges(
       buildStepPlan: _buildPlan.buildStepPlan,
-      buildState: _buildState,
+      buildState: _buildPlan.previousBuildState ?? BuildState(),
     );
     return List.of(
       updates.entries.map((entry) => WatchEvent(entry.value, '${entry.key}')),
@@ -244,38 +215,35 @@ class BuildSeries {
         await close();
         return result;
       }
-      _buildState = _buildPlan.takeBuildState();
     }
 
     buildDirs ??= _buildPlan.buildOptions.buildDirs;
     buildFilters ??= _buildPlan.buildOptions.buildFilters;
+    if (!firstBuild) buildLog.nextBuild();
+    _buildPlan = _buildPlan.copyWith(
+      buildDirs: buildDirs,
+      buildFilters: buildFilters,
+    );
+
     if (firstBuild) {
-      if (_updatesFromLoad != null) {
-        updates = _updatesFromLoad!.toSet()..addAll(updates);
-        _updatesFromLoad = null;
+      if (updates.isNotEmpty) {
+        _buildPlan = await _buildPlan.updateForFileChanges(updates);
       }
     } else {
-      if (_updatesFromLoad != null) {
-        throw StateError('Only first build can have updates from load.');
-      }
+      _buildPlan = await _buildPlan.updateForFileChanges(updates);
     }
 
-    if (!firstBuild) buildLog.nextBuild();
     final build = Build(
-      buildPlan: _buildPlan.copyWith(
-        buildDirs: buildDirs,
-        buildFilters: buildFilters,
-      ),
-      buildState: _buildState,
-      readerWriter: _readerWriter,
+      buildPlan: _buildPlan,
       resourceManager: _resourceManager,
     );
     if (firstBuild) firstBuild = false;
 
-    _currentBuildResult = build.run(updates);
+    _currentBuildResult = build.run();
     final result = await _currentBuildResult!;
     _buildPlan = build.buildPlan.updateForResult(
       previousPhasedAssetDeps: result.phasedAssetDeps,
+      previousBuildState: build.buildState,
     );
     _buildResultsController.add(result);
     return result;

--- a/build_runner/lib/src/build/build_state/build_state.dart
+++ b/build_runner/lib/src/build/build_state/build_state.dart
@@ -8,11 +8,10 @@ import 'package:built_value/serializer.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:meta/meta.dart';
-import 'package:watcher/watcher.dart';
 
 import '../../build_plan/build_packages.dart';
 import '../../build_plan/build_step_plan.dart';
-import '../../build_plan/placeholders.dart';
+
 import 'build_step_id.dart';
 import 'build_step_result.dart';
 import 'glob_id.dart';
@@ -47,60 +46,14 @@ class BuildState {
   /// All post process build step outputs.
   final Set<AssetId> _postProcessOutputs;
 
-  @visibleForTesting
-  BuildState.empty()
-    : _sources = Sources(),
+  BuildState([Iterable<AssetId> sources = const []])
+    : _sources = Sources()..addAll(sources),
       _postProcessResultsByInput = {},
       _postProcessOutputs = {},
       _buildStepResultsByPrimaryInput = {},
       _globResults = {};
 
-  /// Creates from sources.
-  factory BuildState.create({required Set<AssetId> sources}) {
-    final result = BuildState.empty();
-    result._sources.addAll(sources);
-    return result;
-  }
-
-  BuildState._with({
-    required Sources sources,
-    required Map<AssetId, Map<int, PostProcessBuildStepResult>>
-    postProcessResultsByInput,
-    required Set<AssetId> postProcessOutputs,
-    required Map<AssetId, Map<int, BuildStepResult>>
-    buildStepResultsByPrimaryInput,
-    required Map<GlobId, GlobResult> globResults,
-  }) : _postProcessOutputs = postProcessOutputs,
-       _postProcessResultsByInput = postProcessResultsByInput,
-       _globResults = globResults,
-       _buildStepResultsByPrimaryInput = buildStepResultsByPrimaryInput,
-       _sources = sources;
-
-  /// Copies the state and prepares it for the next build.
-  BuildState copyForNextBuild() {
-    return BuildState._with(
-      sources: _sources.clone(),
-      postProcessResultsByInput: {
-        for (final entry in _postProcessResultsByInput.entries)
-          entry.key: Map.of(entry.value),
-      },
-      postProcessOutputs: Set.of(_postProcessOutputs),
-      buildStepResultsByPrimaryInput: {
-        for (final entry in _buildStepResultsByPrimaryInput.entries)
-          entry.key: Map.of(entry.value),
-      },
-      globResults: Map.of(_globResults),
-    );
-  }
-
   // --  Predicates over IDs and iterables over IDs.
-
-  /// Whether [id] is a placeholder.
-  ///
-  /// Placeholders are virtual files that exist in every package. They can't be
-  /// read, but they can be matched as inputs. This allows builders to generate
-  /// a fixed list of outputs for any package.
-  bool isPlaceholder(AssetId id) => Placeholders.isPlaceholderPath(id.path);
 
   /// Whether [id] is one of: source, declared output or actual post process
   /// output.
@@ -183,6 +136,19 @@ class BuildState {
   /// Whether [id] is a post process build output that was actually generated.
   bool isActualPostOutput(AssetId id) => _postProcessOutputs.contains(id);
 
+  /// Whether the builder for [id] has been processed during this build.
+  ///
+  /// That means it has been run, skipped, or it failed.
+  bool isProcessedOutput({
+    required BuildStepPlan? buildStepPlan,
+    required AssetId id,
+  }) {
+    if (isActualPostOutput(id)) return true;
+    final step = buildStepPlan?.stepForDeclaredOutputOrNull(id);
+    if (step != null) return stepResultOrNull(step) != null;
+    return false;
+  }
+
   // -- Digests.
 
   /// Updates a source file digest.
@@ -240,6 +206,8 @@ class BuildState {
 
   // -- Globs.
 
+  bool hasGlobResult(GlobId globId) => _globResults.containsKey(globId);
+
   GlobResult? globResultFor(GlobId globId) => _globResults[globId];
 
   void updateGlobResult(GlobId globId, GlobResult result) {
@@ -278,6 +246,19 @@ class BuildState {
   PostProcessBuildStepResult? postProcessBuildStepResultFor(
     PostProcessBuildStepId step,
   ) => _postProcessResultsByInput[step.input]?[step.actionNumber];
+
+  Iterable<BuildStepId> get failedSteps {
+    final results = <BuildStepId>[];
+    for (final outer in _buildStepResultsByPrimaryInput.entries) {
+      final input = outer.key;
+      for (final inner in outer.value.entries) {
+        if (inner.value.failed) {
+          results.add(BuildStepId(primaryInput: input, phaseNumber: inner.key));
+        }
+      }
+    }
+    return results;
+  }
 
   Iterable<PostProcessBuildStepId> get failedPostProcessSteps {
     final results = <PostProcessBuildStepId>[];
@@ -353,57 +334,6 @@ class BuildState {
   }
 
   // -- Creation of the state and updates for incremental builds.
-
-  /// Updates for the next build.
-  ///
-  /// Returns the set of [AssetId]s to delete.
-  Set<AssetId> updateForNextBuild(
-    BuildStepPlan buildStepPlan,
-    Map<AssetId, ChangeType> updates,
-  ) {
-    final newIds = <AssetId>{};
-    final modifyIds = <AssetId>{};
-    final removeIds = <AssetId>{};
-    for (final entry in updates.entries) {
-      final id = entry.key;
-      final changeType = entry.value;
-      switch (changeType) {
-        case ChangeType.ADD:
-        case ChangeType.MODIFY:
-          if (!isSource(id) || isMissingSource(id)) {
-            newIds.add(id);
-          } else {
-            modifyIds.add(id);
-          }
-        case ChangeType.REMOVE:
-          if (isSource(id)) removeIds.add(id);
-      }
-    }
-
-    _sources.addAll(newIds);
-
-    // Compute declared outputs that will no longer be output because their
-    // primary input was deleted. Mark them as missing sources, allowing them
-    // to remain referenced in `inputs` in order to trigger rebuilds.
-    final sourcesToRemove = removeIds.where(isSource).toList();
-    final transitiveRemovedIds = buildStepPlan.transitiveDeclaredOutputsOf(
-      sourcesToRemove,
-    );
-
-    for (final id in transitiveRemovedIds) {
-      _sources.setMissing(id);
-      final postProcessResults = _postProcessResultsByInput.remove(id);
-      if (postProcessResults != null) {
-        for (final result in postProcessResults.values) {
-          _postProcessOutputs.removeAll(result.outputs);
-        }
-      }
-    }
-
-    _sources.clearComputationResults();
-    transitiveRemovedIds.removeAll(removeIds);
-    return transitiveRemovedIds;
-  }
 
   // -- Testing.
 

--- a/build_runner/lib/src/build/build_state/serialization.dart
+++ b/build_runner/lib/src/build/build_state/serialization.dart
@@ -8,7 +8,7 @@ part of 'build_state.dart';
 ///
 /// Returns `null` if deserialization fails.
 BuildState? deserializeBuildState(Map serializedBuildState) {
-  final buildState = BuildState.empty();
+  final buildState = BuildState();
 
   final sourceIds =
       serializers.deserialize(

--- a/build_runner/lib/src/build/build_state/sources.dart
+++ b/build_runner/lib/src/build/build_state/sources.dart
@@ -24,13 +24,6 @@ class Sources {
 
   Sources();
 
-  Sources clone() {
-    final result = Sources();
-    result.sources.addAll(sources);
-    result.missingSources.addAll(missingSources);
-    return result;
-  }
-
   /// Whether [id] is a source file.
   bool isSource(AssetId id) => sources.containsKey(id);
 
@@ -85,24 +78,6 @@ class Sources {
     missingSources.add(id);
   }
 
-  /// Sets [id] to missing, removing from sources if needed.
-  void setMissing(AssetId id) {
-    if (sources.containsKey(id)) {
-      sources.remove(id);
-      _sortedFileIdsByPackage = null;
-    }
-    missingSources.add(id);
-  }
-
-  /// Removes [id] from sources and missing sources.
-  void remove(AssetId id) {
-    if (sources.containsKey(id)) {
-      sources.remove(id);
-      _sortedFileIdsByPackage = null;
-    }
-    missingSources.remove(id);
-  }
-
   /// All source IDs.
   Iterable<AssetId> get sourceIds => sources.keys;
 
@@ -149,12 +124,6 @@ class Sources {
       value.sort();
     }
     return result;
-  }
-
-  /// Call this after modifications to the graph and before the next build, to
-  /// reset computed values.
-  void clearComputationResults() {
-    _sortedFileIdsByPackageWasComputed = false;
   }
 }
 

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -71,7 +71,7 @@ class AnalysisDriverFilesystem
   /// [invalidatedSources] are removed.
   void startBuild(
     Map<AssetId, int> generatedPhases, {
-    required Set<AssetId>? invalidatedSources,
+    required Iterable<AssetId>? invalidatedSources,
   }) {
     final previousPhaseByPath = _phaseByPath;
     _phaseByPath = <String, int>{};

--- a/build_runner/lib/src/build/resolver/analysis_driver_model.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_model.dart
@@ -47,7 +47,7 @@ class AnalysisDriverModel {
   /// If another build has the lock, waits for it to finish.
   Future<void> takeLockAndStartBuild(
     Map<AssetId, int> declaredOutputPhases, {
-    required Set<AssetId>? invalidatedSources,
+    required Iterable<AssetId>? invalidatedSources,
   }) async {
     _lock = await _pool.request();
     filesystem.startBuild(

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -103,7 +103,7 @@ class ResolversImpl implements Resolvers {
   /// `build.dart` and test builds in `package:build_test` `test_builder.dart`.
   Future<void> takeLockAndStartBuild(
     Map<AssetId, int> declaredOutputPhases, {
-    required Set<AssetId>? invalidatedSources,
+    required Iterable<AssetId>? invalidatedSources,
   }) => _analysisDriverModel.takeLockAndStartBuild(
     declaredOutputPhases,
     invalidatedSources: invalidatedSources,

--- a/build_runner/lib/src/build/single_step_reader_writer.dart
+++ b/build_runner/lib/src/build/single_step_reader_writer.dart
@@ -15,6 +15,7 @@ import '../build_plan/build_configs.dart';
 import '../build_plan/build_packages.dart';
 import '../build_plan/build_step_plan.dart';
 import '../build_plan/phase.dart';
+import '../build_plan/placeholders.dart';
 import '../io/asset_finder.dart';
 import '../io/reader_writer.dart';
 import 'build_state/build_state.dart';
@@ -185,7 +186,7 @@ class SingleStepReaderWriter implements PhasedReader {
     }
 
     final buildState = _runningBuild.buildState;
-    if (buildState.isPlaceholder(id)) return false;
+    if (Placeholders.isPlaceholderPath(id.path)) return false;
     if (!_isFile(id)) {
       if (track) inputTracker.add(id);
       buildState.addMissingSource(id);

--- a/build_runner/lib/src/build_plan/build_inputs.dart
+++ b/build_runner/lib/src/build_plan/build_inputs.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart' hide Builder;
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:crypto/crypto.dart';
+
+part 'build_inputs.g.dart';
+
+/// The state of the file system before a build begins.
+abstract class BuildInputs implements Built<BuildInputs, BuildInputsBuilder> {
+  /// Whether this is a clean build.
+  ///
+  /// If `false`, there is output on disk from a compatible previous build that
+  /// can be reused.
+  bool get cleanBuild;
+
+  /// All source files that are input to the build.
+  BuiltSet<AssetId> get sources;
+
+  /// Content hashes for source files that have declared outputs.
+  BuiltMap<AssetId, Digest> get digests;
+
+  /// Source files that were newly added since the last build.
+  ///
+  /// Empty if [cleanBuild].
+  BuiltSet<AssetId> get addedSources;
+
+  /// Source files that were removed since the last build.
+  ///
+  /// Empty if [cleanBuild].
+  BuiltSet<AssetId> get deletedSources;
+
+  /// Source files that existed in the previous build but have been modified.
+  ///
+  /// Empty if [cleanBuild].
+  BuiltSet<AssetId> get modifiedSources;
+
+  /// Generated outputs that were deleted from disk.
+  ///
+  /// Empty if [cleanBuild].
+  BuiltSet<AssetId> get deletedOutputs;
+
+  /// Sources that were modified or deleted since the last build.
+  ///
+  /// `null` if [cleanBuild].
+  Iterable<AssetId>? get invalidatedSources =>
+      cleanBuild ? null : modifiedSources.followedBy(deletedSources);
+
+  BuildInputs._();
+  factory BuildInputs([void Function(BuildInputsBuilder) updates]) =
+      _$BuildInputs;
+}

--- a/build_runner/lib/src/build_plan/build_inputs.g.dart
+++ b/build_runner/lib/src/build_plan/build_inputs.g.dart
@@ -1,0 +1,203 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'build_inputs.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$BuildInputs extends BuildInputs {
+  @override
+  final bool cleanBuild;
+  @override
+  final BuiltSet<AssetId> sources;
+  @override
+  final BuiltMap<AssetId, Digest> digests;
+  @override
+  final BuiltSet<AssetId> addedSources;
+  @override
+  final BuiltSet<AssetId> deletedSources;
+  @override
+  final BuiltSet<AssetId> modifiedSources;
+  @override
+  final BuiltSet<AssetId> deletedOutputs;
+
+  factory _$BuildInputs([void Function(BuildInputsBuilder)? updates]) =>
+      (BuildInputsBuilder()..update(updates))._build();
+
+  _$BuildInputs._({
+    required this.cleanBuild,
+    required this.sources,
+    required this.digests,
+    required this.addedSources,
+    required this.deletedSources,
+    required this.modifiedSources,
+    required this.deletedOutputs,
+  }) : super._();
+  @override
+  BuildInputs rebuild(void Function(BuildInputsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BuildInputsBuilder toBuilder() => BuildInputsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BuildInputs &&
+        cleanBuild == other.cleanBuild &&
+        sources == other.sources &&
+        digests == other.digests &&
+        addedSources == other.addedSources &&
+        deletedSources == other.deletedSources &&
+        modifiedSources == other.modifiedSources &&
+        deletedOutputs == other.deletedOutputs;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, cleanBuild.hashCode);
+    _$hash = $jc(_$hash, sources.hashCode);
+    _$hash = $jc(_$hash, digests.hashCode);
+    _$hash = $jc(_$hash, addedSources.hashCode);
+    _$hash = $jc(_$hash, deletedSources.hashCode);
+    _$hash = $jc(_$hash, modifiedSources.hashCode);
+    _$hash = $jc(_$hash, deletedOutputs.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BuildInputs')
+          ..add('cleanBuild', cleanBuild)
+          ..add('sources', sources)
+          ..add('digests', digests)
+          ..add('addedSources', addedSources)
+          ..add('deletedSources', deletedSources)
+          ..add('modifiedSources', modifiedSources)
+          ..add('deletedOutputs', deletedOutputs))
+        .toString();
+  }
+}
+
+class BuildInputsBuilder implements Builder<BuildInputs, BuildInputsBuilder> {
+  _$BuildInputs? _$v;
+
+  bool? _cleanBuild;
+  bool? get cleanBuild => _$this._cleanBuild;
+  set cleanBuild(bool? cleanBuild) => _$this._cleanBuild = cleanBuild;
+
+  SetBuilder<AssetId>? _sources;
+  SetBuilder<AssetId> get sources => _$this._sources ??= SetBuilder<AssetId>();
+  set sources(SetBuilder<AssetId>? sources) => _$this._sources = sources;
+
+  MapBuilder<AssetId, Digest>? _digests;
+  MapBuilder<AssetId, Digest> get digests =>
+      _$this._digests ??= MapBuilder<AssetId, Digest>();
+  set digests(MapBuilder<AssetId, Digest>? digests) =>
+      _$this._digests = digests;
+
+  SetBuilder<AssetId>? _addedSources;
+  SetBuilder<AssetId> get addedSources =>
+      _$this._addedSources ??= SetBuilder<AssetId>();
+  set addedSources(SetBuilder<AssetId>? addedSources) =>
+      _$this._addedSources = addedSources;
+
+  SetBuilder<AssetId>? _deletedSources;
+  SetBuilder<AssetId> get deletedSources =>
+      _$this._deletedSources ??= SetBuilder<AssetId>();
+  set deletedSources(SetBuilder<AssetId>? deletedSources) =>
+      _$this._deletedSources = deletedSources;
+
+  SetBuilder<AssetId>? _modifiedSources;
+  SetBuilder<AssetId> get modifiedSources =>
+      _$this._modifiedSources ??= SetBuilder<AssetId>();
+  set modifiedSources(SetBuilder<AssetId>? modifiedSources) =>
+      _$this._modifiedSources = modifiedSources;
+
+  SetBuilder<AssetId>? _deletedOutputs;
+  SetBuilder<AssetId> get deletedOutputs =>
+      _$this._deletedOutputs ??= SetBuilder<AssetId>();
+  set deletedOutputs(SetBuilder<AssetId>? deletedOutputs) =>
+      _$this._deletedOutputs = deletedOutputs;
+
+  BuildInputsBuilder();
+
+  BuildInputsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _cleanBuild = $v.cleanBuild;
+      _sources = $v.sources.toBuilder();
+      _digests = $v.digests.toBuilder();
+      _addedSources = $v.addedSources.toBuilder();
+      _deletedSources = $v.deletedSources.toBuilder();
+      _modifiedSources = $v.modifiedSources.toBuilder();
+      _deletedOutputs = $v.deletedOutputs.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BuildInputs other) {
+    _$v = other as _$BuildInputs;
+  }
+
+  @override
+  void update(void Function(BuildInputsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BuildInputs build() => _build();
+
+  _$BuildInputs _build() {
+    _$BuildInputs _$result;
+    try {
+      _$result =
+          _$v ??
+          _$BuildInputs._(
+            cleanBuild: BuiltValueNullFieldError.checkNotNull(
+              cleanBuild,
+              r'BuildInputs',
+              'cleanBuild',
+            ),
+            sources: sources.build(),
+            digests: digests.build(),
+            addedSources: addedSources.build(),
+            deletedSources: deletedSources.build(),
+            modifiedSources: modifiedSources.build(),
+            deletedOutputs: deletedOutputs.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'sources';
+        sources.build();
+        _$failedField = 'digests';
+        digests.build();
+        _$failedField = 'addedSources';
+        addedSources.build();
+        _$failedField = 'deletedSources';
+        deletedSources.build();
+        _$failedField = 'modifiedSources';
+        modifiedSources.build();
+        _$failedField = 'deletedOutputs';
+        deletedOutputs.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'BuildInputs',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -6,12 +6,14 @@ import 'dart:typed_data';
 
 import 'package:build/build.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:crypto/crypto.dart';
+import 'package:watcher/watcher.dart';
 
 import '../bootstrap/bootstrapper.dart';
 import '../bootstrap/depfile.dart';
 import '../build/build_state/asset_graph_json.dart';
 import '../build/build_state/build_state.dart';
-import '../build/build_state/exceptions.dart';
+
 import '../build/library_cycle_graph/phased_asset_deps.dart';
 import '../constants.dart';
 import '../exceptions.dart';
@@ -23,10 +25,10 @@ import '../logging/build_log.dart';
 import 'build_configs.dart';
 import 'build_directory.dart';
 import 'build_filter.dart';
+import 'build_inputs.dart';
 import 'build_options.dart';
 import 'build_packages.dart';
 import 'build_phase_creator.dart';
-
 import 'build_plan_digest.dart';
 import 'build_step_plan.dart';
 import 'builder_definition.dart';
@@ -44,22 +46,13 @@ class BuildPlan {
   final BuildPackages buildPackages;
   final ReaderWriter readerWriter;
   final BuildConfigs buildConfigs;
-  final BuildStepPlan buildStepPlan;
-
-  final BuildState? _previousBuildState;
-  bool _previousBuildStateWasTaken;
+  final BuildState? previousBuildState;
   final PhasedAssetDeps? previousPhasedAssetDeps;
+
+  final BuildStepPlan buildStepPlan;
   final bool restartIsNeeded;
 
   final Bootstrapper bootstrapper;
-  final BuildState _buildState;
-  bool _buildStateWasTaken;
-  final BuiltSet<AssetId>? updates;
-
-  /// Whether this is a clean build.
-  ///
-  /// If not, it's an incremental build.
-  final bool cleanBuild;
 
   /// Whether build triggers config changed since the previous build.
   final bool triggersChanged;
@@ -85,6 +78,9 @@ class BuildPlan {
   /// Call [deleteFilesAndFolders] to delete them.
   final BuiltList<AssetId> foldersToDelete;
 
+  /// Sources and changes to sources before the build.
+  final BuildInputs buildInputs;
+
   BuildPlan({
     required this.buildPlanDigest,
     required this.builderFactories,
@@ -94,36 +90,28 @@ class BuildPlan {
     required this.readerWriter,
     required this.buildConfigs,
     required this.buildStepPlan,
-    required BuildState? previousBuildState,
-    required bool previousBuildStateWasTaken,
+    required this.previousBuildState,
     required this.previousPhasedAssetDeps,
     required this.restartIsNeeded,
     required this.bootstrapper,
-    required BuildState buildState,
-    required bool buildStateWasTaken,
-    required this.updates,
     required this.filesToDelete,
     required this.foldersToDelete,
-    required this.cleanBuild,
     required this.triggersChanged,
     required BuiltList<bool> phaseOptionsChanged,
     required BuiltList<bool> postBuildOptionsChanged,
-  }) : _previousBuildState = previousBuildState,
-       _previousBuildStateWasTaken = previousBuildStateWasTaken,
-       _buildState = buildState,
-       _buildStateWasTaken = buildStateWasTaken,
-       _phaseOptionsChanged = phaseOptionsChanged,
+    required this.buildInputs,
+  }) : _phaseOptionsChanged = phaseOptionsChanged,
        _postBuildOptionsChanged = postBuildOptionsChanged;
 
   /// Loads a build plan.
   ///
-  /// Loads the package strucure and build configuration; prepares
+  /// Loads the package structure and build configuration; prepares
   /// [readerWriter], deduces the buildPhases that will run, deserializes and
   /// checks the `BuildState`.
   ///
   /// If the build state indicates a restart is needed, [restartIsNeeded] will
   /// be set. Otherwise, if it's valid, the deserialized build state is
-  /// available from [takePreviousBuildState].
+  /// available from [previousBuildState].
   ///
   /// Files that should be deleted before restarting or building are accumulated
   /// in [filesToDelete] and [foldersToDelete]. Call [deleteFilesAndFolders] to
@@ -254,7 +242,6 @@ class BuildPlan {
     final inputSources = await assetTracker.findInputSources();
     final cacheDirSources = await assetTracker.findCacheDirSources();
 
-    BuildState? buildState;
     Set<AssetId>? updates;
     if (previousBuildState != null) {
       updates = {
@@ -263,7 +250,6 @@ class BuildPlan {
         ...previousBuildState.sources,
         ...previousBuildState.actualOutputs,
       };
-      buildState = previousBuildState.copyForNextBuild();
 
       if (restartIsNeeded) {
         // Mark old outputs for deletion.
@@ -281,7 +267,8 @@ class BuildPlan {
       }
     }
 
-    if (buildState == null) {
+    Set<AssetId> sourcesForBuildStepPlan;
+    if (previousBuildState == null) {
       // Files marked for deletion are not inputs.
       inputSources.removeAll(filesToDelete);
 
@@ -299,22 +286,20 @@ class BuildPlan {
         inputSourcesWithoutOutputs.remove(output);
       }
 
-      try {
-        buildState = BuildState.create(sources: inputSourcesWithoutOutputs);
-      } on DuplicateAssetIdException catch (e) {
-        buildLog.error(e.toString());
-        throw const CannotBuildException();
-      }
+      sourcesForBuildStepPlan = inputSourcesWithoutOutputs;
+      updates = inputSourcesWithoutOutputs;
+    } else {
+      sourcesForBuildStepPlan = previousBuildState.sources.toSet();
     }
 
     final buildStepPlan = BuildStepPlan.compute(
       buildPhases: buildPhases,
       placeholderIds: buildPackages.placeholderIds,
-      sources: buildState.sources,
+      sources: sourcesForBuildStepPlan,
     );
     final declaredAndActualOutputs = [
       ...buildStepPlan.declaredOutputs,
-      ...buildState.actualPostOutputs,
+      if (previousBuildState != null) ...previousBuildState.actualPostOutputs,
     ];
 
     if (previousBuildState == null) {
@@ -341,26 +326,28 @@ class BuildPlan {
       );
     }
 
-    return BuildPlan(
+    final finalReaderWriter = readerWriter.copyWith(
+      generatedAssetHider:
+          testingOverrides.flattenOutput
+              ? const NoopGeneratedAssetHider()
+              : buildStepPlan,
+    );
+
+    return _createAndResolve(
       buildPlanDigest: buildPlanDigest,
       builderFactories: builderFactories,
       buildOptions: buildOptions,
       testingOverrides: testingOverrides,
       buildPackages: buildPackages,
-      readerWriter: readerWriter,
+      readerWriter: finalReaderWriter,
       buildConfigs: buildConfigs,
       buildStepPlan: buildStepPlan,
       previousBuildState: previousBuildState,
-      previousBuildStateWasTaken: false,
       previousPhasedAssetDeps: previousPhasedAssetDeps,
       restartIsNeeded: restartIsNeeded,
       bootstrapper: bootstrapper,
-      buildState: buildState,
-      buildStateWasTaken: false,
-      updates: updates?.build(),
       filesToDelete: filesToDelete.toBuiltList(),
       foldersToDelete: foldersToDelete.toBuiltList(),
-      cleanBuild: previousBuildState == null,
       triggersChanged:
           !buildPlanDigest.hasSameTriggersAs(previousBuildPlanDigest),
       phaseOptionsChanged: buildPlanDigest.computeChangedPhaseOptions(
@@ -369,6 +356,7 @@ class BuildPlan {
       postBuildOptionsChanged: buildPlanDigest.computeChangedPostBuildOptions(
         previousBuildPlanDigest,
       ),
+      updates: updates ?? {},
     );
   }
 
@@ -377,15 +365,15 @@ class BuildPlan {
     BuiltSet<BuildDirectory>? buildDirs,
     BuiltSet<BuildFilter>? buildFilters,
     ReaderWriter? readerWriter,
-    bool? cleanBuild,
     bool? triggersChanged,
     PhasedAssetDeps? previousPhasedAssetDeps,
     BuiltList<bool>? phaseOptionsChanged,
     BuiltList<bool>? postBuildOptionsChanged,
     BuildStepPlan? buildStepPlan,
+    BuildState? previousBuildState,
+    BuildInputs? buildInputs,
   }) => BuildPlan(
     buildPlanDigest: buildPlanDigest ?? this.buildPlanDigest,
-    buildStepPlan: buildStepPlan ?? this.buildStepPlan,
     builderFactories: builderFactories,
     buildOptions: buildOptions.copyWith(
       buildDirs: buildDirs,
@@ -395,80 +383,69 @@ class BuildPlan {
     buildPackages: buildPackages,
     buildConfigs: buildConfigs,
     readerWriter: readerWriter ?? this.readerWriter,
-    previousBuildState: _previousBuildState,
-    previousBuildStateWasTaken: _previousBuildStateWasTaken,
+    buildStepPlan: buildStepPlan ?? this.buildStepPlan,
+    previousBuildState: previousBuildState ?? this.previousBuildState,
     previousPhasedAssetDeps:
         previousPhasedAssetDeps ?? this.previousPhasedAssetDeps,
     restartIsNeeded: restartIsNeeded,
     bootstrapper: bootstrapper,
-    buildState: _buildState,
-    buildStateWasTaken: _buildStateWasTaken,
-    updates: updates,
     filesToDelete: filesToDelete,
     foldersToDelete: foldersToDelete,
-    cleanBuild: cleanBuild ?? this.cleanBuild,
     triggersChanged: triggersChanged ?? this.triggersChanged,
     phaseOptionsChanged: phaseOptionsChanged ?? _phaseOptionsChanged,
     postBuildOptionsChanged:
         postBuildOptionsChanged ?? _postBuildOptionsChanged,
+    buildInputs: buildInputs ?? this.buildInputs,
   );
 
   /// Returns a copy of the plan updated for the next incremental build.
   ///
   /// Updates [previousPhasedAssetDeps] from the build result.
   ///
-  /// Sets [cleanBuild], [triggersChanged], `phaseOptionsChanged` and
+  /// Sets [triggersChanged], `phaseOptionsChanged` and
   /// `postBuildOptionsChanged` to `false`.
-  BuildPlan updateForResult({PhasedAssetDeps? previousPhasedAssetDeps}) =>
-      copyWith(
-        cleanBuild: false,
-        triggersChanged: false,
-        previousPhasedAssetDeps: previousPhasedAssetDeps,
-        phaseOptionsChanged: BuiltList<bool>.from(
-          List.filled(
-            buildStepPlan.buildPhases.inBuildPhasesOptionsDigests.length,
-            false,
-          ),
-        ),
-        postBuildOptionsChanged: BuiltList<bool>.from(
-          List.filled(
-            buildStepPlan.buildPhases.postBuildActionsOptionsDigests.length,
-            false,
-          ),
-        ),
-      );
-
-  /// Returns a copy of the plan with [buildStepPlan] updated for changed input
-  /// sources.
-  BuildPlan updateForSources(Iterable<AssetId> sources) {
-    return copyWith(
-      buildStepPlan: BuildStepPlan.compute(
-        buildPhases: buildStepPlan.buildPhases,
-        placeholderIds: buildPackages.placeholderIds,
-        sources: sources,
+  BuildPlan updateForResult({
+    PhasedAssetDeps? previousPhasedAssetDeps,
+    BuildState? previousBuildState,
+  }) => copyWith(
+    triggersChanged: false,
+    previousPhasedAssetDeps: previousPhasedAssetDeps,
+    previousBuildState: previousBuildState,
+    phaseOptionsChanged: BuiltList<bool>.from(
+      List.filled(
+        buildStepPlan.buildPhases.inBuildPhasesOptionsDigests.length,
+        false,
       ),
+    ),
+    postBuildOptionsChanged: BuiltList<bool>.from(
+      List.filled(
+        buildStepPlan.buildPhases.postBuildActionsOptionsDigests.length,
+        false,
+      ),
+    ),
+  );
+
+  Future<BuildPlan> updateForFileChanges(Set<AssetId> updates) {
+    return _createAndResolve(
+      buildPlanDigest: buildPlanDigest,
+      builderFactories: builderFactories,
+      buildOptions: buildOptions,
+      testingOverrides: testingOverrides,
+      buildPackages: buildPackages,
+      readerWriter: readerWriter,
+      buildConfigs: buildConfigs,
+      buildStepPlan: buildStepPlan,
+      previousBuildState: previousBuildState,
+      previousPhasedAssetDeps: previousPhasedAssetDeps,
+      restartIsNeeded: restartIsNeeded,
+      bootstrapper: bootstrapper,
+      filesToDelete: filesToDelete,
+      foldersToDelete: foldersToDelete,
+      triggersChanged: triggersChanged,
+      phaseOptionsChanged: _phaseOptionsChanged,
+      postBuildOptionsChanged: _postBuildOptionsChanged,
+      updates: updates,
     );
-  }
-
-  /// Takes the loaded [BuildState], which may be `null` if none could be
-  /// loaded or if it was invalid.
-  ///
-  /// Subsequent calls will throw. This is because [BuildState] is mutable, so
-  /// the initial loaded state is only available once.
-  BuildState? takePreviousBuildState() {
-    if (_previousBuildStateWasTaken) throw StateError('Already taken.');
-    _previousBuildStateWasTaken = true;
-    return _previousBuildState;
-  }
-
-  /// Takes the [BuildState] for the build.
-  ///
-  /// Subsequent calls will throw. This is because [BuildState] is mutable, so
-  /// the initial state is only available once.
-  BuildState takeBuildState() {
-    if (_buildStateWasTaken) throw StateError('Already taken.');
-    _buildStateWasTaken = true;
-    return _buildState;
   }
 
   /// Whether [phaseNumber] has different options to the previous build
@@ -496,6 +473,212 @@ class BuildPlan {
     for (final id in foldersToDelete) {
       await cleanupReaderWriter.deleteDirectory(id);
     }
+  }
+
+  static Future<BuildPlan> _createAndResolve({
+    required BuildPlanDigest buildPlanDigest,
+    required BuilderFactories builderFactories,
+    required BuildOptions buildOptions,
+    required TestingOverrides testingOverrides,
+    required BuildPackages buildPackages,
+    required ReaderWriter readerWriter,
+    required BuildConfigs buildConfigs,
+    required BuildStepPlan buildStepPlan,
+    required BuildState? previousBuildState,
+    required PhasedAssetDeps? previousPhasedAssetDeps,
+    required bool restartIsNeeded,
+    required Bootstrapper bootstrapper,
+    required BuiltList<AssetId> filesToDelete,
+    required BuiltList<AssetId> foldersToDelete,
+    required bool triggersChanged,
+    required BuiltList<bool> phaseOptionsChanged,
+    required BuiltList<bool> postBuildOptionsChanged,
+    required Set<AssetId> updates,
+  }) async {
+    final result = BuildInputsBuilder();
+
+    final newDigests = <AssetId, Digest>{};
+    final resolvedUpdates = <AssetId, ChangeType>{};
+    final previousSources = <AssetId>{};
+
+    final isCleanBuild = previousBuildState == null;
+    result.cleanBuild = isCleanBuild;
+
+    if (isCleanBuild) {
+      for (final id in updates) {
+        if (await readerWriter.canRead(id)) {
+          result.sources.add(id);
+        }
+      }
+
+      final newBuildStepPlan = BuildStepPlan.compute(
+        buildPhases: buildStepPlan.buildPhases,
+        placeholderIds: buildPackages.placeholderIds,
+        sources: result.sources.build(),
+      );
+      for (final id in result.sources.build()) {
+        if (newBuildStepPlan.declaredOutputsOf(id).isNotEmpty) {
+          try {
+            result.digests[id] = await readerWriter.digest(id);
+          } catch (_) {}
+        }
+      }
+      final newReaderWriter = readerWriter.copyWith(
+        generatedAssetHider:
+            testingOverrides.flattenOutput
+                ? const NoopGeneratedAssetHider()
+                : newBuildStepPlan,
+      );
+      return BuildPlan(
+        buildPlanDigest: buildPlanDigest,
+        builderFactories: builderFactories,
+        buildOptions: buildOptions,
+        testingOverrides: testingOverrides,
+        buildPackages: buildPackages,
+        readerWriter: newReaderWriter,
+        buildConfigs: buildConfigs,
+        buildStepPlan: newBuildStepPlan,
+        previousBuildState: previousBuildState,
+        previousPhasedAssetDeps: previousPhasedAssetDeps,
+        restartIsNeeded: restartIsNeeded,
+        bootstrapper: bootstrapper,
+        filesToDelete: filesToDelete,
+        foldersToDelete: foldersToDelete,
+        triggersChanged: triggersChanged,
+        phaseOptionsChanged: phaseOptionsChanged,
+        postBuildOptionsChanged: postBuildOptionsChanged,
+        buildInputs: result.build(),
+      );
+    }
+
+    readerWriter.cache.invalidate(updates);
+
+    for (final id in updates) {
+      final oldIsSource = previousBuildState.isSource(id);
+      if (oldIsSource) {
+        previousSources.add(id);
+      }
+      final oldExisted = previousBuildState.isFile(
+        buildStepPlan: buildStepPlan,
+        id: id,
+      );
+      final oldDigest =
+          oldIsSource ? previousBuildState.digestOfSource(id) : null;
+      var exists = false;
+      Digest? newDigest;
+
+      if (await readerWriter.canRead(id)) {
+        exists = true;
+        if (oldDigest != null) {
+          try {
+            newDigest = await readerWriter.digest(id);
+            newDigests[id] = newDigest;
+          } catch (_) {
+            exists = false;
+          }
+        }
+      }
+
+      if (oldExisted && !exists) {
+        resolvedUpdates[id] = ChangeType.REMOVE;
+        if (oldIsSource) {
+          result.deletedSources.add(id);
+        } else {
+          result.deletedOutputs.add(id);
+        }
+      } else if (!oldExisted && exists) {
+        result.addedSources.add(id);
+        resolvedUpdates[id] = ChangeType.ADD;
+      } else if (oldExisted &&
+          oldDigest != null &&
+          exists &&
+          oldDigest != newDigest) {
+        result.modifiedSources.add(id);
+        resolvedUpdates[id] = ChangeType.MODIFY;
+      }
+    }
+
+    result.sources.addAll(previousBuildState.sources);
+    for (final entry in resolvedUpdates.entries) {
+      final id = entry.key;
+      switch (entry.value) {
+        case ChangeType.ADD:
+        case ChangeType.MODIFY:
+          if (!previousBuildState.isSource(id) ||
+              previousBuildState.isMissingSource(id)) {
+            result.sources.add(id);
+          }
+        case ChangeType.REMOVE:
+          if (previousBuildState.isSource(id)) {
+            result.sources.remove(id);
+          }
+      }
+    }
+
+    for (final id in result.sources.build()) {
+      if (resolvedUpdates[id] == null) {
+        if (previousBuildState.isSource(id)) {
+          final digest = previousBuildState.digestOfSource(id);
+          if (digest != null) {
+            result.digests[id] = digest;
+          }
+        }
+      } else if (newDigests[id] != null) {
+        result.digests[id] = newDigests[id]!;
+      }
+    }
+
+    final newBuildStepPlan = BuildStepPlan.compute(
+      buildPhases: buildStepPlan.buildPhases,
+      placeholderIds: buildPackages.placeholderIds,
+      sources: result.sources.build(),
+    );
+
+    for (final id in result.sources.build()) {
+      if (result.digests[id] == null &&
+          newBuildStepPlan.declaredOutputsOf(id).isNotEmpty) {
+        try {
+          result.digests[id] = await readerWriter.digest(id);
+        } catch (_) {}
+      }
+    }
+
+    final deletedOutputs =
+        buildStepPlan
+            .transitiveDeclaredOutputsOf(result.deletedSources.build())
+            .toSet();
+    result.deletedOutputs.addAll(deletedOutputs);
+
+    final generatedReaderWriter = readerWriter.copyWith(
+      generatedAssetHider:
+          testingOverrides.flattenOutput
+              ? const NoopGeneratedAssetHider()
+              : newBuildStepPlan,
+    );
+    for (final id in deletedOutputs) {
+      await generatedReaderWriter.delete(id);
+    }
+
+    return BuildPlan(
+      buildPlanDigest: buildPlanDigest,
+      builderFactories: builderFactories,
+      buildOptions: buildOptions,
+      testingOverrides: testingOverrides,
+      buildPackages: buildPackages,
+      readerWriter: generatedReaderWriter,
+      buildConfigs: buildConfigs,
+      buildStepPlan: newBuildStepPlan,
+      previousBuildState: previousBuildState,
+      previousPhasedAssetDeps: previousPhasedAssetDeps,
+      restartIsNeeded: restartIsNeeded,
+      bootstrapper: bootstrapper,
+      filesToDelete: filesToDelete,
+      foldersToDelete: foldersToDelete,
+      triggersChanged: triggersChanged,
+      phaseOptionsChanged: phaseOptionsChanged,
+      postBuildOptionsChanged: postBuildOptionsChanged,
+      buildInputs: result.build(),
+    );
   }
 
   /// Reloads the build plan.

--- a/build_runner/lib/src/build_plan/placeholders.dart
+++ b/build_runner/lib/src/build_plan/placeholders.dart
@@ -25,7 +25,11 @@ class Placeholders {
   static const String packageName = r'$package$';
   static const String packagePath = packageName;
 
-  /// Whether [path] is one of the placeholders.
+  /// Whether [path] is a placeholder path.
+  ///
+  /// Placeholders are virtual files that exist in every package. They can't be
+  /// read, but they can be matched as inputs. This allows builders to generate
+  /// a fixed list of outputs for any package.
   static bool isPlaceholderPath(String path) =>
       path == libPath ||
       path == testPath ||

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -26,7 +26,6 @@ class BuildOutputReader {
   final BuildPlan? _buildPlan;
   final BuildStepPlan? _buildStepPlan;
   final BuildState? _buildState;
-  final Set<AssetId>? _processedOutputs;
   final ReaderWriter? _readerWriter;
 
   late final Set<AssetId> _assetsDeletedByPostProcessBuilders =
@@ -37,8 +36,7 @@ class BuildOutputReader {
     : _buildState = null,
       _buildPlan = null,
       _buildStepPlan = null,
-      _readerWriter = null,
-      _processedOutputs = null;
+      _readerWriter = null;
 
   /// For testing: a build output that does not check build phases to determine
   /// whether outputs were required.
@@ -50,24 +48,16 @@ class BuildOutputReader {
   }) : _buildPlan = null,
        _buildStepPlan = buildStepPlan,
        _buildState = buildState,
-       _readerWriter = readerWriter,
-       _processedOutputs = null;
+       _readerWriter = readerWriter;
 
   /// Creates from build results.
-  ///
-  /// [processedOutputs] is the set of generated outputs in the build that were
-  /// considered for building. This excludes generated outputs that were skipped
-  /// due to not matching build dirs or not matching build filters.
   BuildOutputReader({
     required BuildPlan buildPlan,
-    required ReaderWriter readerWriter,
     required BuildState buildState,
-    required Set<AssetId> processedOutputs,
-  }) : _readerWriter = readerWriter,
+  }) : _readerWriter = buildPlan.readerWriter,
        _buildState = buildState,
        _buildPlan = buildPlan,
-       _buildStepPlan = buildPlan.buildStepPlan,
-       _processedOutputs = processedOutputs;
+       _buildStepPlan = buildPlan.buildStepPlan;
 
   Set<AssetId> _collectAssetsDeletedByPostProcessBuilders() =>
       _buildState?.assetsDeletedByPostProcess ?? const {};
@@ -90,7 +80,10 @@ class BuildOutputReader {
     }
     final step = _buildStepPlan?.stepForDeclaredOutputOrNull(id);
     if (step != null) {
-      if (_processedOutputs?.contains(id) == false) {
+      if (!_buildState.isProcessedOutput(
+        buildStepPlan: _buildStepPlan,
+        id: id,
+      )) {
         // The generated output was not considered for building because its
         // transitive input(s) did not match build dirs and/or build filters.
         return UnreadableReason.notOutput;
@@ -205,7 +198,10 @@ class BuildOutputReader {
           !stepResult.outputs.containsKey(id)) {
         return true;
       }
-      return !_processedOutputs!.contains(id);
+      return !buildState.isProcessedOutput(
+        buildStepPlan: _buildStepPlan,
+        id: id,
+      );
     }
     if (id.path == '.packages') return true;
     if (id.path == '.dart_tool/package_config.json') return true;

--- a/build_runner/test/build/build_state/asset_graph_json_test.dart
+++ b/build_runner/test/build/build_state/asset_graph_json_test.dart
@@ -13,7 +13,7 @@ void main() {
   group('AssetGraphJson', () {
     test('deserialize returns null on version mismatch', () async {
       final validBytes = AssetGraphJson.serialize(
-        buildState: BuildState.empty(),
+        buildState: BuildState(),
         buildPlanDigest: BuildPlanDigest.build((b) {
           b.compileDigest = '';
           b.buildTriggersDigest = '';
@@ -36,7 +36,7 @@ void main() {
 
     test('deserialize returns null on invalid json', () async {
       final validBytes = AssetGraphJson.serialize(
-        buildState: BuildState.empty(),
+        buildState: BuildState(),
         buildPlanDigest: BuildPlanDigest.build((b) {
           b.compileDigest = '';
           b.buildTriggersDigest = '';

--- a/build_runner/test/build/build_state/build_state_test.dart
+++ b/build_runner/test/build/build_state/build_state_test.dart
@@ -6,14 +6,12 @@ import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
 import 'package:build_runner/src/build/build_state/build_state.dart';
 import 'package:build_runner/src/build/build_state/build_step_id.dart';
-import 'package:build_runner/src/build/build_state/build_step_result.dart';
 import 'package:build_runner/src/build/build_state/exceptions.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
 import 'package:build_runner/src/build_plan/build_step_plan.dart';
 import 'package:build_runner/src/build_plan/phase.dart';
 
 import 'package:test/test.dart';
-import 'package:watcher/watcher.dart';
 
 import '../../common/common.dart';
 
@@ -32,7 +30,7 @@ void main() {
 
     group('simple build state', () {
       setUp(() async {
-        buildState = BuildState.create(sources: <AssetId>{});
+        buildState = BuildState(<AssetId>{});
       });
 
       test('add, contains, get, allNodes', () {
@@ -68,27 +66,15 @@ void main() {
       final primaryInputId = makeAssetId('foo|file.txt');
       final excludedInputId = makeAssetId('foo|excluded.txt');
       final primaryOutputId = makeAssetId('foo|file.txt.copy');
-      final syntheticId = makeAssetId('foo|synthetic.txt');
-      final syntheticOutputId = makeAssetId('foo|synthetic.txt.copy');
 
       setUp(() async {
-        buildState = BuildState.create(
-          sources: {primaryInputId, excludedInputId},
-        );
+        buildState = BuildState({primaryInputId, excludedInputId});
         buildStepPlan = BuildStepPlan.compute(
           buildPhases: buildPhases,
           placeholderIds: [],
           sources: buildState.sources,
         );
       });
-
-      void recomputeBuildStepPlan() {
-        buildStepPlan = BuildStepPlan.compute(
-          buildPhases: buildPhases,
-          placeholderIds: [],
-          sources: buildState.sources,
-        );
-      }
 
       test('build', () {
         expect(
@@ -111,91 +97,6 @@ void main() {
         expect(
           buildStepPlan.stepForDeclaredOutput(primaryOutputId).primaryInput,
           primaryInputId,
-        );
-      });
-
-      group('updateAndInvalidate', () {
-        test('add new primary input', () async {
-          final changes = {AssetId('foo', 'new.txt'): ChangeType.ADD};
-          buildState.updateForNextBuild(buildStepPlan, changes);
-          recomputeBuildStepPlan();
-          expect(
-            buildStepPlan.isDeclaredOutput(AssetId('foo', 'new.txt.copy')),
-            isTrue,
-          );
-        });
-
-        test('modify primary input', () async {
-          final changes = {primaryInputId: ChangeType.MODIFY};
-          expect(buildStepPlan.isDeclaredOutput(primaryOutputId), isTrue);
-          final buildStepId = BuildStepId(
-            primaryInput: primaryInputId,
-            phaseNumber: 0,
-          );
-          final stepResult = BuildStepResult((b) {
-            b.result = true;
-            b.isHidden = false;
-            b.inputs.add(primaryInputId);
-          });
-          buildState.updateBuildStepResult(buildStepId, stepResult);
-          buildState.updateForNextBuild(buildStepPlan, changes);
-          recomputeBuildStepPlan();
-          expect(buildState.isSource(primaryInputId), isTrue);
-          expect(buildStepPlan.isDeclaredOutput(primaryOutputId), isTrue);
-        });
-
-        test('add new primary input which replaces a synthetic node', () async {
-          buildState.addMissingSource(syntheticId);
-          expect(buildState.isMissingSource(syntheticId), isTrue);
-
-          final changes = {syntheticId: ChangeType.ADD};
-          buildState.updateForNextBuild(buildStepPlan, changes);
-          recomputeBuildStepPlan();
-
-          expect(buildState.isSource(syntheticId), isTrue);
-          expect(buildStepPlan.isDeclaredOutput(syntheticOutputId), isTrue);
-        });
-
-        test(
-          'add new generated asset which replaces a synthetic node',
-          () async {
-            buildState.addMissingSource(syntheticOutputId);
-            expect(buildState.isMissingSource(syntheticOutputId), isTrue);
-
-            final changes = {syntheticId: ChangeType.ADD};
-            buildState.updateForNextBuild(buildStepPlan, changes);
-            recomputeBuildStepPlan();
-
-            expect(buildStepPlan.isDeclaredOutput(syntheticOutputId), isTrue);
-          },
-        );
-
-        test(
-          'removing nodes deletes primary outputs and secondary edges',
-          () async {
-            final secondaryId = makeAssetId('foo|secondary.txt');
-
-            final buildStepId = BuildStepId(
-              primaryInput: primaryInputId,
-              phaseNumber: 0,
-            );
-            final stepResult = BuildStepResult((b) {
-              b.result = true;
-              b.isHidden = false;
-              b.inputs.add(secondaryId);
-            });
-            buildState.updateBuildStepResult(buildStepId, stepResult);
-
-            buildState.addSourceForTest(secondaryId);
-            expect(buildState.isSource(secondaryId), isTrue);
-
-            final changes = {primaryInputId: ChangeType.REMOVE};
-            buildState.updateForNextBuild(buildStepPlan, changes);
-            recomputeBuildStepPlan();
-
-            expect(buildState.isMissingSource(primaryInputId), isTrue);
-            expect(buildState.isMissingSource(primaryOutputId), isTrue);
-          },
         );
       });
 
@@ -308,59 +209,6 @@ void main() {
               makeAssetId('foo|lib/1.txt.1.2'),
             ]),
           );
-        });
-
-        test('https://github.com/dart-lang/build/issues/1804', () async {
-          final source = AssetId('a', 'lib/a.dart');
-          final renamedSource = AssetId('a', 'lib/A.dart');
-          final generatedPart = AssetId('a', 'lib/a.g.part');
-          final toBeGeneratedDart = AssetId('a', 'lib/A.g.dart');
-          final buildPhases = BuildPhases([
-            InBuildPhase(
-              builder: TestBuilder(
-                buildExtensions: replaceExtension('.dart', '.g.part'),
-              ),
-              key: 'TestBuilder',
-              package: 'a',
-            ),
-            InBuildPhase(
-              builder: TestBuilder(
-                buildExtensions: replaceExtension('.g.part', '.g.dart'),
-              ),
-              key: 'TestBuilder',
-              package: 'a',
-            ),
-          ]);
-          final buildState = BuildState.create(sources: {source});
-
-          final computed = BuildStepPlan.compute(
-            buildPhases: buildPhases,
-            placeholderIds: [],
-            sources: {source},
-          );
-
-          // Pretend a build happened.
-          buildState.addMissingSource(toBeGeneratedDart);
-          final buildStepId = BuildStepId(
-            primaryInput: generatedPart,
-            phaseNumber: 1,
-          );
-          final stepResult = BuildStepResult((b) {
-            b.result = true;
-            b.isHidden = false;
-            b.inputs.addAll([generatedPart, toBeGeneratedDart]);
-          });
-          buildState.updateBuildStepResult(buildStepId, stepResult);
-
-          expect(buildState.isSource(source), isTrue);
-
-          buildState.updateForNextBuild(computed, {
-            renamedSource: ChangeType.ADD,
-            source: ChangeType.REMOVE,
-          });
-
-          // The old generated part file should be marked as missing.
-          expect(buildState.isMissingSource(generatedPart), isTrue);
         });
       });
     });

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -1384,17 +1384,6 @@ targets:
             outputs: {},
             resumeFrom: result,
           );
-
-          final buildState =
-              AssetGraphJson.deserialize(
-                result.readerWriter.testing.readBytes(
-                  makeAssetId('a|$assetGraphJsonPath'),
-                ),
-              )!.buildState;
-          expect(
-            buildState.isMissingSource(makeAssetId('a|lib/a.txt.copy')),
-            isTrue,
-          );
         },
       );
     });
@@ -1443,8 +1432,6 @@ targets:
       final anId = makeAssetId('a|lib/a.txt');
       final aCopyId = makeAssetId('a|lib/a.txt.copy');
       final aCloneId = makeAssetId('a|lib/a.txt.copy.clone');
-      expect(newBuildState.isMissingSource(anId), isTrue);
-      expect(newBuildState.isMissingSource(aCopyId), isTrue);
       expect(
         newBuildState.isSource(aCloneId) ||
             result.buildPlan.buildStepPlan.isDeclaredOutput(aCloneId),

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -66,7 +66,7 @@ void main() {
     });
 
     test('loads with no previous build state', () async {
-      expect(buildPlan.takePreviousBuildState(), null);
+      expect(buildPlan.previousBuildState, null);
     });
 
     Future<void> writeBuildStateAndPlan(
@@ -84,14 +84,14 @@ void main() {
     }
 
     test('loads previous build state', () async {
-      final buildState = buildPlan.takeBuildState();
+      final buildState = buildPlan.previousBuildState ?? BuildState();
       await writeBuildStateAndPlan(buildState, buildPlan);
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
         buildOptions: buildOptions,
         testingOverrides: testingOverrides,
       );
-      final loadedState = buildPlan.takePreviousBuildState();
+      final loadedState = buildPlan.previousBuildState;
 
       expect(loadedState.toString(), buildState.toString());
     });
@@ -110,7 +110,7 @@ void main() {
     });
 
     test('discards previous build state if build phases changed', () async {
-      final buildState = buildPlan.takeBuildState();
+      final buildState = buildPlan.previousBuildState ?? BuildState();
       await writeBuildStateAndPlan(buildState, buildPlan);
 
       buildPlan = await BuildPlan.load(
@@ -126,7 +126,7 @@ void main() {
         ),
       );
 
-      expect(buildPlan.takePreviousBuildState(), null);
+      expect(buildPlan.previousBuildState, null);
 
       // The old state file is in [BuildPlan#filesToDelete] because it's
       // invalid.
@@ -153,7 +153,7 @@ void main() {
               ].build(),
         ),
       );
-      final buildState = buildPlan.takeBuildState();
+      final buildState = buildPlan.previousBuildState ?? BuildState();
 
       // Write an output and add it to the build state as if it was built.
       await readerWriter.writeAsString(outputId, '// output');
@@ -180,7 +180,7 @@ void main() {
         ),
       );
 
-      expect(buildPlan.takePreviousBuildState(), null);
+      expect(buildPlan.previousBuildState, null);
       expect(buildPlan.filesToDelete, isNotEmpty);
 
       // `BuildPlan` can delete lost outputs.
@@ -191,7 +191,7 @@ void main() {
     });
 
     test('discards previous build state if SDK version changed', () async {
-      final buildState = buildPlan.takeBuildState();
+      final buildState = buildPlan.previousBuildState ?? BuildState();
       await writeBuildStateAndPlan(buildState, buildPlan);
 
       buildPlan = await BuildPlan.load(
@@ -203,11 +203,11 @@ void main() {
         ),
       );
 
-      expect(buildPlan.takePreviousBuildState(), null);
+      expect(buildPlan.previousBuildState, null);
     });
 
     test('discards previous build state if packages changed', () async {
-      final buildState = buildPlan.takeBuildState();
+      final buildState = buildPlan.previousBuildState ?? BuildState();
       await writeBuildStateAndPlan(buildState, buildPlan);
 
       final buildPackages2 = BuildPackages.singlePackageBuild('b', [
@@ -222,13 +222,13 @@ void main() {
         testingOverrides: testingOverrides2,
       );
 
-      expect(buildPlan.takePreviousBuildState(), null);
+      expect(buildPlan.previousBuildState, null);
     });
 
     test(
       'discards previous build state if enabled experiments changed',
       () async {
-        final buildState = buildPlan.takeBuildState();
+        final buildState = buildPlan.previousBuildState ?? BuildState();
         await writeBuildStateAndPlan(buildState, buildPlan);
 
         buildPlan = await withEnabledExperiments(
@@ -240,12 +240,12 @@ void main() {
           ['an_experiment'],
         );
 
-        expect(buildPlan.takePreviousBuildState(), null);
+        expect(buildPlan.previousBuildState, null);
       },
     );
 
     test('reports updates', () async {
-      final buildState = buildPlan.takeBuildState();
+      final buildState = BuildState({assetId, assetId2});
 
       // Write an output and add it to the build state as if it was built.
       await readerWriter.writeAsString(outputId, '// output');
@@ -258,6 +258,7 @@ void main() {
         }),
       );
       // Give digests to inputs so they are monitored for modifications.
+      buildState.updateSourceDigest(assetId, Digest([]));
       buildState.updateSourceDigest(assetId2, Digest([]));
 
       await writeBuildStateAndPlan(buildState, buildPlan);
@@ -279,7 +280,15 @@ void main() {
         testingOverrides: testingOverrides,
       );
 
-      expect(buildPlan.updates!, {assetId, assetId2, assetId3, outputId});
+      expect(
+        {
+          ...buildPlan.buildInputs.addedSources,
+          ...buildPlan.buildInputs.modifiedSources,
+          ...buildPlan.buildInputs.deletedSources,
+          ...buildPlan.buildInputs.deletedOutputs,
+        },
+        {assetId, assetId2, assetId3, outputId},
+      );
     });
 
     test('applies target glob from build config', () async {
@@ -304,9 +313,8 @@ void main() {
           buildConfig: {'a': buildConfig1}.build(),
         ),
       );
-      final buildState1 = buildPlan1.takeBuildState();
       // Matches the only `*.dart` source.
-      expect(buildState1.sources, <AssetId>{assetId});
+      expect(buildPlan1.buildInputs.sources.toSet(), <AssetId>{assetId});
 
       // Same again but now glob `*.other`.
       final buildConfig2 = runInBuildConfigZone(
@@ -330,9 +338,8 @@ void main() {
           buildConfig: {'a': buildConfig2}.build(),
         ),
       );
-      final buildState2 = buildPlan2.takeBuildState();
       // Matches the only `*.other` source.
-      expect(buildState2.sources, <AssetId>{assetId2});
+      expect(buildPlan2.buildInputs.sources.toSet(), <AssetId>{assetId2});
     });
 
     test('tracks cleanBuild when build_plan.json does not exist', () async {
@@ -341,19 +348,22 @@ void main() {
         buildOptions: buildOptions,
         testingOverrides: testingOverrides,
       );
-      expect(plan.cleanBuild, isTrue);
+      expect(plan.previousBuildState, isNull);
     });
 
     test(
       'tracks cleanBuild when build_plan.json compileDigest is fresh',
       () async {
-        await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
+        await writeBuildStateAndPlan(
+          buildPlan.previousBuildState ?? BuildState(),
+          buildPlan,
+        );
         buildPlan = await BuildPlan.load(
           builderFactories: builderFactories,
           buildOptions: buildOptions,
           testingOverrides: testingOverrides,
         );
-        expect(buildPlan.cleanBuild, isFalse);
+        expect(buildPlan.previousBuildState, isNotNull);
       },
     );
 
@@ -365,14 +375,17 @@ void main() {
             (b) => b.compileDigest = 'stale_digest',
           ),
         );
-        await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
+        await writeBuildStateAndPlan(
+          buildPlan.previousBuildState ?? BuildState(),
+          buildPlan,
+        );
 
         buildPlan = await BuildPlan.load(
           builderFactories: builderFactories,
           buildOptions: buildOptions,
           testingOverrides: testingOverrides,
         );
-        expect(buildPlan.cleanBuild, isTrue);
+        expect(buildPlan.previousBuildState, isNull);
       },
     );
 
@@ -382,7 +395,10 @@ void main() {
           (b) => b.buildTriggersDigest = 'triggers_1',
         ),
       );
-      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
+      await writeBuildStateAndPlan(
+        buildPlan.previousBuildState ?? BuildState(),
+        buildPlan,
+      );
 
       final buildConfig2 = runInBuildConfigZone(
         () {
@@ -410,7 +426,7 @@ void main() {
           buildConfig: {'a': buildConfig2}.build(),
         ),
       );
-      expect(buildPlan2.cleanBuild, isFalse);
+      expect(buildPlan2.previousBuildState, isNotNull);
       expect(buildPlan2.triggersChanged, isTrue);
     });
 
@@ -420,7 +436,10 @@ void main() {
           (b) => b.inBuildPhasesOptionsDigests[0] = 'dummy_digest_1',
         ),
       );
-      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
+      await writeBuildStateAndPlan(
+        buildPlan.previousBuildState ?? BuildState(),
+        buildPlan,
+      );
 
       final buildConfig2 = runInBuildConfigZone(
         () {
@@ -448,7 +467,7 @@ void main() {
           buildConfig: {'a': buildConfig2}.build(),
         ),
       );
-      expect(buildPlan2.cleanBuild, isFalse);
+      expect(buildPlan2.previousBuildState, isNotNull);
       expect(buildPlan2.phaseOptionsChanged(0), isTrue);
     });
 
@@ -458,14 +477,17 @@ void main() {
           (b) => b.buildPhasesDigest = 'stale_digest',
         ),
       );
-      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
+      await writeBuildStateAndPlan(
+        buildPlan.previousBuildState ?? BuildState(),
+        buildPlan,
+      );
 
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
         buildOptions: buildOptions,
         testingOverrides: testingOverrides,
       );
-      expect(buildPlan.cleanBuild, isTrue);
+      expect(buildPlan.previousBuildState, isNull);
     });
 
     test('tracks dartVersion when SDK version changes', () async {
@@ -474,14 +496,17 @@ void main() {
           (b) => b.dartVersion = 'stale_version',
         ),
       );
-      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
+      await writeBuildStateAndPlan(
+        buildPlan.previousBuildState ?? BuildState(),
+        buildPlan,
+      );
 
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
         buildOptions: buildOptions,
         testingOverrides: testingOverrides,
       );
-      expect(buildPlan.cleanBuild, isTrue);
+      expect(buildPlan.previousBuildState, isNull);
     });
 
     test('tracks enabledExperiments when experiments change', () async {
@@ -490,14 +515,17 @@ void main() {
           (b) => b.enabledExperiments.add('stale_experiment'),
         ),
       );
-      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
+      await writeBuildStateAndPlan(
+        buildPlan.previousBuildState ?? BuildState(),
+        buildPlan,
+      );
 
       buildPlan = await BuildPlan.load(
         builderFactories: builderFactories,
         buildOptions: buildOptions,
         testingOverrides: testingOverrides,
       );
-      expect(buildPlan.cleanBuild, isTrue);
+      expect(buildPlan.previousBuildState, isNull);
     });
 
     test(
@@ -508,14 +536,17 @@ void main() {
             (b) => b.packageLanguageVersions['a'] = '1.0',
           ),
         );
-        await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
+        await writeBuildStateAndPlan(
+          buildPlan.previousBuildState ?? BuildState(),
+          buildPlan,
+        );
 
         buildPlan = await BuildPlan.load(
           builderFactories: builderFactories,
           buildOptions: buildOptions,
           testingOverrides: testingOverrides,
         );
-        expect(buildPlan.cleanBuild, isTrue);
+        expect(buildPlan.previousBuildState, isNull);
       },
     );
 
@@ -524,7 +555,10 @@ void main() {
         buildPackages.outputRoot,
         assetGraphJsonPath,
       );
-      await writeBuildStateAndPlan(buildPlan.takeBuildState(), buildPlan);
+      await writeBuildStateAndPlan(
+        buildPlan.previousBuildState ?? BuildState(),
+        buildPlan,
+      );
 
       final decodedMap =
           json.decode(await readerWriter.readAsString(assetGraphJsonId)) as Map;
@@ -539,7 +573,7 @@ void main() {
         buildOptions: buildOptions,
         testingOverrides: testingOverrides,
       );
-      expect(buildPlan.cleanBuild, isTrue);
+      expect(buildPlan.previousBuildState, isNull);
     });
   });
 }

--- a/build_runner/test/commands/serve/asset_handler_test.dart
+++ b/build_runner/test/commands/serve/asset_handler_test.dart
@@ -28,7 +28,7 @@ void main() {
   late BuildStepPlan buildStepPlan;
 
   setUp(() async {
-    buildState = BuildState.create(sources: <AssetId>{});
+    buildState = BuildState(<AssetId>{});
     readerWriter = InternalTestReaderWriter();
     buildStepPlan = BuildStepPlan(
       (BuildStepPlanBuilder b) =>

--- a/build_runner/test/commands/serve/serve_handler_test.dart
+++ b/build_runner/test/commands/serve/serve_handler_test.dart
@@ -120,7 +120,7 @@ void main() {
     readerWriter = InternalTestReaderWriter(
       outputRootPackage: buildPackages.outputRoot,
     );
-    buildState = BuildState.create(sources: <AssetId>{});
+    buildState = BuildState(<AssetId>{});
     watcher = FakeWatcher(buildPackages);
     serveHandler = ServeHandler(watcher);
     buildStepPlan = BuildStepPlan(

--- a/build_runner/test/io/asset_tracker_test.dart
+++ b/build_runner/test/io/asset_tracker_test.dart
@@ -55,7 +55,7 @@ void main() {
       ]);
       final reader = ReaderWriter(buildPackages);
       final aId = AssetId('a', 'web/a.txt');
-      buildState = BuildState.create(sources: {aId});
+      buildState = BuildState({aId});
       // Assign a digest so the source is recognized as having been used.
       final digest = await reader.digest(aId);
       buildState.updateSourceDigest(aId, digest);
@@ -71,7 +71,25 @@ void main() {
         buildState: buildState,
         buildStepPlan: buildStepPlan,
       );
-      buildState.updateForNextBuild(buildStepPlan, updates);
+      // Advance buildState for the next tests so these initial sources are
+      // known.
+      final newSources = buildState.sources.toSet();
+      for (final entry in updates.entries) {
+        if (entry.value != ChangeType.REMOVE) {
+          newSources.add(entry.key);
+        } else {
+          newSources.remove(entry.key);
+        }
+      }
+      final nextState = BuildState(newSources);
+      for (final id in newSources) {
+        if (buildState.isSource(id)) {
+          final digest = buildState.digestOfSource(id);
+          if (digest != null) nextState.updateSourceDigest(id, digest);
+        }
+      }
+      buildState = nextState;
+
       // We should see no changes initially other than new sdk sources
       expect(
         updates..removeWhere(
@@ -119,7 +137,7 @@ void main() {
 
     test('Collects deleted declared outputs', () async {
       // Create a buildState with no sources (so web/a.txt is not in sources).
-      final emptyBuildState = BuildState.create(sources: const {});
+      final emptyBuildState = BuildState(const {});
 
       // Delete the file from disk so it's actually missing.
       File(p.join(d.sandbox, 'a', 'web', 'a.txt')).deleteSync();

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -41,7 +41,7 @@ void main() {
       buildPackages = BuildPackages.singlePackageBuild('a', [
         BuildPackage.forTesting(name: 'a', isOutput: true),
       ]);
-      buildState = BuildState.create(sources: <AssetId>{});
+      buildState = BuildState(<AssetId>{});
       buildPhases = BuildPhases([]);
     });
 
@@ -73,15 +73,7 @@ void main() {
           buildPackages: buildPackages,
         ),
       );
-      reader = BuildOutputReader(
-        buildPlan: buildPlan,
-        readerWriter: readerWriter,
-        buildState: buildState,
-        processedOutputs: <AssetId>{
-          ...buildPlan.buildStepPlan.declaredOutputs,
-          ...buildState.actualPostOutputs,
-        },
-      );
+      reader = BuildOutputReader(buildPlan: buildPlan, buildState: buildState);
       expect(await reader.canRead(notDeletedId), true);
       expect(await reader.canRead(deletedId), false);
     });
@@ -90,6 +82,8 @@ void main() {
       final id = AssetId('a', 'web/a.txt');
       final primaryId = AssetId('a', 'web/a.dart');
       final buildStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
+
+      var buildState = BuildState(<AssetId>{});
       final stepResult = BuildStepResult((b) {
         b.result = false;
         b.isHidden = false;
@@ -120,15 +114,7 @@ void main() {
           buildPackages: buildPackages,
         ),
       );
-      reader = BuildOutputReader(
-        buildPlan: buildPlan,
-        readerWriter: readerWriter,
-        buildState: buildState,
-        processedOutputs: <AssetId>{
-          ...buildPlan.buildStepPlan.declaredOutputs,
-          ...buildState.actualPostOutputs,
-        },
-      );
+      reader = BuildOutputReader(buildPlan: buildPlan, buildState: buildState);
       expect(
         await reader.unreadableReason(id),
         UnreadableReason.failed,
@@ -147,13 +133,12 @@ void main() {
           buildPackages: buildPackages,
         ),
       );
-      reader = BuildOutputReader(
-        buildPlan: buildPlan,
-        readerWriter: readerWriter,
-        buildState: buildState,
-        // `a` does not match the build filter and is not processed.
-        processedOutputs: {},
-      );
+
+      // If a step is skipped due to build filters it is not evaluated and its
+      // result is not added to the buildState.
+      buildState = BuildState(<AssetId>{});
+
+      reader = BuildOutputReader(buildPlan: buildPlan, buildState: buildState);
 
       expect(
         await reader.unreadableReason(id),

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -100,15 +100,10 @@ void main() {
           buildPackages: buildPackages,
         ),
       );
-      buildState = buildPlan.takeBuildState();
+      buildState = BuildState(buildPlan.buildInputs.sources.toSet());
       buildOutputReader = BuildOutputReader(
         buildPlan: buildPlan,
-        readerWriter: readerWriter,
         buildState: buildState,
-        processedOutputs: <AssetId>{
-          ...buildPlan.buildStepPlan.declaredOutputs,
-          ...buildState.actualPostOutputs,
-        },
       );
 
       for (final id in [
@@ -404,12 +399,7 @@ void main() {
         buildPlan: buildPlan.copyWith(
           buildDirs: {BuildDirectory('foo')}.build(),
         ),
-        readerWriter: readerWriter,
         buildState: buildState,
-        processedOutputs: <AssetId>{
-          ...buildPlan.buildStepPlan.declaredOutputs,
-          ...buildState.actualPostOutputs,
-        },
       );
       final success = await createMergedOutputDirectories(
         buildDirs:
@@ -495,12 +485,7 @@ void main() {
         // Recreate buildOutputReader so it notices the delete.
         buildOutputReader = BuildOutputReader(
           buildPlan: buildPlan,
-          readerWriter: readerWriter,
           buildState: buildState,
-          processedOutputs: <AssetId>{
-            ...buildPlan.buildStepPlan.declaredOutputs,
-            ...buildState.actualPostOutputs,
-          },
         );
         success = await createMergedOutputDirectories(
           buildDirs:


### PR DESCRIPTION
Prior to this change, the `BuildState` from the previous build is directly used as the `BuildState` for the current build.

That means it had destructive methods for removing/updating state as parts of it transition from being about the previous build to being about the new build. Whether each part of the state was about the previous build or the current build was implicit, depending on the caller knowing the sequence of updates.

Instead, keep the previous build state separate and transfer information from it into the new build state only as needed.

`Sources` is likewise now only used for one build, a new one is created for the next build. Its destructive methods are removed.

Instead of `Build` "updating" the `BuildState`, `BuildPlan` now does the work to fully identify sources and their digests, and what changed for an incremental build, putting that information in a new class `BuildInputs`.

Almost all the state in `Build` turns out to have been about keeping track of which part of `BuildState` has been updated. So, it's no longer needed and can be removed :)

`BuildPlan` is starting to get too big+complex, hopefully I can do something there in the next PR to clean up and make the various lifecycles clearer.