### PR TITLE
Test cleanup: prevent output on pass.

### DIFF
--- a/build_runner/test/build/resolution_test.dart
+++ b/build_runner/test/build/resolution_test.dart
@@ -5,14 +5,11 @@
 import 'dart:async';
 
 import 'package:build/build.dart';
-import 'package:build_runner/src/logging/build_log.dart';
-import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
+import '../common/common.dart';
 
 void main() {
-  setUp(() {
-    BuildLog.resetForTests(printOnFailure: printOnFailure);
-  });
+  setUpTestLogging();
 
   test('should resolve a dart file with a part file', () async {
     await testBuilders(

--- a/build_runner/test/build/resolver/resolver_test.dart
+++ b/build_runner/test/build/resolver/resolver_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io' show Platform;
 import 'dart:isolate';
 
 import 'package:analyzer/dart/analysis/results.dart';
@@ -10,19 +9,18 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
-import 'package:build/experiments.dart';
 import 'package:build_runner/src/build/resolver/analysis_driver.dart';
 import 'package:build_runner/src/build/resolver/analysis_driver_model.dart';
 import 'package:build_runner/src/build/resolver/resolvers_impl.dart';
 import 'package:build_runner/src/build/resolver/sdk_summary.dart';
-import 'package:logging/logging.dart';
 import 'package:package_config/package_config.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import '../../common/common.dart';
 
 void main() {
+  setUpTestLogging();
+
   final entryPoint = AssetId('a', 'web/main.dart');
 
   final sharedModel = AnalysisDriverModel();
@@ -389,27 +387,6 @@ void main() {
         expect(lib.languageVersion.effective.minor, sdkLanguageVersion.minor);
       }, resolvers: createResolvers(packageConfig: customPackageConfig));
     });
-
-    test(
-      'allows a version of analyzer compatibile with the current sdk',
-      skip: _skipOnPreRelease,
-      () async {
-        final originalLevel = Logger.root.level;
-        Logger.root.level = Level.WARNING;
-        final listener = Logger.root.onRecord.listen((record) {
-          fail('Got an unexpected warning during analysis:\n\n$record');
-        });
-        addTearDown(() {
-          Logger.root.level = originalLevel;
-          listener.cancel();
-        });
-        await resolveSources({'a|web/main.dart': 'main() {}'}, (
-          resolver,
-        ) async {
-          await resolver.libraryFor(entryPoint);
-        }, resolvers: createResolvers());
-      },
-    );
   });
 
   group('assets that aren\'t a transitive import of input', () {
@@ -748,38 +725,6 @@ void main() {
           );
         },
         resolvers: createResolvers(),
-      );
-    });
-
-    test('Respects withEnabledExperiments', skip: _skipOnPreRelease, () async {
-      Logger.root.level = Level.ALL;
-      Logger.root.onRecord.listen(print);
-      await withEnabledExperiments(
-        () => resolveSources(
-          {
-            'a|web/main.dart':
-                '''
-// @dart=${sdkLanguageVersion.major}.${sdkLanguageVersion.minor}
-int? get x => 1;
-                ''',
-          },
-          (resolver) async {
-            final lib = await resolver.libraryFor(entryPoint);
-            expect(
-              lib.languageVersion.effective.major,
-              sdkLanguageVersion.major,
-            );
-            expect(
-              lib.languageVersion.effective.minor,
-              sdkLanguageVersion.minor,
-            );
-            final errors =
-                await lib.session.getErrors('/a/web/main.dart') as ErrorsResult;
-            expect(errors.diagnostics, isEmpty);
-          },
-          resolvers: createResolvers(),
-        ),
-        ['non-nullable'],
       );
     });
 
@@ -1345,8 +1290,3 @@ int? get x => 1;
     });
   });
 }
-
-final _skipOnPreRelease =
-    Version.parse(Platform.version.split(' ').first).isPreRelease
-    ? 'Skipped on prerelease sdks'
-    : null;

--- a/build_runner/test/build/resolver_reuse_test.dart
+++ b/build_runner/test/build/resolver_reuse_test.dart
@@ -5,14 +5,12 @@
 import 'dart:async';
 
 import 'package:build/build.dart';
