### PR TITLE
Remove ensureAssets calls for JS assets in DdcFrontendServerBuilder

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.8.1
+## 4.8.3
 - Fix circular dependencies causing hangs in `DdcFrontendServerBuilder`.
 
 ## 4.8.2

--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.8.1
+- Fix circular dependencies causing hangs in `DdcFrontendServerBuilder`.
+
 ## 4.8.2
 - Several bug fixes for `DdcFrontendServerBuilder`.
 - Several bug fixes for builder circular dependencies.

--- a/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
@@ -59,28 +59,17 @@ class DdcFrontendServerBuilder implements Builder {
       frontendServerState.entrypointAssetId = ddcEntrypointId;
     }
     final entrypointAssetId = frontendServerState.entrypointAssetId!;
-    final transitiveDeps = await buildStep.trackStage(
-      'CollectTransitiveDeps',
-      () => module.computeTransitiveDependencies(buildStep),
+    final transitiveDeps = await module.computeTransitiveDependencies(
+      buildStep,
     );
-    final transitiveJsDeps = [
-      for (final dep in transitiveDeps)
-        if (dep.primarySource.package != buildStep.inputId.package) ...[
-          dep.primarySource.changeExtension(jsModuleExtension),
-          dep.primarySource.changeExtension(metadataExtension),
-        ],
-    ];
     final transitiveSources = [
       for (final dep in transitiveDeps) ...dep.sources,
     ];
     var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
-    await buildStep.trackStage(
-      'EnsureAssets',
-      () => scratchSpace.ensureAssets([
-        ...module.sources,
-        ...transitiveSources,
-      ], buildStep),
-    );
+    await scratchSpace.ensureAssets([
+      ...module.sources,
+      ...transitiveSources,
+    ], buildStep);
     final root = getRootPackageName();
     final driver = await buildStep.fetchResource(
       frontendServerProxyDriverResource,
@@ -118,17 +107,14 @@ class DdcFrontendServerBuilder implements Builder {
         if (customDir != null) {
           frontendServerState.customScratchSpacePath = customDir;
         }
-        await buildStep.trackStage(
-          'EnsureAssets',
-          () => scratchSpace.ensureAssets([
-            if (frontendServerState.entrypointAssetId!.package ==
-                buildStep.inputId.package)
-              frontendServerState.entrypointAssetId!,
-            ...module.sources,
-            ...transitiveSources,
-            ...scratchSpace.changedFilesInBuild,
-          ], buildStep),
-        );
+        await scratchSpace.ensureAssets([
+          if (frontendServerState.entrypointAssetId!.package ==
+              buildStep.inputId.package)
+            frontendServerState.entrypointAssetId!,
+          ...module.sources,
+          ...transitiveSources,
+          ...scratchSpace.changedFilesInBuild,
+        ], buildStep);
         final compilerOutput = await driver.recompileAndRecord(
           entrypointArg,
           changedAssetUris,
@@ -149,10 +135,6 @@ class DdcFrontendServerBuilder implements Builder {
         }
       });
       await frontendServerState.waitForCompilation(entrypointAssetId);
-      await buildStep.trackStage(
-        'EnsureAssets',
-        () => scratchSpace.ensureAssets(transitiveJsDeps, buildStep),
-      );
 
       // Reads the compiled asset with [extension] from the Frontend Server's
       // filesystem and writes it to the build runner's output.

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.8.2
+version: 4.8.3
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
Fixes issues with circular imports. The builder doesn't need to read JS assets anyway.

Also removes deprecated `trackStage` calls.