### PR TITLE
Defer deletion of obsolete outputs until the end of the build

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.15.3-wip
+
+- Bug fix: in incremental builds, when an input was deleted, its output was
+  deleted at the start of the build. Make it consistent with other output
+  deletions: wait until the end of the build.
+
 ## 2.15.2
 
 - Allow `analyzer` 14.x, require 13.3.0.

--- a/build_runner/lib/src/build_plan/build_inputs.dart
+++ b/build_runner/lib/src/build_plan/build_inputs.dart
@@ -34,7 +34,8 @@ abstract class BuildInputs implements Built<BuildInputs, BuildInputsBuilder> {
   /// Empty if [cleanBuild].
   BuiltSet<AssetId> get deletedSources;
 
-  /// Generated outputs that were deleted from disk.
+  /// Generated outputs that will be deleted from disk at the end of the build
+  /// because their input is gone.
   ///
   /// Empty if [cleanBuild].
   BuiltSet<AssetId> get deletedOutputs;

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -359,17 +359,6 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         .toSet();
     buildInputs.deletedOutputs.addAll(deletedOutputs);
 
-    for (final id in deletedOutputs) {
-      await readerWriter.delete(
-        id,
-        hidden: id.isHidden(
-          buildStepPlan: previousBuildStepPlan,
-          buildState: previousBuild.buildState,
-        ),
-        onDelete: onDelete,
-      );
-    }
-
     return BuildPlan((b) {
       b.buildSpec.replace(buildSpec);
       b.previousBuild.replace(previousBuild);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.15.2
+version: 2.15.3-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.18-wip
+
+- Use `build_runner` 2.15.3.
+
 ## 3.5.17
 
 - Allow `analyzer` 14.x, require 13.3.0.

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.17
+version: 3.5.18-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.15.2'
+  build_runner: '2.15.3-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Working on the next PR I noticed some incorrect code.

All file writes / deletes were supposed to happen at the end of the build.

But there was some redundant code doing some deletes at the beginning.

Th end-of-build deletes hit the same files, so there is no functional difference in this change, except that the deletes now happen later.