-import 'package:build_runner/src/logging/build_log.dart';
-import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
+import '../common/common.dart';
 
 void main() {
-  setUp(() {
-    BuildLog.resetForTests(printOnFailure: printOnFailure);
-  });
+  setUpTestLogging();
+
   group('Resolver Reuse', () {
     test(
       'Does not remove sources due to crawling for an earlier phase',

--- a/build_runner/test/build_plan/build_configs_test.dart
+++ b/build_runner/test/build_plan/build_configs_test.dart
@@ -12,6 +12,7 @@ import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/placeholders.dart';
 import 'package:build_runner/src/build_plan/testing_overrides.dart';
+import 'package:build_runner/src/logging/build_log.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
@@ -22,8 +23,14 @@ void main() {
   group('BuildConfigs.load', () {
     test('warns if required sources are missing', () {
       final logs = <LogRecord>[];
-      final listener = Logger.root.onRecord.listen(logs.add);
-      addTearDown(listener.cancel);
+      buildLog.configuration = buildLog.configuration.rebuild(
+        (b) => b.onLog = logs.add,
+      );
+      addTearDown(() {
+        buildLog.configuration = buildLog.configuration.rebuild(
+          (b) => b.onLog = null,
+        );
+      });
 
       final packageB = BuildPackage(
         name: 'b',

--- a/build_runner/test/build_plan/build_phase_creator_test.dart
+++ b/build_runner/test/build_plan/build_phase_creator_test.dart
@@ -22,6 +22,8 @@ import 'package:test/test.dart';
 import '../common/common.dart';
 
 void main() {
+  setUpTestLogging();
+
   group('BuildPhaseCreator', () {
     final buildPackages = BuildPackages.singlePackageBuild('a', [
       BuildPackage.forTesting(name: 'a', dependencies: ['b'], isOutput: true),

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -28,6 +28,8 @@ import 'package:test/test.dart';
 import '../common/common.dart';
 
 void main() {
+  setUpTestLogging();
+
   group('BuildPlan', () {
     final assetId = AssetId('a', 'lib/a.dart');
     final outputId = AssetId('a', 'lib/a.dart.copy');

--- a/build_runner/test/build_plan/previous_build_test.dart
+++ b/build_runner/test/build_plan/previous_build_test.dart
@@ -30,6 +30,8 @@ import 'package:test/test.dart';
 import '../common/common.dart';
 
 void main() {
+  setUpTestLogging();
+
   group('PreviousBuild', () {
     final assetId = AssetId('a', 'lib/a.dart');
     final outputId = AssetId('a', 'lib/a.dart.copy');

--- a/build_runner/test/commands/serve/serve_handler_test.dart
+++ b/build_runner/test/commands/serve/serve_handler_test.dart
@@ -22,6 +22,7 @@ import 'package:build_runner/src/build_plan/phase.dart';
 import 'package:build_runner/src/commands/serve/server.dart';
 import 'package:build_runner/src/commands/watch/watcher.dart';
 import 'package:build_runner/src/io/build_output_reader.dart';
+import 'package:build_runner/src/logging/build_log.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
@@ -305,8 +306,17 @@ void main() {
     });
 
     test('logs rejected requests', () async {
+      final logController = StreamController<LogRecord>();
+      final originalConfig = buildLog.configuration;
+      buildLog.configuration = buildLog.configuration.rebuild(
+        (b) => b.onLog = logController.add,
+      );
+      addTearDown(() {
+        logController.close();
+        buildLog.configuration = originalConfig;
+      });
       expect(
-        Logger.root.onRecord,
+        logController.stream,
         emitsThrough(
           predicate<LogRecord>(
             (record) =>
@@ -323,8 +333,17 @@ void main() {
 
   test('logs requests if you ask it to', () async {
     addSource('a|web/index.html', 'content');
+    final logController = StreamController<LogRecord>();
+    final originalConfig = buildLog.configuration;
+    buildLog.configuration = buildLog.configuration.rebuild(
+      (b) => b.onLog = logController.add,
+    );
+    addTearDown(() {
+      logController.close();
+      buildLog.configuration = originalConfig;
+    });
     expect(
-      Logger.root.onRecord,
+      logController.stream,
       emitsThrough(
         predicate<LogRecord>(
           (record) =>

--- a/build_runner/test/common/common.dart
+++ b/build_runner/test/common/common.dart
@@ -3,9 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
-
 import 'package:build/build.dart';
+import 'package:build_runner/src/logging/build_log.dart';
 import 'package:crypto/crypto.dart';
+import 'package:test/test.dart';
 
 export 'package:build_test/build_test.dart';
 export 'package:build_test/src/internal_test_reader_writer.dart';
@@ -21,4 +22,19 @@ Digest computeDigest(AssetId id, String contents) {
   if (idString.startsWith(r'$$')) idString = idString.substring(2);
 
   return md5.convert([...utf8.encode(contents), ...idString.codeUnits]);
+}
+
+/// Configures `setUp` that redirects logging to `printOnFailure`.
+///
+/// Runs `addTearDown` that restores the original logging configuration.
+void setUpTestLogging() {
+  setUp(() {
+    final originalConfig = buildLog.configuration;
+    buildLog.configuration = buildLog.configuration.rebuild(
+      (b) => b.printOnFailure = printOnFailure,
+    );
+    addTearDown(() {
+      buildLog.configuration = originalConfig;
+    });
+  });
 }

--- a/build_runner/test/io/asset_tracker_test.dart
+++ b/build_runner/test/io/asset_tracker_test.dart
@@ -24,7 +24,11 @@ import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:watcher/watcher.dart';
 
+import '../common/common.dart';
+
 void main() {
+  setUpTestLogging();
+
   group('AssetTracker.collectChanges()', () {
     late AssetTracker assetTracker;
     late BuildState buildState;

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -31,6 +31,8 @@ import 'package:test/test.dart';
 import '../common/common.dart';
 
 void main() {
+  setUpTestLogging();
+
   group('createMergedDir', () {
     late BuildPlan buildPlan;
     late BuildState buildState;


### PR DESCRIPTION
Arrange that tests that were printing to console don't print to console.

Remove two tests that don't run on "prerelease" SDKs; the CI currently runs against "dev" so they don't run.