### PR TITLE
Always request the entrypoint for DdcFrontendServerBuilder builds

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.8.4
+- Fix deferred rebuilds sometimes crashing `DdcFrontendServerBuilder`.
+
 ## 4.8.3
 - Fix circular dependencies causing hangs in `DdcFrontendServerBuilder`.
 

--- a/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
@@ -75,7 +75,7 @@ class DdcFrontendServerBuilder implements Builder {
       frontendServerProxyDriverResource,
     );
     await buildStep.fetchResource(persistentFrontendServerResource);
-    final entrypointArg = sourceArg(frontendServerState.entrypointAssetId!);
+    final entrypointArg = sourceArg(entrypointAssetId);
     // Translates an AssetId to its scratch space file path.
     //
     // For example, AssetId('app', 'lib/src/foo.dart') becomes:
@@ -108,9 +108,7 @@ class DdcFrontendServerBuilder implements Builder {
           frontendServerState.customScratchSpacePath = customDir;
         }
         await scratchSpace.ensureAssets([
-          if (frontendServerState.entrypointAssetId!.package ==
-              buildStep.inputId.package)
-            frontendServerState.entrypointAssetId!,
+          entrypointAssetId,
           ...module.sources,
           ...transitiveSources,
           ...scratchSpace.changedFilesInBuild,

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.8.3
+version: 4.8.4
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
Fixes an issue where deferred modules crash after failing to resolve their entrypoint. For FES builders, any submodule can potentially recompile the main app, so we now always request `entrypointAssetId`.