### PR TITLE
Allow analyzer 14.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.8
+
+- Allow `analyzer` 14.x, require 13.3.0.
+- Require Dart 3.11.0.
+
 ## 4.0.7
 
 - Replace `Builder` extension method `hasOutputFor` with `matchesInput`.

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,14 +1,14 @@
 name: build
-version: 4.0.7
+version: 4.0.8
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.11.0
 
 dependencies:
-  analyzer: '>=8.0.0 <14.0.0'
+  analyzer: '>=13.3.0 <15.0.0'
   crypto: ^3.0.0
   glob: ^2.0.0
   logging: ^1.0.0

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.3-wip
+
+- Require Dart 3.11.0.
+
 ## 4.1.2
 
 - Security: reject clients that set an Origin header, which includes all browsers.

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_daemon
-version: 4.1.2
+version: 4.1.3-wip
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 resolution: workspace
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.11.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.15.2
+
+- Allow `analyzer` 14.x, require 13.3.0.
+- Require Dart 3.11.0.
+
 ## 2.15.1
 
 - Pass Dart SDK `--packages` arg to builder compiles, so they can be compiled

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -77,8 +77,8 @@ class ResolversImpl implements Resolvers {
       );
       final driver = analysisDriver(
         _analysisDriverModel,
-        // ignore: deprecated_member_use
         AnalysisOptionsImpl()
+          // ignore: deprecated_member_use
           ..contextFeatures = _featureSet(
             enableExperiments: enabledExperiments,
           ),

--- a/build_runner/lib/src/build/resolver/resolvers_impl.dart
+++ b/build_runner/lib/src/build/resolver/resolvers_impl.dart
@@ -77,6 +77,7 @@ class ResolversImpl implements Resolvers {
       );
       final driver = analysisDriver(
         _analysisDriverModel,
+        // ignore: deprecated_member_use
         AnalysisOptionsImpl()
           ..contextFeatures = _featureSet(
             enableExperiments: enabledExperiments,

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_runner
-version: 2.15.1
+version: 2.15.2
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.11.0
 
 platforms:
   linux:
@@ -13,7 +13,7 @@ platforms:
   macos:
 
 dependencies:
-  analyzer: '>=8.0.0 <14.0.0'
+  analyzer: '>=13.3.0 <15.0.0'
   args: ^2.5.0
   async: ^2.5.0
   build: ^4.0.7

--- a/build_runner/test/build_plan/build_packages_test.dart
+++ b/build_runner/test/build_plan/build_packages_test.dart
@@ -38,7 +38,7 @@ void main() {
           (p) => p.name == 'build_runner',
         );
 
-        expect(buildRunner.languageVersion, LanguageVersion(3, 8));
+        expect(buildRunner.languageVersion, LanguageVersion(3, 11));
       });
     });
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.5.17
+
+- Allow `analyzer` 14.x, require 13.3.0.
+- Require Dart 3.11.0.
+
 ## 3.5.16
 
 - Use `build_runner` 2.15.1.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,16 +1,16 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.16
+version: 3.5.17
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.11.0
 
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: ^2.15.1
+  build_runner: '2.15.2'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0
@@ -25,7 +25,7 @@ dependencies:
   watcher: ^1.0.0
 
 dev_dependencies:
-  analyzer: '>=8.0.0 <14.0.0'
+  analyzer: '>=13.3.0 <15.0.0'
 
 topics:
  - build-runner

--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.8.6
+
+- Allow `analyzer` 14.x, require 13.3.0.
+- Require Dart 3.11.0.
+
 ## 4.8.5
 
 - Allow Dart SDK 3.13.x and 3.14 prerelease.

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.8.5
+version: 4.8.6
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace
@@ -8,7 +8,7 @@ environment:
   sdk: '>=3.13.0-107.0.dev <3.14.0-z'
 
 dependencies:
-  analyzer: '>=5.1.0 <14.0.0'
+  analyzer: '>=13.3.0 <15.0.0'
   archive: '>=3.0.0 <5.0.0'
   async: ^2.5.0
   bazel_worker: ^1.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,11 +1,11 @@
 name: example
 publish_to: none
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.11.0
 resolution: workspace
 
 dependencies:
-  analyzer: ">=5.0.0 <14.0.0"
+  analyzer: ">=13.3.0 <15.0.0"
   build: ^4.0.0
   # Not imported in code, but used to constrain `build.yaml` requirements
   build_config: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,5 +21,3 @@ workspace:
 - builder_pkgs/scratch_space
 - example
 - tool
-dependency_overrides:
-  analyzer: 14.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_workspace     # Can be anything
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.11.0
 publish_to: none
 dev_dependencies:
   dart_flutter_team_lints: ^3.1.0
@@ -21,3 +21,5 @@ workspace:
 - builder_pkgs/scratch_space
 - example
 - tool
+dependency_overrides:
+  analyzer: 13.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,4 +22,4 @@ workspace:
 - example
 - tool
 dependency_overrides:
-  analyzer: 13.3.0
+  analyzer: 14.0.0


### PR DESCRIPTION
Allow the latest analyzer release.

It deprecates API used in `build_runner` `resolvers_impl`, but we can resolve that in a future release

I checked the test with the analyzer version range, actually we already need 13 to run, so bump the min version. At the same time bump the min language version to match the analyzer's min lang version.

Prepare for release, except build_daemon which did not benefit from the analyzer version bump so there's no reason to release it.

Tested on CI with dependency overrides to analyzer 13.3.0 and 14, and lastly without the override to actually land :)