### PR TITLE
Check builder package in build.yaml parsing.

### DIFF
--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2-wip
+
+- Reject builder names with the wrong package name.
+
 ## 1.3.1
 
 - Document that `--define` values are parsed as JSON with a fallback.

--- a/build_config/lib/src/key_normalization.dart
+++ b/build_config/lib/src/key_normalization.dart
@@ -93,5 +93,10 @@ String _normalizeUsage(String name, String packageName) {
 String _normalizeDefinition(String name, String packageName) {
   if (name.startsWith(':')) return '$packageName$name';
   if (!name.contains(':')) return '$packageName:$name';
+  if (!name.startsWith('$packageName:')) {
+    throw ArgumentError(
+      'Builder key "$name" does not belong to package "$packageName".',
+    );
+  }
   return name;
 }

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 1.3.1
+version: 1.3.2-wip
 description: >-
   Format definition and support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config

--- a/build_config/test/errors_test.dart
+++ b/build_config/test/errors_test.dart
@@ -141,6 +141,26 @@ targets:
       ),
     );
   });
+
+  test('for builder keys outside package namespace', () {
+    final buildYaml = r'''
+builders:
+  other_package:builder:
+    builder_factories: ["someFactory"]
+    import: package:package_name/builders.dart
+    build_extensions: {".dart": [".json"]}
+''';
+
+    _expectThrows(buildYaml, r'''
+line 1, column 1 of build.yaml: Builder key "other_package:builder" does not belong to package "package_name".
+  ╷
+1 │ ┌ builders:
+2 │ │   other_package:builder:
+3 │ │     builder_factories: ["someFactory"]
+4 │ │     import: package:package_name/builders.dart
+5 │ └     build_extensions: {".dart": [".json"]}
+  ╵''');
+  });
 }
 
 void _expectThrows(String buildYaml, Object matcher) => expect(

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -5,6 +5,7 @@
   deletions: wait until the end of the build.
 - Bug fix: post process builders with `build_to: source` can only write to
   output packages.
+- Bug fix: reject incorrect builder config that has duplicate builder keys.
 
 ## 2.15.2
 

--- a/build_runner/lib/src/build_plan/builder_ordering.dart
+++ b/build_runner/lib/src/build_plan/builder_ordering.dart
@@ -17,6 +17,12 @@ Iterable<BuilderDefinition> findBuilderOrder(
 ) {
   final consistentOrderBuilders = builders.toList()
     ..sort((a, b) => a.key.compareTo(b.key));
+  final seenKeys = <String>{};
+  for (final builder in consistentOrderBuilders) {
+    if (!seenKeys.add(builder.key)) {
+      throw ArgumentError('Duplicate builder key: ${builder.key}');
+    }
+  }
   Iterable<BuilderDefinition> dependencies(BuilderDefinition parent) =>
       consistentOrderBuilders.where(
         (child) =>

--- a/build_runner/test/bootstrap/builder_ordering_test.dart
+++ b/build_runner/test/bootstrap/builder_ordering_test.dart
@@ -219,6 +219,32 @@ void main() {
       final orderedKeys = orderedBuilders.map((b) => b.key);
       expect(orderedKeys, ['a:self_cycle']);
     });
+
+    test('throws on duplicate builder keys', () {
+      final buildConfigs = parseBuildConfigs({
+        'a': {
+          'builders': {
+            'b': {
+              'builder_factories': ['createBuilder'],
+              'build_extensions': <String, List<String>>{},
+              'target': '',
+              'import': '',
+            },
+          },
+        },
+      });
+      final builder = buildConfigs['a']!.builderDefinitions.values.single;
+      expect(
+        () => findBuilderOrder([builder, builder], {}),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            'Duplicate builder key: a:b',
+          ),
+        ),
+      );
+    });
   });
 }
 

--- a/build_runner/test/bootstrap/builder_ordering_test.dart
+++ b/build_runner/test/bootstrap/builder_ordering_test.dart
@@ -221,6 +221,7 @@ void main() {
     });
 
     test('throws on duplicate builder keys', () {
+      // Parse can't return duplicate keys, so parse then duplicate.
       final buildConfigs = parseBuildConfigs({
         'a': {
           'builders': {
@@ -234,8 +235,9 @@ void main() {
         },
       });
       final builder = buildConfigs['a']!.builderDefinitions.values.single;
+      final duplicateBuilders = [builder, builder];
       expect(
-        () => findBuilderOrder([builder, builder], {}),
+        () => findBuilderOrder(duplicateBuilders, {}),
         throwsA(
           isA<ArgumentError>().having(
             (e) => e.message,


### PR DESCRIPTION
Various parts of `build_runner` expect that a package can only define builders in its own package; enforce it in `build_config`, and reject duplicate config in `build_runner` that could be caused by two packages defining the same builder.