### PR TITLE
Accumulate output in `BuildStepImpl` instead of writing to `ReaderWriter`.

### DIFF
--- a/build_runner/lib/src/build/asset_content.dart
+++ b/build_runner/lib/src/build/asset_content.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+/// Asset content and conversions.
+class AssetContent {
+  List<int>? _bytes;
+  final String? _string;
+  final Encoding? _encoding;
+
+  AssetContent.bytes(List<int> bytes)
+    : _bytes = bytes,
+      _string = null,
+      _encoding = null;
+
+  AssetContent.string(String string, {Encoding encoding = utf8})
+    : _bytes = null,
+      _string = string,
+      _encoding = encoding;
+
+  List<int> get bytes => _bytes ??= _encoding!.encode(_string!);
+
+  String stringValue({Encoding encoding = utf8}) {
+    if (_string != null && _encoding == encoding) return _string;
+    return encoding.decode(bytes);
+  }
+
+  Digest get digest => md5.convert(bytes);
+}

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -514,15 +514,15 @@ class Build {
     if (allowedByTriggers) {
       buildLog.finishStep(
         phase: phase,
-        anyOutputs: step.assetsWritten.isNotEmpty,
-        anyChangedOutputs: step.assetsWritten.any(_isChangedOutput),
+        anyOutputs: step.outputs.isNotEmpty,
+        anyChangedOutputs: step.outputs.keys.any(_isChangedOutput),
         lazy: lazy,
       );
     } else {
       buildLog.stepNotTriggered(phase: phase, lazy: lazy);
     }
 
-    return step.assetsWritten;
+    return step.outputs.keys;
   }
 
   /// Whether build triggers allow [phase] to run on [primaryInput].
@@ -661,7 +661,6 @@ class Build {
       buildLog.renderId(input),
       contextId: input,
     );
