### PR TITLE
Fix leak_check test to use discardResolver: false.

### DIFF
--- a/build_runner/test/invalidation/invalidation_leak_checker.dart
+++ b/build_runner/test/invalidation/invalidation_leak_checker.dart
@@ -13,7 +13,11 @@ import 'invalidation_tester.dart';
 ///
 /// Run using `tool/leak_check.sh`.
 void main(List<String> arguments) async {
-  final tester = InvalidationTester(testIsRunning: false);
+  final tester = InvalidationTester(
+    testIsRunning: false,
+    // All the long-running commands keep the resolver, so do that.
+    discardResolver: false,
+  );
 
   tester.sources(['a.1']);
 


### PR DESCRIPTION
Leak check started failing because `InvalidationTester` was updated to create a new resolver for each build to simulate separate "build" commands, and this doesn't do cleanup properly.

But there's no real build that keeps multiple resolvers around, so there isn't an actual leak.

Update the test to set `discardResolver: false` for a realistic leak check.