### PR TITLE
Clearing scratch space on build for DdcFrontendServerBuilder

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.8.9
+- Fix an issue where `DdcFrontendServerBuilder` accumulates changed files across builds.
+
 ## 4.8.8
 
 - Allow all DDC builders to use the scratch space specified by `scratch-space-dir`.

--- a/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
@@ -49,10 +49,6 @@ class DdcFrontendServerBuilder implements Builder {
       for (final dep in transitiveDeps) ...dep.sources,
     ];
     final scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
-    await scratchSpace.ensureAssets([
-      ...module.sources,
-      ...transitiveSources,
-    ], buildStep);
     final root = getRootPackageName();
     final driver = await buildStep.fetchResource(
       frontendServerProxyDriverResource,
@@ -68,41 +64,51 @@ class DdcFrontendServerBuilder implements Builder {
         ? id.path
         : 'packages/${id.package}/${id.path.replaceFirst('lib/', '')}';
 
-    final changedAssetUris = [
-      for (final asset in scratchSpace.changedFilesInBuild)
-        if (asset.path.startsWith('lib/'))
-          Uri(
-            scheme: 'package',
-            path: '${asset.package}/${asset.path.replaceFirst('lib/', '')}',
-          )
-        else
-          Uri(scheme: multiRootScheme, host: '', path: '/${assetPath(asset)}'),
-    ];
     try {
+      final changedAssetUris = <Uri>[];
       frontendServerState.triggerSharedCompilation(entrypointAssetId, () async {
         await scratchSpace.ensureAssets([
           entrypointAssetId,
           ...module.sources,
           ...transitiveSources,
-          ...scratchSpace.changedFilesInBuild,
         ], buildStep);
-        final compilerOutput = await driver.recompileAndRecord(
-          entrypointArg,
-          changedAssetUris,
-          [assetPath(ddcEntrypointId.changeExtension(fesJsExtension))],
-          recompileRestart: frontendServerState.needsRecompileRestart,
-        );
-        if (compilerOutput == null) {
-          throw FrontendServerCompilationException(
-            frontendServerState.entrypointAssetId!,
-            'Frontend Server produced no output.',
+        changedAssetUris.addAll([
+          for (final asset in scratchSpace.changedFilesInBuild)
+            asset.path.startsWith('lib/')
+                ? Uri(
+                    scheme: 'package',
+                    path:
+                        '${asset.package}/${asset.path.replaceFirst('lib/', '')}',
+                  )
+                : Uri(
+                    scheme: multiRootScheme,
+                    host: '',
+                    path: '/${assetPath(asset)}',
+                  ),
+        ]);
+        scratchSpace.dispose();
+        final shouldCompile =
+            changedAssetUris.isNotEmpty ||
+            frontendServerState.needsRecompileRestart;
+        if (shouldCompile) {
+          final compilerOutput = await driver.recompileAndRecord(
+            entrypointArg,
+            changedAssetUris,
+            [assetPath(ddcEntrypointId.changeExtension(fesJsExtension))],
+            recompileRestart: frontendServerState.needsRecompileRestart,
           );
-        }
-        if (compilerOutput.errorCount != 0) {
-          throw FrontendServerCompilationException(
-            frontendServerState.entrypointAssetId!,
-            compilerOutput.errorMessage ?? 'Unknown error',
-          );
+          if (compilerOutput == null) {
+            throw FrontendServerCompilationException(
+              frontendServerState.entrypointAssetId!,
+              'Frontend Server produced no output.',
+            );
+          }
+          if (compilerOutput.errorCount != 0) {
+            throw FrontendServerCompilationException(
+              frontendServerState.entrypointAssetId!,
+              compilerOutput.errorMessage ?? 'Unknown error',
+            );
+          }
         }
       });
       await frontendServerState.waitForCompilation(entrypointAssetId);

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_web_compilers
-version: 4.8.8
+version: 4.8.9
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace


### PR DESCRIPTION
This was causing the Frontend Server to accumulate changes across builds, causing extraneous invalidations. 