### PR TITLE
Add test coverage around resolution

### DIFF
--- a/build_runner/test/invalidation/invalidation_stress_test.dart
+++ b/build_runner/test/invalidation/invalidation_stress_test.dart
@@ -21,8 +21,9 @@ import 'invalidation_tester.dart';
 Future<void> main() async {
   for (var iteration = 0; iteration != 500; ++iteration) {
     test('invalidation stress test $iteration', () async {
-      final tester = InvalidationTester()..logSetup();
       final random = Random(iteration);
+      final tester = InvalidationTester(discardResolver: random.nextBool())
+        ..logSetup();
 
       // Whether to change the imports in source files between builds.
       final changeImports = iteration % 10 == 0;

--- a/build_runner/test/invalidation/invalidation_tester.dart
+++ b/build_runner/test/invalidation/invalidation_tester.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
+import 'package:build_runner/src/build/resolver/resolvers_impl.dart';
 import 'package:build_runner/src/constants.dart';
 import 'package:build_runner/src/logging/build_log.dart';
 import 'package:build_test/build_test.dart';
@@ -23,6 +24,7 @@ import 'package:test/test.dart';
 /// IDs under `.dart_tool` are mapped back to the same namespace.
 class InvalidationTester {
   final bool testIsRunning;
+  final bool discardResolver;
 
   /// The source assets on disk before the first build.
   final Set<AssetId> _sourceAssets = {};
@@ -70,7 +72,14 @@ class InvalidationTester {
   /// Output number, for writing outputs that are different.
   int _outputNumber = 0;
 
-  InvalidationTester({this.testIsRunning = true});
+  /// An invalidation tester.
+  ///
+  /// Set [discardResolver] to control whether the resolver instance is
+  /// discarded between builds. Discarding the resolver makes the builds more
+  /// like independent "build" commands. Keeping the resolver makes the builds
+  /// more like multiple builds by the same "watch" command. So, it's useful to
+  /// test both.
+  InvalidationTester({this.testIsRunning = true, this.discardResolver = true});
 
   /// Starts logging test setup.
   ///
@@ -253,6 +262,7 @@ class InvalidationTester {
       optionalBuilders: _builders.where((b) => b.isOptional).toSet(),
       visibleOutputBuilders: _builders.where((b) => b.outputIsVisible).toSet(),
       testingBuilderConfig: false,
+      resolvers: discardResolver ? ResolversImpl.custom() : null,
     );
     final logString = log.toString();
     if (testIsRunning) {

--- a/build_runner/test/invalidation/resolved_input_invalidation_test.dart
+++ b/build_runner/test/invalidation/resolved_input_invalidation_test.dart
@@ -14,10 +14,19 @@ import 'invalidation_tester.dart';
 ///    `a1 resolves: a2 --> a3 --> a4` means that the generation of a1
 ///    resolves a2, which imports a3, which imports a4
 void main() {
+  for (final discardResolver in [false, true]) {
+    final groupName = discardResolver
+        ? 'discardResolver=true'
+        : 'discardResolver=false';
+    group(groupName, () => _runTests(discardResolver));
+  }
+}
+
+void _runTests(bool discardResolver) {
   late InvalidationTester tester;
 
   setUp(() {
-    tester = InvalidationTester();
+    tester = InvalidationTester(discardResolver: discardResolver);
   });
 
   group('a.1 <== a.2, a.2 resolves: a.1 --> za --> zb', () {


### PR DESCRIPTION
Working on the previous PR highlighted that because the resolution/invalidation unit tests keep a resolver instance they are more like a "watch" command than multiple incremental "build" commands.

This extra test coverage would have helped :)