### PR TITLE
ci: pin dart-lang/ecosystem reusable workflows to commit SHA to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@848b3bf3b757d2e9ae4d60030eeed5756c87783f # main
     with:
       checks: "version,changelog,do-not-submit"
       ignore_license: "**.g.dart"

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -12,6 +12,6 @@ on:
 
 jobs:
   upload:
-    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@848b3bf3b757d2e9ae4d60030eeed5756c87783f # main
     permissions:
       pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@848b3bf3b757d2e9ae4d60030eeed5756c87783f # main
     with:
       write-comments: false
       sdk: dev


### PR DESCRIPTION
## Summary

The `publish.yaml`, `health.yaml`, and `post_summaries.yaml` workflows all call reusable workflows from `dart-lang/ecosystem` using the **mutable branch reference `@main`**:

```yaml
uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
```

Because `@main` is a mutable branch pointer, any commit pushed to `dart-lang/ecosystem`'s `main` branch is immediately picked up by every caller. If the `dart-lang/ecosystem` repository were compromised (supply-chain attack, maintainer account takeover, malicious PR merged), an attacker could inject arbitrary code that runs in the context of this repository with `id-token: write` permissions — enabling unauthorized package publishing to pub.dev.

## Vulnerability class

Supply-chain attack via mutable reusable workflow reference (CWE-829). See [GitHub Security hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#reusing-third-party-workflows).

## Fix

All three workflow files now pin `dart-lang/ecosystem` reusable workflows to the full commit SHA `848b3bf3b757d2e9ae4d60030eeed5756c87783f` (current `main` HEAD at time of writing), with `# main` as a comment for readability.