### PR TITLE
Simplify "expected deletes".

### DIFF
--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -44,6 +44,10 @@ class BuildSeries {
 
   final Completer<void> _closingCompleter = Completer();
 
+  /// Deletes that are part of build output, so the resulting file watch events
+  /// can be ignored.
+  final Set<AssetId> _expectedDeletes = {};
+
   /// Whether the next build is the first build.
   bool firstBuild = true;
 
@@ -63,13 +67,7 @@ class BuildSeries {
   Future<void> get closing => _closingCompleter.future;
 
   /// Filters [changes] to only changes that might trigger a build.
-  ///
-  /// Pass expected deletes in [expectedDeletes]. Expected deletes do not
-  /// trigger a build. A delete that matches is removed from the set.
-  Future<List<AssetChange>> filterChanges(
-    List<AssetChange> changes,
-    Set<AssetId> expectedDeletes,
-  ) async {
+  Future<List<AssetChange>> filterChanges(List<AssetChange> changes) async {
     final result = <AssetChange>[];
     for (final change in changes) {
       final id = change.id;
@@ -81,12 +79,13 @@ class BuildSeries {
         result.add(change);
         continue;
       }
-      if (id.path.startsWith(entrypointDirectoryPath)) {
+
+      // Ignore any expected delete once.
+      if (change.type == ChangeType.REMOVE && _expectedDeletes.remove(id)) {
         continue;
       }
 
-      // Ignore any expected delete once.
-      if (change.type == ChangeType.REMOVE && expectedDeletes.remove(id)) {
+      if (id.path.startsWith(entrypointDirectoryPath)) {
         continue;
       }
 
@@ -319,10 +318,7 @@ class BuildSeries {
         _buildPlan.buildSpec.buildPackages.outputRoot,
         generatedOutputDirectory,
       );
-      await _buildPlan.readerWriter.deleteDirectory(
-        generatedOutputDirectoryId,
-        onDelete: _buildPlan.onDelete,
-      );
+      await _buildPlan.readerWriter.deleteDirectory(generatedOutputDirectoryId);
     }
 
     for (final output in result.outputs) {
@@ -344,7 +340,7 @@ class BuildSeries {
       await _buildPlan.readerWriter.delete(
         entry.key,
         hidden: entry.value,
-        onDelete: _buildPlan.onDelete,
+        onDelete: _expectedDeletes.add,
       );
     }
 

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -32,7 +32,6 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
   ReaderWriter get readerWriter => buildSpec.readerWriter;
 
   /// Callback that gets notified of deletes.
-  void Function(AssetId)? get onDelete;
 
   /// Inputs in the source tree that conflict with declared outputs and must be
   /// deleted.
@@ -153,7 +152,6 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         previousBuild: previousBuild,
         buildDirs: buildDirs,
         buildFilters: buildFilters,
-        onDelete: onDelete,
         filesToCheck: filesToCheck,
         // Updates are being made to a `BuildPlan` that didn't actually run.
         // That means the conflicting file check was already done when that
@@ -167,7 +165,6 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         previousBuildStepPlan: buildStepPlan,
         buildDirs: buildDirs,
         buildFilters: buildFilters,
-        onDelete: onDelete,
         filesToCheck: filesToCheck,
       );
     }
@@ -194,7 +191,6 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
     required PreviousBuild previousBuild,
     required BuiltSet<BuildDirectory> buildDirs,
     required BuiltSet<BuildFilter> buildFilters,
-    void Function(AssetId)? onDelete,
     required Set<AssetId> filesToCheck,
     Set<AssetId>? assetTrackerInputSources,
   }) async {
@@ -253,7 +249,6 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
       b.buildSpec.replace(buildSpec);
       b.previousBuild.replace(previousBuild);
       b.buildStepPlan.replace(buildStepPlan);
-      b.onDelete = onDelete;
       b.conflictingOutputs.replace(conflictingOutputs);
       b.buildInputs.replace(result.build());
       b.buildDirs.replace(buildDirs);
@@ -268,7 +263,6 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
     required BuildStepPlan previousBuildStepPlan,
     required BuiltSet<BuildDirectory> buildDirs,
     required BuiltSet<BuildFilter> buildFilters,
-    void Function(AssetId)? onDelete,
     required Set<AssetId> filesToCheck,
   }) async {
     final readerWriter = buildSpec.readerWriter;
@@ -363,7 +357,6 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
       b.buildSpec.replace(buildSpec);
       b.previousBuild.replace(previousBuild);
       b.buildStepPlan.replace(buildStepPlan);
-      b.onDelete = onDelete;
       b.buildInputs = buildInputs;
       b.buildDirs.replace(buildDirs);
       b.buildFilters.replace(buildFilters);

--- a/build_runner/lib/src/build_plan/build_plan.g.dart
+++ b/build_runner/lib/src/build_plan/build_plan.g.dart
@@ -23,8 +23,6 @@ class _$BuildPlan extends BuildPlan {
   final BuiltSet<BuildDirectory> buildDirs;
   @override
   final BuiltSet<BuildFilter> buildFilters;
-  @override
-  final void Function(AssetId)? onDelete;
 
   factory _$BuildPlan([void Function(BuildPlanBuilder)? updates]) =>
       (BuildPlanBuilder()..update(updates))._build();
@@ -37,7 +35,6 @@ class _$BuildPlan extends BuildPlan {
     required this.buildInputs,
     required this.buildDirs,
     required this.buildFilters,
-    this.onDelete,
   }) : super._();
   @override
   BuildPlan rebuild(void Function(BuildPlanBuilder) updates) =>
@@ -106,10 +103,6 @@ class BuildPlanBuilder implements Builder<BuildPlan, BuildPlanBuilder> {
   set buildStepPlan(BuildStepPlanBuilder? buildStepPlan) =>
       _$this._buildStepPlan = buildStepPlan;
 
-  void Function(AssetId)? _onDelete;
-  void Function(AssetId)? get onDelete => _$this._onDelete;
-  set onDelete(void Function(AssetId)? onDelete) => _$this._onDelete = onDelete;
-
   ListBuilder<AssetId>? _conflictingOutputs;
   ListBuilder<AssetId> get conflictingOutputs =>
       _$this._conflictingOutputs ??= ListBuilder<AssetId>();
@@ -146,7 +139,6 @@ class BuildPlanBuilder implements Builder<BuildPlan, BuildPlanBuilder> {
       _buildInputs = $v.buildInputs.toBuilder();
       _buildDirs = $v.buildDirs.toBuilder();
       _buildFilters = $v.buildFilters.toBuilder();
-      _onDelete = $v.onDelete;
       _$v = null;
     }
     return this;
@@ -178,7 +170,6 @@ class BuildPlanBuilder implements Builder<BuildPlan, BuildPlanBuilder> {
             buildInputs: buildInputs.build(),
             buildDirs: buildDirs.build(),
             buildFilters: buildFilters.build(),
-            onDelete: onDelete,
           );
     } catch (_) {
       late String _$failedField;

--- a/build_runner/lib/src/commands/daemon/daemon_builder.dart
+++ b/build_runner/lib/src/commands/daemon/daemon_builder.dart
@@ -219,7 +219,6 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
     required BuildPlan buildPlan,
     required DaemonOptions daemonOptions,
   }) async {
-    final expectedDeletes = <AssetId>{};
     final outputStreamController = StreamController<ServerLog>(sync: true);
 
     buildLog.configuration = buildLog.configuration.rebuild((b) {
@@ -227,7 +226,6 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
         outputStreamController.add(ServerLog.fromLogRecord(record));
       };
     });
-    buildPlan = buildPlan.rebuild((b) => b.onDelete = expectedDeletes.add);
 
     final buildSeries = BuildSeries(buildPlan);
 
@@ -239,9 +237,7 @@ class BuildRunnerDaemonBuilder implements DaemonBuilder {
               buildPlan.buildSpec.testingOverrides.debounceDelay ??
                   const Duration(milliseconds: 250),
             )
-            .asyncMap(
-              (changes) => buildSeries.filterChanges(changes, expectedDeletes),
-            )
+            .asyncMap(buildSeries.filterChanges)
             .where((changes) => changes.isNotEmpty)
             .map(
               (changes) => changes

--- a/build_runner/lib/src/commands/watch/watcher.dart
+++ b/build_runner/lib/src/commands/watch/watcher.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:build/build.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 import '../../bootstrap/build_process_state.dart';
@@ -22,18 +21,13 @@ class Watcher {
   final BuildPlan _buildPlan;
   final BuildSeries _buildSeries;
 
-  /// Pending expected delete events from the build.
-  final Set<AssetId> _expectedDeletes;
-
-  Watcher._(this._buildPlan, this._buildSeries, this._expectedDeletes);
+  Watcher._(this._buildPlan, this._buildSeries);
 
   BuildPackages get buildPackages => _buildPlan.buildSpec.buildPackages;
 
   factory Watcher({required BuildPlan buildPlan, required Future<void> until}) {
-    final expectedDeletes = <AssetId>{};
-    buildPlan = buildPlan.rebuild((b) => b.onDelete = expectedDeletes.add);
     final buildSeries = BuildSeries(buildPlan);
-    final result = Watcher._(buildPlan, buildSeries, expectedDeletes);
+    final result = Watcher._(buildPlan, buildSeries);
     result._run(until);
     return result;
   }
@@ -76,9 +70,7 @@ class Watcher {
           _buildPlan.buildSpec.testingOverrides.debounceDelay ??
               const Duration(milliseconds: 250),
         )
-        .asyncMap(
-          (changes) => _buildSeries.filterChanges(changes, _expectedDeletes),
-        )
+        .asyncMap(_buildSeries.filterChanges)
         .where((changes) => changes.isNotEmpty)
         .takeUntil(terminate)
         .asyncMapBuffer(_doBuild)
@@ -100,7 +92,6 @@ class Watcher {
 
   Future<BuildResult> _doBuild(List<List<AssetChange>> changes) async {
     final mergedChanges = collectChanges(changes);
-    _expectedDeletes.clear();
     final result = await _buildSeries.run(
       mergedChanges,
       recentlyBootstrapped: false,

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -852,33 +852,6 @@ additional_public_assets:
           },
         );
       });
-
-      test('Will not delete from non-root packages', () async {
-        await testPhases(
-          builderFactories,
-          [
-            BuilderDefinition(
-              '',
-              autoApply: AutoApply.allPackages,
-              hideOutput: true,
-            ),
-          ],
-          {
-            'b|lib/b.txt': 'b',
-            'a|.dart_tool/build/generated/b/lib/b.txt.copy': 'b',
-          },
-          buildPackages: buildPackages,
-          outputs: {r'$$b|lib/b.txt.copy': 'b'},
-          onDelete: (AssetId assetId) {
-            if (assetId.package != 'a') {
-              throw StateError(
-                'Should not delete outside of package:a, '
-                'tried to delete $assetId',
-              );
-            }
-          },
-        );
-      });
     });
 
     test('can read files from external packages', () async {

--- a/build_runner/test/common/test_phases.dart
+++ b/build_runner/test/common/test_phases.dart
@@ -84,7 +84,6 @@ Future<TestBuildersResult> testPhases(
   bool verbose = false,
   Set<BuildDirectory> buildDirs = const {},
   Set<BuildFilter> buildFilters = const {},
-  void Function(AssetId id)? onDelete,
 }) async {
   buildPackages ??= BuildPackages.singlePackageBuild('a', [
     BuildPackage.forTesting(name: 'a', isOutput: true),
@@ -127,7 +126,7 @@ Future<TestBuildersResult> testPhases(
     b.verbose = verbose;
   });
 
-  var buildPlan = await BuildPlan.load(
+  final buildPlan = await BuildPlan.load(
     await BuildSpec.load(
       builderFactories: builderFactories,
       // ignore: invalid_use_of_visible_for_testing_member
@@ -144,13 +143,8 @@ Future<TestBuildersResult> testPhases(
     ),
   );
 
-  if (onDelete != null) {
-    buildPlan = buildPlan.rebuild((b) => b.onDelete = onDelete);
-  }
-
-  BuildResult result;
   final buildSeries = BuildSeries(buildPlan);
-  result = await buildSeries.run({}, recentlyBootstrapped: true);
+  final result = await buildSeries.run({}, recentlyBootstrapped: true);
   await buildSeries.close();
 
   if (checkBuildStatus) {


### PR DESCRIPTION
Simplify handling of "expected deletes": when we do a delete as part of the build, we need to make it not trigger another build.

Because all deletes are now done in `build_series.dart` which also decides what file changes can trigger builds, we can move the logic entirely to `build_series.dart` instead of having it be distributed.

Remove a test that was of dubious value anyway :) it was using the `onDelete` hook to assert that nothing happened, which doesn't guarantee anything much.

Helps with the next PR which needs to track modifications in a similar way to differentiate user-made edits to outputs from build-output writes to outputs.