### PR TITLE
Add support for JS interop extension type mock generation to mockito.

### DIFF
--- a/builder_pkgs/mockito/CHANGELOG.md
+++ b/builder_pkgs/mockito/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.8.0-wip
+
+* Add support for JS interop extension type mock generation to mockito.
+* It is now an error to generate mocks for non-JS interop extension types.
+  Instead, mock the representation type and cast to the extension type where
+  needed.
+
 ## 5.7.0
 
 * Handle JS interop extension types and provide dummy values for them.

--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -106,7 +106,7 @@ class MockBuilder implements Builder {
     );
 
     if (mockLibraryInfo.fakeClasses.isEmpty &&
-        mockLibraryInfo.mockClasses.isEmpty) {
+        mockLibraryInfo.mockSpecs.isEmpty) {
       // Nothing to mock here!
       return;
     }
@@ -147,7 +147,7 @@ class MockBuilder implements Builder {
         Code('// ignore_for_file: invalid_use_of_internal_member\n\n'),
       );
       b.body.addAll(mockLibraryInfo.fakeClasses);
-      b.body.addAll(mockLibraryInfo.mockClasses);
+      b.body.addAll(mockLibraryInfo.mockSpecs);
     });
 
     final emitter = DartEmitter(
@@ -310,6 +310,12 @@ class _TypeVisitor extends RecursiveElementVisitor2<void> {
   void visitEnumElement(EnumElement element) {
     _elements.add(element);
     super.visitEnumElement(element);
+  }
+
+  @override
+  void visitExtensionTypeElement(ExtensionTypeElement element) {
+    _elements.add(element);
+    super.visitExtensionTypeElement(element);
   }
 
   @override
@@ -582,7 +588,8 @@ class _MockTargetGatherer {
     }
     final mockTargets = <_MockTarget>[];
     for (final objectToMock in classesField.toListValue()!) {
-      final typeToMock = objectToMock.toTypeValue();
+      // ignore: experimental_member_use
+      final typeToMock = objectToMock.toTypeValueNotExtensionTypeErased();
       if (typeToMock == null) {
         throw InvalidMockitoAnnotationException(
           'The "classes" argument includes a non-type: $objectToMock',
@@ -639,10 +646,12 @@ class _MockTargetGatherer {
     List<ast.CollectionElement> mockSpecAsts, {
     bool nice = false,
   }) {
-    final mockSpecType = mockSpec.type as analyzer.InterfaceType;
+    final mockSpecType =
+        // ignore: experimental_member_use
+        mockSpec.typeNotExtensionTypeErased as analyzer.InterfaceType;
     assert(mockSpecType.typeArguments.length == 1);
     final mockType = _mockType(mockSpecAsts[index]);
-    final typeToMock = mockSpecType.typeArguments.single;
+    var typeToMock = mockSpecType.typeArguments.single;
     if (typeToMock is analyzer.DynamicType ||
         typeToMock is analyzer.InvalidType) {
       final mockTypeName = mockType?.qualifiedName;
@@ -875,6 +884,20 @@ class _MockTargetGatherer {
         "use the 'customMocks' argument in @GenerateMocks to specify a unique "
         'name';
     for (final mockTarget in _mockTargets) {
+      final interfaceElement = mockTarget.interfaceElement;
+      if (interfaceElement is ExtensionTypeElement) {
+        if (!interfaceElement.isJSInteropType) {
+          final className = interfaceElement.name;
+          final representationType =
+              interfaceElement.representation.type.getDisplayString();
+          throw InvalidMockitoAnnotationException(
+            'Mockito cannot mock non-JS-interop extension types '
+            "(like '$className'). Instead, mock the representation type "
+            "(like '$representationType') and cast the mock to the extension "
+            'type where needed.',
+          );
+        }
+      }
       final name = mockTarget.mockName;
       if (classNamesToMock.containsKey(name)) {
         final firstClass = classNamesToMock[name]!.interfaceElement;
@@ -1154,8 +1177,8 @@ class _MockTargetGatherer {
 }
 
 class _MockLibraryInfo {
-  /// Mock classes to be added to the generated library.
-  final mockClasses = <Class>[];
+  /// Mock classes and extension types to be added to the generated library.
+  final mockSpecs = <Spec>[];
 
   /// Fake classes to be added to the library.
   ///
@@ -1192,17 +1215,21 @@ class _MockLibraryInfo {
            .firstWhereOrNull((library) => library.isDartCore) {
     for (final mockTarget in mockTargets) {
       final fallbackGenerators = mockTarget.fallbackGenerators;
-      mockClasses.add(
-        _MockClassInfo(
-          mockTarget: mockTarget,
-          sourceLibIsNonNullable: true,
-          typeProvider: entryLib.typeProvider,
-          typeSystem: entryLib.typeSystem,
-          mockLibraryInfo: this,
-          fallbackGenerators: fallbackGenerators,
-          inheritanceManager: inheritanceManager,
-        )._buildMockClass(),
+      final mockClassInfo = _MockClassInfo(
+        mockTarget: mockTarget,
+        sourceLibIsNonNullable: true,
+        typeProvider: entryLib.typeProvider,
+        typeSystem: entryLib.typeSystem,
+        mockLibraryInfo: this,
+        fallbackGenerators: fallbackGenerators,
+        inheritanceManager: inheritanceManager,
       );
+      if (mockClassInfo._isExtensionType) {
+        mockSpecs.add(mockClassInfo._buildMockTargetClass());
+        mockSpecs.add(mockClassInfo._buildMockExtensionType());
+      } else {
+        mockSpecs.add(mockClassInfo._buildMockClass());
+      }
     }
   }
 
@@ -1247,6 +1274,202 @@ class _MockClassInfo {
     required this.fallbackGenerators,
     required this.inheritanceManager,
   });
+
+  bool get _isExtensionType =>
+      mockTarget.interfaceElement is ExtensionTypeElement;
+
+  static bool _isJSObject(analyzer.DartType type) =>
+      type is analyzer.InterfaceType &&
+      type.element.name == 'JSObject' &&
+      type.element.library.uri.toString() == 'dart:js_interop';
+
+  Class _buildMockTargetClass() {
+    assert(_isExtensionType);
+
+    final instantiatedAlias = mockTarget.classType.alias;
+    final aliasElement = instantiatedAlias?.element;
+    final aliasedType = aliasElement?.aliasedType as analyzer.InterfaceType?;
+    final typeToMock = aliasedType ?? mockTarget.classType;
+    final classToMock = mockTarget.interfaceElement;
+    final className = aliasElement?.name ?? classToMock.name;
+
+    return Class((cBuilder) {
+      cBuilder
+        ..name = '${mockTarget.mockName}Target'
+        ..extend = referImported('Mock', 'package:mockito/mockito.dart');
+
+      cBuilder.annotations.add(
+        referImported('JSExport', 'dart:js_interop').call([]),
+      );
+
+      cBuilder
+        ..docs.add('/// A class which mocks [$className] for JS interop.')
+        ..docs.add('///')
+        ..docs.add(
+          '/// See the documentation for Mockito\'s code generation '
+          'for more information.',
+        );
+
+      final typeParameters =
+          aliasElement?.typeParameters ?? classToMock.typeParameters;
+
+      _withTypeParameters(
+        mockTarget.hasExplicitTypeArguments ? [] : typeParameters,
+        (typeParamsWithBounds, typeParams) {
+          cBuilder.types.addAll(typeParamsWithBounds);
+
+          final substitution = Substitution.fromPairs2(
+            [...classToMock.typeParameters, ...?aliasElement?.typeParameters],
+            [...typeToMock.typeArguments, ...?instantiatedAlias?.typeArguments],
+          );
+          var members = inheritanceManager
+              .getInterface(classToMock)
+              .map
+              .values
+              .map((member) => member.substitute(substitution));
+
+          members = members.where((m) => m.isExternal);
+
+          cBuilder.methods.addAll(
+            fieldOverrides(members.whereType<PropertyAccessorElement>()),
+          );
+          cBuilder.methods.addAll(
+            methodOverrides(members.whereType<MethodElement>()),
+          );
+        },
+      );
+    });
+  }
+
+  ExtensionType _buildMockExtensionType() {
+    final instantiatedAlias = mockTarget.classType.alias;
+    final aliasElement = instantiatedAlias?.element;
+    final aliasedType = aliasElement?.aliasedType as analyzer.InterfaceType?;
+    final typeToMock = aliasedType ?? mockTarget.classType;
+    final classToMock = mockTarget.interfaceElement as ExtensionTypeElement;
+    final className = aliasElement?.name ?? classToMock.name;
+
+    final representationType = classToMock.representation.type;
+    final representationName = classToMock.representation.name;
+
+    return ExtensionType((cBuilder) {
+      cBuilder
+        ..name = mockTarget.mockName
+        ..primaryConstructorName = '_'
+        ..docs.add('/// An extension type mock which implements [$className].')
+        ..docs.add('///')
+        ..docs.add(
+          '/// See the documentation for Mockito\'s code generation '
+          'for more information.',
+        );
+
+      final typeParameters =
+          aliasElement?.typeParameters ?? classToMock.typeParameters;
+      final typeArguments =
+          instantiatedAlias?.typeArguments ?? typeToMock.typeArguments;
+
+      _withTypeParameters(
+        mockTarget.hasExplicitTypeArguments ? [] : typeParameters,
+        (typeParamsWithBounds, typeParams) {
+          cBuilder.types.addAll(typeParamsWithBounds);
+
+          cBuilder.representationDeclaration = RepresentationDeclaration((r) {
+            r
+              ..name = representationName
+              ..declaredRepresentationType = _typeReference(representationType);
+          });
+
+          cBuilder.implements.add(
+            TypeReference((b) {
+              b
+                ..symbol = className
+                ..url = _typeImport(aliasElement ?? classToMock)
+                ..types.addAll(
+                  mockTarget.hasExplicitTypeArguments
+                      ? typeArguments.map(_typeReference)
+                      : typeParams,
+                );
+            }),
+          );
+
+          // Add factories
+          final typeParamsStr =
+              typeParams.isEmpty
+                  ? ''
+                  : '<${typeParams.map((tp) => tp.symbol).join(', ')}>';
+          final setupType = refer(
+            'void Function(${mockTarget.mockName}Target$typeParamsStr)?',
+          );
+          cBuilder.constructors.addAll([
+            Constructor(
+              (c) =>
+                  c
+                    ..factory = true
+                    ..optionalParameters.add(
+                      Parameter(
+                        (p) =>
+                            p
+                              ..name = 'setup'
+                              ..type = setupType,
+                      ),
+                    )
+                    ..body = Block(
+                      (b) => b.statements.addAll([
+                        declareFinal('target')
+                            .assign(
+                              TypeReference((tr) {
+                                tr
+                                  ..symbol = '${mockTarget.mockName}Target'
+                                  ..types.addAll(typeParams);
+                              }).call([]),
+                            )
+                            .statement,
+                        Code('if (setup != null) { setup(target); }'),
+                        refer(mockTarget.mockName)
+                            .property('withTarget')
+                            .call([refer('target')])
+                            .returned
+                            .statement,
+                      ]),
+                    ),
+            ),
+            Constructor(
+              (c) =>
+                  c
+                    ..factory = true
+                    ..name = 'withTarget'
+                    ..requiredParameters.add(
+                      Parameter(
+                        (p) =>
+                            p
+                              ..name = 'target'
+                              ..type = TypeReference((tr) {
+                                tr
+                                  ..symbol = '${mockTarget.mockName}Target'
+                                  ..types.addAll(typeParams);
+                              }),
+                      ),
+                    )
+                    ..body =
+                        refer(mockTarget.mockName).property('_').call([
+                          _isJSObject(representationType)
+                              ? referImported(
+                                'createJSInteropWrapper',
+                                'dart:js_interop',
+                              ).call([refer('target')])
+                              : referImported(
+                                    'createJSInteropWrapper',
+                                    'dart:js_interop',
+                                  )
+                                  .call([refer('target')])
+                                  .asA(_typeReference(representationType)),
+                        ]).code,
+            ),
+          ]);
+        },
+      );
+    });
+  }
 
   Class _buildMockClass() {
     final instantiatedAlias = mockTarget.classType.alias;
@@ -1462,8 +1685,10 @@ class _MockClassInfo {
       (typeParamsWithBounds, _) {
         builder
           ..name = name
-          ..annotations.add(referImported('override', 'dart:core'))
           ..types.addAll(typeParamsWithBounds);
+        if (!_isExtensionType || name == 'toString') {
+          builder.annotations.add(referImported('override', 'dart:core'));
+        }
         // We allow overriding a method with a private return type by omitting
         // the return type (which is then inherited).
         if (!returnType.containsPrivateName) {
@@ -2219,8 +2444,10 @@ class _MockClassInfo {
   void _buildOverridingGetter(MethodBuilder builder, GetterElement getter) {
     builder
       ..name = getter.displayName
-      ..annotations.add(referImported('override', 'dart:core'))
       ..type = MethodType.getter;
+    if (!_isExtensionType) {
+      builder.annotations.add(referImported('override', 'dart:core'));
+    }
 
     if (!getter.returnType.containsPrivateName) {
       builder.returns = _typeReference(getter.returnType);
@@ -2290,8 +2517,10 @@ class _MockClassInfo {
     final name = setter.displayName;
     builder
       ..name = name
-      ..annotations.add(referImported('override', 'dart:core'))
       ..type = MethodType.setter;
+    if (!_isExtensionType) {
+      builder.annotations.add(referImported('override', 'dart:core'));
+    }
 
     assert(setter.formalParameters.length == 1);
     final parameter = setter.formalParameters.single;

--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -651,7 +651,7 @@ class _MockTargetGatherer {
         mockSpec.typeNotExtensionTypeErased as analyzer.InterfaceType;
     assert(mockSpecType.typeArguments.length == 1);
     final mockType = _mockType(mockSpecAsts[index]);
-    var typeToMock = mockSpecType.typeArguments.single;
+    final typeToMock = mockSpecType.typeArguments.single;
     if (typeToMock is analyzer.DynamicType ||
         typeToMock is analyzer.InvalidType) {
       final mockTypeName = mockType?.qualifiedName;

--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -1237,7 +1237,7 @@ class _MockLibraryInfo {
         inheritanceManager: inheritanceManager,
       );
       if (mockClassInfo._isExtensionType) {
-        mockSpecs.add(mockClassInfo._buildMockTargetClass());
+        mockSpecs.add(mockClassInfo._buildMockJsInteropTargetClass());
         mockSpecs.add(mockClassInfo._buildMockExtensionType());
       } else {
         mockSpecs.add(mockClassInfo._buildMockClass());
@@ -1290,7 +1290,11 @@ class _MockClassInfo {
   bool get _isExtensionType =>
       mockTarget.interfaceElement is ExtensionTypeElement;
 
-  Class _buildMockTargetClass() {
+  /// Builds a mock implementation class for a JS interop extension type.
+  ///
+  /// This class is meant to be passed to createJSInteropWrapper.
+  /// It will only contain external members of the mocked type.
+  Class _buildMockJsInteropTargetClass() {
     assert(_isExtensionType);
 
     final instantiatedAlias = mockTarget.classType.alias;
@@ -1335,13 +1339,14 @@ class _MockClassInfo {
             [...classToMock.typeParameters, ...?aliasElement?.typeParameters],
             [...typeToMock.typeArguments, ...?instantiatedAlias?.typeArguments],
           );
-          var members = inheritanceManager
-              .getInterface(classToMock)
-              .map
-              .values
-              .map((member) => member.substitute(substitution));
-
-          members = members.where((m) => m.isExternal);
+          final members =
+              inheritanceManager
+                  .getInterface(classToMock)
+                  .map
+                  .values
+                  .map((member) => member.substitute(substitution))
+                  .where((m) => m.isExternal)
+                  .toList();
 
           cBuilder.methods.addAll(
             fieldOverrides(members.whereType<PropertyAccessorElement>()),
@@ -1407,80 +1412,57 @@ class _MockClassInfo {
 
           // Add factories
           cBuilder.constructors.addAll([
-            Constructor(
-              (c) =>
-                  c
-                    ..factory = true
-                    ..optionalParameters.add(
-                      Parameter(
-                        (p) =>
-                            p
-                              ..name = 'proto'
-                              ..named = true
-                              ..type = TypeReference((b) => b
-                                ..symbol = 'JSObject'
-                                ..url = 'dart:js_interop'
-                                ..isNullable = true),
-                      ),
-                    )
-                    ..body = refer(mockTarget.mockName)
-                        .property('withTarget')
-                        .call(
-                          [
-                            TypeReference((tr) {
-                              tr
-                                ..symbol = '${mockTarget.mockName}Target'
-                                ..types.addAll(typeParams);
-                            }).call([]),
-                          ],
-                          {'proto': refer('proto')},
-                        )
-                        .code,
-            ),
-            Constructor(
-              (c) =>
-                  c
-                    ..factory = true
-                    ..name = 'withTarget'
-                    ..requiredParameters.add(
-                      Parameter(
-                        (p) =>
-                            p
-                              ..name = 'target'
-                              ..type = TypeReference((tr) {
-                                tr
-                                  ..symbol = '${mockTarget.mockName}Target'
-                                  ..types.addAll(typeParams);
-                              }),
-                      ),
-                    )
-                    ..optionalParameters.add(
-                      Parameter(
-                        (p) =>
-                            p
-                              ..name = 'proto'
-                              ..named = true
-                              ..type = TypeReference((b) => b
-                                ..symbol = 'JSObject'
-                                ..url = 'dart:js_interop'
-                                ..isNullable = true),
-                      ),
-                    )
-                    ..body =
-                        refer(mockTarget.mockName).property('_').call([
-                          _isJSObject(representationType)
-                              ? referImported(
-                                'createJSInteropWrapper',
-                                'dart:js_interop',
-                              ).call([refer('target'), refer('proto')])
-                              : referImported(
-                                    'createJSInteropWrapper',
-                                    'dart:js_interop',
-                                  )
-                                  .call([refer('target'), refer('proto')])
-                                  .asA(_typeReference(representationType)),
-                        ]).code,
-            ),
+            Constructor((c) {
+              c
+                ..factory = true
+                ..optionalParameters.add(
+                  Parameter((p) {
+                    p
+                      ..name = 'prototype'
+                      ..named = true
+                      ..type = TypeReference((b) {
+                        b
+                          ..symbol = 'JSObject'
+                          ..url = 'dart:js_interop'
+                          ..isNullable = true;
+                      });
+                  }),
+                )
+                ..optionalParameters.add(
+                  Parameter((p) {
+                    p
+                      ..name = 'target'
+                      ..named = true
+                      ..type = TypeReference((tr) {
+                        tr
+                          ..symbol = '${mockTarget.mockName}Target'
+                          ..types.addAll(typeParams)
+                          ..isNullable = true;
+                      });
+                  }),
+                );
+              final targetOrNew = refer('target').ifNullThen(
+                TypeReference((tr) {
+                  tr
+                    ..symbol = '${mockTarget.mockName}Target'
+                    ..types.addAll(typeParams);
+                }).call([]),
+              );
+              c.body =
+                  refer(mockTarget.mockName).property('_').call([
+                    _isJSObject(representationType)
+                        ? referImported(
+                          'createJSInteropWrapper',
+                          'dart:js_interop',
+                        ).call([targetOrNew, refer('prototype')])
+                        : referImported(
+                              'createJSInteropWrapper',
+                              'dart:js_interop',
+                            )
+                            .call([targetOrNew, refer('prototype')])
+                            .asA(_typeReference(representationType)),
+                  ]).code;
+            }),
           ]);
         },
       );

--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -886,15 +886,27 @@ class _MockTargetGatherer {
     for (final mockTarget in _mockTargets) {
       final interfaceElement = mockTarget.interfaceElement;
       if (interfaceElement is ExtensionTypeElement) {
+        final typeName = interfaceElement.name;
         if (!interfaceElement.isJSInteropType) {
-          final className = interfaceElement.name;
           final representationType =
               interfaceElement.representation.type.getDisplayString();
           throw InvalidMockitoAnnotationException(
             'Mockito cannot mock non-JS-interop extension types '
-            "(like '$className'). Instead, mock the representation type "
+            "(like '$typeName'). Instead, mock the representation type "
             "(like '$representationType') and cast the mock to the extension "
             'type where needed.',
+          );
+        }
+        final representationType = interfaceElement.representation.type;
+        final ultimateType = _baseRepresentationType(representationType);
+        if (!_isJSObject(ultimateType)) {
+          final representationTypeName = representationType.getDisplayString();
+          throw InvalidMockitoAnnotationException(
+            'Mockito cannot mock JS interop extension types wrapping '
+            "'$representationTypeName' (like '$typeName'). "
+            "Only extension types wrapping 'JSObject' are mockable. "
+            'For other types, you can create a real JS object or array and set '
+            "the properties directly using 'dart:js_interop_unsafe'.",
           );
         }
       }
@@ -1278,11 +1290,6 @@ class _MockClassInfo {
   bool get _isExtensionType =>
       mockTarget.interfaceElement is ExtensionTypeElement;
 
-  static bool _isJSObject(analyzer.DartType type) =>
-      type is analyzer.InterfaceType &&
-      type.element.name == 'JSObject' &&
-      type.element.library.uri.toString() == 'dart:js_interop';
-
   Class _buildMockTargetClass() {
     assert(_isExtensionType);
 
@@ -1305,6 +1312,12 @@ class _MockClassInfo {
       cBuilder
         ..docs.add('/// A class which mocks [$className] for JS interop.')
         ..docs.add('///')
+        ..docs.add(
+          '/// This class is meant to be passed to createJSInteropWrapper.',
+        )
+        ..docs.add(
+          '/// It will only contain external members of the mocked type.',
+        )
         ..docs.add(
           '/// See the documentation for Mockito\'s code generation '
           'for more information.',
@@ -1393,13 +1406,6 @@ class _MockClassInfo {
           );
 
           // Add factories
-          final typeParamsStr =
-              typeParams.isEmpty
-                  ? ''
-                  : '<${typeParams.map((tp) => tp.symbol).join(', ')}>';
-          final setupType = refer(
-            'void Function(${mockTarget.mockName}Target$typeParamsStr)?',
-          );
           cBuilder.constructors.addAll([
             Constructor(
               (c) =>
@@ -1409,29 +1415,27 @@ class _MockClassInfo {
                       Parameter(
                         (p) =>
                             p
-                              ..name = 'setup'
-                              ..type = setupType,
+                              ..name = 'proto'
+                              ..named = true
+                              ..type = TypeReference((b) => b
+                                ..symbol = 'JSObject'
+                                ..url = 'dart:js_interop'
+                                ..isNullable = true),
                       ),
                     )
-                    ..body = Block(
-                      (b) => b.statements.addAll([
-                        declareFinal('target')
-                            .assign(
-                              TypeReference((tr) {
-                                tr
-                                  ..symbol = '${mockTarget.mockName}Target'
-                                  ..types.addAll(typeParams);
-                              }).call([]),
-                            )
-                            .statement,
-                        Code('if (setup != null) { setup(target); }'),
-                        refer(mockTarget.mockName)
-                            .property('withTarget')
-                            .call([refer('target')])
-                            .returned
-                            .statement,
-                      ]),
-                    ),
+                    ..body = refer(mockTarget.mockName)
+                        .property('withTarget')
+                        .call(
+                          [
+                            TypeReference((tr) {
+                              tr
+                                ..symbol = '${mockTarget.mockName}Target'
+                                ..types.addAll(typeParams);
+                            }).call([]),
+                          ],
+                          {'proto': refer('proto')},
+                        )
+                        .code,
             ),
             Constructor(
               (c) =>
@@ -1450,18 +1454,30 @@ class _MockClassInfo {
                               }),
                       ),
                     )
+                    ..optionalParameters.add(
+                      Parameter(
+                        (p) =>
+                            p
+                              ..name = 'proto'
+                              ..named = true
+                              ..type = TypeReference((b) => b
+                                ..symbol = 'JSObject'
+                                ..url = 'dart:js_interop'
+                                ..isNullable = true),
+                      ),
+                    )
                     ..body =
                         refer(mockTarget.mockName).property('_').call([
                           _isJSObject(representationType)
                               ? referImported(
                                 'createJSInteropWrapper',
                                 'dart:js_interop',
-                              ).call([refer('target')])
+                              ).call([refer('target'), refer('proto')])
                               : referImported(
                                     'createJSInteropWrapper',
                                     'dart:js_interop',
                                   )
-                                  .call([refer('target')])
+                                  .call([refer('target'), refer('proto')])
                                   .asA(_typeReference(representationType)),
                         ]).code,
             ),
@@ -3000,6 +3016,21 @@ extension on int {
 
 bool _needsOverrideForVoidStub(ExecutableElement method) =>
     method.returnType is analyzer.VoidType || method.returnType.isFutureOfVoid;
+
+bool _isJSObject(analyzer.DartType type) =>
+    type is analyzer.InterfaceType &&
+    type.element.name == 'JSObject' &&
+    type.element.library.uri.toString() == 'dart:js_interop';
+
+analyzer.DartType _baseRepresentationType(analyzer.DartType type) {
+  var current = type;
+  while (current is analyzer.InterfaceType &&
+      current.element is ExtensionTypeElement) {
+    if (_isJSObject(current)) break;
+    current = (current.element as ExtensionTypeElement).representation.type;
+  }
+  return current;
+}
 
 /// This casts `ElementAnnotation` to the internal `ElementAnnotationImpl`
 /// class, since analyzer doesn't provide public interface to access

--- a/builder_pkgs/mockito/pubspec.yaml
+++ b/builder_pkgs/mockito/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   sdk: ^3.7.0
 
 dependencies:
-  analyzer: ^13.0.0
+  analyzer: ^13.3.0
   build: '>=3.0.0 <5.0.0'
   code_builder: ^4.5.0
   collection: ^1.19.0

--- a/builder_pkgs/mockito/pubspec.yaml
+++ b/builder_pkgs/mockito/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.7.0
+version: 5.8.0-wip
 description: >-
   A mock framework inspired by Mockito with APIs for Fakes, Mocks,
   behavior verification, and stubbing.

--- a/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
+++ b/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
@@ -1823,6 +1823,117 @@ void main() {
       ),
     );
   });
+
+  test('generates mock for a JS interop extension type', () async {
+    final mocksContent = await buildWithNonNullable({
+      ...annotationsAsset,
+      'foo|lib/foo.dart': dedent(r'''
+        import 'dart:js_interop';
+        extension type E(JSObject o) {
+          external int get foo;
+          external set foo(int val);
+          external String bar(String s);
+          external String toString({bool? option});
+          int get nonExternalGetter => 42;
+          void nonExternalMethod() {}
+        }
+        '''),
+      'foo|test/foo_test.dart': '''
+        import 'package:foo/foo.dart';
+        import 'package:mockito/annotations.dart';
+        @GenerateMocks([E])
+        void main() {}
+        ''',
+    });
+    expect(mocksContent, contains('class MockETarget extends'));
+    expect(mocksContent, contains('int get foo =>'));
+    expect(mocksContent, contains('set foo(int? val) =>'));
+    expect(mocksContent, contains('String bar(String? s) =>'));
+    expect(mocksContent, contains('String toString({bool? option}) =>'));
+    // Ensure toString has @override, but other members do not
+    expect(mocksContent, matches(RegExp(r'@override\s+String toString\(')));
+    expect(mocksContent, isNot(matches(RegExp(r'@override\s+int get foo'))));
+    expect(mocksContent, isNot(matches(RegExp(r'@override\s+String bar'))));
+
+    // Ensure non-external members and representation field are NOT generated
+    expect(mocksContent, isNot(contains('nonExternalGetter')));
+    expect(mocksContent, isNot(contains('nonExternalMethod')));
+    expect(mocksContent, isNot(contains('JSObject get o')));
+
+    expect(mocksContent, contains('extension type MockE'));
+    expect(
+      mocksContent,
+      contains('factory MockE([void Function(MockETarget)? setup])'),
+    );
+    expect(mocksContent, contains('if (setup != null) {'));
+    expect(mocksContent, contains('setup(target);'));
+    expect(mocksContent, contains('return MockE.withTarget(target);'));
+    expect(mocksContent, contains('createJSInteropWrapper(target)'));
+  });
+
+  test('generates mock for a generic JS interop extension type', () async {
+    final mocksContent = await buildWithNonNullable({
+      ...annotationsAsset,
+      'foo|lib/foo.dart': dedent(r'''
+        import 'dart:js_interop';
+        extension type E<T extends JSObject>(JSObject o) {
+          external T get foo;
+          external void bar(T val);
+        }
+        '''),
+      'foo|test/foo_test.dart': '''
+        import 'package:foo/foo.dart';
+        import 'package:mockito/annotations.dart';
+        @GenerateMocks([E])
+        void main() {}
+        ''',
+    });
+    expect(
+      mocksContent,
+      contains('class MockETarget<T extends _i1.JSObject> extends _i2.Mock'),
+    );
+    expect(mocksContent, contains('T get foo =>'));
+    expect(mocksContent, contains('void bar(T? val) =>'));
+    expect(
+      mocksContent,
+      matches(
+        RegExp(
+          r'extension type MockE<T extends _i1.JSObject>\._\(_i1.JSObject \w+\)\s+implements _i\d+\.E<T>',
+        ),
+      ),
+    );
+    expect(
+      mocksContent,
+      contains('factory MockE([void Function(MockETarget<T>)? setup])'),
+    );
+    expect(
+      mocksContent,
+      contains('factory MockE.withTarget(MockETarget<T> target) =>'),
+    );
+  });
+
+  test('throws when trying to mock a non-JS interop extension type', () async {
+    await _expectBuilderThrows(
+      assets: {
+        ...annotationsAsset,
+        'foo|lib/foo.dart': dedent(r'''
+          class Foo {}
+          extension type E(Foo o) implements Foo {}
+          '''),
+        'foo|test/foo_test.dart': '''
+          import 'package:foo/foo.dart';
+          import 'package:mockito/annotations.dart';
+          @GenerateMocks([E])
+          void main() {}
+          ''',
+      },
+      message: contains(
+        "Mockito cannot mock non-JS-interop extension types (like 'E'). "
+        "Instead, mock the representation type (like 'Foo') "
+        "and cast the mock to the extension type where needed.",
+      ),
+    );
+  });
 }
 
 /// Expect that [testBuilder], given [assets], throws an

--- a/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
+++ b/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
@@ -1930,7 +1930,7 @@ void main() {
       message: contains(
         "Mockito cannot mock non-JS-interop extension types (like 'E'). "
         "Instead, mock the representation type (like 'Foo') "
-        "and cast the mock to the extension type where needed.",
+        'and cast the mock to the extension type where needed.',
       ),
     );
   });

--- a/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
+++ b/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
@@ -1861,11 +1861,18 @@ void main() {
     expect(mocksContent, isNot(contains('JSObject get o')));
 
     expect(mocksContent, contains('extension type MockE'));
-    expect(mocksContent, contains('factory MockE({_i1.JSObject? proto}) =>'));
-    expect(mocksContent, contains('factory MockE.withTarget('));
     expect(
       mocksContent,
-      matches(RegExp(r'_i1\.createJSInteropWrapper\(\s*target,\s*proto,\s*\)')),
+      containsIgnoringFormatting(
+        'factory MockE({\n'
+        '    _i1.JSObject? prototype,\n'
+        '    MockETarget? target,\n'
+        '  }) =>\n'
+        '      MockE._(_i1.createJSInteropWrapper(\n'
+        '        target ?? MockETarget(),\n'
+        '        prototype,\n'
+        '      ));',
+      ),
     );
   });
 
@@ -1900,16 +1907,18 @@ void main() {
         ),
       ),
     );
-    expect(mocksContent, contains('factory MockE({_i1.JSObject? proto}) =>'));
     expect(
       mocksContent,
-      matches(
-        RegExp(r'factory MockE\.withTarget\(\s*MockETarget<T> target,\s*\{'),
+      containsIgnoringFormatting(
+        'factory MockE({\n'
+        '    _i1.JSObject? prototype,\n'
+        '    MockETarget<T>? target,\n'
+        '  }) =>\n'
+        '      MockE._(_i1.createJSInteropWrapper(\n'
+        '        target ?? MockETarget<T>(),\n'
+        '        prototype,\n'
+        '      ));',
       ),
-    );
-    expect(
-      mocksContent,
-      matches(RegExp(r'_i1\.createJSInteropWrapper\(\s*target,\s*proto,\s*\)')),
     );
   });
 
@@ -1985,13 +1994,17 @@ void main() {
     expect(mocksContent, contains('void foo()'));
     expect(mocksContent, contains('void bar()'));
     expect(mocksContent, contains('extension type MockB'));
-    expect(mocksContent, contains('factory MockB({_i1.JSObject? proto}) =>'));
     expect(
       mocksContent,
-      matches(
-        RegExp(
-          r'factory MockB\.withTarget\(\s*MockBTarget target,\s*\{\s*_i1\.JSObject\? proto,\s*\}\s*\)\s*=>\s*MockB\._\(\s*\(?\(?_i1\.createJSInteropWrapper\(\s*target,\s*proto,\s*\)\s*as _i\d+\.A\)?\)?\s*\);',
-        ),
+      containsIgnoringFormatting(
+        'factory MockB({\n'
+        '    _i1.JSObject? prototype,\n'
+        '    MockBTarget? target,\n'
+        '  }) =>\n'
+        '      MockB._((_i1.createJSInteropWrapper(\n'
+        '        target ?? MockBTarget(),\n'
+        '        prototype,\n'
+        '      ) as _i3.A));',
       ),
     );
   });
@@ -2020,7 +2033,16 @@ void main() {
       expect(mocksContent, contains('extension type MockEA'));
       expect(
         mocksContent,
-        contains('factory MockEA({_i1.JSObject? proto}) =>'),
+        containsIgnoringFormatting(
+          'factory MockEA({\n'
+          '    _i1.JSObject? prototype,\n'
+          '    MockEATarget? target,\n'
+          '  }) =>\n'
+          '      MockEA._(_i1.createJSInteropWrapper(\n'
+          '        target ?? MockEATarget(),\n'
+          '        prototype,\n'
+          '      ));',
+        ),
       );
       expect(mocksContent, matches(RegExp(r'implements _i\d+\.E<_i\d+\.A>')));
     },

--- a/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
+++ b/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
@@ -1995,6 +1995,36 @@ void main() {
       ),
     );
   });
+
+  test(
+    'generates mock for an instantiated generic JS interop extension type',
+    () async {
+      final mocksContent = await buildWithNonNullable({
+        ...annotationsAsset,
+        'foo|lib/foo.dart': dedent(r'''
+        import 'dart:js_interop';
+        extension type A(JSObject o) {}
+        extension type E<T extends JSObject>(JSObject o) {
+          external T get foo;
+        }
+        '''),
+        'foo|test/foo_test.dart': '''
+        import 'package:foo/foo.dart';
+        import 'package:mockito/annotations.dart';
+        @GenerateMocks([], customMocks: [MockSpec<E<A>>(as: #MockEA)])
+        void main() {}
+        ''',
+      });
+      expect(mocksContent, contains('class MockEATarget extends'));
+      expect(mocksContent, matches(RegExp(r'_i\d+\.A get foo')));
+      expect(mocksContent, contains('extension type MockEA'));
+      expect(
+        mocksContent,
+        contains('factory MockEA({_i1.JSObject? proto}) =>'),
+      );
+      expect(mocksContent, matches(RegExp(r'implements _i\d+\.E<_i\d+\.A>')));
+    },
+  );
 }
 
 /// Expect that [testBuilder], given [assets], throws an

--- a/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
+++ b/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
@@ -1861,14 +1861,12 @@ void main() {
     expect(mocksContent, isNot(contains('JSObject get o')));
 
     expect(mocksContent, contains('extension type MockE'));
+    expect(mocksContent, contains('factory MockE({_i1.JSObject? proto}) =>'));
+    expect(mocksContent, contains('factory MockE.withTarget('));
     expect(
       mocksContent,
-      contains('factory MockE([void Function(MockETarget)? setup])'),
+      matches(RegExp(r'_i1\.createJSInteropWrapper\(\s*target,\s*proto,\s*\)')),
     );
-    expect(mocksContent, contains('if (setup != null) {'));
-    expect(mocksContent, contains('setup(target);'));
-    expect(mocksContent, contains('return MockE.withTarget(target);'));
-    expect(mocksContent, contains('createJSInteropWrapper(target)'));
   });
 
   test('generates mock for a generic JS interop extension type', () async {
@@ -1902,15 +1900,44 @@ void main() {
         ),
       ),
     );
+    expect(mocksContent, contains('factory MockE({_i1.JSObject? proto}) =>'));
     expect(
       mocksContent,
-      contains('factory MockE([void Function(MockETarget<T>)? setup])'),
+      matches(
+        RegExp(r'factory MockE\.withTarget\(\s*MockETarget<T> target,\s*\{'),
+      ),
     );
     expect(
       mocksContent,
-      contains('factory MockE.withTarget(MockETarget<T> target) =>'),
+      matches(RegExp(r'_i1\.createJSInteropWrapper\(\s*target,\s*proto,\s*\)')),
     );
   });
+
+  test(
+    'throws when trying to mock a JS interop extension type wrapping JSArray',
+    () async {
+      await _expectBuilderThrows(
+        assets: {
+          ...annotationsAsset,
+          'foo|lib/foo.dart': dedent(r'''
+          import 'dart:js_interop';
+          extension type Foo(JSArray<JSString> foo) {}
+          '''),
+          'foo|test/foo_test.dart': '''
+          import 'package:foo/foo.dart';
+          import 'package:mockito/annotations.dart';
+          @GenerateMocks([Foo])
+          void main() {}
+          ''',
+        },
+        message: contains(
+          "Mockito cannot mock JS interop extension types wrapping 'JSArray<JSString>' (like 'Foo'). "
+          "Only extension types wrapping 'JSObject' are mockable. "
+          "For other types, you can create a real JS object or array and set the properties directly using 'dart:js_interop_unsafe'.",
+        ),
+      );
+    },
+  );
 
   test('throws when trying to mock a non-JS interop extension type', () async {
     await _expectBuilderThrows(
@@ -1931,6 +1958,40 @@ void main() {
         "Mockito cannot mock non-JS-interop extension types (like 'E'). "
         "Instead, mock the representation type (like 'Foo') "
         'and cast the mock to the extension type where needed.',
+      ),
+    );
+  });
+
+  test('generates mock for a nested JS interop extension type', () async {
+    final mocksContent = await buildWithNonNullable({
+      ...annotationsAsset,
+      'foo|lib/foo.dart': dedent(r'''
+        import 'dart:js_interop';
+        extension type A(JSObject o) {
+          external void foo();
+        }
+        extension type B(A o) implements A {
+          external void bar();
+        }
+        '''),
+      'foo|test/foo_test.dart': '''
+        import 'package:foo/foo.dart';
+        import 'package:mockito/annotations.dart';
+        @GenerateMocks([B])
+        void main() {}
+        ''',
+    });
+    expect(mocksContent, contains('class MockBTarget extends'));
+    expect(mocksContent, contains('void foo()'));
+    expect(mocksContent, contains('void bar()'));
+    expect(mocksContent, contains('extension type MockB'));
+    expect(mocksContent, contains('factory MockB({_i1.JSObject? proto}) =>'));
+    expect(
+      mocksContent,
+      matches(
+        RegExp(
+          r'factory MockB\.withTarget\(\s*MockBTarget target,\s*\{\s*_i1\.JSObject\? proto,\s*\}\s*\)\s*=>\s*MockB\._\(\s*\(?\(?_i1\.createJSInteropWrapper\(\s*target,\s*proto,\s*\)\s*as _i\d+\.A\)?\)?\s*\);',
+        ),
       ),
     );
   });


### PR DESCRIPTION
Users need a way to mock JS interop types to test interactions with external JS code. Currently mockito uses the erased (i.e. representation) type when it encounters one of these JS interop extension types.

This change uses the new analyzer APIs that provide access to the extension type itself to generate mocks for these types. It does this by generating an implementation Dart "Target" class that is labeled with @JSExport so that it can be treated as a JSObject. We then create a wrapper mock extension type for that Target class that actually implements the mocked type.

Because we lose access to the Dart mock object once we have wrapped it with createJSInteropWrapper, we provide 2 ways to setup the mock. The mock extension type either takes a pre-constructed Target Dart object or it can provide a setup function where the mock will construct the Target object and provide it to the setup function so that user can do any set up on the mock.

I've also updated it so it's now an error to explicitly try to mock an extension type. It's impossible to mock extension type members since they are statically dispatched so a user should instead be mocking the representation type. If they need to they should then down cast to an extension type.