### PR TITLE
Restrict post process builder `build_to: source` output.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Bug fix: in incremental builds, when an input was deleted, its output was
   deleted at the start of the build. Make it consistent with other output
   deletions: wait until the end of the build.
+- Bug fix: post process builders with `build_to: source` can only write to
+  output packages.
 
 ## 2.15.2
 

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -633,6 +633,7 @@ class Build {
       inputId: input,
       buildFilesystem: _builderFilesystem,
       addAsset: (assetId) {
+        if (!hideOutput) buildPackages.throwIfReadonly(assetId);
         if (_isFile(assetId)) {
           throw InvalidOutputException(assetId, 'Asset already exists');
         }

--- a/build_runner/lib/src/build_plan/build_packages.dart
+++ b/build_runner/lib/src/build_plan/build_packages.dart
@@ -215,36 +215,11 @@ class BuildPackages implements AssetPathProvider {
   String pathFor(
     AssetId id, {
     required bool hide,
-    bool checkDeleteAllowed = false,
+    bool checkWriteAllowed = false,
   }) {
-    if (checkDeleteAllowed) {
-      // Delete is allowed if it's a hidden output in `outputRoot` or if it's a
-      // package in the build.
-      final isUnderCacheDirectory = id.path.startsWith('$cacheDirectoryPath/');
-      final deleteIsAllowed =
-          hide ||
-          (isUnderCacheDirectory && id.package == outputRoot) ||
-          outputPackages.contains(id.package);
-      if (!deleteIsAllowed) {
-        if (isUnderCacheDirectory) {
-          throw InvalidOutputException(
-            id,
-            'Tried to delete from $cacheDirectoryPath in wrong package, should '
-            'be $outputRoot.',
-          );
-        } else {
-          throw InvalidOutputException(
-            id,
-            'Tried to delete from package not in the build. Packages in the '
-            'build are: ${outputPackages.join(', ')}',
-          );
-        }
-      }
-    }
+    if (hide) id = AssetPathProvider.hide(id, outputRoot);
+    if (checkWriteAllowed) throwIfReadonly(id);
 
-    if (hide) {
-      id = AssetPathProvider.hide(id, outputRoot);
-    }
     final package = packages[id.package];
     if (package == null) {
       throw PackageNotFoundException(id.package);
@@ -254,6 +229,32 @@ class BuildPackages implements AssetPathProvider {
       path = path.replaceAll('/', Platform.pathSeparator);
     }
     return p.join(package.path, path);
+  }
+
+  /// Throws if [id] is not allowed to be written or deleted.
+  ///
+  /// Write or delete is allowed if [id] is in the cache directory for
+  /// `outputRoot` or is in a package that is a build output.
+  void throwIfReadonly(AssetId id) {
+    final isUnderCacheDirectory = id.path.startsWith('$cacheDirectoryPath/');
+    final writeIsAllowed =
+        (isUnderCacheDirectory && id.package == outputRoot) ||
+        outputPackages.contains(id.package);
+    if (!writeIsAllowed) {
+      if (isUnderCacheDirectory) {
+        throw InvalidOutputException(
+          id,
+          'Tried to write or delete from $cacheDirectoryPath in wrong '
+          'package, should be $outputRoot.',
+        );
+      } else {
+        throw InvalidOutputException(
+          id,
+          'Tried to write or delete in a package not in the build. Packages '
+          'in the build are: ${outputPackages.join(', ')}',
+        );
+      }
+    }
   }
 
   /// Gets transitive deps of [packageName].

--- a/build_runner/lib/src/io/asset_path_provider.dart
+++ b/build_runner/lib/src/io/asset_path_provider.dart
@@ -13,11 +13,11 @@ abstract interface class AssetPathProvider {
   /// Set [hide] to get a path in the hidden "build cache" folder instead of the
   /// directory containing manually written source code.
   ///
-  /// Set [checkDeleteAllowed] to throw if the path is read only.
+  /// Set [checkWriteAllowed] to throw if the path is read only.
   String pathFor(
     AssetId id, {
     required bool hide,
-    bool checkDeleteAllowed = false,
+    bool checkWriteAllowed = false,
   });
 
   /// Returns [id] hidden in [buildCachePackage].

--- a/build_runner/lib/src/io/reader_writer.dart
+++ b/build_runner/lib/src/io/reader_writer.dart
@@ -60,12 +60,12 @@ class ReaderWriter implements AssetReader, AssetWriter {
   String _pathFor(
     AssetId id, {
     bool hidden = false,
-    bool checkDeleteAllowed = false,
+    bool checkWriteAllowed = false,
   }) {
     return assetPathProvider.pathFor(
       id,
       hide: hidden && !forceVisibleForTesting,
-      checkDeleteAllowed: checkDeleteAllowed,
+      checkWriteAllowed: checkWriteAllowed,
     );
   }
 
@@ -118,7 +118,7 @@ class ReaderWriter implements AssetReader, AssetWriter {
     bool hidden = false,
   }) {
     TimedActivity.write.run(() {
-      final path = _pathFor(id, hidden: hidden);
+      final path = _pathFor(id, hidden: hidden, checkWriteAllowed: true);
       filesystem.writeAsBytesSync(path, bytes);
     });
     return Future.value();
@@ -132,7 +132,7 @@ class ReaderWriter implements AssetReader, AssetWriter {
     bool hidden = false,
   }) {
     TimedActivity.write.run(() {
-      final path = _pathFor(id, hidden: hidden);
+      final path = _pathFor(id, hidden: hidden, checkWriteAllowed: true);
       filesystem.writeAsStringSync(path, contents, encoding: encoding);
     });
     return Future.value();
@@ -155,7 +155,7 @@ class ReaderWriter implements AssetReader, AssetWriter {
   }) {
     TimedActivity.write.run(() {
       onDelete?.call(id);
-      final path = _pathFor(id, hidden: hidden, checkDeleteAllowed: true);
+      final path = _pathFor(id, hidden: hidden, checkWriteAllowed: true);
       filesystem.deleteSync(path);
     });
     return Future.value();
@@ -167,7 +167,7 @@ class ReaderWriter implements AssetReader, AssetWriter {
     void Function(AssetId)? onDelete,
   }) {
     TimedActivity.write.run(() {
-      final path = _pathFor(id, hidden: hidden);
+      final path = _pathFor(id, hidden: hidden, checkWriteAllowed: true);
       filesystem.deleteDirectorySync(path);
     });
     return Future.value();

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -281,7 +281,6 @@ void main() {
           outputs: {'a|lib/lib.txt': 'libText', 'a|root.txt': 'rootText'},
         );
       });
-
       test('one phase, one builder, one-to-many outputs', () async {
         await testPhases(
           BuilderFactories({
@@ -760,36 +759,40 @@ additional_public_assets:
     );
 
     group('with `hideOutput: true`', () {
-      late BuildPackages buildPackages;
-
-      setUp(() {
-        buildPackages = BuildPackages.singlePackageBuild('a', [
-          BuildPackage(
-            name: 'a',
-            path: 'a/',
-            dependencies: ['b'],
-            isOutput: true,
-          ),
-          BuildPackage(name: 'b', path: 'a/b/'),
-        ]);
-      });
       test('can output files in non-root packages', () async {
-        await testPhases(
-          builderFactories,
-          [
-            BuilderDefinition(
-              '',
-              autoApply: AutoApply.allPackages,
-              hideOutput: true,
-              appliesBuilders: ['a:post_copy_builder'],
-            ),
-            postCopyABuilderDefinition,
-          ],
+        await testBuilders(
+          [testBuilder],
           {'b|lib/b.txt': 'b'},
-          buildPackages: buildPackages,
-          outputs: {r'$$b|lib/b.txt.copy': 'b', r'$$b|lib/b.txt.post': 'b'},
+          postProcessBuilders: [
+            CopyingPostProcessBuilder(outputExtension: '.post'),
+          ],
+          appliesBuilders: {
+            testBuilder: ['CopyingPostProcessBuilder'],
+          },
+          rootPackage: 'a',
+          outputs: {r'b|lib/b.txt.copy': 'b', r'b|lib/b.txt.post': 'b'},
         );
       });
+
+      test(
+        'cannot output files in non-root packages with hideOutput: false',
+        () async {
+          final differentPackagePostProcessBuilder =
+              DifferentPackagePostProcessBuilder();
+          final result = await testBuilders(
+            [testBuilder],
+            {'a|lib/a.txt': 'a'},
+            postProcessBuilders: [differentPackagePostProcessBuilder],
+            appliesBuilders: {
+              testBuilder: ['DifferentPackagePostProcessBuilder'],
+            },
+            visibleOutputPostProcessBuilders: {
+              differentPackagePostProcessBuilder,
+            },
+          );
+          expect(result.succeeded, false);
+        },
+      );
 
       test('handles mixed hidden and non-hidden outputs', () async {
         final result = await testBuilders(
@@ -1900,6 +1903,20 @@ class SiblingCopyBuilder extends Builder {
     await buildStep.writeAsString(
       buildStep.inputId.addExtension('.new'),
       await buildStep.readAsString(sibling),
+    );
+  }
+}
+
+/// A builder that writes to a different package.
+class DifferentPackagePostProcessBuilder implements PostProcessBuilder {
+  @override
+  final inputExtensions = const ['.txt'];
+
+  @override
+  Future<void> build(PostProcessBuildStep buildStep) async {
+    await buildStep.writeAsBytes(
+      AssetId('different_package', 'lib/a.txt'),
+      <int>[],
     );
   }
 }

--- a/build_runner/test/build_plan/build_packages_test.dart
+++ b/build_runner/test/build_plan/build_packages_test.dart
@@ -7,6 +7,7 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:build/build.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_paths.dart';
@@ -39,6 +40,25 @@ void main() {
         );
 
         expect(buildRunner.languageVersion, LanguageVersion(3, 11));
+      });
+
+      test('checkWriteAllowed', () {
+        expect(
+          buildPackages.pathFor(
+            AssetId('build_runner', 'lib/a.txt'),
+            hide: false,
+            checkWriteAllowed: true,
+          ),
+          isNotNull,
+        );
+        expect(
+          () => buildPackages.pathFor(
+            AssetId('not_build_runner', 'lib/a.txt'),
+            hide: false,
+            checkWriteAllowed: true,
+          ),
+          throwsA(isA<InvalidOutputException>()),
+        );
       });
     });
 

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.5.18-wip
 
+- Add `visibleOutputPostProcessBuilders` to `testBuilders`.
 - Use `build_runner` 2.15.3.
 
 ## 3.5.17

--- a/build_test/lib/src/internal_test_reader_writer.dart
+++ b/build_test/lib/src/internal_test_reader_writer.dart
@@ -165,7 +165,7 @@ class InMemoryAssetPathProvider implements AssetPathProvider {
   String pathFor(
     AssetId id, {
     required bool hide,
-    bool checkDeleteAllowed = false,
+    bool checkWriteAllowed = false,
   }) {
     if (hide) {
       id = AssetPathProvider.hide(id, outputRootPackage);

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -189,6 +189,7 @@ Future<TestBuilderResult> testBuilders(
   Resolvers? resolvers,
   Set<Builder> optionalBuilders = const {},
   Set<Builder> visibleOutputBuilders = const {},
+  Set<PostProcessBuilder> visibleOutputPostProcessBuilders = const {},
   Map<Builder, List<String>> appliesBuilders = const {},
   bool testingBuilderConfig = true,
   TestReaderWriter? readerWriter,
@@ -213,8 +214,14 @@ Future<TestBuilderResult> testBuilders(
     }
   }
   final postProcessBuilderFactories = <PostProcessBuilderFactory>[];
+  final visibleOutputPostProcessBuilderFactories =
+      Set<PostProcessBuilderFactory>.identity();
   for (final postProcessBuilder in postProcessBuilders) {
-    postProcessBuilderFactories.add((_) => postProcessBuilder);
+    PostProcessBuilder factory(_) => postProcessBuilder;
+    postProcessBuilderFactories.add(factory);
+    if (visibleOutputPostProcessBuilders.contains(postProcessBuilder)) {
+      visibleOutputPostProcessBuilderFactories.add(factory);
+    }
   }
   return testBuilderFactories(
     builderFactories,
@@ -230,6 +237,8 @@ Future<TestBuilderResult> testBuilders(
     resolvers: resolvers,
     optionalBuilderFactories: optionalBuilderFactories,
     visibleOutputBuilderFactories: visibleOutputBuilderFactories,
+    visibleOutputPostProcessBuilderFactories:
+        visibleOutputPostProcessBuilderFactories,
     appliesBuilders: appliesBuildersToFactories,
     testingBuilderConfig: testingBuilderConfig,
     readerWriter: readerWriter,
@@ -286,6 +295,10 @@ Future<TestBuilderResult> testBuilders(
 /// [visibleOutputBuilderFactories]. The builder then writes its outputs next to
 /// its input, instead of hidden under `.dart_tool`.
 ///
+/// To mark a post process builder's output as visible, add it to
+/// [visibleOutputPostProcessBuilderFactories]. The builder then writes its
+/// outputs next to its input, instead of hidden under `.dart_tool`.
+///
 /// To cause a builder to apply another builder, as `applies_builders` in
 /// `build.yaml`, pass [appliesBuilders].
 ///
@@ -320,6 +333,8 @@ Future<TestBuilderResult> testBuilderFactories(
   Resolvers? resolvers,
   Set<BuilderFactory> optionalBuilderFactories = const {},
   Set<BuilderFactory> visibleOutputBuilderFactories = const {},
+  Set<PostProcessBuilderFactory> visibleOutputPostProcessBuilderFactories =
+      const {},
   Map<BuilderFactory, List<String>> appliesBuilders = const {},
   bool testingBuilderConfig = true,
   TestReaderWriter? readerWriter,
@@ -449,7 +464,14 @@ Future<TestBuilderResult> testBuilderFactories(
       name,
       postProcessBuilderNameToBuilderFactory.keys.toSet(),
     );
-    builderDefinitions.add(PostProcessBuilderDefinition(name));
+    builderDefinitions.add(
+      PostProcessBuilderDefinition(
+        name,
+        hideOutput: !visibleOutputPostProcessBuilderFactories.contains(
+          postProcessBuilderFactory,
+        ),
+      ),
+    );
     postProcessBuilderNameToBuilderFactory[name] = postProcessBuilderFactory;
   }
 


### PR DESCRIPTION
Stop post process builders writing to the source tree for packages that are not in the build output.

In all other cases location of outputs is derived from location of inputs, so outputs were correct by construction and there was no general check disallowing this kind of write.

Expand the current "deleteIsAllowed" check, which was doing exactly this check for deletes, to "writeIsAllowed", so we catch this type of bug generally. Extract `throwIfReadonly` so we can also call it during the build, to get a better error message / failure state.

Add support for testing post process builders with `build_to: source` to `testBuilders` in `package:build_test`, use it in an existing related test, add a test for the `build_to: source` case.