### PR TITLE
Include nullable JS interop members and annotate members with @JSExport when needed

### DIFF
--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -1619,8 +1619,7 @@ class _MockClassInfo {
           (includeNullables || typeSystem._returnTypeIsNonNullable(accessor))) {
         yield Method((mBuilder) => _buildOverridingGetter(mBuilder, accessor));
       }
-      if (accessor is SetterElement &&
-          (includeNullables || sourceLibIsNonNullable)) {
+      if (accessor is SetterElement && sourceLibIsNonNullable) {
         yield Method((mBuilder) => _buildOverridingSetter(mBuilder, accessor));
       }
     }

--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -959,7 +959,12 @@ class _MockTargetGatherer {
         );
       }
 
-      _checkMethodsToStubAreValid(mockTarget);
+      _checkMethodsToStubAreValid(
+        mockTarget,
+        // Mock target classes for JS interop types generate all members and
+        // JS interop types are the only extension types we allow.
+        checkAllMembers: mockTarget.interfaceElement is ExtensionTypeElement,
+      );
     });
   }
 
@@ -969,7 +974,13 @@ class _MockTargetGatherer {
   /// A method is not valid for stubbing if:
   /// - It has a private type anywhere in its signature; Mockito cannot override
   ///   such a method.
-  void _checkMethodsToStubAreValid(_MockTarget mockTarget) {
+  ///
+  /// If [checkAllMembers] is true, assumes all members will be generated and
+  /// therefore checked.
+  void _checkMethodsToStubAreValid(
+    _MockTarget mockTarget, {
+    required bool checkAllMembers,
+  }) {
     final interfaceElement = mockTarget.interfaceElement;
     final className = interfaceElement.name;
     final substitution = Substitution.fromInterfaceType(mockTarget.classType);
@@ -983,7 +994,8 @@ class _MockTargetGatherer {
         relevantMembers.expand((member) {
           final nameWithEquals =
               member is SetterElement ? '${member.name}=' : member.name;
-          if (_entryLib.typeSystem._returnTypeIsNonNullable(member) ||
+          if (checkAllMembers ||
+              _entryLib.typeSystem._returnTypeIsNonNullable(member) ||
               _entryLib.typeSystem._hasNonNullableParameter(member) ||
               _needsOverrideForVoidStub(member)) {
             return _checkFunction(
@@ -1349,10 +1361,16 @@ class _MockClassInfo {
                   .toList();
 
           cBuilder.methods.addAll(
-            fieldOverrides(members.whereType<PropertyAccessorElement>()),
+            fieldOverrides(
+              members.whereType<PropertyAccessorElement>(),
+              includeNullables: true,
+            ),
           );
           cBuilder.methods.addAll(
-            methodOverrides(members.whereType<MethodElement>()),
+            methodOverrides(
+              members.whereType<MethodElement>(),
+              includeNullables: true,
+            ),
           );
         },
       );
@@ -1580,10 +1598,11 @@ class _MockClassInfo {
   ///
   /// Only public instance fields which have either a potentially non-nullable
   /// return type (for getters) or a parameter with a potentially non-nullable
-  /// type (for setters) are yielded.
+  /// type (for setters) are yielded, unless [includeNullables] is true.
   Iterable<Method> fieldOverrides(
-    Iterable<PropertyAccessorElement> accessors,
-  ) sync* {
+    Iterable<PropertyAccessorElement> accessors, {
+    bool includeNullables = false,
+  }) sync* {
     for (final accessor in accessors) {
       if (accessor.isPrivate) {
         continue;
@@ -1597,10 +1616,11 @@ class _MockClassInfo {
         continue;
       }
       if (accessor is GetterElement &&
-          typeSystem._returnTypeIsNonNullable(accessor)) {
+          (includeNullables || typeSystem._returnTypeIsNonNullable(accessor))) {
         yield Method((mBuilder) => _buildOverridingGetter(mBuilder, accessor));
       }
-      if (accessor is SetterElement && sourceLibIsNonNullable) {
+      if (accessor is SetterElement &&
+          (includeNullables || sourceLibIsNonNullable)) {
         yield Method((mBuilder) => _buildOverridingSetter(mBuilder, accessor));
       }
     }
@@ -1623,8 +1643,11 @@ class _MockClassInfo {
   ///
   /// Only public instance methods which have either a potentially non-nullable
   /// return type or a parameter with a potentially non-nullable type are
-  /// yielded.
-  Iterable<Method> methodOverrides(Iterable<MethodElement> methods) sync* {
+  /// yielded, unless [includeNullables] is true.
+  Iterable<Method> methodOverrides(
+    Iterable<MethodElement> methods, {
+    bool includeNullables = false,
+  }) sync* {
     for (final method in methods) {
       if (method.isPrivate) {
         continue;
@@ -1643,7 +1666,7 @@ class _MockClassInfo {
         // narrow the return type.
         continue;
       }
-      if (_methodNeedsOverride(method)) {
+      if (includeNullables || _methodNeedsOverride(method)) {
         _checkForConflictWithCore(method.name!);
         yield Method((mBuilder) => _buildOverridingMethod(mBuilder, method));
       }
@@ -1668,6 +1691,55 @@ class _MockClassInfo {
             ).call([refer('this')]).statement,
   );
 
+  /// Add needed annotation for the overriding member [builder] that overrides
+  /// [member].
+  ///
+  /// - If [member] is not an external JS interop member, adds an `@override`
+  ///   annotation to [builder]. Since the mock class for a JS interop
+  ///   extension type doesn't implement the extension type, the built member
+  ///   doesn't need an `@override` annotation.
+  /// - If [member] is an external JS interop member with an `@JS` annotation,
+  ///   adds a corresponding `@JSExport` annotation to [builder] with the same
+  ///   value.
+  void _addAnnotationsForOverridingMember(
+    MethodBuilder builder,
+    ExecutableElement member,
+  ) {
+    final isJSInteropMember = _isExtensionType && member.isExternal;
+    if (isJSInteropMember) {
+      final jsName = _getJSName(member);
+      if (jsName != null) {
+        builder.annotations.add(
+          referImported(
+            'JSExport',
+            'dart:js_interop',
+          ).call([literalString(jsName)]),
+        );
+      }
+    } else {
+      builder.annotations.add(referImported('override', 'dart:core'));
+    }
+  }
+
+  /// Returns the string value from the `dart:js_interop` `@JS()` annotation on
+  /// [element] if it exists and is non-empty.
+  String? _getJSName(Element element) {
+    for (final annotation in element.metadata.annotations) {
+      final annotationElement = annotation.element;
+      if (annotationElement is ConstructorElement &&
+          annotationElement.enclosingElement.name == 'JS' &&
+          annotationElement.library.uri.toString() == 'dart:js_interop') {
+        final value =
+            annotation
+                .computeConstantValue()
+                ?.getField('name')
+                ?.toStringValue();
+        if (value != null && value.isNotEmpty) return value;
+      }
+    }
+    return null;
+  }
+
   /// Build a method which overrides [method], with all non-nullable
   /// parameter types widened to be nullable.
   ///
@@ -1684,9 +1756,7 @@ class _MockClassInfo {
         builder
           ..name = name
           ..types.addAll(typeParamsWithBounds);
-        if (!_isExtensionType || name == 'toString') {
-          builder.annotations.add(referImported('override', 'dart:core'));
-        }
+        _addAnnotationsForOverridingMember(builder, method);
         // We allow overriding a method with a private return type by omitting
         // the return type (which is then inherited).
         if (!returnType.containsPrivateName) {
@@ -2443,9 +2513,7 @@ class _MockClassInfo {
     builder
       ..name = getter.displayName
       ..type = MethodType.getter;
-    if (!_isExtensionType) {
-      builder.annotations.add(referImported('override', 'dart:core'));
-    }
+    _addAnnotationsForOverridingMember(builder, getter);
 
     if (!getter.returnType.containsPrivateName) {
       builder.returns = _typeReference(getter.returnType);
@@ -2516,9 +2584,7 @@ class _MockClassInfo {
     builder
       ..name = name
       ..type = MethodType.setter;
-    if (!_isExtensionType) {
-      builder.annotations.add(referImported('override', 'dart:core'));
-    }
+    _addAnnotationsForOverridingMember(builder, setter);
 
     assert(setter.formalParameters.length == 1);
     final parameter = setter.formalParameters.single;

--- a/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
+++ b/builder_pkgs/mockito/test/builder/custom_mocks_test.dart
@@ -1833,7 +1833,6 @@ void main() {
           external int get foo;
           external set foo(int val);
           external String bar(String s);
-          external String toString({bool? option});
           int get nonExternalGetter => 42;
           void nonExternalMethod() {}
         }
@@ -1849,9 +1848,6 @@ void main() {
     expect(mocksContent, contains('int get foo =>'));
     expect(mocksContent, contains('set foo(int? val) =>'));
     expect(mocksContent, contains('String bar(String? s) =>'));
-    expect(mocksContent, contains('String toString({bool? option}) =>'));
-    // Ensure toString has @override, but other members do not
-    expect(mocksContent, matches(RegExp(r'@override\s+String toString\(')));
     expect(mocksContent, isNot(matches(RegExp(r'@override\s+int get foo'))));
     expect(mocksContent, isNot(matches(RegExp(r'@override\s+String bar'))));
 
@@ -1922,6 +1918,44 @@ void main() {
     );
   });
 
+  test('generates mock for a JS interop extension type with potentially '
+      'nullable getters, setters, and methods', () async {
+    final mocksContent = await buildWithNonNullable({
+      ...annotationsAsset,
+      'foo|lib/foo.dart': dedent(r'''
+        import 'dart:js_interop';
+        extension type E<T extends JSAny>(JSObject o) {
+          external int? get nullableGetter;
+          external T? get nullableGenericGetter;
+          external set nullableSetter(int? val);
+          external set nullableGenericSetter(T? val);
+          external String? nullableMethod(String s);
+          external T? nullableGenericMethod(String s);
+          external int nullableParamMethod(String? s);
+          external int nullableGenericParamMethod(T? s);
+        }
+        '''),
+      'foo|test/foo_test.dart': '''
+        import 'package:foo/foo.dart';
+        import 'package:mockito/annotations.dart';
+        @GenerateMocks([E])
+        void main() {}
+        ''',
+    });
+    expect(
+      mocksContent,
+      contains('class MockETarget<T extends _i1.JSAny> extends _i2.Mock'),
+    );
+    expect(mocksContent, contains('int? get nullableGetter =>'));
+    expect(mocksContent, contains('T? get nullableGenericGetter =>'));
+    expect(mocksContent, contains('set nullableSetter(int? val) =>'));
+    expect(mocksContent, contains('set nullableGenericSetter(T? val) =>'));
+    expect(mocksContent, contains('String? nullableMethod(String? s) =>'));
+    expect(mocksContent, contains('T? nullableGenericMethod(String? s) =>'));
+    expect(mocksContent, contains('int nullableParamMethod(String? s) =>'));
+    expect(mocksContent, contains('int nullableGenericParamMethod(T? s) =>'));
+  });
+
   test(
     'throws when trying to mock a JS interop extension type wrapping JSArray',
     () async {
@@ -1967,6 +2001,105 @@ void main() {
         "Mockito cannot mock non-JS-interop extension types (like 'E'). "
         "Instead, mock the representation type (like 'Foo') "
         'and cast the mock to the extension type where needed.',
+      ),
+    );
+  });
+
+  // Check that we still verify the nullable members for JS interop since we
+  // always generate them.
+  test(
+    'throws when trying to mock an external nullable JS interop getter with a '
+    'private type',
+    () async {
+      await _expectBuilderThrows(
+        assets: {
+          ...annotationsAsset,
+          'foo|lib/foo.dart': dedent(r'''
+          import 'dart:js_interop';
+          extension type _D._(int _) {}
+          extension type E._(JSObject _) {
+            external _D? get foo;
+          }
+          '''),
+          'foo|test/foo_test.dart': '''
+          import 'package:foo/foo.dart';
+          import 'package:mockito/annotations.dart';
+          @GenerateMocks([E])
+          void main() {}
+          ''',
+        },
+        message: contains(
+          "The property accessor 'E.foo' features a private return type, and "
+          'cannot be stubbed.',
+        ),
+      );
+    },
+  );
+
+  test('generates mock for a JS interop extension type translating `@JS` to '
+      '`@JSExport`', () async {
+    final mocksContent = await buildWithNonNullable({
+      ...annotationsAsset,
+      'foo|lib/foo.dart': dedent(r'''
+        import 'dart:js_interop';
+        extension type E(JSObject o) {
+          @JS('jsGetter')
+          external int get getterWithJs;
+          @JS('jsSetter')
+          external set setterWithJs(int val);
+          @JS('jsMethod')
+          external String methodWithJs(String s);
+          @JS()
+          external bool get getterWithEmptyJs;
+          @JS('')
+          external bool get getterWithJsEmptyString;
+        }
+        '''),
+      'foo|test/foo_test.dart': '''
+        import 'package:foo/foo.dart';
+        import 'package:mockito/annotations.dart';
+        @GenerateMocks([E])
+        void main() {}
+        ''',
+    });
+    expect(mocksContent, contains('class MockETarget extends'));
+    expect(
+      mocksContent,
+      contains(
+        "@_i1.JSExport('jsGetter')\n"
+        '  int get getterWithJs =>',
+      ),
+    );
+    expect(
+      mocksContent,
+      contains(
+        "@_i1.JSExport('jsSetter')\n"
+        '  set setterWithJs(int? val) =>',
+      ),
+    );
+    expect(
+      mocksContent,
+      contains(
+        "@_i1.JSExport('jsMethod')\n"
+        '  String methodWithJs(String? s) =>',
+      ),
+    );
+    expect(
+      mocksContent,
+      isNot(
+        contains(
+          '@_i1.JSExport()\n'
+          '  bool get getterWithEmptyJs =>',
+        ),
+      ),
+    );
+    expect(
+      mocksContent,
+      isNot(
+        contains(
+          "@_i1.JSExport('')\n"
+          '  bool get getterWithJsEmptyString =>',
+        ),
       ),
     );
   });


### PR DESCRIPTION
- By default, mockito only includes members if they have a non-nullable return type or parameter types as it can't leverage noSuchMethod in those cases. In the JS interop case, however, we should include *all* external members as they are needed to make sure `createJSInteropWrapper` generates a wrapper with all the needed members.
- Some external members are renamed with `@JS`. In order for `createJSInteropWrapper` to mock correctly, the corresponding members in the Target class need an `@JSExport` rename.
- Removes a small check for `@override` for `toString` in a JS interop type - extension types are not allowed to override `Object` members, so we don't need the check.