### PR TITLE
Ignore child process stdin closed.

### DIFF
--- a/build_runner/lib/src/bootstrap/processes.dart
+++ b/build_runner/lib/src/bootstrap/processes.dart
@@ -114,6 +114,11 @@ class ParentProcess {
     // Due to https://github.com/dart-lang/sdk/issues/61571 the end of the message
     // can't be signalled by closing stdin, that would cause a crash on Windows.
     // So send `_sentinal` instead.
+    //
+    // Ignore asynchronous errors that occur if the child exits early and closes
+    //  its stdin pipe.
+    unawaited(process.stdin.done.catchError((_) {}));
+
     try {
       process.stdin.write(message);
       process.stdin.write(_sentinel);


### PR DESCRIPTION
One test is flaky due to child process being run in an unusual way that means it sometimes closes before the parent is done writing

https://github.com/dart-lang/build/actions/runs/27269902916/job/80536623889?pr=4972

hopefully this fixes it: I wasn't able to repro locally, but have seen the issue on CI multiple times.

Don't mention in CHANGELOG because this should not be a user visible bug, it's only hit because the test passes an arg to the child process that causes it to exit quickly.