### PR TITLE
Allow all DDC builders to use the scratch space specified by `scratch-space-dir`

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.8.8
+
+- Allow all DDC builders to use the scratch space specified by `scratch-space-dir`.
+
 ## 4.8.7
 
 - Fix `DdcFrontendServerBuilder` retaining old compile requests.

--- a/builder_pkgs/build_web_compilers/lib/builders.dart
+++ b/builder_pkgs/build_web_compilers/lib/builders.dart
@@ -57,11 +57,14 @@ Builder ddcBuilder(BuilderOptions options) {
   _ensureSameDdcHotReloadOptions(options);
   _ensureSameDdcOptions(options);
 
+  final scratchDir = _readScratchSpaceDirOption(options);
+  if (scratchDir != null) {
+    configureScratchSpace(scratchDir);
+  }
+
   if (_readWebHotReloadOption(options)) {
     frontendServerEnvironment = _readEnvironmentOption(options);
-    return DdcFrontendServerBuilder(
-      scratchSpaceDir: _readScratchSpaceDirOption(options),
-    );
+    return DdcFrontendServerBuilder();
   }
 
   return DevCompilerBuilder(

--- a/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_resources.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_resources.dart
@@ -31,9 +31,6 @@ class FrontendServerState {
   /// Whether the next recompile should be a recompile-restart.
   bool needsRecompileRestart = false;
 
-  /// The custom scratch space path provided to the builder, if any.
-  String? customScratchSpacePath;
-
   /// Looks for and loads a `.web.entrypoint.json` file if it exists.
   ///
   /// Returns whether or not the `.web.entrypoint.json` was found and loaded.

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/build_modules.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/build_modules.dart
@@ -18,7 +18,8 @@ export 'module_library_builder.dart'
     show ModuleLibraryBuilder, moduleLibraryExtension;
 export 'modules.dart';
 export 'platform.dart' show DartPlatform;
-export 'scratch_space.dart' show scratchSpace, scratchSpaceResource;
+export 'scratch_space.dart'
+    show configureScratchSpace, scratchSpace, scratchSpaceResource;
 export 'workers.dart'
     show
         dartdevkDriverResource,

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/scratch_space.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/scratch_space.dart
@@ -19,7 +19,14 @@ final _logger = Logger('BuildModules');
 
 /// A shared [ScratchSpace] for ddc and analyzer workers that persists
 /// throughout builds.
-final scratchSpace = ScratchSpace();
+ScratchSpace? _scratchSpace;
+ScratchSpace get scratchSpace => _scratchSpace ??= ScratchSpace();
+
+void configureScratchSpace(String? path) {
+  if (path != null) {
+    _scratchSpace = ScratchSpace.existing(Directory(path));
+  }
+}
 
 /// A shared [Resource] for a [ScratchSpace], which cleans up the contents of
 /// the [ScratchSpace] in dispose, but doesn't delete it entirely.

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/workers.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/workers.dart
@@ -11,7 +11,6 @@ import 'package:build/build.dart';
 import 'package:path/path.dart' as p;
 
 import '../build_frontend_server/frontend_server_driver.dart';
-import '../build_frontend_server/frontend_server_resources.dart';
 import '../common.dart';
 import 'scratch_space.dart';
 
@@ -150,12 +149,8 @@ Future<PersistentFrontendServer> startFrontendServerWorker() async {
   if (__persistentFrontendServer != null) return __persistentFrontendServer!;
 
   // We bind the Frontend Server worker's filesystem root to that of the scratch
-  // space. If a scratch space is provided by the build options (instead of
-  // being created dynamically), use that.
-  final customPath = frontendServerState.customScratchSpacePath;
-  final fesRoot = customPath != null
-      ? Directory(customPath).uri
-      : scratchSpace.tempDir.uri;
+  // space.
+  final fesRoot = scratchSpace.tempDir.uri;
   final fes = await PersistentFrontendServer.start(
     sdkRoot: sdkDir,
     fileSystemRoot: fesRoot,

--- a/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
@@ -4,10 +4,8 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:build/build.dart';
-import 'package:scratch_space/scratch_space.dart';
 
 import 'build_modules/build_modules.dart';
 import 'common.dart';
@@ -16,21 +14,6 @@ import 'platforms.dart';
 
 /// A builder that compiles DDC modules with the Frontend Server.
 class DdcFrontendServerBuilder implements Builder {
-  /// A custom directory to use for the scratch space, if provided.
-  ///
-  /// Used to share the scratch space directory with the `fes_manager` process
-  /// when it is initialized separately from the build daemon (like in tests).
-  final String? scratchSpaceDir;
-
-  /// Caches [ScratchSpace]s by their directory path.
-  ///
-  /// We typically expect one scratch space to be provided per compilation,
-  /// but integration tests frequently run separate compilations on the same
-  /// entrypoint in the same process.
-  static final Map<String, ScratchSpace> _scratchSpaceCache = {};
-
-  DdcFrontendServerBuilder({this.scratchSpaceDir});
-
   @override
   Map<String, List<String>> get buildExtensions => {
     moduleExtension(ddcPlatform): [
@@ -65,7 +48,7 @@ class DdcFrontendServerBuilder implements Builder {
     final transitiveSources = [
       for (final dep in transitiveDeps) ...dep.sources,
     ];
-    var scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
+    final scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
     await scratchSpace.ensureAssets([
       ...module.sources,
       ...transitiveSources,
@@ -97,16 +80,6 @@ class DdcFrontendServerBuilder implements Builder {
     ];
     try {
       frontendServerState.triggerSharedCompilation(entrypointAssetId, () async {
-        final customDir = scratchSpaceDir;
-        if (customDir != null) {
-          scratchSpace = _scratchSpaceCache.putIfAbsent(
-            customDir,
-            () => ScratchSpace.existing(Directory(customDir)),
-          );
-        }
-        if (customDir != null) {
-          frontendServerState.customScratchSpacePath = customDir;
-        }
         await scratchSpace.ensureAssets([
           entrypointAssetId,
           ...module.sources,

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.8.7
+version: 4.8.8
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
Prior to this, just the Frontend Server-related DDC builders would use a custom scratch space, which was causing issues if a non-FES builder in the same pipeline (such as a DDC module builder) executed first. Now we synchronize all scratch spaces across all builders.