### PR TITLE
Release build 4.0.7, build_runner 3.15.1.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.7-wip
+## 4.0.7
 
 - Replace `Builder` extension method `hasOutputFor` with `matchesInput`.
   Deprecate `hasOutputFor`. The new `matchesInput` is identical, but now that

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 4.0.7-wip
+version: 4.0.7
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.1-wip
+## 1.3.1
 
 - Document that `--define` values are parsed as JSON with a fallback.
 - Require Dart 3.8.0.

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 1.3.1-wip
+version: 1.3.1
 description: >-
   Format definition and support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.1.2-wip
+## 4.1.2
 
 - Security: reject clients that set an Origin header, which includes all browsers.
 - Internal: remove use of `package:mockito` in test.

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version:  4.1.2-wip
+version: 4.1.2
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 resolution: workspace

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.15.1-wip
+## 2.15.1
 
 - Pass Dart SDK `--packages` arg to builder compiles, so they can be compiled
   with different packages to the current version solve.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.15.1-wip
+version: 2.15.1
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace
@@ -16,7 +16,7 @@ dependencies:
   analyzer: '>=8.0.0 <14.0.0'
   args: ^2.5.0
   async: ^2.5.0
-  build: ^4.0.7-wip
+  build: ^4.0.7
   build_config: ">=1.3.0 <1.4.0"
   build_daemon: ^4.0.0
   built_collection: ^5.1.1

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.5.16-wip
+## 3.5.16
 
 - Use `build_runner` 2.15.1.
 - Require Dart 3.8.0.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.16-wip
+version: 3.5.16
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.15.1-wip'
+  build_runner: ^2.15.1
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Do a release to get refactor + small changes + bug fixes out before new features related to parts with imports.

I need to benchmark before releasing to check I didn't regress in all that refactoring, I'll do so :)

`build_daemon` and `build_config` releases aren't needed but I don't see any reason to wait for them either :)

Benchmarks

<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
Version | Size | Web | Clean Mean (s) | Clean CI (s) | No-Changes Mean (s) | No-Changes CI (s) | Incremental Mean (s) | Incremental CI (s) | Graph Size (KiB)
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
pub | 10 | FALSE | 25.77 | 0.04 | 0.78 | 0.01 | 0.93 | 0.02 | 340
unreleased | 10 | FALSE | 25.81 | 0.07 | 0.83 | 0.01 | 0.98 | 0.01 | 176
pub | 10 | TRUE | 30.28 | 0.09 | 1.5 | 0 | 2 | 0.01 | 10317
unreleased | 10 | TRUE | 30.41 | 0.05 | 1.57 | 0 | 2.11 | 0.01 | 1058
pub | 2000 | FALSE | 54.38 | 0.44 | 2.65 | 0.01 | 22.74 | 0.71 | 20637
unreleased | 2000 | FALSE | 51.89 | 0.14 | 2.66 | 0.01 | 21.64 | 0.5 | 14424
pub | 2000 | TRUE | 67.09 | 0.16 | 10.62 | 0.02 | 31.06 | 0.05 | 151079
unreleased | 2000 | TRUE | 64.2 | 0.28 | 8.92 | 0.05 | 29.36 | 0.62 | 25731

the "CI" columns are some attempt at confidence interval from multiple runs + stdev, showing that the results are stable enough to be comparable.

Looks like it's about the same on small runs and a bit faster on big ones; the optimization that reduced asset_graph.json size probably helps thre.