### PR TITLE
Fix flaky test.

### DIFF
--- a/build_runner/test/integration_tests/watch_command_test.dart
+++ b/build_runner/test/integration_tests/watch_command_test.dart
@@ -204,7 +204,7 @@ $yaml
     // The first build after retry is marked as a new build.
     await watch.expect('Starting build #5');
     // But the next identical build failure is not logged as a new build.
-    final block = await watch.expectAndGetBlock('0s compiling builders');
+    final block = await watch.expectAndGetBlock('compiling builders');
     expect(block, isNot(contains('Starting build')));
 
     // Restore the correct build script and it gets compiled and runs.


### PR DESCRIPTION
Fix a flake caused by `0s compiling builders` not always being logged due to timing.

Sometimes `1s compiling builders` is the first line logged.

Just check for `compiling builders`.