### PR TITLE
Add `OutputStrategy`: overwrite, keep, verify.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.15.4-wip
+
+- New default output behavior: always fix incorrect generated files. For
+  example: if you "dart run build_runner build", modify a generated file,
+  then build again, it will be fixed, undoing your modifications.
+- New option, `--keep-modified-outputs`. Use this to get the old output
+  behavior: manual modifications to generated files are kept. They will be
+  overwritten if a build is triggered due to an input file change, a
+  configuration change or `dart run build_runner clean`.
+- New option, `--only-check`, for use in continuous builds and tests. With this
+  option `build_runner` writes nothing, but builds and compares with the files
+  already on disk. If there is any difference between disk and expected output
+  then the differences are logged and the build fails.
+
 ## 2.15.3
 
 - Simplify deletion of stale outputs: don't try to handle package renames.

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -474,6 +474,9 @@ class Build {
         phase: phase,
         anyOutputs: step.outputs.isNotEmpty,
         anyChangedOutputs: step.outputs.keys.any(_isChangedOutput),
+        anyFixedOutputs: step.outputs.keys.any(
+          buildPlan.buildInputs.invalidOutputs.contains,
+        ),
         lazy: lazy,
       );
     } else {
@@ -707,27 +710,23 @@ class Build {
     Iterable<AssetId> outputs,
   ) async {
     return await TimedActivity.track.runAsync(() async {
-      // Update state for primary input if needed.
-      if (buildStepPlan.isDeclaredOutput(step.primaryInput)) {
+      final primaryInput = step.primaryInput;
+      final primaryInputIsDeclaredOutput = buildStepPlan.isDeclaredOutput(
+        primaryInput,
+      );
+
+      if (primaryInputIsDeclaredOutput) {
+        // Update state for primary input if needed.
         if (!buildState.isProcessedOutput(
           buildStepPlan: buildStepPlan,
-          id: step.primaryInput,
+          id: primaryInput,
         )) {
-          await _buildOutput(step.primaryInput);
+          await _buildOutput(primaryInput);
         }
-      }
 
-      // If a primary input source file has been deleted, the build is skipped.
-      if (!buildStepPlan.isDeclaredOutput(step.primaryInput) &&
-          (buildInputs.deletedSources.contains(step.primaryInput) ||
-              buildInputs.deletedOutputs.contains(step.primaryInput))) {
-        return StepAction.skipMissingPrimaryInput;
-      }
-
-      // Propagate results for declared output primary input.
-      if (buildStepPlan.isDeclaredOutput(step.primaryInput)) {
+        // Propagate results for declared output primary input.
         final inputStepResult = buildState.stepResult(
-          buildStepPlan.stepForDeclaredOutput(step.primaryInput),
+          buildStepPlan.stepForDeclaredOutput(primaryInput),
         );
 
         // If the primary input's generating step failed, this build is also
@@ -740,8 +739,14 @@ class Build {
         // skipped.
         if (!buildState.isActualOutput(
           buildStepPlan: buildStepPlan,
-          id: step.primaryInput,
+          id: primaryInput,
         )) {
+          return StepAction.skipMissingPrimaryInput;
+        }
+      } else {
+        // If a primary input source file is deleted, the build is skipped.
+        if (buildInputs.deletedSources.contains(primaryInput) ||
+            buildInputs.invalidOutputs.contains(primaryInput)) {
           return StepAction.skipMissingPrimaryInput;
         }
       }
@@ -754,9 +759,7 @@ class Build {
         return StepAction.run;
       }
 
-      final primaryInput = step.primaryInput;
-
-      if (buildStepPlan.isDeclaredOutput(primaryInput)) {
+      if (primaryInputIsDeclaredOutput) {
         final inputStep = buildStepPlan.stepForDeclaredOutput(primaryInput);
         final oldResult = previousBuildState?.stepResultOrNull(inputStep);
         final newResult = buildState.stepResult(inputStep);
@@ -774,7 +777,7 @@ class Build {
 
       for (final output in outputs) {
         if (buildInputs.deletedSources.contains(output) ||
-            buildInputs.deletedOutputs.contains(output)) {
+            buildInputs.invalidOutputs.contains(output)) {
           return StepAction.run;
         }
       }
@@ -926,7 +929,7 @@ class Build {
         return true;
       }
     } else if (buildInputs.deletedSources.contains(input) ||
-        buildInputs.deletedOutputs.contains(input)) {
+        buildInputs.invalidOutputs.contains(input)) {
       return true;
     }
     return false;

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -6,11 +6,13 @@ import 'dart:async';
 
 import 'package:build/build.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:crypto/crypto.dart';
 import 'package:watcher/watcher.dart';
 
 import '../build_plan/build_directory.dart';
 import '../build_plan/build_filter.dart';
 import '../build_plan/build_plan.dart';
+import '../build_plan/output_strategy.dart';
 import '../commands/watch/asset_change.dart';
 import '../constants.dart';
 import '../io/asset_tracker.dart';
@@ -66,6 +68,9 @@ class BuildSeries {
   /// Then, no further builds are allowed.
   Future<void> get closing => _closingCompleter.future;
 
+  OutputStrategy get _outputStrategy =>
+      _buildPlan.buildSpec.buildOptions.outputStrategy;
+
   /// Filters [changes] to only changes that might trigger a build.
   Future<List<AssetChange>> filterChanges(List<AssetChange> changes) async {
     final result = <AssetChange>[];
@@ -80,9 +85,34 @@ class BuildSeries {
         continue;
       }
 
-      // Ignore any expected delete once.
-      if (change.type == ChangeType.REMOVE && _expectedDeletes.remove(id)) {
-        continue;
+      // Ignore deletes and writes done by `build_runner`, for output strategies
+      // that do deletes and writes.
+      if (_outputStrategy == .overwrite || _outputStrategy == .keep) {
+        // Ignore deletes done by `build_runner`.
+        if (change.type == .REMOVE && _expectedDeletes.remove(id)) {
+          continue;
+        }
+
+        // Ignore writes done by `build_runner`. It's necessary to check content
+        // because `package:watcher` can coalesce two modify events into one.
+        // If the first is by `build_runner` and the second is an external
+        // change then just ignoring the event would be incorrect.
+        if ((change.type == .ADD || change.type == .MODIFY) &&
+            _buildPlan.buildStepPlan.isDeclaredOutput(id)) {
+          final expectedContent = _buildPlan.previousBuild.buildState
+              ?.contentOf(id: id, buildStepPlan: _buildPlan.buildStepPlan);
+          if (expectedContent != null) {
+            try {
+              final bytes = await _buildPlan.readerWriter.readAsBytes(
+                id,
+                hidden: id.isHidden(buildStepPlan: _buildPlan.buildStepPlan),
+              );
+              if (md5.convert(bytes) == expectedContent.digest) {
+                continue;
+              }
+            } catch (_) {}
+          }
+        }
       }
 
       if (id.path.startsWith(entrypointDirectoryPath)) {
@@ -129,10 +159,10 @@ class BuildSeries {
         continue;
       }
 
-      // Ignore creation or modification of outputs.
+      // Handle modifications and creations of outputs.
       if (_buildPlan.buildStepPlan.isDeclaredOutput(id) &&
-          change.type != ChangeType.REMOVE) {
-        continue;
+          change.type != .REMOVE) {
+        if (_outputStrategy == OutputStrategy.keep) continue;
       }
 
       // It's an add of a "missing source" or a deletion of an input.
@@ -159,6 +189,7 @@ class BuildSeries {
           buildStepPlan: _buildPlan.buildStepPlan,
           buildState: _buildPlan.previousBuild.buildState ?? BuildState(),
         );
+
     return List.of(
       updates.entries.map((entry) => WatchEvent(entry.value, '${entry.key}')),
     );
@@ -230,11 +261,7 @@ class BuildSeries {
         ..buildFilters.replace(buildFilters!),
     );
 
-    if (firstBuild) {
-      if (updates.isNotEmpty) {
-        _buildPlan = await _buildPlan.updateForFileChanges(updates);
-      }
-    } else {
+    if (!firstBuild || updates.isNotEmpty) {
       _buildPlan = await _buildPlan.updateForFileChanges(updates);
     }
 
@@ -253,7 +280,13 @@ class BuildSeries {
   Future<BuildResult> _runBuildAndWrite(Build build) async {
     var result = await build.run();
 
-    await _writeBuildOutput(result);
+    if (_outputStrategy == .verify) {
+      if (result.status == .success) {
+        result = await _verifyBuildOutput(result);
+      }
+    } else {
+      await _writeBuildOutput(result);
+    }
     result = await _createMergedOutputDirectories(result);
 
     _buildPlan = build.buildPlan.withCompatiblePreviousBuild(
@@ -262,7 +295,7 @@ class BuildSeries {
     );
     return result.copyWith(
       errors: buildLog.finishBuild(
-        result: result.status == BuildStatus.success,
+        result: result.status == .success,
         outputs: result.outputs.length,
       ),
     );
@@ -272,46 +305,7 @@ class BuildSeries {
   ///
   /// Serializes and writes the updated `asset_graph.json`.
   Future<void> _writeBuildOutput(BuildResult result) async {
-    // Outputs to delete and whether each is hidden.
-    final deletes = <AssetId, bool>{
-      // Conflicting outputs and incompatible outputs are always not hidden.
-      for (final id in _buildPlan.conflictingOutputs) id: false,
-      for (final id
-          in _buildPlan.previousBuild.incompatibleBuildOutputsToDelete)
-        id: false,
-    };
-
-    final previousState = _buildPlan.previousBuild.buildState;
-    if (previousState != null) {
-      // Delete outputs that are no longer outputs.
-      final currentState = result.buildState!;
-      for (final stepResult in previousState.actualStepResults) {
-        for (final id in stepResult.outputs.keys) {
-          final stepId = _buildPlan.buildStepPlan.stepForDeclaredOutputOrNull(
-            id,
-          );
-          if (stepId == null) {
-            // Step was removed from the build.
-            deletes[id] = stepResult.isHidden;
-          } else {
-            final stepResultOrNull = currentState.stepResultOrNull(stepId);
-            if (stepResultOrNull != null &&
-                !stepResultOrNull.outputs.containsKey(id)) {
-              // Step ran but did not produce the output.
-              deletes[id] = stepResult.isHidden;
-            }
-          }
-        }
-      }
-      // Delete post process outputs.
-      for (final postProcessResult in previousState.actualPostProcessResults) {
-        for (final id in postProcessResult.outputs.keys) {
-          if (!currentState.isActualPostOutput(id)) {
-            deletes[id] = postProcessResult.hidden;
-          }
-        }
-      }
-    }
+    final deletes = _computeDeletes(result);
 
     if (_buildPlan.buildInputs.cleanBuild) {
       final generatedOutputDirectoryId = AssetId(
@@ -359,6 +353,109 @@ class BuildSeries {
       assetGraphId,
       assetGraphContent.bytes,
     );
+  }
+
+  /// Outputs to delete and whether each is hidden.
+  Map<AssetId, bool> _computeDeletes(BuildResult result) {
+    final deletes = <AssetId, bool>{
+      for (final id in _buildPlan.conflictingOutputs) id: false,
+      for (final id
+          in _buildPlan.previousBuild.incompatibleBuildOutputsToDelete)
+        id: false,
+    };
+
+    final previousState = _buildPlan.previousBuild.buildState;
+    if (previousState != null) {
+      final currentState = result.buildState!;
+      for (final stepResult in previousState.actualStepResults) {
+        for (final id in stepResult.outputs.keys) {
+          final stepId = _buildPlan.buildStepPlan.stepForDeclaredOutputOrNull(
+            id,
+          );
+          if (stepId == null) {
+            deletes[id] = stepResult.isHidden;
+          } else {
+            final stepResultOrNull = currentState.stepResultOrNull(stepId);
+            if (stepResultOrNull != null &&
+                !stepResultOrNull.outputs.containsKey(id)) {
+              deletes[id] = stepResult.isHidden;
+            }
+          }
+        }
+      }
+      for (final postProcessResult in previousState.actualPostProcessResults) {
+        for (final id in postProcessResult.outputs.keys) {
+          if (!currentState.isActualPostOutput(id)) {
+            deletes[id] = postProcessResult.hidden;
+          }
+        }
+      }
+    }
+    return deletes;
+  }
+
+  /// Verifies outputs on disk match [result].
+  ///
+  /// If there are unexpected, missing, or incorrect outputs on disk, logs them
+  /// and returns a failed result.
+  Future<BuildResult> _verifyBuildOutput(BuildResult result) async {
+    final allDeletes = _computeDeletes(result);
+    final deletes = {
+      for (final MapEntry(key: id, value: hidden) in allDeletes.entries)
+        if (!hidden) id,
+    };
+
+    final unexpected = <AssetId>[];
+    final missing = <AssetId>[];
+    final incorrect = <AssetId>[];
+
+    for (final output in result.outputs) {
+      deletes.remove(output);
+      final hidden = output.isHidden(
+        buildStepPlan: _buildPlan.buildStepPlan,
+        buildState: result.buildState!,
+      );
+      if (hidden) continue;
+
+      final expectedContent = result.buildState!.contentOf(
+        id: output,
+        buildStepPlan: _buildPlan.buildStepPlan,
+      )!;
+      final exists = await _buildPlan.readerWriter.canRead(output);
+      if (!exists) {
+        missing.add(output);
+      } else {
+        final existingBytes = await _buildPlan.readerWriter.readAsBytes(output);
+        final existingDigest = AssetContent.bytes(existingBytes).digest;
+        if (existingDigest != expectedContent.digest) {
+          incorrect.add(output);
+        }
+      }
+    }
+
+    for (final toDelete in deletes) {
+      final exists = await _buildPlan.readerWriter.canRead(toDelete);
+      if (exists) {
+        unexpected.add(toDelete);
+      }
+    }
+
+    if (unexpected.isNotEmpty || missing.isNotEmpty || incorrect.isNotEmpty) {
+      final lines = <String>[
+        for (final id in unexpected) 'U ${buildLog.renderId(id)}',
+        for (final id in missing) 'M ${buildLog.renderId(id)}',
+        for (final id in incorrect) 'I ${buildLog.renderId(id)}',
+      ]..sort();
+
+      final message = StringBuffer(
+        'Verify failed due to Incorrect|Missing|Unexpected:\n\n',
+      );
+      message.write(lines.join('\n'));
+      buildLog.error(message.toString());
+
+      return result.copyWith(status: BuildStatus.failure);
+    }
+    return result;
   }
 
   /// Creates merged output directories if they are configured.

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -15,6 +15,7 @@ import '../build_plan/build_plan.dart';
 import '../build_plan/output_strategy.dart';
 import '../commands/watch/asset_change.dart';
 import '../constants.dart';
+import '../io/asset_path_provider.dart';
 import '../io/asset_tracker.dart';
 import '../io/create_merged_dir.dart';
 import '../logging/build_log.dart';
@@ -161,8 +162,9 @@ class BuildSeries {
 
       // Handle modifications and creations of outputs.
       if (_buildPlan.buildStepPlan.isDeclaredOutput(id) &&
-          change.type != .REMOVE) {
-        if (_outputStrategy == OutputStrategy.keep) continue;
+          change.type != .REMOVE &&
+          _outputStrategy == OutputStrategy.keep) {
+        continue;
       }
 
       // It's an add of a "missing source" or a deletion of an input.
@@ -305,8 +307,6 @@ class BuildSeries {
   ///
   /// Serializes and writes the updated `asset_graph.json`.
   Future<void> _writeBuildOutput(BuildResult result) async {
-    final deletes = _computeDeletes(result);
-
     if (_buildPlan.buildInputs.cleanBuild) {
       final generatedOutputDirectoryId = AssetId(
         _buildPlan.buildSpec.buildPackages.outputRoot,
@@ -316,7 +316,6 @@ class BuildSeries {
     }
 
     for (final output in result.outputs) {
-      deletes.remove(output);
       final content = result.buildState!.contentOf(
         id: output,
         buildStepPlan: _buildPlan.buildStepPlan,
@@ -330,10 +329,9 @@ class BuildSeries {
         ),
       );
     }
-    for (final entry in deletes.entries) {
+    for (final toDelete in _computeDeletes(result)) {
       await _buildPlan.readerWriter.delete(
-        entry.key,
-        hidden: entry.value,
+        toDelete,
         onDelete: _expectedDeletes.add,
       );
     }
@@ -355,30 +353,61 @@ class BuildSeries {
     );
   }
 
-  /// Outputs to delete and whether each is hidden.
-  Map<AssetId, bool> _computeDeletes(BuildResult result) {
-    final deletes = <AssetId, bool>{
-      for (final id in _buildPlan.conflictingOutputs) id: false,
-      for (final id
-          in _buildPlan.previousBuild.incompatibleBuildOutputsToDelete)
-        id: false,
-    };
+  /// Files that should be deleted: outputs of the previous build that are no
+  /// longer declared outputs, plus files on disk that match declared outputs
+  /// that were not actually output.
+  ///
+  /// Set [onlyVisible] to skip hidden files.
+  Set<AssetId> _computeDeletes(BuildResult result, {bool onlyVisible = false}) {
+    final deletes = <AssetId>{};
+    final currentState = result.buildState!;
+    for (final id in _buildPlan.conflictingOutputs) {
+      if (!currentState.isActualOutput(
+            id: id,
+            buildStepPlan: _buildPlan.buildStepPlan,
+          ) &&
+          !currentState.isActualPostOutput(id)) {
+        deletes.add(id);
+      }
+    }
+    for (final id
+        in _buildPlan.previousBuild.incompatibleBuildOutputsToDelete) {
+      if (!currentState.isActualOutput(
+            id: id,
+            buildStepPlan: _buildPlan.buildStepPlan,
+          ) &&
+          !currentState.isActualPostOutput(id)) {
+        deletes.add(id);
+      }
+    }
+
+    final outputRoot = _buildPlan.buildSpec.buildPackages.outputRoot;
+    // Adds a delete result, unless it's a hidden file and `onlyVisible` was
+    // requested.
+    void maybeAddDelete(AssetId id, bool isHidden) {
+      if (isHidden) {
+        if (!onlyVisible) {
+          deletes.add(AssetPathProvider.hide(id, outputRoot));
+        }
+      } else {
+        deletes.add(id);
+      }
+    }
 
     final previousState = _buildPlan.previousBuild.buildState;
     if (previousState != null) {
-      final currentState = result.buildState!;
       for (final stepResult in previousState.actualStepResults) {
         for (final id in stepResult.outputs.keys) {
           final stepId = _buildPlan.buildStepPlan.stepForDeclaredOutputOrNull(
             id,
           );
           if (stepId == null) {
-            deletes[id] = stepResult.isHidden;
+            maybeAddDelete(id, stepResult.isHidden);
           } else {
             final stepResultOrNull = currentState.stepResultOrNull(stepId);
             if (stepResultOrNull != null &&
                 !stepResultOrNull.outputs.containsKey(id)) {
-              deletes[id] = stepResult.isHidden;
+              maybeAddDelete(id, stepResult.isHidden);
             }
           }
         }
@@ -386,7 +415,7 @@ class BuildSeries {
       for (final postProcessResult in previousState.actualPostProcessResults) {
         for (final id in postProcessResult.outputs.keys) {
           if (!currentState.isActualPostOutput(id)) {
-            deletes[id] = postProcessResult.hidden;
+            maybeAddDelete(id, postProcessResult.hidden);
           }
         }
       }
@@ -398,19 +427,17 @@ class BuildSeries {
   ///
   /// If there are unexpected, missing, or incorrect outputs on disk, logs them
   /// and returns a failed result.
+  ///
+  /// Only outputs and deletes in the source tree are checked; hidden outputs
+  /// and deletes of hidden files are skipped. This supports the presubmit use
+  /// case where source tree generated files are checked in but `.dart_tool`
+  /// generated files are not.
   Future<BuildResult> _verifyBuildOutput(BuildResult result) async {
-    final allDeletes = _computeDeletes(result);
-    final deletes = {
-      for (final MapEntry(key: id, value: hidden) in allDeletes.entries)
-        if (!hidden) id,
-    };
-
     final unexpected = <AssetId>[];
     final missing = <AssetId>[];
     final incorrect = <AssetId>[];
 
     for (final output in result.outputs) {
-      deletes.remove(output);
       final hidden = output.isHidden(
         buildStepPlan: _buildPlan.buildStepPlan,
         buildState: result.buildState!,
@@ -433,7 +460,7 @@ class BuildSeries {
       }
     }
 
-    for (final toDelete in deletes) {
+    for (final toDelete in _computeDeletes(result, onlyVisible: true)) {
       final exists = await _buildPlan.readerWriter.canRead(toDelete);
       if (exists) {
         unexpected.add(toDelete);

--- a/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
+++ b/build_runner/lib/src/build/resolver/analysis_driver_filesystem.dart
@@ -91,7 +91,7 @@ class AnalysisDriverFilesystem
     }
 
     for (final id in buildInputs.deletedSources.followedBy(
-      buildInputs.deletedOutputs,
+      buildInputs.invalidOutputs,
     )) {
       final path = id.asPath;
       if (_data.remove(path) != null) {

--- a/build_runner/lib/src/build_plan/build_inputs.dart
+++ b/build_runner/lib/src/build_plan/build_inputs.dart
@@ -35,10 +35,11 @@ abstract class BuildInputs implements Built<BuildInputs, BuildInputsBuilder> {
   BuiltSet<AssetId> get deletedSources;
 
   /// Generated outputs that will be deleted from disk at the end of the build
-  /// because their input is gone.
+  /// because their input is gone, or that will be forcefully overwritten
+  /// because they have been manually modified or deleted by the user.
   ///
   /// Empty if [cleanBuild].
-  BuiltSet<AssetId> get deletedOutputs;
+  BuiltSet<AssetId> get invalidOutputs;
 
   BuildInputs._();
   factory BuildInputs([void Function(BuildInputsBuilder) updates]) =

--- a/build_runner/lib/src/build_plan/build_inputs.g.dart
+++ b/build_runner/lib/src/build_plan/build_inputs.g.dart
@@ -18,7 +18,7 @@ class _$BuildInputs extends BuildInputs {
   @override
   final BuiltSet<AssetId> deletedSources;
   @override
-  final BuiltSet<AssetId> deletedOutputs;
+  final BuiltSet<AssetId> invalidOutputs;
 
   factory _$BuildInputs([void Function(BuildInputsBuilder)? updates]) =>
       (BuildInputsBuilder()..update(updates))._build();
@@ -29,7 +29,7 @@ class _$BuildInputs extends BuildInputs {
     required this.sourceContents,
     required this.updatedSources,
     required this.deletedSources,
-    required this.deletedOutputs,
+    required this.invalidOutputs,
   }) : super._();
   @override
   BuildInputs rebuild(void Function(BuildInputsBuilder) updates) =>
@@ -47,7 +47,7 @@ class _$BuildInputs extends BuildInputs {
         sourceContents == other.sourceContents &&
         updatedSources == other.updatedSources &&
         deletedSources == other.deletedSources &&
-        deletedOutputs == other.deletedOutputs;
+        invalidOutputs == other.invalidOutputs;
   }
 
   @override
@@ -58,7 +58,7 @@ class _$BuildInputs extends BuildInputs {
     _$hash = $jc(_$hash, sourceContents.hashCode);
     _$hash = $jc(_$hash, updatedSources.hashCode);
     _$hash = $jc(_$hash, deletedSources.hashCode);
-    _$hash = $jc(_$hash, deletedOutputs.hashCode);
+    _$hash = $jc(_$hash, invalidOutputs.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -71,7 +71,7 @@ class _$BuildInputs extends BuildInputs {
           ..add('sourceContents', sourceContents)
           ..add('updatedSources', updatedSources)
           ..add('deletedSources', deletedSources)
-          ..add('deletedOutputs', deletedOutputs))
+          ..add('invalidOutputs', invalidOutputs))
         .toString();
   }
 }
@@ -105,11 +105,11 @@ class BuildInputsBuilder implements Builder<BuildInputs, BuildInputsBuilder> {
   set deletedSources(SetBuilder<AssetId>? deletedSources) =>
       _$this._deletedSources = deletedSources;
 
-  SetBuilder<AssetId>? _deletedOutputs;
-  SetBuilder<AssetId> get deletedOutputs =>
-      _$this._deletedOutputs ??= SetBuilder<AssetId>();
-  set deletedOutputs(SetBuilder<AssetId>? deletedOutputs) =>
-      _$this._deletedOutputs = deletedOutputs;
+  SetBuilder<AssetId>? _invalidOutputs;
+  SetBuilder<AssetId> get invalidOutputs =>
+      _$this._invalidOutputs ??= SetBuilder<AssetId>();
+  set invalidOutputs(SetBuilder<AssetId>? invalidOutputs) =>
+      _$this._invalidOutputs = invalidOutputs;
 
   BuildInputsBuilder();
 
@@ -121,7 +121,7 @@ class BuildInputsBuilder implements Builder<BuildInputs, BuildInputsBuilder> {
       _sourceContents = $v.sourceContents.toBuilder();
       _updatedSources = $v.updatedSources.toBuilder();
       _deletedSources = $v.deletedSources.toBuilder();
-      _deletedOutputs = $v.deletedOutputs.toBuilder();
+      _invalidOutputs = $v.invalidOutputs.toBuilder();
       _$v = null;
     }
     return this;
@@ -155,7 +155,7 @@ class BuildInputsBuilder implements Builder<BuildInputs, BuildInputsBuilder> {
             sourceContents: sourceContents.build(),
             updatedSources: updatedSources.build(),
             deletedSources: deletedSources.build(),
-            deletedOutputs: deletedOutputs.build(),
+            invalidOutputs: invalidOutputs.build(),
           );
     } catch (_) {
       late String _$failedField;
@@ -168,8 +168,8 @@ class BuildInputsBuilder implements Builder<BuildInputs, BuildInputsBuilder> {
         updatedSources.build();
         _$failedField = 'deletedSources';
         deletedSources.build();
-        _$failedField = 'deletedOutputs';
-        deletedOutputs.build();
+        _$failedField = 'invalidOutputs';
+        invalidOutputs.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(
           r'BuildInputs',

--- a/build_runner/lib/src/build_plan/build_options.dart
+++ b/build_runner/lib/src/build_plan/build_options.dart
@@ -15,6 +15,7 @@ import '../build_runner_command_line.dart';
 import 'build_directory.dart';
 import 'build_filter.dart';
 import 'build_paths.dart';
+import 'output_strategy.dart';
 
 /// The command line options common to all `build_runner` commands that do a
 /// build.
@@ -39,6 +40,7 @@ class BuildOptions {
   final bool dartAotPerf;
   final bool isReleaseBuild;
   final bool outputSymlinksOnly;
+  final OutputStrategy outputStrategy;
   final bool verbose;
   final bool verboseDurations;
 
@@ -57,6 +59,7 @@ class BuildOptions {
     required this.enableExperiments,
     required this.isReleaseBuild,
     required this.outputSymlinksOnly,
+    required this.outputStrategy,
     required this.verbose,
     required this.verboseDurations,
   });
@@ -77,6 +80,7 @@ class BuildOptions {
     BuiltList<String>? enableExperiments,
     bool? isReleaseBuild,
     bool? outputSymlinksOnly,
+    OutputStrategy? outputStrategy,
     bool? verbose,
     bool? verboseDurations,
   }) => BuildOptions(
@@ -91,6 +95,7 @@ class BuildOptions {
     enableExperiments: enableExperiments ?? BuiltList(),
     isReleaseBuild: isReleaseBuild ?? false,
     outputSymlinksOnly: outputSymlinksOnly ?? false,
+    outputStrategy: outputStrategy ?? OutputStrategy.overwrite,
     verbose: verbose ?? false,
     verboseDurations: verboseDurations ?? false,
   );
@@ -146,6 +151,7 @@ class BuildOptions {
       enableExperiments: commandLine.enableExperiments!,
       isReleaseBuild: commandLine.release!,
       outputSymlinksOnly: commandLine.symlink!,
+      outputStrategy: commandLine.outputStrategy,
       verbose: commandLine.verbose!,
       verboseDurations: commandLine.verboseDurations!,
       compileStrategy: commandLine.compileStrategy,
@@ -167,6 +173,7 @@ class BuildOptions {
     enableExperiments: enableExperiments,
     isReleaseBuild: isReleaseBuild,
     outputSymlinksOnly: outputSymlinksOnly,
+    outputStrategy: outputStrategy,
     verbose: verbose,
     verboseDurations: verboseDurations,
     compileStrategy: compileStrategy ?? this.compileStrategy,

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -20,6 +20,7 @@ import 'build_filter.dart';
 import 'build_inputs.dart';
 import 'build_spec.dart';
 import 'build_step_plan.dart';
+import 'output_strategy.dart';
 import 'previous_build.dart';
 
 part 'build_plan.g.dart';
@@ -285,9 +286,10 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         buildStepPlan: buildStepPlan,
         id: id,
       );
-      final oldContent = oldIsSource
-          ? previousBuildState.contentOfSource(id)
-          : null;
+      final oldContent = previousBuildState.contentOf(
+        id: id,
+        buildStepPlan: previousBuildStepPlan,
+      );
       var exists = false;
       AssetContent? newContent;
 
@@ -315,7 +317,7 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
           buildInputs.sources.remove(id);
           buildInputs.sourceContents.remove(id);
         } else {
-          buildInputs.deletedOutputs.add(id);
+          buildInputs.invalidOutputs.add(id);
         }
       } else if (!oldExisted && exists) {
         buildInputs.updatedSources.add(id);
@@ -324,8 +326,13 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
           oldContent != null &&
           exists &&
           oldContent.digest != newContent!.digest) {
-        buildInputs.updatedSources.add(id);
-        buildInputs.sourceContents[id] = newContent;
+        if (oldIsSource) {
+          buildInputs.updatedSources.add(id);
+          buildInputs.sourceContents[id] = newContent;
+        } else if (buildSpec.buildOptions.outputStrategy !=
+            OutputStrategy.keep) {
+          buildInputs.invalidOutputs.add(id);
+        }
       }
     }
 
@@ -348,10 +355,10 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
       }
     }
 
-    final deletedOutputs = previousBuildStepPlan
+    final invalidOutputs = previousBuildStepPlan
         .transitiveDeclaredOutputsOf(buildInputs.deletedSources.build())
         .toSet();
-    buildInputs.deletedOutputs.addAll(deletedOutputs);
+    buildInputs.invalidOutputs.addAll(invalidOutputs);
 
     return BuildPlan((b) {
       b.buildSpec.replace(buildSpec);

--- a/build_runner/lib/src/build_plan/output_strategy.dart
+++ b/build_runner/lib/src/build_plan/output_strategy.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The strategy to use with regard to existing output on disk.
+enum OutputStrategy {
+  /// Overwrite incorrect outputs with correct content.
+  ///
+  /// This is the default.
+  overwrite,
+
+  /// Preserve incorrect outputs until the build step that writes the output is
+  /// triggered by an input change.
+  ///
+  /// This was the only behavior available before 2.16.0. It's useful for trying
+  /// changes to generated code.
+  keep,
+
+  /// Do no writes or deletes.
+  ///
+  /// Check the output and fail if it doesn't match the expected output. Useful
+  /// as a presubmit check.
+  verify,
+}

--- a/build_runner/lib/src/build_runner_command_line.dart
+++ b/build_runner/lib/src/build_runner_command_line.dart
@@ -10,6 +10,7 @@ import 'package:build_daemon/constants.dart';
 import 'package:built_collection/built_collection.dart';
 
 import 'bootstrap/compile_type.dart';
+import 'build_plan/output_strategy.dart';
 import 'internal.dart';
 
 enum CommandType {
@@ -70,11 +71,30 @@ class BuildRunnerCommandLine {
     return CompileStrategy.tryAot;
   }
 
+  OutputStrategy get outputStrategy {
+    if (argResults?.wasParsed(onlyCheckOption) ?? false) {
+      if (argResults?.wasParsed(keepModifiedOutputsOption) ?? false) {
+        throw UsageException(
+          'Cannot specify both --$onlyCheckOption and '
+          '--$keepModifiedOutputsOption',
+          usage,
+        );
+      }
+      return OutputStrategy.verify;
+    }
+    if (argResults?.wasParsed(keepModifiedOutputsOption) ?? false) {
+      return OutputStrategy.keep;
+    }
+    return OutputStrategy.overwrite;
+  }
+
   static Future<BuildRunnerCommandLine?> parse(Iterable<String> arguments) =>
       _CommandRunner().run(arguments);
 
-  BuildRunnerCommandLine(this.type, ArgResults argResults)
-    : arguments = argResults.arguments.build(),
+  final ArgResults? argResults;
+
+  BuildRunnerCommandLine(this.type, this.argResults)
+    : arguments = argResults!.arguments.build(),
       rest = argResults.rest.build(),
       buildFilter = argResults.listNamed(buildFilterOption),
       buildMode = argResults.stringNamed(buildModeFlag),
@@ -161,6 +181,8 @@ const symlinkOption = 'symlink';
 const verboseDurationsOption = 'verbose-durations';
 const verboseOption = 'verbose';
 const workspaceOption = 'workspace';
+const keepModifiedOutputsOption = 'keep-modified-outputs';
+const onlyCheckOption = 'only-check';
 
 // Removed options, kept to not break old command lines.
 const deleteFilesByDefaultOption = 'delete-conflicting-outputs';
@@ -277,6 +299,21 @@ class _Build extends _Command<BuildRunnerCommandLine> {
         defaultsTo: symlinksDefault,
         negatable: true,
         help: 'Symlink files in the output directories, instead of copying.',
+      )
+      ..addFlag(
+        keepModifiedOutputsOption,
+        defaultsTo: false,
+        negatable: false,
+        help: 'Keeps manual modifications to output files.',
+      )
+      ..addFlag(
+        onlyCheckOption,
+        defaultsTo: false,
+        negatable: false,
+        help:
+            'For presubmit checks. Turns off writes and deletes. Logs '
+            "differences between expected output and what's on disk. Fails the "
+            'build if there is any difference.',
       )
       ..addMultiOption(
         buildFilterOption,

--- a/build_runner/lib/src/io/asset_tracker.dart
+++ b/build_runner/lib/src/io/asset_tracker.dart
@@ -11,6 +11,7 @@ import 'package:glob/glob.dart';
 import 'package:watcher/watcher.dart';
 
 import '../build/build_state/build_state.dart';
+import '../build/resolver/asset_ids.dart';
 import '../build_plan/build_configs.dart';
 import '../build_plan/build_packages.dart';
 import '../build_plan/build_step_plan.dart';
@@ -44,6 +45,7 @@ class AssetTracker {
       generatedSources,
       buildState,
       declaredAndActualOutputs,
+      buildStepPlan: buildStepPlan,
     );
   }
 
@@ -68,8 +70,9 @@ class AssetTracker {
     Set<AssetId> inputSources,
     Set<AssetId> generatedSources,
     BuildState buildState,
-    Iterable<AssetId> declaredAndActualOutputs,
-  ) async {
+    Iterable<AssetId> declaredAndActualOutputs, {
+    required BuildStepPlan buildStepPlan,
+  }) async {
     final allSources = <AssetId>{}
       ..addAll(inputSources)
       ..addAll(generatedSources);
@@ -99,6 +102,28 @@ class AssetTracker {
 
       final currentDigest = await _readerWriter.digest(id);
       if (currentDigest != originalDigest.digest) {
+        updates[id] = ChangeType.MODIFY;
+      }
+    }
+
+    final preExistingOutputs = declaredAndActualOutputs.toSet().intersection(
+      allSources,
+    );
+    for (final id in preExistingOutputs) {
+      final originalContent = buildState.contentOf(
+        buildStepPlan: buildStepPlan,
+        id: id,
+      );
+      if (originalContent == null) continue;
+
+      final currentDigest = await _readerWriter.digest(
+        id,
+        hidden: id.isHidden(
+          buildStepPlan: buildStepPlan,
+          buildState: buildState,
+        ),
+      );
+      if (currentDigest != originalContent.digest) {
         updates[id] = ChangeType.MODIFY;
       }
     }

--- a/build_runner/lib/src/logging/build_log.dart
+++ b/build_runner/lib/src/logging/build_log.dart
@@ -402,12 +402,15 @@ class BuildLog {
     required bool lazy,
     required bool anyOutputs,
     required bool anyChangedOutputs,
+    bool anyFixedOutputs = false,
   }) {
     final phaseName = phase.name(lazy: lazy);
     final progress = _getProgress(phase: phase, lazy: lazy);
     progress.nextInput = null;
     if (anyChangedOutputs) {
       progress.builtNew++;
+    } else if (anyFixedOutputs) {
+      progress.builtFixed++;
     } else if (anyOutputs) {
       progress.builtSame++;
     } else {
@@ -683,6 +686,8 @@ class BuildLog {
       if (progress.notTriggered != 0)
         '${separator()}${progress.notTriggered} not triggered',
       if (progress.builtNew != 0) '${separator()}${progress.builtNew} output',
+      if (progress.builtFixed != 0)
+        '${separator()}${progress.builtFixed} fixed',
       if (progress.builtSame != 0) '${separator()}${progress.builtSame} same',
       if (progress.builtNothing != 0)
         '${separator()}${progress.builtNothing} no-op',
@@ -761,6 +766,10 @@ class _PhaseProgress {
   /// Build steps that ran and output new or different output.
   int builtNew = 0;
 
+  /// Build steps that ran and fixed an output that was modified outside the
+  /// build.
+  int builtFixed = 0;
+
   /// Build steps that ran but output the same output as they did previously.
   int builtSame = 0;
 
@@ -774,7 +783,7 @@ class _PhaseProgress {
 
   /// The number of build steps that have run in this phase.
   int get runCount =>
-      skipped + notTriggered + builtNew + builtSame + builtNothing;
+      skipped + notTriggered + builtNew + builtSame + builtFixed + builtNothing;
 
   /// Whether this progress in displayed.
   ///

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.15.3
+version: 2.15.4-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -125,7 +125,7 @@ void main() {
         {
           ...buildPlan.buildInputs.updatedSources,
           ...buildPlan.buildInputs.deletedSources,
-          ...buildPlan.buildInputs.deletedOutputs,
+          ...buildPlan.buildInputs.invalidOutputs,
         },
         {assetId, assetId2, assetId3, outputId},
       );

--- a/build_runner/test/integration_tests/output_strategy_test.dart
+++ b/build_runner/test/integration_tests/output_strategy_test.dart
@@ -1,0 +1,114 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@Tags(['integration3'])
+library;
+
+import 'package:build_runner/src/logging/build_log.dart';
+import 'package:test/test.dart';
+
+import '../common/common.dart';
+
+void main() async {
+  test('output strategy', () async {
+    final pubspecs = await Pubspecs.load();
+    final tester = BuildRunnerTester(pubspecs);
+
+    tester.writeFixturePackage(FixturePackages.copyBuilder());
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {'web/a.txt': 'a', 'web/b.txt': 'b', 'web/c.txt': 'c'},
+    );
+
+    // Default output strategy "overwrite" fixes manually modified output.
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'a');
+    tester.write('root_pkg/web/a.txt.copy', 'User modified a');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'a');
+
+    // With --keep-modified-outputs, manually modified output is kept.
+    tester.write('root_pkg/web/a.txt.copy', 'User modified a');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --keep-modified-outputs',
+    );
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'User modified a');
+
+    // With --only-check after an "overwrite" build, passes.
+    tester.write('root_pkg/web/a.txt', 'a');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --only-check',
+    );
+
+    // With --only-check incremental build after modifications to outputs, fails
+    // with log describing the differences.
+    tester.write('root_pkg/web/a.txt.copy', 'User modified a');
+    tester.delete('root_pkg/web/b.txt.copy');
+    tester.delete('root_pkg/web/c.txt');
+    var output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --only-check',
+      expectExitCode: 1,
+    );
+    expect(
+      output,
+      contains('Verify failed due to Incorrect|Missing|Unexpected:'),
+    );
+    expect(output, contains('I web/a.txt.copy'));
+    expect(output, contains('M web/b.txt.copy'));
+    expect(output, contains('U web/c.txt.copy'));
+
+    // With --only-check incrementally after fixing manually, passes.
+    tester.write('root_pkg/web/a.txt.copy', 'a2');
+    tester.write('root_pkg/web/b.txt.copy', 'b');
+    tester.write('root_pkg/web/c.txt', 'c');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+
+    // With --only-check on clean build with correct outputs, passes.
+    tester.delete('root_pkg/.dart_tool');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --only-check',
+    );
+
+    // With --only-check clean build with incorrect outputs, fails.
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    tester.write('root_pkg/web/a.txt.copy', 'User modified a');
+    tester.delete('root_pkg/web/b.txt.copy');
+    tester.delete('root_pkg/.dart_tool');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit --only-check',
+      expectExitCode: 1,
+    );
+    expect(
+      output,
+      contains('Verify failed due to Incorrect|Missing|Unexpected:'),
+    );
+    expect(output, contains('I web/a.txt.copy'));
+    expect(output, contains('M web/b.txt.copy'));
+
+    // watch --only-check stream verification.
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    final watch = await tester.start(
+      'root_pkg',
+      'dart run build_runner watch --force-jit --only-check',
+    );
+    await watch.expect(BuildLog.successPattern);
+
+    tester.write('root_pkg/web/a.txt.copy', 'User modified a');
+    await watch.expect('Verify failed due to Incorrect|Missing|Unexpected:');
+    await watch.expect('I web/a.txt.copy');
+    await watch.expect(BuildLog.failurePattern);
+
+    tester.write('root_pkg/web/a.txt.copy', 'a');
+    await watch.expect(BuildLog.successPattern);
+    await watch.kill();
+  });
+}

--- a/build_runner/test/integration_tests/watch_command_test.dart
+++ b/build_runner/test/integration_tests/watch_command_test.dart
@@ -75,6 +75,11 @@ void main() async {
     await watch.expect('wrote 1 output');
     expect(tester.read('root_pkg/web/a.txt.copy'), 'updated');
 
+    // Modified output.
+    tester.write('root_pkg/web/a.txt.copy', 'manually modified');
+    await watch.expect('wrote 1 output');
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'updated');
+
     // File change during build.
     tester.write('root_pkg/web/a.txt', 'a');
     await watch.expect('builder_pkg:test_builder');

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.19-wip
+
+- Use `build_runner` 2.15.4.
+
 ## 3.5.18
 
 - Add `visibleOutputPostProcessBuilders` to `testBuilders`.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.18
+version: 3.5.19-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.15.3'
+  build_runner: '2.15.4-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Add output strategies: `overwrite`, `keep`, and `verify`.

`overwrite` is the new default: incorrect output files on disk are always regenerated and fixed. \
`keep`, enabled with `--keep-modified-outputs`, is the old behavior. Modified output files are only rebuilt if something triggers the build step that outputs them. \
`verify`, enabled with `--only-check`, is new, for use in presubmit checks.

Internal changes:

- Rename `BuildInputs.deletedOutputs` to `invalidOutputs` to represent both deleted and manually modified outputs.
- Now that builds can be triggered by changes to outputs, add handling to `build_series.dart` for deciding whether a file watcher change event is an output of the build or an external change.