### PR TITLE
Require Dart 3.8.0, reformat.

### DIFF
--- a/_benchmark/lib/benchmarks/built_value_generator_benchmark.dart
+++ b/_benchmark/lib/benchmarks/built_value_generator_benchmark.dart
@@ -20,7 +20,8 @@ class BuiltValueGeneratorBenchmark implements Benchmark {
     // TODO(davidmorgan): add a way to pick `build` and generator versions.
     workspace.write(
       'pubspec.yaml',
-      source: '''
+      source:
+          '''
 name: ${workspace.name}
 publish_to: none
 
@@ -62,7 +63,8 @@ ${config.dependencyOverrides}
       if (config.config.mostlyNoCodegen && libraryNumber > 1) {
         workspace.write(
           'lib/$libraryName',
-          source: '''
+          source:
+              '''
 // ignore_for_file: unused_import
 ${[for (final importName in importNames) "import '$importName';"].join('\n')}
 
@@ -72,7 +74,8 @@ class Value {}
       } else {
         workspace.write(
           'lib/$libraryName',
-          source: '''
+          source:
+              '''
 // ignore_for_file: unused_import
 import 'package:built_value/built_value.dart';
 

--- a/_benchmark/lib/benchmarks/combined_generator_benchmark.dart
+++ b/_benchmark/lib/benchmarks/combined_generator_benchmark.dart
@@ -17,7 +17,8 @@ class CombinedGeneratorBenchmark implements Benchmark {
 
     workspace.write(
       'pubspec.yaml',
-      source: '''
+      source:
+          '''
 name: ${workspace.name}
 publish_to: none
 
@@ -68,7 +69,8 @@ ${config.dependencyOverrides}
       // service.
       workspace.write(
         'lib/$libraryName',
-        source: '''
+        source:
+            '''
 // ignore_for_file: unused_import
 import 'package:built_value/built_value.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -104,7 +106,8 @@ class Service$libraryNumber {
       final mockName = testName.replaceAll('.dart', '.mocks.dart');
       workspace.write(
         'test/$testName',
-        source: '''
+        source:
+            '''
 // ignore_for_file: unused_import
 import 'package:mockito/annotations.dart';
 import 'package:${workspace.name}/$libraryName';

--- a/_benchmark/lib/benchmarks/freezed_generator_benchmark.dart
+++ b/_benchmark/lib/benchmarks/freezed_generator_benchmark.dart
@@ -20,7 +20,8 @@ class FreezedGeneratorBenchmark implements Benchmark {
     // TODO(davidmorgan): add a way to pick `build` and generator versions.
     workspace.write(
       'pubspec.yaml',
-      source: '''
+      source:
+          '''
 name: ${workspace.name}
 publish_to: none
 
@@ -66,7 +67,8 @@ ${config.dependencyOverrides}
       if (config.config.mostlyNoCodegen && libraryNumber > 1) {
         workspace.write(
           'lib/$libraryName',
-          source: '''
+          source:
+              '''
 // ignore_for_file: unused_import
 ${[for (final importName in importNames) "import '$importName';"].join('\n')}
 
@@ -76,7 +78,8 @@ class Value {}
       } else {
         workspace.write(
           'lib/$libraryName',
-          source: '''
+          source:
+              '''
 // ignore_for_file: unused_import
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/_benchmark/lib/benchmarks/json_serializable_generator_benchmark.dart
+++ b/_benchmark/lib/benchmarks/json_serializable_generator_benchmark.dart
@@ -21,7 +21,8 @@ class JsonSerializableGeneratorBenchmark implements Benchmark {
     // TODO(davidmorgan): add a way to pick `build` and generator versions.
     workspace.write(
       'pubspec.yaml',
-      source: '''
+      source:
+          '''
 name: ${workspace.name}
 publish_to: none
 
@@ -63,7 +64,8 @@ ${config.dependencyOverrides}
       if (config.config.mostlyNoCodegen && libraryNumber > 1) {
         workspace.write(
           'lib/$libraryName',
-          source: '''
+          source:
+              '''
 // ignore_for_file: unused_import
 ${[for (final importName in importNames) "import '$importName';"].join('\n')}
 
@@ -73,7 +75,8 @@ class Value {}
       } else {
         workspace.write(
           'lib/$libraryName',
-          source: '''
+          source:
+              '''
 // ignore_for_file: unused_import
 import 'package:json_annotation/json_annotation.dart';
 

--- a/_benchmark/lib/benchmarks/mockito_generator_benchmark.dart
+++ b/_benchmark/lib/benchmarks/mockito_generator_benchmark.dart
@@ -28,7 +28,8 @@ class MockitoGeneratorBenchmark implements Benchmark {
     // TODO(davidmorgan): add a way to pick `build` and generator versions.
     workspace.write(
       'pubspec.yaml',
-      source: '''
+      source:
+          '''
 name: ${workspace.name}
 publish_to: none
 
@@ -90,7 +91,8 @@ ${config.dependencyOverrides}
       );
       workspace.write(
         'lib/$libraryName',
-        source: '''
+        source:
+            '''
 // ignore_for_file: unused_import
 ${[for (final importName in importNames) "import '$importName';"].join('\n')}
 

--- a/_benchmark/lib/config.dart
+++ b/_benchmark/lib/config.dart
@@ -45,14 +45,12 @@ class Config {
       (e) => e.packageName == argResults['generator'],
     ),
     rootDirectory: Directory(argResults['root-directory'] as String),
-    sizes:
-        argResults['size'] == null
-            ? [1, 100, 250, 500, 750, 1000]
-            : [int.parse(argResults['size'] as String)],
-    shapes:
-        argResults['shape'] == null
-            ? Shape.values
-            : [Shape.values.singleWhere((e) => e.name == argResults['shape'])],
+    sizes: argResults['size'] == null
+        ? [1, 100, 250, 500, 750, 1000]
+        : [int.parse(argResults['size'] as String)],
+    shapes: argResults['shape'] == null
+        ? Shape.values
+        : [Shape.values.singleWhere((e) => e.name == argResults['shape'])],
     mostlyNoCodegen: argResults['mostly-no-codegen'] as bool,
     web: argResults['web'] as bool,
   );

--- a/_benchmark/lib/workspace.dart
+++ b/_benchmark/lib/workspace.dart
@@ -32,7 +32,8 @@ class Workspace {
   void writeWebEntrypoint() {
     write(
       'web/index.html',
-      source: '''
+      source:
+          '''
 <!DOCTYPE html>
 <html><head>
     <meta charset="utf-8">
@@ -45,7 +46,8 @@ class Workspace {
     );
     write(
       'web/main.dart',
-      source: '''
+      source:
+          '''
 /// ignore_for_file: unused_import
 import 'package:$name/app.dart';
 void main() {

--- a/_benchmark/pubspec.yaml
+++ b/_benchmark/pubspec.yaml
@@ -1,7 +1,7 @@
 name: _benchmark
 publish_to: none
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 resolution: workspace
 
 dependencies:

--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Replace `Builder` extension method `hasOutputFor` with `matchesInput`.
   Deprecate `hasOutputFor`. The new `matchesInput` is identical, but now that
   zero-output builders are supported the old name is misleading.
+- Require Dart 3.8.0.
 
 ## 4.0.6
 

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 
 dependencies:
   analyzer: '>=8.0.0 <14.0.0'

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.3.1-wip
 
 - Document that `--define` values are parsed as JSON with a fallback.
+- Require Dart 3.8.0.
 
 ## 1.3.0
 

--- a/build_config/lib/src/build_config.dart
+++ b/build_config/lib/src/build_config.dart
@@ -94,10 +94,9 @@ class BuildConfig {
       () {
         final key = '$packageName:$packageName';
         final target = BuildTarget(
-          dependencies:
-              dependencies
-                  .map((dep) => normalizeTargetKeyUsage(dep, packageName))
-                  .toList(),
+          dependencies: dependencies
+              .map((dep) => normalizeTargetKeyUsage(dep, packageName))
+              .toList(),
           sources: InputSet.anything,
         );
         return BuildConfig(
@@ -158,12 +157,12 @@ class BuildConfig {
     this.triggersByBuilder = const {},
   }) : buildTargets =
            identical(buildTargets, BuildConfig._placeholderBuildTarget)
-               ? {
-                 _defaultTarget(packageName ?? currentPackage): BuildTarget(
-                   dependencies: currentPackageDefaultDependencies,
-                 ),
-               }
-               : buildTargets,
+           ? {
+               _defaultTarget(packageName ?? currentPackage): BuildTarget(
+                 dependencies: currentPackageDefaultDependencies,
+               ),
+             }
+           : buildTargets,
        globalOptions = (globalOptions ?? const {}).map(
          (key, config) =>
              MapEntry(normalizeBuilderKeyUsage(key, currentPackage), config),

--- a/build_config/lib/src/build_target.dart
+++ b/build_config/lib/src/build_target.dart
@@ -38,10 +38,9 @@ class BuildTarget {
     Iterable<String>? dependencies,
     Map<String, TargetBuilderConfig>? builders,
   }) : autoApplyBuilders = autoApplyBuilders ?? true,
-       dependencies =
-           (dependencies ?? currentPackageDefaultDependencies)
-               .map((d) => normalizeTargetKeyUsage(d, currentPackage))
-               .toList(),
+       dependencies = (dependencies ?? currentPackageDefaultDependencies)
+           .map((d) => normalizeTargetKeyUsage(d, currentPackage))
+           .toList(),
        builders = (builders ?? const {}).map(
          (key, config) =>
              MapEntry(normalizeBuilderKeyUsage(key, currentPackage), config),
@@ -54,14 +53,13 @@ class BuildTarget {
   }
 
   @override
-  String toString() =>
-      {
-        'package': package,
-        'sources': sources,
-        'dependencies': dependencies,
-        'builders': builders,
-        'autoApplyBuilders': autoApplyBuilders,
-      }.toString();
+  String toString() => {
+    'package': package,
+    'sources': sources,
+    'dependencies': dependencies,
+    'builders': builders,
+    'autoApplyBuilders': autoApplyBuilders,
+  }.toString();
 }
 
 /// The configuration a particular [BuildTarget] applies to a Builder.
@@ -119,14 +117,13 @@ class TargetBuilderConfig {
   }
 
   @override
-  String toString() =>
-      {
-        'isEnabled': isEnabled,
-        'generateFor': generateFor,
-        'options': options,
-        'devOptions': devOptions,
-        'releaseOptions': releaseOptions,
-      }.toString();
+  String toString() => {
+    'isEnabled': isEnabled,
+    'generateFor': generateFor,
+    'options': options,
+    'devOptions': devOptions,
+    'releaseOptions': releaseOptions,
+  }.toString();
 }
 
 /// The configuration for a Builder applied globally.
@@ -179,11 +176,10 @@ class GlobalBuilderConfig {
   }
 
   @override
-  String toString() =>
-      {
-        'options': options,
-        'devOptions': devOptions,
-        'releaseOptions': releaseOptions,
-        'runsBefore': runsBefore,
-      }.toString();
+  String toString() => {
+    'options': options,
+    'devOptions': devOptions,
+    'releaseOptions': releaseOptions,
+    'runsBefore': runsBefore,
+  }.toString();
 }

--- a/build_config/lib/src/builder_definition.dart
+++ b/build_config/lib/src/builder_definition.dart
@@ -94,10 +94,9 @@ class BuilderDefinition {
     BuildTo? buildTo,
     TargetBuilderConfigDefaults? defaults,
   }) : // ignore: deprecated_member_use
-       target =
-           target != null
-               ? normalizeTargetKeyUsage(target, currentPackage)
-               : null,
+       target = target != null
+           ? normalizeTargetKeyUsage(target, currentPackage)
+           : null,
        autoApply = autoApply ?? AutoApply.none,
        requiredInputs = requiredInputs?.toList() ?? const [],
        runsBefore =
@@ -140,18 +139,17 @@ class BuilderDefinition {
   }
 
   @override
-  String toString() =>
-      {
-        'autoApply': autoApply,
-        'import': import,
-        'builderFactories': builderFactories,
-        'buildExtensions': buildExtensions,
-        'requiredInputs': requiredInputs,
-        'runsBefore': runsBefore,
-        'isOptional': isOptional,
-        'buildTo': buildTo,
-        'defaults': defaults,
-      }.toString();
+  String toString() => {
+    'autoApply': autoApply,
+    'import': import,
+    'builderFactories': builderFactories,
+    'buildExtensions': buildExtensions,
+    'requiredInputs': requiredInputs,
+    'runsBefore': runsBefore,
+    'isOptional': isOptional,
+    'buildTo': buildTo,
+    'defaults': defaults,
+  }.toString();
 }
 
 /// The definition of a `PostProcessBuilder` in the `post_process_builders`
@@ -206,12 +204,11 @@ class PostProcessBuilderDefinition {
   }
 
   @override
-  String toString() =>
-      {
-        'import': import,
-        'builderFactory': builderFactory,
-        'defaults': defaults,
-      }.toString();
+  String toString() => {
+    'import': import,
+    'builderFactory': builderFactory,
+    'defaults': defaults,
+  }.toString();
 }
 
 /// Default values that builder authors can specify when users don't fill in the

--- a/build_config/lib/src/key_normalization.dart
+++ b/build_config/lib/src/key_normalization.dart
@@ -44,8 +44,8 @@ String normalizeBuilderKeyUsage(String builderKey, String packageName) =>
 ///   - "some_package:some_target" => "some_package|some_target"
 String normalizeTargetKeyDefinition(String targetKey, String packageName) =>
     targetKey == _defaultTargetNamePlaceholder
-        ? '$packageName:$packageName'
-        : _normalizeDefinition(targetKey, packageName);
+    ? '$packageName:$packageName'
+    : _normalizeDefinition(targetKey, packageName);
 
 /// Returns the normalized [targetKey] usage when used from [packageName].
 ///

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/dart-lang/build/tree/master/build_config
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 
 dependencies:
   checked_yaml: ^2.0.0

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.1.2-wip
 
 - Internal: remove use of `package:mockito` in test.
+- Require Dart 3.8.0.
 
 ## 4.1.1
 

--- a/build_daemon/example/example.dart
+++ b/build_daemon/example/example.dart
@@ -49,35 +49,29 @@ void main(List<String> args) async {
   if (Random().nextBool()) {
     client.registerBuildTarget(
       DefaultBuildTarget(
-        (b) =>
-            b
-              ..target = 'web'
-              ..outputLocation =
-                  OutputLocation(
-                    (b) =>
-                        b
-                          ..output = 'web_output'
-                          ..useSymlinks = false
-                          ..hoist = true,
-                  ).toBuilder()
-              ..blackListPatterns.replace([RegExp(r'.*_test\.dart$')]),
+        (b) => b
+          ..target = 'web'
+          ..outputLocation = OutputLocation(
+            (b) => b
+              ..output = 'web_output'
+              ..useSymlinks = false
+              ..hoist = true,
+          ).toBuilder()
+          ..blackListPatterns.replace([RegExp(r'.*_test\.dart$')]),
       ),
     );
     print('Registered example web target...');
   } else {
     client.registerBuildTarget(
       DefaultBuildTarget(
-        (b) =>
-            b
-              ..target = 'test'
-              ..outputLocation =
-                  OutputLocation(
-                    (b) =>
-                        b
-                          ..output = 'test_output'
-                          ..useSymlinks = true
-                          ..hoist = false,
-                  ).toBuilder(),
+        (b) => b
+          ..target = 'test'
+          ..outputLocation = OutputLocation(
+            (b) => b
+              ..output = 'test_output'
+              ..useSymlinks = true
+              ..hoist = false,
+          ).toBuilder(),
       ),
     );
 

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -39,11 +39,10 @@ Future<void> _handleDaemonStartup(
       );
     },
   );
-  final stdout =
-      process.stdout
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())
-          .asBroadcastStream();
+  final stdout = process.stdout
+      .transform(utf8.decoder)
+      .transform(const LineSplitter())
+      .asBroadcastStream();
 
   // The daemon may log critical information prior to it successfully
   // starting. Capture this data and forward to the logHandler.
@@ -63,12 +62,11 @@ Future<void> _handleDaemonStartup(
         } catch (e, s) {
           logHandler(
             ServerLog(
-              (builder) =>
-                  builder
-                    ..message = 'Failed to read log message:\n$nextLogRecord'
-                    ..level = Level.SEVERE
-                    ..error = '$e'
-                    ..stackTrace = '$s',
+              (builder) => builder
+                ..message = 'Failed to read log message:\n$nextLogRecord'
+                ..level = Level.SEVERE
+                ..error = '$e'
+                ..stackTrace = '$s',
             ),
           );
         }

--- a/build_daemon/lib/daemon.dart
+++ b/build_daemon/lib/daemon.dart
@@ -74,14 +74,13 @@ class Daemon {
     _createVersionFile();
     _createOptionsFile(options);
 
-    final server =
-        _server = Server(
-          builder,
-          timeout,
-          changeProvider,
-          serializersOverride: serializersOverride,
-          shouldBuild: shouldBuild,
-        );
+    final server = _server = Server(
+      builder,
+      timeout,
+      changeProvider,
+      serializersOverride: serializersOverride,
+      shouldBuild: shouldBuild,
+    );
     final port = await server.listen();
     _createPortFile(port);
 

--- a/build_daemon/lib/data/build_target_request.g.dart
+++ b/build_daemon/lib/data/build_target_request.g.dart
@@ -96,8 +96,9 @@ class _$BuildTargetRequest extends BuildTargetRequest {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'BuildTargetRequest')
-      ..add('target', target)).toString();
+    return (newBuiltValueToStringHelper(
+      r'BuildTargetRequest',
+    )..add('target', target)).toString();
   }
 }
 

--- a/build_daemon/lib/src/server.dart
+++ b/build_daemon/lib/src/server.dart
@@ -95,14 +95,12 @@ class Server {
             // We can only get explicit build requests if we have a manual
             // change provider.
             final changeProvider = _changeProvider;
-            final changes =
-                changeProvider is ManualChangeProvider
-                    ? await changeProvider.collectChanges()
-                    : <WatchEvent>[];
-            final targets =
-                changes.isEmpty
-                    ? _buildTargetManager.targets
-                    : _buildTargetManager.targetsForChanges(changes);
+            final changes = changeProvider is ManualChangeProvider
+                ? await changeProvider.collectChanges()
+                : <WatchEvent>[];
+            final targets = changes.isEmpty
+                ? _buildTargetManager.targets
+                : _buildTargetManager.targetsForChanges(changes);
             await _build(targets, changes);
           }
         },
@@ -149,8 +147,9 @@ class Server {
     Set<BuildTarget> buildTargets,
     Iterable<WatchEvent> changes,
   ) => _pool.withResource(() {
-    _interestedChannels =
-        buildTargets.expand(_buildTargetManager.channels).toSet();
+    _interestedChannels = buildTargets
+        .expand(_buildTargetManager.channels)
+        .toSet();
     return _builder.build(buildTargets, changes);
   });
   void _forwardData() {
@@ -175,15 +174,15 @@ class Server {
             );
             String messageForChannel;
             if (wantsChangedAssets) {
-              messageForChannel =
-                  message ??= jsonEncode(_serializers.serialize(status));
+              messageForChannel = message ??= jsonEncode(
+                _serializers.serialize(status),
+              );
             } else {
-              messageForChannel =
-                  messageWithoutChangedAssets ??= jsonEncode(
-                    _serializers.serialize(
-                      status.rebuild((b) => b.changedAssets = null),
-                    ),
-                  );
+              messageForChannel = messageWithoutChangedAssets ??= jsonEncode(
+                _serializers.serialize(
+                  status.rebuild((b) => b.changedAssets = null),
+                ),
+              );
             }
             channel.sink.add(messageForChannel);
           }

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/dart-lang/build/tree/master/build_daemon
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/build_daemon/test/managers/build_target_manager_test.dart
+++ b/build_daemon/test/managers/build_target_manager_test.dart
@@ -84,16 +84,14 @@ void main() {
     final channelA = DummyChannel();
     final channelB = DummyChannel();
     final targetA = DefaultBuildTarget(
-      (b) =>
-          b
-            ..target = 'foo'
-            ..blackListPatterns.replace([RegExp('bar')]),
+      (b) => b
+        ..target = 'foo'
+        ..blackListPatterns.replace([RegExp('bar')]),
     );
     final targetB = DefaultBuildTarget(
-      (b) =>
-          b
-            ..target = 'foo'
-            ..blackListPatterns.replace([RegExp('bar')]),
+      (b) => b
+        ..target = 'foo'
+        ..blackListPatterns.replace([RegExp('bar')]),
     );
     manager
       ..addBuildTarget(targetA, channelA)
@@ -107,10 +105,9 @@ void main() {
     final channelB = DummyChannel();
     final targetA = DefaultBuildTarget((b) => b..target = 'foo');
     final targetB = DefaultBuildTarget(
-      (b) =>
-          b
-            ..target = 'foo'
-            ..blackListPatterns.replace([RegExp('bar')]),
+      (b) => b
+        ..target = 'foo'
+        ..blackListPatterns.replace([RegExp('bar')]),
     );
     manager
       ..addBuildTarget(targetA, channelA)
@@ -124,10 +121,9 @@ void main() {
       final manager = BuildTargetManager();
       final channel = DummyChannel();
       final target = DefaultBuildTarget(
-        (b) =>
-            b
-              ..target = 'foo'
-              ..blackListPatterns.replace([RegExp(r'.*_test\.dart$')]),
+        (b) => b
+          ..target = 'foo'
+          ..blackListPatterns.replace([RegExp(r'.*_test\.dart$')]),
       );
       manager.addBuildTarget(target, channel);
       var targets = manager.targetsForChanges([

--- a/build_daemon/test/server_test.dart
+++ b/build_daemon/test/server_test.dart
@@ -106,10 +106,9 @@ void main() {
 
       // Register second client which is interested in changes.
       final targetWithChanges = DefaultBuildTarget(
-        (b) =>
-            b
-              ..target = ''
-              ..reportChangedAssets = true,
+        (b) => b
+          ..target = ''
+          ..reportChangedAssets = true,
       );
       interstedClient.sink.add(
         jsonEncode(

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -15,6 +15,7 @@
   crashing.
 - Bug fix: fix `dart run build_runner test` to correctly pass arguments after
   `--` to the test process.
+- Require Dart 3.8.0.
 
 ## 2.15.0
 

--- a/build_runner/bin/build_runner.dart
+++ b/build_runner/bin/build_runner.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 import 'package:build_runner/src/build_runner.dart';
 
 Future<void> main(List<String> arguments) async {
-  exitCode =
-      await BuildRunner(arguments: arguments, builderFactories: null).run();
+  exitCode = await BuildRunner(
+    arguments: arguments,
+    builderFactories: null,
+  ).run();
 }

--- a/build_runner/lib/src/bootstrap/aot_compiler.dart
+++ b/build_runner/lib/src/bootstrap/aot_compiler.dart
@@ -86,11 +86,10 @@ class AotCompiler implements Compiler {
 
     var stderr = result.stderr as String;
     // Tidy up the compiler output to leave just the failure.
-    stderr =
-        stderr
-            .replaceAll('Error: AOT compilation failed', '')
-            .replaceAll('Bad state: Generating AOT snapshot failed!', '')
-            .trim();
+    stderr = stderr
+        .replaceAll('Error: AOT compilation failed', '')
+        .replaceAll('Bad state: Generating AOT snapshot failed!', '')
+        .trim();
     return CompileResult(messages: result.exitCode == 0 ? null : stderr);
   }
 }

--- a/build_runner/lib/src/bootstrap/bootstrapper.dart
+++ b/build_runner/lib/src/bootstrap/bootstrapper.dart
@@ -130,26 +130,21 @@ class Bootstrapper {
       // The child process needs to know how it was compiled to check its
       // freshness, so pass `--force-aot` or `--force-jit`, except for when
       // strategy is alwaysJit.
-      final result =
-          _compiler.compileType == CompileType.aot
-              ? await ParentProcess.runAotSnapshotAndSend(
-                aotSnapshot: p.join(
-                  buildPaths.outputRootPath,
-                  entrypointAotPath,
-                ),
-                arguments: _insertFlag(arguments, '--force-aot'),
-                message: buildProcessState.serialize(),
-                runUnderPerf: dartAotPerf,
-              )
-              : await ParentProcess.runAndSend(
-                script: p.join(buildPaths.outputRootPath, entrypointDillPath),
-                arguments:
-                    compileStrategy == CompileStrategy.commandForcesJit
-                        ? arguments.toList()
-                        : _insertFlag(arguments, '--force-jit'),
-                message: buildProcessState.serialize(),
-                jitVmArgs: jitVmArgs,
-              );
+      final result = _compiler.compileType == CompileType.aot
+          ? await ParentProcess.runAotSnapshotAndSend(
+              aotSnapshot: p.join(buildPaths.outputRootPath, entrypointAotPath),
+              arguments: _insertFlag(arguments, '--force-aot'),
+              message: buildProcessState.serialize(),
+              runUnderPerf: dartAotPerf,
+            )
+          : await ParentProcess.runAndSend(
+              script: p.join(buildPaths.outputRootPath, entrypointDillPath),
+              arguments: compileStrategy == CompileStrategy.commandForcesJit
+                  ? arguments.toList()
+                  : _insertFlag(arguments, '--force-jit'),
+              message: buildProcessState.serialize(),
+              jitVmArgs: jitVmArgs,
+            );
       buildProcessState.deserializeAndSet(result.message);
       final exitCode = result.exitCode;
 
@@ -170,8 +165,9 @@ class Bootstrapper {
   Future<void> _writeBuildScript() async {
     final buildScript = await generateBuildScript(buildPaths: buildPaths);
     final path = p.join(buildPaths.outputRootPath, entrypointScriptPath);
-    final existingBuildScript =
-        File(path).existsSync() ? File(path).readAsStringSync() : null;
+    final existingBuildScript = File(path).existsSync()
+        ? File(path).readAsStringSync()
+        : null;
     if (buildScript != existingBuildScript) {
       File(path)
         ..createSync(recursive: true)

--- a/build_runner/lib/src/bootstrap/build_process_lock.dart
+++ b/build_runner/lib/src/bootstrap/build_process_lock.dart
@@ -140,15 +140,14 @@ class BuildProcessLock {
   );
 
   /// The lock file for [BuildPaths.workspacePath].
-  File? get _workspaceLockFile =>
-      paths.workspacePath == null
-          ? null
-          : File(
-            p.join(
-              paths.workspacePath!,
-              '.dart_tool/build/lock/$_workspaceLockName',
-            ),
-          );
+  File? get _workspaceLockFile => paths.workspacePath == null
+      ? null
+      : File(
+          p.join(
+            paths.workspacePath!,
+            '.dart_tool/build/lock/$_workspaceLockName',
+          ),
+        );
 
   /// Deletes the lock request files.
   void _clearRequested() {

--- a/build_runner/lib/src/bootstrap/build_process_state.dart
+++ b/build_runner/lib/src/bootstrap/build_process_state.dart
@@ -113,14 +113,13 @@ class BuildProcessState {
           as String;
 
   /// The [BuildPaths] used for the process lock.
-  BuildPaths? get _buildPaths =>
-      _state.containsKey('packagePath')
-          ? BuildPaths(
-            packagePath: _state['packagePath'] as String,
-            workspacePath: _state['workspacePath'] as String?,
-            buildWorkspace: _state['buildWorkspace'] as bool,
-          )
-          : null;
+  BuildPaths? get _buildPaths => _state.containsKey('packagePath')
+      ? BuildPaths(
+          packagePath: _state['packagePath'] as String,
+          workspacePath: _state['workspacePath'] as String?,
+          buildWorkspace: _state['buildWorkspace'] as bool,
+        )
+      : null;
   set _buildPaths(BuildPaths? value) {
     _state['packagePath'] = value?.packagePath;
     _state['workspacePath'] = value?.workspacePath;

--- a/build_runner/lib/src/bootstrap/kernel_compiler.dart
+++ b/build_runner/lib/src/bootstrap/kernel_compiler.dart
@@ -86,8 +86,9 @@ class KernelCompiler implements Compiler {
 
     var stderr = result.stderr as String;
     // Tidy up the compiler output to leave just the failure.
-    stderr =
-        stderr.replaceAll('Bad state: Generating kernel failed!', '').trim();
+    stderr = stderr
+        .replaceAll('Bad state: Generating kernel failed!', '')
+        .trim();
     return CompileResult(messages: result.exitCode == 0 ? null : stderr);
   }
 }

--- a/build_runner/lib/src/bootstrap/processes.dart
+++ b/build_runner/lib/src/bootstrap/processes.dart
@@ -61,23 +61,23 @@ class ParentProcess {
     );
     return runUnderPerf
         ? await _runAndSend(
-          executable: 'perf',
-          arguments: [
-            'record',
-            '-g',
-            '--output',
-            'perf.data',
-            dartAotRuntime,
-            aotSnapshot,
-            ...arguments,
-          ],
-          message: message,
-        )
+            executable: 'perf',
+            arguments: [
+              'record',
+              '-g',
+              '--output',
+              'perf.data',
+              dartAotRuntime,
+              aotSnapshot,
+              ...arguments,
+            ],
+            message: message,
+          )
         : await _runAndSend(
-          executable: dartAotRuntime,
-          arguments: [aotSnapshot, ...arguments],
-          message: message,
-        );
+            executable: dartAotRuntime,
+            arguments: [aotSnapshot, ...arguments],
+            message: message,
+          );
   }
 
   static Future<RunAndSendResult> _runAndSend({
@@ -228,11 +228,10 @@ class ChildProcess {
   ) async {
     _isRunning = true;
     buildProcessState.deserializeAndSet(await receive());
-    final exitCode =
-        await BuildRunner(
-          arguments: arguments,
-          builderFactories: builderFactories,
-        ).run();
+    final exitCode = await BuildRunner(
+      arguments: arguments,
+      builderFactories: builderFactories,
+    ).run();
     await exitWithMessage(
       exitCode: exitCode,
       message: buildProcessState.serialize(),

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -84,10 +84,9 @@ class Build {
 
   Build({required this.buildPlan, required this.resourceManager})
     : readerWriter = buildPlan.readerWriter,
-      previousDepsLoader =
-          buildPlan.previousPhasedAssetDeps == null
-              ? null
-              : AssetDepsLoader.fromDeps(buildPlan.previousPhasedAssetDeps!),
+      previousDepsLoader = buildPlan.previousPhasedAssetDeps == null
+          ? null
+          : AssetDepsLoader.fromDeps(buildPlan.previousPhasedAssetDeps!),
       resolvers = buildPlan.testingOverrides.resolvers ?? _defaultResolvers,
       resolversImpl = switch (buildPlan.testingOverrides.resolvers ??
           _defaultResolvers) {
@@ -109,11 +108,8 @@ class Build {
   BuildInputs get buildInputs => buildPlan.buildInputs;
   BuildStepPlan get buildStepPlan => buildPlan.buildStepPlan;
 
-  BuildOutputReader get buildOutputReader =>
-      _buildOutputReader ??= BuildOutputReader(
-        buildPlan: buildPlan,
-        buildState: buildState,
-      );
+  BuildOutputReader get buildOutputReader => _buildOutputReader ??=
+      BuildOutputReader(buildPlan: buildPlan, buildState: buildState);
 
   Future<BuildResult> run() async {
     buildLog.configuration = buildLog.configuration.rebuild(
@@ -213,12 +209,9 @@ class Build {
         // say "not generated yet", in which case the old value is retained.
         final currentPhasedAssetDeps =
             resolversImpl?.phasedAssetDeps() ?? PhasedAssetDeps();
-        final updatedPhasedAssetDeps =
-            buildPlan.previousPhasedAssetDeps == null
-                ? currentPhasedAssetDeps
-                : buildPlan.previousPhasedAssetDeps!.update(
-                  currentPhasedAssetDeps,
-                );
+        final updatedPhasedAssetDeps = buildPlan.previousPhasedAssetDeps == null
+            ? currentPhasedAssetDeps
+            : buildPlan.previousPhasedAssetDeps!.update(currentPhasedAssetDeps);
         await readerWriter.writeAsBytes(
           AssetId(buildPackages.outputRoot, assetGraphJsonPath),
           AssetGraphJson.serialize(
@@ -422,11 +415,8 @@ class Build {
         buildStepPlan: buildStepPlan,
         buildState: buildState,
         assetBuilder: _buildOutput,
-        assetIsProcessedOutput:
-            (id) => buildState.isProcessedOutput(
-              buildStepPlan: buildStepPlan,
-              id: id,
-            ),
+        assetIsProcessedOutput: (id) =>
+            buildState.isProcessedOutput(buildStepPlan: buildStepPlan, id: id),
         globEvaluator: _evaluateGlob,
       ),
       runningBuildStep: RunningBuildStep(
@@ -649,11 +639,8 @@ class Build {
         buildStepPlan: buildStepPlan,
         buildState: buildState,
         assetBuilder: _buildOutput,
-        assetIsProcessedOutput:
-            (id) => buildState.isProcessedOutput(
-              buildStepPlan: buildStepPlan,
-              id: id,
-            ),
+        assetIsProcessedOutput: (id) =>
+            buildState.isProcessedOutput(buildStepPlan: buildStepPlan, id: id),
         globEvaluator: _evaluateGlob,
       ),
       runningBuildStep: RunningBuildStep(
@@ -904,8 +891,8 @@ class Build {
     required int phaseNumber,
   }) async {
     // If the result has already been calculated, return it.
-    final entrypointGraph = (await previousLibraryCycleGraphLoader
-        .libraryCycleGraphOf(
+    final entrypointGraph =
+        (await previousLibraryCycleGraphLoader.libraryCycleGraphOf(
           previousDepsLoader!,
           entrypointId,
         )).valueAt(phase: phaseNumber);
@@ -1153,21 +1140,19 @@ class Build {
     Set<AssetId>? unusedAssets,
   }) async {
     final inputTracker = stepReaderWriter.inputTracker;
-    final usedInputs =
-        unusedAssets != null && unusedAssets.isNotEmpty
-            ? inputTracker.inputs.difference(unusedAssets)
-            : inputTracker.inputs;
+    final usedInputs = unusedAssets != null && unusedAssets.isNotEmpty
+        ? inputTracker.inputs.difference(unusedAssets)
+        : inputTracker.inputs;
     final result = errors.isEmpty;
     final phaseNum = stepReaderWriter.phase;
 
-    final buildStepResultBuilder =
-        BuildStepResultBuilder()
-          ..result = result
-          ..isHidden = buildPhases.inBuildPhases[phaseNum].hideOutput
-          ..inputs.replace(usedInputs)
-          ..globsEvaluated.replace(inputTracker.globsEvaluated)
-          ..resolverEntrypoints.replace(inputTracker.resolverEntrypoints)
-          ..errors.replace(errors);
+    final buildStepResultBuilder = BuildStepResultBuilder()
+      ..result = result
+      ..isHidden = buildPhases.inBuildPhases[phaseNum].hideOutput
+      ..inputs.replace(usedInputs)
+      ..globsEvaluated.replace(inputTracker.globsEvaluated)
+      ..resolverEntrypoints.replace(inputTracker.resolverEntrypoints)
+      ..errors.replace(errors);
     for (final output in outputs) {
       if (stepReaderWriter.assetsWritten.contains(output)) {
         buildStepResultBuilder.outputs[output] = await readerWriter.digest(
@@ -1186,8 +1171,9 @@ class Build {
 
   bool _isChangedOutput(AssetId output) {
     final generatingStep = buildStepPlan.stepForDeclaredOutput(output);
-    final oldDigest =
-        previousBuildState?.stepResultOrNull(generatingStep)?.outputs[output];
+    final oldDigest = previousBuildState
+        ?.stepResultOrNull(generatingStep)
+        ?.outputs[output];
     final newDigest = buildState.stepResult(generatingStep).outputs[output];
     return oldDigest != newDigest;
   }

--- a/build_runner/lib/src/build/build_result.dart
+++ b/build_runner/lib/src/build/build_result.dart
@@ -36,10 +36,9 @@ class BuildResult {
     PhasedAssetDeps? phasedAssetDeps,
     required this.buildOutputReader,
     FailureType? failureType,
-  }) : failureType =
-           failureType == null && status == BuildStatus.failure
-               ? FailureType.general
-               : failureType,
+  }) : failureType = failureType == null && status == BuildStatus.failure
+           ? FailureType.general
+           : failureType,
        errors = errors ?? BuiltList(),
        outputs = outputs ?? BuiltList(),
        phasedAssetDeps = phasedAssetDeps ?? PhasedAssetDeps();

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -146,14 +146,15 @@ class BuildSeries {
           id.path == 'build.${_buildPlan.buildOptions.configKey}.yaml');
 
   Future<List<WatchEvent>> checkForChanges() async {
-    final updates = await AssetTracker(
-      _buildPlan.readerWriter,
-      _buildPlan.buildPackages,
-      _buildPlan.buildConfigs,
-    ).collectChanges(
-      buildStepPlan: _buildPlan.buildStepPlan,
-      buildState: _buildPlan.previousBuildState ?? BuildState(),
-    );
+    final updates =
+        await AssetTracker(
+          _buildPlan.readerWriter,
+          _buildPlan.buildPackages,
+          _buildPlan.buildConfigs,
+        ).collectChanges(
+          buildStepPlan: _buildPlan.buildStepPlan,
+          buildState: _buildPlan.previousBuildState ?? BuildState(),
+        );
     return List.of(
       updates.entries.map((entry) => WatchEvent(entry.value, '${entry.key}')),
     );

--- a/build_runner/lib/src/build/build_state/build_state.dart
+++ b/build_runner/lib/src/build/build_state/build_state.dart
@@ -198,10 +198,9 @@ class BuildState {
   /// Updates a build step result after the step runs.
   void updateBuildStepResult(BuildStepId buildStepId, BuildStepResult result) {
     _buildStepResultsByPrimaryInput.putIfAbsent(
-          buildStepId.primaryInput,
-          () => {},
-        )[buildStepId.phaseNumber] =
-        result;
+      buildStepId.primaryInput,
+      () => {},
+    )[buildStepId.phaseNumber] = result;
   }
 
   // -- Globs.

--- a/build_runner/lib/src/build/build_state/identity_serializer.dart
+++ b/build_runner/lib/src/build/build_state/identity_serializer.dart
@@ -28,8 +28,9 @@ class IdentitySerializer<T> implements PrimitiveSerializer<T> {
   /// A serializer wrapping [delegate] to deduplicate by identity.
   IdentitySerializer(this.delegate)
     : _primitiveDelegate = delegate is PrimitiveSerializer<T> ? delegate : null,
-      _structuredDelegate =
-          delegate is StructuredSerializer<T> ? delegate : null;
+      _structuredDelegate = delegate is StructuredSerializer<T>
+          ? delegate
+          : null;
 
   /// Sets the stored object values to [objects].
   ///
@@ -80,10 +81,9 @@ class IdentitySerializer<T> implements PrimitiveSerializer<T> {
     return _ids.putIfAbsent(object, () {
       // Otherwise, serialize it, store the value and serialized value, and
       // return the index of the last of `_objects` as the ID.
-      final serialized =
-          _primitiveDelegate == null
-              ? _structuredDelegate!.serialize(serializers, object)
-              : _primitiveDelegate.serialize(serializers, object);
+      final serialized = _primitiveDelegate == null
+          ? _structuredDelegate!.serialize(serializers, object)
+          : _primitiveDelegate.serialize(serializers, object);
       _serializedObjects.add(serialized);
       return (_objects..add(object)).length - 1;
     });

--- a/build_runner/lib/src/build/build_step_impl.dart
+++ b/build_runner/lib/src/build/build_step_impl.dart
@@ -71,8 +71,9 @@ class BuildStepImpl implements BuildStep {
 
   @override
   Future<PackageConfig> get packageConfig async {
-    final resolved =
-        _resolvedPackageConfig ??= Result.capture(_resolvePackageConfig());
+    final resolved = _resolvedPackageConfig ??= Result.capture(
+      _resolvePackageConfig(),
+    );
 
     return (await resolved).asFuture;
   }

--- a/build_runner/lib/src/build/library_cycle_graph/asset_deps.g.dart
+++ b/build_runner/lib/src/build/library_cycle_graph/asset_deps.g.dart
@@ -96,8 +96,9 @@ class _$AssetDeps extends AssetDeps {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'AssetDeps')
-      ..add('deps', deps)).toString();
+    return (newBuiltValueToStringHelper(
+      r'AssetDeps',
+    )..add('deps', deps)).toString();
   }
 }
 

--- a/build_runner/lib/src/build/library_cycle_graph/asset_deps_loader.dart
+++ b/build_runner/lib/src/build/library_cycle_graph/asset_deps_loader.dart
@@ -38,16 +38,18 @@ class AssetDepsLoader {
 
   /// Parses directives in [content] to return an [AssetDeps].
   ExpiringValue<AssetDeps> _parse(AssetId id, ExpiringValue<String> content) {
-    final result =
-        ExpiringValueBuilder<AssetDeps>()..expiresAfter = content.expiresAfter;
+    final result = ExpiringValueBuilder<AssetDeps>()
+      ..expiresAfter = content.expiresAfter;
 
     final depsNodeBuilder = AssetDepsBuilder();
 
     if (content.value == '') {
       result.value = AssetDeps.empty;
     } else {
-      final parsed =
-          parseString(content: content.value, throwIfDiagnostics: false).unit;
+      final parsed = parseString(
+        content: content.value,
+        throwIfDiagnostics: false,
+      ).unit;
 
       for (final directive in parsed.directives) {
         if (directive is! UriBasedDirective) continue;

--- a/build_runner/lib/src/build/library_cycle_graph/library_cycle.g.dart
+++ b/build_runner/lib/src/build/library_cycle_graph/library_cycle.g.dart
@@ -37,8 +37,9 @@ class _$LibraryCycle extends LibraryCycle {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'LibraryCycle')
-      ..add('ids', ids)).toString();
+    return (newBuiltValueToStringHelper(
+      r'LibraryCycle',
+    )..add('ids', ids)).toString();
   }
 }
 

--- a/build_runner/lib/src/build/library_cycle_graph/library_cycle_graph_loader.dart
+++ b/build_runner/lib/src/build/library_cycle_graph/library_cycle_graph_loader.dart
@@ -218,8 +218,9 @@ class LibraryCycleGraphLoader {
       // If a recursive `_load` happens then the associated cycles and graphs
       // are also fully computed before this `_load` continues: the work that
       // remains is only work for later phases.
-      final assetDeps =
-          _assetDeps[idToLoad] = await assetDepsLoader.load(idToLoad);
+      final assetDeps = _assetDeps[idToLoad] = await assetDepsLoader.load(
+        idToLoad,
+      );
       _removeIdToLoad(idToLoadPhase, idToLoad);
 
       if (assetDeps.isComplete) {
@@ -275,22 +276,21 @@ class LibraryCycleGraphLoader {
         idsToComputeCyclesFrom,
         edgesFromId,
       );
-      final newCycles =
-          newComponentLists.map((list) {
-            // Compare to the library cycle computed at `phase - 1`. If the
-            // cycles are the same size then they must have the same contents,
-            // because cycles only change by growing as phases progress. In that
-            // case, reuse the existing [LibraryCycle].
-            final maybePhasedCycle = _cycles[list.first];
-            if (maybePhasedCycle != null) {
-              final value = maybePhasedCycle.valueAt(phase: phase - 1);
-              if (value.ids.length == list.length) {
-                return value;
-              }
-            }
-            // The cycle is new or has changed, return a new value.
-            return LibraryCycle((b) => b..ids.replace(list));
-          }).toList();
+      final newCycles = newComponentLists.map((list) {
+        // Compare to the library cycle computed at `phase - 1`. If the
+        // cycles are the same size then they must have the same contents,
+        // because cycles only change by growing as phases progress. In that
+        // case, reuse the existing [LibraryCycle].
+        final maybePhasedCycle = _cycles[list.first];
+        if (maybePhasedCycle != null) {
+          final value = maybePhasedCycle.valueAt(phase: phase - 1);
+          if (value.ids.length == list.length) {
+            return value;
+          }
+        }
+        // The cycle is new or has changed, return a new value.
+        return LibraryCycle((b) => b..ids.replace(list));
+      }).toList();
 
       // Build graphs from cycles.
       _buildGraphs(phase, newCycles: newCycles);
@@ -300,10 +300,9 @@ class LibraryCycleGraphLoader {
         // it gets a new dep that leads back to the cycle then that whole path
         // joins the cycle. Get this expirey phase from the graph built by
         // `_buildGraphs`.
-        final expiresAfter =
-            _graphs[cycle.ids.first]!
-                .expiringValueAt(phase: phase)
-                .expiresAfter;
+        final expiresAfter = _graphs[cycle.ids.first]!
+            .expiringValueAt(phase: phase)
+            .expiresAfter;
 
         // Merge the computed cycle into any existing phased value for each ID.
         // The phased value can differ by ID: they are in the same cycle at this
@@ -496,7 +495,8 @@ class LibraryCycleGraphLoader {
       PhasedAssetDeps((b) => b.assetDeps.addAll(_assetDeps));
 
   @override
-  String toString() => '''
+  String toString() =>
+      '''
 LibraryCycleGraphLoader(
   _runningAtPhases: $_runningAtPhases
   _assetDeps: $_assetDeps,

--- a/build_runner/lib/src/build/library_cycle_graph/phased_asset_deps.g.dart
+++ b/build_runner/lib/src/build/library_cycle_graph/phased_asset_deps.g.dart
@@ -99,8 +99,9 @@ class _$PhasedAssetDeps extends PhasedAssetDeps {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'PhasedAssetDeps')
-      ..add('assetDeps', assetDeps)).toString();
+    return (newBuiltValueToStringHelper(
+      r'PhasedAssetDeps',
+    )..add('assetDeps', assetDeps)).toString();
   }
 }
 

--- a/build_runner/lib/src/build/library_cycle_graph/phased_value.g.dart
+++ b/build_runner/lib/src/build/library_cycle_graph/phased_value.g.dart
@@ -27,8 +27,9 @@ class _$PhasedValueSerializer
     final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
-    final parameterT =
-        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+    final parameterT = isUnderspecified
+        ? FullType.object
+        : specifiedType.parameters[0];
 
     final result = <Object?>[
       'values',
@@ -52,14 +53,13 @@ class _$PhasedValueSerializer
     final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
-    final parameterT =
-        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+    final parameterT = isUnderspecified
+        ? FullType.object
+        : specifiedType.parameters[0];
 
-    final result =
-        isUnderspecified
-            ? PhasedValueBuilder<Object?>()
-            : serializers.newBuilder(specifiedType)
-                as PhasedValueBuilder<Object?>;
+    final result = isUnderspecified
+        ? PhasedValueBuilder<Object?>()
+        : serializers.newBuilder(specifiedType) as PhasedValueBuilder<Object?>;
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -101,8 +101,9 @@ class _$ExpiringValueSerializer
     final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
-    final parameterT =
-        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+    final parameterT = isUnderspecified
+        ? FullType.object
+        : specifiedType.parameters[0];
 
     final result = <Object?>[
       'value',
@@ -127,14 +128,14 @@ class _$ExpiringValueSerializer
     final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
-    final parameterT =
-        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+    final parameterT = isUnderspecified
+        ? FullType.object
+        : specifiedType.parameters[0];
 
-    final result =
-        isUnderspecified
-            ? ExpiringValueBuilder<Object?>()
-            : serializers.newBuilder(specifiedType)
-                as ExpiringValueBuilder<Object?>;
+    final result = isUnderspecified
+        ? ExpiringValueBuilder<Object?>()
+        : serializers.newBuilder(specifiedType)
+              as ExpiringValueBuilder<Object?>;
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -191,8 +192,9 @@ class _$PhasedValue<T> extends PhasedValue<T> {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'PhasedValue')
-      ..add('values', values)).toString();
+    return (newBuiltValueToStringHelper(
+      r'PhasedValue',
+    )..add('values', values)).toString();
   }
 }
 

--- a/build_runner/lib/src/build/post_process_build_step_impl.dart
+++ b/build_runner/lib/src/build/post_process_build_step_impl.dart
@@ -30,10 +30,9 @@ class PostProcessBuildStepImpl implements PostProcessBuildStep {
   );
 
   @override
-  Future<Digest> digest(AssetId id) =>
-      inputId == id
-          ? _readerWriter.digest(id)
-          : Future.error(InvalidInputException(id));
+  Future<Digest> digest(AssetId id) => inputId == id
+      ? _readerWriter.digest(id)
+      : Future.error(InvalidInputException(id));
 
   @override
   Future<List<int>> readInputAsBytes() => _readerWriter.readAsBytes(inputId);

--- a/build_runner/lib/src/build/resolver/analysis_driver.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver.dart
@@ -43,14 +43,13 @@ Packages _buildAnalyzerPackages(
   for (final package in packageConfig.packages)
     package.name: Package(
       name: package.name,
-      languageVersion:
-          package.languageVersion == null
-              ? sdkLanguageVersion
-              : Version(
-                package.languageVersion!.major,
-                package.languageVersion!.minor,
-                0,
-              ),
+      languageVersion: package.languageVersion == null
+          ? sdkLanguageVersion
+          : Version(
+              package.languageVersion!.major,
+              package.languageVersion!.minor,
+              0,
+            ),
       // Analyzer does not see the original file paths at all, we need to
       // make them match the paths that we give it, so we use the
       // `assetPath` function to create those.

--- a/build_runner/lib/src/build/resolver/build_resolver.dart
+++ b/build_runner/lib/src/build/resolver/build_resolver.dart
@@ -158,23 +158,22 @@ class BuildResolver {
   }
 
   Stream<LibraryElement> get sdkLibraries {
-    final loadLibraries =
-        _sdkLibraries ??= Future.sync(() {
-          final publicSdkUris = _driver.sdkLibraryUris.where(
-            (e) => !e.path.startsWith('_'),
-          );
+    final loadLibraries = _sdkLibraries ??= Future.sync(() {
+      final publicSdkUris = _driver.sdkLibraryUris.where(
+        (e) => !e.path.startsWith('_'),
+      );
 
-          return Future.wait(
-            publicSdkUris.map((uri) {
-              return _driverPool.withResource(() async {
-                final result =
-                    await _driver.currentSession.getLibraryByUri(uri.toString())
-                        as LibraryElementResult;
-                return result.element;
-              });
-            }),
-          );
-        });
+      return Future.wait(
+        publicSdkUris.map((uri) {
+          return _driverPool.withResource(() async {
+            final result =
+                await _driver.currentSession.getLibraryByUri(uri.toString())
+                    as LibraryElementResult;
+            return result.element;
+          });
+        }),
+      );
+    });
 
     return Stream.fromFuture(loadLibraries).expand((libraries) => libraries);
   }
@@ -211,8 +210,8 @@ class BuildResolver {
     required InputTracker inputTracker,
     required bool transitive,
   }) => _analysisDriverModel.updateDriver(
-    withDriver:
-        (withDriver) => _driverPool.withResource(() => withDriver(_driver)),
+    withDriver: (withDriver) =>
+        _driverPool.withResource(() => withDriver(_driver)),
     phasedReader: phasedReader,
     inputTracker: inputTracker,
     entrypoint: entrypoint,

--- a/build_runner/lib/src/build/resolver/build_step_resolver.dart
+++ b/build_runner/lib/src/build/resolver/build_step_resolver.dart
@@ -52,17 +52,16 @@ class BuildStepResolver implements ReleasableResolver {
       // `BuildStep.canRead`. They'd still be reachable by crawling the element
       // model manually.
       yield current;
-      final toCrawl =
-          current.firstFragment.libraryImports
-              .map((import) => import.importedLibrary)
-              .followedBy(
-                current.firstFragment.libraryExports.map(
-                  (export) => export.exportedLibrary,
-                ),
-              )
-              .nonNulls
-              .where((library) => !seen.contains(library))
-              .toSet();
+      final toCrawl = current.firstFragment.libraryImports
+          .map((import) => import.importedLibrary)
+          .followedBy(
+            current.firstFragment.libraryExports.map(
+              (export) => export.exportedLibrary,
+            ),
+          )
+          .nonNulls
+          .where((library) => !seen.contains(library))
+          .toSet();
       toVisit.addAll(toCrawl);
       seen.addAll(toCrawl);
     }

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -70,10 +70,9 @@ class ResolversImpl implements Resolvers {
     await _initializationPool.withResource(() async {
       if (_buildResolver != null) return;
       _warnOnLanguageVersionMismatch();
-      final loadedConfig =
-          _packageConfig ??= await loadPackageConfigUri(
-            Uri.parse(buildProcessState.packageConfigUri),
-          );
+      final loadedConfig = _packageConfig ??= await loadPackageConfigUri(
+        Uri.parse(buildProcessState.packageConfigUri),
+      );
       final driver = analysisDriver(
         _analysisDriverModel,
         AnalysisOptionsImpl()
@@ -125,8 +124,9 @@ class ResolversImpl implements Resolvers {
 void _warnOnLanguageVersionMismatch() async {
   if (sdkLanguageVersion <= ExperimentStatus.currentVersion) return;
 
-  final upgradeCommand =
-      isFlutter ? 'flutter packages upgrade' : 'dart pub upgrade';
+  final upgradeCommand = isFlutter
+      ? 'flutter packages upgrade'
+      : 'dart pub upgrade';
   buildLog.warning(
     'SDK language version $sdkLanguageVersion is newer than `analyzer` '
     'language version ${ExperimentStatus.currentVersion}. '

--- a/build_runner/lib/src/build/resolver/sdk_summary.dart
+++ b/build_runner/lib/src/build/resolver/sdk_summary.dart
@@ -73,8 +73,9 @@ Future<String> defaultSdkSummaryGenerator() async {
       final tempDir = await Directory(cacheDir).createTemp();
       final tempFile = File(p.join(tempDir.path, p.basename(summaryPath)));
       await tempFile.create();
-      final embedderYamlPath =
-          isFlutter ? p.join(_dartUiPath, '_embedder.yaml') : null;
+      final embedderYamlPath = isFlutter
+          ? p.join(_dartUiPath, '_embedder.yaml')
+          : null;
       await tempFile.writeAsBytes(
         await buildSdkSummary(
           sdkPath: _runningDartSdkPath,

--- a/build_runner/lib/src/build/run_builder.dart
+++ b/build_runner/lib/src/build/run_builder.dart
@@ -71,10 +71,9 @@ Future<void> runBuilder(
       resolvers,
       resources,
       loadPackageConfig,
-      reportUnusedAssets:
-          reportUnusedAssetsForInput == null
-              ? null
-              : (assets) => reportUnusedAssetsForInput(input, assets),
+      reportUnusedAssets: reportUnusedAssetsForInput == null
+          ? null
+          : (assets) => reportUnusedAssetsForInput(input, assets),
     );
     try {
       await builder.build(buildStep);

--- a/build_runner/lib/src/build/timing.dart
+++ b/build_runner/lib/src/build/timing.dart
@@ -288,35 +288,37 @@ class AsyncTimeTracker extends TimeSliceGroup implements TimeTracker {
       final tracker = self[_zoneKey] as AsyncTimeTracker;
       return tracker._trackSyncSlice(parent, zone, () => parent.run(zone, f));
     },
-    runUnary: <R, T>(
-      Zone self,
-      ZoneDelegate parent,
-      Zone zone,
-      R Function(T) f,
-      T arg,
-    ) {
-      final tracker = self[_zoneKey] as AsyncTimeTracker;
-      return tracker._trackSyncSlice(
-        parent,
-        zone,
-        () => parent.runUnary(zone, f, arg),
-      );
-    },
-    runBinary: <R, T1, T2>(
-      Zone self,
-      ZoneDelegate parent,
-      Zone zone,
-      R Function(T1, T2) f,
-      T1 arg1,
-      T2 arg2,
-    ) {
-      final tracker = self[_zoneKey] as AsyncTimeTracker;
-      return tracker._trackSyncSlice(
-        parent,
-        zone,
-        () => parent.runBinary(zone, f, arg1, arg2),
-      );
-    },
+    runUnary:
+        <R, T>(
+          Zone self,
+          ZoneDelegate parent,
+          Zone zone,
+          R Function(T) f,
+          T arg,
+        ) {
+          final tracker = self[_zoneKey] as AsyncTimeTracker;
+          return tracker._trackSyncSlice(
+            parent,
+            zone,
+            () => parent.runUnary(zone, f, arg),
+          );
+        },
+    runBinary:
+        <R, T1, T2>(
+          Zone self,
+          ZoneDelegate parent,
+          Zone zone,
+          R Function(T1, T2) f,
+          T1 arg1,
+          T2 arg2,
+        ) {
+          final tracker = self[_zoneKey] as AsyncTimeTracker;
+          return tracker._trackSyncSlice(
+            parent,
+            zone,
+            () => parent.runBinary(zone, f, arg1, arg2),
+          );
+        },
   );
 
   @override

--- a/build_runner/lib/src/build_plan/build_configs.dart
+++ b/build_runner/lib/src/build_plan/build_configs.dart
@@ -96,10 +96,10 @@ class BuildConfigs {
         (readerWriter == null
             ? null
             : await findBuildConfigOverrides(
-              buildPackages: buildPackages,
-              readerWriter: readerWriter,
-              configKey: configKey,
-            ));
+                buildPackages: buildPackages,
+                readerWriter: readerWriter,
+                configKey: configKey,
+              ));
     for (final package in buildPackages.packages.values) {
       final config =
           configOverrides?[package.name] ??
@@ -108,29 +108,28 @@ class BuildConfigs {
 
       BuiltList<String> defaultInclude;
       if (package.isOutput) {
-        defaultInclude =
-            [
-              ...(testingOverrides?.defaultRootPackageSources ??
-                  defaultInBuildPackageSources),
-              ...config.additionalPublicAssets,
-            ].build();
+        defaultInclude = [
+          ...(testingOverrides?.defaultRootPackageSources ??
+              defaultInBuildPackageSources),
+          ...config.additionalPublicAssets,
+        ].build();
       } else if (package.name == r'$sdk') {
-        defaultInclude =
-            const ['lib/dev_compiler/**.js', 'lib/_internal/**.sum'].build();
+        defaultInclude = const [
+          'lib/dev_compiler/**.js',
+          'lib/_internal/**.sum',
+        ].build();
       } else {
-        defaultInclude =
-            [
-              ...defaultDependencyVisibleAssets,
-              ...config.additionalPublicAssets,
-            ].build();
+        defaultInclude = [
+          ...defaultDependencyVisibleAssets,
+          ...config.additionalPublicAssets,
+        ].build();
       }
       publicAssetsByPackage[package.name] = InputMatcher(
         const InputSet(),
-        defaultInclude:
-            [
-              ...defaultDependencyVisibleAssets, // public by default
-              ...config.additionalPublicAssets, // user-defined public assets
-            ].build(),
+        defaultInclude: [
+          ...defaultDependencyVisibleAssets, // public by default
+          ...config.additionalPublicAssets, // user-defined public assets
+        ].build(),
       );
       final buildTargets = config.buildTargets.values.map(
         (target) => BuildTarget(target, defaultInclude: defaultInclude),
@@ -141,8 +140,9 @@ class BuildConfigs {
           Placeholders.packageName,
           Placeholders.libPath,
         ];
-        final requiredPackagePaths =
-            package.isOutput ? requiredRootSourcePaths : requiredSourcePaths;
+        final requiredPackagePaths = package.isOutput
+            ? requiredRootSourcePaths
+            : requiredSourcePaths;
         final requiredIds = requiredPackagePaths.map(
           (path) => AssetId(package.name, path),
         );
@@ -347,36 +347,34 @@ Future<BuiltMap<String, BuildConfig>> findBuildConfigOverrides({
 ///
 /// This is also the default list of files for targets in non-root packages when
 /// an explicit include is not provided.
-final BuiltList<String> defaultDependencyVisibleAssets =
-    [
-      'CHANGELOG*',
-      'lib/**',
-      'bin/**',
-      'LICENSE*',
-      'pubspec.yaml',
-      'README*',
-    ].build();
+final BuiltList<String> defaultDependencyVisibleAssets = [
+  'CHANGELOG*',
+  'lib/**',
+  'bin/**',
+  'LICENSE*',
+  'pubspec.yaml',
+  'README*',
+].build();
 
 /// The default list of files to include when an explicit include is not
 /// provided.
 ///
 /// This should be a superset of [defaultDependencyVisibleAssets].
-final BuiltList<String> defaultInBuildPackageSources =
-    [
-      'assets/**',
-      'benchmark/**',
-      'bin/**',
-      'CHANGELOG*',
-      'example/**',
-      'lib/**',
-      'test/**',
-      'integration_test/**',
-      'tool/**',
-      'web/**',
-      'node/**',
-      'LICENSE*',
-      'pubspec.yaml',
-      'pubspec.lock',
-      'README*',
-      r'$package$',
-    ].build();
+final BuiltList<String> defaultInBuildPackageSources = [
+  'assets/**',
+  'benchmark/**',
+  'bin/**',
+  'CHANGELOG*',
+  'example/**',
+  'lib/**',
+  'test/**',
+  'integration_test/**',
+  'tool/**',
+  'web/**',
+  'node/**',
+  'LICENSE*',
+  'pubspec.yaml',
+  'pubspec.lock',
+  'README*',
+  r'$package$',
+].build();

--- a/build_runner/lib/src/build_plan/build_directory.dart
+++ b/build_runner/lib/src/build_plan/build_directory.dart
@@ -21,8 +21,8 @@ class BuildDirectory {
   static BuiltSet<String> buildPaths(BuiltSet<BuildDirectory> buildDirs) =>
       // The empty string means build everything.
       buildDirs.any((b) => b.directory == '')
-          ? BuiltSet()
-          : buildDirs.map((b) => b.directory).toBuiltSet();
+      ? BuiltSet()
+      : buildDirs.map((b) => b.directory).toBuiltSet();
 }
 
 class OutputLocation {

--- a/build_runner/lib/src/build_plan/build_options.dart
+++ b/build_runner/lib/src/build_plan/build_options.dart
@@ -114,14 +114,13 @@ class BuildOptions {
     }
 
     final result = BuildOptions(
-      buildDirs:
-          {
-            ..._parseBuildDirs(commandLine),
-            if (restIsBuildDirs) ..._parsePositionalBuildDirs(commandLine),
-            if (extraDirs != null)
-              for (final dir in extraDirs)
-                BuildDirectory(_checkTopLevel(commandLine, dir)),
-          }.build(),
+      buildDirs: {
+        ..._parseBuildDirs(commandLine),
+        if (restIsBuildDirs) ..._parsePositionalBuildDirs(commandLine),
+        if (extraDirs != null)
+          for (final dir in extraDirs)
+            BuildDirectory(_checkTopLevel(commandLine, dir)),
+      }.build(),
       buildPaths: buildPaths,
       builderConfigOverrides: _parseBuilderConfigOverrides(
         commandLine,

--- a/build_runner/lib/src/build_plan/build_package.dart
+++ b/build_runner/lib/src/build_plan/build_package.dart
@@ -74,7 +74,8 @@ class BuildPackage {
       Object.hash(name, path, watch, isOutput, languageVersion, dependencies);
 
   @override
-  String toString() => '''
+  String toString() =>
+      '''
 BuildPackage(
   name: $name,
   path: $path,

--- a/build_runner/lib/src/build_plan/build_packages.dart
+++ b/build_runner/lib/src/build_plan/build_packages.dart
@@ -120,11 +120,10 @@ class BuildPackages implements AssetPathProvider {
     packages = packagesBuilder.build();
 
     final asPackageConfig = _packagesToConfig(packages.values);
-    final outputPackages =
-        packages.values
-            .where((b) => b.isOutput)
-            .map((p) => p.name)
-            .toBuiltSet();
+    final outputPackages = packages.values
+        .where((b) => b.isOutput)
+        .map((p) => p.name)
+        .toBuiltSet();
 
     final transitiveDependencies = _computeAllTransitiveDeps(packages);
     final buildPackages = _computePeers(outputPackages, transitiveDependencies);
@@ -200,11 +199,10 @@ class BuildPackages implements AssetPathProvider {
   BuildPackage? operator [](String packageName) => packages[packageName];
 
   /// Map from package name to package language version.
-  BuiltMap<String, LanguageVersion?> get languageVersions =>
-      {
-        for (final package in packages.values)
-          package.name: package.languageVersion,
-      }.build();
+  BuiltMap<String, LanguageVersion?> get languageVersions => {
+    for (final package in packages.values)
+      package.name: package.languageVersion,
+  }.build();
 
   @override
   String pathFor(

--- a/build_runner/lib/src/build_plan/build_packages_loader.dart
+++ b/build_runner/lib/src/build_plan/build_packages_loader.dart
@@ -40,9 +40,8 @@ class BuildPackagesLoader {
     final buildType = paths.buildType;
 
     final packageConfig = await loadPackageConfig(packageConfigFile);
-    final packageConfigs =
-        packageConfig.packages.toList()
-          ..sort((a, b) => a.name.compareTo(b.name));
+    final packageConfigs = packageConfig.packages.toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
 
     String? workspaceName;
     List<String>? workspacePackages;

--- a/build_runner/lib/src/build_plan/build_phases.dart
+++ b/build_runner/lib/src/build_plan/build_phases.dart
@@ -41,10 +41,7 @@ class BuildPhases {
        postBuildActionsOptionsDigests = _digestsOf(
          postBuildPhase?.builderActions ?? [],
        ),
-       digest = _computeDigest([
-         ...inBuildPhases,
-         if (postBuildPhase != null) postBuildPhase,
-       ]);
+       digest = _computeDigest([...inBuildPhases, ?postBuildPhase]);
 
   /// The phases, [inBuildPhases] followed by [postBuildPhase], by number.
   BuildPhase operator [](int index) {
@@ -97,10 +94,9 @@ class BuildPhases {
       if (packagesInBuild.contains(action.package)) continue;
       // This should happen only with a manual build script since the build
       // phases generation filters these out.
-      final name =
-          action is InBuildPhase
-              ? action.displayName
-              : (action as PostBuildAction).builderLabel;
+      final name = action is InBuildPhase
+          ? action.displayName
+          : (action as PostBuildAction).builderLabel;
       buildLog.error(
         'A build phase ($name) is attempting '
         'to operate on package "${action.package}" without "hideOutput". '

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -130,12 +130,11 @@ class BuildPlan {
       compileStrategy: buildOptions.compileStrategy,
     );
     var restartIsNeeded = false;
-    final compileFreshness =
-        testingOverrides.checkBuilderFreshness
-            ? await bootstrapper.checkCompileFreshness(
-              digestsAreFresh: recentlyBootstrapped,
-            )
-            : FreshnessResult(outputIsFresh: true, digest: 'dummy_digest');
+    final compileFreshness = testingOverrides.checkBuilderFreshness
+        ? await bootstrapper.checkCompileFreshness(
+            digestsAreFresh: recentlyBootstrapped,
+          )
+        : FreshnessResult(outputIsFresh: true, digest: 'dummy_digest');
     if (!compileFreshness.outputIsFresh) {
       restartIsNeeded = true;
     }
@@ -143,9 +142,10 @@ class BuildPlan {
     final buildPackages =
         testingOverrides.buildPackages ??
         await BuildPackages.forPaths(buildOptions.buildPaths);
-    final readerWriter = (testingOverrides.readerWriter ??
-            ReaderWriter(buildPackages))
-        .copyWith(cache: InMemoryFilesystemCache());
+    final readerWriter =
+        (testingOverrides.readerWriter ?? ReaderWriter(buildPackages)).copyWith(
+          cache: InMemoryFilesystemCache(),
+        );
     final buildConfigs = await BuildConfigs.load(
       readerWriter: readerWriter,
       buildPackages: buildPackages,
@@ -275,12 +275,11 @@ class BuildPlan {
       // Compute build steps just to get declared outputs and prune the input
       // sources to remove them. They are computed again below based on the
       // pruned inputs.
-      final declaredOutputs =
-          BuildStepPlan.compute(
-            buildPhases: buildPhases,
-            placeholderIds: buildPackages.placeholderIds,
-            sources: inputSources,
-          ).declaredOutputs;
+      final declaredOutputs = BuildStepPlan.compute(
+        buildPhases: buildPhases,
+        placeholderIds: buildPackages.placeholderIds,
+        sources: inputSources,
+      ).declaredOutputs;
       final inputSourcesWithoutOutputs = Set<AssetId>.from(inputSources);
       for (final output in declaredOutputs) {
         inputSourcesWithoutOutputs.remove(output);
@@ -303,11 +302,10 @@ class BuildPlan {
     ];
 
     if (previousBuildState == null) {
-      final conflictsInDeps =
-          declaredAndActualOutputs
-              .where((n) => !buildPackages.outputPackages.contains(n.package))
-              .where(inputSources.contains)
-              .toSet();
+      final conflictsInDeps = declaredAndActualOutputs
+          .where((n) => !buildPackages.outputPackages.contains(n.package))
+          .where(inputSources.contains)
+          .toSet();
       if (conflictsInDeps.isNotEmpty) {
         buildLog.error(
           'There are existing files in dependencies which conflict '
@@ -327,10 +325,9 @@ class BuildPlan {
     }
 
     final finalReaderWriter = readerWriter.copyWith(
-      generatedAssetHider:
-          testingOverrides.flattenOutput
-              ? const NoopGeneratedAssetHider()
-              : buildStepPlan,
+      generatedAssetHider: testingOverrides.flattenOutput
+          ? const NoopGeneratedAssetHider()
+          : buildStepPlan,
     );
 
     return _createAndResolve(
@@ -348,8 +345,9 @@ class BuildPlan {
       bootstrapper: bootstrapper,
       filesToDelete: filesToDelete.toBuiltList(),
       foldersToDelete: foldersToDelete.toBuiltList(),
-      triggersChanged:
-          !buildPlanDigest.hasSameTriggersAs(previousBuildPlanDigest),
+      triggersChanged: !buildPlanDigest.hasSameTriggersAs(
+        previousBuildPlanDigest,
+      ),
       phaseOptionsChanged: buildPlanDigest.computeChangedPhaseOptions(
         previousBuildPlanDigest,
       ),
@@ -524,10 +522,9 @@ class BuildPlan {
         }
       }
       final newReaderWriter = readerWriter.copyWith(
-        generatedAssetHider:
-            testingOverrides.flattenOutput
-                ? const NoopGeneratedAssetHider()
-                : newBuildStepPlan,
+        generatedAssetHider: testingOverrides.flattenOutput
+            ? const NoopGeneratedAssetHider()
+            : newBuildStepPlan,
       );
       return BuildPlan(
         buildPlanDigest: buildPlanDigest,
@@ -562,8 +559,9 @@ class BuildPlan {
         buildStepPlan: buildStepPlan,
         id: id,
       );
-      final oldDigest =
-          oldIsSource ? previousBuildState.digestOfSource(id) : null;
+      final oldDigest = oldIsSource
+          ? previousBuildState.digestOfSource(id)
+          : null;
       var exists = false;
       Digest? newDigest;
 
@@ -643,17 +641,15 @@ class BuildPlan {
       }
     }
 
-    final deletedOutputs =
-        buildStepPlan
-            .transitiveDeclaredOutputsOf(result.deletedSources.build())
-            .toSet();
+    final deletedOutputs = buildStepPlan
+        .transitiveDeclaredOutputsOf(result.deletedSources.build())
+        .toSet();
     result.deletedOutputs.addAll(deletedOutputs);
 
     final generatedReaderWriter = readerWriter.copyWith(
-      generatedAssetHider:
-          testingOverrides.flattenOutput
-              ? const NoopGeneratedAssetHider()
-              : newBuildStepPlan,
+      generatedAssetHider: testingOverrides.flattenOutput
+          ? const NoopGeneratedAssetHider()
+          : newBuildStepPlan,
     );
     for (final id in deletedOutputs) {
       await generatedReaderWriter.delete(id);

--- a/build_runner/lib/src/build_plan/build_plan_digest.g.dart
+++ b/build_runner/lib/src/build_plan/build_plan_digest.g.dart
@@ -324,8 +324,8 @@ class BuildPlanDigestBuilder
       _enabledExperiments = $v.enabledExperiments.toBuilder();
       _packageLanguageVersions = $v.packageLanguageVersions.toBuilder();
       _inBuildPhasesOptionsDigests = $v.inBuildPhasesOptionsDigests.toBuilder();
-      _postBuildActionsOptionsDigests =
-          $v.postBuildActionsOptionsDigests.toBuilder();
+      _postBuildActionsOptionsDigests = $v.postBuildActionsOptionsDigests
+          .toBuilder();
       _$v = null;
     }
     return this;
@@ -369,8 +369,8 @@ class BuildPlanDigestBuilder
             enabledExperiments: enabledExperiments.build(),
             packageLanguageVersions: packageLanguageVersions.build(),
             inBuildPhasesOptionsDigests: inBuildPhasesOptionsDigests.build(),
-            postBuildActionsOptionsDigests:
-                postBuildActionsOptionsDigests.build(),
+            postBuildActionsOptionsDigests: postBuildActionsOptionsDigests
+                .build(),
           );
     } catch (_) {
       late String _$failedField;

--- a/build_runner/lib/src/build_plan/build_step_plan.g.dart
+++ b/build_runner/lib/src/build_plan/build_step_plan.g.dart
@@ -102,8 +102,8 @@ class BuildStepPlanBuilder
     if ($v != null) {
       _buildPhases = $v.buildPhases;
       _buildStepsByDeclaredOutput = $v.buildStepsByDeclaredOutput.toBuilder();
-      _declaredOutputsByPrimaryInput =
-          $v.declaredOutputsByPrimaryInput.toBuilder();
+      _declaredOutputsByPrimaryInput = $v.declaredOutputsByPrimaryInput
+          .toBuilder();
       _buildStepsByPhase = $v.buildStepsByPhase.toBuilder();
       _$v = null;
     }
@@ -135,8 +135,8 @@ class BuildStepPlanBuilder
               'buildPhases',
             ),
             buildStepsByDeclaredOutput: buildStepsByDeclaredOutput.build(),
-            declaredOutputsByPrimaryInput:
-                declaredOutputsByPrimaryInput.build(),
+            declaredOutputsByPrimaryInput: declaredOutputsByPrimaryInput
+                .build(),
             buildStepsByPhase: buildStepsByPhase.build(),
           );
     } catch (_) {

--- a/build_runner/lib/src/build_plan/build_triggers.dart
+++ b/build_runner/lib/src/build_plan/build_triggers.dart
@@ -244,8 +244,7 @@ abstract class AnnotationBuildTrigger
     return false;
   }
 
-  String? get warning =>
-      annotation.contains(_regexp)
-          ? null
-          : 'Invalid annotation trigger: `$annotation`';
+  String? get warning => annotation.contains(_regexp)
+      ? null
+      : 'Invalid annotation trigger: `$annotation`';
 }

--- a/build_runner/lib/src/build_plan/build_triggers.g.dart
+++ b/build_runner/lib/src/build_plan/build_triggers.g.dart
@@ -44,8 +44,9 @@ class _$ImportBuildTrigger extends ImportBuildTrigger {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'ImportBuildTrigger')
-      ..add('import', import)).toString();
+    return (newBuiltValueToStringHelper(
+      r'ImportBuildTrigger',
+    )..add('import', import)).toString();
   }
 }
 
@@ -130,8 +131,9 @@ class _$AnnotationBuildTrigger extends AnnotationBuildTrigger {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'AnnotationBuildTrigger')
-      ..add('annotation', annotation)).toString();
+    return (newBuiltValueToStringHelper(
+      r'AnnotationBuildTrigger',
+    )..add('annotation', annotation)).toString();
   }
 }
 

--- a/build_runner/lib/src/build_plan/builder_definition.dart
+++ b/build_runner/lib/src/build_plan/builder_definition.dart
@@ -80,11 +80,10 @@ sealed class AbstractBuilderDefinition {
     final rootBuildConfig = orderedConfigs.singleWhere(
       (c) => c.packageName == buildPackages.outputRoot,
     );
-    final orderedBuilders =
-        findBuilderOrder(
-          builderDefinitions,
-          rootBuildConfig.globalOptions,
-        ).toList();
+    final orderedBuilders = findBuilderOrder(
+      builderDefinitions,
+      rootBuildConfig.globalOptions,
+    ).toList();
 
     final postProcessBuilderDefinitions = orderedConfigs
         .expand((c) => c.postProcessBuilderDefinitions.values)
@@ -174,8 +173,8 @@ class BuilderDefinition implements AbstractBuilderDefinition {
         return restrictForWorkspacePackages == null
             ? true
             : restrictForWorkspacePackages
-                .peersOf(package.name)
-                .contains(this.package);
+                  .peersOf(package.name)
+                  .contains(this.package);
       case AutoApply.rootPackage:
         // In a workspace build, "root package" means an output package that
         // depends transitively on the builder.

--- a/build_runner/lib/src/build_plan/builder_factories.dart
+++ b/build_runner/lib/src/build_plan/builder_factories.dart
@@ -18,14 +18,13 @@ class BuilderFactories {
   BuilderFactories(
     Map<String, List<BuilderFactory>> builderFactories, {
     Map<String, PostProcessBuilderFactory>? postProcessBuilderFactories,
-  }) : builderFactories =
-           builderFactories
-               .map<String, BuiltList<BuilderFactory>>(
-                 (k, v) => MapEntry(k, v.build()),
-               )
-               .build(),
-       postProcessBuilderFactories =
-           (postProcessBuilderFactories ?? {}).build();
+  }) : builderFactories = builderFactories
+           .map<String, BuiltList<BuilderFactory>>(
+             (k, v) => MapEntry(k, v.build()),
+           )
+           .build(),
+       postProcessBuilderFactories = (postProcessBuilderFactories ?? {})
+           .build();
 
   /// Whether there are factories for all definitions in [builderDefinitions].
   ///

--- a/build_runner/lib/src/build_plan/builder_ordering.dart
+++ b/build_runner/lib/src/build_plan/builder_ordering.dart
@@ -15,8 +15,8 @@ Iterable<BuilderDefinition> findBuilderOrder(
   Iterable<BuilderDefinition> builders,
   Map<String, GlobalBuilderConfig> globalBuilderConfigs,
 ) {
-  final consistentOrderBuilders =
-      builders.toList()..sort((a, b) => a.key.compareTo(b.key));
+  final consistentOrderBuilders = builders.toList()
+    ..sort((a, b) => a.key.compareTo(b.key));
   Iterable<BuilderDefinition> dependencies(BuilderDefinition parent) =>
       consistentOrderBuilders.where(
         (child) =>

--- a/build_runner/lib/src/build_plan/input_matcher.dart
+++ b/build_runner/lib/src/build_plan/input_matcher.dart
@@ -21,8 +21,9 @@ class InputMatcher {
   final List<Glob>? excludeGlobs;
 
   InputMatcher(InputSet inputSet, {BuiltList<String>? defaultInclude})
-    : includeGlobs =
-          (inputSet.include ?? defaultInclude)?.map(Glob.new).toList(),
+    : includeGlobs = (inputSet.include ?? defaultInclude)
+          ?.map(Glob.new)
+          .toList(),
       excludeGlobs = inputSet.exclude?.map(Glob.new).toList();
 
   /// Whether [input] is included in this set of assets.

--- a/build_runner/lib/src/build_runner_command_line.dart
+++ b/build_runner/lib/src/build_runner_command_line.dart
@@ -96,14 +96,13 @@ class BuildRunnerCommandLine {
       // Only "build" and "watch" support --workspace, default to false for
       // other commands.
       workspace = argResults.boolNamed(workspaceOption) ?? false,
-      removedOptionsUsed =
-          removedOptions
-              .where(
-                (option) =>
-                    argResults.options.contains(option) &&
-                    argResults.wasParsed(option),
-              )
-              .toBuiltList();
+      removedOptionsUsed = removedOptions
+          .where(
+            (option) =>
+                argResults.options.contains(option) &&
+                argResults.wasParsed(option),
+          )
+          .toBuiltList();
 
   String get usage {
     // Calling `usage` only works if the command has been added to a

--- a/build_runner/lib/src/commands/clean_command.dart
+++ b/build_runner/lib/src/commands/clean_command.dart
@@ -21,10 +21,9 @@ class CleanCommand implements BuildRunnerCommand {
     // Delete specific directories and files instead of the whole cache
     // directory, which can't be deleted on Windows due to the open lock file.
 
-    final basePath =
-        buildPaths.buildWorkspace
-            ? buildPaths.workspacePath!
-            : buildPaths.packagePath;
+    final basePath = buildPaths.buildWorkspace
+        ? buildPaths.workspacePath!
+        : buildPaths.packagePath;
 
     final entrypointDir = Directory(p.join(basePath, entrypointDirectoryPath));
     if (entrypointDir.existsSync()) {

--- a/build_runner/lib/src/commands/daemon/asset_server.dart
+++ b/build_runner/lib/src/commands/daemon/asset_server.dart
@@ -36,9 +36,8 @@ class AssetServer {
         })
         .add(
           AssetHandler(
-            () async =>
-                (await builder.buildSeries.currentBuildResult)
-                    .buildOutputReader,
+            () async => (await builder.buildSeries.currentBuildResult)
+                .buildOutputReader,
             outputRootPackage,
           ).handle,
         );

--- a/build_runner/lib/src/commands/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/commands/daemon/daemon_builder.dart
@@ -64,8 +64,9 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
     Iterable<WatchEvent> fileChanges,
   ) async {
     final defaultTargets = targets.cast<DefaultBuildTarget>();
-    final updates =
-        fileChanges.map((change) => AssetId.parse(change.path)).toSet();
+    final updates = fileChanges
+        .map((change) => AssetId.parse(change.path))
+        .toSet();
 
     final targetNames = targets.map((t) => t.target).toSet();
     _logMessage(Level.INFO, 'About to build ${targetNames.toList()}...');
@@ -246,16 +247,14 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
             )
             .where((changes) => changes.isNotEmpty)
             .map(
-              (changes) =>
-                  changes
-                      .map((change) => WatchEvent(change.type, '${change.id}'))
-                      .toList(),
+              (changes) => changes
+                  .map((change) => WatchEvent(change.type, '${change.id}'))
+                  .toList(),
             );
 
-    final changeProvider =
-        daemonOptions.buildMode == BuildMode.Auto
-            ? AutoChangeProviderImpl(graphEvents())
-            : ManualChangeProviderImpl(buildSeries.checkForChanges);
+    final changeProvider = daemonOptions.buildMode == BuildMode.Auto
+        ? AutoChangeProviderImpl(graphEvents())
+        : ManualChangeProviderImpl(buildSeries.checkForChanges);
 
     return BuildRunnerDaemonBuilder._(
       buildPlan,

--- a/build_runner/lib/src/commands/daemon_command.dart
+++ b/build_runner/lib/src/commands/daemon_command.dart
@@ -85,8 +85,7 @@ class DaemonCommand implements BuildRunnerCommand {
       //
       // `BuildRunnerDaemonBuilder` sets its own `onLog` replacing this one.
       buildLog.configuration = buildLog.configuration.rebuild((b) {
-        b.onLog =
-            (record) => stdout.writeln('''
+        b.onLog = (record) => stdout.writeln('''
 $logStartMarker
 ${jsonEncode(serializers.serialize(ServerLog.fromLogRecord(record)))}
 $logEndMarker''');

--- a/build_runner/lib/src/commands/run_command.dart
+++ b/build_runner/lib/src/commands/run_command.dart
@@ -56,36 +56,34 @@ class RunCommand implements BuildRunnerCommand {
     }
 
     // Create a temporary directory in which to execute the script.
-    final tempPath =
-        Directory.systemTemp
-            .createTempSync('build_runner_run_script')
-            .absolute
-            .uri
-            .toFilePath();
+    final tempPath = Directory.systemTemp
+        .createTempSync('build_runner_run_script')
+        .absolute
+        .uri
+        .toFilePath();
 
     // Use a completer to determine the exit code.
     final exitCodeCompleter = Completer<int>();
 
-    final result =
-        await BuildCommand(
-          builderFactories: builderFactories,
-          buildOptions: buildOptions.copyWith(
-            compileStrategy: CompileStrategy.forceJit,
-            buildDirs: buildOptions.buildDirs.rebuild((b) {
-              b.add(
-                BuildDirectory(
-                  '',
-                  outputLocation: OutputLocation(
-                    tempPath,
-                    useSymlinks: buildOptions.outputSymlinksOnly,
-                    hoist: false,
-                  ),
-                ),
-              );
-            }),
-          ),
-          testingOverrides: testingOverrides,
-        ).run();
+    final result = await BuildCommand(
+      builderFactories: builderFactories,
+      buildOptions: buildOptions.copyWith(
+        compileStrategy: CompileStrategy.forceJit,
+        buildDirs: buildOptions.buildDirs.rebuild((b) {
+          b.add(
+            BuildDirectory(
+              '',
+              outputLocation: OutputLocation(
+                tempPath,
+                useSymlinks: buildOptions.outputSymlinksOnly,
+                hoist: false,
+              ),
+            ),
+          );
+        }),
+      ),
+      testingOverrides: testingOverrides,
+    ).run();
     if (result != ExitCode.success.code) {
       buildLog.warning('Skipping script run due to build failure.');
       return result;

--- a/build_runner/lib/src/commands/serve/path_to_asset_id.dart
+++ b/build_runner/lib/src/commands/serve/path_to_asset_id.dart
@@ -31,7 +31,7 @@ List<AssetId> pathToAssetIds(
 /// Returns null for paths that neither a lib nor starts from a rootDir
 String? assetIdToPath(AssetId assetId, String rootDir) =>
     assetId.path.startsWith('lib/')
-        ? assetId.path.replaceFirst('lib/', 'packages/${assetId.package}/')
-        : assetId.path.startsWith('$rootDir/')
-        ? assetId.path.substring(rootDir.length + 1)
-        : null;
+    ? assetId.path.replaceFirst('lib/', 'packages/${assetId.package}/')
+    : assetId.path.startsWith('$rootDir/')
+    ? assetId.path.substring(rootDir.length + 1)
+    : null;

--- a/build_runner/lib/src/commands/serve/server.dart
+++ b/build_runner/lib/src/commands/serve/server.dart
@@ -102,8 +102,8 @@ class ServeHandler {
   ) async {
     final buildResult = await _watcher.currentBuildResult;
     final reader = buildResult.buildOutputReader;
-    final assertPathList =
-        (jsonDecode(await request.readAsString()) as List).cast<String>();
+    final assertPathList = (jsonDecode(await request.readAsString()) as List)
+        .cast<String>();
     final results = <String, String>{};
     for (final path in assertPathList) {
       final assetIds = pathToAssetIds(
@@ -244,7 +244,8 @@ final _injectLiveReloadClientCode = _injectBuildUpdatesClientCode(
 /// Hot-/live- reload config
 ///
 /// Listen WebSocket for updates in build results
-String _buildUpdatesInjectedJS(String scriptName) => '''\n
+String _buildUpdatesInjectedJS(String scriptName) =>
+    '''\n
 // Injected by build_runner for build updates support
 window.\$dartLoader.forceLoadModule('packages/build_runner/src/commands/serve/$scriptName');
 ''';
@@ -259,22 +260,18 @@ class AssetHandler {
 
   Future<shelf.Response> handle(shelf.Request request, {String rootDir = ''}) =>
       (request.url.path.endsWith('/') || request.url.path.isEmpty)
-          ? _handle(
-            request,
-            pathToAssetIds(_outputRootPackage, rootDir, [
-              ...request.url.pathSegments.where((p) => p.isNotEmpty),
-              'index.html',
-            ]),
-            fallbackToDirectoryList: true,
-          )
-          : _handle(
-            request,
-            pathToAssetIds(
-              _outputRootPackage,
-              rootDir,
-              request.url.pathSegments,
-            ),
-          );
+      ? _handle(
+          request,
+          pathToAssetIds(_outputRootPackage, rootDir, [
+            ...request.url.pathSegments.where((p) => p.isNotEmpty),
+            'index.html',
+          ]),
+          fallbackToDirectoryList: true,
+        )
+      : _handle(
+          request,
+          pathToAssetIds(_outputRootPackage, rootDir, request.url.pathSegments),
+        );
 
   Future<shelf.Response> _handle(
     shelf.Request request,
@@ -327,7 +324,7 @@ class AssetHandler {
         contentType = '$contentType; charset=utf-8';
       }
       final headers = <String, Object>{
-        if (contentType != null) HttpHeaders.contentTypeHeader: contentType,
+        HttpHeaders.contentTypeHeader: ?contentType,
         HttpHeaders.etagHeader: etag,
         // We always want this revalidated, which requires specifying both
         // max-age=0 and must-revalidate.
@@ -363,11 +360,10 @@ class AssetHandler {
     final glob = p.url.join(directoryPath, '*');
     final reader = await _reader();
 
-    final result =
-        await reader
-            .findAssets(Glob(glob), package: from.package)
-            .map((a) => a.path)
-            .toList();
+    final result = await reader
+        .findAssets(Glob(glob), package: from.package)
+        .map((a) => a.path)
+        .toList();
     final message = StringBuffer('Could not find ${from.path}');
     if (result.isEmpty) {
       message.write(' or any files in $directoryPath. ');
@@ -388,8 +384,9 @@ shelf.Handler _logRequests(shelf.Handler innerHandler) {
     final watch = Stopwatch()..start();
     try {
       final response = await innerHandler(request);
-      final logFn =
-          response.statusCode >= 500 ? buildLog.warning : buildLog.info;
+      final logFn = response.statusCode >= 500
+          ? buildLog.warning
+          : buildLog.info;
       final msg = _requestLabel(
         startTime,
         response.statusCode,

--- a/build_runner/lib/src/commands/serve_command.dart
+++ b/build_runner/lib/src/commands/serve_command.dart
@@ -69,12 +69,11 @@ class ServeCommand implements BuildRunnerCommand {
         return ExitCode.osError.code;
       }
 
-      final watcher =
-          await WatchCommand(
-            builderFactories: builderFactories,
-            buildOptions: buildOptions,
-            testingOverrides: testingOverrides,
-          ).watch();
+      final watcher = await WatchCommand(
+        builderFactories: builderFactories,
+        buildOptions: buildOptions,
+        testingOverrides: testingOverrides,
+      ).watch();
       if (watcher == null) {
         return ChildProcess.recompileBuildersExitCode;
       }

--- a/build_runner/lib/src/commands/serve_options.dart
+++ b/build_runner/lib/src/commands/serve_options.dart
@@ -36,8 +36,9 @@ class ServeOptions {
         );
       }
 
-      final port =
-          parts.length == 2 ? int.tryParse(parts[1]) : nextDefaultPort++;
+      final port = parts.length == 2
+          ? int.tryParse(parts[1])
+          : nextDefaultPort++;
       if (port == null) {
         throw UsageException(
           'Unable to parse port number in `$arg`',

--- a/build_runner/lib/src/commands/test_command.dart
+++ b/build_runner/lib/src/commands/test_command.dart
@@ -45,12 +45,11 @@ class TestCommand implements BuildRunnerCommand {
       b.verboseDurations = buildOptions.verboseDurations;
       b.onLog = testingOverrides.onLog;
     });
-    final tempPath =
-        Directory.systemTemp
-            .createTempSync('build_runner_test')
-            .absolute
-            .uri
-            .toFilePath();
+    final tempPath = Directory.systemTemp
+        .createTempSync('build_runner_test')
+        .absolute
+        .uri
+        .toFilePath();
     try {
       final buildPackages =
           testingOverrides.buildPackages ??
@@ -69,25 +68,24 @@ dev_dependencies:
         return ExitCode.config.code;
       }
 
-      final result =
-          await BuildCommand(
-            builderFactories: builderFactories,
-            buildOptions: buildOptions.copyWith(
-              buildDirs: buildOptions.buildDirs.rebuild((b) {
-                b.add(
-                  BuildDirectory(
-                    'test',
-                    outputLocation: OutputLocation(
-                      tempPath,
-                      useSymlinks: buildOptions.outputSymlinksOnly,
-                      hoist: false,
-                    ),
-                  ),
-                );
-              }),
-            ),
-            testingOverrides: testingOverrides,
-          ).run();
+      final result = await BuildCommand(
+        builderFactories: builderFactories,
+        buildOptions: buildOptions.copyWith(
+          buildDirs: buildOptions.buildDirs.rebuild((b) {
+            b.add(
+              BuildDirectory(
+                'test',
+                outputLocation: OutputLocation(
+                  tempPath,
+                  useSymlinks: buildOptions.outputSymlinksOnly,
+                  hoist: false,
+                ),
+              ),
+            );
+          }),
+        ),
+        testingOverrides: testingOverrides,
+      ).run();
       if (result != ExitCode.success.code) {
         stdout.writeln('Skipping tests due to build failure');
         return result;
@@ -127,10 +125,9 @@ void _ensureProcessExit(Process process) {
   });
 }
 
-Stream<ProcessSignal> get _exitProcessSignals =>
-    Platform.isWindows
-        ? ProcessSignal.sigint.watch()
-        : StreamGroup.merge([
-          ProcessSignal.sigterm.watch(),
-          ProcessSignal.sigint.watch(),
-        ]);
+Stream<ProcessSignal> get _exitProcessSignals => Platform.isWindows
+    ? ProcessSignal.sigint.watch()
+    : StreamGroup.merge([
+        ProcessSignal.sigterm.watch(),
+        ProcessSignal.sigint.watch(),
+      ]);

--- a/build_runner/lib/src/commands/watch/asset_change.dart
+++ b/build_runner/lib/src/commands/watch/asset_change.dart
@@ -27,8 +27,9 @@ class AssetChange {
 
   static String _normalizeRelativePath(BuildPackage package, WatchEvent event) {
     final pkgPath = package.path;
-    final absoluteEventPath =
-        p.isAbsolute(event.path) ? event.path : p.absolute(event.path);
+    final absoluteEventPath = p.isAbsolute(event.path)
+        ? event.path
+        : p.absolute(event.path);
     if (!p.isWithin(pkgPath, absoluteEventPath)) {
       throw ArgumentError('"$absoluteEventPath" is not in "$pkgPath".');
     }

--- a/build_runner/lib/src/commands/watch/watcher.dart
+++ b/build_runner/lib/src/commands/watch/watcher.dart
@@ -64,11 +64,10 @@ class Watcher {
     // Start watching files immediately, before the first build is even started.
     final packagesWatcher = BuildPackagesWatcher(
       _buildPlan.buildPackages,
-      watch:
-          (buildPackage) => BuildPackageWatcher(
-            buildPackage,
-            watch: _buildPlan.testingOverrides.directoryWatcherFactory,
-          ),
+      watch: (buildPackage) => BuildPackageWatcher(
+        buildPackage,
+        watch: _buildPlan.testingOverrides.directoryWatcherFactory,
+      ),
     );
     packagesWatcher
         .watch()

--- a/build_runner/lib/src/io/asset_tracker.dart
+++ b/build_runner/lib/src/io/asset_tracker.dart
@@ -70,10 +70,9 @@ class AssetTracker {
     BuildState buildState,
     Iterable<AssetId> declaredAndActualOutputs,
   ) async {
-    final allSources =
-        <AssetId>{}
-          ..addAll(inputSources)
-          ..addAll(generatedSources);
+    final allSources = <AssetId>{}
+      ..addAll(inputSources)
+      ..addAll(generatedSources);
     final updates = <AssetId, ChangeType>{};
     void addUpdates(Iterable<AssetId> assets, ChangeType type) {
       for (final asset in assets) {
@@ -110,17 +109,17 @@ class AssetTracker {
     return buildTarget.sourceIncludes.isEmpty
         ? const Stream<AssetId>.empty()
         : StreamGroup.merge(
-          buildTarget.sourceIncludes.map(
-            (glob) => _listIdsSafe(glob, package: buildTarget.package)
-                .where(
-                  (id) => _buildConfigs.isVisibleInBuild(
-                    id,
-                    _buildPackages[buildTarget.package]!,
-                  ),
-                )
-                .where((id) => !buildTarget.excludesSource(id)),
-          ),
-        );
+            buildTarget.sourceIncludes.map(
+              (glob) => _listIdsSafe(glob, package: buildTarget.package)
+                  .where(
+                    (id) => _buildConfigs.isVisibleInBuild(
+                      id,
+                      _buildPackages[buildTarget.package]!,
+                    ),
+                  )
+                  .where((id) => !buildTarget.excludesSource(id)),
+            ),
+          );
   }
 
   Stream<AssetId> _listGeneratedAssetIds() {

--- a/build_runner/lib/src/io/create_merged_dir.dart
+++ b/build_runner/lib/src/io/create_merged_dir.dart
@@ -194,12 +194,12 @@ Future<String> _writeModifiedPackageConfig(
       for (final package in buildPackages.packages.values)
         {
           'name': package.name,
-          'rootUri':
-              package.name == rootPackage
-                  ? '../'
-                  : '../packages/${package.name}',
-          'packageUri':
-              package.name == rootPackage ? 'packages/${package.name}' : '',
+          'rootUri': package.name == rootPackage
+              ? '../'
+              : '../packages/${package.name}',
+          'packageUri': package.name == rootPackage
+              ? 'packages/${package.name}'
+              : '',
           if (package.languageVersion != null)
             'languageVersion': '${package.languageVersion}',
         },

--- a/build_runner/lib/src/io/filesystem_cache.dart
+++ b/build_runner/lib/src/io/filesystem_cache.dart
@@ -200,8 +200,9 @@ class InMemoryFilesystemCache implements FilesystemCache {
     List<int> contents, {
     required void Function() writer,
   }) {
-    final uint8ListContents =
-        contents is Uint8List ? contents : Uint8List.fromList(contents);
+    final uint8ListContents = contents is Uint8List
+        ? contents
+        : Uint8List.fromList(contents);
     _bytesContentCache[id] = uint8ListContents;
     _existsCache[id] = true;
     _pendingWrites[id] = _PendingWrite(

--- a/build_runner/lib/src/logging/build_log.dart
+++ b/build_runner/lib/src/logging/build_log.dart
@@ -224,12 +224,11 @@ class BuildLog {
       );
       _display.block(render());
     } else {
-      final renderedContext =
-          context == null
-              ? null
-              : AnsiBufferLine(
-                renderLinkedContext(context, contextId: contextId),
-              ).toString();
+      final renderedContext = context == null
+          ? null
+          : AnsiBufferLine(
+              renderLinkedContext(context, contextId: contextId),
+            ).toString();
       _display.message(
         severity,
         [
@@ -643,10 +642,9 @@ class BuildLog {
   }
 
   AnsiBufferLine _renderCompiling({required CompileType compileType}) {
-    final progress =
-        compileType == CompileType.aot
-            ? _aotCompileProgress!
-            : _jitCompileProgress!;
+    final progress = compileType == CompileType.aot
+        ? _aotCompileProgress!
+        : _jitCompileProgress!;
     return AnsiBufferLine([
       renderDuration(progress.duration),
       ' ',
@@ -710,8 +708,8 @@ class BuildLog {
     if (!configuration.throttleProgressUpdates) return true;
     final interval =
         configuration.mode == BuildLogMode.build && _display.displayingBlocks
-            ? const Duration(milliseconds: 100)
-            : const Duration(seconds: 1);
+        ? const Duration(milliseconds: 100)
+        : const Duration(seconds: 1);
     if (_progressStopwatch.elapsed >= interval) {
       _progressStopwatch.reset();
       return true;

--- a/build_runner/lib/src/logging/build_log_logger.dart
+++ b/build_runner/lib/src/logging/build_log_logger.dart
@@ -131,16 +131,14 @@ class BuildLogLogger implements Logger {
   String get name => phaseName ?? '';
 
   @override
-  Stream<Level?> get onLevelChanged =>
-      throw UnsupportedError(
-        'Builders are not allowed to subscribe to logger level changes.',
-      );
+  Stream<Level?> get onLevelChanged => throw UnsupportedError(
+    'Builders are not allowed to subscribe to logger level changes.',
+  );
 
   @override
-  Stream<LogRecord> get onRecord =>
-      throw UnsupportedError(
-        'Builders are not allowed to subscribe to log records.',
-      );
+  Stream<LogRecord> get onRecord => throw UnsupportedError(
+    'Builders are not allowed to subscribe to log records.',
+  );
 
   @override
   Logger? get parent => null;

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 
 platforms:
   linux:

--- a/build_runner/test/build/build_state/build_state_test.dart
+++ b/build_runner/test/build/build_state/build_state_test.dart
@@ -233,11 +233,10 @@ void main() {
       final b = makeAssetId('foo|b');
       final c = makeAssetId('foo|c');
       plan = BuildStepPlan(
-        (builder) =>
-            builder
-              ..buildPhases = BuildPhases([])
-              ..declaredOutputsByPrimaryInput.addValues(a, [b])
-              ..declaredOutputsByPrimaryInput.addValues(b, [c]),
+        (builder) => builder
+          ..buildPhases = BuildPhases([])
+          ..declaredOutputsByPrimaryInput.addValues(a, [b])
+          ..declaredOutputsByPrimaryInput.addValues(b, [c]),
       );
 
       expect(plan.transitiveDeclaredOutputsOf([a]), unorderedEquals({a, b, c}));
@@ -251,12 +250,11 @@ void main() {
       final c = makeAssetId('foo|c');
       final d = makeAssetId('foo|d');
       plan = BuildStepPlan(
-        (builder) =>
-            builder
-              ..buildPhases = BuildPhases([])
-              ..declaredOutputsByPrimaryInput.addValues(a, [b, c])
-              ..declaredOutputsByPrimaryInput.addValues(b, [d])
-              ..declaredOutputsByPrimaryInput.addValues(c, [d]),
+        (builder) => builder
+          ..buildPhases = BuildPhases([])
+          ..declaredOutputsByPrimaryInput.addValues(a, [b, c])
+          ..declaredOutputsByPrimaryInput.addValues(b, [d])
+          ..declaredOutputsByPrimaryInput.addValues(c, [d]),
       );
 
       expect(
@@ -271,11 +269,10 @@ void main() {
       final c = makeAssetId('foo|c');
       final d = makeAssetId('foo|d');
       plan = BuildStepPlan(
-        (builder) =>
-            builder
-              ..buildPhases = BuildPhases([])
-              ..declaredOutputsByPrimaryInput.addValues(a, [b])
-              ..declaredOutputsByPrimaryInput.addValues(c, [d]),
+        (builder) => builder
+          ..buildPhases = BuildPhases([])
+          ..declaredOutputsByPrimaryInput.addValues(a, [b])
+          ..declaredOutputsByPrimaryInput.addValues(c, [d]),
       );
 
       expect(

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -45,10 +45,9 @@ void main() {
       'test_builder': [(_) => testBuilder],
     },
     postProcessBuilderFactories: {
-      'a:post_copy_builder':
-          (options) => CopyingPostProcessBuilder(
-            outputExtension: options.config['extension'] as String? ?? '.post',
-          ),
+      'a:post_copy_builder': (options) => CopyingPostProcessBuilder(
+        outputExtension: options.config['extension'] as String? ?? '.post',
+      ),
     },
   );
   final globBuilder = GlobbingBuilder(Glob('**.txt'));
@@ -363,8 +362,9 @@ void main() {
                 ),
               ],
             },
-            postProcessBuilderFactories:
-                builderFactories.postProcessBuilderFactories.toMap(),
+            postProcessBuilderFactories: builderFactories
+                .postProcessBuilderFactories
+                .toMap(),
           ),
           builders,
           {
@@ -503,10 +503,9 @@ targets:
 
         final assetGraphJsonId = makeAssetId('a|$assetGraphJsonPath');
         expect(result.readerWriter.testing.exists(assetGraphJsonId), isTrue);
-        final cachedBuildState =
-            AssetGraphJson.deserialize(
-              result.readerWriter.testing.readBytes(assetGraphJsonId),
-            )!.buildState;
+        final cachedBuildState = AssetGraphJson.deserialize(
+          result.readerWriter.testing.readBytes(assetGraphJsonId),
+        )!.buildState;
         expect(
           cachedBuildState.sources,
           unorderedEquals([makeAssetId('a|web/a.txt')]),
@@ -828,8 +827,8 @@ additional_public_assets:
 
     test('can read files from external packages', () async {
       final builder = TestBuilder(
-        extraWork:
-            (buildStep, _) => buildStep.canRead(makeAssetId('b|lib/b.txt')),
+        extraWork: (buildStep, _) =>
+            buildStep.canRead(makeAssetId('b|lib/b.txt')),
       );
       await testBuilders(
         [builder],
@@ -1153,10 +1152,9 @@ targets:
     );
 
     final graphId = makeAssetId('a|$assetGraphJsonPath');
-    final cachedBuildState =
-        AssetGraphJson.deserialize(
-          result.readerWriter.testing.readBytes(graphId),
-        )!.buildState;
+    final cachedBuildState = AssetGraphJson.deserialize(
+      result.readerWriter.testing.readBytes(graphId),
+    )!.buildState;
     final outputId = AssetId('a', 'lib/a.txt.out');
 
     final buildStepId = BuildStepId(
@@ -1423,12 +1421,11 @@ targets:
       );
 
       /// Should be deleted using the writer, and converted to missingSource.
-      final newBuildState =
-          AssetGraphJson.deserialize(
-            result.readerWriter.testing.readBytes(
-              makeAssetId('a|$assetGraphJsonPath'),
-            ),
-          )!.buildState;
+      final newBuildState = AssetGraphJson.deserialize(
+        result.readerWriter.testing.readBytes(
+          makeAssetId('a|$assetGraphJsonPath'),
+        ),
+      )!.buildState;
       final anId = makeAssetId('a|lib/a.txt');
       final aCopyId = makeAssetId('a|lib/a.txt.copy');
       final aCloneId = makeAssetId('a|lib/a.txt.copy.clone');
@@ -1533,12 +1530,11 @@ targets:
       );
 
       // Read cached build state and validate.
-      final buildState =
-          AssetGraphJson.deserialize(
-            result.readerWriter.testing.readBytes(
-              makeAssetId('a|$assetGraphJsonPath'),
-            ),
-          )!.buildState;
+      final buildState = AssetGraphJson.deserialize(
+        result.readerWriter.testing.readBytes(
+          makeAssetId('a|$assetGraphJsonPath'),
+        ),
+      )!.buildState;
       final fileAId = makeAssetId('a|lib/file.a');
       final fileCId = makeAssetId('a|lib/file.c');
       expect(buildState.isSource(fileAId), isTrue);
@@ -1772,12 +1768,9 @@ targets:
         resumeFrom: result,
       );
 
-      final finalBuildState =
-          AssetGraphJson.deserialize(
-            result.readerWriter.testing.readBytes(
-              AssetId('a', assetGraphJsonPath),
-            ),
-          )!.buildState;
+      final finalBuildState = AssetGraphJson.deserialize(
+        result.readerWriter.testing.readBytes(AssetId('a', assetGraphJsonPath)),
+      )!.buildState;
 
       expect(
         finalBuildState

--- a/build_runner/test/build/library_cycle_graph/library_cycle_graph_loader_test.dart
+++ b/build_runner/test/build/library_cycle_graph/library_cycle_graph_loader_test.dart
@@ -486,9 +486,10 @@ void main() {
             final randomForLoads = Random(seed);
 
             List<AssetId> randomLoads() {
-              return ([a1, a2, a3, a4, a5, a6, a7, a8, a9]..shuffle(
-                randomForLoads,
-              )).take(randomForLoads.nextInt(3)).toList();
+              return ([a1, a2, a3, a4, a5, a6, a7, a8, a9]
+                    ..shuffle(randomForLoads))
+                  .take(randomForLoads.nextInt(3))
+                  .toList();
             }
 
             final loader = LibraryCycleGraphLoader();

--- a/build_runner/test/build/resolver/resolver_test.dart
+++ b/build_runner/test/build/resolver/resolver_test.dart
@@ -68,11 +68,10 @@ void runTests(ResolversFactory resolversFactory) {
       (resolver) async {
         final lib = await resolver.libraryFor(entryPoint);
         expect(lib.firstFragment.libraryImports.length, 2);
-        final libA =
-            lib
-              ..firstFragment.libraryImports
-                  .where((l) => l.importedLibrary!.name == 'a')
-                  .single;
+        final libA = lib
+          ..firstFragment.libraryImports
+              .where((l) => l.importedLibrary!.name == 'a')
+              .single;
         expect(libA.getClass('Foo'), isNull);
       },
       resolvers: createResolvers(),
@@ -112,11 +111,10 @@ void runTests(ResolversFactory resolversFactory) {
       (resolver) async {
         final lib = await resolver.libraryFor(entryPoint);
         expect(lib.firstFragment.libraryImports.length, 2);
-        final libB =
-            lib
-              ..firstFragment.libraryImports
-                  .where((l) => l.importedLibrary!.name == 'b')
-                  .single;
+        final libB = lib
+          ..firstFragment.libraryImports
+              .where((l) => l.importedLibrary!.name == 'b')
+              .single;
         expect(libB.getClass('Foo'), isNull);
       },
       resolvers: createResolvers(),
@@ -593,8 +591,9 @@ void runTests(ResolversFactory resolversFactory) {
           'a|lib/d.dart': 'library a.d;',
         },
         (resolver) async {
-          final libs =
-              await resolver.libraries.where((l) => !l.isInSdk).toList();
+          final libs = await resolver.libraries
+              .where((l) => !l.isInSdk)
+              .toList();
           expect(
             libs.map((l) => l.name),
             unorderedEquals(['a.main', 'a.a', 'a.b', 'a.c', 'a.d']),
@@ -660,8 +659,12 @@ void runTests(ResolversFactory resolversFactory) {
         },
         (resolver) async {
           final main = (await resolver.findLibraryByName('web.main'))!;
-          final meta =
-              main.getClass('Foo')!.supertype!.element.metadata.annotations[0];
+          final meta = main
+              .getClass('Foo')!
+              .supertype!
+              .element
+              .metadata
+              .annotations[0];
           expect(meta, isNotNull);
           expect(meta.computeConstantValue()?.toIntValue(), 0);
         },
@@ -706,10 +709,9 @@ void runTests(ResolversFactory resolversFactory) {
         },
         (resolver) async {
           final entry = await resolver.libraryFor(AssetId('a', 'lib/a.dart'));
-          final classDefinition =
-              entry.firstFragment.libraryImports
-                  .map((l) => l.importedLibrary!.getClass('SomeClass'))
-                  .singleWhere((c) => c != null)!;
+          final classDefinition = entry.firstFragment.libraryImports
+              .map((l) => l.importedLibrary!.getClass('SomeClass'))
+              .singleWhere((c) => c != null)!;
           expect(
             await resolver.assetIdForElement(classDefinition),
             AssetId('a', 'lib/b.dart'),
@@ -738,13 +740,12 @@ void runTests(ResolversFactory resolversFactory) {
         },
         (resolver) async {
           final entry = await resolver.libraryFor(AssetId('a', 'lib/a.dart'));
-          final element =
-              entry.topLevelFunctions
-                  .firstWhere((e) => e.name == 'main')
-                  .metadata
-                  .annotations
-                  .single
-                  .element!;
+          final element = entry.topLevelFunctions
+              .firstWhere((e) => e.name == 'main')
+              .metadata
+              .annotations
+              .single
+              .element!;
           await expectLater(
             () => resolver.assetIdForElement(element),
             throwsA(isA<UnresolvableAssetException>()),
@@ -760,7 +761,8 @@ void runTests(ResolversFactory resolversFactory) {
       await withEnabledExperiments(
         () => resolveSources(
           {
-            'a|web/main.dart': '''
+            'a|web/main.dart':
+                '''
 // @dart=${sdkLanguageVersion.major}.${sdkLanguageVersion.minor}
 int? get x => 1;
                 ''',
@@ -1364,8 +1366,8 @@ Future<void> _runBuilder(
 
 final _skipOnPreRelease =
     Version.parse(Platform.version.split(' ').first).isPreRelease
-        ? 'Skipped on prerelease sdks'
-        : null;
+    ? 'Skipped on prerelease sdks'
+    : null;
 
 abstract class ResolversFactory {
   /// Whether [create] returns a shared instance that persists between tests.

--- a/build_runner/test/build/resolver_reuse_test.dart
+++ b/build_runner/test/build/resolver_reuse_test.dart
@@ -36,11 +36,10 @@ void main() {
         );
         final nonOptionalWritesImportedFile = TestBuilder(
           buildExtensions: replaceExtension('.dart', '.imported.dart'),
-          build:
-              (buildStep, _) => buildStep.writeAsString(
-                buildStep.inputId.changeExtension('.imported.dart'),
-                'class SomeClass {}',
-              ),
+          build: (buildStep, _) => buildStep.writeAsString(
+            buildStep.inputId.changeExtension('.imported.dart'),
+            'class SomeClass {}',
+          ),
         );
         final nonOptionalResolveImportedFile = TestBuilder(
           buildExtensions: appendExtension('.bar'),
@@ -51,16 +50,14 @@ void main() {
             await buildStep.canRead(buildStep.inputId.addExtension('.foo'));
             // Check that the `.imported.dart` library is still reachable
             // through the resolver.
-            final importedLibrary =
-                inputLibrary.firstFragment.libraryImports
-                    .firstWhere(
-                      (l) => l.importedLibrary!.uri.path.endsWith(
-                        '.imported.dart',
-                      ),
-                    )
-                    .importedLibrary!;
-            final classNames =
-                importedLibrary.classes.map((c) => c.name).toList();
+            final importedLibrary = inputLibrary.firstFragment.libraryImports
+                .firstWhere(
+                  (l) => l.importedLibrary!.uri.path.endsWith('.imported.dart'),
+                )
+                .importedLibrary!;
+            final classNames = importedLibrary.classes
+                .map((c) => c.name)
+                .toList();
             return buildStep.writeAsString(
               buildStep.inputId.addExtension('.bar'),
               '$classNames',
@@ -104,9 +101,13 @@ void main() {
           build: (buildStep, _) async {
             if (buildStep.inputId.path != 'lib/a.dart') return;
             final library = await buildStep.inputLibrary;
-            final annotation =
-                library.topLevelFunctions.single.metadata.annotations.single
-                    .computeConstantValue();
+            final annotation = library
+                .topLevelFunctions
+                .single
+                .metadata
+                .annotations
+                .single
+                .computeConstantValue();
             await buildStep.writeAsString(
               buildStep.inputId.changeExtension('.g2.dart'),
               '//$annotation',

--- a/build_runner/test/build/run_builder_test.dart
+++ b/build_runner/test/build/run_builder_test.dart
@@ -101,10 +101,11 @@ void main() {
           );
           expect(buildPackage.root, Uri.parse('asset:build/'));
           expect(buildPackage.packageUriRoot, Uri.parse('asset:build/lib/'));
-          expect(buildPackage.languageVersion, LanguageVersion(3, 7));
+          expect(buildPackage.languageVersion, LanguageVersion(3, 8));
 
-          final resolvedBuildUri =
-              config.resolve(Uri.parse('package:build/foo.txt'))!;
+          final resolvedBuildUri = config.resolve(
+            Uri.parse('package:build/foo.txt'),
+          )!;
           expect(
             await buildStep.canRead(AssetId.resolve(resolvedBuildUri)),
             isTrue,
@@ -132,7 +133,7 @@ void main() {
           Package(
             'build',
             Uri.file('/foo/bar/'),
-            languageVersion: LanguageVersion(3, 7),
+            languageVersion: LanguageVersion(3, 8),
           ),
         ]),
       );

--- a/build_runner/test/build_plan/build_configs_test.dart
+++ b/build_runner/test/build_plan/build_configs_test.dart
@@ -48,27 +48,26 @@ void main() {
         buildPackages: buildPackages,
         testingOverrides: TestingOverrides(
           defaultRootPackageSources: ['**'].build(),
-          buildConfig:
+          buildConfig: {
+            'a': BuildConfig.fromMap(
+              'a',
+              ['b'],
               {
-                'a': BuildConfig.fromMap(
-                  'a',
-                  ['b'],
-                  {
-                    'targets': {
-                      r'$default': {
-                        'sources': ['lib/**'],
-                      },
-                    },
+                'targets': {
+                  r'$default': {
+                    'sources': ['lib/**'],
                   },
-                ),
-                'b': BuildConfig.fromMap('b', [], {
-                  'targets': {
-                    r'$default': {
-                      'sources': ['web/**'],
-                    },
-                  },
-                }),
-              }.build(),
+                },
+              },
+            ),
+            'b': BuildConfig.fromMap('b', [], {
+              'targets': {
+                r'$default': {
+                  'sources': ['web/**'],
+                },
+              },
+            }),
+          }.build(),
         ),
       );
 
@@ -174,14 +173,13 @@ void main() {
         buildPackages: buildPackages,
         testingOverrides: TestingOverrides(
           defaultRootPackageSources: ['**'].build(),
-          buildConfig:
-              {
-                'b': BuildConfig.parse(
-                  'b',
-                  [],
-                  'additional_public_assets: ["test/**"]',
-                ),
-              }.build(),
+          buildConfig: {
+            'b': BuildConfig.parse(
+              'b',
+              [],
+              'additional_public_assets: ["test/**"]',
+            ),
+          }.build(),
         ),
       );
 
@@ -207,19 +205,18 @@ void main() {
       final buildConfigs = await BuildConfigs.load(
         buildPackages: buildPackages,
         testingOverrides: TestingOverrides(
-          buildConfig:
-              {
-                'a': BuildConfig.fromMap('a', [], {
-                  'targets': {
-                    'another': <String, dynamic>{},
-                    '\$default': {
-                      'sources': {
-                        'exclude': ['lib/src/**'],
-                      },
-                    },
+          buildConfig: {
+            'a': BuildConfig.fromMap('a', [], {
+              'targets': {
+                'another': <String, dynamic>{},
+                '\$default': {
+                  'sources': {
+                    'exclude': ['lib/src/**'],
                   },
-                }),
-              }.build(),
+                },
+              },
+            }),
+          }.build(),
         ),
       );
 
@@ -234,19 +231,18 @@ void main() {
       final buildConfigs = await BuildConfigs.load(
         buildPackages: buildPackages,
         testingOverrides: TestingOverrides(
-          buildConfig:
-              {
-                'a': BuildConfig.fromMap('a', [], {
-                  'targets': {
-                    'another': <String, dynamic>{},
-                    '\$default': {
-                      'sources': {
-                        'exclude': ['lib/src/**'],
-                      },
-                    },
+          buildConfig: {
+            'a': BuildConfig.fromMap('a', [], {
+              'targets': {
+                'another': <String, dynamic>{},
+                '\$default': {
+                  'sources': {
+                    'exclude': ['lib/src/**'],
                   },
-                }),
-              }.build(),
+                },
+              },
+            }),
+          }.build(),
         ),
       );
       expect(

--- a/build_runner/test/build_plan/build_packages_test.dart
+++ b/build_runner/test/build_plan/build_packages_test.dart
@@ -38,7 +38,7 @@ void main() {
           (p) => p.name == 'build_runner',
         );
 
-        expect(buildRunner.languageVersion, LanguageVersion(3, 7));
+        expect(buildRunner.languageVersion, LanguageVersion(3, 8));
       });
     });
 
@@ -471,16 +471,14 @@ void fakeHostedPackages(Directory tempDirectory, Iterable<String> packages) {
     final yaml = Map<Object, Object>.from(
       loadYaml(file.readAsStringSync()) as YamlMap,
     );
-    final packagesYaml =
-        yaml['packages'] = Map<Object, Object>.from(
-          yaml['packages'] as YamlMap,
-        );
+    final packagesYaml = yaml['packages'] = Map<Object, Object>.from(
+      yaml['packages'] as YamlMap,
+    );
     for (final package in packages) {
       if (packagesYaml.containsKey(package)) {
-        final packageYaml =
-            packagesYaml[package] = Map<Object, Object>.from(
-              packagesYaml[package] as YamlMap,
-            );
+        final packageYaml = packagesYaml[package] = Map<Object, Object>.from(
+          packagesYaml[package] as YamlMap,
+        );
         packageYaml['source'] = 'hosted';
       }
     }

--- a/build_runner/test/build_plan/build_phase_creator_test.dart
+++ b/build_runner/test/build_plan/build_phase_creator_test.dart
@@ -35,25 +35,20 @@ void main() {
           defaultRootPackageSources: ['**'].build(),
         ),
       );
-      final phases =
-          await BuildPhaseCreator(
-            builderFactories: BuilderFactories({
-              'b:cool_builder': [CoolBuilder.new],
-            }),
-            buildPackages: buildPackages,
-            buildConfigs: buildConfigs,
-            builderDefinitions: [
-              BuilderDefinition(
-                'b:cool_builder',
-                autoApply: AutoApply.allPackages,
-              ),
-            ],
-            builderConfigOverrides:
-                {
-                  'b:cool_builder': {'option_a': 'a', 'option_c': 'c'}.build(),
-                }.build(),
-            isReleaseBuild: false,
-          ).createBuildPhases();
+      final phases = await BuildPhaseCreator(
+        builderFactories: BuilderFactories({
+          'b:cool_builder': [CoolBuilder.new],
+        }),
+        buildPackages: buildPackages,
+        buildConfigs: buildConfigs,
+        builderDefinitions: [
+          BuilderDefinition('b:cool_builder', autoApply: AutoApply.allPackages),
+        ],
+        builderConfigOverrides: {
+          'b:cool_builder': {'option_a': 'a', 'option_c': 'c'}.build(),
+        }.build(),
+        isReleaseBuild: false,
+      ).createBuildPhases();
       for (final phase in phases.inBuildPhases) {
         expect((phase.builder as CoolBuilder).optionA, equals('a'));
         expect((phase.builder as CoolBuilder).optionB, equals('defaultB'));
@@ -66,24 +61,23 @@ void main() {
       () async {
         await runInBuildConfigZone(
           () async {
-            final overrides =
-                {
-                  'a': BuildConfig(
-                    packageName: 'a',
-                    buildTargets: {
-                      'a:a': BuildTarget(dependencies: {'b:b'}),
+            final overrides = {
+              'a': BuildConfig(
+                packageName: 'a',
+                buildTargets: {
+                  'a:a': BuildTarget(dependencies: {'b:b'}),
+                },
+                globalOptions: {
+                  'b:cool_builder': GlobalBuilderConfig(
+                    options: const {
+                      'option_a': 'global a',
+                      'option_b': 'global b',
                     },
-                    globalOptions: {
-                      'b:cool_builder': GlobalBuilderConfig(
-                        options: const {
-                          'option_a': 'global a',
-                          'option_b': 'global b',
-                        },
-                        releaseOptions: const {'option_b': 'release global b'},
-                      ),
-                    },
+                    releaseOptions: const {'option_b': 'release global b'},
                   ),
-                }.build();
+                },
+              ),
+            }.build();
             final buildConfigs = await BuildConfigs.load(
               buildPackages: buildPackages,
               testingOverrides: TestingOverrides(
@@ -91,25 +85,23 @@ void main() {
                 buildConfig: overrides,
               ),
             );
-            final phases =
-                await BuildPhaseCreator(
-                  builderFactories: BuilderFactories({
-                    'b:cool_builder': [CoolBuilder.new],
-                  }),
-                  buildPackages: buildPackages,
-                  buildConfigs: buildConfigs,
-                  builderDefinitions: [
-                    BuilderDefinition(
-                      'b:cool_builder',
-                      autoApply: AutoApply.allPackages,
-                    ),
-                  ],
-                  builderConfigOverrides:
-                      {
-                        'b:cool_builder': {'option_c': '--define c'}.build(),
-                      }.build(),
-                  isReleaseBuild: true,
-                ).createBuildPhases();
+            final phases = await BuildPhaseCreator(
+              builderFactories: BuilderFactories({
+                'b:cool_builder': [CoolBuilder.new],
+              }),
+              buildPackages: buildPackages,
+              buildConfigs: buildConfigs,
+              builderDefinitions: [
+                BuilderDefinition(
+                  'b:cool_builder',
+                  autoApply: AutoApply.allPackages,
+                ),
+              ],
+              builderConfigOverrides: {
+                'b:cool_builder': {'option_c': '--define c'}.build(),
+              }.build(),
+              isReleaseBuild: true,
+            ).createBuildPhases();
             for (final phase in phases.inBuildPhases) {
               expect(
                 (phase.builder as CoolBuilder).optionA,
@@ -139,22 +131,18 @@ void main() {
           defaultRootPackageSources: ['**'].build(),
         ),
       );
-      final phases =
-          await BuildPhaseCreator(
-            builderFactories: BuilderFactories({
-              'b:cool_builder': [CoolBuilder.new],
-            }),
-            buildPackages: buildPackages,
-            buildConfigs: buildConfigs,
-            builderDefinitions: [
-              BuilderDefinition(
-                'b:cool_builder',
-                autoApply: AutoApply.dependents,
-              ),
-            ],
-            builderConfigOverrides: BuiltMap(),
-            isReleaseBuild: false,
-          ).createBuildPhases();
+      final phases = await BuildPhaseCreator(
+        builderFactories: BuilderFactories({
+          'b:cool_builder': [CoolBuilder.new],
+        }),
+        buildPackages: buildPackages,
+        buildConfigs: buildConfigs,
+        builderDefinitions: [
+          BuilderDefinition('b:cool_builder', autoApply: AutoApply.dependents),
+        ],
+        builderConfigOverrides: BuiltMap(),
+        isReleaseBuild: false,
+      ).createBuildPhases();
       expect(phases, hasLength(1));
       expect(phases.inBuildPhases.first.package, 'a');
     });
@@ -174,18 +162,17 @@ void main() {
         ),
         BuilderDefinition('b:not_by_default', autoApply: AutoApply.none),
       ];
-      final phases =
-          await BuildPhaseCreator(
-            builderFactories: BuilderFactories({
-              'b:cool_builder': [CoolBuilder.new],
-              'b:not_by_default': [(_) => TestBuilder()],
-            }),
-            buildPackages: buildPackages,
-            buildConfigs: buildConfigs,
-            builderDefinitions: builderDefinitions,
-            builderConfigOverrides: BuiltMap(),
-            isReleaseBuild: false,
-          ).createBuildPhases();
+      final phases = await BuildPhaseCreator(
+        builderFactories: BuilderFactories({
+          'b:cool_builder': [CoolBuilder.new],
+          'b:not_by_default': [(_) => TestBuilder()],
+        }),
+        buildPackages: buildPackages,
+        buildConfigs: buildConfigs,
+        builderDefinitions: builderDefinitions,
+        builderConfigOverrides: BuiltMap(),
+        isReleaseBuild: false,
+      ).createBuildPhases();
       expect(phases, hasLength(2));
       expect(
         phases.inBuildPhases,
@@ -215,23 +202,22 @@ void main() {
           defaultRootPackageSources: ['**'].build(),
         ),
       );
-      final phases =
-          await BuildPhaseCreator(
-            builderFactories: BuilderFactories({
-              'c:cool_builder': [CoolBuilder.new],
-            }),
-            buildPackages: buildPackages,
-            buildConfigs: buildConfigs,
-            builderDefinitions: [
-              BuilderDefinition(
-                'c:cool_builder',
-                autoApply: AutoApply.dependents,
-                hideOutput: false,
-              ),
-            ],
-            builderConfigOverrides: BuiltMap(),
-            isReleaseBuild: false,
-          ).createBuildPhases();
+      final phases = await BuildPhaseCreator(
+        builderFactories: BuilderFactories({
+          'c:cool_builder': [CoolBuilder.new],
+        }),
+        buildPackages: buildPackages,
+        buildConfigs: buildConfigs,
+        builderDefinitions: [
+          BuilderDefinition(
+            'c:cool_builder',
+            autoApply: AutoApply.dependents,
+            hideOutput: false,
+          ),
+        ],
+        builderConfigOverrides: BuiltMap(),
+        isReleaseBuild: false,
+      ).createBuildPhases();
       expect(phases, hasLength(1));
       expect(
         phases.inBuildPhases,
@@ -275,18 +261,17 @@ void main() {
             hideOutput: false,
           ),
         ];
-        final phases =
-            await BuildPhaseCreator(
-              builderFactories: BuilderFactories({
-                'c:cool_builder': [CoolBuilder.new],
-                'c:not_by_default': [(_) => TestBuilder()],
-              }),
-              buildPackages: buildPackages,
-              buildConfigs: buildConfigs,
-              builderDefinitions: builderDefinitions,
-              builderConfigOverrides: BuiltMap(),
-              isReleaseBuild: false,
-            ).createBuildPhases();
+        final phases = await BuildPhaseCreator(
+          builderFactories: BuilderFactories({
+            'c:cool_builder': [CoolBuilder.new],
+            'c:not_by_default': [(_) => TestBuilder()],
+          }),
+          buildPackages: buildPackages,
+          buildConfigs: buildConfigs,
+          builderDefinitions: builderDefinitions,
+          builderConfigOverrides: BuiltMap(),
+          isReleaseBuild: false,
+        ).createBuildPhases();
         expect(phases, hasLength(2));
         expect(
           phases.inBuildPhases,
@@ -304,15 +289,14 @@ void main() {
     test('returns empty phases if a dependency is missing', () async {
       await runInBuildConfigZone(
         () async {
-          final overrides =
-              {
-                'a': BuildConfig(
-                  packageName: 'a',
-                  buildTargets: {
-                    'a:a': BuildTarget(dependencies: {'b:not_default'}),
-                  },
-                ),
-              }.build();
+          final overrides = {
+            'a': BuildConfig(
+              packageName: 'a',
+              buildTargets: {
+                'a:a': BuildTarget(dependencies: {'b:not_default'}),
+              },
+            ),
+          }.build();
           final buildConfigs = await BuildConfigs.load(
             buildPackages: buildPackages,
             testingOverrides: TestingOverrides(
@@ -321,22 +305,21 @@ void main() {
             ),
           );
           expect(
-            () =>
-                BuildPhaseCreator(
-                  builderFactories: BuilderFactories({
-                    'b:cool_builder': [CoolBuilder.new],
-                  }),
-                  buildPackages: buildPackages,
-                  buildConfigs: buildConfigs,
-                  builderDefinitions: [
-                    BuilderDefinition(
-                      'b:cool_builder',
-                      autoApply: AutoApply.allPackages,
-                    ),
-                  ],
-                  builderConfigOverrides: BuiltMap(),
-                  isReleaseBuild: false,
-                ).createBuildPhases(),
+            () => BuildPhaseCreator(
+              builderFactories: BuilderFactories({
+                'b:cool_builder': [CoolBuilder.new],
+              }),
+              buildPackages: buildPackages,
+              buildConfigs: buildConfigs,
+              builderDefinitions: [
+                BuilderDefinition(
+                  'b:cool_builder',
+                  autoApply: AutoApply.allPackages,
+                ),
+              ],
+              builderConfigOverrides: BuiltMap(),
+              isReleaseBuild: false,
+            ).createBuildPhases(),
             throwsA(const TypeMatcher<CannotBuildException>()),
           );
         },
@@ -355,18 +338,17 @@ void main() {
             buildPackages: buildPackages,
             testingOverrides: TestingOverrides(
               defaultRootPackageSources: ['**'].build(),
-              buildConfig:
-                  {
-                    'a': BuildConfig(
-                      packageName: 'a',
-                      buildTargets: {
-                        'a|a': BuildTarget(
-                          autoApplyBuilders: false,
-                          builders: builderConfigs,
-                        ),
-                      },
+              buildConfig: {
+                'a': BuildConfig(
+                  packageName: 'a',
+                  buildTargets: {
+                    'a|a': BuildTarget(
+                      autoApplyBuilders: false,
+                      builders: builderConfigs,
                     ),
-                  }.build(),
+                  },
+                ),
+              }.build(),
             ),
           ),
           'a',
@@ -470,22 +452,21 @@ void main() {
         ];
 
         expect(
-          () =>
-              BuildPhaseCreator(
-                builderFactories: BuilderFactories(
-                  {
-                    'a:regular': [CoolBuilder.new],
-                  },
-                  postProcessBuilderFactories: {
-                    'a:post': (_) => _InvalidPostProcessBuilder(),
-                  },
-                ),
-                buildPackages: buildPackages,
-                buildConfigs: buildConfigs,
-                builderDefinitions: builderDefinitions,
-                builderConfigOverrides: BuiltMap(),
-                isReleaseBuild: false,
-              ).createBuildPhases(),
+          () => BuildPhaseCreator(
+            builderFactories: BuilderFactories(
+              {
+                'a:regular': [CoolBuilder.new],
+              },
+              postProcessBuilderFactories: {
+                'a:post': (_) => _InvalidPostProcessBuilder(),
+              },
+            ),
+            buildPackages: buildPackages,
+            buildConfigs: buildConfigs,
+            builderDefinitions: builderDefinitions,
+            builderConfigOverrides: BuiltMap(),
+            isReleaseBuild: false,
+          ).createBuildPhases(),
           throwsA(isArgumentError),
         );
       },

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -117,12 +117,11 @@ void main() {
         builderFactories: builderFactories,
         buildOptions: buildOptions,
         testingOverrides: testingOverrides.copyWith(
-          builderDefinitions:
-              [
-                BuilderDefinition(''),
-                // Apply a second builder so build phases change.
-                BuilderDefinition('b2'),
-              ].build(),
+          builderDefinitions: [
+            BuilderDefinition(''),
+            // Apply a second builder so build phases change.
+            BuilderDefinition('b2'),
+          ].build(),
         ),
       );
 
@@ -141,16 +140,15 @@ void main() {
         builderFactories: builderFactories,
         buildOptions: buildOptions,
         testingOverrides: testingOverrides.copyWith(
-          builderDefinitions:
-              [
-                BuilderDefinition(
-                  '',
-                  // Hidden output is easy to find and delete, it's under one
-                  // generated root. Unhide the output so there can be lost
-                  // outputs.
-                  hideOutput: false,
-                ),
-              ].build(),
+          builderDefinitions: [
+            BuilderDefinition(
+              '',
+              // Hidden output is easy to find and delete, it's under one
+              // generated root. Unhide the output so there can be lost
+              // outputs.
+              hideOutput: false,
+            ),
+          ].build(),
         ),
       );
       final buildState = buildPlan.previousBuildState ?? BuildState();
@@ -171,12 +169,11 @@ void main() {
         builderFactories: builderFactories,
         buildOptions: buildOptions,
         testingOverrides: testingOverrides.copyWith(
-          builderDefinitions:
-              [
-                BuilderDefinition(''),
-                // Apply a second builder so build phases change.
-                BuilderDefinition('b2'),
-              ].build(),
+          builderDefinitions: [
+            BuilderDefinition(''),
+            // Apply a second builder so build phases change.
+            BuilderDefinition('b2'),
+          ].build(),
         ),
       );
 
@@ -198,8 +195,10 @@ void main() {
         builderFactories: builderFactories,
         buildOptions: buildOptions,
         testingOverrides: testingOverrides.copyWith(
-          builderDefinitions:
-              [BuilderDefinition(''), BuilderDefinition('b2')].build(),
+          builderDefinitions: [
+            BuilderDefinition(''),
+            BuilderDefinition('b2'),
+          ].build(),
         ),
       );
 

--- a/build_runner/test/commands/serve/serve_handler_test.dart
+++ b/build_runner/test/commands/serve/serve_handler_test.dart
@@ -354,13 +354,14 @@ void main() {
       ),
     );
     expect(jsonDecode(await response.readAsString()), {
-      'index.html':
-          computeDigest(AssetId('a', 'web/index.html'), 'content1').toString(),
-      'packages/a/some.dart.js':
-          computeDigest(
-            AssetId('a', 'lib/some.dart.js'),
-            'content2',
-          ).toString(),
+      'index.html': computeDigest(
+        AssetId('a', 'web/index.html'),
+        'content1',
+      ).toString(),
+      'packages/a/some.dart.js': computeDigest(
+        AssetId('a', 'lib/some.dart.js'),
+        'content2',
+      ).toString(),
     });
   });
 
@@ -468,18 +469,16 @@ void main() {
             (Request request) =>
                 Response(200, context: {'onConnect': onConnect});
 
-        createMockConnection = (
-          WebSocketChannel serverChannel,
-          String rootDir,
-        ) async {
-          final mockResponse = await handler.createHandlerByRootDir(rootDir)(
-            FakeRequest(),
-          );
-          final onConnect =
-              mockResponse.context['onConnect']
-                  as void Function(WebSocketChannel, String);
-          onConnect(serverChannel, '');
-        };
+        createMockConnection =
+            (WebSocketChannel serverChannel, String rootDir) async {
+              final mockResponse = await handler.createHandlerByRootDir(
+                rootDir,
+              )(FakeRequest());
+              final onConnect =
+                  mockResponse.context['onConnect']
+                      as void Function(WebSocketChannel, String);
+              onConnect(serverChannel, '');
+            };
 
         handler = BuildUpdatesWebSocketHandler(mockHandlerFactory);
 
@@ -552,22 +551,20 @@ void main() {
       test('emits build results digests', () async {
         addSource('a|web/index.html', 'content1');
         addSource('a|lib/some.dart.js', 'content2');
-        final indexHash =
-            computeDigest(
-              AssetId('a', 'web/index.html'),
-              'content1',
-            ).toString();
+        final indexHash = computeDigest(
+          AssetId('a', 'web/index.html'),
+          'content1',
+        ).toString();
         expect(
           clientChannel1.stream.map((s) => jsonDecode(s.toString())),
           emitsInOrder([
             {'index.html': indexHash},
             {
               'index.html': indexHash,
-              'packages/a/some.dart.js':
-                  computeDigest(
-                    AssetId('a', 'lib/some.dart.js'),
-                    'content2',
-                  ).toString(),
+              'packages/a/some.dart.js': computeDigest(
+                AssetId('a', 'lib/some.dart.js'),
+                'content2',
+              ).toString(),
             },
             emitsDone,
           ]),
@@ -583,11 +580,10 @@ void main() {
         await handler.emitUpdateMessage(
           BuildResult(
             status: BuildStatus.success,
-            outputs:
-                [
-                  AssetId('a', 'web/index.html'),
-                  AssetId('a', 'lib/some.dart.js'),
-                ].build(),
+            outputs: [
+              AssetId('a', 'web/index.html'),
+              AssetId('a', 'lib/some.dart.js'),
+            ].build(),
             buildOutputReader: finalizedReader,
           ),
         );
@@ -598,20 +594,18 @@ void main() {
         addSource('a|web1/index.html', 'content1');
         addSource('a|web2/index.html', 'content2');
         addSource('a|lib/some.dart.js', 'content3');
-        final someDartHash =
-            computeDigest(
-              AssetId('a', 'lib/some.dart.js'),
-              'content3',
-            ).toString();
+        final someDartHash = computeDigest(
+          AssetId('a', 'lib/some.dart.js'),
+          'content3',
+        ).toString();
         expect(
           clientChannel1.stream.map((s) => jsonDecode(s.toString())),
           emitsInOrder([
             {
-              'index.html':
-                  computeDigest(
-                    AssetId('a', 'web1/index.html'),
-                    'content1',
-                  ).toString(),
+              'index.html': computeDigest(
+                AssetId('a', 'web1/index.html'),
+                'content1',
+              ).toString(),
               'packages/a/some.dart.js': someDartHash,
             },
             emitsDone,
@@ -621,11 +615,10 @@ void main() {
           clientChannel2.stream.map((s) => jsonDecode(s.toString())),
           emitsInOrder([
             {
-              'index.html':
-                  computeDigest(
-                    AssetId('a', 'web2/index.html'),
-                    'content2',
-                  ).toString(),
+              'index.html': computeDigest(
+                AssetId('a', 'web2/index.html'),
+                'content2',
+              ).toString(),
               'packages/a/some.dart.js': someDartHash,
             },
             emitsDone,
@@ -636,12 +629,11 @@ void main() {
         await handler.emitUpdateMessage(
           BuildResult(
             status: BuildStatus.success,
-            outputs:
-                [
-                  AssetId('a', 'web1/index.html'),
-                  AssetId('a', 'web2/index.html'),
-                  AssetId('a', 'lib/some.dart.js'),
-                ].build(),
+            outputs: [
+              AssetId('a', 'web1/index.html'),
+              AssetId('a', 'web2/index.html'),
+              AssetId('a', 'lib/some.dart.js'),
+            ].build(),
             buildOutputReader: finalizedReader,
           ),
         );

--- a/build_runner/test/commands/serve/serve_integration_test.dart
+++ b/build_runner/test/commands/serve/serve_integration_test.dart
@@ -37,29 +37,25 @@ void main() {
     final buildPackages = BuildPackages.singlePackageBuild('example', [
       BuildPackage(name: 'example', path: path, isOutput: true, watch: true),
     ]);
-    readerWriter =
-        InternalTestReaderWriter(outputRootPackage: 'example')
-          ..testing.writeString(
-            AssetId('example', 'web/initial.txt'),
-            'initial',
-          )
-          ..testing.writeString(
-            AssetId('example', 'web/large.txt'),
-            'large' * 10000,
-          )
-          ..testing.writeString(
-            makeAssetId('example|.dart_tool/package_config.json'),
-            jsonEncode({
-              'configVersion': 2,
-              'packages': [
-                {
-                  'name': 'example',
-                  'rootUri': 'file://fake/pkg/path',
-                  'packageUri': 'lib/',
-                },
-              ],
-            }),
-          );
+    readerWriter = InternalTestReaderWriter(outputRootPackage: 'example')
+      ..testing.writeString(AssetId('example', 'web/initial.txt'), 'initial')
+      ..testing.writeString(
+        AssetId('example', 'web/large.txt'),
+        'large' * 10000,
+      )
+      ..testing.writeString(
+        makeAssetId('example|.dart_tool/package_config.json'),
+        jsonEncode({
+          'configVersion': 2,
+          'packages': [
+            {
+              'name': 'example',
+              'rootUri': 'file://fake/pkg/path',
+              'packageUri': 'lib/',
+            },
+          ],
+        }),
+      );
 
     terminateController = StreamController<ProcessSignal>();
     final watchCommnd = WatchCommand(
@@ -71,11 +67,10 @@ void main() {
         builderDefinitions: [BuilderDefinition('')].build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
-        onLog:
-            (record) => printOnFailure(
-              '[${record.level}] '
-              '${record.loggerName}: ${record.message}',
-            ),
+        onLog: (record) => printOnFailure(
+          '[${record.level}] '
+          '${record.loggerName}: ${record.message}',
+        ),
         directoryWatcherFactory: FakeWatcher.new,
         terminateEventStream: terminateController.stream,
       ),

--- a/build_runner/test/common/build_runner_tester.dart
+++ b/build_runner/test/common/build_runner_tester.dart
@@ -212,7 +212,8 @@ class BuildRunnerTester {
       workingDirectory: p.join(tempDirectory.path, directory),
       environment: environment,
     );
-    final output = '''
+    final output =
+        '''
 === $directory: $commandLine
 ${result.stdout}${result.stderr}===
 ''';
@@ -369,12 +370,11 @@ class BuildRunnerProcess {
   }
 
   String get _testLine {
-    var result =
-        StackTrace.current
-            .toString()
-            .split('\n')
-            .where((l) => l.contains('_test.dart'))
-            .first;
+    var result = StackTrace.current
+        .toString()
+        .split('\n')
+        .where((l) => l.contains('_test.dart'))
+        .first;
     result = result.substring(result.lastIndexOf('/') + 1);
     result = result.substring(0, result.lastIndexOf(':'));
     return result;

--- a/build_runner/test/common/fixture_packages.dart
+++ b/build_runner/test/common/fixture_packages.dart
@@ -32,7 +32,8 @@ class FixturePackages {
     dependencies: ['build', 'build_runner'],
     pathDependencies: pathDependencies,
     files: {
-      'build.yaml': '''
+      'build.yaml':
+          '''
 builders:
   test_builder:
     import: 'package:$packageName/builder.dart'
@@ -42,7 +43,8 @@ builders:
     build_to: ${buildToCache ? 'cache' : 'source'}
     applies_builders: $appliesBuilders
 ''',
-      'lib/builder.dart': '''
+      'lib/builder.dart':
+          '''
 import 'package:build/build.dart';
 
 Builder testBuilderFactory(BuilderOptions options) => TestBuilder();
@@ -135,7 +137,8 @@ class ReadBuilder implements Builder {
     name: packageName,
     dependencies: ['build', 'build_runner'],
     files: {
-      'build.yaml': '''
+      'build.yaml':
+          '''
 builders:
   test_builder:
     import: "package:$packageName/builder.dart"

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -89,12 +89,9 @@ Future<TestBuildersResult> testPhases(
   buildPackages ??= BuildPackages.singlePackageBuild('a', [
     BuildPackage.forTesting(name: 'a', isOutput: true),
   ]);
-  var readerWriter =
-      resumeFrom == null
-          ? InternalTestReaderWriter(
-            outputRootPackage: buildPackages.outputRoot,
-          )
-          : resumeFrom.readerWriter;
+  var readerWriter = resumeFrom == null
+      ? InternalTestReaderWriter(outputRootPackage: buildPackages.outputRoot)
+      : resumeFrom.readerWriter;
 
   if (onDelete != null) {
     readerWriter = readerWriter.copyWith(onDelete: onDelete);
@@ -195,13 +192,12 @@ void checkBuild(
     }
   }
 
-  AssetId mapHidden(AssetId id) =>
-      unhiddenAssets.contains(id)
-          ? AssetId(
-            buildCachePackage,
-            '.dart_tool/build/generated/${id.package}/${id.path}',
-          )
-          : id;
+  AssetId mapHidden(AssetId id) => unhiddenAssets.contains(id)
+      ? AssetId(
+          buildCachePackage,
+          '.dart_tool/build/generated/${id.package}/${id.path}',
+        )
+      : id;
 
   if (status == BuildStatus.success) {
     checkOutputs(

--- a/build_runner/test/integration_tests/build_command_define_test.dart
+++ b/build_runner/test/integration_tests/build_command_define_test.dart
@@ -174,21 +174,19 @@ global_options:
     // Global options `runs_before` from workspace root `build.yaml` are used.
     tester.writePackage(
       name: 'pkg_a',
-      files:
-          FixturePackages.copyBuilder(
-            packageName: 'pkg_a',
-            outputExtension: '.a',
-          ).files,
+      files: FixturePackages.copyBuilder(
+        packageName: 'pkg_a',
+        outputExtension: '.a',
+      ).files,
       dependencies: ['build', 'build_runner'],
       inWorkspace: true,
     );
     tester.writePackage(
       name: 'pkg_b',
-      files:
-          FixturePackages.copyBuilder(
-            packageName: 'pkg_b',
-            outputExtension: '.b',
-          ).files,
+      files: FixturePackages.copyBuilder(
+        packageName: 'pkg_b',
+        outputExtension: '.b',
+      ).files,
       dependencies: ['build', 'build_runner'],
       inWorkspace: true,
     );

--- a/build_runner/test/integration_tests/serve_command_test.dart
+++ b/build_runner/test/integration_tests/serve_command_test.dart
@@ -51,8 +51,9 @@ void main() async {
     );
 
     // Responds with etags, accepts and checks them.
-    final etag =
-        (await serve.fetch('a.txt')).headers[HttpHeaders.etagHeader]!.single;
+    final etag = (await serve.fetch(
+      'a.txt',
+    )).headers[HttpHeaders.etagHeader]!.single;
     await serve.fetch(
       'a.txt',
       headers: {HttpHeaders.ifNoneMatchHeader: etag},
@@ -60,12 +61,14 @@ void main() async {
     );
 
     // Etag changes if file changes.
-    final etag2 =
-        (await serve.fetch('a.txt')).headers[HttpHeaders.etagHeader]!.single;
+    final etag2 = (await serve.fetch(
+      'a.txt',
+    )).headers[HttpHeaders.etagHeader]!.single;
     tester.write('root_pkg/web/a.txt', 'b');
     await serve.expect(BuildLog.successPattern);
-    final etag3 =
-        (await serve.fetch('a.txt')).headers[HttpHeaders.etagHeader]!.single;
+    final etag3 = (await serve.fetch(
+      'a.txt',
+    )).headers[HttpHeaders.etagHeader]!.single;
     expect(etag, etag2);
     expect(etag, isNot(etag3));
 

--- a/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
+++ b/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
@@ -40,7 +40,8 @@ builders:
     auto_apply: root_package
     build_to: source
 ''',
-        'lib/builder.dart': '''
+        'lib/builder.dart':
+            '''
 import 'package:build/build.dart';
 
 part 'builder.g.dart';

--- a/build_runner/test/integration_tests/watch_command_test.dart
+++ b/build_runner/test/integration_tests/watch_command_test.dart
@@ -184,7 +184,8 @@ builders:
     // something broken.
     tester.update(
       'builder_pkg/build.yaml',
-      (yaml) => '''
+      (yaml) =>
+          '''
 $yaml
   missing_builder:
     import: 'package:builder_pkg/builder.dart'

--- a/build_runner/test/invalidation/asset_input_invalidation_test.dart
+++ b/build_runner/test/invalidation/asset_input_invalidation_test.dart
@@ -234,10 +234,9 @@ void main() {
       tester.builder(from: '.1', to: '.2', isOptional: true)
         ..reads('.1')
         ..writes('.2');
-      bBuilder =
-          tester.builder(from: '.3', to: '.4')
-            ..reads('.3')
-            ..writes('.4');
+      bBuilder = tester.builder(from: '.3', to: '.4')
+        ..reads('.3')
+        ..writes('.4');
     });
 
     test('only b.4 is built', () async {

--- a/build_runner/test/invalidation/invalidation_stress_test.dart
+++ b/build_runner/test/invalidation/invalidation_stress_test.dart
@@ -106,12 +106,11 @@ Future<void> main() async {
               'pkg',
               '.dart_tool/build/generated/pkg/lib/$output.dart',
             );
-            final outputContents =
-                tester.readerWriter!.testing.exists(assetId)
-                    ? tester.readerWriter!.testing.readString(assetId)
-                    : tester.readerWriter!.testing.exists(hiddenAssetId)
-                    ? tester.readerWriter!.testing.readString(hiddenAssetId)
-                    : '';
+            final outputContents = tester.readerWriter!.testing.exists(assetId)
+                ? tester.readerWriter!.testing.readString(assetId)
+                : tester.readerWriter!.testing.exists(hiddenAssetId)
+                ? tester.readerWriter!.testing.readString(hiddenAssetId)
+                : '';
             // The test builder output is a list of "$name,$hash" for each input
             // that was read, including transitively resolved sources. Check it
             // for [input]. If found, this output is invalidated: recursively
@@ -129,8 +128,8 @@ Future<void> main() async {
         // If [changeImports] then change some imports; it's only possible to
         // change imports for files that will be output.
         if (changeImports && expectedOutputs.isNotEmpty) {
-          final sourceToChangeImports =
-              expectedOutputs.toList()[random.nextInt(expectedOutputs.length)];
+          final sourceToChangeImports = expectedOutputs
+              .toList()[random.nextInt(expectedOutputs.length)];
           importGraph[sourceToChangeImports] = randomImportList();
           tester.importGraph(importGraph);
         }

--- a/build_runner/test/invalidation/invalidation_tester.dart
+++ b/build_runner/test/invalidation/invalidation_tester.dart
@@ -277,10 +277,9 @@ class InvalidationTester {
   }
 
   /// The size of the asset graph that was written by [build], in bytes.
-  int get assetGraphJsonSize =>
-      readerWriter!.testing
-          .readBytes(AssetId('pkg', assetGraphJsonPath))
-          .length;
+  int get assetGraphJsonSize => readerWriter!.testing
+      .readBytes(AssetId('pkg', assetGraphJsonPath))
+      .length;
 }
 
 /// Strategy used by generators for outputting files.
@@ -444,10 +443,9 @@ class TestBuilder implements Builder {
     final recordedInput = <String>[];
 
     void recordInput(AssetId id, String? content) {
-      final hash =
-          content == null
-              ? null
-              : base64.encode(md5.convert(utf8.encode(content)).bytes);
+      final hash = content == null
+          ? null
+          : base64.encode(md5.convert(utf8.encode(content)).bytes);
       recordedInput.add('$id${hash == null ? '' : ',$hash'}');
     }
 
@@ -469,10 +467,8 @@ class TestBuilder implements Builder {
         recordInput(readId, content);
         final random = Random(content.hashCode);
 
-        final pick =
-            _tester._pickableInputs[random.nextInt(
-              _tester._pickableInputs.length,
-            )];
+        final pick = _tester
+            ._pickableInputs[random.nextInt(_tester._pickableInputs.length)];
         if (_tester._logSetup) {
           _tester._setupLog.add(
             'builder $buildExtensions on '
@@ -481,10 +477,8 @@ class TestBuilder implements Builder {
         }
         pickedOtherReads.add(pick);
 
-        final resolvePick =
-            _tester._pickableInputs[random.nextInt(
-              _tester._pickableInputs.length,
-            )];
+        final resolvePick = _tester
+            ._pickableInputs[random.nextInt(_tester._pickableInputs.length)];
         if (_tester._logSetup) {
           _tester._setupLog.add(
             'builder $buildExtensions on '

--- a/build_runner/test/io/asset_tracker_test.dart
+++ b/build_runner/test/io/asset_tracker_test.dart
@@ -149,10 +149,9 @@ void main() {
       );
 
       final planWithOutput = BuildStepPlan(
-        (BuildStepPlanBuilder b) =>
-            b
-              ..buildPhases = BuildPhases(const <InBuildPhase>[])
-              ..buildStepsByDeclaredOutput.addAll({outputId: buildStepId}),
+        (BuildStepPlanBuilder b) => b
+          ..buildPhases = BuildPhases(const <InBuildPhase>[])
+          ..buildStepsByDeclaredOutput.addAll({outputId: buildStepId}),
       );
 
       final changes = await assetTracker.collectChanges(

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -94,8 +94,10 @@ void main() {
         buildOptions: BuildOptions.forTests(),
         testingOverrides: TestingOverrides(
           buildPhases: phases,
-          defaultRootPackageSources:
-              [...defaultInBuildPackageSources, 'foo/**'].build(),
+          defaultRootPackageSources: [
+            ...defaultInBuildPackageSources,
+            'foo/**',
+          ].build(),
           readerWriter: readerWriter,
           buildPackages: buildPackages,
         ),
@@ -136,10 +138,9 @@ void main() {
 
     test('creates a valid merged output directory', () async {
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {
-              BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
-            }.build(),
+        buildDirs: {
+          BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -158,10 +159,9 @@ void main() {
       );
 
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {
-              BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
-            }.build(),
+        buildDirs: {
+          BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -182,14 +182,13 @@ void main() {
 
     test('can create multiple merged directories', () async {
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {
-              BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
-              BuildDirectory(
-                '',
-                outputLocation: OutputLocation(anotherTmpDir.path),
-              ),
-            }.build(),
+        buildDirs: {
+          BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
+          BuildDirectory(
+            '',
+            outputLocation: OutputLocation(anotherTmpDir.path),
+          ),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -203,17 +202,10 @@ void main() {
 
     test('errors if there are conflicting directories', () async {
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {
-              BuildDirectory(
-                'web',
-                outputLocation: OutputLocation(tmpDir.path),
-              ),
-              BuildDirectory(
-                'foo',
-                outputLocation: OutputLocation(tmpDir.path),
-              ),
-            }.build(),
+        buildDirs: {
+          BuildDirectory('web', outputLocation: OutputLocation(tmpDir.path)),
+          BuildDirectory('foo', outputLocation: OutputLocation(tmpDir.path)),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -236,9 +228,9 @@ void main() {
 
     test('removes the provided root from the output path', () async {
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {BuildDirectory('web', outputLocation: OutputLocation(tmpDir.path))}
-                .build(),
+        buildDirs: {
+          BuildDirectory('web', outputLocation: OutputLocation(tmpDir.path)),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -253,13 +245,12 @@ void main() {
 
     test('skips output directories with no assets', () async {
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {
-              BuildDirectory(
-                'no_assets_here',
-                outputLocation: OutputLocation(tmpDir.path),
-              ),
-            }.build(),
+        buildDirs: {
+          BuildDirectory(
+            'no_assets_here',
+            outputLocation: OutputLocation(tmpDir.path),
+          ),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -271,9 +262,9 @@ void main() {
 
     test('does not output the input directory', () async {
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {BuildDirectory('web', outputLocation: OutputLocation(tmpDir.path))}
-                .build(),
+        buildDirs: {
+          BuildDirectory('web', outputLocation: OutputLocation(tmpDir.path)),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -286,17 +277,13 @@ void main() {
 
     test('outputs the packages when input root is provided', () async {
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {
-              BuildDirectory(
-                'web',
-                outputLocation: OutputLocation(tmpDir.path),
-              ),
-              BuildDirectory(
-                'foo',
-                outputLocation: OutputLocation(anotherTmpDir.path),
-              ),
-            }.build(),
+        buildDirs: {
+          BuildDirectory('web', outputLocation: OutputLocation(tmpDir.path)),
+          BuildDirectory(
+            'foo',
+            outputLocation: OutputLocation(anotherTmpDir.path),
+          ),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -321,10 +308,9 @@ void main() {
 
     test('does not nest packages symlinks with no root', () async {
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {
-              BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
-            }.build(),
+        buildDirs: {
+          BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -336,17 +322,13 @@ void main() {
 
     test('only outputs files contained in the provided root', () async {
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {
-              BuildDirectory(
-                'web',
-                outputLocation: OutputLocation(tmpDir.path),
-              ),
-              BuildDirectory(
-                'foo',
-                outputLocation: OutputLocation(anotherTmpDir.path),
-              ),
-            }.build(),
+        buildDirs: {
+          BuildDirectory('web', outputLocation: OutputLocation(tmpDir.path)),
+          BuildDirectory(
+            'foo',
+            outputLocation: OutputLocation(anotherTmpDir.path),
+          ),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -379,10 +361,9 @@ void main() {
       );
 
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {
-              BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
-            }.build(),
+        buildDirs: {
+          BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -402,10 +383,9 @@ void main() {
         buildState: buildState,
       );
       final success = await createMergedOutputDirectories(
-        buildDirs:
-            {
-              BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
-            }.build(),
+        buildDirs: {
+          BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
+        }.build(),
         buildPackages: buildPackages,
         readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
@@ -437,10 +417,9 @@ void main() {
 
       test('fails the build', () async {
         final success = await createMergedOutputDirectories(
-          buildDirs:
-              {
-                BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
-              }.build(),
+          buildDirs: {
+            BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
+          }.build(),
           buildPackages: buildPackages,
           readerWriter: readerWriter,
           buildOutputReader: buildOutputReader,
@@ -464,10 +443,9 @@ void main() {
     group('Empty directory cleanup', () {
       test('removes directories that become empty', () async {
         var success = await createMergedOutputDirectories(
-          buildDirs:
-              {
-                BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
-              }.build(),
+          buildDirs: {
+            BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
+          }.build(),
           buildPackages: buildPackages,
           readerWriter: readerWriter,
           buildOutputReader: buildOutputReader,
@@ -488,10 +466,9 @@ void main() {
           buildState: buildState,
         );
         success = await createMergedOutputDirectories(
-          buildDirs:
-              {
-                BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
-              }.build(),
+          buildDirs: {
+            BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
+          }.build(),
           buildPackages: buildPackages,
           readerWriter: readerWriter,
           buildOutputReader: buildOutputReader,

--- a/build_runner/test/logging/ansi_buffer_test.dart
+++ b/build_runner/test/logging/ansi_buffer_test.dart
@@ -87,12 +87,11 @@ void main() {
     });
 
     test('removes OSC 8 hyperlink control sequences', () {
-      final text =
-          [
-            AnsiBuffer.openHyperlink(Uri.parse('file:///tmp/example.dart')),
-            'example.dart',
-            AnsiBuffer.closeHyperlink,
-          ].join();
+      final text = [
+        AnsiBuffer.openHyperlink(Uri.parse('file:///tmp/example.dart')),
+        'example.dart',
+        AnsiBuffer.closeHyperlink,
+      ].join();
       expect(AnsiBuffer.removeAnsi(text), 'example.dart');
     });
 

--- a/build_runner/test/logging/build_log_console_mode_test.dart
+++ b/build_runner/test/logging/build_log_console_mode_test.dart
@@ -284,12 +284,11 @@ E An error.'''),
 
       final rawLine = renderRaw().single;
       final targetUri = _packageFileUri(buildPackages, assetId);
-      final linkedText =
-          [
-            AnsiBuffer.openHyperlink(targetUri),
-            'lib/src/logging/build_log.dart',
-            AnsiBuffer.closeHyperlink,
-          ].join();
+      final linkedText = [
+        AnsiBuffer.openHyperlink(targetUri),
+        'lib/src/logging/build_log.dart',
+        AnsiBuffer.closeHyperlink,
+      ].join();
 
       expect(rawLine, contains(linkedText));
       expect(render().single, contains('lib/src/logging/build_log.dart'));
@@ -313,12 +312,11 @@ E An error.'''),
 
       final rawLine = renderRaw().first;
       final targetUri = _packageFileUri(buildPackages, assetId);
-      final linkedText =
-          [
-            AnsiBuffer.openHyperlink(targetUri),
-            'lib/src/logging/build_log.dart',
-            AnsiBuffer.closeHyperlink,
-          ].join();
+      final linkedText = [
+        AnsiBuffer.openHyperlink(targetUri),
+        'lib/src/logging/build_log.dart',
+        AnsiBuffer.closeHyperlink,
+      ].join();
 
       expect(rawLine, contains(linkedText));
       expect(

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.5.16-wip
 
 - Use `build_runner` 2.15.1.
+- Require Dart 3.8.0.
 
 ## 3.5.15
 

--- a/build_test/lib/src/builder.dart
+++ b/build_test/lib/src/builder.dart
@@ -60,15 +60,14 @@ BuildBehavior copyFrom(AssetId assetId) =>
 /// A build behavior which writes either 'true' or 'false' depending on whether
 /// [assetId] can be read.
 BuildBehavior writeCanRead(AssetId assetId) =>
-    (
-      BuildStep buildStep,
-      Map<String, List<String>> buildExtensions,
-    ) => _copyToAll(
-      buildStep,
-      buildExtensions,
-      readFrom: (_) => assetId,
-      read: (buildStep, assetId) async => '${await buildStep.canRead(assetId)}',
-    );
+    (BuildStep buildStep, Map<String, List<String>> buildExtensions) =>
+        _copyToAll(
+          buildStep,
+          buildExtensions,
+          readFrom: (_) => assetId,
+          read: (buildStep, assetId) async =>
+              '${await buildStep.canRead(assetId)}',
+        );
 
 /// A [Builder.buildExtensions] which operats on assets ending in [from] and
 /// creates outputs with [postFix] appended as the extension.
@@ -79,10 +78,9 @@ Map<String, List<String>> appendExtension(
   String from = '',
   int numCopies = 1,
 }) => {
-  from:
-      numCopies == 1
-          ? ['$from$postFix']
-          : List.generate(numCopies, (i) => '$from$postFix.$i'),
+  from: numCopies == 1
+      ? ['$from$postFix']
+      : List.generate(numCopies, (i) => '$from$postFix.$i'),
 };
 
 Map<String, List<String>> replaceExtension(String from, String to) => {

--- a/build_test/lib/src/internal_test_reader_writer.dart
+++ b/build_test/lib/src/internal_test_reader_writer.dart
@@ -208,46 +208,42 @@ class _ReaderWriterTestingImpl implements ReaderWriterTesting {
       );
 
   @override
-  Iterable<AssetId> get inputsTracked =>
-      InputTracker.inputTrackersForTesting[_readerWriter.filesystem]!
-          .expand((tracker) => tracker.inputs)
-          .toSet();
+  Iterable<AssetId> get inputsTracked => InputTracker
+      .inputTrackersForTesting[_readerWriter.filesystem]!
+      .expand((tracker) => tracker.inputs)
+      .toSet();
 
   @override
   Iterable<AssetId> inputsTrackedFor({
     AssetId? primaryInput,
     String? builderLabel,
-  }) =>
-      InputTracker.inputTrackersForTesting[_readerWriter.filesystem]!
-          .where((inputTracker) {
-            return (primaryInput == null ||
-                    primaryInput == inputTracker.primaryInput) &&
-                (builderLabel == null ||
-                    builderLabel == inputTracker.builderLabel);
-          })
-          .expand((tracker) => tracker.inputs)
-          .toSet();
+  }) => InputTracker.inputTrackersForTesting[_readerWriter.filesystem]!
+      .where((inputTracker) {
+        return (primaryInput == null ||
+                primaryInput == inputTracker.primaryInput) &&
+            (builderLabel == null || builderLabel == inputTracker.builderLabel);
+      })
+      .expand((tracker) => tracker.inputs)
+      .toSet();
 
   @override
-  Iterable<AssetId> get resolverEntrypointsTracked =>
-      InputTracker.inputTrackersForTesting[_readerWriter.filesystem]!
-          .expand((tracker) => tracker.resolverEntrypoints)
-          .toSet();
+  Iterable<AssetId> get resolverEntrypointsTracked => InputTracker
+      .inputTrackersForTesting[_readerWriter.filesystem]!
+      .expand((tracker) => tracker.resolverEntrypoints)
+      .toSet();
 
   @override
   Iterable<AssetId> resolverEntrypointsTrackedFor({
     AssetId? primaryInput,
     String? builderLabel,
-  }) =>
-      InputTracker.inputTrackersForTesting[_readerWriter.filesystem]!
-          .where((inputTracker) {
-            return (primaryInput == null ||
-                    primaryInput == inputTracker.primaryInput) &&
-                (builderLabel == null ||
-                    builderLabel == inputTracker.builderLabel);
-          })
-          .expand((tracker) => tracker.resolverEntrypoints)
-          .toSet();
+  }) => InputTracker.inputTrackersForTesting[_readerWriter.filesystem]!
+      .where((inputTracker) {
+        return (primaryInput == null ||
+                primaryInput == inputTracker.primaryInput) &&
+            (builderLabel == null || builderLabel == inputTracker.builderLabel);
+      })
+      .expand((tracker) => tracker.resolverEntrypoints)
+      .toSet();
 
   @override
   Iterable<AssetId> get assetsRead => _readerWriter.assetsRead;

--- a/build_test/lib/src/package_reader.dart
+++ b/build_test/lib/src/package_reader.dart
@@ -111,10 +111,9 @@ class PackageAssetReader {
   String get _rootPackagePath {
     // If the root package has a pub layout, use `packagePath`.
     final rootPackage = _rootPackage;
-    final root =
-        rootPackage != null
-            ? packageConfig[rootPackage]?.root.toFilePath()
-            : null;
+    final root = rootPackage != null
+        ? packageConfig[rootPackage]?.root.toFilePath()
+        : null;
     if (root != null && Directory(p.join(root, 'lib')).existsSync()) {
       return root;
     }

--- a/build_test/lib/src/test_bootstrap_builder.dart
+++ b/build_test/lib/src/test_bootstrap_builder.dart
@@ -30,14 +30,14 @@ class TestBootstrapBuilder extends Builder {
   Future<void> build(BuildStep buildStep) async {
     final id = buildStep.inputId;
     final contents = await buildStep.readAsString(id);
-    final assetPath =
-        id.pathSegments.first == 'lib'
-            ? p.url.join('packages', id.package, id.path)
-            : id.path;
+    final assetPath = id.pathSegments.first == 'lib'
+        ? p.url.join('packages', id.package, id.path)
+        : id.path;
 
     final vmRuntimes = [Runtime.vm];
-    final browserRuntimes =
-        Runtime.builtIn.where((r) => r.isBrowser == true).toList();
+    final browserRuntimes = Runtime.builtIn
+        .where((r) => r.isBrowser == true)
+        .toList();
     final nodeRuntimes = [Runtime.nodeJS];
     final config = await _ConfigLoader.instance.load(id.package, buildStep);
     if (config != null) {

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -342,10 +342,9 @@ Future<TestBuilderResult> testBuilderFactories(
   // Differentiate input packages and all packages. Builders run on input
   // packages; they can read/resolve all packages. Additional packages are
   // supplied by passing a `readerWriter`.
-  final inputPackages =
-      inputIds.isEmpty
-          ? {rootPackage!}
-          : {for (final id in inputIds) id.package};
+  final inputPackages = inputIds.isEmpty
+      ? {rootPackage!}
+      : {for (final id in inputIds) id.package};
   final allPackages = inputPackages.toSet();
   if (readerWriter != null) {
     for (final asset in readerWriter.testing.assets) {
@@ -372,10 +371,9 @@ Future<TestBuilderResult> testBuilderFactories(
     b.onLog = onLog;
     b.verbose = verbose;
   });
-  resolvers ??=
-      packageConfig == null && enabledExperiments.isEmpty
-          ? _defaultResolvers
-          : ResolversImpl.custom(packageConfig: packageConfig);
+  resolvers ??= packageConfig == null && enabledExperiments.isEmpty
+      ? _defaultResolvers
+      : ResolversImpl.custom(packageConfig: packageConfig);
 
   // Build a `buildPackages` based on [sourceAssets].
   final otherPackages = allPackages.toSet()..remove(rootPackage);
@@ -456,33 +454,33 @@ Future<TestBuilderResult> testBuilderFactories(
         // [testingBuilderConfig] is false, use the defaults. These skip some
         // files, for example picking up `lib/**` but not all files in the package root.
         testingBuilderConfig
-            ? {
-              for (final package in inputPackages)
-                package: build_config.BuildConfig.fromMap(package, [], {
-                  'targets': {
-                    package: {
-                      'sources': [
-                        r'\$package$',
-                        r'lib/$lib$',
-                        r'test/$test$',
-                        r'web/$web$',
-                        if (package == rootPackage)
-                          ...defaultInBuildPackageSources,
-                        if (package != rootPackage)
-                          ...defaultDependencyVisibleAssets,
-                        ...inputIds
-                            .where(
-                              (id) =>
-                                  id.package == package &&
-                                  !id.path.startsWith('.dart_tool/'),
-                            )
-                            .map((id) => Glob.quote(id.path)),
-                      ],
-                    },
+        ? {
+            for (final package in inputPackages)
+              package: build_config.BuildConfig.fromMap(package, [], {
+                'targets': {
+                  package: {
+                    'sources': [
+                      r'\$package$',
+                      r'lib/$lib$',
+                      r'test/$test$',
+                      r'web/$web$',
+                      if (package == rootPackage)
+                        ...defaultInBuildPackageSources,
+                      if (package != rootPackage)
+                        ...defaultDependencyVisibleAssets,
+                      ...inputIds
+                          .where(
+                            (id) =>
+                                id.package == package &&
+                                !id.path.startsWith('.dart_tool/'),
+                          )
+                          .map((id) => Glob.quote(id.path)),
+                    ],
                   },
-                }),
-            }.build()
-            : null,
+                },
+              }),
+          }.build()
+        : null,
     reportUnusedAssetsForInput: reportUnusedAssetsForInput,
     flattenOutput: flattenOutput,
   );

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 
 dependencies:
   build: ^4.0.0

--- a/build_test/test/in_memory_reader_test.dart
+++ b/build_test/test/in_memory_reader_test.dart
@@ -16,10 +16,9 @@ void main() {
     late InternalTestReaderWriter readerWriter;
 
     setUp(() {
-      readerWriter =
-          InternalTestReaderWriter(outputRootPackage: packageName)
-            ..testing.writeString(libAsset, 'libAsset')
-            ..testing.writeString(testAsset, 'testAsset');
+      readerWriter = InternalTestReaderWriter(outputRootPackage: packageName)
+        ..testing.writeString(libAsset, 'libAsset')
+        ..testing.writeString(testAsset, 'testAsset');
     });
 
     test('#findAssets should list files in lib/', () async {

--- a/build_test/test/test_builder_test.dart
+++ b/build_test/test/test_builder_test.dart
@@ -141,10 +141,9 @@ Future<void> main() async {
           final input = step.inputId;
           await step.writeAsString(input.changeExtension('.temp'), 'out');
 
-          final outputFromOther =
-              input.path.contains('foo')
-                  ? AssetId('a', 'bar.temp')
-                  : AssetId('a', 'foo.temp');
+          final outputFromOther = input.path.contains('foo')
+              ? AssetId('a', 'bar.temp')
+              : AssetId('a', 'foo.temp');
 
           expect(await step.canRead(outputFromOther), isFalse);
         },

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -45,7 +45,8 @@ class CssBuilder implements Builder {
     r'$package$': ['web/generated.css'],
   };
 
-  static String _cssContent() => '''
+  static String _cssContent() =>
+      '''
 /*
 Generated at: ${DateTime.now()}
 */
@@ -106,9 +107,8 @@ class TextBuilder implements Builder {
           .replaceFirst('.json', '.dart'),
     );
 
-    final messages =
-        (json.decode(await buildStep.readAsString(inputId)) as Map)
-            .cast<String, String>();
+    final messages = (json.decode(await buildStep.readAsString(inputId)) as Map)
+        .cast<String, String>();
 
     final outputBuffer = StringBuffer('// Generated, do not edit\n');
     messages.forEach((key, value) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 publish_to: none
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 resolution: workspace
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_workspace     # Can be anything
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 publish_to: none
 dev_dependencies:
   dart_flutter_team_lints: ^3.1.0

--- a/tool/build_runner_build.dart
+++ b/tool/build_runner_build.dart
@@ -33,10 +33,9 @@ void main(List<String> arguments) {
     'build_runner_build',
   );
   tempDirectory.createSync(recursive: true);
-  final maybeOverride =
-      buildRunnerOverride == null
-          ? ''
-          : '''
+  final maybeOverride = buildRunnerOverride == null
+      ? ''
+      : '''
 dependency_overrides:
   build_runner:
     path: $buildRunnerOverride
@@ -114,10 +113,9 @@ $maybeOverride
 }
 
 extension type PackageConfig(Map<String, Object?> node) {
-  List<Package> get packages =>
-      (node['packages'] as List<Object?>)
-          .map((p) => Package(p as Map<String, Object?>))
-          .toList();
+  List<Package> get packages => (node['packages'] as List<Object?>)
+      .map((p) => Package(p as Map<String, Object?>))
+      .toList();
   Package packageNamed(String name) =>
       packages.singleWhere((package) => package.name == name);
 }

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -4,7 +4,7 @@ description: Collection of scripts used during development of build packages.
 resolution: workspace
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.8.0
 
 dependencies:
   path: ^1.8.0


### PR DESCRIPTION
The 3.8 formatter is better for built_value lambdas.

It's been out for a long time, let's start using it :)

- Update min version in pubspecs
- Run `dart format .`
- Add to CHANGELOGs
- Fix two new lint warnings re: null aware elements
- Fix test expectations that hard coded 3.7