### PR TITLE
Split BuildSpec out of BuildPlan.

### DIFF
--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -18,6 +18,7 @@ import '../build_plan/build_options.dart';
 import '../build_plan/build_packages.dart';
 import '../build_plan/build_phases.dart';
 import '../build_plan/build_plan.dart';
+import '../build_plan/build_spec.dart';
 import '../build_plan/build_step_plan.dart';
 import '../build_plan/phase.dart';
 import '../build_plan/testing_overrides.dart';
@@ -87,8 +88,9 @@ class Build {
       previousDepsLoader = buildPlan.previousPhasedAssetDeps == null
           ? null
           : AssetDepsLoader.fromDeps(buildPlan.previousPhasedAssetDeps!),
-      resolvers = buildPlan.testingOverrides.resolvers ?? _defaultResolvers,
-      resolversImpl = switch (buildPlan.testingOverrides.resolvers ??
+      resolvers =
+          buildPlan.buildSpec.testingOverrides.resolvers ?? _defaultResolvers,
+      resolversImpl = switch (buildPlan.buildSpec.testingOverrides.resolvers ??
           _defaultResolvers) {
         ResolversImpl r => r,
         _ => null,
@@ -99,10 +101,11 @@ class Build {
     }
   }
 
-  BuildOptions get buildOptions => buildPlan.buildOptions;
-  TestingOverrides get testingOverrides => buildPlan.testingOverrides;
-  BuildPackages get buildPackages => buildPlan.buildPackages;
-  BuildConfigs get buildConfigs => buildPlan.buildConfigs;
+  BuildSpec get buildSpec => buildPlan.buildSpec;
+  BuildOptions get buildOptions => buildSpec.buildOptions;
+  TestingOverrides get testingOverrides => buildSpec.testingOverrides;
+  BuildPackages get buildPackages => buildSpec.buildPackages;
+  BuildConfigs get buildConfigs => buildSpec.buildConfigs;
   BuildPhases get buildPhases => buildPlan.buildStepPlan.buildPhases;
   BuildState? get previousBuildState => buildPlan.previousBuildState;
   BuildInputs get buildInputs => buildPlan.buildInputs;
@@ -166,14 +169,14 @@ class Build {
     await resourceManager.disposeAll();
 
     // If requested, create output directories. If that fails, fail the build.
-    if (buildPlan.buildOptions.buildDirs.any(
+    if (buildPlan.buildDirs.any(
           (target) => target.outputLocation?.path.isNotEmpty ?? false,
         ) &&
         result.status == BuildStatus.success) {
       if (!await createMergedOutputDirectories(
         buildPackages: buildPackages,
         outputSymlinksOnly: buildOptions.outputSymlinksOnly,
-        buildDirs: buildOptions.buildDirs,
+        buildDirs: buildPlan.buildDirs,
         buildOutputReader: buildOutputReader,
         readerWriter: readerWriter,
       )) {
@@ -215,7 +218,7 @@ class Build {
         await readerWriter.writeAsBytes(
           AssetId(buildPackages.outputRoot, assetGraphJsonPath),
           AssetGraphJson.serialize(
-            buildPlanDigest: buildPlan.buildPlanDigest,
+            buildPlanDigest: buildSpec.buildPlanDigest,
             buildState: buildState,
             phasedAssetDeps: updatedPhasedAssetDeps,
           ),
@@ -346,8 +349,8 @@ class Build {
       for (final id in assetsToCheck) {
         if (!shouldBuildForDirs(
           id,
-          buildDirs: buildPlan.buildOptions.buildDirs,
-          buildFilters: buildPlan.buildOptions.buildFilters,
+          buildDirs: buildPlan.buildDirs,
+          buildFilters: buildPlan.buildFilters,
           phase: phase,
           buildConfigs: buildConfigs,
         )) {

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -72,8 +72,8 @@ class BuildSeries {
       final id = change.id;
 
       // Changes to the entrypoint are handled via depfiles.
-      if (_buildPlan.bootstrapper.isCompileDependency(
-        _buildPlan.buildPackages.pathFor(id, hide: false),
+      if (_buildPlan.buildSpec.bootstrapper.isCompileDependency(
+        _buildPlan.buildSpec.buildPackages.pathFor(id, hide: false),
       )) {
         result.add(change);
         continue;
@@ -106,7 +106,7 @@ class BuildSeries {
         if (change.type != ChangeType.ADD) continue;
 
         // It's an add: handle if it's a new input.
-        if (_buildPlan.buildConfigs.anyMatchesAsset(id)) {
+        if (_buildPlan.buildSpec.buildConfigs.anyMatchesAsset(id)) {
           result.add(change);
         }
         continue;
@@ -116,7 +116,7 @@ class BuildSeries {
 
       // If not copying to a merged output directory, ignore changes to files
       // with no outputs.
-      if (!_buildPlan.buildOptions.anyMergedOutputDirectory &&
+      if (!_buildPlan.buildSpec.buildOptions.anyMergedOutputDirectory &&
           !(_buildPlan.previousBuildState?.isMissingSource(id) ?? false) &&
           _buildPlan.previousBuildState?.digestOf(
                 id: id,
@@ -142,15 +142,16 @@ class BuildSeries {
   bool _isBuildConfiguration(AssetId id) =>
       id.path == 'build.yaml' ||
       id.path.endsWith('.build.yaml') ||
-      (id.package == _buildPlan.buildPackages.outputRoot &&
-          id.path == 'build.${_buildPlan.buildOptions.configKey}.yaml');
+      (id.package == _buildPlan.buildSpec.buildPackages.outputRoot &&
+          id.path ==
+              'build.${_buildPlan.buildSpec.buildOptions.configKey}.yaml');
 
   Future<List<WatchEvent>> checkForChanges() async {
     final updates =
         await AssetTracker(
           _buildPlan.readerWriter,
-          _buildPlan.buildPackages,
-          _buildPlan.buildConfigs,
+          _buildPlan.buildSpec.buildPackages,
+          _buildPlan.buildSpec.buildConfigs,
         ).collectChanges(
           buildStepPlan: _buildPlan.buildStepPlan,
           buildState: _buildPlan.previousBuildState ?? BuildState(),
@@ -195,7 +196,7 @@ class BuildSeries {
         throw StateError('`recentlyBootstrapped` but updates not empty.');
       }
     } else {
-      final kernelFreshness = await _buildPlan.bootstrapper
+      final kernelFreshness = await _buildPlan.buildSpec.bootstrapper
           .checkCompileFreshness(digestsAreFresh: false);
       if (!kernelFreshness.outputIsFresh) {
         final result = BuildResult.buildScriptChanged();
@@ -210,7 +211,7 @@ class BuildSeries {
       await _buildPlan.deleteFilesAndFolders();
       // A config change might have caused new builders to be needed, which
       // needs a restart to change the build script.
-      if (_buildPlan.restartIsNeeded) {
+      if (_buildPlan.buildSpec.restartIsNeeded) {
         final result = BuildResult.buildScriptChanged();
         _buildResultsController.add(result);
         await close();
@@ -218,12 +219,13 @@ class BuildSeries {
       }
     }
 
-    buildDirs ??= _buildPlan.buildOptions.buildDirs;
-    buildFilters ??= _buildPlan.buildOptions.buildFilters;
+    buildDirs ??= _buildPlan.buildDirs;
+    buildFilters ??= _buildPlan.buildFilters;
     if (!firstBuild) buildLog.nextBuild();
-    _buildPlan = _buildPlan.copyWith(
-      buildDirs: buildDirs,
-      buildFilters: buildFilters,
+    _buildPlan = _buildPlan.rebuild(
+      (b) => b
+        ..buildDirs.replace(buildDirs!)
+        ..buildFilters.replace(buildFilters!),
     );
 
     if (firstBuild) {

--- a/build_runner/lib/src/build/build_state/asset_graph_json.dart
+++ b/build_runner/lib/src/build/build_state/asset_graph_json.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import '../../build_plan/build_plan_digest.dart';
+import '../../build_plan/build_spec_digest.dart';
 import '../library_cycle_graph/phased_asset_deps.dart';
 import 'build_state.dart';
 import 'serializers.dart';
@@ -15,7 +15,7 @@ import 'serializers.dart';
 /// Enough information to determine whether an incremental build is possible,
 /// and if so exactly what should be rebuilt.
 class AssetGraphJson {
-  final BuildPlanDigest buildPlanDigest;
+  final BuildSpecDigest buildPlanDigest;
   final BuildState buildState;
   final PhasedAssetDeps phasedAssetDeps;
 
@@ -27,7 +27,7 @@ class AssetGraphJson {
 
   /// Serializes for `asset_graph.json`.
   static Uint8List serialize({
-    required BuildPlanDigest buildPlanDigest,
+    required BuildSpecDigest buildPlanDigest,
     required BuildState buildState,
     required PhasedAssetDeps phasedAssetDeps,
   }) {
@@ -35,7 +35,7 @@ class AssetGraphJson {
     // `identityAssetIdSeralizer`.
     final serializedBuildState = serializeBuildState(buildState);
     final serializedBuildPlanDigest = serializers.serializeWith(
-      BuildPlanDigest.serializer,
+      BuildSpecDigest.serializer,
       buildPlanDigest,
     );
     final serializedPhasedAssetDeps = serializers.serializeWith(
@@ -69,7 +69,7 @@ class AssetGraphJson {
       );
 
       final buildPlanDigest = serializers.deserializeWith(
-        BuildPlanDigest.serializer,
+        BuildSpecDigest.serializer,
         deserialized['buildPlanDigest'],
       );
 
@@ -96,5 +96,5 @@ class AssetGraphJson {
 }
 
 /// Increment whenever older `asset_graph.json` files should be rejected.
-const _version = 42;
+const _version = 43;
 final jsonUtf8 = json.fuse(utf8);

--- a/build_runner/lib/src/build/build_state/serializers.dart
+++ b/build_runner/lib/src/build/build_state/serializers.dart
@@ -9,7 +9,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 import 'package:crypto/crypto.dart';
 
-import '../../build_plan/build_plan_digest.dart';
+import '../../build_plan/build_spec_digest.dart';
 import '../library_cycle_graph/asset_deps.dart';
 import '../library_cycle_graph/phased_asset_deps.dart';
 import '../library_cycle_graph/phased_value.dart';
@@ -35,7 +35,7 @@ final identityAssetIdSerializer = IdentitySerializer<AssetId>(
 
 @SerializersFor([
   AssetDeps,
-  BuildPlanDigest,
+  BuildSpecDigest,
   BuildStepId,
   BuildStepResult,
   GlobId,

--- a/build_runner/lib/src/build/build_state/serializers.g.dart
+++ b/build_runner/lib/src/build/build_state/serializers.g.dart
@@ -9,7 +9,7 @@ part of 'serializers.dart';
 Serializers _$serializers =
     (Serializers().toBuilder()
           ..add(AssetDeps.serializer)
-          ..add(BuildPlanDigest.serializer)
+          ..add(BuildSpecDigest.serializer)
           ..add(BuildStepId.serializer)
           ..add(BuildStepResult.serializer)
           ..add(ExpiringValue.serializer)

--- a/build_runner/lib/src/build_plan/build_options.dart
+++ b/build_runner/lib/src/build_plan/build_options.dart
@@ -20,9 +20,19 @@ import 'build_paths.dart';
 /// build.
 class BuildOptions {
   final BuiltMap<String, BuiltMap<String, Object?>> builderConfigOverrides;
+
+  /// The globally-configured build filters.
+  ///
+  /// These can be overridden elsewhere for individual builds.
   final BuiltSet<BuildDirectory> buildDirs;
+
   final BuildPaths buildPaths;
+
+  /// The globally-configured build filters.
+  ///
+  /// These can be overridden elsewhere for individual builds.
   final BuiltSet<BuildFilter> buildFilters;
+
   final CompileStrategy compileStrategy;
   final String? configKey;
   final BuiltList<String> enableExperiments;

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -4,65 +4,57 @@
 
 import 'dart:typed_data';
 
-import 'package:build/build.dart';
+import 'package:build/build.dart' hide Builder;
 import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
 import 'package:crypto/crypto.dart';
 import 'package:watcher/watcher.dart';
 
-import '../bootstrap/bootstrapper.dart';
-import '../bootstrap/depfile.dart';
 import '../build/build_state/asset_graph_json.dart';
 import '../build/build_state/build_state.dart';
-
 import '../build/library_cycle_graph/phased_asset_deps.dart';
 import '../constants.dart';
 import '../exceptions.dart';
 import '../io/asset_tracker.dart';
-import '../io/filesystem_cache.dart';
 import '../io/generated_asset_hider.dart';
 import '../io/reader_writer.dart';
 import '../logging/build_log.dart';
-import 'build_configs.dart';
 import 'build_directory.dart';
 import 'build_filter.dart';
 import 'build_inputs.dart';
-import 'build_options.dart';
-import 'build_packages.dart';
-import 'build_phase_creator.dart';
-import 'build_plan_digest.dart';
+import 'build_spec.dart';
+import 'build_spec_digest.dart';
 import 'build_step_plan.dart';
-import 'builder_definition.dart';
-import 'builder_factories.dart';
-import 'testing_overrides.dart';
+
+part 'build_plan.g.dart';
 
 /// Options and derived configuration for a build.
-class BuildPlan {
-  final BuildPlanDigest buildPlanDigest;
+abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
+  BuildSpec get buildSpec;
 
-  final BuilderFactories builderFactories;
-  final BuildOptions buildOptions;
-  final TestingOverrides testingOverrides;
+  /// Per-build build dirs, which can differ from the global option in
+  /// `BuildOptions`.
+  BuiltSet<BuildDirectory> get buildDirs;
 
-  final BuildPackages buildPackages;
-  final ReaderWriter readerWriter;
-  final BuildConfigs buildConfigs;
-  final BuildState? previousBuildState;
-  final PhasedAssetDeps? previousPhasedAssetDeps;
+  /// Per-build build filters, which can differ from the global option in
+  /// `BuildOptions`.
+  BuiltSet<BuildFilter> get buildFilters;
 
-  final BuildStepPlan buildStepPlan;
-  final bool restartIsNeeded;
+  ReaderWriter get readerWriter;
 
-  final Bootstrapper bootstrapper;
+  BuildState? get previousBuildState;
+  PhasedAssetDeps? get previousPhasedAssetDeps;
+  BuildStepPlan get buildStepPlan;
 
   /// Whether build triggers config changed since the previous build.
-  final bool triggersChanged;
+  bool get triggersChanged;
 
   /// Whether phase options per phase changed since the previous build.
-  final BuiltList<bool> _phaseOptionsChanged;
+  BuiltList<bool> get phaseOptionsChangedList;
 
   /// Whether post process phase options per phase changed since the previous
   /// build.
-  final BuiltList<bool> _postBuildOptionsChanged;
+  BuiltList<bool> get postBuildOptionsChangedList;
 
   /// Files to delete before restarting or before the next build.
   ///
@@ -71,121 +63,33 @@ class BuildPlan {
   /// - The build state, if it's invalid.
   ///
   /// Call [deleteFilesAndFolders] to delete them.
-  final BuiltList<AssetId> filesToDelete;
+  BuiltList<AssetId> get filesToDelete;
 
   /// Folders to delete before restarting or before the next build.
   ///
   /// Call [deleteFilesAndFolders] to delete them.
-  final BuiltList<AssetId> foldersToDelete;
+  BuiltList<AssetId> get foldersToDelete;
 
   /// Sources and changes to sources before the build.
-  final BuildInputs buildInputs;
+  BuildInputs get buildInputs;
 
-  BuildPlan({
-    required this.buildPlanDigest,
-    required this.builderFactories,
-    required this.buildOptions,
-    required this.testingOverrides,
-    required this.buildPackages,
-    required this.readerWriter,
-    required this.buildConfigs,
-    required this.buildStepPlan,
-    required this.previousBuildState,
-    required this.previousPhasedAssetDeps,
-    required this.restartIsNeeded,
-    required this.bootstrapper,
-    required this.filesToDelete,
-    required this.foldersToDelete,
-    required this.triggersChanged,
-    required BuiltList<bool> phaseOptionsChanged,
-    required BuiltList<bool> postBuildOptionsChanged,
-    required this.buildInputs,
-  }) : _phaseOptionsChanged = phaseOptionsChanged,
-       _postBuildOptionsChanged = postBuildOptionsChanged;
+  BuildPlan._();
+  factory BuildPlan([void Function(BuildPlanBuilder) updates]) = _$BuildPlan;
 
-  /// Loads a build plan.
+  /// Loads the build plan for [buildSpec].
   ///
-  /// Loads the package structure and build configuration; prepares
-  /// [readerWriter], deduces the buildPhases that will run, deserializes and
-  /// checks the `BuildState`.
-  ///
-  /// If the build state indicates a restart is needed, [restartIsNeeded] will
-  /// be set. Otherwise, if it's valid, the deserialized build state is
-  /// available from [previousBuildState].
+  /// Deserializes and checks the `BuildState`. If it's compatible, it's
+  /// available as [previousBuildState]. If not, it's discarded.
   ///
   /// Files that should be deleted before restarting or building are accumulated
   /// in [filesToDelete] and [foldersToDelete]. Call [deleteFilesAndFolders] to
   /// delete them.
   ///
-  /// Set [recentlyBootstrapped] to false to do checks that are also done during
-  /// bootstrapping.
-  static Future<BuildPlan> load({
-    required BuilderFactories builderFactories,
-    required BuildOptions buildOptions,
-    required TestingOverrides testingOverrides,
-    bool recentlyBootstrapped = true,
-  }) async {
-    final bootstrapper = Bootstrapper(
-      buildPaths: buildOptions.buildPaths,
-      compileStrategy: buildOptions.compileStrategy,
-    );
-    var restartIsNeeded = false;
-    final compileFreshness = testingOverrides.checkBuilderFreshness
-        ? await bootstrapper.checkCompileFreshness(
-            digestsAreFresh: recentlyBootstrapped,
-          )
-        : FreshnessResult(outputIsFresh: true, digest: 'dummy_digest');
-    if (!compileFreshness.outputIsFresh) {
-      restartIsNeeded = true;
-    }
-
-    final buildPackages =
-        testingOverrides.buildPackages ??
-        await BuildPackages.forPaths(buildOptions.buildPaths);
-    final readerWriter =
-        (testingOverrides.readerWriter ?? ReaderWriter(buildPackages)).copyWith(
-          cache: InMemoryFilesystemCache(),
-        );
-    final buildConfigs = await BuildConfigs.load(
-      readerWriter: readerWriter,
-      buildPackages: buildPackages,
-      testingOverrides: testingOverrides,
-      configKey: buildOptions.configKey,
-    );
-
-    var builderDefinitions =
-        testingOverrides.builderDefinitions ??
-        await AbstractBuilderDefinition.load(
-          buildPackages: buildPackages,
-          readerWriter: readerWriter,
-        );
-
-    // Check that there is a factory available for every builder, if not the
-    // config has changed since the script was written and a restart is needed.
-    if (!builderFactories.hasFactoriesFor(builderDefinitions)) {
-      restartIsNeeded = true;
-      builderDefinitions = BuiltList();
-    }
-
-    final buildPhases =
-        testingOverrides.buildPhases ??
-        await BuildPhaseCreator(
-          builderFactories: builderFactories,
-          buildPackages: buildPackages,
-          buildConfigs: buildConfigs,
-          builderDefinitions: builderDefinitions,
-          builderConfigOverrides: buildOptions.builderConfigOverrides,
-          isReleaseBuild: buildOptions.isReleaseBuild,
-          workspace: buildOptions.buildPaths.buildWorkspace,
-        ).createBuildPhases();
-    buildPhases.checkOutputLocations(buildPackages.outputPackages);
-
-    final buildPlanDigest = BuildPlanDigest(
-      compileDigest: compileFreshness.digest,
-      buildConfigs: buildConfigs,
-      buildPhases: buildPhases,
-      buildPackages: buildPackages,
-    );
+  /// [buildInputs] are resolved.
+  static Future<BuildPlan> load(BuildSpec buildSpec) async {
+    final readerWriter = buildSpec.readerWriter;
+    final buildPackages = buildSpec.buildPackages;
+    final buildPlanDigest = buildSpec.buildPlanDigest;
 
     final assetGraphJsonId = AssetId(
       buildPackages.outputRoot,
@@ -195,7 +99,7 @@ class BuildPlan {
       buildPackages.outputRoot,
       generatedOutputDirectory,
     );
-    BuildPlanDigest? previousBuildPlanDigest;
+    BuildSpecDigest? previousBuildPlanDigest;
     BuildState? previousBuildState;
     final filesToDelete = <AssetId>{};
     final foldersToDelete = <AssetId>{};
@@ -211,7 +115,7 @@ class BuildPlan {
         previousPhasedAssetDeps = assetGraphJson.phasedAssetDeps;
       }
       if (previousBuildState != null) {
-        if (restartIsNeeded ||
+        if (buildSpec.restartIsNeeded ||
             !buildPlanDigest.canIncrementallyBuildFrom(
               previousBuildPlanDigest,
             )) {
@@ -237,7 +141,7 @@ class BuildPlan {
     final assetTracker = AssetTracker(
       readerWriter,
       buildPackages,
-      buildConfigs,
+      buildSpec.buildConfigs,
     );
     final inputSources = await assetTracker.findInputSources();
     final cacheDirSources = await assetTracker.findCacheDirSources();
@@ -251,7 +155,7 @@ class BuildPlan {
         ...previousBuildState.actualOutputs,
       };
 
-      if (restartIsNeeded) {
+      if (buildSpec.restartIsNeeded) {
         // Mark old outputs for deletion.
         filesToDelete.addAll(previousBuildState.outputsToDelete(buildPackages));
         foldersToDelete.add(generatedOutputDirectoryId);
@@ -276,7 +180,7 @@ class BuildPlan {
       // sources to remove them. They are computed again below based on the
       // pruned inputs.
       final declaredOutputs = BuildStepPlan.compute(
-        buildPhases: buildPhases,
+        buildPhases: buildSpec.buildPhases,
         placeholderIds: buildPackages.placeholderIds,
         sources: inputSources,
       ).declaredOutputs;
@@ -292,7 +196,7 @@ class BuildPlan {
     }
 
     final buildStepPlan = BuildStepPlan.compute(
-      buildPhases: buildPhases,
+      buildPhases: buildSpec.buildPhases,
       placeholderIds: buildPackages.placeholderIds,
       sources: sourcesForBuildStepPlan,
     );
@@ -325,24 +229,19 @@ class BuildPlan {
     }
 
     final finalReaderWriter = readerWriter.copyWith(
-      generatedAssetHider: testingOverrides.flattenOutput
+      generatedAssetHider: buildSpec.testingOverrides.flattenOutput
           ? const NoopGeneratedAssetHider()
           : buildStepPlan,
     );
 
     return _createAndResolve(
-      buildPlanDigest: buildPlanDigest,
-      builderFactories: builderFactories,
-      buildOptions: buildOptions,
-      testingOverrides: testingOverrides,
-      buildPackages: buildPackages,
+      buildSpec: buildSpec,
+      buildDirs: buildSpec.buildOptions.buildDirs,
+      buildFilters: buildSpec.buildOptions.buildFilters,
       readerWriter: finalReaderWriter,
-      buildConfigs: buildConfigs,
       buildStepPlan: buildStepPlan,
       previousBuildState: previousBuildState,
       previousPhasedAssetDeps: previousPhasedAssetDeps,
-      restartIsNeeded: restartIsNeeded,
-      bootstrapper: bootstrapper,
       filesToDelete: filesToDelete.toBuiltList(),
       foldersToDelete: foldersToDelete.toBuiltList(),
       triggersChanged: !buildPlanDigest.hasSameTriggersAs(
@@ -358,44 +257,6 @@ class BuildPlan {
     );
   }
 
-  BuildPlan copyWith({
-    BuildPlanDigest? buildPlanDigest,
-    BuiltSet<BuildDirectory>? buildDirs,
-    BuiltSet<BuildFilter>? buildFilters,
-    ReaderWriter? readerWriter,
-    bool? triggersChanged,
-    PhasedAssetDeps? previousPhasedAssetDeps,
-    BuiltList<bool>? phaseOptionsChanged,
-    BuiltList<bool>? postBuildOptionsChanged,
-    BuildStepPlan? buildStepPlan,
-    BuildState? previousBuildState,
-    BuildInputs? buildInputs,
-  }) => BuildPlan(
-    buildPlanDigest: buildPlanDigest ?? this.buildPlanDigest,
-    builderFactories: builderFactories,
-    buildOptions: buildOptions.copyWith(
-      buildDirs: buildDirs,
-      buildFilters: buildFilters,
-    ),
-    testingOverrides: testingOverrides,
-    buildPackages: buildPackages,
-    buildConfigs: buildConfigs,
-    readerWriter: readerWriter ?? this.readerWriter,
-    buildStepPlan: buildStepPlan ?? this.buildStepPlan,
-    previousBuildState: previousBuildState ?? this.previousBuildState,
-    previousPhasedAssetDeps:
-        previousPhasedAssetDeps ?? this.previousPhasedAssetDeps,
-    restartIsNeeded: restartIsNeeded,
-    bootstrapper: bootstrapper,
-    filesToDelete: filesToDelete,
-    foldersToDelete: foldersToDelete,
-    triggersChanged: triggersChanged ?? this.triggersChanged,
-    phaseOptionsChanged: phaseOptionsChanged ?? _phaseOptionsChanged,
-    postBuildOptionsChanged:
-        postBuildOptionsChanged ?? _postBuildOptionsChanged,
-    buildInputs: buildInputs ?? this.buildInputs,
-  );
-
   /// Returns a copy of the plan updated for the next incremental build.
   ///
   /// Updates [previousPhasedAssetDeps] from the build result.
@@ -405,43 +266,46 @@ class BuildPlan {
   BuildPlan updateForResult({
     PhasedAssetDeps? previousPhasedAssetDeps,
     BuildState? previousBuildState,
-  }) => copyWith(
-    triggersChanged: false,
-    previousPhasedAssetDeps: previousPhasedAssetDeps,
-    previousBuildState: previousBuildState,
-    phaseOptionsChanged: BuiltList<bool>.from(
-      List.filled(
-        buildStepPlan.buildPhases.inBuildPhasesOptionsDigests.length,
-        false,
+  }) => rebuild((b) {
+    b.triggersChanged = false;
+    if (previousPhasedAssetDeps == null) {
+      b.previousPhasedAssetDeps = null;
+    } else {
+      b.previousPhasedAssetDeps.replace(previousPhasedAssetDeps);
+    }
+    b.previousBuildState = previousBuildState;
+    b.phaseOptionsChangedList.replace(
+      BuiltList<bool>.from(
+        List.filled(
+          buildStepPlan.buildPhases.inBuildPhasesOptionsDigests.length,
+          false,
+        ),
       ),
-    ),
-    postBuildOptionsChanged: BuiltList<bool>.from(
-      List.filled(
-        buildStepPlan.buildPhases.postBuildActionsOptionsDigests.length,
-        false,
+    );
+    b.postBuildOptionsChangedList.replace(
+      BuiltList<bool>.from(
+        List.filled(
+          buildStepPlan.buildPhases.postBuildActionsOptionsDigests.length,
+          false,
+        ),
       ),
-    ),
-  );
+    );
+  });
 
   Future<BuildPlan> updateForFileChanges(Set<AssetId> updates) {
     return _createAndResolve(
-      buildPlanDigest: buildPlanDigest,
-      builderFactories: builderFactories,
-      buildOptions: buildOptions,
-      testingOverrides: testingOverrides,
-      buildPackages: buildPackages,
+      buildSpec: buildSpec,
+      buildDirs: buildDirs,
+      buildFilters: buildFilters,
       readerWriter: readerWriter,
-      buildConfigs: buildConfigs,
       buildStepPlan: buildStepPlan,
       previousBuildState: previousBuildState,
       previousPhasedAssetDeps: previousPhasedAssetDeps,
-      restartIsNeeded: restartIsNeeded,
-      bootstrapper: bootstrapper,
       filesToDelete: filesToDelete,
       foldersToDelete: foldersToDelete,
       triggersChanged: triggersChanged,
-      phaseOptionsChanged: _phaseOptionsChanged,
-      postBuildOptionsChanged: _postBuildOptionsChanged,
+      phaseOptionsChanged: phaseOptionsChangedList,
+      postBuildOptionsChanged: postBuildOptionsChangedList,
       updates: updates,
     );
   }
@@ -449,12 +313,12 @@ class BuildPlan {
   /// Whether [phaseNumber] has different options to the previous build
   /// and must be fully rebuilt.
   bool phaseOptionsChanged(int phaseNumber) =>
-      _phaseOptionsChanged[phaseNumber];
+      phaseOptionsChangedList[phaseNumber];
 
   /// Whether [actionNumber] has different options to the previous build
   /// and must be fully rebuilt.
   bool postBuildOptionsChanged(int actionNumber) =>
-      _postBuildOptionsChanged[actionNumber];
+      postBuildOptionsChangedList[actionNumber];
 
   Future<void> deleteFilesAndFolders() async {
     // Hidden outputs are deleted if needed by deleting the entire folder. So,
@@ -474,18 +338,13 @@ class BuildPlan {
   }
 
   static Future<BuildPlan> _createAndResolve({
-    required BuildPlanDigest buildPlanDigest,
-    required BuilderFactories builderFactories,
-    required BuildOptions buildOptions,
-    required TestingOverrides testingOverrides,
-    required BuildPackages buildPackages,
+    required BuildSpec buildSpec,
+    required BuiltSet<BuildDirectory> buildDirs,
+    required BuiltSet<BuildFilter> buildFilters,
     required ReaderWriter readerWriter,
-    required BuildConfigs buildConfigs,
     required BuildStepPlan buildStepPlan,
     required BuildState? previousBuildState,
     required PhasedAssetDeps? previousPhasedAssetDeps,
-    required bool restartIsNeeded,
-    required Bootstrapper bootstrapper,
     required BuiltList<AssetId> filesToDelete,
     required BuiltList<AssetId> foldersToDelete,
     required bool triggersChanged,
@@ -511,7 +370,7 @@ class BuildPlan {
 
       final newBuildStepPlan = BuildStepPlan.compute(
         buildPhases: buildStepPlan.buildPhases,
-        placeholderIds: buildPackages.placeholderIds,
+        placeholderIds: buildSpec.buildPackages.placeholderIds,
         sources: result.sources.build(),
       );
       for (final id in result.sources.build()) {
@@ -522,30 +381,25 @@ class BuildPlan {
         }
       }
       final newReaderWriter = readerWriter.copyWith(
-        generatedAssetHider: testingOverrides.flattenOutput
+        generatedAssetHider: buildSpec.testingOverrides.flattenOutput
             ? const NoopGeneratedAssetHider()
             : newBuildStepPlan,
       );
-      return BuildPlan(
-        buildPlanDigest: buildPlanDigest,
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides,
-        buildPackages: buildPackages,
-        readerWriter: newReaderWriter,
-        buildConfigs: buildConfigs,
-        buildStepPlan: newBuildStepPlan,
-        previousBuildState: previousBuildState,
-        previousPhasedAssetDeps: previousPhasedAssetDeps,
-        restartIsNeeded: restartIsNeeded,
-        bootstrapper: bootstrapper,
-        filesToDelete: filesToDelete,
-        foldersToDelete: foldersToDelete,
-        triggersChanged: triggersChanged,
-        phaseOptionsChanged: phaseOptionsChanged,
-        postBuildOptionsChanged: postBuildOptionsChanged,
-        buildInputs: result.build(),
-      );
+      return BuildPlan((b) {
+        b.buildSpec.replace(buildSpec);
+        b.buildDirs.replace(buildDirs);
+        b.buildFilters.replace(buildFilters);
+        b.readerWriter = newReaderWriter;
+        b.buildStepPlan.replace(newBuildStepPlan);
+        b.previousBuildState = previousBuildState;
+        b.previousPhasedAssetDeps = previousPhasedAssetDeps?.toBuilder();
+        b.filesToDelete.replace(filesToDelete);
+        b.foldersToDelete.replace(foldersToDelete);
+        b.triggersChanged = triggersChanged;
+        b.phaseOptionsChangedList.replace(phaseOptionsChanged);
+        b.postBuildOptionsChangedList.replace(postBuildOptionsChanged);
+        b.buildInputs.replace(result.build());
+      });
     }
 
     readerWriter.cache.invalidate(updates);
@@ -628,7 +482,7 @@ class BuildPlan {
 
     final newBuildStepPlan = BuildStepPlan.compute(
       buildPhases: buildStepPlan.buildPhases,
-      placeholderIds: buildPackages.placeholderIds,
+      placeholderIds: buildSpec.buildPackages.placeholderIds,
       sources: result.sources.build(),
     );
 
@@ -647,7 +501,7 @@ class BuildPlan {
     result.deletedOutputs.addAll(deletedOutputs);
 
     final generatedReaderWriter = readerWriter.copyWith(
-      generatedAssetHider: testingOverrides.flattenOutput
+      generatedAssetHider: buildSpec.testingOverrides.flattenOutput
           ? const NoopGeneratedAssetHider()
           : newBuildStepPlan,
     );
@@ -655,26 +509,25 @@ class BuildPlan {
       await generatedReaderWriter.delete(id);
     }
 
-    return BuildPlan(
-      buildPlanDigest: buildPlanDigest,
-      builderFactories: builderFactories,
-      buildOptions: buildOptions,
-      testingOverrides: testingOverrides,
-      buildPackages: buildPackages,
-      readerWriter: generatedReaderWriter,
-      buildConfigs: buildConfigs,
-      buildStepPlan: newBuildStepPlan,
-      previousBuildState: previousBuildState,
-      previousPhasedAssetDeps: previousPhasedAssetDeps,
-      restartIsNeeded: restartIsNeeded,
-      bootstrapper: bootstrapper,
-      filesToDelete: filesToDelete,
-      foldersToDelete: foldersToDelete,
-      triggersChanged: triggersChanged,
-      phaseOptionsChanged: phaseOptionsChanged,
-      postBuildOptionsChanged: postBuildOptionsChanged,
-      buildInputs: result.build(),
-    );
+    return BuildPlan((b) {
+      b.buildSpec.replace(buildSpec);
+      b.buildDirs.replace(buildDirs);
+      b.buildFilters.replace(buildFilters);
+      b.readerWriter = generatedReaderWriter;
+      b.buildStepPlan.replace(newBuildStepPlan);
+      b.previousBuildState = previousBuildState;
+      if (previousPhasedAssetDeps == null) {
+        b.previousPhasedAssetDeps = null;
+      } else {
+        b.previousPhasedAssetDeps.replace(previousPhasedAssetDeps);
+      }
+      b.filesToDelete.replace(filesToDelete);
+      b.foldersToDelete.replace(foldersToDelete);
+      b.triggersChanged = triggersChanged;
+      b.phaseOptionsChangedList.replace(phaseOptionsChanged);
+      b.postBuildOptionsChangedList.replace(postBuildOptionsChanged);
+      b.buildInputs.replace(result.build());
+    });
   }
 
   /// Reloads the build plan.
@@ -683,11 +536,16 @@ class BuildPlan {
   /// `recentlyBootstrapped` to `false` to redo checks from bootstrapping.
   ///
   /// The caller must call [deleteFilesAndFolders] on the result and check
-  /// [restartIsNeeded].
-  Future<BuildPlan> reload() => BuildPlan.load(
-    builderFactories: builderFactories,
-    buildOptions: buildOptions,
-    testingOverrides: testingOverrides,
-    recentlyBootstrapped: false,
+  /// `buildSpec.restartIsNeeded`.
+  Future<BuildPlan> reload() async => BuildPlan.load(
+    await BuildSpec.load(
+      builderFactories: buildSpec.builderFactories,
+      buildOptions: buildSpec.buildOptions.copyWith(
+        buildDirs: buildDirs,
+        buildFilters: buildFilters,
+      ),
+      testingOverrides: buildSpec.testingOverrides,
+      recentlyBootstrapped: false,
+    ),
   );
 }

--- a/build_runner/lib/src/build_plan/build_plan.g.dart
+++ b/build_runner/lib/src/build_plan/build_plan.g.dart
@@ -1,0 +1,302 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'build_plan.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$BuildPlan extends BuildPlan {
+  @override
+  final BuildSpec buildSpec;
+  @override
+  final BuiltSet<BuildDirectory> buildDirs;
+  @override
+  final BuiltSet<BuildFilter> buildFilters;
+  @override
+  final ReaderWriter readerWriter;
+  @override
+  final BuildState? previousBuildState;
+  @override
+  final PhasedAssetDeps? previousPhasedAssetDeps;
+  @override
+  final BuildStepPlan buildStepPlan;
+  @override
+  final bool triggersChanged;
+  @override
+  final BuiltList<bool> phaseOptionsChangedList;
+  @override
+  final BuiltList<bool> postBuildOptionsChangedList;
+  @override
+  final BuiltList<AssetId> filesToDelete;
+  @override
+  final BuiltList<AssetId> foldersToDelete;
+  @override
+  final BuildInputs buildInputs;
+
+  factory _$BuildPlan([void Function(BuildPlanBuilder)? updates]) =>
+      (BuildPlanBuilder()..update(updates))._build();
+
+  _$BuildPlan._({
+    required this.buildSpec,
+    required this.buildDirs,
+    required this.buildFilters,
+    required this.readerWriter,
+    this.previousBuildState,
+    this.previousPhasedAssetDeps,
+    required this.buildStepPlan,
+    required this.triggersChanged,
+    required this.phaseOptionsChangedList,
+    required this.postBuildOptionsChangedList,
+    required this.filesToDelete,
+    required this.foldersToDelete,
+    required this.buildInputs,
+  }) : super._();
+  @override
+  BuildPlan rebuild(void Function(BuildPlanBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BuildPlanBuilder toBuilder() => BuildPlanBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BuildPlan &&
+        buildSpec == other.buildSpec &&
+        buildDirs == other.buildDirs &&
+        buildFilters == other.buildFilters &&
+        readerWriter == other.readerWriter &&
+        previousBuildState == other.previousBuildState &&
+        previousPhasedAssetDeps == other.previousPhasedAssetDeps &&
+        buildStepPlan == other.buildStepPlan &&
+        triggersChanged == other.triggersChanged &&
+        phaseOptionsChangedList == other.phaseOptionsChangedList &&
+        postBuildOptionsChangedList == other.postBuildOptionsChangedList &&
+        filesToDelete == other.filesToDelete &&
+        foldersToDelete == other.foldersToDelete &&
+        buildInputs == other.buildInputs;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, buildSpec.hashCode);
+    _$hash = $jc(_$hash, buildDirs.hashCode);
+    _$hash = $jc(_$hash, buildFilters.hashCode);
+    _$hash = $jc(_$hash, readerWriter.hashCode);
+    _$hash = $jc(_$hash, previousBuildState.hashCode);
+    _$hash = $jc(_$hash, previousPhasedAssetDeps.hashCode);
+    _$hash = $jc(_$hash, buildStepPlan.hashCode);
+    _$hash = $jc(_$hash, triggersChanged.hashCode);
+    _$hash = $jc(_$hash, phaseOptionsChangedList.hashCode);
+    _$hash = $jc(_$hash, postBuildOptionsChangedList.hashCode);
+    _$hash = $jc(_$hash, filesToDelete.hashCode);
+    _$hash = $jc(_$hash, foldersToDelete.hashCode);
+    _$hash = $jc(_$hash, buildInputs.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BuildPlan')
+          ..add('buildSpec', buildSpec)
+          ..add('buildDirs', buildDirs)
+          ..add('buildFilters', buildFilters)
+          ..add('readerWriter', readerWriter)
+          ..add('previousBuildState', previousBuildState)
+          ..add('previousPhasedAssetDeps', previousPhasedAssetDeps)
+          ..add('buildStepPlan', buildStepPlan)
+          ..add('triggersChanged', triggersChanged)
+          ..add('phaseOptionsChangedList', phaseOptionsChangedList)
+          ..add('postBuildOptionsChangedList', postBuildOptionsChangedList)
+          ..add('filesToDelete', filesToDelete)
+          ..add('foldersToDelete', foldersToDelete)
+          ..add('buildInputs', buildInputs))
+        .toString();
+  }
+}
+
+class BuildPlanBuilder implements Builder<BuildPlan, BuildPlanBuilder> {
+  _$BuildPlan? _$v;
+
+  BuildSpecBuilder? _buildSpec;
+  BuildSpecBuilder get buildSpec => _$this._buildSpec ??= BuildSpecBuilder();
+  set buildSpec(BuildSpecBuilder? buildSpec) => _$this._buildSpec = buildSpec;
+
+  SetBuilder<BuildDirectory>? _buildDirs;
+  SetBuilder<BuildDirectory> get buildDirs =>
+      _$this._buildDirs ??= SetBuilder<BuildDirectory>();
+  set buildDirs(SetBuilder<BuildDirectory>? buildDirs) =>
+      _$this._buildDirs = buildDirs;
+
+  SetBuilder<BuildFilter>? _buildFilters;
+  SetBuilder<BuildFilter> get buildFilters =>
+      _$this._buildFilters ??= SetBuilder<BuildFilter>();
+  set buildFilters(SetBuilder<BuildFilter>? buildFilters) =>
+      _$this._buildFilters = buildFilters;
+
+  ReaderWriter? _readerWriter;
+  ReaderWriter? get readerWriter => _$this._readerWriter;
+  set readerWriter(ReaderWriter? readerWriter) =>
+      _$this._readerWriter = readerWriter;
+
+  BuildState? _previousBuildState;
+  BuildState? get previousBuildState => _$this._previousBuildState;
+  set previousBuildState(BuildState? previousBuildState) =>
+      _$this._previousBuildState = previousBuildState;
+
+  PhasedAssetDepsBuilder? _previousPhasedAssetDeps;
+  PhasedAssetDepsBuilder get previousPhasedAssetDeps =>
+      _$this._previousPhasedAssetDeps ??= PhasedAssetDepsBuilder();
+  set previousPhasedAssetDeps(
+    PhasedAssetDepsBuilder? previousPhasedAssetDeps,
+  ) => _$this._previousPhasedAssetDeps = previousPhasedAssetDeps;
+
+  BuildStepPlanBuilder? _buildStepPlan;
+  BuildStepPlanBuilder get buildStepPlan =>
+      _$this._buildStepPlan ??= BuildStepPlanBuilder();
+  set buildStepPlan(BuildStepPlanBuilder? buildStepPlan) =>
+      _$this._buildStepPlan = buildStepPlan;
+
+  bool? _triggersChanged;
+  bool? get triggersChanged => _$this._triggersChanged;
+  set triggersChanged(bool? triggersChanged) =>
+      _$this._triggersChanged = triggersChanged;
+
+  ListBuilder<bool>? _phaseOptionsChangedList;
+  ListBuilder<bool> get phaseOptionsChangedList =>
+      _$this._phaseOptionsChangedList ??= ListBuilder<bool>();
+  set phaseOptionsChangedList(ListBuilder<bool>? phaseOptionsChangedList) =>
+      _$this._phaseOptionsChangedList = phaseOptionsChangedList;
+
+  ListBuilder<bool>? _postBuildOptionsChangedList;
+  ListBuilder<bool> get postBuildOptionsChangedList =>
+      _$this._postBuildOptionsChangedList ??= ListBuilder<bool>();
+  set postBuildOptionsChangedList(
+    ListBuilder<bool>? postBuildOptionsChangedList,
+  ) => _$this._postBuildOptionsChangedList = postBuildOptionsChangedList;
+
+  ListBuilder<AssetId>? _filesToDelete;
+  ListBuilder<AssetId> get filesToDelete =>
+      _$this._filesToDelete ??= ListBuilder<AssetId>();
+  set filesToDelete(ListBuilder<AssetId>? filesToDelete) =>
+      _$this._filesToDelete = filesToDelete;
+
+  ListBuilder<AssetId>? _foldersToDelete;
+  ListBuilder<AssetId> get foldersToDelete =>
+      _$this._foldersToDelete ??= ListBuilder<AssetId>();
+  set foldersToDelete(ListBuilder<AssetId>? foldersToDelete) =>
+      _$this._foldersToDelete = foldersToDelete;
+
+  BuildInputsBuilder? _buildInputs;
+  BuildInputsBuilder get buildInputs =>
+      _$this._buildInputs ??= BuildInputsBuilder();
+  set buildInputs(BuildInputsBuilder? buildInputs) =>
+      _$this._buildInputs = buildInputs;
+
+  BuildPlanBuilder();
+
+  BuildPlanBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _buildSpec = $v.buildSpec.toBuilder();
+      _buildDirs = $v.buildDirs.toBuilder();
+      _buildFilters = $v.buildFilters.toBuilder();
+      _readerWriter = $v.readerWriter;
+      _previousBuildState = $v.previousBuildState;
+      _previousPhasedAssetDeps = $v.previousPhasedAssetDeps?.toBuilder();
+      _buildStepPlan = $v.buildStepPlan.toBuilder();
+      _triggersChanged = $v.triggersChanged;
+      _phaseOptionsChangedList = $v.phaseOptionsChangedList.toBuilder();
+      _postBuildOptionsChangedList = $v.postBuildOptionsChangedList.toBuilder();
+      _filesToDelete = $v.filesToDelete.toBuilder();
+      _foldersToDelete = $v.foldersToDelete.toBuilder();
+      _buildInputs = $v.buildInputs.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BuildPlan other) {
+    _$v = other as _$BuildPlan;
+  }
+
+  @override
+  void update(void Function(BuildPlanBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BuildPlan build() => _build();
+
+  _$BuildPlan _build() {
+    _$BuildPlan _$result;
+    try {
+      _$result =
+          _$v ??
+          _$BuildPlan._(
+            buildSpec: buildSpec.build(),
+            buildDirs: buildDirs.build(),
+            buildFilters: buildFilters.build(),
+            readerWriter: BuiltValueNullFieldError.checkNotNull(
+              readerWriter,
+              r'BuildPlan',
+              'readerWriter',
+            ),
+            previousBuildState: previousBuildState,
+            previousPhasedAssetDeps: _previousPhasedAssetDeps?.build(),
+            buildStepPlan: buildStepPlan.build(),
+            triggersChanged: BuiltValueNullFieldError.checkNotNull(
+              triggersChanged,
+              r'BuildPlan',
+              'triggersChanged',
+            ),
+            phaseOptionsChangedList: phaseOptionsChangedList.build(),
+            postBuildOptionsChangedList: postBuildOptionsChangedList.build(),
+            filesToDelete: filesToDelete.build(),
+            foldersToDelete: foldersToDelete.build(),
+            buildInputs: buildInputs.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'buildSpec';
+        buildSpec.build();
+        _$failedField = 'buildDirs';
+        buildDirs.build();
+        _$failedField = 'buildFilters';
+        buildFilters.build();
+
+        _$failedField = 'previousPhasedAssetDeps';
+        _previousPhasedAssetDeps?.build();
+        _$failedField = 'buildStepPlan';
+        buildStepPlan.build();
+
+        _$failedField = 'phaseOptionsChangedList';
+        phaseOptionsChangedList.build();
+        _$failedField = 'postBuildOptionsChangedList';
+        postBuildOptionsChangedList.build();
+        _$failedField = 'filesToDelete';
+        filesToDelete.build();
+        _$failedField = 'foldersToDelete';
+        foldersToDelete.build();
+        _$failedField = 'buildInputs';
+        buildInputs.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'BuildPlan',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/build_runner/lib/src/build_plan/build_spec.dart
+++ b/build_runner/lib/src/build_plan/build_spec.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+
+import '../bootstrap/bootstrapper.dart';
+import '../bootstrap/depfile.dart';
+
+import '../io/filesystem_cache.dart';
+import '../io/reader_writer.dart';
+import 'build_configs.dart';
+import 'build_options.dart';
+import 'build_packages.dart';
+import 'build_phase_creator.dart';
+import 'build_phases.dart';
+import 'build_spec_digest.dart';
+import 'builder_definition.dart';
+import 'builder_factories.dart';
+import 'testing_overrides.dart';
+
+part 'build_spec.g.dart';
+
+/// The build options, configuration and setup that stay the same across a
+/// series of incremental builds.
+abstract class BuildSpec implements Built<BuildSpec, BuildSpecBuilder> {
+  BuildSpecDigest get buildPlanDigest;
+  BuilderFactories get builderFactories;
+  BuildOptions get buildOptions;
+  TestingOverrides get testingOverrides;
+  Bootstrapper get bootstrapper;
+  BuildPackages get buildPackages;
+  BuildConfigs get buildConfigs;
+  BuildPhases get buildPhases;
+  ReaderWriter get readerWriter;
+  bool get restartIsNeeded;
+
+  BuildSpec._();
+  factory BuildSpec([void Function(BuildSpecBuilder) updates]) = _$BuildSpec;
+
+  /// Loads the package structure and build configuration.
+  ///
+  /// Determines whether [restartIsNeeded] to pick up new builder factories or
+  /// changes to `build_runner` code.
+  ///
+  /// Set [recentlyBootstrapped] to false to do checks that are also done during
+  /// bootstrapping.
+  static Future<BuildSpec> load({
+    required BuilderFactories builderFactories,
+    required BuildOptions buildOptions,
+    required TestingOverrides testingOverrides,
+    bool recentlyBootstrapped = true,
+  }) async {
+    final bootstrapper = Bootstrapper(
+      buildPaths: buildOptions.buildPaths,
+      compileStrategy: buildOptions.compileStrategy,
+    );
+    var restartIsNeeded = false;
+    final compileFreshness = testingOverrides.checkBuilderFreshness
+        ? await bootstrapper.checkCompileFreshness(
+            digestsAreFresh: recentlyBootstrapped,
+          )
+        : FreshnessResult(outputIsFresh: true, digest: 'dummy_digest');
+    if (!compileFreshness.outputIsFresh) {
+      restartIsNeeded = true;
+    }
+
+    final buildPackages =
+        testingOverrides.buildPackages ??
+        await BuildPackages.forPaths(buildOptions.buildPaths);
+    final readerWriter =
+        (testingOverrides.readerWriter ?? ReaderWriter(buildPackages)).copyWith(
+          cache: InMemoryFilesystemCache(),
+        );
+    final buildConfigs = await BuildConfigs.load(
+      readerWriter: readerWriter,
+      buildPackages: buildPackages,
+      testingOverrides: testingOverrides,
+      configKey: buildOptions.configKey,
+    );
+
+    var builderDefinitions =
+        testingOverrides.builderDefinitions ??
+        await AbstractBuilderDefinition.load(
+          buildPackages: buildPackages,
+          readerWriter: readerWriter,
+        );
+
+    // Check that there is a factory available for every builder, if not the
+    // config has changed since the script was written and a restart is needed.
+    if (!builderFactories.hasFactoriesFor(builderDefinitions)) {
+      restartIsNeeded = true;
+      builderDefinitions = BuiltList();
+    }
+
+    final buildPhases =
+        testingOverrides.buildPhases ??
+        await BuildPhaseCreator(
+          builderFactories: builderFactories,
+          buildPackages: buildPackages,
+          buildConfigs: buildConfigs,
+          builderDefinitions: builderDefinitions,
+          builderConfigOverrides: buildOptions.builderConfigOverrides,
+          isReleaseBuild: buildOptions.isReleaseBuild,
+          workspace: buildOptions.buildPaths.buildWorkspace,
+        ).createBuildPhases();
+    buildPhases.checkOutputLocations(buildPackages.outputPackages);
+
+    final buildPlanDigest = BuildSpecDigest(
+      compileDigest: compileFreshness.digest,
+      buildConfigs: buildConfigs,
+      buildPhases: buildPhases,
+      buildPackages: buildPackages,
+    );
+
+    return BuildSpec(
+      (b) => b
+        ..buildPlanDigest.replace(buildPlanDigest)
+        ..builderFactories = builderFactories
+        ..buildOptions = buildOptions
+        ..testingOverrides = testingOverrides
+        ..bootstrapper = bootstrapper
+        ..buildPackages = buildPackages
+        ..buildConfigs = buildConfigs
+        ..buildPhases = buildPhases
+        ..readerWriter = readerWriter
+        ..restartIsNeeded = restartIsNeeded,
+    );
+  }
+}

--- a/build_runner/lib/src/build_plan/build_spec.g.dart
+++ b/build_runner/lib/src/build_plan/build_spec.g.dart
@@ -1,0 +1,262 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'build_spec.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$BuildSpec extends BuildSpec {
+  @override
+  final BuildSpecDigest buildPlanDigest;
+  @override
+  final BuilderFactories builderFactories;
+  @override
+  final BuildOptions buildOptions;
+  @override
+  final TestingOverrides testingOverrides;
+  @override
+  final Bootstrapper bootstrapper;
+  @override
+  final BuildPackages buildPackages;
+  @override
+  final BuildConfigs buildConfigs;
+  @override
+  final BuildPhases buildPhases;
+  @override
+  final ReaderWriter readerWriter;
+  @override
+  final bool restartIsNeeded;
+
+  factory _$BuildSpec([void Function(BuildSpecBuilder)? updates]) =>
+      (BuildSpecBuilder()..update(updates))._build();
+
+  _$BuildSpec._({
+    required this.buildPlanDigest,
+    required this.builderFactories,
+    required this.buildOptions,
+    required this.testingOverrides,
+    required this.bootstrapper,
+    required this.buildPackages,
+    required this.buildConfigs,
+    required this.buildPhases,
+    required this.readerWriter,
+    required this.restartIsNeeded,
+  }) : super._();
+  @override
+  BuildSpec rebuild(void Function(BuildSpecBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BuildSpecBuilder toBuilder() => BuildSpecBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BuildSpec &&
+        buildPlanDigest == other.buildPlanDigest &&
+        builderFactories == other.builderFactories &&
+        buildOptions == other.buildOptions &&
+        testingOverrides == other.testingOverrides &&
+        bootstrapper == other.bootstrapper &&
+        buildPackages == other.buildPackages &&
+        buildConfigs == other.buildConfigs &&
+        buildPhases == other.buildPhases &&
+        readerWriter == other.readerWriter &&
+        restartIsNeeded == other.restartIsNeeded;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, buildPlanDigest.hashCode);
+    _$hash = $jc(_$hash, builderFactories.hashCode);
+    _$hash = $jc(_$hash, buildOptions.hashCode);
+    _$hash = $jc(_$hash, testingOverrides.hashCode);
+    _$hash = $jc(_$hash, bootstrapper.hashCode);
+    _$hash = $jc(_$hash, buildPackages.hashCode);
+    _$hash = $jc(_$hash, buildConfigs.hashCode);
+    _$hash = $jc(_$hash, buildPhases.hashCode);
+    _$hash = $jc(_$hash, readerWriter.hashCode);
+    _$hash = $jc(_$hash, restartIsNeeded.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BuildSpec')
+          ..add('buildPlanDigest', buildPlanDigest)
+          ..add('builderFactories', builderFactories)
+          ..add('buildOptions', buildOptions)
+          ..add('testingOverrides', testingOverrides)
+          ..add('bootstrapper', bootstrapper)
+          ..add('buildPackages', buildPackages)
+          ..add('buildConfigs', buildConfigs)
+          ..add('buildPhases', buildPhases)
+          ..add('readerWriter', readerWriter)
+          ..add('restartIsNeeded', restartIsNeeded))
+        .toString();
+  }
+}
+
+class BuildSpecBuilder implements Builder<BuildSpec, BuildSpecBuilder> {
+  _$BuildSpec? _$v;
+
+  BuildSpecDigestBuilder? _buildPlanDigest;
+  BuildSpecDigestBuilder get buildPlanDigest =>
+      _$this._buildPlanDigest ??= BuildSpecDigestBuilder();
+  set buildPlanDigest(BuildSpecDigestBuilder? buildPlanDigest) =>
+      _$this._buildPlanDigest = buildPlanDigest;
+
+  BuilderFactories? _builderFactories;
+  BuilderFactories? get builderFactories => _$this._builderFactories;
+  set builderFactories(BuilderFactories? builderFactories) =>
+      _$this._builderFactories = builderFactories;
+
+  BuildOptions? _buildOptions;
+  BuildOptions? get buildOptions => _$this._buildOptions;
+  set buildOptions(BuildOptions? buildOptions) =>
+      _$this._buildOptions = buildOptions;
+
+  TestingOverrides? _testingOverrides;
+  TestingOverrides? get testingOverrides => _$this._testingOverrides;
+  set testingOverrides(TestingOverrides? testingOverrides) =>
+      _$this._testingOverrides = testingOverrides;
+
+  Bootstrapper? _bootstrapper;
+  Bootstrapper? get bootstrapper => _$this._bootstrapper;
+  set bootstrapper(Bootstrapper? bootstrapper) =>
+      _$this._bootstrapper = bootstrapper;
+
+  BuildPackages? _buildPackages;
+  BuildPackages? get buildPackages => _$this._buildPackages;
+  set buildPackages(BuildPackages? buildPackages) =>
+      _$this._buildPackages = buildPackages;
+
+  BuildConfigs? _buildConfigs;
+  BuildConfigs? get buildConfigs => _$this._buildConfigs;
+  set buildConfigs(BuildConfigs? buildConfigs) =>
+      _$this._buildConfigs = buildConfigs;
+
+  BuildPhases? _buildPhases;
+  BuildPhases? get buildPhases => _$this._buildPhases;
+  set buildPhases(BuildPhases? buildPhases) =>
+      _$this._buildPhases = buildPhases;
+
+  ReaderWriter? _readerWriter;
+  ReaderWriter? get readerWriter => _$this._readerWriter;
+  set readerWriter(ReaderWriter? readerWriter) =>
+      _$this._readerWriter = readerWriter;
+
+  bool? _restartIsNeeded;
+  bool? get restartIsNeeded => _$this._restartIsNeeded;
+  set restartIsNeeded(bool? restartIsNeeded) =>
+      _$this._restartIsNeeded = restartIsNeeded;
+
+  BuildSpecBuilder();
+
+  BuildSpecBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _buildPlanDigest = $v.buildPlanDigest.toBuilder();
+      _builderFactories = $v.builderFactories;
+      _buildOptions = $v.buildOptions;
+      _testingOverrides = $v.testingOverrides;
+      _bootstrapper = $v.bootstrapper;
+      _buildPackages = $v.buildPackages;
+      _buildConfigs = $v.buildConfigs;
+      _buildPhases = $v.buildPhases;
+      _readerWriter = $v.readerWriter;
+      _restartIsNeeded = $v.restartIsNeeded;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BuildSpec other) {
+    _$v = other as _$BuildSpec;
+  }
+
+  @override
+  void update(void Function(BuildSpecBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BuildSpec build() => _build();
+
+  _$BuildSpec _build() {
+    _$BuildSpec _$result;
+    try {
+      _$result =
+          _$v ??
+          _$BuildSpec._(
+            buildPlanDigest: buildPlanDigest.build(),
+            builderFactories: BuiltValueNullFieldError.checkNotNull(
+              builderFactories,
+              r'BuildSpec',
+              'builderFactories',
+            ),
+            buildOptions: BuiltValueNullFieldError.checkNotNull(
+              buildOptions,
+              r'BuildSpec',
+              'buildOptions',
+            ),
+            testingOverrides: BuiltValueNullFieldError.checkNotNull(
+              testingOverrides,
+              r'BuildSpec',
+              'testingOverrides',
+            ),
+            bootstrapper: BuiltValueNullFieldError.checkNotNull(
+              bootstrapper,
+              r'BuildSpec',
+              'bootstrapper',
+            ),
+            buildPackages: BuiltValueNullFieldError.checkNotNull(
+              buildPackages,
+              r'BuildSpec',
+              'buildPackages',
+            ),
+            buildConfigs: BuiltValueNullFieldError.checkNotNull(
+              buildConfigs,
+              r'BuildSpec',
+              'buildConfigs',
+            ),
+            buildPhases: BuiltValueNullFieldError.checkNotNull(
+              buildPhases,
+              r'BuildSpec',
+              'buildPhases',
+            ),
+            readerWriter: BuiltValueNullFieldError.checkNotNull(
+              readerWriter,
+              r'BuildSpec',
+              'readerWriter',
+            ),
+            restartIsNeeded: BuiltValueNullFieldError.checkNotNull(
+              restartIsNeeded,
+              r'BuildSpec',
+              'restartIsNeeded',
+            ),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'buildPlanDigest';
+        buildPlanDigest.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'BuildSpec',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/build_runner/lib/src/build_plan/build_spec_digest.dart
+++ b/build_runner/lib/src/build_plan/build_spec_digest.dart
@@ -13,14 +13,14 @@ import 'build_configs.dart';
 import 'build_packages.dart';
 import 'build_phases.dart';
 
-part 'build_plan_digest.g.dart';
+part 'build_spec_digest.g.dart';
 
 /// The configuration and digests of configuration used to determine whether the
 /// current build is compatible with the previous build.
-abstract class BuildPlanDigest
-    implements Built<BuildPlanDigest, BuildPlanDigestBuilder> {
-  static Serializer<BuildPlanDigest> get serializer =>
-      _$buildPlanDigestSerializer;
+abstract class BuildSpecDigest
+    implements Built<BuildSpecDigest, BuildSpecDigestBuilder> {
+  static Serializer<BuildSpecDigest> get serializer =>
+      _$buildSpecDigestSerializer;
 
   String? get compileDigest;
   String get buildTriggersDigest;
@@ -31,18 +31,18 @@ abstract class BuildPlanDigest
   BuiltList<String> get inBuildPhasesOptionsDigests;
   BuiltList<String> get postBuildActionsOptionsDigests;
 
-  BuildPlanDigest._();
+  BuildSpecDigest._();
 
-  factory BuildPlanDigest.build([
-    void Function(BuildPlanDigestBuilder)? updates,
-  ]) = _$BuildPlanDigest;
+  factory BuildSpecDigest.build([
+    void Function(BuildSpecDigestBuilder)? updates,
+  ]) = _$BuildSpecDigest;
 
-  factory BuildPlanDigest({
+  factory BuildSpecDigest({
     required String? compileDigest,
     required BuildConfigs buildConfigs,
     required BuildPhases buildPhases,
     required BuildPackages buildPackages,
-  }) => BuildPlanDigest.build((b) {
+  }) => BuildSpecDigest.build((b) {
     b.compileDigest = compileDigest;
     b.buildTriggersDigest = buildConfigs.buildTriggers.digest.toString();
     b.buildPhasesDigest = buildPhases.digest.toString();
@@ -64,7 +64,7 @@ abstract class BuildPlanDigest
   /// [other].
   ///
   /// If [other] is `null`, returns `false`.
-  bool canIncrementallyBuildFrom(BuildPlanDigest? other) {
+  bool canIncrementallyBuildFrom(BuildSpecDigest? other) {
     return other != null &&
         compileDigest == other.compileDigest &&
         buildPhasesDigest == other.buildPhasesDigest &&
@@ -73,7 +73,7 @@ abstract class BuildPlanDigest
         packageLanguageVersions == other.packageLanguageVersions;
   }
 
-  bool hasSameTriggersAs(BuildPlanDigest? other) {
+  bool hasSameTriggersAs(BuildSpecDigest? other) {
     return buildTriggersDigest == other?.buildTriggersDigest;
   }
 
@@ -82,7 +82,7 @@ abstract class BuildPlanDigest
   ///
   /// If [other] is `null` or has a different number of phases, all results are
   /// `true`.
-  BuiltList<bool> computeChangedPhaseOptions(BuildPlanDigest? other) {
+  BuiltList<bool> computeChangedPhaseOptions(BuildSpecDigest? other) {
     if (other == null ||
         other.inBuildPhasesOptionsDigests.length !=
             inBuildPhasesOptionsDigests.length) {
@@ -104,7 +104,7 @@ abstract class BuildPlanDigest
   ///
   /// If [other] is `null` or has a different number of post build actions, all
   /// results are`true`.
-  BuiltList<bool> computeChangedPostBuildOptions(BuildPlanDigest? other) {
+  BuiltList<bool> computeChangedPostBuildOptions(BuildSpecDigest? other) {
     if (other == null ||
         postBuildActionsOptionsDigests.length !=
             other.postBuildActionsOptionsDigests.length) {

--- a/build_runner/lib/src/build_plan/build_spec_digest.g.dart
+++ b/build_runner/lib/src/build_plan/build_spec_digest.g.dart
@@ -1,25 +1,25 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'build_plan_digest.dart';
+part of 'build_spec_digest.dart';
 
 // **************************************************************************
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<BuildPlanDigest> _$buildPlanDigestSerializer =
-    _$BuildPlanDigestSerializer();
+Serializer<BuildSpecDigest> _$buildSpecDigestSerializer =
+    _$BuildSpecDigestSerializer();
 
-class _$BuildPlanDigestSerializer
-    implements StructuredSerializer<BuildPlanDigest> {
+class _$BuildSpecDigestSerializer
+    implements StructuredSerializer<BuildSpecDigest> {
   @override
-  final Iterable<Type> types = const [BuildPlanDigest, _$BuildPlanDigest];
+  final Iterable<Type> types = const [BuildSpecDigest, _$BuildSpecDigest];
   @override
-  final String wireName = 'BuildPlanDigest';
+  final String wireName = 'BuildSpecDigest';
 
   @override
   Iterable<Object?> serialize(
     Serializers serializers,
-    BuildPlanDigest object, {
+    BuildSpecDigest object, {
     FullType specifiedType = FullType.unspecified,
   }) {
     final result = <Object?>[
@@ -81,12 +81,12 @@ class _$BuildPlanDigestSerializer
   }
 
   @override
-  BuildPlanDigest deserialize(
+  BuildSpecDigest deserialize(
     Serializers serializers,
     Iterable<Object?> serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    final result = BuildPlanDigestBuilder();
+    final result = BuildSpecDigestBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -177,7 +177,7 @@ class _$BuildPlanDigestSerializer
   }
 }
 
-class _$BuildPlanDigest extends BuildPlanDigest {
+class _$BuildSpecDigest extends BuildSpecDigest {
   @override
   final String? compileDigest;
   @override
@@ -195,10 +195,10 @@ class _$BuildPlanDigest extends BuildPlanDigest {
   @override
   final BuiltList<String> postBuildActionsOptionsDigests;
 
-  factory _$BuildPlanDigest([void Function(BuildPlanDigestBuilder)? updates]) =>
-      (BuildPlanDigestBuilder()..update(updates))._build();
+  factory _$BuildSpecDigest([void Function(BuildSpecDigestBuilder)? updates]) =>
+      (BuildSpecDigestBuilder()..update(updates))._build();
 
-  _$BuildPlanDigest._({
+  _$BuildSpecDigest._({
     this.compileDigest,
     required this.buildTriggersDigest,
     required this.buildPhasesDigest,
@@ -209,16 +209,16 @@ class _$BuildPlanDigest extends BuildPlanDigest {
     required this.postBuildActionsOptionsDigests,
   }) : super._();
   @override
-  BuildPlanDigest rebuild(void Function(BuildPlanDigestBuilder) updates) =>
+  BuildSpecDigest rebuild(void Function(BuildSpecDigestBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  BuildPlanDigestBuilder toBuilder() => BuildPlanDigestBuilder()..replace(this);
+  BuildSpecDigestBuilder toBuilder() => BuildSpecDigestBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is BuildPlanDigest &&
+    return other is BuildSpecDigest &&
         compileDigest == other.compileDigest &&
         buildTriggersDigest == other.buildTriggersDigest &&
         buildPhasesDigest == other.buildPhasesDigest &&
@@ -246,7 +246,7 @@ class _$BuildPlanDigest extends BuildPlanDigest {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'BuildPlanDigest')
+    return (newBuiltValueToStringHelper(r'BuildSpecDigest')
           ..add('compileDigest', compileDigest)
           ..add('buildTriggersDigest', buildTriggersDigest)
           ..add('buildPhasesDigest', buildPhasesDigest)
@@ -262,9 +262,9 @@ class _$BuildPlanDigest extends BuildPlanDigest {
   }
 }
 
-class BuildPlanDigestBuilder
-    implements Builder<BuildPlanDigest, BuildPlanDigestBuilder> {
-  _$BuildPlanDigest? _$v;
+class BuildSpecDigestBuilder
+    implements Builder<BuildSpecDigest, BuildSpecDigestBuilder> {
+  _$BuildSpecDigest? _$v;
 
   String? _compileDigest;
   String? get compileDigest => _$this._compileDigest;
@@ -312,9 +312,9 @@ class BuildPlanDigestBuilder
     ListBuilder<String>? postBuildActionsOptionsDigests,
   ) => _$this._postBuildActionsOptionsDigests = postBuildActionsOptionsDigests;
 
-  BuildPlanDigestBuilder();
+  BuildSpecDigestBuilder();
 
-  BuildPlanDigestBuilder get _$this {
+  BuildSpecDigestBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _compileDigest = $v.compileDigest;
@@ -332,38 +332,38 @@ class BuildPlanDigestBuilder
   }
 
   @override
-  void replace(BuildPlanDigest other) {
-    _$v = other as _$BuildPlanDigest;
+  void replace(BuildSpecDigest other) {
+    _$v = other as _$BuildSpecDigest;
   }
 
   @override
-  void update(void Function(BuildPlanDigestBuilder)? updates) {
+  void update(void Function(BuildSpecDigestBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  BuildPlanDigest build() => _build();
+  BuildSpecDigest build() => _build();
 
-  _$BuildPlanDigest _build() {
-    _$BuildPlanDigest _$result;
+  _$BuildSpecDigest _build() {
+    _$BuildSpecDigest _$result;
     try {
       _$result =
           _$v ??
-          _$BuildPlanDigest._(
+          _$BuildSpecDigest._(
             compileDigest: compileDigest,
             buildTriggersDigest: BuiltValueNullFieldError.checkNotNull(
               buildTriggersDigest,
-              r'BuildPlanDigest',
+              r'BuildSpecDigest',
               'buildTriggersDigest',
             ),
             buildPhasesDigest: BuiltValueNullFieldError.checkNotNull(
               buildPhasesDigest,
-              r'BuildPlanDigest',
+              r'BuildSpecDigest',
               'buildPhasesDigest',
             ),
             dartVersion: BuiltValueNullFieldError.checkNotNull(
               dartVersion,
-              r'BuildPlanDigest',
+              r'BuildSpecDigest',
               'dartVersion',
             ),
             enabledExperiments: enabledExperiments.build(),
@@ -385,7 +385,7 @@ class BuildPlanDigestBuilder
         postBuildActionsOptionsDigests.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(
-          r'BuildPlanDigest',
+          r'BuildSpecDigest',
           _$failedField,
           e.toString(),
         );

--- a/build_runner/lib/src/commands/build_command.dart
+++ b/build_runner/lib/src/commands/build_command.dart
@@ -10,6 +10,7 @@ import '../build/build_result.dart';
 import '../build/build_series.dart';
 import '../build_plan/build_options.dart';
 import '../build_plan/build_plan.dart';
+import '../build_plan/build_spec.dart';
 import '../build_plan/builder_factories.dart';
 import '../build_plan/testing_overrides.dart';
 import '../logging/build_log.dart';
@@ -47,13 +48,14 @@ class BuildCommand implements BuildRunnerCommand {
       b.onLog = testingOverrides.onLog;
     });
 
-    final buildPlan = await BuildPlan.load(
+    final buildSpec = await BuildSpec.load(
       builderFactories: builderFactories,
       buildOptions: buildOptions,
       testingOverrides: testingOverrides,
     );
+    final buildPlan = await BuildPlan.load(buildSpec);
     await buildPlan.deleteFilesAndFolders();
-    if (buildPlan.restartIsNeeded) {
+    if (buildSpec.restartIsNeeded) {
       return BuildResult.buildScriptChanged();
     }
 

--- a/build_runner/lib/src/commands/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/commands/daemon/daemon_builder.dart
@@ -56,7 +56,8 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
   final _buildScriptUpdateCompleter = Completer<void>();
   Future<void> get buildScriptUpdated => _buildScriptUpdateCompleter.future;
 
-  String get _currentPackageName => _buildPlan.buildPackages.currentPackage;
+  String get _currentPackageName =>
+      _buildPlan.buildSpec.buildPackages.currentPackage;
 
   @override
   Future<void> build(
@@ -226,8 +227,8 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
         outputStreamController.add(ServerLog.fromLogRecord(record));
       };
     });
-    buildPlan = buildPlan.copyWith(
-      readerWriter: buildPlan.readerWriter.copyWith(
+    buildPlan = buildPlan.rebuild(
+      (b) => b.readerWriter = buildPlan.readerWriter.copyWith(
         onDelete: expectedDeletes.add,
       ),
     );
@@ -236,10 +237,10 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
 
     // Only actually used for the AutoChangeProvider.
     Stream<List<WatchEvent>> graphEvents() =>
-        BuildPackagesWatcher(buildPlan.buildPackages)
+        BuildPackagesWatcher(buildPlan.buildSpec.buildPackages)
             .watch()
             .debounceBuffer(
-              buildPlan.testingOverrides.debounceDelay ??
+              buildPlan.buildSpec.testingOverrides.debounceDelay ??
                   const Duration(milliseconds: 250),
             )
             .asyncMap(

--- a/build_runner/lib/src/commands/daemon_command.dart
+++ b/build_runner/lib/src/commands/daemon_command.dart
@@ -17,6 +17,7 @@ import '../bootstrap/build_process_state.dart';
 import '../bootstrap/processes.dart';
 import '../build_plan/build_options.dart';
 import '../build_plan/build_plan.dart';
+import '../build_plan/build_spec.dart';
 import '../build_plan/builder_factories.dart';
 import '../build_plan/testing_overrides.dart';
 import '../logging/build_log.dart';
@@ -91,13 +92,14 @@ ${jsonEncode(serializers.serialize(ServerLog.fromLogRecord(record)))}
 $logEndMarker''');
       });
 
-      final buildPlan = await BuildPlan.load(
+      final buildSpec = await BuildSpec.load(
         builderFactories: builderFactories,
         buildOptions: buildOptions,
         testingOverrides: testingOverrides,
       );
+      final buildPlan = await BuildPlan.load(buildSpec);
       await buildPlan.deleteFilesAndFolders();
-      if (buildPlan.restartIsNeeded) {
+      if (buildSpec.restartIsNeeded) {
         return ChildProcess.recompileBuildersExitCode;
       }
 
@@ -120,7 +122,7 @@ $logEndMarker''');
       final server = await AssetServer.run(
         daemonOptions,
         builder,
-        buildPlan.buildPackages.outputRoot,
+        buildPlan.buildSpec.buildPackages.outputRoot,
       );
       File(
         assetServerPortFilePath(workingDirectory),

--- a/build_runner/lib/src/commands/watch/watcher.dart
+++ b/build_runner/lib/src/commands/watch/watcher.dart
@@ -27,12 +27,12 @@ class Watcher {
 
   Watcher._(this._buildPlan, this._buildSeries, this._expectedDeletes);
 
-  BuildPackages get buildPackages => _buildPlan.buildPackages;
+  BuildPackages get buildPackages => _buildPlan.buildSpec.buildPackages;
 
   factory Watcher({required BuildPlan buildPlan, required Future<void> until}) {
     final expectedDeletes = <AssetId>{};
-    buildPlan = buildPlan.copyWith(
-      readerWriter: buildPlan.readerWriter.copyWith(
+    buildPlan = buildPlan.rebuild(
+      (b) => b.readerWriter = buildPlan.readerWriter.copyWith(
         onDelete: expectedDeletes.add,
       ),
     );
@@ -63,10 +63,10 @@ class Watcher {
 
     // Start watching files immediately, before the first build is even started.
     final packagesWatcher = BuildPackagesWatcher(
-      _buildPlan.buildPackages,
+      _buildPlan.buildSpec.buildPackages,
       watch: (buildPackage) => BuildPackageWatcher(
         buildPackage,
-        watch: _buildPlan.testingOverrides.directoryWatcherFactory,
+        watch: _buildPlan.buildSpec.testingOverrides.directoryWatcherFactory,
       ),
     );
     packagesWatcher
@@ -77,7 +77,7 @@ class Watcher {
           return change;
         })
         .debounceBuffer(
-          _buildPlan.testingOverrides.debounceDelay ??
+          _buildPlan.buildSpec.testingOverrides.debounceDelay ??
               const Duration(milliseconds: 250),
         )
         .asyncMap(

--- a/build_runner/lib/src/commands/watch_command.dart
+++ b/build_runner/lib/src/commands/watch_command.dart
@@ -13,6 +13,7 @@ import '../bootstrap/processes.dart';
 import '../build/build_result.dart';
 import '../build_plan/build_options.dart';
 import '../build_plan/build_plan.dart';
+import '../build_plan/build_spec.dart';
 import '../build_plan/builder_factories.dart';
 import '../build_plan/testing_overrides.dart';
 import '../logging/build_log.dart';
@@ -53,13 +54,14 @@ class WatchCommand implements BuildRunnerCommand {
       b.onLog = testingOverrides.onLog;
     });
 
-    final buildPlan = await BuildPlan.load(
+    final buildSpec = await BuildSpec.load(
       builderFactories: builderFactories,
       buildOptions: buildOptions,
       testingOverrides: testingOverrides,
     );
+    final buildPlan = await BuildPlan.load(buildSpec);
     await buildPlan.deleteFilesAndFolders();
-    if (buildPlan.restartIsNeeded) return null;
+    if (buildSpec.restartIsNeeded) return null;
 
     final terminator = Terminator(testingOverrides.terminateEventStream);
 

--- a/build_runner/lib/src/internal.dart
+++ b/build_runner/lib/src/internal.dart
@@ -17,6 +17,7 @@ export 'build_plan/build_package.dart';
 export 'build_plan/build_packages.dart';
 export 'build_plan/build_phases.dart';
 export 'build_plan/build_plan.dart';
+export 'build_plan/build_spec.dart';
 export 'build_plan/builder_definition.dart';
 export 'build_plan/builder_factories.dart';
 export 'build_plan/testing_overrides.dart';

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -182,7 +182,9 @@ class BuildOutputReader {
     // an output package of the build.
     if (!id.path.startsWith('lib/')) {
       if (rootDir != null && !p.isWithin(rootDir, id.path)) return true;
-      if (!_buildPlan.buildPackages.outputPackages.contains(id.package)) {
+      if (!_buildPlan.buildSpec.buildPackages.outputPackages.contains(
+        id.package,
+      )) {
         return true;
       }
     }

--- a/build_runner/test/build/build_state/asset_graph_json_test.dart
+++ b/build_runner/test/build/build_state/asset_graph_json_test.dart
@@ -6,7 +6,7 @@ import 'dart:convert';
 import 'package:build_runner/src/build/build_state/asset_graph_json.dart';
 import 'package:build_runner/src/build/build_state/build_state.dart';
 import 'package:build_runner/src/build/library_cycle_graph/phased_asset_deps.dart';
-import 'package:build_runner/src/build_plan/build_plan_digest.dart';
+import 'package:build_runner/src/build_plan/build_spec_digest.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -14,7 +14,7 @@ void main() {
     test('deserialize returns null on version mismatch', () async {
       final validBytes = AssetGraphJson.serialize(
         buildState: BuildState(),
-        buildPlanDigest: BuildPlanDigest.build((b) {
+        buildPlanDigest: BuildSpecDigest.build((b) {
           b.compileDigest = '';
           b.buildTriggersDigest = '';
           b.buildPhasesDigest = '';
@@ -37,7 +37,7 @@ void main() {
     test('deserialize returns null on invalid json', () async {
       final validBytes = AssetGraphJson.serialize(
         buildState: BuildState(),
-        buildPlanDigest: BuildPlanDigest.build((b) {
+        buildPlanDigest: BuildSpecDigest.build((b) {
           b.compileDigest = '';
           b.buildTriggersDigest = '';
           b.buildPhasesDigest = '';

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -15,6 +15,7 @@ import 'package:build_runner/src/build_plan/build_options.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_plan.dart';
+import 'package:build_runner/src/build_plan/build_spec.dart';
 import 'package:build_runner/src/build_plan/builder_definition.dart';
 import 'package:build_runner/src/build_plan/builder_factories.dart';
 import 'package:build_runner/src/build_plan/testing_overrides.dart';
@@ -40,6 +41,16 @@ void main() {
     late TestingOverrides testingOverrides;
     late BuildPlan buildPlan;
 
+    Future<BuildPlan> loadPlan([TestingOverrides? overrides]) async {
+      return BuildPlan.load(
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: overrides ?? testingOverrides,
+        ),
+      );
+    }
+
     setUp(() async {
       buildPackages = BuildPackages.singlePackageBuild('a', [
         BuildPackage.forTesting(name: 'a', watch: true, isOutput: true),
@@ -58,11 +69,7 @@ void main() {
         buildPackages: buildPackages,
         checkBuilderFreshness: false,
       );
-      buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides,
-      );
+      buildPlan = await loadPlan();
     });
 
     test('loads with no previous build state', () async {
@@ -76,7 +83,7 @@ void main() {
       await readerWriter.writeAsBytes(
         assetGraphJsonId,
         AssetGraphJson.serialize(
-          buildPlanDigest: buildPlan.buildPlanDigest,
+          buildPlanDigest: buildPlan.buildSpec.buildPlanDigest,
           buildState: buildState,
           phasedAssetDeps: PhasedAssetDeps(),
         ),
@@ -86,11 +93,7 @@ void main() {
     test('loads previous build state', () async {
       final buildState = buildPlan.previousBuildState ?? BuildState();
       await writeBuildStateAndPlan(buildState, buildPlan);
-      buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides,
-      );
+      buildPlan = await loadPlan();
       final loadedState = buildPlan.previousBuildState;
 
       expect(loadedState.toString(), buildState.toString());
@@ -98,15 +101,17 @@ void main() {
 
     test('requires restart if a factory is missing', () async {
       final buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides.copyWith(
-          builderDefinitions: [BuilderDefinition('missing')].build(),
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: testingOverrides.copyWith(
+            builderDefinitions: [BuilderDefinition('missing')].build(),
+          ),
         ),
       );
 
       expect(buildPlan.buildStepPlan.buildPhases.inBuildPhases.isEmpty, true);
-      expect(buildPlan.restartIsNeeded, true);
+      expect(buildPlan.buildSpec.restartIsNeeded, true);
     });
 
     test('discards previous build state if build phases changed', () async {
@@ -114,14 +119,16 @@ void main() {
       await writeBuildStateAndPlan(buildState, buildPlan);
 
       buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides.copyWith(
-          builderDefinitions: [
-            BuilderDefinition(''),
-            // Apply a second builder so build phases change.
-            BuilderDefinition('b2'),
-          ].build(),
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: testingOverrides.copyWith(
+            builderDefinitions: [
+              BuilderDefinition(''),
+              // Apply a second builder so build phases change.
+              BuilderDefinition('b2'),
+            ].build(),
+          ),
         ),
       );
 
@@ -137,18 +144,20 @@ void main() {
 
     test('tracks lost outputs if build phases changed', () async {
       var buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides.copyWith(
-          builderDefinitions: [
-            BuilderDefinition(
-              '',
-              // Hidden output is easy to find and delete, it's under one
-              // generated root. Unhide the output so there can be lost
-              // outputs.
-              hideOutput: false,
-            ),
-          ].build(),
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: testingOverrides.copyWith(
+            builderDefinitions: [
+              BuilderDefinition(
+                '',
+                // Hidden output is easy to find and delete, it's under one
+                // generated root. Unhide the output so there can be lost
+                // outputs.
+                hideOutput: false,
+              ),
+            ].build(),
+          ),
         ),
       );
       final buildState = buildPlan.previousBuildState ?? BuildState();
@@ -166,14 +175,16 @@ void main() {
       await writeBuildStateAndPlan(buildState, buildPlan);
 
       buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides.copyWith(
-          builderDefinitions: [
-            BuilderDefinition(''),
-            // Apply a second builder so build phases change.
-            BuilderDefinition('b2'),
-          ].build(),
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: testingOverrides.copyWith(
+            builderDefinitions: [
+              BuilderDefinition(''),
+              // Apply a second builder so build phases change.
+              BuilderDefinition('b2'),
+            ].build(),
+          ),
         ),
       );
 
@@ -192,13 +203,15 @@ void main() {
       await writeBuildStateAndPlan(buildState, buildPlan);
 
       buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides.copyWith(
-          builderDefinitions: [
-            BuilderDefinition(''),
-            BuilderDefinition('b2'),
-          ].build(),
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: testingOverrides.copyWith(
+            builderDefinitions: [
+              BuilderDefinition(''),
+              BuilderDefinition('b2'),
+            ].build(),
+          ),
         ),
       );
 
@@ -216,9 +229,11 @@ void main() {
         buildPackages: buildPackages2,
       );
       buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides2,
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: testingOverrides2,
+        ),
       );
 
       expect(buildPlan.previousBuildState, null);
@@ -231,10 +246,12 @@ void main() {
         await writeBuildStateAndPlan(buildState, buildPlan);
 
         buildPlan = await withEnabledExperiments(
-          () => BuildPlan.load(
-            builderFactories: builderFactories,
-            buildOptions: buildOptions,
-            testingOverrides: testingOverrides,
+          () async => BuildPlan.load(
+            await BuildSpec.load(
+              builderFactories: builderFactories,
+              buildOptions: buildOptions,
+              testingOverrides: testingOverrides,
+            ),
           ),
           ['an_experiment'],
         );
@@ -273,11 +290,7 @@ void main() {
       // Remove generated.
       await readerWriter.delete(outputId);
 
-      buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides,
-      );
+      buildPlan = await loadPlan();
 
       expect(
         {
@@ -306,10 +319,12 @@ void main() {
         [],
       );
       final buildPlan1 = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides.copyWith(
-          buildConfig: {'a': buildConfig1}.build(),
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: testingOverrides.copyWith(
+            buildConfig: {'a': buildConfig1}.build(),
+          ),
         ),
       );
       // Matches the only `*.dart` source.
@@ -331,10 +346,12 @@ void main() {
         [],
       );
       final buildPlan2 = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides.copyWith(
-          buildConfig: {'a': buildConfig2}.build(),
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: testingOverrides.copyWith(
+            buildConfig: {'a': buildConfig2}.build(),
+          ),
         ),
       );
       // Matches the only `*.other` source.
@@ -342,11 +359,7 @@ void main() {
     });
 
     test('tracks cleanBuild when build_plan.json does not exist', () async {
-      final plan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides,
-      );
+      final plan = await loadPlan();
       expect(plan.previousBuildState, isNull);
     });
 
@@ -357,11 +370,7 @@ void main() {
           buildPlan.previousBuildState ?? BuildState(),
           buildPlan,
         );
-        buildPlan = await BuildPlan.load(
-          builderFactories: builderFactories,
-          buildOptions: buildOptions,
-          testingOverrides: testingOverrides,
-        );
+        buildPlan = await loadPlan();
         expect(buildPlan.previousBuildState, isNotNull);
       },
     );
@@ -369,30 +378,22 @@ void main() {
     test(
       'tracks cleanBuild when build_plan.json compileDigest is stale',
       () async {
-        buildPlan = buildPlan.copyWith(
-          buildPlanDigest: buildPlan.buildPlanDigest.rebuild(
-            (b) => b.compileDigest = 'stale_digest',
-          ),
+        buildPlan = buildPlan.rebuild(
+          (b) => b.buildSpec.buildPlanDigest.compileDigest = 'stale_digest',
         );
         await writeBuildStateAndPlan(
           buildPlan.previousBuildState ?? BuildState(),
           buildPlan,
         );
 
-        buildPlan = await BuildPlan.load(
-          builderFactories: builderFactories,
-          buildOptions: buildOptions,
-          testingOverrides: testingOverrides,
-        );
+        buildPlan = await loadPlan();
         expect(buildPlan.previousBuildState, isNull);
       },
     );
 
     test('tracks triggersChanged when triggers change', () async {
-      buildPlan = buildPlan.copyWith(
-        buildPlanDigest: buildPlan.buildPlanDigest.rebuild(
-          (b) => b.buildTriggersDigest = 'triggers_1',
-        ),
+      buildPlan = buildPlan.rebuild(
+        (b) => b.buildSpec.buildPlanDigest.buildTriggersDigest = 'triggers_1',
       );
       await writeBuildStateAndPlan(
         buildPlan.previousBuildState ?? BuildState(),
@@ -419,10 +420,12 @@ void main() {
       );
 
       final buildPlan2 = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides.copyWith(
-          buildConfig: {'a': buildConfig2}.build(),
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: testingOverrides.copyWith(
+            buildConfig: {'a': buildConfig2}.build(),
+          ),
         ),
       );
       expect(buildPlan2.previousBuildState, isNotNull);
@@ -430,10 +433,9 @@ void main() {
     });
 
     test('tracks phaseOptionsChanged when builder options change', () async {
-      buildPlan = buildPlan.copyWith(
-        buildPlanDigest: buildPlan.buildPlanDigest.rebuild(
-          (b) => b.inBuildPhasesOptionsDigests[0] = 'dummy_digest_1',
-        ),
+      buildPlan = buildPlan.rebuild(
+        (b) => b.buildSpec.buildPlanDigest.inBuildPhasesOptionsDigests[0] =
+            'dummy_digest_1',
       );
       await writeBuildStateAndPlan(
         buildPlan.previousBuildState ?? BuildState(),
@@ -460,10 +462,12 @@ void main() {
       );
 
       final buildPlan2 = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides.copyWith(
-          buildConfig: {'a': buildConfig2}.build(),
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: testingOverrides.copyWith(
+            buildConfig: {'a': buildConfig2}.build(),
+          ),
         ),
       );
       expect(buildPlan2.previousBuildState, isNotNull);
@@ -471,47 +475,35 @@ void main() {
     });
 
     test('tracks buildPhasesDigest when build phases change', () async {
-      buildPlan = buildPlan.copyWith(
-        buildPlanDigest: buildPlan.buildPlanDigest.rebuild(
-          (b) => b.buildPhasesDigest = 'stale_digest',
-        ),
+      buildPlan = buildPlan.rebuild(
+        (b) => b.buildSpec.buildPlanDigest.buildPhasesDigest = 'stale_digest',
       );
       await writeBuildStateAndPlan(
         buildPlan.previousBuildState ?? BuildState(),
         buildPlan,
       );
 
-      buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides,
-      );
+      buildPlan = await loadPlan();
       expect(buildPlan.previousBuildState, isNull);
     });
 
     test('tracks dartVersion when SDK version changes', () async {
-      buildPlan = buildPlan.copyWith(
-        buildPlanDigest: buildPlan.buildPlanDigest.rebuild(
-          (b) => b.dartVersion = 'stale_version',
-        ),
+      buildPlan = buildPlan.rebuild(
+        (b) => b.buildSpec.buildPlanDigest.dartVersion = 'stale_version',
       );
       await writeBuildStateAndPlan(
         buildPlan.previousBuildState ?? BuildState(),
         buildPlan,
       );
 
-      buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides,
-      );
+      buildPlan = await loadPlan();
       expect(buildPlan.previousBuildState, isNull);
     });
 
     test('tracks enabledExperiments when experiments change', () async {
-      buildPlan = buildPlan.copyWith(
-        buildPlanDigest: buildPlan.buildPlanDigest.rebuild(
-          (b) => b.enabledExperiments.add('stale_experiment'),
+      buildPlan = buildPlan.rebuild(
+        (b) => b.buildSpec.buildPlanDigest.enabledExperiments.add(
+          'stale_experiment',
         ),
       );
       await writeBuildStateAndPlan(
@@ -519,32 +511,23 @@ void main() {
         buildPlan,
       );
 
-      buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides,
-      );
+      buildPlan = await loadPlan();
       expect(buildPlan.previousBuildState, isNull);
     });
 
     test(
       'tracks packageLanguageVersions when package language versions change',
       () async {
-        buildPlan = buildPlan.copyWith(
-          buildPlanDigest: buildPlan.buildPlanDigest.rebuild(
-            (b) => b.packageLanguageVersions['a'] = '1.0',
-          ),
+        buildPlan = buildPlan.rebuild(
+          (b) =>
+              b.buildSpec.buildPlanDigest.packageLanguageVersions['a'] = '1.0',
         );
         await writeBuildStateAndPlan(
           buildPlan.previousBuildState ?? BuildState(),
           buildPlan,
         );
 
-        buildPlan = await BuildPlan.load(
-          builderFactories: builderFactories,
-          buildOptions: buildOptions,
-          testingOverrides: testingOverrides,
-        );
+        buildPlan = await loadPlan();
         expect(buildPlan.previousBuildState, isNull);
       },
     );
@@ -567,11 +550,7 @@ void main() {
         json.encode(decodedMap),
       );
 
-      buildPlan = await BuildPlan.load(
-        builderFactories: builderFactories,
-        buildOptions: buildOptions,
-        testingOverrides: testingOverrides,
-      );
+      buildPlan = await loadPlan();
       expect(buildPlan.previousBuildState, isNull);
     });
   });

--- a/build_runner/test/build_plan/sdk_version_match_test.dart
+++ b/build_runner/test/build_plan/sdk_version_match_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:build_runner/src/build_plan/build_plan_digest.dart';
+import 'package:build_runner/src/build_plan/build_spec_digest.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -132,17 +132,19 @@ Future<TestBuildersResult> testPhases(
   });
 
   final buildPlan = await BuildPlan.load(
-    builderFactories: builderFactories,
-    // ignore: invalid_use_of_visible_for_testing_member
-    buildOptions: BuildOptions.forTests(
-      buildDirs: buildDirs.build(),
-      buildFilters: buildFilters.build(),
-      verbose: verbose,
-    ),
-    testingOverrides: TestingOverrides(
-      builderDefinitions: builders.build(),
-      buildPackages: buildPackages,
-      readerWriter: readerWriter,
+    await BuildSpec.load(
+      builderFactories: builderFactories,
+      // ignore: invalid_use_of_visible_for_testing_member
+      buildOptions: BuildOptions.forTests(
+        buildDirs: buildDirs.build(),
+        buildFilters: buildFilters.build(),
+        verbose: verbose,
+      ),
+      testingOverrides: TestingOverrides(
+        builderDefinitions: builders.build(),
+        buildPackages: buildPackages,
+        readerWriter: readerWriter,
+      ),
     ),
   );
   await buildPlan.deleteFilesAndFolders();

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -18,6 +18,7 @@ import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
 import 'package:build_runner/src/build_plan/build_plan.dart';
+import 'package:build_runner/src/build_plan/build_spec.dart';
 import 'package:build_runner/src/build_plan/builder_factories.dart';
 import 'package:build_runner/src/build_plan/phase.dart';
 import 'package:build_runner/src/build_plan/testing_overrides.dart';
@@ -65,12 +66,14 @@ void main() {
       readerWriter.testing.writeString(deletedId, '');
 
       final buildPlan = await BuildPlan.load(
-        builderFactories: BuilderFactories({}),
-        buildOptions: BuildOptions.forTests(),
-        testingOverrides: TestingOverrides(
-          buildPhases: buildPhases,
-          readerWriter: readerWriter,
-          buildPackages: buildPackages,
+        await BuildSpec.load(
+          builderFactories: BuilderFactories({}),
+          buildOptions: BuildOptions.forTests(),
+          testingOverrides: TestingOverrides(
+            buildPhases: buildPhases,
+            readerWriter: readerWriter,
+            buildPackages: buildPackages,
+          ),
         ),
       );
       reader = BuildOutputReader(buildPlan: buildPlan, buildState: buildState);
@@ -104,14 +107,16 @@ void main() {
       ]);
 
       var buildPlan = await BuildPlan.load(
-        builderFactories: BuilderFactories({}),
-        buildOptions: BuildOptions.forTests(
-          buildDirs: {BuildDirectory('web')}.build(),
-        ),
-        testingOverrides: TestingOverrides(
-          buildPhases: buildPhases,
-          readerWriter: readerWriter,
-          buildPackages: buildPackages,
+        await BuildSpec.load(
+          builderFactories: BuilderFactories({}),
+          buildOptions: BuildOptions.forTests(
+            buildDirs: {BuildDirectory('web')}.build(),
+          ),
+          testingOverrides: TestingOverrides(
+            buildPhases: buildPhases,
+            readerWriter: readerWriter,
+            buildPackages: buildPackages,
+          ),
         ),
       );
       reader = BuildOutputReader(buildPlan: buildPlan, buildState: buildState);
@@ -122,15 +127,17 @@ void main() {
       );
 
       buildPlan = await BuildPlan.load(
-        builderFactories: BuilderFactories({}),
-        buildOptions: BuildOptions.forTests(
-          buildDirs: {BuildDirectory('web')}.build(),
-          buildFilters: {BuildFilter(Glob('b'), Glob('foo'))}.build(),
-        ),
-        testingOverrides: TestingOverrides(
-          buildPhases: buildPhases,
-          readerWriter: readerWriter,
-          buildPackages: buildPackages,
+        await BuildSpec.load(
+          builderFactories: BuilderFactories({}),
+          buildOptions: BuildOptions.forTests(
+            buildDirs: {BuildDirectory('web')}.build(),
+            buildFilters: {BuildFilter(Glob('b'), Glob('foo'))}.build(),
+          ),
+          testingOverrides: TestingOverrides(
+            buildPhases: buildPhases,
+            readerWriter: readerWriter,
+            buildPackages: buildPackages,
+          ),
         ),
       );
 

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -17,6 +17,7 @@ import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
 import 'package:build_runner/src/build_plan/build_plan.dart';
+import 'package:build_runner/src/build_plan/build_spec.dart';
 import 'package:build_runner/src/build_plan/builder_factories.dart';
 import 'package:build_runner/src/build_plan/phase.dart';
 import 'package:build_runner/src/build_plan/testing_overrides.dart';
@@ -90,16 +91,18 @@ void main() {
         readerWriter.testing.writeString(source.key, source.value);
       }
       buildPlan = await BuildPlan.load(
-        builderFactories: BuilderFactories({}),
-        buildOptions: BuildOptions.forTests(),
-        testingOverrides: TestingOverrides(
-          buildPhases: phases,
-          defaultRootPackageSources: [
-            ...defaultInBuildPackageSources,
-            'foo/**',
-          ].build(),
-          readerWriter: readerWriter,
-          buildPackages: buildPackages,
+        await BuildSpec.load(
+          builderFactories: BuilderFactories({}),
+          buildOptions: BuildOptions.forTests(),
+          testingOverrides: TestingOverrides(
+            buildPhases: phases,
+            defaultRootPackageSources: [
+              ...defaultInBuildPackageSources,
+              'foo/**',
+            ].build(),
+            readerWriter: readerWriter,
+            buildPackages: buildPackages,
+          ),
         ),
       );
       buildState = BuildState(buildPlan.buildInputs.sources.toSet());
@@ -377,8 +380,8 @@ void main() {
 
     test('doesnt always write files not matching outputDirs', () async {
       buildOutputReader = BuildOutputReader(
-        buildPlan: buildPlan.copyWith(
-          buildDirs: {BuildDirectory('foo')}.build(),
+        buildPlan: buildPlan.rebuild(
+          (b) => b.buildDirs.replace({BuildDirectory('foo')}),
         ),
         buildState: buildState,
       );

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -486,12 +486,14 @@ Future<TestBuilderResult> testBuilderFactories(
   );
 
   final buildPlan = await BuildPlan.load(
-    builderFactories: BuilderFactories(
-      builderNameToBuilderFactory,
-      postProcessBuilderFactories: postProcessBuilderNameToBuilderFactory,
+    await BuildSpec.load(
+      builderFactories: BuilderFactories(
+        builderNameToBuilderFactory,
+        postProcessBuilderFactories: postProcessBuilderNameToBuilderFactory,
+      ),
+      buildOptions: BuildOptions.forTests(verbose: verbose),
+      testingOverrides: testingOverrides,
     ),
-    buildOptions: BuildOptions.forTests(verbose: verbose),
-    testingOverrides: testingOverrides,
   );
   await buildPlan.deleteFilesAndFolders();
 


### PR DESCRIPTION
Start to make lifecycles clearer: split out `BuildPlan` fields with the longest lifecycle into a new class `BuildSpec`.

 - `BuildPlanDigest` -> `BuildSpecDigest`
 - Add explicit buildDirs and buildFilters fields to `BuildPlan`, they are overrides of the ones in `BuildOptions`; this allows `BuildOptions` to be fixed in `BuildSpec`
 - Convert `BuildPlan` and `BuildSpec` to built_value classes so we don't have to maintain constructor and copyWith 