### PR TITLE
Fix test flakiness.

### DIFF
--- a/builder_pkgs/build_web_compilers/test/build_frontend_server/fes_manager_test.dart
+++ b/builder_pkgs/build_web_compilers/test/build_frontend_server/fes_manager_test.dart
@@ -251,6 +251,21 @@ void main() {
                 .transform(utf8.decoder)
                 .transform(const LineSplitter())
                 .asBroadcastStream();
+
+        // Perform an initial compile to ensure the Frontend Server is warmed up
+        // and initialized for subsequent expression compilation and metadata
+        // merging tests.
+        testSocket.writeln(
+          jsonEncode({
+            'instruction': 'COMPILE',
+            'entrypoint': 'org-dartlang-app:///web/main.dart',
+          }),
+        );
+        final responseLine = await testSocketLines.first;
+        final response = jsonDecode(responseLine) as Map<String, dynamic>;
+        if (response['errorCount'] != 0) {
+          throw StateError('Failed to run initial compile: $response');
+        }
       });
 
       tearDownAll(() async {


### PR DESCRIPTION
Fix #4968 

Gemini figured out the flake was due to random test ordering, and suggests adding an initial compile so expression evaluation will always succeed.

@Markzipan it's not clear to me if this is a good answer or if it's doing too much setup for some of the tests, what do you think please?