### PR TITLE
Fix trigger evaluation reading ungenerated parts.

### DIFF
--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -433,6 +433,7 @@ class Build {
     final allowedByTriggers = await _allowedByTriggers(
       inputTracker: step.inputTracker,
       phase: phase,
+      phaseNum: buildStepId.phaseNumber,
       primaryInput: buildStepId.primaryInput,
     );
     final logger = buildLog.loggerFor(
@@ -489,6 +490,7 @@ class Build {
   Future<bool> _allowedByTriggers({
     required InputTracker inputTracker,
     required InBuildPhase phase,
+    required int phaseNum,
     required AssetId primaryInput,
   }) async {
     final runsIfTriggered = phase.options.config['run_only_if_triggered'];
@@ -512,6 +514,7 @@ class Build {
           inputTracker,
           primaryInput,
           compilationUnit,
+          phaseNum,
         );
         if (trigger.triggersOn(compilationUnits)) return true;
       } else {
@@ -531,6 +534,7 @@ class Build {
     InputTracker inputTracker,
     AssetId id,
     CompilationUnit compilationUnit,
+    int phaseNum,
   ) async {
     final result = [compilationUnit];
     for (final directive in compilationUnit.directives) {
@@ -539,7 +543,15 @@ class Build {
         Uri.parse(directive.uri.stringValue!),
         from: id,
       );
-      if (!_builderFilesystem.isFile(partId)) continue;
+      // Check that the part is readable, including generating it if it's
+      // an output from an earlier phase.
+      if (!await _builderFilesystem.isReadable(
+        partId,
+        phaseNum,
+        catchInvalidInputs: true,
+      )) {
+        continue;
+      }
       inputTracker.add(partId);
       result.add(
         _parseCompilationUnit(

--- a/build_runner/test/integration_tests/build_command_triggers_test.dart
+++ b/build_runner/test/integration_tests/build_command_triggers_test.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['integration4'])
+library;
+
+import 'package:build_runner/src/logging/build_log.dart';
+import 'package:test/test.dart';
+
+import '../common/common.dart';
+
+void main() {
+  test('build command triggers', () async {
+    final tester = BuildRunnerTester(await Pubspecs.load());
+
+    tester.writePackage(
+      name: 'pkg',
+      dependencies: ['build', 'build_runner'],
+      files: {
+        'build.yaml': '''
+builders:
+  early_triggered_builder:
+    import: 'package:pkg/builder.dart'
+    builder_factories: ['earlyBuilderFactory']
+    build_extensions: {'.dart': ['.early.txt']}
+    auto_apply: 'root_package'
+    build_to: 'cache'
+    runs_before: ['pkg:part_builder']
+  part_builder:
+    import: 'package:pkg/builder.dart'
+    builder_factories: ['writeTriggeringPartBuilderFactory']
+    build_extensions: {'.dart': ['.g.dart']}
+    auto_apply: 'root_package'
+    build_to: 'cache'
+    runs_before: ['pkg:late_triggered_builder']
+  late_triggered_builder:
+    import: 'package:pkg/builder.dart'
+    builder_factories: ['lateBuilderFactory']
+    build_extensions: {'.dart': ['.late.txt']}
+    auto_apply: 'root_package'
+    build_to: 'cache'
+
+targets:
+  \$default:
+    builders:
+      pkg:early_triggered_builder:
+        options: {run_only_if_triggered: true}
+      pkg:late_triggered_builder:
+        options: {run_only_if_triggered: true}
+
+triggers:
+  pkg:early_triggered_builder:
+    - annotation someAnnotation
+  pkg:late_triggered_builder:
+    - annotation someAnnotation
+''',
+        'lib/builder.dart': '''
+import 'package:build/build.dart';
+
+Builder earlyBuilderFactory(_) => WriteIfTriggeredBuilder('.early.txt');
+Builder writeTriggeringPartBuilderFactory(_) => WriteTriggeringPartBuilder();
+Builder lateBuilderFactory(_) => WriteIfTriggeredBuilder('.late.txt');
+
+class WriteTriggeringPartBuilder implements Builder {
+  @override Map<String, List<String>> get buildExtensions
+      => {'.dart': ['.g.dart']};
+  @override Future<void> build(BuildStep b) async {
+    await b.writeAsString(
+      b.inputId.changeExtension('.g.dart'),
+      "part of 'a.dart';\\n@someAnnotation\\nclass B {}");
+  }
+}
+
+class WriteIfTriggeredBuilder implements Builder {
+  final String extension;
+  WriteIfTriggeredBuilder(this.extension);
+  @override Map<String, List<String>> get buildExtensions =>
+      {'.dart': [extension]};
+  @override Future<void> build(BuildStep b) async {
+    await b.writeAsString(b.inputId.changeExtension(extension), 'triggered');
+  }
+}
+''',
+        'lib/a.dart': '''
+part 'a.g.dart';
+class A {}
+const someAnnotation = null;
+''',
+      },
+    );
+
+    final output = await tester.run('pkg', 'dart run build_runner build');
+    expect(output, contains(BuildLog.successPattern));
+
+    // early_triggered_builder didn't fire, the part with the trigger in it
+    // was not generated yet.
+    expect(
+      tester.read('pkg/.dart_tool/build/generated/pkg/lib/a.early.txt'),
+      isNull,
+    );
+    // late_triggered_builder did fire due to the generated part.
+    expect(
+      tester.read('pkg/.dart_tool/build/generated/pkg/lib/a.late.txt'),
+      contains('triggered'),
+    );
+  });
+}


### PR DESCRIPTION
Fix a recently-introduced bug whereby checking triggers would try to parse ungenerated part files and crash due to them not being available yet.

Add test coverage beyond checking that it doesn't crash: also check that triggers fire based on what should be readable when the builder runs.