### PR TITLE
[build_web_compilers] Use two phase hot restart

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.8.1-wip
+- Bump the min sdk to 3.13.0-107.0.dev.
+- Internal only changes.
+
 ## 4.8.0
 
 - Improve error message when a transitive import uses a disallowed platform

--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.8.1-wip
+## 4.8.1
 - Bump the min sdk to 3.13.0-107.0.dev.
 - Internal only changes.
 

--- a/builder_pkgs/build_web_compilers/bin/fes_manager.dart
+++ b/builder_pkgs/build_web_compilers/bin/fes_manager.dart
@@ -171,8 +171,9 @@ class FesManager {
             );
 
             final bytes = result?.expressionData;
-            final expressionDataString =
-                bytes != null ? base64.encode(bytes) : null;
+            final expressionDataString = bytes != null
+                ? base64.encode(bytes)
+                : null;
 
             socket.writeln(
               jsonEncode({
@@ -241,16 +242,14 @@ class FesManager {
     _cachedEntrypoint = entrypoint;
     final recompileRestart = request['recompileRestart'] as bool? ?? false;
     // Rename the build system's '.ddc.js' extensions to FES's '.dart.lib.js'.
-    final filesToWrite =
-        (request['filesToWrite'] as List)
-            .cast<String>()
-            .map((f) => f.replaceAll(jsModuleExtension, fesJsExtension))
-            .toList();
-    final invalidatedFiles =
-        (request['invalidatedFiles'] as List)
-            .cast<String>()
-            .map(Uri.parse)
-            .toList();
+    final filesToWrite = (request['filesToWrite'] as List)
+        .cast<String>()
+        .map((f) => f.replaceAll(jsModuleExtension, fesJsExtension))
+        .toList();
+    final invalidatedFiles = (request['invalidatedFiles'] as List)
+        .cast<String>()
+        .map(Uri.parse)
+        .toList();
     // Copy invalidated files to FES's scratch space.
     _copyFilesToScratchSpace(invalidatedFiles);
 
@@ -316,13 +315,12 @@ class FesManager {
       _lastCompiledInvalidations.addAll(invalidatedPaths);
       // Sync the modified files to the Frontend Server's scratch space.
       _copyFilesToScratchSpace(invalidatedPaths.map(Uri.parse));
-      final compileResult =
-          isColdStart
-              ? await fes.compile(_cachedEntrypoint!)
-              : await fes.recompile(
-                _cachedEntrypoint!,
-                invalidatedPaths.map(Uri.parse).toList(),
-              );
+      final compileResult = isColdStart
+          ? await fes.compile(_cachedEntrypoint!)
+          : await fes.recompile(
+              _cachedEntrypoint!,
+              invalidatedPaths.map(Uri.parse).toList(),
+            );
       final isSuccess = compileResult != null && compileResult.errorCount == 0;
       if (isSuccess) {
         await fes.accept();

--- a/builder_pkgs/build_web_compilers/lib/builders.dart
+++ b/builder_pkgs/build_web_compilers/lib/builders.dart
@@ -158,18 +158,18 @@ Builder dart2wasmModuleBuilder(BuilderOptions options) {
 // General purpose builders
 PostProcessBuilder dartSourceCleanup(BuilderOptions options) =>
     (options.config['enabled'] as bool? ?? false)
-        ? const FileDeletingBuilder([
-          '.dart',
-          '.js.map',
-          '.ddc.js.metadata',
-          '.ddc_merged_metadata',
-        ])
-        : const FileDeletingBuilder([
-          '.dart',
-          '.js.map',
-          '.ddc.js.metadata',
-          '.ddc_merged_metadata',
-        ], isEnabled: false);
+    ? const FileDeletingBuilder([
+        '.dart',
+        '.js.map',
+        '.ddc.js.metadata',
+        '.ddc_merged_metadata',
+      ])
+    : const FileDeletingBuilder([
+        '.dart',
+        '.js.map',
+        '.ddc.js.metadata',
+        '.ddc_merged_metadata',
+      ], isEnabled: false);
 
 /// Throws if it is ever given different options.
 void _ensureSameDdcOptions(BuilderOptions options) {

--- a/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_driver.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_driver.dart
@@ -272,11 +272,10 @@ class PersistentFrontendServer {
   final WebMemoryFilesystem _fileSystem;
 
   PersistentFrontendServer._({
-    required FrontendServerClient client,
+    required this._client,
     required this.outputDillUri,
-    required WebMemoryFilesystem fileSystem,
-  }) : _client = client,
-       _fileSystem = fileSystem;
+    required this._fileSystem,
+  });
 
   FrontendServerClient get client => _client;
   WebMemoryFilesystem get fileSystem => _fileSystem;
@@ -717,7 +716,7 @@ enum StdoutState { CollectDiagnostic, CollectDependencies }
 
 /// Handles stdin/stdout communication with the Frontend Server.
 class StdoutHandler {
-  StdoutHandler({required Logger logger}) : _logger = logger {
+  StdoutHandler({required this._logger}) {
     reset();
   }
   final Logger _logger;

--- a/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_driver.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_driver.dart
@@ -394,12 +394,11 @@ class PersistentFrontendServer {
 
     try {
       final socket = await Socket.connect(InternetAddress.loopbackIPv4, port);
-      final socketLines =
-          socket
-              .cast<List<int>>()
-              .transform(utf8.decoder)
-              .transform(const LineSplitter())
-              .asBroadcastStream();
+      final socketLines = socket
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .asBroadcastStream();
       return _FesSocketConnection(socket, socketLines);
     } catch (e) {
       throw StateError('Failed to connect to FES manager at port $port: $e');
@@ -626,10 +625,10 @@ class WebMemoryFilesystem {
             manifest[filePath] as Map,
           );
       final codeOffsets = (offsets['code'] as List<dynamic>).cast<int>();
-      final sourcemapOffsets =
-          (offsets['sourcemap'] as List<dynamic>).cast<int>();
-      final metadataOffsets =
-          (offsets['metadata'] as List<dynamic>).cast<int>();
+      final sourcemapOffsets = (offsets['sourcemap'] as List<dynamic>)
+          .cast<int>();
+      final metadataOffsets = (offsets['metadata'] as List<dynamic>)
+          .cast<int>();
 
       if (codeOffsets.length != 2 ||
           sourcemapOffsets.length != 2 ||
@@ -996,10 +995,9 @@ class SocketFrontendServerClient implements FrontendServerClient {
     await _socket.flush();
     final responseLine = await nextResponseFuture;
     final response = jsonDecode(responseLine) as Map<String, dynamic>;
-    final bytes =
-        response['expressionData'] != null
-            ? base64.decode(response['expressionData'] as String)
-            : null;
+    final bytes = response['expressionData'] != null
+        ? base64.decode(response['expressionData'] as String)
+        : null;
     return CompilerOutput(
       '',
       (response['errorCount'] as int?) ?? 0,

--- a/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_resources.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_resources.dart
@@ -44,9 +44,9 @@ class FrontendServerState {
       p.join(rootDir, '.web.entrypoint.json'),
     );
     if (await buildStep.canRead(webEntrypointAsset)) {
-      final contents =
-          json.decode(await buildStep.readAsString(webEntrypointAsset))
-              as Map<String, Object?>;
+      final contents = json.decode(
+        await buildStep.readAsString(webEntrypointAsset),
+      ) as Map<String, Object?>;
       entrypointAssetId = AssetId.parse(contents['entrypoint'] as String);
       return true;
     }

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/errors.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/errors.dart
@@ -186,10 +186,9 @@ class UnsupportedModules implements Exception {
           libraryId,
           await reader.readAsString(libraryId),
         );
-        final unsupportedSdkDeps =
-            library.sdkDeps
-                .where((lib) => !platform.supportsLibrary(lib))
-                .toList();
+        final unsupportedSdkDeps = library.sdkDeps
+            .where((lib) => !platform.supportsLibrary(lib))
+            .toList();
         if (unsupportedSdkDeps.isEmpty) continue;
 
         final targetAssetId = library.id.dartAssetId;

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/kernel_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/kernel_builder.dart
@@ -176,13 +176,12 @@ Future<void> _createKernel({
     await scratchSpace.ensureAssets(allAssetIds, buildStep);
 
     if (trackUnusedInputs) {
-      usedInputsFile =
-          await File(
-            p.join(
-              (await Directory.systemTemp.createTemp('kernel_builder_')).path,
-              'used_inputs.txt',
-            ),
-          ).create();
+      usedInputsFile = await File(
+        p.join(
+          (await Directory.systemTemp.createTemp('kernel_builder_')).path,
+          'used_inputs.txt',
+        ),
+      ).create();
       kernelInputPathToId = {};
     }
 
@@ -211,12 +210,11 @@ Future<void> _createKernel({
     );
     final response = await frontendWorker.doWork(
       request,
-      trackWork:
-          (response) => buildStep.trackStage(
-            'Kernel Generate',
-            () => response,
-            isExternal: true,
-          ),
+      trackWork: (response) => buildStep.trackStage(
+        'Kernel Generate',
+        () => response,
+        isExternal: true,
+      ),
     );
     if (response.exitCode != EXIT_CODE_OK || !await outputFile.exists()) {
       throw KernelException(
@@ -269,12 +267,11 @@ Future<void> reportUnusedKernelInputs(
   if (usedPaths.isEmpty || usedPaths.first == '') return;
 
   String? firstMissingInputPath;
-  final usedIds =
-      usedPaths.map((usedPath) {
-        final id = inputPathToId[usedPath];
-        if (id == null) firstMissingInputPath ??= usedPath;
-        return id;
-      }).toSet();
+  final usedIds = usedPaths.map((usedPath) {
+    final id = inputPathToId[usedPath];
+    if (id == null) firstMissingInputPath ??= usedPath;
+    return id;
+  }).toSet();
 
   if (firstMissingInputPath != null) {
     log.warning(
@@ -459,9 +456,8 @@ Future<void> _addRequestArguments(
 }
 
 String _sourceArg(AssetId id) {
-  final uri =
-      id.path.startsWith('lib')
-          ? canonicalUriFor(id)
-          : '$multiRootScheme:///${id.path}';
+  final uri = id.path.startsWith('lib')
+      ? canonicalUriFor(id)
+      : '$multiRootScheme:///${id.path}';
   return '--source=$uri';
 }

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/meta_module.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/meta_module.dart
@@ -44,15 +44,15 @@ Module _moduleForComponent(
   // public srcs (not under lib/src).
   final sources = componentLibraries.map((n) => n.id).toSet();
   final nonSrcIds = sources.where((id) => !id.path.startsWith('lib/src/'));
-  final primaryId =
-      nonSrcIds.isNotEmpty ? nonSrcIds.reduce(_min) : sources.reduce(_min);
+  final primaryId = nonSrcIds.isNotEmpty
+      ? nonSrcIds.reduce(_min)
+      : sources.reduce(_min);
   // Expand to include all the part files of each node, these aren't
   // included as individual `_AssetNodes`s in `connectedComponents`.
   sources.addAll(componentLibraries.expand((n) => n.parts));
-  final directDependencies =
-      <AssetId>{}
-        ..addAll(componentLibraries.expand((n) => n.depsForPlatform(platform)))
-        ..removeAll(sources);
+  final directDependencies = <AssetId>{}
+    ..addAll(componentLibraries.expand((n) => n.depsForPlatform(platform)))
+    ..removeAll(sources);
   final isSupported = componentLibraries
       .expand((l) => l.sdkDeps)
       .every(platform.supportsLibrary);
@@ -116,8 +116,9 @@ Map<AssetId, Set<AssetId>> _findReverseEntrypointDeps(
 ///   * Else merge it into with others that are depended on by the same set of
 ///   entrypoints
 List<Module> _mergeModules(Iterable<Module> modules, Set<AssetId> entrypoints) {
-  final entrypointModules =
-      modules.where((m) => m.sources.any(entrypoints.contains)).toList();
+  final entrypointModules = modules
+      .where((m) => m.sources.any(entrypoints.contains))
+      .toList();
 
   // Groups of modules that can be merged into an existing entrypoint module.
   final entrypointModuleGroups = {
@@ -213,8 +214,10 @@ List<Module> _computeModules(
     hashCode: (l) => l.id.hashCode,
   );
 
-  final entryIds =
-      libraries.values.where((l) => l.isEntryPoint).map((l) => l.id).toSet();
+  final entryIds = libraries.values
+      .where((l) => l.isEntryPoint)
+      .map((l) => l.id)
+      .toSet();
   return _mergeModules(
     connectedComponents.map((c) => _moduleForComponent(c, platform)),
     entryIds,

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/meta_module_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/meta_module_builder.dart
@@ -41,8 +41,9 @@ class MetaModuleBuilder implements Builder {
   Future build(BuildStep buildStep) async {
     if (buildStep.inputId.package == r'$sdk') return;
 
-    final libraryAssets =
-        await buildStep.findAssets(Glob('**$moduleLibraryExtension')).toList();
+    final libraryAssets = await buildStep
+        .findAssets(Glob('**$moduleLibraryExtension'))
+        .toList();
 
     final metaModule = await MetaModule.forLibraries(
       buildStep,

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/module_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/module_builder.dart
@@ -43,15 +43,13 @@ class ModuleBuilder implements Builder {
   @override
   Future build(BuildStep buildStep) async {
     final metaModules = await buildStep.fetchResource(metaModuleCache);
-    final metaModuleExtensionString =
-        usesWebHotReload
-            ? metaModuleExtension(_platform)
-            : metaModuleCleanExtension(_platform);
-    final metaModule =
-        (await metaModules.find(
-          AssetId(buildStep.inputId.package, 'lib/$metaModuleExtensionString'),
-          buildStep,
-        ))!;
+    final metaModuleExtensionString = usesWebHotReload
+        ? metaModuleExtension(_platform)
+        : metaModuleCleanExtension(_platform);
+    final metaModule = (await metaModules.find(
+      AssetId(buildStep.inputId.package, 'lib/$metaModuleExtensionString'),
+      buildStep,
+    ))!;
     var outputModule = metaModule.modules.firstWhereOrNull(
       (m) => m.primarySource == buildStep.inputId,
     );

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/module_cache.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/module_cache.dart
@@ -68,17 +68,17 @@ class DecodingCache<T> {
     if (!await reader.canRead(id)) return null;
     _Entry<T> entry;
     if (!_cached.containsKey(id)) {
-      entry =
-          _cached[id] = _Entry(
-            Result.capture(reader.readAsBytes(id).then(_fromBytes)),
-            digest: Result.capture(reader.digest(id)),
-          );
+      entry = _cached[id] = _Entry(
+        Result.capture(reader.readAsBytes(id).then(_fromBytes)),
+        digest: Result.capture(reader.digest(id)),
+      );
     } else {
       entry = _cached[id]!;
       if (entry.needsCheck) {
         await (entry.onGoingCheck ??= () async {
-          final previousDigest =
-              entry.digest == null ? null : await Result.release(entry.digest!);
+          final previousDigest = entry.digest == null
+              ? null
+              : await Result.release(entry.digest!);
           entry.digest = Result.capture(reader.digest(id));
           if (await Result.release(entry.digest!) != previousDigest) {
             entry.value = Result.capture(

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/module_library.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/module_library.dart
@@ -52,13 +52,12 @@ class ModuleLibrary {
   ModuleLibrary._(
     this.id, {
     required this.isEntryPoint,
-    required Set<AssetId> deps,
+    required this._deps,
     required this.parts,
     required this.conditionalDeps,
     required this.sdkDeps,
     required this.hasMain,
-  }) : _deps = deps,
-       isImportable = true;
+  }) : isImportable = true;
 
   ModuleLibrary._nonImportable(this.id)
     : isImportable = false,
@@ -247,8 +246,8 @@ class ModuleLibrary {
   }
 }
 
-Set<AssetId> _deserializeAssetIds(Iterable serlialized) =>
-    Set.from(serlialized.map((decoded) => AssetId.parse(decoded as String)));
+Set<AssetId> _deserializeAssetIds(Iterable serialized) =>
+    Set.from(serialized.map((decoded) => AssetId.parse(decoded as String)));
 
 bool _isPart(CompilationUnit dart) =>
     dart.directives.any((directive) => directive is PartOfDirective);

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/module_library.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/module_library.dart
@@ -196,14 +196,13 @@ class ModuleLibrary {
       deps: _deserializeAssetIds(json['deps'] as Iterable),
       parts: _deserializeAssetIds(json['parts'] as Iterable),
       sdkDeps: Set.of((json['sdkDeps'] as Iterable).cast<String>()),
-      conditionalDeps:
-          (json['conditionalDeps'] as Iterable).map((conditions) {
-            return Map.of(
-              (conditions as Map<String, dynamic>).map(
-                (k, v) => MapEntry(k, AssetId.parse(v as String)),
-              ),
-            );
-          }).toList(),
+      conditionalDeps: (json['conditionalDeps'] as Iterable).map((conditions) {
+        return Map.of(
+          (conditions as Map<String, dynamic>).map(
+            (k, v) => MapEntry(k, AssetId.parse(v as String)),
+          ),
+        );
+      }).toList(),
       hasMain: json['hasMain'] as bool,
     );
   }
@@ -212,13 +211,11 @@ class ModuleLibrary {
     'isEntrypoint': isEntryPoint,
     'deps': _deps.map((id) => id.toString()).toList(),
     'parts': parts.map((id) => id.toString()).toList(),
-    'conditionalDeps':
-        conditionalDeps
-            .map(
-              (conditions) =>
-                  conditions.map((k, v) => MapEntry(k, v.toString())),
-            )
-            .toList(),
+    'conditionalDeps': conditionalDeps
+        .map(
+          (conditions) => conditions.map((k, v) => MapEntry(k, v.toString())),
+        )
+        .toList(),
     'sdkDeps': sdkDeps.toList(),
     'hasMain': hasMain,
   });

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/scratch_space.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/scratch_space.dart
@@ -104,8 +104,8 @@ String _scratchSpacePackageConfig(String rootConfig, Uri packageConfigUri) {
       'version 2 is supported.',
     );
   }
-  final packages =
-      (parsedRootConfig['packages'] as List).cast<Map<String, dynamic>>();
+  final packages = (parsedRootConfig['packages'] as List)
+      .cast<Map<String, dynamic>>();
   var foundRoot = false;
   for (final package in packages) {
     var rootUri = packageConfigUri.resolve(package['rootUri'] as String);

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/workers.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/workers.dart
@@ -16,10 +16,9 @@ import '../common.dart';
 import 'scratch_space.dart';
 
 // If no terminal is attached, prevent a new one from launching.
-final _processMode =
-    stdin.hasTerminal
-        ? ProcessStartMode.normal
-        : ProcessStartMode.detachedWithStdio;
+final _processMode = stdin.hasTerminal
+    ? ProcessStartMode.normal
+    : ProcessStartMode.detachedWithStdio;
 
 /// Completes once the dartdevk workers have been shut down.
 Future<void> get dartdevkWorkersAreDone =>
@@ -154,8 +153,9 @@ Future<PersistentFrontendServer> startFrontendServerWorker() async {
   // space. If a scratch space is provided by the build options (instead of
   // being created dynamically), use that.
   final customPath = frontendServerState.customScratchSpacePath;
-  final fesRoot =
-      customPath != null ? Directory(customPath).uri : scratchSpace.tempDir.uri;
+  final fesRoot = customPath != null
+      ? Directory(customPath).uri
+      : scratchSpace.tempDir.uri;
   final fes = await PersistentFrontendServer.start(
     sdkRoot: sdkDir,
     fileSystemRoot: fesRoot,

--- a/builder_pkgs/build_web_compilers/lib/src/common.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/common.dart
@@ -96,10 +96,9 @@ Future<void> fixAndCopySourceMap(
     final uri = Uri.parse(source);
     // We only want to rewrite multi-root scheme uris.
     if (uri.scheme.isEmpty) return source;
-    final newSegments =
-        uri.pathSegments.first == 'packages'
-            ? uri.pathSegments
-            : uri.pathSegments.skip(1);
+    final newSegments = uri.pathSegments.first == 'packages'
+        ? uri.pathSegments
+        : uri.pathSegments.skip(1);
     return Uri(path: p.url.joinAll(['/', ...newSegments])).toString();
   }
 
@@ -154,18 +153,16 @@ void fixMetadataSources(Map<String, dynamic> json, Uri scratchUri) {
 ///
 /// Corresponds to the library name for the Library Bundler module system.
 String ddcModuleName(AssetId jsId) {
-  final jsPath =
-      jsId.path.startsWith('lib/')
-          ? jsId.path.replaceFirst('lib/', 'packages/${jsId.package}/')
-          : jsId.path;
+  final jsPath = jsId.path.startsWith('lib/')
+      ? jsId.path.replaceFirst('lib/', 'packages/${jsId.package}/')
+      : jsId.path;
   return jsPath.substring(0, jsPath.length - jsModuleExtension.length);
 }
 
 String ddcLibraryId(AssetId jsId) {
-  final jsPath =
-      jsId.path.startsWith('lib/')
-          ? jsId.path.replaceFirst('lib/', 'package:${jsId.package}/')
-          : '$multiRootScheme:///${jsId.path}';
+  final jsPath = jsId.path.startsWith('lib/')
+      ? jsId.path.replaceFirst('lib/', 'package:${jsId.package}/')
+      : '$multiRootScheme:///${jsId.path}';
   final prefix = jsPath.substring(0, jsPath.length - jsModuleExtension.length);
   return '$prefix.dart';
 }

--- a/builder_pkgs/build_web_compilers/lib/src/dart2js_bootstrap.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/dart2js_bootstrap.dart
@@ -82,13 +82,12 @@ Future<void> _bootstrapDart2Js(
     final allSrcs = allDeps.expand((module) => module.sources);
     await scratchSpace.ensureAssets(allSrcs, buildStep);
 
-    final dartUri =
-        dartEntrypointId.path.startsWith('lib/')
-            ? Uri.parse(
-              'package:${dartEntrypointId.package}/'
-              '${dartEntrypointId.path.substring('lib/'.length)}',
-            )
-            : Uri.parse('$multiRootScheme:///${dartEntrypointId.path}');
+    final dartUri = dartEntrypointId.path.startsWith('lib/')
+        ? Uri.parse(
+            'package:${dartEntrypointId.package}/'
+            '${dartEntrypointId.path.substring('lib/'.length)}',
+          )
+        : Uri.parse('$multiRootScheme:///${dartEntrypointId.path}');
     final jsOutputPath =
         p.withoutExtension(
           dartUri.scheme == 'package'
@@ -99,19 +98,19 @@ Future<void> _bootstrapDart2Js(
     final librariesSpec =
         librariesPath ?? p.joinAll([sdkDir, 'lib', 'libraries.json']);
     _validateUserArgs(dart2JsArgs);
-    args =
-        dart2JsArgs.toList()..addAll([
-          '--libraries-spec=$librariesSpec',
-          '--packages=$multiRootScheme:///.dart_tool/package_config.json',
-          '--multi-root-scheme=$multiRootScheme',
-          '--multi-root=${scratchSpace.tempDir.uri.toFilePath()}',
-          for (final experiment in enabledExperiments)
-            '--enable-experiment=$experiment',
-          if (nativeNullAssertions != null)
-            '--${nativeNullAssertions ? '' : 'no-'}native-null-assertions',
-          '-o$jsOutputPath',
-          '$dartUri',
-        ]);
+    args = dart2JsArgs.toList()
+      ..addAll([
+        '--libraries-spec=$librariesSpec',
+        '--packages=$multiRootScheme:///.dart_tool/package_config.json',
+        '--multi-root-scheme=$multiRootScheme',
+        '--multi-root=${scratchSpace.tempDir.uri.toFilePath()}',
+        for (final experiment in enabledExperiments)
+          '--enable-experiment=$experiment',
+        if (nativeNullAssertions != null)
+          '--${nativeNullAssertions ? '' : 'no-'}native-null-assertions',
+        '-o$jsOutputPath',
+        '$dartUri',
+      ]);
   }
 
   log.info('Running `dart compile js` with ${args.join(' ')}\n');

--- a/builder_pkgs/build_web_compilers/lib/src/dart2wasm_bootstrap.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/dart2wasm_bootstrap.dart
@@ -98,13 +98,12 @@ Future<Dart2WasmBootstrapResult> _bootstrapDart2Wasm(
     final allSrcs = allDeps.expand((module) => module.sources);
     await scratchSpace.ensureAssets(allSrcs, buildStep);
 
-    final dartUri =
-        dartEntrypointId.path.startsWith('lib/')
-            ? Uri.parse(
-              'package:${dartEntrypointId.package}/'
-              '${dartEntrypointId.path.substring('lib/'.length)}',
-            )
-            : Uri.parse('$multiRootScheme:///${dartEntrypointId.path}');
+    final dartUri = dartEntrypointId.path.startsWith('lib/')
+        ? Uri.parse(
+            'package:${dartEntrypointId.package}/'
+            '${dartEntrypointId.path.substring('lib/'.length)}',
+          )
+        : Uri.parse('$multiRootScheme:///${dartEntrypointId.path}');
     final wasmOutputPath =
         p.withoutExtension(
           dartUri.scheme == 'package'
@@ -180,10 +179,9 @@ Future<Dart2WasmBootstrapResult> _bootstrapDart2Wasm(
       await buildStep.writeAsBytes(archiveId, TarEncoder().encode(archive));
     }
 
-    final loaderContents =
-        await scratchSpace
-            .fileFor(dartEntrypointId.changeExtension(moduleJsExtension))
-            .readAsBytes();
+    final loaderContents = await scratchSpace
+        .fileFor(dartEntrypointId.changeExtension(moduleJsExtension))
+        .readAsBytes();
     await buildStep.writeAsBytes(
       dartEntrypointId.changeExtension(javaScriptModuleExtension),
       loaderContents,

--- a/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
@@ -52,11 +52,9 @@ class DdcFrontendServerBuilder implements Builder {
     );
     final ddcEntrypointId = module.primarySource;
     final entrypoint = frontendServerState.entrypointAssetId;
-    final isEntrypoint =
-        entrypoint == null
-            ? ddcEntrypointId.changeExtension('.ddc.module') ==
-                buildStep.inputId
-            : ddcEntrypointId == entrypoint;
+    final isEntrypoint = entrypoint == null
+        ? ddcEntrypointId.changeExtension('.ddc.module') == buildStep.inputId
+        : ddcEntrypointId == entrypoint;
     if (isEntrypoint && entrypoint == null) {
       frontendServerState.entrypointAssetId = ddcEntrypointId;
     }
@@ -89,10 +87,9 @@ class DdcFrontendServerBuilder implements Builder {
     );
     await buildStep.fetchResource(persistentFrontendServerResource);
     final entrypointArg = sourceArg(frontendServerState.entrypointAssetId!);
-    String assetPath(AssetId id) =>
-        id.package == root
-            ? id.path
-            : 'packages/${id.package}/${id.path.replaceFirst('lib/', '')}';
+    String assetPath(AssetId id) => id.package == root
+        ? id.path
+        : 'packages/${id.package}/${id.path.replaceFirst('lib/', '')}';
     final changedAssetUris = [
       for (final asset in scratchSpace.changedFilesInBuild)
         Uri(scheme: multiRootScheme, host: '', path: '/${assetPath(asset)}'),
@@ -103,8 +100,9 @@ class DdcFrontendServerBuilder implements Builder {
         final customDir = scratchSpaceDir;
         if (customDir != null) {
           frontendServerState.customScratchSpacePath = customDir;
-          sSpace =
-              _scratchSpace ??= ScratchSpace.existing(Directory(customDir));
+          sSpace = _scratchSpace ??= ScratchSpace.existing(
+            Directory(customDir),
+          );
         } else {
           sSpace = scratchSpace;
         }

--- a/builder_pkgs/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -100,19 +100,18 @@ Future<void> bootstrapDdc(
 
   final dartEntrypointParts = _context.split(dartEntrypointId.path);
   final packageName = module.primarySource.package;
-  final entrypointLibraryName =
-      ddcLibraryBundle
-          ? _context.joinAll([
-            // Convert to a package: uri for files under lib.
-            if (dartEntrypointParts.first == 'lib') 'package:$packageName',
-            ...dartEntrypointParts,
-          ])
-          : _context.joinAll([
-            // Convert to a package: uri for files under lib.
-            if (dartEntrypointParts.first == 'lib') 'package:$packageName',
-            // Strip top-level directory from the path.
-            ...dartEntrypointParts.skip(1),
-          ]);
+  final entrypointLibraryName = ddcLibraryBundle
+      ? _context.joinAll([
+          // Convert to a package: uri for files under lib.
+          if (dartEntrypointParts.first == 'lib') 'package:$packageName',
+          ...dartEntrypointParts,
+        ])
+      : _context.joinAll([
+          // Convert to a package: uri for files under lib.
+          if (dartEntrypointParts.first == 'lib') 'package:$packageName',
+          // Strip top-level directory from the path.
+          ...dartEntrypointParts.skip(1),
+        ]);
 
   final entrypointJsId = dartEntrypointId.changeExtension(entrypointExtension);
 
@@ -130,13 +129,12 @@ Future<void> bootstrapDdc(
       // `packages/` for lib modules. We set baseUrl to `/` to simplify things,
       // and we only allow you to serve top level directories.
       final moduleName = ddcModuleName(jsId);
-      modulePaths[moduleName] =
-          jsId.path.startsWith('lib')
-              ? '$moduleName$jsModuleExtension'
-              : _context.relative(
-                jsId.path,
-                from: _context.dirname(dartEntrypointId.path),
-              );
+      modulePaths[moduleName] = jsId.path.startsWith('lib')
+          ? '$moduleName$jsModuleExtension'
+          : _context.relative(
+              jsId.path,
+              from: _context.dirname(dartEntrypointId.path),
+            );
     }
     final bootstrapEndModuleName = _context.relative(
       bootstrapEndId.path,
@@ -287,10 +285,9 @@ String _appBootstrap({
   required String oldModuleScope,
   required bool? nativeNullAssertions,
 }) {
-  final nativeAssertsCode =
-      nativeNullAssertions == null
-          ? ''
-          : 'dart_sdk.dart.nativeNonNullAsserts($nativeNullAssertions);';
+  final nativeAssertsCode = nativeNullAssertions == null
+      ? ''
+      : 'dart_sdk.dart.nativeNonNullAsserts($nativeNullAssertions);';
   return '''
 define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_sdk) {
   $nativeAssertsCode
@@ -330,7 +327,8 @@ define("$bootstrapModuleName", ["$moduleName", "dart_sdk"], function(app, dart_s
 
 /// The actual entrypoint JS file which injects all the necessary scripts to
 /// run the app.
-String _entryPointJs(String bootstrapModuleName) => '''
+String _entryPointJs(String bootstrapModuleName) =>
+    '''
 (function() {
   $_currentDirectoryScript
   $_baseUrlScript
@@ -457,7 +455,8 @@ for (let moduleName of Object.getOwnPropertyNames(modulePaths)) {
 /// other tools.
 ///
 /// Posts a message to the window when done.
-final _initializeTools = '''
+final _initializeTools =
+    '''
 $_baseUrlScript
   dart_sdk._debugger.registerDevtoolsFormatter();
   \$dartLoader.getModuleLibraries = dart_sdk.dart.getModuleLibraries;
@@ -488,7 +487,8 @@ $_baseUrlScript
 ///
 /// Adds error handler code for require.js which requests a `.errors` file for
 /// any failed module, and logs it to the console.
-final _requireJsConfig = '''
+final _requireJsConfig =
+    '''
 // Whenever we fail to load a JS module, try to request the corresponding
 // `.errors` file, and log it to the console.
 (function() {
@@ -684,7 +684,8 @@ String generateDDCLibraryBundleBootstrapScript({
   });
   // Write the "true" main boostrapper last as part of the loader's convention.
   scriptsJs.write('{"src": "$mainBoostrapperUrl", "id": "data-main"}\n');
-  final boostrapScript = '''
+  final boostrapScript =
+      '''
 // Save the current directory so we can access it in a closure.
   let _currentDirectory = (function () {
     let _url = document.currentScript.src;

--- a/builder_pkgs/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/dev_compiler_bootstrap.dart
@@ -786,57 +786,46 @@ $_simpleLoaderScript
       });
     }
 
-    let currentUri = _currentScript.src;
-    // We should have written a file containing all the scripts that need to be
-    // reloaded into the page. This is then read when a hot restart is triggered
-    // in DDC via the `\$dartReloadModifiedModules` callback.
-    let reloadedSources = _currentDirectory + 'reloaded_sources.json';
-
     if (!window.\$dartReloadModifiedModules) {
-      window.\$dartReloadModifiedModules = (function(appName, callback) {
-        const xhttp = new XMLHttpRequest();
-        xhttp.withCredentials = true;
-        xhttp.onreadystatechange = function() {
-          // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/readyState
-          if (this.readyState == 4 && this.status == 200 || this.status == 304) {
-            const scripts = JSON.parse(this.responseText);
-            let numToLoad = 0;
-            let numLoaded = 0;
-            for (let i = 0; i < scripts.length; i++) {
-              const script = scripts[i];
-              const module = script.module;
-              if (module == null) continue;
-              const src = script.src;
-              const oldSrc = window.\$dartLoader.moduleIdToUrl.get(module);
-
-              // We might actually load from a different uri, delete the old one
-              // just to be sure.
-              window.\$dartLoader.urlToModuleId.delete(oldSrc);
-
-              window.\$dartLoader.moduleIdToUrl.set(module, src);
-              window.\$dartLoader.urlToModuleId.set(src, module);
-
-              numToLoad++;
-
-              let el = document.getElementById(module);
-              if (el) el.remove();
-              el = window.\$dartCreateScript();
-              el.src = policy.createScriptURL(src);
-              el.async = false;
-              el.defer = true;
-              el.id = module;
-              el.onload = function() {
-                numLoaded++;
-                if (numToLoad == numLoaded) callback();
-              };
-              document.head.appendChild(el);
-            }
-            // Call `callback` right away if we found no updated scripts.
-            if (numToLoad == 0) callback();
+      window.\$dartReloadModifiedModules = (function(filesToReload, appName) {
+        return new Promise(function(resolve) {
+          function callback() {
+            resolve(filesToReload);
           }
-        };
-        xhttp.open("GET", reloadedSources, true);
-        xhttp.send();
+          let numToLoad = 0;
+          let numLoaded = 0;
+          for (let i = 0; i < filesToReload.length; i++) {
+            const file = filesToReload[i];
+            const module = file.module;
+            if (module == null) continue;
+            const src = file.src;
+            const oldSrc = window.\$dartLoader.moduleIdToUrl.get(module);
+
+            // We might actually load from a different uri, delete the old one
+            // just to be sure.
+            window.\$dartLoader.urlToModuleId.delete(oldSrc);
+
+            window.\$dartLoader.moduleIdToUrl.set(module, src);
+            window.\$dartLoader.urlToModuleId.set(src, module);
+
+            numToLoad++;
+
+            let el = document.getElementById(module);
+            if (el) el.remove();
+            el = window.\$dartCreateScript();
+            el.src = policy.createScriptURL(src);
+            el.async = false;
+            el.defer = true;
+            el.id = module;
+            el.onload = function() {
+              numLoaded++;
+              if (numToLoad == numLoaded) callback();
+            };
+            document.head.appendChild(el);
+          }
+          // Call `callback` right away if we found no updated scripts.
+          if (numToLoad == 0) callback();
+        });
       });
     }
   };

--- a/builder_pkgs/build_web_compilers/lib/src/dev_compiler_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/dev_compiler_builder.dart
@@ -188,76 +188,73 @@ Future<void> _createDevCompilerModule(
   File? usedInputsFile;
 
   if (trackUnusedInputs) {
-    usedInputsFile =
-        await File(
-          p.join(
-            (await Directory.systemTemp.createTemp('ddk_builder_')).path,
-            'used_inputs.txt',
-          ),
-        ).create();
+    usedInputsFile = await File(
+      p.join(
+        (await Directory.systemTemp.createTemp('ddk_builder_')).path,
+        'used_inputs.txt',
+      ),
+    ).create();
     kernelInputPathToId = {};
   }
 
-  final request =
-      WorkRequest()
-        ..arguments.addAll([
-          '--dart-sdk-summary=$sdkSummary',
-          '--modules=${ddcLibraryBundle ? 'ddc' : 'amd'}',
-          '--no-summarize',
-          if (generateFullDill) '--experimental-output-compiled-kernel',
-          if (emitDebugSymbols) '--emit-debug-symbols',
-          if (canaryFeatures || ddcLibraryBundle) '--canary',
-          '-o',
-          jsOutputFile.path,
-          debugMode ? '--source-map' : '--no-source-map',
-          for (final dep in transitiveDeps) _summaryArg(dep),
-          '--packages=$multiRootScheme:///.dart_tool/package_config.json',
-          '--module-name=${ddcModuleName(jsId)}',
-          '--multi-root-scheme=$multiRootScheme',
-          '--multi-root=.',
-          '--track-widget-creation',
-          '--inline-source-map',
-          '--libraries-file=${p.toUri(librariesPath)}',
-          '--experimental-emit-debug-metadata',
-          if (useIncrementalCompiler) ...[
-            '--reuse-compiler-result',
-            '--use-incremental-compiler',
-          ],
-          if (usedInputsFile != null)
-            '--used-inputs-file=${usedInputsFile.uri.toFilePath()}',
-          for (final source in module.sources) sourceArg(source),
-          for (final define in environment.entries)
-            '-D${define.key}=${define.value}',
-          for (final experiment in enabledExperiments)
-            '--enable-experiment=$experiment',
-        ])
-        ..inputs.add(
-          Input()
-            ..path = sdkSummary
-            ..digest = [0],
-        )
-        ..inputs.addAll(
-          await Future.wait(
-            transitiveKernelDeps.map((dep) async {
-              final file = scratchSpace.fileFor(dep);
-              if (kernelInputPathToId != null) {
-                kernelInputPathToId[file.uri.toString()] = dep;
-              }
-              return Input()
-                ..path = file.path
-                ..digest = (await buildStep.digest(dep)).bytes;
-            }),
-          ),
-        );
+  final request = WorkRequest()
+    ..arguments.addAll([
+      '--dart-sdk-summary=$sdkSummary',
+      '--modules=${ddcLibraryBundle ? 'ddc' : 'amd'}',
+      '--no-summarize',
+      if (generateFullDill) '--experimental-output-compiled-kernel',
+      if (emitDebugSymbols) '--emit-debug-symbols',
+      if (canaryFeatures || ddcLibraryBundle) '--canary',
+      '-o',
+      jsOutputFile.path,
+      debugMode ? '--source-map' : '--no-source-map',
+      for (final dep in transitiveDeps) _summaryArg(dep),
+      '--packages=$multiRootScheme:///.dart_tool/package_config.json',
+      '--module-name=${ddcModuleName(jsId)}',
+      '--multi-root-scheme=$multiRootScheme',
+      '--multi-root=.',
+      '--track-widget-creation',
+      '--inline-source-map',
+      '--libraries-file=${p.toUri(librariesPath)}',
+      '--experimental-emit-debug-metadata',
+      if (useIncrementalCompiler) ...[
+        '--reuse-compiler-result',
+        '--use-incremental-compiler',
+      ],
+      if (usedInputsFile != null)
+        '--used-inputs-file=${usedInputsFile.uri.toFilePath()}',
+      for (final source in module.sources) sourceArg(source),
+      for (final define in environment.entries)
+        '-D${define.key}=${define.value}',
+      for (final experiment in enabledExperiments)
+        '--enable-experiment=$experiment',
+    ])
+    ..inputs.add(
+      Input()
+        ..path = sdkSummary
+        ..digest = [0],
+    )
+    ..inputs.addAll(
+      await Future.wait(
+        transitiveKernelDeps.map((dep) async {
+          final file = scratchSpace.fileFor(dep);
+          if (kernelInputPathToId != null) {
+            kernelInputPathToId[file.uri.toString()] = dep;
+          }
+          return Input()
+            ..path = file.path
+            ..digest = (await buildStep.digest(dep)).bytes;
+        }),
+      ),
+    );
 
   try {
     final driverResource = dartdevkDriverResource;
     final driver = await buildStep.fetchResource(driverResource);
     final response = await driver.doWork(
       request,
-      trackWork:
-          (response) =>
-              buildStep.trackStage('Compile', () => response, isExternal: true),
+      trackWork: (response) =>
+          buildStep.trackStage('Compile', () => response, isExternal: true),
     );
 
     // TODO(jakemac53): Fix the ddc worker mode so it always sends back a bad

--- a/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -280,10 +280,9 @@ final class EntrypointBuilderOptions {
     return EntrypointBuilderOptions(
       compilers: compilers,
       nativeNullAssertions: nativeNullAssertions,
-      loaderExtension:
-          config.containsKey(loaderOption)
-              ? config[loaderOption] as String?
-              : defaultLoaderOption,
+      loaderExtension: config.containsKey(loaderOption)
+          ? config[loaderOption] as String?
+          : defaultLoaderOption,
       usesWebHotReload: usesWebHotReload,
       ddcLibraryBundle: usesDdcLibraryBundle,
       librariesPath: librariesPath,
@@ -326,12 +325,11 @@ final class EntrypointBuilderOptions {
     return switch (from) {
       null => const [],
       final List list => list.map((arg) => '$arg').toList(),
-      final String other =>
-        throw ArgumentError.value(
-          other,
-          key,
-          'There may have been a failure decoding as JSON, expected a list.',
-        ),
+      final String other => throw ArgumentError.value(
+        other,
+        key,
+        'There may have been a failure decoding as JSON, expected a list.',
+      ),
       final other => throw ArgumentError.value(other, key, 'Expected a list'),
     };
   }
@@ -391,10 +389,9 @@ class WebEntrypointBuilder implements Builder {
                 await bootstrapDdc(
                   buildStep,
                   nativeNullAssertions: options.nativeNullAssertions,
-                  requiredAssets:
-                      usesDdcLibraryBundle
-                          ? _ddcLibraryBundleSdkResources
-                          : _ddcSdkResources,
+                  requiredAssets: usesDdcLibraryBundle
+                      ? _ddcLibraryBundleSdkResources
+                      : _ddcSdkResources,
                   usesWebHotReload: usesWebHotReload,
                   ddcLibraryBundle: usesDdcLibraryBundle,
                   unsafeAllowUnsupportedModules:
@@ -539,11 +536,10 @@ Future<bool> _isAppEntryPoint(AssetId dartId, AssetReader reader) async {
   assert(dartId.extension == '.dart');
   // Skip reporting errors here, dartdevc will report them later with nicer
   // formatting.
-  final parsed =
-      parseString(
-        content: await reader.readAsString(dartId),
-        throwIfDiagnostics: false,
-      ).unit;
+  final parsed = parseString(
+    content: await reader.readAsString(dartId),
+    throwIfDiagnostics: false,
+  ).unit;
   // Allow two or fewer arguments so that entrypoints intended for use with
   // [spawnUri] get counted.
   //

--- a/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -316,7 +316,7 @@ final class EntrypointBuilderOptions {
           wasmSourceMapExtension,
           wasmEntrypointArchiveExtension,
         ],
-        if (loaderExtension case final loader?) loader,
+        ?loaderExtension,
       ],
     };
   }

--- a/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_marker_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_marker_builder.dart
@@ -48,11 +48,12 @@ class WebEntrypointMarkerBuilder implements Builder {
     final webEntrypointJson = <String, Object?>{};
 
     if (hasCachedState) {
-      webEntrypointJson['entrypoint'] =
-          frontendServerState.entrypointAssetId.toString();
+      webEntrypointJson['entrypoint'] = frontendServerState.entrypointAssetId
+          .toString();
     } else {
-      final webAssets =
-          await buildStep.findAssets(Glob('$webAssetsPath/**')).toList();
+      final webAssets = await buildStep
+          .findAssets(Glob('$webAssetsPath/**'))
+          .toList();
 
       for (final asset in webAssets) {
         if (asset.extension == '.dart') {

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_web_compilers
-version: 4.8.0
+version: 4.8.1-wip
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace
 
 environment:
-  sdk: '>=3.7.0 <3.13.0-z'
+  sdk: '>=3.13.0-107.0.dev <3.13.0-z'
 
 dependencies:
   analyzer: '>=5.1.0 <14.0.0'

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.8.1-wip
+version: 4.8.1
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace

--- a/builder_pkgs/build_web_compilers/test/build_frontend_server/fes_manager_test.dart
+++ b/builder_pkgs/build_web_compilers/test/build_frontend_server/fes_manager_test.dart
@@ -61,12 +61,11 @@ void main() {
       socket.writeln(
         jsonEncode({'instruction': 'READ_OUTPUT_FILE', 'path': 'non_existent'}),
       );
-      final responseLine =
-          await socket
-              .cast<List<int>>()
-              .transform(utf8.decoder)
-              .transform(const LineSplitter())
-              .first;
+      final responseLine = await socket
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .first;
       final response = jsonDecode(responseLine) as Map<String, dynamic>;
       expect(response.containsKey('error'), isTrue);
 
@@ -109,12 +108,11 @@ void main() {
       expect(port, isNotNull);
 
       final socket = await Socket.connect(InternetAddress.loopbackIPv4, port!);
-      final socketLines =
-          socket
-              .cast<List<int>>()
-              .transform(utf8.decoder)
-              .transform(const LineSplitter())
-              .asBroadcastStream();
+      final socketLines = socket
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .asBroadcastStream();
 
       socket.writeln(
         jsonEncode({
@@ -178,12 +176,11 @@ void main() {
       socket.writeln(
         jsonEncode({'instruction': 'READ_OUTPUT_FILE', 'path': 'non_existent'}),
       );
-      final responseLine =
-          await socket
-              .cast<List<int>>()
-              .transform(utf8.decoder)
-              .transform(const LineSplitter())
-              .first;
+      final responseLine = await socket
+          .cast<List<int>>()
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .first;
 
       final response = jsonDecode(responseLine) as Map<String, dynamic>;
       expect(response.containsKey('error'), isTrue);
@@ -245,12 +242,11 @@ void main() {
         final port = json['port'] as int;
 
         testSocket = await Socket.connect(InternetAddress.loopbackIPv4, port);
-        testSocketLines =
-            testSocket
-                .cast<List<int>>()
-                .transform(utf8.decoder)
-                .transform(const LineSplitter())
-                .asBroadcastStream();
+        testSocketLines = testSocket
+            .cast<List<int>>()
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .asBroadcastStream();
 
         // Perform an initial compile to ensure the Frontend Server is warmed up
         // and initialized for subsequent expression compilation and metadata

--- a/builder_pkgs/build_web_compilers/test/build_modules/kernel_builder_test.dart
+++ b/builder_pkgs/build_web_compilers/test/build_modules/kernel_builder_test.dart
@@ -71,17 +71,18 @@ void main() {
           trackUnusedInputs: trackUnusedInputs,
         );
 
-        final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-          'a|web/index$kernelOutputExtension': containsAllInOrder(
-            utf8.encode('web/index.dart'),
-          ),
-          'b|lib/b$kernelOutputExtension': containsAllInOrder(
-            utf8.encode('package:b/b.dart'),
-          ),
-          'c|lib/c$kernelOutputExtension': containsAllInOrder(
-            utf8.encode('package:c/c.dart'),
-          ),
-        });
+        final expectedOutputs = Map.of(startingExpectedOutputs)
+          ..addAll({
+            'a|web/index$kernelOutputExtension': containsAllInOrder(
+              utf8.encode('web/index.dart'),
+            ),
+            'b|lib/b$kernelOutputExtension': containsAllInOrder(
+              utf8.encode('package:b/b.dart'),
+            ),
+            'c|lib/c$kernelOutputExtension': containsAllInOrder(
+              utf8.encode('package:c/c.dart'),
+            ),
+          });
 
         final reportedUnused = <AssetId, Iterable<AssetId>>{};
         await testBuilders(

--- a/builder_pkgs/build_web_compilers/test/build_modules/meta_module_builder_test.dart
+++ b/builder_pkgs/build_web_compilers/test/build_modules/meta_module_builder_test.dart
@@ -20,8 +20,10 @@ void main() {
     await testBuilder(
       MetaModuleBuilder(testPlatform),
       {
-        'a|lib/a.module.library':
-            ModuleLibrary.fromSource(assetA, '').serialize(),
+        'a|lib/a.module.library': ModuleLibrary.fromSource(
+          assetA,
+          '',
+        ).serialize(),
       },
       outputs: {
         'a|lib/${metaModuleExtension(testPlatform)}': encodedMatchesMetaModule(
@@ -47,10 +49,14 @@ void main() {
       await testBuilder(
         MetaModuleBuilder(testPlatform),
         {
-          'a|lib/a.module.library':
-              ModuleLibrary.fromSource(assetA, '').serialize(),
-          'a|lib/b.module.library':
-              ModuleLibrary.fromSource(assetB, "import 'dart:io';").serialize(),
+          'a|lib/a.module.library': ModuleLibrary.fromSource(
+            assetA,
+            '',
+          ).serialize(),
+          'a|lib/b.module.library': ModuleLibrary.fromSource(
+            assetB,
+            "import 'dart:io';",
+          ).serialize(),
         },
         outputs: {
           'a|lib/${metaModuleExtension(testPlatform)}':
@@ -75,16 +81,14 @@ void main() {
         await testBuilder(
           MetaModuleBuilder(testPlatform),
           {
-            'a|lib/a.module.library':
-                ModuleLibrary.fromSource(
-                  assetA,
-                  "import 'b.dart';",
-                ).serialize(),
-            'a|lib/b.module.library':
-                ModuleLibrary.fromSource(
-                  assetB,
-                  "import 'dart:io';import 'a.dart';",
-                ).serialize(),
+            'a|lib/a.module.library': ModuleLibrary.fromSource(
+              assetA,
+              "import 'b.dart';",
+            ).serialize(),
+            'a|lib/b.module.library': ModuleLibrary.fromSource(
+              assetB,
+              "import 'dart:io';import 'a.dart';",
+            ).serialize(),
           },
           outputs: {
             'a|lib/${metaModuleExtension(testPlatform)}':
@@ -108,13 +112,14 @@ void main() {
       await testBuilder(
         MetaModuleBuilder(testPlatform),
         {
-          'a|lib/a.module.library':
-              ModuleLibrary.fromSource(
-                assetA,
-                "import 'src/b.dart';",
-              ).serialize(),
-          'a|lib/src/b.module.library':
-              ModuleLibrary.fromSource(assetB, "import 'dart:io';").serialize(),
+          'a|lib/a.module.library': ModuleLibrary.fromSource(
+            assetA,
+            "import 'src/b.dart';",
+          ).serialize(),
+          'a|lib/src/b.module.library': ModuleLibrary.fromSource(
+            assetB,
+            "import 'dart:io';",
+          ).serialize(),
         },
         outputs: {
           'a|lib/${metaModuleExtension(testPlatform)}':
@@ -144,10 +149,14 @@ void main() {
       await testBuilder(
         MetaModuleBuilder(testPlatform),
         {
-          'a|lib/a.module.library':
-              ModuleLibrary.fromSource(assetA, "import 'b.dart';").serialize(),
-          'a|lib/b.module.library':
-              ModuleLibrary.fromSource(assetB, "import 'dart:io';").serialize(),
+          'a|lib/a.module.library': ModuleLibrary.fromSource(
+            assetA,
+            "import 'b.dart';",
+          ).serialize(),
+          'a|lib/b.module.library': ModuleLibrary.fromSource(
+            assetB,
+            "import 'dart:io';",
+          ).serialize(),
         },
         outputs: {
           'a|lib/${metaModuleExtension(testPlatform)}':

--- a/builder_pkgs/build_web_compilers/test/build_modules/module_builder_test.dart
+++ b/builder_pkgs/build_web_compilers/test/build_modules/module_builder_test.dart
@@ -48,16 +48,26 @@ void main() {
         'a|lib/${metaModuleCleanExtension(platform)}': jsonEncode(
           metaModule.toJson(),
         ),
-        'a|lib/a$moduleLibraryExtension':
-            ModuleLibrary.fromSource(assetA, '').serialize(),
-        'a|lib/b$moduleLibraryExtension':
-            ModuleLibrary.fromSource(assetB, '').serialize(),
-        'a|lib/c$moduleLibraryExtension':
-            ModuleLibrary.fromSource(assetC, '').serialize(),
-        'a|lib/d$moduleLibraryExtension':
-            ModuleLibrary.fromSource(assetD, '').serialize(),
-        'a|lib/e$moduleLibraryExtension':
-            ModuleLibrary.fromSource(assetE, '').serialize(),
+        'a|lib/a$moduleLibraryExtension': ModuleLibrary.fromSource(
+          assetA,
+          '',
+        ).serialize(),
+        'a|lib/b$moduleLibraryExtension': ModuleLibrary.fromSource(
+          assetB,
+          '',
+        ).serialize(),
+        'a|lib/c$moduleLibraryExtension': ModuleLibrary.fromSource(
+          assetC,
+          '',
+        ).serialize(),
+        'a|lib/d$moduleLibraryExtension': ModuleLibrary.fromSource(
+          assetD,
+          '',
+        ).serialize(),
+        'a|lib/e$moduleLibraryExtension': ModuleLibrary.fromSource(
+          assetE,
+          '',
+        ).serialize(),
       },
       outputs: {
         'a|lib/a${moduleExtension(platform)}': encodedMatchesModule(moduleA),
@@ -109,16 +119,26 @@ void main() {
         'a|lib/${metaModuleExtension(platform)}': jsonEncode(
           metaModule.toJson(),
         ),
-        'a|lib/a$moduleLibraryExtension':
-            ModuleLibrary.fromSource(assetA, '').serialize(),
-        'a|lib/b$moduleLibraryExtension':
-            ModuleLibrary.fromSource(assetB, '').serialize(),
-        'a|lib/c$moduleLibraryExtension':
-            ModuleLibrary.fromSource(assetC, '').serialize(),
-        'a|lib/d$moduleLibraryExtension':
-            ModuleLibrary.fromSource(assetD, '').serialize(),
-        'a|lib/e$moduleLibraryExtension':
-            ModuleLibrary.fromSource(assetE, '').serialize(),
+        'a|lib/a$moduleLibraryExtension': ModuleLibrary.fromSource(
+          assetA,
+          '',
+        ).serialize(),
+        'a|lib/b$moduleLibraryExtension': ModuleLibrary.fromSource(
+          assetB,
+          '',
+        ).serialize(),
+        'a|lib/c$moduleLibraryExtension': ModuleLibrary.fromSource(
+          assetC,
+          '',
+        ).serialize(),
+        'a|lib/d$moduleLibraryExtension': ModuleLibrary.fromSource(
+          assetD,
+          '',
+        ).serialize(),
+        'a|lib/e$moduleLibraryExtension': ModuleLibrary.fromSource(
+          assetE,
+          '',
+        ).serialize(),
       },
       outputs: {
         'a|lib/a${moduleExtension(platform)}': encodedMatchesModule(moduleA),

--- a/builder_pkgs/build_web_compilers/test/dart2js_bootstrap_test.dart
+++ b/builder_pkgs/build_web_compilers/test/dart2js_bootstrap_test.dart
@@ -75,11 +75,12 @@ void main() {
           'native_null_assertions': false,
         }),
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|web/index.dart.js.map': isNotNull,
-        'a|web/index.dart.js.tar.gz': isNotNull,
-        'a|web/index.dart.js': decodedMatches(contains('world')),
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|web/index.dart.js.map': isNotNull,
+          'a|web/index.dart.js.tar.gz': isNotNull,
+          'a|web/index.dart.js': decodedMatches(contains('world')),
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,
@@ -95,10 +96,11 @@ void main() {
           'dart2js_args': ['--no-source-maps'],
         }),
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|web/index.dart.js.tar.gz': anything,
-        'a|web/index.dart.js': anything,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|web/index.dart.js.tar.gz': anything,
+          'a|web/index.dart.js': anything,
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,

--- a/builder_pkgs/build_web_compilers/test/dart2wasm_bootstrap_test.dart
+++ b/builder_pkgs/build_web_compilers/test/dart2wasm_bootstrap_test.dart
@@ -59,12 +59,13 @@ void main() {
         const BuilderOptions({'compiler': 'dart2wasm'}),
       );
 
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|web/index.dart.js': decodedMatches(contains('compileStreaming')),
-        'a|web/index.mjs': isNotNull,
-        'a|web/index.wasm.map': isNotNull,
-        'a|web/index.wasm': isNotNull,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|web/index.dart.js': decodedMatches(contains('compileStreaming')),
+          'a|web/index.mjs': isNotNull,
+          'a|web/index.wasm.map': isNotNull,
+          'a|web/index.wasm': isNotNull,
+        });
 
       await testBuilders(
         [...startingBuilders, builder],
@@ -82,30 +83,31 @@ void main() {
           },
         }),
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|web/index.dart.js': decodedMatches(
-          stringContainsInOrder([
-            'if',
-            // Depending on whether dart2wasm emitted a .support.js file,
-            // this check either comes from dart2wasm or from our own script
-            // doing its own feature detection as a fallback. Which one is
-            // used depends on the SDK version, we can only assume that the
-            // check is guaranteed to include WebAssembly.validate to check
-            // for WASM features.
-            'WebAssembly.validate',
-            '{',
-            'compileStreaming',
-            '} else {',
-            'scriptTag.src = relativeURL("./index.dart2js.js");',
-          ]),
-        ),
-        'a|web/index.dart.js.tar.gz': isNotNull,
-        'a|web/index.dart2js.js': decodedMatches(contains('Hello world!')),
-        'a|web/index.dart2js.js.map': isNotNull,
-        'a|web/index.mjs': isNotNull,
-        'a|web/index.wasm.map': isNotNull,
-        'a|web/index.wasm': isNotNull,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|web/index.dart.js': decodedMatches(
+            stringContainsInOrder([
+              'if',
+              // Depending on whether dart2wasm emitted a .support.js file,
+              // this check either comes from dart2wasm or from our own script
+              // doing its own feature detection as a fallback. Which one is
+              // used depends on the SDK version, we can only assume that the
+              // check is guaranteed to include WebAssembly.validate to check
+              // for WASM features.
+              'WebAssembly.validate',
+              '{',
+              'compileStreaming',
+              '} else {',
+              'scriptTag.src = relativeURL("./index.dart2js.js");',
+            ]),
+          ),
+          'a|web/index.dart.js.tar.gz': isNotNull,
+          'a|web/index.dart2js.js': decodedMatches(contains('Hello world!')),
+          'a|web/index.dart2js.js.map': isNotNull,
+          'a|web/index.mjs': isNotNull,
+          'a|web/index.wasm.map': isNotNull,
+          'a|web/index.wasm': isNotNull,
+        });
 
       await testBuilders(
         [...startingBuilders, builder],
@@ -123,41 +125,42 @@ void main() {
           },
         }),
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|web/index.dart.js': decodedMatches(
-          allOf([
-            // Worker detection.
-            contains("const isWorker = typeof document === 'undefined'"),
-            // thisScript guarded for worker context.
-            contains(
-              'const thisScript = isWorker ? undefined'
-              ' : document.currentScript',
-            ),
-            // relativeURL has worker branch using self.location.href.
-            contains('new URL(ref, self.location.href)'),
-            // forceJS is extracted from script src params as well
-            // as location search.
-            contains(
-              'new URL(thisScript.src).searchParams'
-              ".get('force_js')",
-            ),
-            contains(
-              'new URLSearchParams(self.location.search)'
-              ".get('force_js')",
-            ),
-            // JS fallback uses importScripts in worker context.
-            contains('importScripts(relativeURL('),
-            // Wasm module import uses relativeURL.
-            contains('await import(relativeURL('),
-          ]),
-        ),
-        'a|web/index.dart.js.tar.gz': isNotNull,
-        'a|web/index.dart2js.js': isNotNull,
-        'a|web/index.dart2js.js.map': isNotNull,
-        'a|web/index.mjs': isNotNull,
-        'a|web/index.wasm.map': isNotNull,
-        'a|web/index.wasm': isNotNull,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|web/index.dart.js': decodedMatches(
+            allOf([
+              // Worker detection.
+              contains("const isWorker = typeof document === 'undefined'"),
+              // thisScript guarded for worker context.
+              contains(
+                'const thisScript = isWorker ? undefined'
+                ' : document.currentScript',
+              ),
+              // relativeURL has worker branch using self.location.href.
+              contains('new URL(ref, self.location.href)'),
+              // forceJS is extracted from script src params as well
+              // as location search.
+              contains(
+                'new URL(thisScript.src).searchParams'
+                ".get('force_js')",
+              ),
+              contains(
+                'new URLSearchParams(self.location.search)'
+                ".get('force_js')",
+              ),
+              // JS fallback uses importScripts in worker context.
+              contains('importScripts(relativeURL('),
+              // Wasm module import uses relativeURL.
+              contains('await import(relativeURL('),
+            ]),
+          ),
+          'a|web/index.dart.js.tar.gz': isNotNull,
+          'a|web/index.dart2js.js': isNotNull,
+          'a|web/index.dart2js.js.map': isNotNull,
+          'a|web/index.mjs': isNotNull,
+          'a|web/index.wasm.map': isNotNull,
+          'a|web/index.wasm': isNotNull,
+        });
 
       await testBuilders(
         [...startingBuilders, builder],
@@ -168,14 +171,15 @@ void main() {
   });
 
   test('can disable generation of loader script', () async {
-    final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-      'a|web/index.dart.js.tar.gz': isNotNull,
-      'a|web/index.dart2js.js': decodedMatches(contains('Hello world!')),
-      'a|web/index.dart2js.js.map': isNotNull,
-      'a|web/index.mjs': isNotNull,
-      'a|web/index.wasm.map': isNotNull,
-      'a|web/index.wasm': isNotNull,
-    });
+    final expectedOutputs = Map.of(startingExpectedOutputs)
+      ..addAll({
+        'a|web/index.dart.js.tar.gz': isNotNull,
+        'a|web/index.dart2js.js': decodedMatches(contains('Hello world!')),
+        'a|web/index.dart2js.js.map': isNotNull,
+        'a|web/index.mjs': isNotNull,
+        'a|web/index.wasm.map': isNotNull,
+        'a|web/index.wasm': isNotNull,
+      });
 
     final builder = WebEntrypointBuilder.fromOptions(
       const BuilderOptions({
@@ -205,16 +209,17 @@ void main() {
         },
       }),
     );
-    final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-      'a|web/index.dart.js.tar.gz': isNotNull,
-      'a|web/index.dart2js.js': isNotNull,
-      'a|web/index.dart2js.js.map': isNotNull,
-      'a|web/index.dart.js': isNotNull,
-      'a|web/index.wasm.tar.gz': isNotNull,
-      'a|web/index.mjs': isNotNull,
-      'a|web/index.wasm.map': isNotNull,
-      'a|web/index.wasm': isNotNull,
-    });
+    final expectedOutputs = Map.of(startingExpectedOutputs)
+      ..addAll({
+        'a|web/index.dart.js.tar.gz': isNotNull,
+        'a|web/index.dart2js.js': isNotNull,
+        'a|web/index.dart2js.js.map': isNotNull,
+        'a|web/index.dart.js': isNotNull,
+        'a|web/index.wasm.tar.gz': isNotNull,
+        'a|web/index.mjs': isNotNull,
+        'a|web/index.wasm.map': isNotNull,
+        'a|web/index.wasm': isNotNull,
+      });
 
     await testBuilders(
       [...startingBuilders, builder],

--- a/builder_pkgs/build_web_compilers/test/ddc_library_bundle_bootstrap_test.dart
+++ b/builder_pkgs/build_web_compilers/test/ddc_library_bundle_bootstrap_test.dart
@@ -92,38 +92,39 @@ void main() {
         // Just do some basic sanity checking, integration tests will validate
         // things actually work.
         final builder = WebEntrypointBuilder.fromOptions(defaultBuilderOptions);
-        final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-          'a|web/index.dart.bootstrap.js': decodedMatches(
-            allOf([
-              // Calls 'main' via the embedder.
-              contains('dartDevEmbedder.runMain'),
-            ]),
-          ),
-          'a|web/index.dart.bootstrap.end.js': isNotEmpty,
-          'a|web/index.dart.ddc_merged_metadata': isNotEmpty,
-          'a|web/index.ddc.js': decodedMatches(
-            // Contains the library declaration of the entrypoint library.
-            contains(
-              'dartDevEmbedder.defineLibrary("org-dartlang-app:///web/index.dart"',
+        final expectedOutputs = Map.of(startingExpectedOutputs)
+          ..addAll({
+            'a|web/index.dart.bootstrap.js': decodedMatches(
+              allOf([
+                // Calls 'main' via the embedder.
+                contains('dartDevEmbedder.runMain'),
+              ]),
             ),
-          ),
-          'a|web/index.dart.js': decodedMatches(
-            allOf([
-              // Contains a script pointer to main's bootstrap.js file.
-              contains('"src": "index.dart.bootstrap.js", "id": "data-main"'),
-              // Maps non-lib modules to remove the top level dir.
-              contains('"src": "index.ddc.js", "id": "web/index"'),
-              // Maps lib modules to packages path
-              contains('"src": "packages/a/a.ddc.js", "id": "packages/a/a"'),
-              contains('"src": "packages/b/b.ddc.js", "id": "packages/b/b"'),
-              // Imports the dart sdk.
-              contains('"id": "dart_sdk"'),
-              isNot(contains('lib/a')),
-              contains('loadConfig.isWindows = false;'),
-            ]),
-          ),
-          'a|web/index.digests': decodedMatches(contains('packages/')),
-        });
+            'a|web/index.dart.bootstrap.end.js': isNotEmpty,
+            'a|web/index.dart.ddc_merged_metadata': isNotEmpty,
+            'a|web/index.ddc.js': decodedMatches(
+              // Contains the library declaration of the entrypoint library.
+              contains(
+                'dartDevEmbedder.defineLibrary("org-dartlang-app:///web/index.dart"',
+              ),
+            ),
+            'a|web/index.dart.js': decodedMatches(
+              allOf([
+                // Contains a script pointer to main's bootstrap.js file.
+                contains('"src": "index.dart.bootstrap.js", "id": "data-main"'),
+                // Maps non-lib modules to remove the top level dir.
+                contains('"src": "index.ddc.js", "id": "web/index"'),
+                // Maps lib modules to packages path
+                contains('"src": "packages/a/a.ddc.js", "id": "packages/a/a"'),
+                contains('"src": "packages/b/b.ddc.js", "id": "packages/b/b"'),
+                // Imports the dart sdk.
+                contains('"id": "dart_sdk"'),
+                isNot(contains('lib/a')),
+                contains('loadConfig.isWindows = false;'),
+              ]),
+            ),
+            'a|web/index.digests': decodedMatches(contains('packages/')),
+          });
         await testBuilders(
           [...startingBuilders, builder],
           startingAssets,

--- a/builder_pkgs/build_web_compilers/test/ddc_library_bundle_builder_test.dart
+++ b/builder_pkgs/build_web_compilers/test/ddc_library_bundle_builder_test.dart
@@ -89,19 +89,24 @@ void main() {
             ddcLibraryBundle: ddcLibraryBundle,
           );
 
-          final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-            'a|lib/a$jsModuleExtension': decodedMatches(contains('hello')),
-            'a|lib/a$jsSourceMapExtension': decodedMatches(contains('a.dart')),
-            'a|lib/a$metadataExtension': isNotNull,
-            'a|web/index$jsModuleExtension': decodedMatches(contains('main')),
-            'a|web/index$jsSourceMapExtension': decodedMatches(
-              contains('index.dart'),
-            ),
-            'a|web/index$metadataExtension': isNotNull,
-            'b|lib/b$jsModuleExtension': decodedMatches(contains('world')),
-            'b|lib/b$jsSourceMapExtension': decodedMatches(contains('b.dart')),
-            'b|lib/b$metadataExtension': isNotNull,
-          });
+          final expectedOutputs = Map.of(startingExpectedOutputs)
+            ..addAll({
+              'a|lib/a$jsModuleExtension': decodedMatches(contains('hello')),
+              'a|lib/a$jsSourceMapExtension': decodedMatches(
+                contains('a.dart'),
+              ),
+              'a|lib/a$metadataExtension': isNotNull,
+              'a|web/index$jsModuleExtension': decodedMatches(contains('main')),
+              'a|web/index$jsSourceMapExtension': decodedMatches(
+                contains('index.dart'),
+              ),
+              'a|web/index$metadataExtension': isNotNull,
+              'b|lib/b$jsModuleExtension': decodedMatches(contains('world')),
+              'b|lib/b$jsSourceMapExtension': decodedMatches(
+                contains('b.dart'),
+              ),
+              'b|lib/b$metadataExtension': isNotNull,
+            });
 
           final reportedUnused = <AssetId, Iterable<AssetId>>{};
           await testBuilders(
@@ -136,19 +141,20 @@ void main() {
           environment: {'foo': 'zap'},
           ddcLibraryBundle: ddcLibraryBundle,
         );
-        final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-          'a|lib/a$jsModuleExtension': isNotNull,
-          'a|lib/a$jsSourceMapExtension': isNotNull,
-          'a|lib/a$metadataExtension': isNotNull,
-          'a|web/index$jsModuleExtension': decodedMatches(
-            contains('print("zap")'),
-          ),
-          'a|web/index$jsSourceMapExtension': isNotNull,
-          'a|web/index$metadataExtension': isNotNull,
-          'b|lib/b$jsModuleExtension': isNotNull,
-          'b|lib/b$jsSourceMapExtension': isNotNull,
-          'b|lib/b$metadataExtension': isNotNull,
-        });
+        final expectedOutputs = Map.of(startingExpectedOutputs)
+          ..addAll({
+            'a|lib/a$jsModuleExtension': isNotNull,
+            'a|lib/a$jsSourceMapExtension': isNotNull,
+            'a|lib/a$metadataExtension': isNotNull,
+            'a|web/index$jsModuleExtension': decodedMatches(
+              contains('print("zap")'),
+            ),
+            'a|web/index$jsSourceMapExtension': isNotNull,
+            'a|web/index$metadataExtension': isNotNull,
+            'b|lib/b$jsModuleExtension': isNotNull,
+            'b|lib/b$jsSourceMapExtension': isNotNull,
+            'b|lib/b$metadataExtension': isNotNull,
+          });
         await testBuilders(
           [...startingBuilders, builder],
           startingAssets,
@@ -162,17 +168,18 @@ void main() {
           canaryFeatures: true,
           ddcLibraryBundle: ddcLibraryBundle,
         );
-        final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-          'a|lib/a$jsModuleExtension': decodedMatches(contains('canary')),
-          'a|lib/a$jsSourceMapExtension': isNotNull,
-          'a|lib/a$metadataExtension': isNotNull,
-          'a|web/index$jsModuleExtension': isNotNull,
-          'a|web/index$jsSourceMapExtension': isNotNull,
-          'a|web/index$metadataExtension': isNotNull,
-          'b|lib/b$jsModuleExtension': isNotNull,
-          'b|lib/b$jsSourceMapExtension': isNotNull,
-          'b|lib/b$metadataExtension': isNotNull,
-        });
+        final expectedOutputs = Map.of(startingExpectedOutputs)
+          ..addAll({
+            'a|lib/a$jsModuleExtension': decodedMatches(contains('canary')),
+            'a|lib/a$jsSourceMapExtension': isNotNull,
+            'a|lib/a$metadataExtension': isNotNull,
+            'a|web/index$jsModuleExtension': isNotNull,
+            'a|web/index$jsSourceMapExtension': isNotNull,
+            'a|web/index$metadataExtension': isNotNull,
+            'b|lib/b$jsModuleExtension': isNotNull,
+            'b|lib/b$jsSourceMapExtension': isNotNull,
+            'b|lib/b$metadataExtension': isNotNull,
+          });
         await testBuilders(
           [...startingBuilders, builder],
           startingAssets,
@@ -187,19 +194,20 @@ void main() {
             platform: ddcPlatform,
             ddcLibraryBundle: ddcLibraryBundle,
           );
-          final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-            'a|lib/a$jsModuleExtension': decodedMatches(
-              isNot(contains('canary')),
-            ),
-            'a|lib/a$jsSourceMapExtension': isNotNull,
-            'a|lib/a$metadataExtension': isNotNull,
-            'a|web/index$jsModuleExtension': isNotNull,
-            'a|web/index$jsSourceMapExtension': isNotNull,
-            'a|web/index$metadataExtension': isNotNull,
-            'b|lib/b$jsModuleExtension': isNotNull,
-            'b|lib/b$jsSourceMapExtension': isNotNull,
-            'b|lib/b$metadataExtension': isNotNull,
-          });
+          final expectedOutputs = Map.of(startingExpectedOutputs)
+            ..addAll({
+              'a|lib/a$jsModuleExtension': decodedMatches(
+                isNot(contains('canary')),
+              ),
+              'a|lib/a$jsSourceMapExtension': isNotNull,
+              'a|lib/a$metadataExtension': isNotNull,
+              'a|web/index$jsModuleExtension': isNotNull,
+              'a|web/index$jsSourceMapExtension': isNotNull,
+              'a|web/index$metadataExtension': isNotNull,
+              'b|lib/b$jsModuleExtension': isNotNull,
+              'b|lib/b$jsSourceMapExtension': isNotNull,
+              'b|lib/b$metadataExtension': isNotNull,
+            });
           await testBuilders(
             [...startingBuilders, builder],
             startingAssets,
@@ -217,20 +225,21 @@ void main() {
           generateFullDill: true,
           ddcLibraryBundle: ddcLibraryBundle,
         );
-        final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-          'a|lib/a$fullKernelExtension': isNotNull,
-          'a|lib/a$jsModuleExtension': isNotNull,
-          'a|lib/a$jsSourceMapExtension': isNotNull,
-          'a|lib/a$metadataExtension': isNotNull,
-          'a|web/index$fullKernelExtension': isNotNull,
-          'a|web/index$jsModuleExtension': isNotNull,
-          'a|web/index$jsSourceMapExtension': isNotNull,
-          'a|web/index$metadataExtension': isNotNull,
-          'b|lib/b$fullKernelExtension': isNotNull,
-          'b|lib/b$jsModuleExtension': isNotNull,
-          'b|lib/b$jsSourceMapExtension': isNotNull,
-          'b|lib/b$metadataExtension': isNotNull,
-        });
+        final expectedOutputs = Map.of(startingExpectedOutputs)
+          ..addAll({
+            'a|lib/a$fullKernelExtension': isNotNull,
+            'a|lib/a$jsModuleExtension': isNotNull,
+            'a|lib/a$jsSourceMapExtension': isNotNull,
+            'a|lib/a$metadataExtension': isNotNull,
+            'a|web/index$fullKernelExtension': isNotNull,
+            'a|web/index$jsModuleExtension': isNotNull,
+            'a|web/index$jsSourceMapExtension': isNotNull,
+            'a|web/index$metadataExtension': isNotNull,
+            'b|lib/b$fullKernelExtension': isNotNull,
+            'b|lib/b$jsModuleExtension': isNotNull,
+            'b|lib/b$jsSourceMapExtension': isNotNull,
+            'b|lib/b$metadataExtension': isNotNull,
+          });
         await testBuilders(
           [...startingBuilders, builder],
           startingAssets,
@@ -243,17 +252,18 @@ void main() {
           platform: ddcPlatform,
           ddcLibraryBundle: ddcLibraryBundle,
         );
-        final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-          'a|lib/a$jsModuleExtension': isNotNull,
-          'a|lib/a$jsSourceMapExtension': isNotNull,
-          'a|lib/a$metadataExtension': isNotNull,
-          'a|web/index$jsModuleExtension': isNotNull,
-          'a|web/index$jsSourceMapExtension': isNotNull,
-          'a|web/index$metadataExtension': isNotNull,
-          'b|lib/b$jsModuleExtension': isNotNull,
-          'b|lib/b$jsSourceMapExtension': isNotNull,
-          'b|lib/b$metadataExtension': isNotNull,
-        });
+        final expectedOutputs = Map.of(startingExpectedOutputs)
+          ..addAll({
+            'a|lib/a$jsModuleExtension': isNotNull,
+            'a|lib/a$jsSourceMapExtension': isNotNull,
+            'a|lib/a$metadataExtension': isNotNull,
+            'a|web/index$jsModuleExtension': isNotNull,
+            'a|web/index$jsSourceMapExtension': isNotNull,
+            'a|web/index$metadataExtension': isNotNull,
+            'b|lib/b$jsModuleExtension': isNotNull,
+            'b|lib/b$jsSourceMapExtension': isNotNull,
+            'b|lib/b$metadataExtension': isNotNull,
+          });
         await testBuilders(
           [...startingBuilders, builder],
           startingAssets,
@@ -267,20 +277,21 @@ void main() {
           emitDebugSymbols: true,
           ddcLibraryBundle: ddcLibraryBundle,
         );
-        final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-          'a|lib/a$jsModuleExtension': isNotNull,
-          'a|lib/a$jsSourceMapExtension': isNotNull,
-          'a|lib/a$metadataExtension': isNotNull,
-          'a|lib/a$symbolsExtension': isNotNull,
-          'a|web/index$jsModuleExtension': isNotNull,
-          'a|web/index$jsSourceMapExtension': isNotNull,
-          'a|web/index$metadataExtension': isNotNull,
-          'a|web/index$symbolsExtension': isNotNull,
-          'b|lib/b$jsModuleExtension': isNotNull,
-          'b|lib/b$jsSourceMapExtension': isNotNull,
-          'b|lib/b$metadataExtension': isNotNull,
-          'b|lib/b$symbolsExtension': isNotNull,
-        });
+        final expectedOutputs = Map.of(startingExpectedOutputs)
+          ..addAll({
+            'a|lib/a$jsModuleExtension': isNotNull,
+            'a|lib/a$jsSourceMapExtension': isNotNull,
+            'a|lib/a$metadataExtension': isNotNull,
+            'a|lib/a$symbolsExtension': isNotNull,
+            'a|web/index$jsModuleExtension': isNotNull,
+            'a|web/index$jsSourceMapExtension': isNotNull,
+            'a|web/index$metadataExtension': isNotNull,
+            'a|web/index$symbolsExtension': isNotNull,
+            'b|lib/b$jsModuleExtension': isNotNull,
+            'b|lib/b$jsSourceMapExtension': isNotNull,
+            'b|lib/b$metadataExtension': isNotNull,
+            'b|lib/b$symbolsExtension': isNotNull,
+          });
         await testBuilders(
           [...startingBuilders, builder],
           startingAssets,
@@ -293,17 +304,18 @@ void main() {
           platform: ddcPlatform,
           ddcLibraryBundle: ddcLibraryBundle,
         );
-        final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-          'b|lib/b$jsModuleExtension': isNotNull,
-          'b|lib/b$jsSourceMapExtension': isNotNull,
-          'b|lib/b$metadataExtension': isNotNull,
-          'a|lib/a$jsModuleExtension': isNotNull,
-          'a|lib/a$jsSourceMapExtension': isNotNull,
-          'a|lib/a$metadataExtension': isNotNull,
-          'a|web/index$jsModuleExtension': isNotNull,
-          'a|web/index$jsSourceMapExtension': isNotNull,
-          'a|web/index$metadataExtension': isNotNull,
-        });
+        final expectedOutputs = Map.of(startingExpectedOutputs)
+          ..addAll({
+            'b|lib/b$jsModuleExtension': isNotNull,
+            'b|lib/b$jsSourceMapExtension': isNotNull,
+            'b|lib/b$metadataExtension': isNotNull,
+            'a|lib/a$jsModuleExtension': isNotNull,
+            'a|lib/a$jsSourceMapExtension': isNotNull,
+            'a|lib/a$metadataExtension': isNotNull,
+            'a|web/index$jsModuleExtension': isNotNull,
+            'a|web/index$jsSourceMapExtension': isNotNull,
+            'a|web/index$metadataExtension': isNotNull,
+          });
         await testBuilders(
           [...startingBuilders, builder],
           startingAssets,
@@ -316,23 +328,24 @@ void main() {
           platform: ddcPlatform,
           ddcLibraryBundle: ddcLibraryBundle,
         );
-        final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-          'a|lib/a$jsModuleExtension': isNotNull,
-          'a|lib/a$jsSourceMapExtension': isNotNull,
-          'a|lib/a$metadataExtension': decodedMatches(
-            isNot(contains('scratch')),
-          ),
-          'a|web/index$jsModuleExtension': isNotNull,
-          'a|web/index$jsSourceMapExtension': isNotNull,
-          'a|web/index$metadataExtension': decodedMatches(
-            isNot(contains('scratch')),
-          ),
-          'b|lib/b$jsModuleExtension': isNotNull,
-          'b|lib/b$jsSourceMapExtension': isNotNull,
-          'b|lib/b$metadataExtension': decodedMatches(
-            isNot(contains('scratch')),
-          ),
-        });
+        final expectedOutputs = Map.of(startingExpectedOutputs)
+          ..addAll({
+            'a|lib/a$jsModuleExtension': isNotNull,
+            'a|lib/a$jsSourceMapExtension': isNotNull,
+            'a|lib/a$metadataExtension': decodedMatches(
+              isNot(contains('scratch')),
+            ),
+            'a|web/index$jsModuleExtension': isNotNull,
+            'a|web/index$jsSourceMapExtension': isNotNull,
+            'a|web/index$metadataExtension': decodedMatches(
+              isNot(contains('scratch')),
+            ),
+            'b|lib/b$jsModuleExtension': isNotNull,
+            'b|lib/b$jsSourceMapExtension': isNotNull,
+            'b|lib/b$metadataExtension': decodedMatches(
+              isNot(contains('scratch')),
+            ),
+          });
         await testBuilders(
           [...startingBuilders, builder],
           startingAssets,

--- a/builder_pkgs/build_web_compilers/test/dev_compiler_bootstrap_test.dart
+++ b/builder_pkgs/build_web_compilers/test/dev_compiler_bootstrap_test.dart
@@ -97,28 +97,31 @@ void main() {
       // Just do some basic sanity checking, integration tests will validate
       // things actually work.
       final builder = WebEntrypointBuilder.fromOptions(defaultBuilderOptions);
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|web/index.dart.bootstrap.js': decodedMatches(
-          allOf([
-            // Maps non-lib modules to remove the top level dir.
-            contains('"web/index": "index.ddc"'),
-            // Maps lib modules to packages path
-            contains('"packages/a/a": "packages/a/a.ddc"'),
-            contains('"packages/b/b": "packages/b/b.ddc"'),
-            // Requires the top level module and dart sdk.
-            contains(
-              'define("index.dart.bootstrap", ["web/index", "dart_sdk"]',
-            ),
-            // Calls main on the top level module.
-            contains('(app.web__index || app.index).main()'),
-            isNot(contains('lib/a')),
-          ]),
-        ),
-        'a|web/index.dart.bootstrap.end.js': isEmpty,
-        'a|web/index.dart.ddc_merged_metadata': isNotEmpty,
-        'a|web/index.dart.js': decodedMatches(contains('index.dart.bootstrap')),
-        'a|web/index.digests': decodedMatches(contains('packages/')),
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|web/index.dart.bootstrap.js': decodedMatches(
+            allOf([
+              // Maps non-lib modules to remove the top level dir.
+              contains('"web/index": "index.ddc"'),
+              // Maps lib modules to packages path
+              contains('"packages/a/a": "packages/a/a.ddc"'),
+              contains('"packages/b/b": "packages/b/b.ddc"'),
+              // Requires the top level module and dart sdk.
+              contains(
+                'define("index.dart.bootstrap", ["web/index", "dart_sdk"]',
+              ),
+              // Calls main on the top level module.
+              contains('(app.web__index || app.index).main()'),
+              isNot(contains('lib/a')),
+            ]),
+          ),
+          'a|web/index.dart.bootstrap.end.js': isEmpty,
+          'a|web/index.dart.ddc_merged_metadata': isNotEmpty,
+          'a|web/index.dart.js': decodedMatches(
+            contains('index.dart.bootstrap'),
+          ),
+          'a|web/index.digests': decodedMatches(contains('packages/')),
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,

--- a/builder_pkgs/build_web_compilers/test/dev_compiler_builder_test.dart
+++ b/builder_pkgs/build_web_compilers/test/dev_compiler_builder_test.dart
@@ -88,19 +88,20 @@ void main() {
           ddcLibraryBundle: ddcLibraryBundle,
         );
 
-        final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-          'a|lib/a$jsModuleExtension': decodedMatches(contains('hello')),
-          'a|lib/a$jsSourceMapExtension': decodedMatches(contains('a.dart')),
-          'a|lib/a$metadataExtension': isNotNull,
-          'a|web/index$jsModuleExtension': decodedMatches(contains('main')),
-          'a|web/index$jsSourceMapExtension': decodedMatches(
-            contains('index.dart'),
-          ),
-          'a|web/index$metadataExtension': isNotNull,
-          'b|lib/b$jsModuleExtension': decodedMatches(contains('world')),
-          'b|lib/b$jsSourceMapExtension': decodedMatches(contains('b.dart')),
-          'b|lib/b$metadataExtension': isNotNull,
-        });
+        final expectedOutputs = Map.of(startingExpectedOutputs)
+          ..addAll({
+            'a|lib/a$jsModuleExtension': decodedMatches(contains('hello')),
+            'a|lib/a$jsSourceMapExtension': decodedMatches(contains('a.dart')),
+            'a|lib/a$metadataExtension': isNotNull,
+            'a|web/index$jsModuleExtension': decodedMatches(contains('main')),
+            'a|web/index$jsSourceMapExtension': decodedMatches(
+              contains('index.dart'),
+            ),
+            'a|web/index$metadataExtension': isNotNull,
+            'b|lib/b$jsModuleExtension': decodedMatches(contains('world')),
+            'b|lib/b$jsSourceMapExtension': decodedMatches(contains('b.dart')),
+            'b|lib/b$metadataExtension': isNotNull,
+          });
 
         final reportedUnused = <AssetId, Iterable<AssetId>>{};
         await testBuilders(
@@ -135,19 +136,20 @@ void main() {
         environment: {'foo': 'zap'},
         ddcLibraryBundle: ddcLibraryBundle,
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|lib/a$jsModuleExtension': isNotNull,
-        'a|lib/a$jsSourceMapExtension': isNotNull,
-        'a|lib/a$metadataExtension': isNotNull,
-        'a|web/index$jsModuleExtension': decodedMatches(
-          contains('print("zap")'),
-        ),
-        'a|web/index$jsSourceMapExtension': isNotNull,
-        'a|web/index$metadataExtension': isNotNull,
-        'b|lib/b$jsModuleExtension': isNotNull,
-        'b|lib/b$jsSourceMapExtension': isNotNull,
-        'b|lib/b$metadataExtension': isNotNull,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|lib/a$jsModuleExtension': isNotNull,
+          'a|lib/a$jsSourceMapExtension': isNotNull,
+          'a|lib/a$metadataExtension': isNotNull,
+          'a|web/index$jsModuleExtension': decodedMatches(
+            contains('print("zap")'),
+          ),
+          'a|web/index$jsSourceMapExtension': isNotNull,
+          'a|web/index$metadataExtension': isNotNull,
+          'b|lib/b$jsModuleExtension': isNotNull,
+          'b|lib/b$jsSourceMapExtension': isNotNull,
+          'b|lib/b$metadataExtension': isNotNull,
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,
@@ -161,17 +163,18 @@ void main() {
         canaryFeatures: true,
         ddcLibraryBundle: ddcLibraryBundle,
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|lib/a$jsModuleExtension': decodedMatches(contains('canary')),
-        'a|lib/a$jsSourceMapExtension': isNotNull,
-        'a|lib/a$metadataExtension': isNotNull,
-        'a|web/index$jsModuleExtension': isNotNull,
-        'a|web/index$jsSourceMapExtension': isNotNull,
-        'a|web/index$metadataExtension': isNotNull,
-        'b|lib/b$jsModuleExtension': isNotNull,
-        'b|lib/b$jsSourceMapExtension': isNotNull,
-        'b|lib/b$metadataExtension': isNotNull,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|lib/a$jsModuleExtension': decodedMatches(contains('canary')),
+          'a|lib/a$jsSourceMapExtension': isNotNull,
+          'a|lib/a$metadataExtension': isNotNull,
+          'a|web/index$jsModuleExtension': isNotNull,
+          'a|web/index$jsSourceMapExtension': isNotNull,
+          'a|web/index$metadataExtension': isNotNull,
+          'b|lib/b$jsModuleExtension': isNotNull,
+          'b|lib/b$jsSourceMapExtension': isNotNull,
+          'b|lib/b$metadataExtension': isNotNull,
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,
@@ -184,17 +187,20 @@ void main() {
         platform: ddcPlatform,
         ddcLibraryBundle: ddcLibraryBundle,
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|lib/a$jsModuleExtension': decodedMatches(isNot(contains('canary'))),
-        'a|lib/a$jsSourceMapExtension': isNotNull,
-        'a|lib/a$metadataExtension': isNotNull,
-        'a|web/index$jsModuleExtension': isNotNull,
-        'a|web/index$jsSourceMapExtension': isNotNull,
-        'a|web/index$metadataExtension': isNotNull,
-        'b|lib/b$jsModuleExtension': isNotNull,
-        'b|lib/b$jsSourceMapExtension': isNotNull,
-        'b|lib/b$metadataExtension': isNotNull,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|lib/a$jsModuleExtension': decodedMatches(
+            isNot(contains('canary')),
+          ),
+          'a|lib/a$jsSourceMapExtension': isNotNull,
+          'a|lib/a$metadataExtension': isNotNull,
+          'a|web/index$jsModuleExtension': isNotNull,
+          'a|web/index$jsSourceMapExtension': isNotNull,
+          'a|web/index$metadataExtension': isNotNull,
+          'b|lib/b$jsModuleExtension': isNotNull,
+          'b|lib/b$jsSourceMapExtension': isNotNull,
+          'b|lib/b$metadataExtension': isNotNull,
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,
@@ -208,20 +214,21 @@ void main() {
         generateFullDill: true,
         ddcLibraryBundle: ddcLibraryBundle,
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|lib/a$fullKernelExtension': isNotNull,
-        'a|lib/a$jsModuleExtension': isNotNull,
-        'a|lib/a$jsSourceMapExtension': isNotNull,
-        'a|lib/a$metadataExtension': isNotNull,
-        'a|web/index$fullKernelExtension': isNotNull,
-        'a|web/index$jsModuleExtension': isNotNull,
-        'a|web/index$jsSourceMapExtension': isNotNull,
-        'a|web/index$metadataExtension': isNotNull,
-        'b|lib/b$fullKernelExtension': isNotNull,
-        'b|lib/b$jsModuleExtension': isNotNull,
-        'b|lib/b$jsSourceMapExtension': isNotNull,
-        'b|lib/b$metadataExtension': isNotNull,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|lib/a$fullKernelExtension': isNotNull,
+          'a|lib/a$jsModuleExtension': isNotNull,
+          'a|lib/a$jsSourceMapExtension': isNotNull,
+          'a|lib/a$metadataExtension': isNotNull,
+          'a|web/index$fullKernelExtension': isNotNull,
+          'a|web/index$jsModuleExtension': isNotNull,
+          'a|web/index$jsSourceMapExtension': isNotNull,
+          'a|web/index$metadataExtension': isNotNull,
+          'b|lib/b$fullKernelExtension': isNotNull,
+          'b|lib/b$jsModuleExtension': isNotNull,
+          'b|lib/b$jsSourceMapExtension': isNotNull,
+          'b|lib/b$metadataExtension': isNotNull,
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,
@@ -234,17 +241,18 @@ void main() {
         platform: ddcPlatform,
         ddcLibraryBundle: ddcLibraryBundle,
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|lib/a$jsModuleExtension': isNotNull,
-        'a|lib/a$jsSourceMapExtension': isNotNull,
-        'a|lib/a$metadataExtension': isNotNull,
-        'a|web/index$jsModuleExtension': isNotNull,
-        'a|web/index$jsSourceMapExtension': isNotNull,
-        'a|web/index$metadataExtension': isNotNull,
-        'b|lib/b$jsModuleExtension': isNotNull,
-        'b|lib/b$jsSourceMapExtension': isNotNull,
-        'b|lib/b$metadataExtension': isNotNull,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|lib/a$jsModuleExtension': isNotNull,
+          'a|lib/a$jsSourceMapExtension': isNotNull,
+          'a|lib/a$metadataExtension': isNotNull,
+          'a|web/index$jsModuleExtension': isNotNull,
+          'a|web/index$jsSourceMapExtension': isNotNull,
+          'a|web/index$metadataExtension': isNotNull,
+          'b|lib/b$jsModuleExtension': isNotNull,
+          'b|lib/b$jsSourceMapExtension': isNotNull,
+          'b|lib/b$metadataExtension': isNotNull,
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,
@@ -258,20 +266,21 @@ void main() {
         emitDebugSymbols: true,
         ddcLibraryBundle: ddcLibraryBundle,
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|lib/a$jsModuleExtension': isNotNull,
-        'a|lib/a$jsSourceMapExtension': isNotNull,
-        'a|lib/a$metadataExtension': isNotNull,
-        'a|lib/a$symbolsExtension': isNotNull,
-        'a|web/index$jsModuleExtension': isNotNull,
-        'a|web/index$jsSourceMapExtension': isNotNull,
-        'a|web/index$metadataExtension': isNotNull,
-        'a|web/index$symbolsExtension': isNotNull,
-        'b|lib/b$jsModuleExtension': isNotNull,
-        'b|lib/b$jsSourceMapExtension': isNotNull,
-        'b|lib/b$metadataExtension': isNotNull,
-        'b|lib/b$symbolsExtension': isNotNull,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|lib/a$jsModuleExtension': isNotNull,
+          'a|lib/a$jsSourceMapExtension': isNotNull,
+          'a|lib/a$metadataExtension': isNotNull,
+          'a|lib/a$symbolsExtension': isNotNull,
+          'a|web/index$jsModuleExtension': isNotNull,
+          'a|web/index$jsSourceMapExtension': isNotNull,
+          'a|web/index$metadataExtension': isNotNull,
+          'a|web/index$symbolsExtension': isNotNull,
+          'b|lib/b$jsModuleExtension': isNotNull,
+          'b|lib/b$jsSourceMapExtension': isNotNull,
+          'b|lib/b$metadataExtension': isNotNull,
+          'b|lib/b$symbolsExtension': isNotNull,
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,
@@ -284,17 +293,18 @@ void main() {
         platform: ddcPlatform,
         ddcLibraryBundle: ddcLibraryBundle,
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'b|lib/b$jsModuleExtension': isNotNull,
-        'b|lib/b$jsSourceMapExtension': isNotNull,
-        'b|lib/b$metadataExtension': isNotNull,
-        'a|lib/a$jsModuleExtension': isNotNull,
-        'a|lib/a$jsSourceMapExtension': isNotNull,
-        'a|lib/a$metadataExtension': isNotNull,
-        'a|web/index$jsModuleExtension': isNotNull,
-        'a|web/index$jsSourceMapExtension': isNotNull,
-        'a|web/index$metadataExtension': isNotNull,
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'b|lib/b$jsModuleExtension': isNotNull,
+          'b|lib/b$jsSourceMapExtension': isNotNull,
+          'b|lib/b$metadataExtension': isNotNull,
+          'a|lib/a$jsModuleExtension': isNotNull,
+          'a|lib/a$jsSourceMapExtension': isNotNull,
+          'a|lib/a$metadataExtension': isNotNull,
+          'a|web/index$jsModuleExtension': isNotNull,
+          'a|web/index$jsSourceMapExtension': isNotNull,
+          'a|web/index$metadataExtension': isNotNull,
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,
@@ -307,19 +317,24 @@ void main() {
         platform: ddcPlatform,
         ddcLibraryBundle: ddcLibraryBundle,
       );
-      final expectedOutputs = Map.of(startingExpectedOutputs)..addAll({
-        'a|lib/a$jsModuleExtension': isNotNull,
-        'a|lib/a$jsSourceMapExtension': isNotNull,
-        'a|lib/a$metadataExtension': decodedMatches(isNot(contains('scratch'))),
-        'a|web/index$jsModuleExtension': isNotNull,
-        'a|web/index$jsSourceMapExtension': isNotNull,
-        'a|web/index$metadataExtension': decodedMatches(
-          isNot(contains('scratch')),
-        ),
-        'b|lib/b$jsModuleExtension': isNotNull,
-        'b|lib/b$jsSourceMapExtension': isNotNull,
-        'b|lib/b$metadataExtension': decodedMatches(isNot(contains('scratch'))),
-      });
+      final expectedOutputs = Map.of(startingExpectedOutputs)
+        ..addAll({
+          'a|lib/a$jsModuleExtension': isNotNull,
+          'a|lib/a$jsSourceMapExtension': isNotNull,
+          'a|lib/a$metadataExtension': decodedMatches(
+            isNot(contains('scratch')),
+          ),
+          'a|web/index$jsModuleExtension': isNotNull,
+          'a|web/index$jsSourceMapExtension': isNotNull,
+          'a|web/index$metadataExtension': decodedMatches(
+            isNot(contains('scratch')),
+          ),
+          'b|lib/b$jsModuleExtension': isNotNull,
+          'b|lib/b$jsSourceMapExtension': isNotNull,
+          'b|lib/b$metadataExtension': decodedMatches(
+            isNot(contains('scratch')),
+          ),
+        });
       await testBuilders(
         [...startingBuilders, builder],
         startingAssets,

--- a/builder_pkgs/build_web_compilers/test/entrypoint_options_test.dart
+++ b/builder_pkgs/build_web_compilers/test/entrypoint_options_test.dart
@@ -75,8 +75,7 @@ void main() {
   });
 
   test('can enable multiple compilers', () {
-    final yamlOptions =
-        loadYaml('''
+    final yamlOptions = loadYaml('''
 compilers:
   dart2js:
     args:
@@ -86,8 +85,7 @@ compilers:
     args:
       - "-O3"
 loader: .dart.js
-''')
-            as Map;
+''') as Map;
 
     final options = EntrypointBuilderOptions.fromOptions(
       BuilderOptions(yamlOptions.cast()),

--- a/builder_pkgs/build_web_compilers/web/stack_trace_mapper.dart
+++ b/builder_pkgs/build_web_compilers/web/stack_trace_mapper.dart
@@ -43,10 +43,9 @@ List<String> fixSourceMapSources(List<String> uris) {
     final uri = Uri.parse(source);
     // We only want to rewrite multi-root scheme uris.
     if (uri.scheme.isEmpty) return source;
-    final newSegments =
-        uri.pathSegments.first == 'packages'
-            ? uri.pathSegments
-            : uri.pathSegments.skip(1);
+    final newSegments = uri.pathSegments.first == 'packages'
+        ? uri.pathSegments
+        : uri.pathSegments.skip(1);
     return Uri(path: p.url.joinAll(['/', ...newSegments])).toString();
   }).toList();
 }
@@ -105,10 +104,9 @@ class LazyMapping extends Mapping {
         parsedMap['sources'] = fixSourceMapSources(
           (parsedMap['sources'] as List).cast(),
         );
-        final mapping =
-            parse(jsonEncode(parsedMap)) as SingleMapping
-              ..targetUrl = uri
-              ..sourceRoot = '${p.dirname(uri)}/';
+        final mapping = parse(jsonEncode(parsedMap)) as SingleMapping
+          ..targetUrl = uri
+          ..sourceRoot = '${p.dirname(uri)}/';
         _bundle.addMapping(mapping);
       }
     }


### PR DESCRIPTION
* Update the injected `$dartReloadModifiedModules` method to return the descriptors for the scripts that were reloaded.
* Bumps the min SDK constrain to support the two phase restart logic that requires the new API.

Issue: https://github.com/dart-lang/build/issues/4928

Required for dwds changes: https://github.com/dart-lang/webdev/pull/2827.
