### PR TITLE
Refactor BuildOutputReader and createMergedOutputDirectories.

### DIFF
--- a/build_runner/lib/src/build/asset_content.dart
+++ b/build_runner/lib/src/build/asset_content.dart
@@ -46,6 +46,19 @@ class AssetContent {
     return encoding.decode(bytes);
   }
 
+  /// Returns a copy with [newBytes].
+  ///
+  /// If this instance has a digest, it's copied without checking that
+  /// [newBytes] matches the digest. This supports the current build_runner
+  /// behavior that manual changes to output content are ignored, see
+  /// https://github.com/dart-lang/build/issues/4985.
+  AssetContent withBytes(List<int> newBytes) {
+    if (_bytes == newBytes) return this;
+    final result = AssetContent.bytes(newBytes);
+    if (_digest != null) result._digest = _digest;
+    return result;
+  }
+
   Digest get digest => _digest ??= md5.convert(bytes);
 }
 

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -78,9 +78,6 @@ class Build {
   /// transitive source.
   final Map<LibraryCycleGraph, bool> changedGraphs = Map.identity();
 
-  /// The build output.
-  BuildOutputReader? _buildOutputReader;
-
   late final BuilderFilesystem _builderFilesystem = BuilderFilesystem(
     buildPackages: buildPackages,
     buildConfigs: buildConfigs,
@@ -116,9 +113,6 @@ class Build {
   BuildState? get previousBuildState => buildPlan.previousBuild.buildState;
   BuildInputs get buildInputs => buildPlan.buildInputs;
   BuildStepPlan get buildStepPlan => buildPlan.buildStepPlan;
-
-  BuildOutputReader get buildOutputReader => _buildOutputReader ??=
-      BuildOutputReader(buildPlan: buildPlan, buildState: buildState);
 
   Future<BuildResult> run() async {
     buildLog.configuration = buildLog.configuration.rebuild(
@@ -214,7 +208,9 @@ class Build {
               status: BuildStatus.failure,
               outputs: BuiltList(),
               buildState: buildState,
-              buildOutputReader: buildOutputReader,
+              buildOutputReader: BuildOutputReader(
+                builderFilesystem: _builderFilesystem.forAfterBuild(),
+              ),
             ),
           );
         }
@@ -303,7 +299,9 @@ class Build {
       status: BuildStatus.success,
       outputs: outputs.build(),
       buildState: buildState,
-      buildOutputReader: buildOutputReader,
+      buildOutputReader: BuildOutputReader(
+        builderFilesystem: _builderFilesystem.forAfterBuild(),
+      ),
     );
   }
 

--- a/build_runner/lib/src/build/build_result.dart
+++ b/build_runner/lib/src/build/build_result.dart
@@ -27,8 +27,10 @@ class BuildResult {
   /// The imports graph for resolved sources.
   final PhasedAssetDeps phasedAssetDeps;
 
-  // The build output.
-  final BuildOutputReader buildOutputReader;
+  /// The build output.
+  ///
+  /// `null` if the build failed with no output.
+  final BuildOutputReader? buildOutputReader;
 
   // The build state.
   final BuildState? buildState;
@@ -84,7 +86,7 @@ Build Failed :(
   factory BuildResult.buildScriptChanged() => BuildResult(
     status: BuildStatus.failure,
     failureType: FailureType.buildScriptChanged,
-    buildOutputReader: BuildOutputReader.empty(),
+    buildOutputReader: null,
   );
 }
 

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -379,8 +379,7 @@ class BuildSeries {
         outputSymlinksOnly:
             _buildPlan.buildSpec.buildOptions.outputSymlinksOnly,
         buildDirs: _buildPlan.buildDirs,
-        buildOutputReader: result.buildOutputReader,
-        readerWriter: _buildPlan.readerWriter,
+        buildOutputReader: result.buildOutputReader!,
       )) {
         return result.copyWith(
           status: BuildStatus.failure,

--- a/build_runner/lib/src/build/build_state/build_state.dart
+++ b/build_runner/lib/src/build/build_state/build_state.dart
@@ -187,6 +187,24 @@ class BuildState {
     );
   }
 
+  /// Updates the [step] post process output [id] to [content].
+  ///
+  /// Throws if not a post process output.
+  void updatePostProcessOutputContent({
+    required PostProcessBuildStepId step,
+    required AssetId id,
+    required AssetContent content,
+  }) {
+    final stepResult = postProcessBuildStepResultFor(step);
+    if (stepResult == null || !stepResult.outputs.containsKey(id)) {
+      throw StateError(
+        'Step $step does not have result with post process output $id.',
+      );
+    }
+    _postProcessResultsByInput[step.input]![step.actionNumber] = stepResult
+        .rebuild((b) => b..outputs[id] = content);
+  }
+
   /// The content of [id].
   ///
   /// If it is a source, returns `null` if it has not been read.
@@ -273,6 +291,9 @@ class BuildState {
   PostProcessBuildStepResult? postProcessBuildStepResultFor(
     PostProcessBuildStepId step,
   ) => _postProcessResultsByInput[step.input]?[step.actionNumber];
+
+  PostProcessBuildStepId? postProcessStepFor(AssetId id) =>
+      _postProcessOutputs[id];
 
   bool isHiddenPostProcessOutput(AssetId id) {
     final stepId = _postProcessOutputs[id];

--- a/build_runner/lib/src/build/builder_filesystem.dart
+++ b/build_runner/lib/src/build/builder_filesystem.dart
@@ -29,8 +29,8 @@ class BuilderFilesystem {
   final BuildState buildState;
   final BuildStepPlan buildStepPlan;
   final ReaderWriter readerWriter;
-  final AssetBuilder assetBuilder;
-  final GlobEvaluator globEvaluator;
+  final AssetBuilder? assetBuilder;
+  final GlobEvaluator? globEvaluator;
 
   BuilderFilesystem({
     required this.buildPackages,
@@ -38,9 +38,19 @@ class BuilderFilesystem {
     required this.buildState,
     required this.buildStepPlan,
     required this.readerWriter,
-    required this.assetBuilder,
-    required this.globEvaluator,
+    this.assetBuilder,
+    this.globEvaluator,
   });
+
+  /// Returns a copy without in-build hooks: [assetBuilder], [globEvaluator],
+  /// content update listener.
+  BuilderFilesystem forAfterBuild() => BuilderFilesystem(
+    buildPackages: buildPackages,
+    buildConfigs: buildConfigs,
+    buildState: buildState,
+    buildStepPlan: buildStepPlan,
+    readerWriter: readerWriter,
+  );
 
   void Function(AssetId, AssetContent?)? _onUpdateContent;
 
@@ -84,7 +94,7 @@ class BuilderFilesystem {
 
   /// Updates [id] with [content].
   ///
-  /// It must be a source or declared output.
+  /// It must be a source, declared output or post process output.
   void updateContent({required AssetId id, required AssetContent content}) {
     if (buildState.isSource(id)) {
       updateSourceContent(id, content);
@@ -94,6 +104,16 @@ class BuilderFilesystem {
     if (step != null) {
       buildState.updateDeclaredOutputContent(
         step: step,
+        id: id,
+        content: content,
+      );
+      _onUpdateContent?.call(id, content);
+      return;
+    }
+    final postProcessStep = buildState.postProcessStepFor(id);
+    if (postProcessStep != null) {
+      buildState.updatePostProcessOutputContent(
+        step: postProcessStep,
         id: id,
         content: content,
       );
@@ -150,7 +170,9 @@ class BuilderFilesystem {
     } on AssetNotFoundException {
       await ChildProcess.exitDueToAssetDeleted(id);
     }
-    final content = AssetContent.bytes(bytes);
+    final content = maybeResult != null
+        ? maybeResult.withBytes(bytes)
+        : AssetContent.bytes(bytes);
     updateContent(id: id, content: content);
     return content;
   }
@@ -200,7 +222,9 @@ class BuilderFilesystem {
         return false;
       }
 
-      await assetBuilder(id);
+      // If a build is running: build the asset if needed.
+      await assetBuilder?.call(id);
+
       return buildState.isActualSuccessfulOutput(
         buildStepPlan: buildStepPlan,
         id: id,
@@ -209,14 +233,9 @@ class BuilderFilesystem {
     return buildState.isSource(id);
   }
 
-  /// Triggers the evaluation of the [glob] query inside the build engine.
-  Future<GlobId> evaluateGlob(String glob, String package, int phase) async {
-    final globId = GlobId(package: package, glob: glob, phaseNumber: phase);
-    await globEvaluator(globId);
-    return globId;
-  }
-
   /// Returns all readable assets matching [glob] under [package].
+  ///
+  /// Throws if a build is not running.
   Stream<AssetId> findAssets(
     Glob glob, {
     required String package,
@@ -224,8 +243,13 @@ class BuilderFilesystem {
     void Function(GlobId)? trackGlob,
   }) {
     final streamCompleter = StreamCompleter<AssetId>();
+    final globId = GlobId(
+      package: package,
+      glob: glob.pattern,
+      phaseNumber: phase,
+    );
 
-    evaluateGlob(glob.pattern, package, phase).then((globId) {
+    globEvaluator!(globId).then((_) {
       if (trackGlob != null) trackGlob(globId);
       final globResult = buildState.globResultFor(globId)!;
       streamCompleter.setSourceStream(Stream.fromIterable(globResult.results));
@@ -266,7 +290,7 @@ class BuilderFilesystem {
           buildStepPlan: buildStepPlan,
           id: id,
         )) {
-          await assetBuilder(id);
+          await assetBuilder?.call(id);
         }
         final isSuccessOutput = buildState.isActualSuccessfulOutput(
           buildStepPlan: buildStepPlan,

--- a/build_runner/lib/src/build_plan/build_configs.dart
+++ b/build_runner/lib/src/build_plan/build_configs.dart
@@ -8,6 +8,7 @@ import 'package:build/build.dart';
 import 'package:build_config/build_config.dart' hide BuildTarget;
 import 'package:built_collection/built_collection.dart';
 import 'package:glob/glob.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import '../exceptions.dart';
@@ -53,6 +54,17 @@ class BuildConfigs {
     this.buildTriggers,
     this._publicAssetsByPackage,
   );
+
+  @visibleForTesting
+  BuildConfigs.empty()
+    : buildTargets = BuiltMap(),
+      buildTargetsByPackage = BuiltListMultimap(),
+      buildConfigByPackage = BuiltMap(),
+      buildTriggers = BuildTriggers(
+        triggers: BuiltMap(),
+        warningsByPackage: BuiltMap(),
+      ),
+      _publicAssetsByPackage = BuiltMap();
 
   /// Loads [BuildConfigs] for [buildPackages].
   ///

--- a/build_runner/lib/src/commands/serve/server.dart
+++ b/build_runner/lib/src/commands/serve/server.dart
@@ -102,6 +102,7 @@ class ServeHandler {
   ) async {
     final buildResult = await _watcher.currentBuildResult;
     final reader = buildResult.buildOutputReader;
+    if (reader == null) return shelf.Response.notFound('Not Found');
     final assertPathList = (jsonDecode(await request.readAsString()) as List)
         .cast<String>();
     final results = <String, String>{};
@@ -164,7 +165,7 @@ class BuildUpdatesWebSocketHandler {
 
   Future emitUpdateMessage(BuildResult buildResult) async {
     if (buildResult.status != BuildStatus.success) return;
-    final reader = buildResult.buildOutputReader;
+    final reader = buildResult.buildOutputReader!;
     final digests = <AssetId, String>{};
     for (final assetId in buildResult.outputs) {
       final digest = await reader.digest(assetId);
@@ -251,7 +252,7 @@ window.\$dartLoader.forceLoadModule('packages/build_runner/src/commands/serve/$s
 ''';
 
 class AssetHandler {
-  final Future<BuildOutputReader> Function() _reader;
+  final Future<BuildOutputReader?> Function() _reader;
   final String _outputRootPackage;
 
   final _typeResolver = MimeTypeResolver();
@@ -279,6 +280,7 @@ class AssetHandler {
     bool fallbackToDirectoryList = false,
   }) async {
     final reader = await _reader();
+    if (reader == null) return shelf.Response.notFound('Not Found');
 
     // Use the first of [assetIds] that exists.
     AssetId? assetId;
@@ -359,6 +361,7 @@ class AssetHandler {
     final directoryPath = p.url.dirname(from.path);
     final glob = p.url.join(directoryPath, '*');
     final reader = await _reader();
+    if (reader == null) return 'Build failed.';
 
     final result = await reader
         .findAssets(Glob(glob), package: from.package)

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -7,15 +7,13 @@ import 'dart:async';
 import 'package:build/build.dart';
 import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import '../build/asset_content.dart';
 import '../build/build_state/build_state.dart';
+import '../build/builder_filesystem.dart';
 import '../build/resolver/asset_ids.dart';
-import '../build_plan/build_plan.dart';
 import '../build_plan/build_step_plan.dart';
-import 'reader_writer.dart';
 
 /// A view of the build output.
 ///
@@ -25,69 +23,45 @@ import 'reader_writer.dart';
 /// Files are only visible if they were a required part of the build, even if
 /// they exist on disk from a previous build.
 class BuildOutputReader {
-  final BuildPlan? _buildPlan;
-  final BuildStepPlan? _buildStepPlan;
-  final BuildState? _buildState;
-  final ReaderWriter? _readerWriter;
+  final BuilderFilesystem _builderFilesystem;
+
+  BuildState get _buildState => _builderFilesystem.buildState;
+  BuildStepPlan get _buildStepPlan => _builderFilesystem.buildStepPlan;
 
   late final Set<AssetId> _assetsDeletedByPostProcessBuilders =
       _collectAssetsDeletedByPostProcessBuilders();
 
-  /// For an unexpected failure condition, a fully empty output.
-  BuildOutputReader.empty()
-    : _buildState = null,
-      _buildPlan = null,
-      _buildStepPlan = null,
-      _readerWriter = null;
-
-  /// For testing: a build output that does not check build phases to determine
-  /// whether outputs were required.
-  @visibleForTesting
-  BuildOutputReader.buildStateOnly({
-    required ReaderWriter readerWriter,
-    required BuildState buildState,
-    BuildStepPlan? buildStepPlan,
-  }) : _buildPlan = null,
-       _buildState = buildState,
-       _buildStepPlan = buildStepPlan,
-       _readerWriter = readerWriter;
-
   /// Creates from build results.
-  BuildOutputReader({
-    required BuildPlan buildPlan,
-    required BuildState buildState,
-  }) : _readerWriter = buildPlan.readerWriter,
-       _buildState = buildState,
-       _buildPlan = buildPlan,
-       _buildStepPlan = buildPlan.buildStepPlan;
+  BuildOutputReader({required BuilderFilesystem builderFilesystem})
+    : _builderFilesystem = builderFilesystem;
 
   Set<AssetId> _collectAssetsDeletedByPostProcessBuilders() =>
-      _buildState?.assetsDeletedByPostProcess ?? const {};
+      _buildState.assetsDeletedByPostProcess;
 
-  String pathFor(AssetId id) => _readerWriter!.assetPathProvider.pathFor(
-    id,
-    hide: id.isHidden(buildStepPlan: _buildStepPlan, buildState: _buildState),
-  );
+  String pathFor(AssetId id) {
+    return _builderFilesystem.readerWriter.assetPathProvider.pathFor(
+      id,
+      hide: id.isHidden(buildStepPlan: _buildStepPlan, buildState: _buildState),
+    );
+  }
 
   /// Returns a reason why [id] is not readable, or null if it is readable.
   Future<UnreadableReason?> unreadableReason(AssetId id) async {
-    if (_buildState == null || _readerWriter == null) {
-      return UnreadableReason.notFound;
-    }
+    final buildState = _buildState;
+    final builderFilesystem = _builderFilesystem;
     if (!_isFile(id)) {
       return UnreadableReason.notFound;
     }
     if (_assetsDeletedByPostProcessBuilders.contains(id)) {
       return UnreadableReason.deleted;
     }
-    if (!_isFile(id)) return UnreadableReason.assetType;
 
-    if (_buildState.isActualPostOutput(id)) {
+    if (buildState.isActualPostOutput(id)) {
       return null;
     }
-    final step = _buildStepPlan?.stepForDeclaredOutputOrNull(id);
+    final step = _buildStepPlan.stepForDeclaredOutputOrNull(id);
     if (step != null) {
-      if (!_buildState.isProcessedOutput(
+      if (!buildState.isProcessedOutput(
         buildStepPlan: _buildStepPlan,
         id: id,
       )) {
@@ -95,11 +69,11 @@ class BuildOutputReader {
         // transitive input(s) did not match build dirs and/or build filters.
         return UnreadableReason.notOutput;
       }
-      final stepResult = _buildState.stepResult(step);
+      final stepResult = buildState.stepResult(step);
       if (stepResult.failed) {
         return UnreadableReason.failed;
       }
-      if (!_buildState.isActualOutput(buildStepPlan: _buildStepPlan!, id: id)) {
+      if (!buildState.isActualOutput(buildStepPlan: _buildStepPlan, id: id)) {
         return UnreadableReason.notOutput;
       }
 
@@ -108,17 +82,17 @@ class BuildOutputReader {
       return null;
     }
 
-    if (_buildState.isSource(id) &&
-        await _readerWriter.canRead(
+    if (buildState.isSource(id) &&
+        await builderFilesystem.readerWriter.canRead(
           id,
           hidden: id.isHidden(
             buildStepPlan: _buildStepPlan,
-            buildState: _buildState,
+            buildState: buildState,
           ),
         )) {
       return null;
     }
-    return UnreadableReason.unknown;
+    return UnreadableReason.notFound;
   }
 
   Future<bool> canRead(AssetId id) async =>
@@ -137,25 +111,35 @@ class BuildOutputReader {
     return _ensureDigest(id);
   }
 
-  Future<List<int>> readAsBytes(AssetId id) => _readerWriter!.readAsBytes(
-    id,
-    hidden: id.isHidden(buildStepPlan: _buildStepPlan, buildState: _buildState),
-  );
+  Future<List<int>> readAsBytes(AssetId id) async {
+    try {
+      final content = await _builderFilesystem.contentOf(id);
+      return content.bytes;
+      // ignore: avoid_catching_errors
+    } on StateError {
+      // BuilderFilesystem throws StateError if !isFile(id).
+      throw AssetNotFoundException(id);
+    }
+  }
+
+  Future<String> readAsString(AssetId id) async {
+    try {
+      final content = await _builderFilesystem.contentOf(id);
+      return content.stringValue();
+      // ignore: avoid_catching_errors
+    } on StateError {
+      // BuilderFilesystem throws StateError if !isFile(id).
+      throw AssetNotFoundException(id);
+    }
+  }
 
   Stream<AssetId> findAssets(Glob glob, {required String package}) async* {
-    if (_buildState == null || _readerWriter == null) return;
     for (final id in _buildState.findFiles(
       package: package,
       buildStepPlan: _buildStepPlan,
       glob: glob,
     )) {
-      if (await _readerWriter.canRead(
-        id,
-        hidden: id.isHidden(
-          buildStepPlan: _buildStepPlan,
-          buildState: _buildState,
-        ),
-      )) {
+      if (await canRead(id)) {
         yield id;
       }
     }
@@ -165,41 +149,27 @@ class BuildOutputReader {
   /// necessary.
   ///
   /// Note that [id] must exist in the asset graph.
-  FutureOr<Digest> _ensureDigest(AssetId id) {
-    final content = _buildState!.contentOf(
+  FutureOr<Digest> _ensureDigest(AssetId id) async {
+    final content = _buildState.contentOf(
       buildStepPlan: _buildStepPlan,
       id: id,
     );
     if (content != null) return content.digest;
-    return _readerWriter!
-        .readAsBytes(
-          id,
-          hidden: id.isHidden(
-            buildStepPlan: _buildStepPlan,
-            buildState: _buildState,
-          ),
-        )
-        .then((bytes) {
-          final content = AssetContent.bytes(bytes);
-          _buildState.updateSourceContent(id, content);
-          return content.digest;
-        });
+    final bytes = await readAsBytes(id);
+    return AssetContent.bytes(bytes).digest;
   }
 
   /// A lazily computed view of all the assets available after a build.
   List<AssetId> allAssets({String? rootDir}) {
-    if (_buildState == null) return [];
     final result = <AssetId>[];
     for (final id in _buildState.sources) {
       if (!_shouldSkipId(id, rootDir)) {
         result.add(id);
       }
     }
-    if (_buildStepPlan != null) {
-      for (final id in _buildStepPlan.declaredOutputs) {
-        if (!_shouldSkipId(id, rootDir)) {
-          result.add(id);
-        }
+    for (final id in _buildStepPlan.declaredOutputs) {
+      if (!_shouldSkipId(id, rootDir)) {
+        result.add(id);
       }
     }
     result.addAll(_buildState.actualPostOutputs);
@@ -207,7 +177,6 @@ class BuildOutputReader {
   }
 
   bool _shouldSkipId(AssetId id, String? rootDir) {
-    if (_buildPlan == null) return false;
     if (!_isFile(id)) return true;
     if (_assetsDeletedByPostProcessBuilders.contains(id)) return true;
 
@@ -215,17 +184,17 @@ class BuildOutputReader {
     // an output package of the build.
     if (!id.path.startsWith('lib/')) {
       if (rootDir != null && !p.isWithin(rootDir, id.path)) return true;
-      if (!_buildPlan.buildSpec.buildPackages.outputPackages.contains(
+      if (!_builderFilesystem.buildPackages.outputPackages.contains(
         id.package,
       )) {
         return true;
       }
     }
 
-    if (_buildState!.isActualPostOutput(id)) {
+    if (_buildState.isActualPostOutput(id)) {
       return false;
     }
-    final step = _buildStepPlan?.stepForDeclaredOutputOrNull(id);
+    final step = _buildStepPlan.stepForDeclaredOutputOrNull(id);
     if (step != null) {
       final stepResult = _buildState.stepResultOrNull(step);
       if (stepResult == null ||
@@ -244,14 +213,7 @@ class BuildOutputReader {
   }
 
   bool _isFile(AssetId id) =>
-      _buildState!.isFile(buildStepPlan: _buildStepPlan, id: id);
+      _buildState.isFile(buildStepPlan: _buildStepPlan, id: id);
 }
 
-enum UnreadableReason {
-  notFound,
-  notOutput,
-  assetType,
-  deleted,
-  failed,
-  unknown,
-}
+enum UnreadableReason { notFound, notOutput, deleted, failed }

--- a/build_runner/lib/src/io/create_merged_dir.dart
+++ b/build_runner/lib/src/io/create_merged_dir.dart
@@ -16,8 +16,6 @@ import '../build_plan/build_packages.dart';
 import '../logging/build_log.dart';
 import '../logging/timed_activities.dart';
 import 'build_output_reader.dart';
-import 'filesystem.dart';
-import 'reader_writer.dart';
 
 /// Pool for async file operations, we don't want to use too many file handles.
 final _descriptorPool = Pool(32);
@@ -33,16 +31,8 @@ Future<bool> createMergedOutputDirectories({
   required BuildPackages buildPackages,
   required bool outputSymlinksOnly,
   required BuildOutputReader buildOutputReader,
-  required ReaderWriter readerWriter,
 }) async {
   return await TimedActivity.write.runAsync(() async {
-    if (outputSymlinksOnly && readerWriter.filesystem is! IoFilesystem) {
-      buildLog.error(
-        'The current environment does not support symlinks, but symlinks were '
-        'requested.',
-      );
-      return false;
-    }
     final conflictingOutputs = _conflicts(buildDirs);
     if (conflictingOutputs.isNotEmpty) {
       buildLog.error(
@@ -63,7 +53,6 @@ Future<bool> createMergedOutputDirectories({
           // TODO(grouma) - retrieve symlink information from target only.
           symlinkOnly: outputSymlinksOnly || outputLocation.useSymlinks,
           hoist: outputLocation.hoist,
-          readerWriter: readerWriter,
         )) {
           return false;
         }
@@ -90,7 +79,6 @@ Future<bool> _createMergedOutputDir({
   required bool symlinkOnly,
   required bool hoist,
   required BuildOutputReader buildOutputReader,
-  required ReaderWriter readerWriter,
 }) async {
   try {
     final outputRootPackage = buildPackages[buildPackages.outputRoot]!;
@@ -252,8 +240,6 @@ Future<String> _writeAsset(
 
     try {
       if (symlinkOnly) {
-        // We assert at the top of `createMergedOutputDirectories` that the
-        // reader filesystem is `IoFilesystem`, so symlinks make sense.
         await Link(
           _filePathFor(outputDir, assetPath),
         ).create(buildOutputReader.pathFor(id), recursive: true);

--- a/build_runner/test/commands/serve/asset_handler_test.dart
+++ b/build_runner/test/commands/serve/asset_handler_test.dart
@@ -11,6 +11,10 @@ import 'package:build_runner/src/build/build_state/build_step_id.dart';
 import 'package:build_runner/src/build/build_state/build_step_result.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_id.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_result.dart';
+import 'package:build_runner/src/build/builder_filesystem.dart';
+import 'package:build_runner/src/build_plan/build_configs.dart';
+import 'package:build_runner/src/build_plan/build_package.dart';
+import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
 import 'package:build_runner/src/build_plan/build_step_plan.dart';
 import 'package:build_runner/src/build_plan/phase.dart';
@@ -27,6 +31,7 @@ void main() {
   late InternalTestReaderWriter readerWriter;
   late BuildState buildState;
   late BuildStepPlan buildStepPlan;
+  late BuildPackages buildPackages;
 
   setUp(() async {
     buildState = BuildState();
@@ -35,10 +40,17 @@ void main() {
       (BuildStepPlanBuilder b) =>
           b..buildPhases = BuildPhases(const <InBuildPhase>[]),
     );
-    reader = BuildOutputReader.buildStateOnly(
-      readerWriter: readerWriter,
-      buildState: buildState,
-      buildStepPlan: buildStepPlan,
+    buildPackages = BuildPackages.singlePackageBuild('a', [
+      BuildPackage.forTesting(name: 'a', isOutput: true),
+    ]);
+    reader = BuildOutputReader(
+      builderFilesystem: BuilderFilesystem(
+        buildPackages: buildPackages,
+        buildConfigs: BuildConfigs.empty(),
+        buildState: buildState,
+        buildStepPlan: buildStepPlan,
+        readerWriter: readerWriter,
+      ),
     );
     handler = AssetHandler(() async => reader, 'a');
   });
@@ -139,10 +151,14 @@ void main() {
       b.buildPhases = BuildPhases(const <InBuildPhase>[]);
       b.buildStepsByDeclaredOutput.addAll({outputId: buildStepId});
     });
-    reader = BuildOutputReader.buildStateOnly(
-      readerWriter: readerWriter,
-      buildState: buildState,
-      buildStepPlan: buildStepPlan,
+    reader = BuildOutputReader(
+      builderFilesystem: BuilderFilesystem(
+        buildPackages: buildPackages,
+        buildConfigs: BuildConfigs.empty(),
+        buildState: buildState,
+        buildStepPlan: buildStepPlan,
+        readerWriter: readerWriter,
+      ),
     );
     handler = AssetHandler(() async => reader, 'a');
     final stepResult = BuildStepResult((b) {

--- a/build_runner/test/commands/serve/serve_handler_test.dart
+++ b/build_runner/test/commands/serve/serve_handler_test.dart
@@ -15,6 +15,8 @@ import 'package:build_runner/src/build/build_state/build_step_id.dart';
 import 'package:build_runner/src/build/build_state/build_step_result.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_id.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_result.dart';
+import 'package:build_runner/src/build/builder_filesystem.dart';
+import 'package:build_runner/src/build_plan/build_configs.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_phases.dart';
@@ -129,10 +131,14 @@ void main() {
       (BuildStepPlanBuilder b) =>
           b..buildPhases = BuildPhases(const <InBuildPhase>[]),
     );
-    finalizedReader = BuildOutputReader.buildStateOnly(
-      readerWriter: readerWriter,
-      buildState: buildState,
-      buildStepPlan: buildStepPlan,
+    finalizedReader = BuildOutputReader(
+      builderFilesystem: BuilderFilesystem(
+        buildPackages: buildPackages,
+        buildConfigs: BuildConfigs.empty(),
+        buildState: buildState,
+        buildStepPlan: buildStepPlan,
+        readerWriter: readerWriter,
+      ),
     );
     watcher.addFutureResult(
       Future.value(
@@ -269,10 +275,14 @@ void main() {
         b.buildStepsByDeclaredOutput.addAll({outputId: buildStepId});
       });
 
-      finalizedReader = BuildOutputReader.buildStateOnly(
-        readerWriter: readerWriter,
-        buildState: buildState,
-        buildStepPlan: buildStepPlan,
+      finalizedReader = BuildOutputReader(
+        builderFilesystem: BuilderFilesystem(
+          buildPackages: buildPackages,
+          buildConfigs: BuildConfigs.empty(),
+          buildState: buildState,
+          buildStepPlan: buildStepPlan,
+          readerWriter: readerWriter,
+        ),
       );
 
       final stepResult = BuildStepResult((b) {

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -12,6 +12,7 @@ import 'package:build_runner/src/build/build_state/build_step_id.dart';
 import 'package:build_runner/src/build/build_state/build_step_result.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_id.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_result.dart';
+import 'package:build_runner/src/build/builder_filesystem.dart';
 import 'package:build_runner/src/build_plan/build_directory.dart';
 import 'package:build_runner/src/build_plan/build_filter.dart';
 import 'package:build_runner/src/build_plan/build_options.dart';
@@ -80,7 +81,15 @@ void main() {
           ),
         ),
       );
-      reader = BuildOutputReader(buildPlan: buildPlan, buildState: buildState);
+      reader = BuildOutputReader(
+        builderFilesystem: BuilderFilesystem(
+          buildPackages: buildPlan.buildSpec.buildPackages,
+          buildConfigs: buildPlan.buildSpec.buildConfigs,
+          buildState: buildState,
+          buildStepPlan: buildPlan.buildStepPlan,
+          readerWriter: buildPlan.readerWriter,
+        ),
+      );
       expect(await reader.canRead(notDeletedId), true);
       expect(await reader.canRead(deletedId), false);
     });
@@ -123,7 +132,15 @@ void main() {
           ),
         ),
       );
-      reader = BuildOutputReader(buildPlan: buildPlan, buildState: buildState);
+      reader = BuildOutputReader(
+        builderFilesystem: BuilderFilesystem(
+          buildPackages: buildPlan.buildSpec.buildPackages,
+          buildConfigs: buildPlan.buildSpec.buildConfigs,
+          buildState: buildState,
+          buildStepPlan: buildPlan.buildStepPlan,
+          readerWriter: buildPlan.readerWriter,
+        ),
+      );
       expect(
         await reader.unreadableReason(id),
         UnreadableReason.failed,
@@ -149,7 +166,15 @@ void main() {
       // result is not added to the buildState.
       buildState = BuildState();
 
-      reader = BuildOutputReader(buildPlan: buildPlan, buildState: buildState);
+      reader = BuildOutputReader(
+        builderFilesystem: BuilderFilesystem(
+          buildPackages: buildPlan.buildSpec.buildPackages,
+          buildConfigs: buildPlan.buildSpec.buildConfigs,
+          buildState: buildState,
+          buildStepPlan: buildPlan.buildStepPlan,
+          readerWriter: buildPlan.readerWriter,
+        ),
+      );
 
       expect(
         await reader.unreadableReason(id),

--- a/build_runner/test/io/create_merged_dir_test.dart
+++ b/build_runner/test/io/create_merged_dir_test.dart
@@ -11,6 +11,7 @@ import 'package:build_runner/src/build/build_state/build_state.dart';
 import 'package:build_runner/src/build/build_state/build_step_result.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_id.dart';
 import 'package:build_runner/src/build/build_state/post_process_build_step_result.dart';
+import 'package:build_runner/src/build/builder_filesystem.dart';
 import 'package:build_runner/src/build/resolver/asset_ids.dart';
 import 'package:build_runner/src/build_plan/build_configs.dart';
 import 'package:build_runner/src/build_plan/build_directory.dart';
@@ -111,8 +112,13 @@ void main() {
       );
       buildState = BuildState(buildPlan.buildInputs.sourceContents.toMap());
       buildOutputReader = BuildOutputReader(
-        buildPlan: buildPlan,
-        buildState: buildState,
+        builderFilesystem: BuilderFilesystem(
+          buildPackages: buildPlan.buildSpec.buildPackages,
+          buildConfigs: buildPlan.buildSpec.buildConfigs,
+          buildState: buildState,
+          buildStepPlan: buildPlan.buildStepPlan,
+          readerWriter: buildPlan.readerWriter,
+        ),
       );
 
       for (final id in [
@@ -153,7 +159,6 @@ void main() {
           BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -174,7 +179,6 @@ void main() {
           BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -201,7 +205,6 @@ void main() {
           ),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -218,7 +221,6 @@ void main() {
           BuildDirectory('foo', outputLocation: OutputLocation(tmpDir.path)),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -230,7 +232,6 @@ void main() {
       final success = await createMergedOutputDirectories(
         buildDirs: {BuildDirectory('web'), BuildDirectory('foo')}.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -243,7 +244,6 @@ void main() {
           BuildDirectory('web', outputLocation: OutputLocation(tmpDir.path)),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -263,7 +263,6 @@ void main() {
           ),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -277,7 +276,6 @@ void main() {
           BuildDirectory('web', outputLocation: OutputLocation(tmpDir.path)),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -296,7 +294,6 @@ void main() {
           ),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -323,7 +320,6 @@ void main() {
           BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -341,7 +337,6 @@ void main() {
           ),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -376,7 +371,6 @@ void main() {
           BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
@@ -388,28 +382,29 @@ void main() {
 
     test('doesnt always write files not matching outputDirs', () async {
       buildOutputReader = BuildOutputReader(
-        buildPlan: buildPlan.rebuild(
-          (b) => b.buildDirs.replace({BuildDirectory('foo')}),
+        builderFilesystem: BuilderFilesystem(
+          buildPackages: buildPlan.buildSpec.buildPackages,
+          buildConfigs: buildPlan.buildSpec.buildConfigs,
+          buildState: buildState,
+          buildStepPlan: buildPlan.buildStepPlan,
+          readerWriter: buildPlan.readerWriter,
         ),
-        buildState: buildState,
       );
       final success = await createMergedOutputDirectories(
         buildDirs: {
-          BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
+          BuildDirectory('foo', outputLocation: OutputLocation(tmpDir.path)),
         }.build(),
         buildPackages: buildPackages,
-        readerWriter: readerWriter,
         buildOutputReader: buildOutputReader,
         outputSymlinksOnly: false,
       );
       expect(success, isTrue);
 
       final expectedFiles = <String, dynamic>{
-        'foo/d.txt': 'd',
-        'foo/d.txt.copy': 'd',
+        'd.txt': 'd',
+        'd.txt.copy': 'd',
         'packages/a/a.txt': 'a',
         'packages/b/c.txt': 'c',
-        'web/b.txt': 'b',
         '.dart_tool/package_config.json': _expectedPackageConfig('a', [
           'a',
           'b',
@@ -432,7 +427,6 @@ void main() {
             BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
           }.build(),
           buildPackages: buildPackages,
-          readerWriter: readerWriter,
           buildOutputReader: buildOutputReader,
           outputSymlinksOnly: false,
         );
@@ -458,7 +452,6 @@ void main() {
             BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
           }.build(),
           buildPackages: buildPackages,
-          readerWriter: readerWriter,
           buildOutputReader: buildOutputReader,
           outputSymlinksOnly: false,
         );
@@ -473,15 +466,19 @@ void main() {
         }
         // Recreate buildOutputReader so it notices the delete.
         buildOutputReader = BuildOutputReader(
-          buildPlan: buildPlan,
-          buildState: buildState,
+          builderFilesystem: BuilderFilesystem(
+            buildPackages: buildPlan.buildSpec.buildPackages,
+            buildConfigs: buildPlan.buildSpec.buildConfigs,
+            buildState: buildState,
+            buildStepPlan: buildPlan.buildStepPlan,
+            readerWriter: buildPlan.readerWriter,
+          ),
         );
         success = await createMergedOutputDirectories(
           buildDirs: {
             BuildDirectory('', outputLocation: OutputLocation(tmpDir.path)),
           }.build(),
           buildPackages: buildPackages,
-          readerWriter: readerWriter,
           buildOutputReader: buildOutputReader,
           outputSymlinksOnly: false,
         );


### PR DESCRIPTION
`BuildOutputReader` and `createMergedOutputDirectories` were not updated since `ReaderWriter` stopped doing caching, so they now go the real filesystem more than they used to.

Refactor to use `BuilderFilesystem`.

When reading post process outputs that were reused from a previous build, store the content into `BuildState`, so the filesystem is only consulted once.

In `BuildResult` use a null `BuildOutputReader` to mean "failed with no output", so we don't have to allow a `BuildOutputReader` with null fields.

Trim the `UnreadableReason` enum to entries that need to be distinct.

Remove obsolete check for IoFilesystem for symlinks in `create_merged_dir.dart`.