-    final outputs = <AssetId>{};
     var deletedPrimaryInput = false;
     final step = PostProcessBuildStepImpl(
       inputId: input,
@@ -671,7 +670,6 @@ class Build {
         if (_isFile(assetId)) {
           throw InvalidOutputException(assetId, 'Asset already exists');
         }
-        outputs.add(assetId);
       },
       deleteAsset: (assetId) {
         if (!_isFile(assetId)) {
@@ -695,11 +693,12 @@ class Build {
       }
     }, logger);
 
-    final assetsWritten = step.assetsWritten;
-
+    for (final entry in step.outputs.entries) {
+      await readerWriter.writeAsBytes(entry.key, entry.value.bytes);
+    }
     final stepResult = PostProcessBuildStepResult(
       hidden: hideOutput,
-      outputs: assetsWritten,
+      outputs: step.outputs.keys,
       errors: logger.errors,
       deletedPrimaryInput: deletedPrimaryInput,
     );
@@ -708,7 +707,7 @@ class Build {
       stepResult,
     );
 
-    return assetsWritten;
+    return step.outputs.keys;
   }
 
   void _markStepSkipped(BuildStepId buildStepId, Iterable<AssetId> outputs) {
@@ -1134,10 +1133,10 @@ class Build {
       ..resolverEntrypoints.replace(inputTracker.resolverEntrypoints)
       ..errors.replace(errors);
     for (final output in outputs) {
-      if (step.assetsWritten.contains(output)) {
-        buildStepResultBuilder.outputs[output] = await readerWriter.digest(
-          output,
-        );
+      if (step.outputs.containsKey(output)) {
+        final content = step.outputs[output]!;
+        await readerWriter.writeAsBytes(output, content.bytes);
+        buildStepResultBuilder.outputs[output] = content.digest;
       }
     }
     final buildStepResult = buildStepResultBuilder.build();

--- a/build_runner/lib/src/build/build_step_impl.dart
+++ b/build_runner/lib/src/build/build_step_impl.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:async/async.dart';
 import 'package:build/build.dart';
@@ -14,8 +13,10 @@ import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:package_config/package_config_types.dart';
 
+import 'asset_content.dart';
 import 'builder_filesystem.dart';
 import 'input_tracker.dart';
+import 'resolver/delegating_resolver.dart';
 
 /// A single step in the build processes.
 ///
@@ -39,12 +40,8 @@ class BuildStepImpl implements BuildStep {
   @override
   final Set<AssetId> allowedOutputs;
 
-  /// The result of any writes which are starting during this step.
-  final _writeResults = <Future<Result<void>>>[];
-
   final InputTracker inputTracker;
-  final Set<AssetId> _assetsWritten = {};
-  Iterable<AssetId> get assetsWritten => _assetsWritten;
+  final Map<AssetId, AssetContent> outputs = {};
 
   final int phase;
 
@@ -57,6 +54,8 @@ class BuildStepImpl implements BuildStep {
   final void Function(Iterable<AssetId>)? _reportUnusedAssets;
 
   Future<Result<PackageConfig>>? _resolvedPackageConfig;
+
+  Future<ReleasableResolver>? _resolver;
 
   BuildStepImpl({
     required this.inputId,
@@ -91,17 +90,15 @@ class BuildStepImpl implements BuildStep {
       throw UnsupportedError('Resolvers are not available in this build.');
     }
 
-    return _DelayedResolver(_resolver ??= resolvers.get(this));
+    return DelegatingResolver(_resolver ??= resolvers.get(this));
   }
-
-  Future<ReleasableResolver>? _resolver;
 
   Future<bool> _isReadable(
     AssetId id, {
     bool catchInvalidInputs = false,
     bool track = true,
   }) async {
-    if (_assetsWritten.contains(id)) return true;
+    if (outputs.containsKey(id)) return true;
     if (track) inputTracker.add(id);
     return await buildFilesystem.isReadable(
       id,
@@ -142,6 +139,9 @@ class BuildStepImpl implements BuildStep {
     if (!isReadable) {
       throw AssetNotFoundException(id);
     }
+    if (outputs.containsKey(id)) {
+      return outputs[id]!.bytes;
+    }
     await buildFilesystem.ensureDigest(id);
     return buildFilesystem.readerWriter.readAsBytes(id);
   }
@@ -156,6 +156,9 @@ class BuildStepImpl implements BuildStep {
     final isReadable = await _isReadable(id, track: track);
     if (!isReadable) {
       throw AssetNotFoundException(id);
+    }
+    if (outputs.containsKey(id)) {
+      return outputs[id]!.stringValue(encoding: encoding);
     }
     await buildFilesystem.ensureDigest(id);
     return buildFilesystem.readerWriter.readAsString(id, encoding: encoding);
@@ -173,15 +176,10 @@ class BuildStepImpl implements BuildStep {
   }
 
   @override
-  Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes) {
+  Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes) async {
     if (_isComplete) throw BuildStepCompletedException();
     _checkOutput(id);
-    final done = _futureOrWrite(bytes, (List<int> b) {
-      _assetsWritten.add(id);
-      return buildFilesystem.readerWriter.writeAsBytes(id, b);
-    });
-    _writeResults.add(Result.capture(done));
-    return done;
+    outputs[id] = AssetContent.bytes(await bytes);
   }
 
   @override
@@ -189,19 +187,10 @@ class BuildStepImpl implements BuildStep {
     AssetId id,
     FutureOr<String> content, {
     Encoding encoding = utf8,
-  }) {
+  }) async {
     if (_isComplete) throw BuildStepCompletedException();
     _checkOutput(id);
-    final done = _futureOrWrite(content, (String c) {
-      _assetsWritten.add(id);
-      return buildFilesystem.readerWriter.writeAsString(
-        id,
-        c,
-        encoding: encoding,
-      );
-    });
-    _writeResults.add(Result.capture(done));
-    return done;
+    outputs[id] = AssetContent.string(await content, encoding: encoding);
   }
 
   @override
@@ -211,6 +200,9 @@ class BuildStepImpl implements BuildStep {
 
     if (!isReadable) {
       throw AssetNotFoundException(id);
+    }
+    if (outputs.containsKey(id)) {
+      return outputs[id]!.digest;
     }
     return buildFilesystem.ensureDigest(id);
   }
@@ -222,11 +214,6 @@ class BuildStepImpl implements BuildStep {
     bool isExternal = false,
   }) => action();
 
-  Future<void> _futureOrWrite<T>(
-    FutureOr<T> content,
-    Future<void> Function(T content) write,
-  ) => (content is Future<T>) ? content.then(write) : write(content);
-
   /// Waits for work to finish and cleans up resources.
   ///
   /// This method should be called after a build has completed. After the
@@ -234,7 +221,6 @@ class BuildStepImpl implements BuildStep {
   /// [Resolver] for this build step - if any - has been released.
   Future<void> complete() async {
     _isComplete = true;
-    await Future.wait(_writeResults.map(Result.release));
     try {
       (await _resolver)?.release();
     } catch (_) {}
@@ -247,7 +233,7 @@ class BuildStepImpl implements BuildStep {
       throw UnexpectedOutputException(id, expected: allowedOutputs);
     }
 
-    if (_assetsWritten.contains(id)) {
+    if (outputs.containsKey(id)) {
       throw InvalidOutputException(
         id,
         'This build step already wrote to `$id`. Duplicate writes to the same '
@@ -260,55 +246,6 @@ class BuildStepImpl implements BuildStep {
   void reportUnusedAssets(Iterable<AssetId> assets) {
     _reportUnusedAssets?.call(assets);
   }
-}
-
-class _DelayedResolver implements Resolver {
-  final Future<Resolver> _delegate;
-
-  _DelayedResolver(this._delegate);
-
-  @override
-  Future<bool> isLibrary(AssetId assetId) async =>
-      (await _delegate).isLibrary(assetId);
-
-  @override
-  Stream<LibraryElement> get libraries {
-    final completer = StreamCompleter<LibraryElement>();
-    _delegate.then((r) => completer.setSourceStream(r.libraries));
-    return completer.stream;
-  }
-
-  @override
-  Future<AstNode?> astNodeFor(
-    Fragment fragment, {
-    bool resolve = false,
-  }) async => (await _delegate).astNodeFor(fragment, resolve: resolve);
-
-  @override
-  Future<CompilationUnit> compilationUnitFor(
-    AssetId assetId, {
-    bool allowSyntaxErrors = false,
-  }) async => (await _delegate).compilationUnitFor(
-    assetId,
-    allowSyntaxErrors: allowSyntaxErrors,
-  );
-
-  @override
-  Future<LibraryElement> libraryFor(
-    AssetId assetId, {
-    bool allowSyntaxErrors = false,
-  }) async => (await _delegate).libraryFor(
-    assetId,
-    allowSyntaxErrors: allowSyntaxErrors,
-  );
-
-  @override
-  Future<LibraryElement?> findLibraryByName(String libraryName) async =>
-      (await _delegate).findLibraryByName(libraryName);
-
-  @override
-  Future<AssetId> assetIdForElement(Element element) async =>
-      (await _delegate).assetIdForElement(element);
 }
 
 final _lib = Uri.parse('lib/');

--- a/build_runner/lib/src/build/post_process_build_step_impl.dart
+++ b/build_runner/lib/src/build/post_process_build_step_impl.dart
@@ -5,11 +5,11 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:async/async.dart';
 import 'package:build/build.dart';
 import 'package:crypto/crypto.dart' show Digest;
 
 import '../io/reader_writer.dart';
+import 'asset_content.dart';
 import 'builder_filesystem.dart';
 
 class PostProcessBuildStepImpl implements PostProcessBuildStep {
@@ -21,11 +21,7 @@ class PostProcessBuildStepImpl implements PostProcessBuildStep {
   final void Function(AssetId) _addAsset;
   final void Function(AssetId) _deleteAsset;
 
-  /// The result of any writes which are starting during this step.
-  final _writeResults = <Future<Result<void>>>[];
-
-  final Set<AssetId> _assetsWritten = {};
-  Iterable<AssetId> get assetsWritten => _assetsWritten;
+  final Map<AssetId, AssetContent> outputs = {};
 
   PostProcessBuildStepImpl({
     required this.inputId,
@@ -55,15 +51,9 @@ class PostProcessBuildStepImpl implements PostProcessBuildStep {
   }
 
   @override
-  Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes) {
+  Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes) async {
     _addAsset(id);
-    _assetsWritten.add(id);
-    final done = _futureOrWrite(
-      bytes,
-      (List<int> b) => _readerWriter.writeAsBytes(id, b),
-    );
-    _writeResults.add(Result.capture(done));
-    return done;
+    outputs[id] = AssetContent.bytes(await bytes);
   }
 
   @override
@@ -71,15 +61,9 @@ class PostProcessBuildStepImpl implements PostProcessBuildStep {
     AssetId id,
     FutureOr<String> content, {
     Encoding encoding = utf8,
-  }) {
+  }) async {
     _addAsset(id);
-    _assetsWritten.add(id);
-    final done = _futureOrWrite(
-      content,
-      (String c) => _readerWriter.writeAsString(id, c, encoding: encoding),
-    );
-    _writeResults.add(Result.capture(done));
-    return done;
+    outputs[id] = AssetContent.string(await content, encoding: encoding);
   }
 
   /// Marks an asset for deletion in the post process step.
@@ -93,12 +77,5 @@ class PostProcessBuildStepImpl implements PostProcessBuildStep {
   /// This method should be called after a build has completed. After the
   /// returned [Future] completes then all outputs have been written.
   @override
-  Future<void> complete() async {
-    await Future.wait(_writeResults.map(Result.release));
-  }
+  Future<void> complete() async {}
 }
-
-Future<void> _futureOrWrite<T>(
-  FutureOr<T> content,
-  Future<void> Function(T content) write,
-) => (content is Future<T>) ? content.then(write) : write(content);

--- a/build_runner/lib/src/build/resolver/delegating_resolver.dart
+++ b/build_runner/lib/src/build/resolver/delegating_resolver.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:async/async.dart';
+import 'package:build/build.dart';
+
+/// [Resolver] implementation that delegates to a `Future<Resolver>`.
+class DelegatingResolver implements Resolver {
+  final Future<Resolver> _delegate;
+
+  DelegatingResolver(this._delegate);
+
+  @override
+  Future<bool> isLibrary(AssetId assetId) async =>
+      (await _delegate).isLibrary(assetId);
+
+  @override
+  Stream<LibraryElement> get libraries {
+    final completer = StreamCompleter<LibraryElement>();
+    _delegate.then((r) => completer.setSourceStream(r.libraries));
+    return completer.stream;
+  }
+
+  @override
+  Future<AstNode?> astNodeFor(
+    Fragment fragment, {
+    bool resolve = false,
+  }) async => (await _delegate).astNodeFor(fragment, resolve: resolve);
+
+  @override
+  Future<CompilationUnit> compilationUnitFor(
+    AssetId assetId, {
+    bool allowSyntaxErrors = false,
+  }) async => (await _delegate).compilationUnitFor(
+    assetId,
+    allowSyntaxErrors: allowSyntaxErrors,
+  );
+
+  @override
+  Future<LibraryElement> libraryFor(
+    AssetId assetId, {
+    bool allowSyntaxErrors = false,
+  }) async => (await _delegate).libraryFor(
+    assetId,
+    allowSyntaxErrors: allowSyntaxErrors,
+  );
+
+  @override
+  Future<LibraryElement?> findLibraryByName(String libraryName) async =>
+      (await _delegate).findLibraryByName(libraryName);
+
+  @override
+  Future<AssetId> assetIdForElement(Element element) async =>
+      (await _delegate).assetIdForElement(element);
+}


### PR DESCRIPTION
Since we will have part outputs that change multiple times during the build, just pushing generated output to the (cached) filesystem is no longer a good abstraction.

Accumulate results in build steps instead of writing directly to `ReaderWriter`; for now, write at the end of the step.

Similarly for `post_process_build_step_impl.dart`.

Further cleanup for `build_step_impl.dart`:

 - Rename `assetsWritten` to `outputs`.
 - Move `_DelayedResolver` out, rename it to `DelegatingResolver`.
 - Stop storing writes as futures and waiting for them on completion, just wait for them immediately.