### PR TITLE
fix(build_daemon): reject cross-origin WebSocket handshakes (CSWSH)

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,11 +1,6 @@
 ## 4.1.2-wip
 
-- Security: reject cross-origin WebSocket handshakes in the build daemon by
-  passing an empty `allowedOrigins` to `webSocketHandler`. This prevents a
-  malicious web page from connecting to the loopback daemon (Cross-Site
-  WebSocket Hijacking) to trigger builds or read build output. Non-browser
-  clients are unaffected.
-
+- Security: reject clients that set an Origin header, which includes all browsers.
 - Internal: remove use of `package:mockito` in test.
 - Require Dart 3.8.0.
 

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 4.1.2-wip
 
+- Security: reject cross-origin WebSocket handshakes in the build daemon by
+  passing an empty `allowedOrigins` to `webSocketHandler`. This prevents a
+  malicious web page from connecting to the loopback daemon (Cross-Site
+  WebSocket Hijacking) to trigger builds or read build output. Non-browser
+  clients are unaffected.
+
 - Internal: remove use of `package:mockito` in test.
 - Require Dart 3.8.0.
 

--- a/build_daemon/lib/src/server.dart
+++ b/build_daemon/lib/src/server.dart
@@ -74,6 +74,8 @@ class Server {
 
   /// Starts listening for build daemon clients.
   Future<int> listen() async {
+    // The client does not set the Origin header. Reject any client that does,
+    // which includes all browsers.
     final handler = webSocketHandler((WebSocketChannel channel, _) async {
       channel.stream.listen(
         (message) async {
@@ -108,15 +110,7 @@ class Server {
           _removeChannel(channel);
         },
       );
-    },
-        // Reject cross-origin browser handshakes (Cross-Site WebSocket
-        // Hijacking protection). The daemon's only legitimate client is a
-        // non-browser Dart program, which sends no `Origin` header and so is
-        // still accepted by `shelf_web_socket`. An empty allow-list causes any
-        // browser-initiated handshake (which always carries an `Origin`) to be
-        // rejected with a 403, preventing a malicious web page from connecting
-        // to the loopback daemon and driving builds / reading build output.
-        allowedOrigins: const []);
+    }, allowedOrigins: const []);
     final server = _server = await HttpMultiServer.loopback(0);
     // Serve requests in an error zone to prevent failures
     // when running from another error zone.

--- a/build_daemon/lib/src/server.dart
+++ b/build_daemon/lib/src/server.dart
@@ -108,7 +108,15 @@ class Server {
           _removeChannel(channel);
         },
       );
-    });
+    },
+        // Reject cross-origin browser handshakes (Cross-Site WebSocket
+        // Hijacking protection). The daemon's only legitimate client is a
+        // non-browser Dart program, which sends no `Origin` header and so is
+        // still accepted by `shelf_web_socket`. An empty allow-list causes any
+        // browser-initiated handshake (which always carries an `Origin`) to be
+        // rejected with a 403, preventing a malicious web page from connecting
+        // to the loopback daemon and driving builds / reading build output.
+        allowedOrigins: const []);
     final server = _server = await HttpMultiServer.loopback(0);
     // Serve requests in an error zone to prevent failures
     // when running from another error zone.

