### PR TITLE
Add build_modules exports to build_web_compilers

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 4.8.0-wip
+## 4.8.0
 
 - Improve error message when a transitive import uses a disallowed platform
   library. Print an import path to the problem library.
+- Add several `build_modules` exports to `build_web_compilers`.
 
 ## 4.7.0
 

--- a/builder_pkgs/build_web_compilers/lib/build_web_compilers.dart
+++ b/builder_pkgs/build_web_compilers/lib/build_web_compilers.dart
@@ -3,6 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'src/archive_extractor.dart' show Dart2JsArchiveExtractor;
+export 'src/build_modules/build_modules.dart'
+    show
+        DartPlatform,
+        MissingModulesException,
+        Module,
+        ModuleBuilder,
+        UnsupportedModules,
+        moduleExtension,
+        scratchSpace,
+        scratchSpaceResource;
 export 'src/common.dart'
     show
         fullKernelExtension,

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.8.0-wip
+version: 4.8.0
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
`build_modules` was moved back into `build_web_compilers`. It didn't have many imports (based on pub.dev), but this broke projects using [jaspr_tailwind](https://pub.dev/packages/jaspr_tailwind) since it depends on `scratchSpace` and `scratchSpaceResource`.

I've added the following exports back to `build_web_compilers`:
```
        DartPlatform
        MissingModulesException
        Module
        ModuleBuilder
        UnsupportedModules
        moduleExtension
        scratchSpace
        scratchSpaceResource
```

Only the last two are strictly necessary, but the others seemed reasonable for someone interacting with `build_modules` artifacts.

See: https://github.com/dart-lang/build/issues/4963