### PR TITLE
Fix integration test failures due to source modifications.

### DIFF
--- a/build_runner/test/common/build_runner_tester.dart
+++ b/build_runner/test/common/build_runner_tester.dart
@@ -462,9 +462,61 @@ class Pubspecs {
 
   Pubspecs(this.packageConfig);
 
+  static Future<Pubspecs>? _loadFuture;
+
   /// Creates [Pubspecs] with package config from the current isolate.
-  static Future<Pubspecs> load() async =>
-      Pubspecs(await loadPackageConfigUri((await Isolate.packageConfig)!));
+  ///
+  /// Packages not in the pub cache are copied to a temporary directory so that
+  /// they are safe from concurrent modifications during tests.
+  static Future<Pubspecs> load() => _loadFuture ??= _load();
+
+  static Future<Pubspecs> _load() async {
+    final config = await loadPackageConfigUri((await Isolate.packageConfig)!);
+    final copiedPackagesDir = Directory.systemTemp.createTempSync(
+      'BuildRunnerTester-packages-',
+    );
+
+    final updatedPackages = <Package>[];
+    for (final package in config.packages) {
+      if (package.root.path.contains('.pub-cache') ||
+          package.root.path.contains('pub/Cache') ||
+          // The workspace is awkward to copy and not needed.
+          package.name == 'build_workspace') {
+        updatedPackages.add(package);
+        continue;
+      }
+      final destinationPath = p.join(copiedPackagesDir.path, package.name);
+      _copyPackage(package.root.toFilePath(), destinationPath);
+      final newRoot = Uri.directory(destinationPath);
+      updatedPackages.add(
+        Package(
+          package.name,
+          newRoot,
+          packageUriRoot: newRoot.resolve('lib/'),
+          languageVersion: package.languageVersion,
+          extraData: package.extraData,
+        ),
+      );
+    }
+    return Pubspecs(
+      PackageConfig(updatedPackages, extraData: config.extraData),
+    );
+  }
+
+  static void _copyPackage(String source, String dest) {
+    for (final name in ['lib', 'bin']) {
+      final entityPath = p.join(source, name);
+      if (FileSystemEntity.isDirectorySync(entityPath)) {
+        copyPathSync(entityPath, p.join(dest, name));
+      }
+    }
+    for (final name in ['pubspec.yaml', 'build.yaml']) {
+      final entityPath = p.join(source, name);
+      if (FileSystemEntity.isFileSync(entityPath)) {
+        File(entityPath).copySync(p.join(dest, name));
+      }
+    }
+  }
 
   /// Returns `pubspec.yaml` content for the package called [name].
   ///


### PR DESCRIPTION
I realized that when running tests locally I sometimes modify source files during the test run ... and this causes random failures because build_runner will often notice the changes and behave differently.

Make the tests more stable for local runs by copying sources on startup.