### PR TITLE
Fix workspace vs package build config conflict

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Bug fix: fix crash if a resolved Dart source contains invalid utf8.
 - Bug fix: fix incorrect output when builder code changes during builder
   compile.
+- Bug fix: do a clean build when switching between a workspace build and a
+  package build, as incremental builds were sometimes incorrect.
 - Require Dart 3.8.0.
 
 ## 2.15.0

--- a/build_runner/lib/src/bootstrap/high_resolution_mtime.dart
+++ b/build_runner/lib/src/bootstrap/high_resolution_mtime.dart
@@ -120,7 +120,7 @@ class HighResolutionMtime {
     return mtime;
   }
 
-  static NanosecondsSinceEpoch _getHighResMtimeWithFallback(String filePath) {
+  static NanosecondsSinceEpoch getHighResMtimeWithFallback(String filePath) {
     return getHighResMtimeOrNull(filePath) ??
         File(filePath).lastModifiedSync().nanosecondsSinceEpoch;
   }
@@ -131,7 +131,7 @@ class HighResolutionMtime {
   /// This ensures that any subsequent file modifications will receive a
   /// strictly greater modification time.
   static Future<void> waitForNewMtime(String path) async {
-    final stampTime = _getHighResMtimeWithFallback(path);
+    final stampTime = getHighResMtimeWithFallback(path);
     final tempFile = File('$path.tmp');
     var delayMs = 1;
     try {
@@ -140,7 +140,7 @@ class HighResolutionMtime {
       // slow success.
       while (true) {
         tempFile.writeAsBytesSync(const []);
-        if (_getHighResMtimeWithFallback(tempFile.path) > stampTime) {
+        if (getHighResMtimeWithFallback(tempFile.path) > stampTime) {
           break;
         }
         await Future<void>.delayed(Duration(milliseconds: delayMs));

--- a/build_runner/lib/src/build_plan/build_packages.dart
+++ b/build_runner/lib/src/build_plan/build_packages.dart
@@ -68,6 +68,10 @@ class BuildPackages implements AssetPathProvider {
   /// A [PackageConfig] representation of this `BuildPackages`.
   final PackageConfig asPackageConfig;
 
+  /// Whether an alternate root's asset graph is newer than ours, which means
+  /// that the current build `asset_graph.json` is stale.
+  final bool hasNewerAlternateRootBuild;
+
   /// Transitive dependencies by package name.
   final BuiltSetMultimap<String, String> _transitiveDependencies;
 
@@ -84,6 +88,7 @@ class BuildPackages implements AssetPathProvider {
     required this.asPackageConfig,
     required BuiltSetMultimap<String, String> transitiveDependencies,
     required BuiltSetMultimap<String, String> buildPackages,
+    this.hasNewerAlternateRootBuild = false,
   }) : _transitiveDependencies = transitiveDependencies,
        _peerPackages = buildPackages;
 
@@ -91,6 +96,7 @@ class BuildPackages implements AssetPathProvider {
     required String currentPackage,
     String? singlePackageToBuild,
     required String outputRoot,
+    bool hasNewerAlternateRootBuild = false,
     required BuiltMap<String, BuildPackage> packages,
   }) {
     for (final package in packages.values) {
@@ -138,6 +144,7 @@ class BuildPackages implements AssetPathProvider {
       asPackageConfig: asPackageConfig,
       transitiveDependencies: transitiveDependencies,
       buildPackages: buildPackages,
+      hasNewerAlternateRootBuild: hasNewerAlternateRootBuild,
     );
   }
 

--- a/build_runner/lib/src/build_plan/build_packages_loader.dart
+++ b/build_runner/lib/src/build_plan/build_packages_loader.dart
@@ -10,6 +10,8 @@ import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
+import '../bootstrap/high_resolution_mtime.dart';
+import '../constants.dart';
 import 'build_package.dart';
 import 'build_packages.dart';
 import 'build_paths.dart';
@@ -45,15 +47,18 @@ class BuildPackagesLoader {
 
     String? workspaceName;
     List<String>? workspacePackages;
-    if (buildType != BuildType.singlePackage) {
+    if (workspacePath != null) {
       final workspacePubspec = Pubspecs.load(
-        p.join(workspacePath!, 'pubspec.yaml'),
+        p.join(workspacePath, 'pubspec.yaml'),
       );
       workspaceName = workspacePubspec['name']! as String;
-      final workspacePackageGraph = _buildPackagesForPath(workspacePath);
-      workspacePackages = List.from(
-        workspacePackageGraph['roots'] as List<Object?>,
-      );
+
+      if (buildType != BuildType.singlePackage) {
+        final workspacePackageGraph = _buildPackagesForPath(workspacePath);
+        workspacePackages = List.from(
+          workspacePackageGraph['roots'] as List<Object?>,
+        );
+      }
     }
 
     final currentPackagePubspec = Pubspecs.load(
@@ -101,12 +106,61 @@ class BuildPackagesLoader {
       );
     }
 
+    final hasNewerAlternateRootBuild = _hasNewerAlternateRootBuild(
+      buildType: buildType,
+      workspaceName: workspaceName,
+      outputRootName: outputRootName,
+      packagesInBuild: packagesInBuild,
+      buildPackages: buildPackages,
+    );
+
     return BuildPackages.compute(
       currentPackage: currentPackage,
       singlePackageToBuild: singlePackageToBuild,
       outputRoot: outputRootName,
+      hasNewerAlternateRootBuild: hasNewerAlternateRootBuild,
       packages: buildPackages.build(),
     );
+  }
+
+  /// Determines whether there is a more recent build using a different root
+  /// that makes the current build's `asset_graph.json` stale.
+  static bool _hasNewerAlternateRootBuild({
+    required BuildType buildType,
+    required String? workspaceName,
+    required String outputRootName,
+    required Set<String> packagesInBuild,
+    required MapBuilder<String, BuildPackage> buildPackages,
+  }) {
+    if (workspaceName == null) return false;
+
+    final alternateRoots = buildType == BuildType.workspace
+        ? packagesInBuild.where((p) => p != workspaceName)
+        : [workspaceName];
+    if (alternateRoots.isEmpty) return false;
+
+    final currentAssetGraphFile = File(
+      p.join(buildPackages[outputRootName]!.path, assetGraphJsonPath),
+    );
+    if (!currentAssetGraphFile.existsSync()) return false;
+
+    final currentMtime = HighResolutionMtime.getHighResMtimeWithFallback(
+      currentAssetGraphFile.path,
+    );
+
+    for (final alternateRoot in alternateRoots) {
+      final alternateAssetGraphFile = File(
+        p.join(buildPackages[alternateRoot]!.path, assetGraphJsonPath),
+      );
+      if (alternateAssetGraphFile.existsSync()) {
+        final alternateMtime = HighResolutionMtime.getHighResMtimeWithFallback(
+          alternateAssetGraphFile.path,
+        );
+        if (alternateMtime > currentMtime) return true;
+      }
+    }
+
+    return false;
   }
 }
 

--- a/build_runner/lib/src/build_plan/previous_build.dart
+++ b/build_runner/lib/src/build_plan/previous_build.dart
@@ -54,7 +54,6 @@ abstract class PreviousBuild
     final readerWriter = buildSpec.readerWriter;
     final buildPackages = buildSpec.buildPackages;
     final buildPlanDigest = buildSpec.buildPlanDigest;
-    final restartIsNeeded = buildSpec.restartIsNeeded;
     final assetGraphJsonId = AssetId(
       buildPackages.outputRoot,
       assetGraphJsonPath,
@@ -74,10 +73,12 @@ abstract class PreviousBuild
         previousPhasedAssetDeps = assetGraphJson.phasedAssetDeps;
       }
       if (previousBuildState != null) {
-        if (restartIsNeeded ||
-            !buildPlanDigest.canIncrementallyBuildFrom(
-              previousBuildPlanDigest,
-            )) {
+        final forceCleanBuild =
+            buildSpec.restartIsNeeded ||
+            buildPackages.hasNewerAlternateRootBuild ||
+            !buildPlanDigest.canIncrementallyBuildFrom(previousBuildPlanDigest);
+
+        if (forceCleanBuild) {
           incompatibleBuildOutputsToDelete.addAll(
             previousBuildState.outputsToDelete(buildPackages),
           );

--- a/build_runner/test/common/fixture_packages.dart
+++ b/build_runner/test/common/fixture_packages.dart
@@ -47,9 +47,19 @@ builders:
           '''
 import 'package:build/build.dart';
 
-Builder testBuilderFactory(BuilderOptions options) => TestBuilder();
+Builder testBuilderFactory(BuilderOptions options) => TestBuilder(
+      options.config['copy_from'] == null
+          ? null
+          : AssetId.parse(options.config['copy_from'] as String),
+      options.config['extra_content'] as Object? ?? '',
+    );
 
 class TestBuilder implements Builder {
+  final AssetId? otherInput;
+  final Object extraContent;
+
+  TestBuilder(this.otherInput, this.extraContent);
+
   @override
   Map<String, List<String>> get buildExtensions
       => {'.txt': ['.txt$outputExtension']};
@@ -57,9 +67,10 @@ class TestBuilder implements Builder {
   @override
   Future<void> build(BuildStep buildStep) async {
 ${delayAtBuildStart ? 'await Future.delayed(Duration(seconds: 1));' : ''}
-    buildStep.writeAsString(
+    await buildStep.writeAsString(
         buildStep.inputId.addExtension('$outputExtension'),
-        await buildStep.readAsString(buildStep.inputId),
+        await buildStep.readAsString(otherInput ?? buildStep.inputId) +
+            '\$extraContent',
     );
   }
 }

--- a/build_runner/test/integration_tests/build_command_define_test.dart
+++ b/build_runner/test/integration_tests/build_command_define_test.dart
@@ -14,18 +14,10 @@ void main() async {
     final pubspecs = await Pubspecs.load();
     final tester = BuildRunnerTester(pubspecs);
 
-    tester.writePackage(
-      name: 'builder_pkg',
-      dependencies: ['build', 'build_runner'],
-      files: {
-        'build.yaml': r'''
-builders:
-  test_builder:
-    import: 'package:builder_pkg/builder.dart'
-    builder_factories: ['testBuilderFactory']
-    build_extensions: {'.txt': ['.txt.copy']}
-    auto_apply: root_package
-    build_to: source
+    tester.writeFixturePackage(FixturePackages.copyBuilder());
+    tester.update(
+      'builder_pkg/build.yaml',
+      (content) => '''$content
     defaults:
       options:
         copy_from: root_pkg|web/a.txt
@@ -34,32 +26,6 @@ builders:
       release_options:
         extra_content: "(default release)"
 ''',
-        'lib/builder.dart': '''
-import 'package:build/build.dart';
-
-Builder testBuilderFactory(BuilderOptions options) =>
-    TestBuilder(
-        AssetId.parse(options.config['copy_from'] as String),
-        options.config['extra_content'] as Object? ?? '');
-
-class TestBuilder implements Builder {
-  final AssetId copyFrom;
-  final Object extraContent;
-
-  TestBuilder(this.copyFrom, this.extraContent);
-
-  @override
-  Map<String, List<String>> get buildExtensions => {'.txt': ['.txt.copy']};
-
-  @override
-  Future<void> build(BuildStep buildStep) async {
-    buildStep.writeAsString(
-        buildStep.inputId.addExtension('.copy'),
-        await buildStep.readAsString(copyFrom) + '\$extraContent',
-    );
-  }
-}''',
-      },
     );
     tester.writePackage(
       name: 'root_pkg',

--- a/build_runner/test/integration_tests/build_command_workspace_root_test.dart
+++ b/build_runner/test/integration_tests/build_command_workspace_root_test.dart
@@ -83,5 +83,30 @@ dependencies:
       tester.read('p1/lib/p1.txt.copy'),
       '3',
     ); // No build of nested package.
+
+    tester.write('p1/build.yaml', r'''
+global_options:
+  builder_pkg:test_builder:
+    options:
+      extra_content: "(p1 local)"
+''');
+    tester.write('build.yaml', r'''
+global_options:
+  builder_pkg:test_builder:
+    options:
+      extra_content: "(workspace global)"
+''');
+
+    // Workspace build uses root `build.yaml` for options.
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
+    expect(tester.read('p1/lib/p1.txt.copy'), '4(workspace global)');
+
+    // Package build in `p1` uses `p1/build.yaml`.
+    await tester.run('p1', 'dart run build_runner build --force-jit');
+    expect(tester.read('p1/lib/p1.txt.copy'), '4(p1 local)');
+
+    // Workspace build uses root `build.yaml` again.
+    await tester.run('', 'dart run build_runner build --force-jit --workspace');
+    expect(tester.read('p1/lib/p1.txt.copy'), '4(workspace global)');
   });
 }

--- a/build_runner/test/integration_tests/builder_changes_test.dart
+++ b/build_runner/test/integration_tests/builder_changes_test.dart
@@ -34,22 +34,19 @@ void main() async {
     // modified code.
     tester.update(
       'builder_pkg/lib/builder.dart',
-      (script) => script.replaceAll(
-        'await buildStep.readAsString(buildStep.inputId)',
-        "'v1'",
-      ),
+      (script) => script.replaceAll(r"'$extraContent'", "'(v1)'"),
     );
     await watch.expect('Starting build #2 with updated builders.');
     await watch.expect(RegExp(r'1s compiling builders/jit'));
     tester.update(
       'builder_pkg/lib/builder.dart',
-      (script) => script.replaceAll("'v1'", "'v2'"),
+      (script) => script.replaceAll("'(v1)'", "'(v2)'"),
     );
     await watch.expect('Starting build #3 with updated builders.');
     await watch.expect(BuildLog.successPattern);
     await watch.kill();
 
     // Verify that the output is from the latest modified code.
-    expect(tester.read('root_pkg/web/a.txt.copy'), 'v2');
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'a(v2)');
   });
 }


### PR DESCRIPTION
Fix #4920.

If the most recent build was of a different scope, workspace vs package, do a clean build.

Otherwise the most recent build might be incompatible and it wouldn't be detected.

Add end to end test coverage; refactor a builder with configurable output that was used a few times into the existing test fixture and use that everywhere.