### PR TITLE
mockito: avoid generating dummy classes for ProtobufEnum subtypes and GeneratedMessage subtypes

### DIFF
--- a/builder_pkgs/mockito/CHANGELOG.md
+++ b/builder_pkgs/mockito/CHANGELOG.md
@@ -4,6 +4,8 @@
 * It is now an error to generate mocks for non-JS interop extension types.
   Instead, mock the representation type and cast to the extension type where
   needed.
+* Avoid generating fake classes for dummy values of ProtobufEnum subclasses or
+  GeneratedMessage subclasses from the protobuf package.
 
 ## 5.7.0
 

--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -2040,6 +2040,16 @@ class _MockClassInfo {
           ..url = 'dart:async'
           ..types.add(elementType);
       }).property('empty').call([]);
+    } else if (type.isProtobufEnum) {
+      return referImported(
+        type.element.name!,
+        type.element.library.uri.toString(),
+      ).property('values').property('first');
+    } else if (type.isProtobufMessage) {
+      return referImported(
+        type.element.name!,
+        type.element.library.uri.toString(),
+      ).call([]);
     } else if (type.isDartTypedDataSealed) {
       // These types (XXXList + ByteData) from dart:typed_data are
       // sealed, e.g. "non-subtypeable", but they
@@ -3008,6 +3018,26 @@ extension on analyzer.DartType {
   bool get isFutureOfVoid =>
       isDartAsyncFuture &&
       (this as analyzer.InterfaceType).typeArguments.first is analyzer.VoidType;
+
+  bool get isProtobufEnum {
+    final element = this.element;
+    if (element is! ClassElement) return false;
+    final supertype = element.supertype?.element;
+    final library = supertype?.library;
+    return library?.uri.toString() ==
+            'package:protobuf/src/protobuf/internal.dart' &&
+        supertype?.name == 'ProtobufEnum';
+  }
+
+  bool get isProtobufMessage {
+    final element = this.element;
+    if (element is! ClassElement) return false;
+    final supertype = element.supertype?.element;
+    final library = supertype?.library;
+    return library?.uri.toString() ==
+            'package:protobuf/src/protobuf/internal.dart' &&
+        supertype?.name == 'GeneratedMessage';
+  }
 
   /// Returns whether this type is a sealed type from the dart:typed_data
   /// library.

--- a/builder_pkgs/mockito/test/builder/auto_mocks_test.dart
+++ b/builder_pkgs/mockito/test/builder/auto_mocks_test.dart
@@ -72,6 +72,17 @@ const immutable = _Immutable();
 ''',
 };
 
+const protobufAssets = {
+  'protobuf|lib/src/protobuf/internal.dart': '''
+    class ProtobufEnum {
+      final int value;
+      final String name;
+      const ProtobufEnum(this.value, this.name);
+    }
+    class GeneratedMessage {}
+  ''',
+};
+
 const simpleTestAsset = {
   'foo|test/foo_test.dart': '''
 import 'package:foo/foo.dart';
@@ -98,6 +109,12 @@ void main() {
         packageUriRoot: Uri.file('/foo/lib/'),
         languageVersion: LanguageVersion(3, 3),
       ),
+      Package(
+        'protobuf',
+        Uri.file('/protobuf/'),
+        packageUriRoot: Uri.file('/protobuf/lib/'),
+        languageVersion: LanguageVersion(3, 3),
+      ),
     ]);
     final builder = buildMocks(BuilderOptions(config));
     await testBuilders(
@@ -120,6 +137,12 @@ void main() {
         'foo',
         Uri.file('/foo/'),
         packageUriRoot: Uri.file('/foo/lib/'),
+        languageVersion: LanguageVersion(3, 3),
+      ),
+      Package(
+        'protobuf',
+        Uri.file('/protobuf/'),
+        packageUriRoot: Uri.file('/protobuf/lib/'),
         languageVersion: LanguageVersion(3, 3),
       ),
     ]);
@@ -148,6 +171,7 @@ void main() {
         ...metaAssets,
         ...annotationsAsset,
         ...simpleTestAsset,
+        ...protobufAssets,
         'foo|lib/foo.dart': sourceAssetText,
       },
       outputs: {'foo|test/foo_test.mocks.dart': output},
@@ -164,6 +188,7 @@ void main() {
       'foo|lib/foo.dart': sourceAssetText,
       ...annotationsAsset,
       ...simpleTestAsset,
+      ...protobufAssets,
     });
     final mocksAsset = AssetId('foo', 'test/foo_test.mocks.dart');
     return readerWriter.testing.readString(mocksAsset);
@@ -2771,6 +2796,50 @@ void main() {
       _containsAllOf('returnValue: _i2.Bar.one'),
     );
   });
+
+  test(
+    'creates dummy ProtobufEnum return value and does not fake the class',
+    () async {
+      final mocksContent = await buildWithSingleNonNullableSource(
+        dedent(r'''
+      import 'package:protobuf/src/protobuf/internal.dart';
+      class MyEnum extends ProtobufEnum {
+        static const MyEnum v1 = MyEnum(1, 'v1');
+        static const List<MyEnum> values = [v1];
+        const MyEnum(int v, String n) : super(v, n);
+      }
+      class Foo {
+        MyEnum m() => MyEnum.v1;
+      }
+      '''),
+      );
+      expect(
+        mocksContent,
+        containsIgnoringFormatting('returnValue: _i2.MyEnum.values.first'),
+      );
+      expect(mocksContent, isNot(contains('_FakeMyEnum')));
+    },
+  );
+
+  test(
+    'creates dummy GeneratedMessage return value and does not fake the class',
+    () async {
+      final mocksContent = await buildWithSingleNonNullableSource(
+        dedent(r'''
+      import 'package:protobuf/src/protobuf/internal.dart';
+      class MyMessage extends GeneratedMessage {}
+      class Foo {
+        MyMessage m() => MyMessage();
+      }
+      '''),
+      );
+      expect(
+        mocksContent,
+        containsIgnoringFormatting('returnValue: _i2.MyMessage()'),
+      );
+      expect(mocksContent, isNot(contains('_FakeMyMessage')));
+    },
+  );
 
   test('creates a dummy non-null function-typed return value, with optional '
       'parameters', () async {


### PR DESCRIPTION
The unnamed GeneratedMessage subtype constructor will not have side effects. The first value of a ProtobufEnum subtype will exist. This lets us generate less.

In addition, we may not be able to generate fakes for these classes, if generated subtypes of ProtobufEnum and GeneratedMessage become final. Which I have hopes for. See https://github.com/google/protobuf.dart/issues/820