--- a/build_daemon/lib/src/server.dart
+++ b/build_daemon/lib/src/server.dart
@@ -76,44 +76,44 @@ class Server {
   Future<int> listen() async {
     // The client does not set the Origin header. Reject any client that does,
     // which includes all browsers.
-    final handler = webSocketHandler(
-      allowedOrigins: const [],
-      (WebSocketChannel channel, _) async {
-        channel.stream.listen(
-          (message) async {
-            dynamic request;
-            try {
-              request = _serializers.deserialize(jsonDecode(message as String));
-            } catch (e, s) {
-              _logMessage(
-                Level.WARNING,
-                'Unable to parse message: $message',
-                e,
-                s,
-              );
-              return;
-            }
-            if (request is BuildTargetRequest) {
-              _buildTargetManager.addBuildTarget(request.target, channel);
-            } else if (request is BuildRequest) {
-              // We can only get explicit build requests if we have a manual
-              // change provider.
-              final changeProvider = _changeProvider;
-              final changes = changeProvider is ManualChangeProvider
-                  ? await changeProvider.collectChanges()
-                  : <WatchEvent>[];
-              final targets = changes.isEmpty
-                  ? _buildTargetManager.targets
-                  : _buildTargetManager.targetsForChanges(changes);
-              await _build(targets, changes);
-            }
-          },
-          onDone: () {
-            _removeChannel(channel);
-          },
-        );
-      },
-    );
+    final handler = webSocketHandler(allowedOrigins: const [], (
+      WebSocketChannel channel,
+      _,
+    ) async {
+      channel.stream.listen(
+        (message) async {
+          dynamic request;
+          try {
+            request = _serializers.deserialize(jsonDecode(message as String));
+          } catch (e, s) {
+            _logMessage(
+              Level.WARNING,
+              'Unable to parse message: $message',
+              e,
+              s,
+            );
+            return;
+          }
+          if (request is BuildTargetRequest) {
+            _buildTargetManager.addBuildTarget(request.target, channel);
+          } else if (request is BuildRequest) {
+            // We can only get explicit build requests if we have a manual
+            // change provider.
+            final changeProvider = _changeProvider;
+            final changes = changeProvider is ManualChangeProvider
+                ? await changeProvider.collectChanges()
+                : <WatchEvent>[];
+            final targets = changes.isEmpty
+                ? _buildTargetManager.targets
+                : _buildTargetManager.targetsForChanges(changes);
+            await _build(targets, changes);
+          }
+        },
+        onDone: () {
+          _removeChannel(channel);
+        },
+      );
+    });
     final server = _server = await HttpMultiServer.loopback(0);
     // Serve requests in an error zone to prevent failures
     // when running from another error zone.

--- a/build_daemon/lib/src/server.dart
+++ b/build_daemon/lib/src/server.dart
@@ -76,41 +76,44 @@ class Server {
   Future<int> listen() async {
     // The client does not set the Origin header. Reject any client that does,
     // which includes all browsers.
-    final handler = webSocketHandler((WebSocketChannel channel, _) async {
-      channel.stream.listen(
-        (message) async {
-          dynamic request;
-          try {
-            request = _serializers.deserialize(jsonDecode(message as String));
-          } catch (e, s) {
-            _logMessage(
-              Level.WARNING,
-              'Unable to parse message: $message',
-              e,
-              s,
-            );
-            return;
-          }
-          if (request is BuildTargetRequest) {
-            _buildTargetManager.addBuildTarget(request.target, channel);
-          } else if (request is BuildRequest) {
-            // We can only get explicit build requests if we have a manual
-            // change provider.
-            final changeProvider = _changeProvider;
-            final changes = changeProvider is ManualChangeProvider
-                ? await changeProvider.collectChanges()
-                : <WatchEvent>[];
-            final targets = changes.isEmpty
-                ? _buildTargetManager.targets
-                : _buildTargetManager.targetsForChanges(changes);
-            await _build(targets, changes);
-          }
-        },
-        onDone: () {
-          _removeChannel(channel);
-        },
-      );
-    }, allowedOrigins: const []);
+    final handler = webSocketHandler(
+      allowedOrigins: const [],
+      (WebSocketChannel channel, _) async {
+        channel.stream.listen(
+          (message) async {
+            dynamic request;
+            try {
+              request = _serializers.deserialize(jsonDecode(message as String));
+            } catch (e, s) {
+              _logMessage(
+                Level.WARNING,
+                'Unable to parse message: $message',
+                e,
+                s,
+              );
+              return;
+            }
+            if (request is BuildTargetRequest) {
+              _buildTargetManager.addBuildTarget(request.target, channel);
+            } else if (request is BuildRequest) {
+              // We can only get explicit build requests if we have a manual
+              // change provider.
+              final changeProvider = _changeProvider;
+              final changes = changeProvider is ManualChangeProvider
+                  ? await changeProvider.collectChanges()
+                  : <WatchEvent>[];
+              final targets = changes.isEmpty
+                  ? _buildTargetManager.targets
+                  : _buildTargetManager.targetsForChanges(changes);
+              await _build(targets, changes);
+            }
+          },
+          onDone: () {
+            _removeChannel(channel);
+          },
+        );
+      },
+    );
     final server = _server = await HttpMultiServer.loopback(0);
     // Serve requests in an error zone to prevent failures
     // when running from another error zone.


### PR DESCRIPTION
## What

`build_daemon` creates its control WebSocket server with `webSocketHandler(...)` from `package:shelf_web_socket` but does not pass `allowedOrigins`. In `shelf_web_socket`, Origin validation is opt-in, so without an allow-list the server accepts WebSocket handshakes from any browser origin. Since browsers permit cross-origin WebSocket connections (the same-origin policy does not block the handshake; the server must validate `Origin` itself), a web page the developer visits can open a WebSocket to the loopback daemon, trigger builds, and receive build status / changed-asset URIs / build logs.

This is a Cross-Site WebSocket Hijacking (CSWSH) hardening gap (CWE-1385).

## Fix

Pass `allowedOrigins: const []` to `webSocketHandler`. An empty allow-list rejects every browser-initiated handshake (which always carries an `Origin` header) with a 403, while non-browser clients — the daemon's only legitimate client is a Dart program using `IOWebSocketChannel`, which sends no `Origin` header — continue to connect normally. No client changes are required.

## Verification

- `dart analyze` — no issues.
- `dart test test/server_test.dart` — all tests pass (the existing non-browser client connects unchanged).

## Notes

This is a defense-in-depth fix. Practical exploitation is limited because the daemon binds a random ephemeral port (`HttpMultiServer.loopback(0)`), but adding the Origin check closes the cross-origin browser vector with no downside to legitimate clients.

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.