### PR TITLE
Set flattenBuild in passed ReaderWriter.

### DIFF
--- a/build_test/lib/src/internal_test_reader_writer.dart
+++ b/build_test/lib/src/internal_test_reader_writer.dart
@@ -68,6 +68,19 @@ class InternalTestReaderWriter extends ReaderWriter
     InputTracker.captureInputTrackersForTesting = true;
   }
 
+  InternalTestReaderWriter copyWith({bool? forceVisibleForTesting}) =>
+      InternalTestReaderWriter.using(
+        assetsRead: assetsRead,
+        assetsWritten: assetsWritten,
+        assetFinder: assetFinder,
+        assetPathProvider: assetPathProvider,
+        buildCachePackage: buildCachePackage,
+        filesystem: filesystem,
+        onCanReadController: onCanReadController,
+        forceVisibleForTesting:
+            forceVisibleForTesting ?? this.forceVisibleForTesting,
+      );
+
   @override
   ReaderWriterTesting get testing => _ReaderWriterTestingImpl(this);
 

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -353,10 +353,18 @@ Future<TestBuilderResult> testBuilderFactories(
   }
   rootPackage ??= allPackages.first;
 
-  readerWriter ??= TestReaderWriter(
-    rootPackage: rootPackage,
-    flattenOutput: flattenOutput,
-  );
+  var internalReaderWriter = readerWriter as InternalTestReaderWriter?;
+  if (internalReaderWriter == null) {
+    internalReaderWriter = InternalTestReaderWriter(
+      outputRootPackage: rootPackage,
+      forceVisibleForTesting: flattenOutput,
+    );
+  } else {
+    internalReaderWriter = internalReaderWriter.copyWith(
+      forceVisibleForTesting: flattenOutput,
+    );
+  }
+  readerWriter = internalReaderWriter;
 
   sourceAssets.forEach((serializedId, contents) {
     final id = makeAssetId(serializedId);
@@ -448,7 +456,7 @@ Future<TestBuilderResult> testBuilderFactories(
   final testingOverrides = TestingOverrides(
     builderDefinitions: builderDefinitions.build(),
     buildPackages: buildPackages,
-    readerWriter: readerWriter as InternalTestReaderWriter,
+    readerWriter: readerWriter,
     resolvers: resolvers,
     checkBuilderFreshness: false,
     buildConfig:

--- a/build_test/test/test_builder_test.dart
+++ b/build_test/test/test_builder_test.dart
@@ -517,6 +517,24 @@ import 'package:glob/glob.dart';
       contains(AssetId('a', 'a.txt.copy')),
     );
   });
+
+  test(
+    'output is flattened with `flattenOutput` and passed `readerWriter`',
+    () async {
+      final readerWriter = TestReaderWriter(rootPackage: 'a');
+      final result = await testBuilder(
+        TestBuilder(),
+        {'a|a.txt': ''},
+        outputs: {'a|a.txt.copy': ''},
+        flattenOutput: true,
+        readerWriter: readerWriter,
+      );
+      expect(
+        result.readerWriter.testing.assets,
+        contains(AssetId('a', 'a.txt.copy')),
+      );
+    },
+  );
 }
 
 /// Concatenates the contents of multiple text files into a single output.


### PR DESCRIPTION
Another one needed for google3: behavior changed recently so that passing in a `TestReaderWriter` caused `flattenBuild` to be ignored, restore the old behavior.