### PR TITLE
Add regression test for issue 4975.

### DIFF
--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -234,6 +234,36 @@ void main() {
         );
       });
 
+      test(
+        'PostProcessBuilder does not collide with missing read inputs (#4975)',
+        () async {
+          final readOutputBuilder = TestBuilder(
+            extraWork: (buildStep, _) async {
+              try {
+                await buildStep.readAsString(
+                  AssetId('a', 'lib/output.txt.g.dart'),
+                );
+              } catch (_) {}
+            },
+          );
+          TestBuilder builderFactory(_) => readOutputBuilder;
+          await testBuilderFactories(
+            [builderFactory],
+            postProcessBuilderFactories: [
+              (_) => CopyingPostProcessBuilder(outputExtension: '.g.dart'),
+            ],
+            appliesBuilders: {
+              builderFactory: ['CopyingPostProcessBuilder'],
+            },
+            {'a|lib/output.txt': 'output'},
+            outputs: {
+              'a|lib/output.txt.copy': 'output',
+              'a|lib/output.txt.g.dart': 'output',
+            },
+          );
+        },
+      );
+
       test('with placeholder as input', () async {
         final builder1 = PlaceholderBuilder(
           {'lib.txt': 'libText'}.build(),


### PR DESCRIPTION
It turns out #4975 was fixed in recent refactoring, already released.

Add a regression test.

Fully AI generated: both the investigation and the test.

I have manually reviewed the test and it looks good, it tests the right thing and is a good way to do it.

Investigation: "Please investigate https://github.com/dart-lang/build/issues/4975." --> " I have investigated issue 4975 https://github.com/dart-lang/build/issues/4975 and have good news: your recent refactoring completely avoids this bug!" ... followed by description of why the bug happened and why it's now fixed.

Fix: Please enter "rw" mode and add the smallest possible test that would have caught this; verify that it fails with 2.15.0 and passes with 2.15.1. --> this PR.

I had to run dartfmt myself though :)