### PR TITLE
Check builder factories.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bug fix: post process builders with `build_to: source` can only write to
   output packages.
 - Bug fix: reject incorrect builder config that has duplicate builder keys.
+- Bug fix: reject invalid builder factories in `build.yaml`.
 
 ## 2.15.2
 

--- a/build_runner/lib/src/bootstrap/build_script_generate.dart
+++ b/build_runner/lib/src/bootstrap/build_script_generate.dart
@@ -162,7 +162,7 @@ class BuilderFactoriesExpressions {
       final factories = entry.value
           .map((f) => f.render(importPrefixes))
           .join(', ');
-      result.writeln("'${entry.key}': [$factories],");
+      result.writeln("'${_checkKey(entry.key)}': [$factories],");
     }
     return result.toString();
   }
@@ -170,9 +170,19 @@ class BuilderFactoriesExpressions {
   String get renderPostProcessBuilderFactories {
     final result = StringBuffer();
     for (final entry in postProcessBuilderFactories.entries) {
-      result.writeln("'${entry.key}': ${entry.value.render(importPrefixes)},");
+      result.writeln(
+        "'${_checkKey(entry.key)}': ${entry.value.render(importPrefixes)},",
+      );
     }
     return result.toString();
+  }
+
+  /// Throws if [key] is not a valid builder key.
+  String _checkKey(String key) {
+    if (!_validBuilderKeyPattern.hasMatch(key)) {
+      throw ArgumentError('Invalid builder key $key.');
+    }
+    return key;
   }
 }
 
@@ -181,7 +191,7 @@ List<FactoryExpression> _builderFactories(BuilderDefinition definition) {
   final import = _buildScriptImport(definition.import);
   return [
     for (final f in definition.builderFactories)
-      FactoryExpression(import: import, name: f),
+      FactoryExpression(builderKey: definition.key, import: import, name: f),
   ];
 }
 
@@ -190,7 +200,11 @@ FactoryExpression _postProcessBuilderFactory(
   PostProcessBuilderDefinition definition,
 ) {
   final import = _buildScriptImport(definition.import);
-  return FactoryExpression(import: import, name: definition.builderFactory);
+  return FactoryExpression(
+    builderKey: definition.key,
+    import: import,
+    name: definition.builderFactory,
+  );
 }
 
 /// Returns the actual import to put in the generated script based on an import
@@ -209,8 +223,30 @@ class FactoryExpression {
   final String import;
   final String name;
 
-  FactoryExpression({required this.name, required this.import});
+  FactoryExpression({
+    required String builderKey,
+    required this.name,
+    required this.import,
+  }) {
+    if (!_factoryNamePattern.hasMatch(name)) {
+      throw ArgumentError('Invalid factory name for $builderKey.');
+    }
+    if (_invalidInStringLiteral.hasMatch(import)) {
+      throw ArgumentError('Invalid import for $builderKey.');
+    }
+  }
 
   String render(Map<String, String> importPrefixes) =>
       '${importPrefixes[import]}.$name';
 }
+
+/// A top-level function or static method.
+final _factoryNamePattern = RegExp(
+  r'^[a-zA-Z_$][a-zA-Z0-9_$]*(\.[a-zA-Z_$][a-zA-Z0-9_$]*)?$',
+);
+
+/// A builder key.
+final _validBuilderKeyPattern = RegExp(r'^[a-zA-Z0-9_\-:]+$');
+
+/// Characters that are not allowed in a single quoted string literal.
+final _invalidInStringLiteral = RegExp(r"['\\\r\n$]");

--- a/build_runner/test/bootstrap/build_script_generate_test.dart
+++ b/build_runner/test/bootstrap/build_script_generate_test.dart
@@ -1,0 +1,109 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build_runner/src/bootstrap/build_script_generate.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FactoryExpression', () {
+    test('accepts valid identifiers', () {
+      expect(
+        () => FactoryExpression(
+          builderKey: 'a:a',
+          name: 'valid',
+          import: 'package:a/a.dart',
+        ),
+        returnsNormally,
+      );
+      expect(
+        () => FactoryExpression(
+          builderKey: 'a:a',
+          name: 'Valid.named',
+          import: 'package:a/a.dart',
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('rejects identifiers with invalid characters', () {
+      expect(
+        () => FactoryExpression(
+          builderKey: 'a:a',
+          name: 'invalid(){}',
+          import: 'package:a/a.dart',
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => FactoryExpression(
+          builderKey: 'a:a',
+          name: 'Builder != ()',
+          import: 'package:a/a.dart',
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects imports with invalid characters', () {
+      expect(
+        () => FactoryExpression(
+          builderKey: 'a:a',
+          name: 'valid',
+          import: "package:a/a.dart';\n",
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => FactoryExpression(
+          builderKey: 'a:a',
+          name: 'valid',
+          import: r'package:a/a.dart$',
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => FactoryExpression(
+          builderKey: 'a:a',
+          name: 'valid',
+          import: "package:a/a.dart'",
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('BuilderFactoriesExpressions', () {
+    test('accepts valid builder keys', () {
+      final expressions = BuilderFactoriesExpressions(
+        builderFactories: {
+          'valid_package:valid-builder': [
+            FactoryExpression(
+              builderKey: 'valid_package:valid-builder',
+              name: 'valid',
+              import: 'package:a/a.dart',
+            ),
+          ],
+        },
+        postProcessBuilderFactories: {},
+      );
+      expect(() => expressions.renderBuilderFactories, returnsNormally);
+    });
+
+    test('rejects builder keys with invalid characters', () {
+      final expressions = BuilderFactoriesExpressions(
+        builderFactories: {
+          "a:a'; //": [
+            FactoryExpression(
+              builderKey: "a:a'; //",
+              name: 'valid',
+              import: 'package:a/a.dart',
+            ),
+          ],
+        },
+        postProcessBuilderFactories: {},
+      );
+      expect(() => expressions.renderBuilderFactories, throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
Builders are already code from a builder package that we run; so malformed builder factories don't add much to that.

But, we might as well validate them.