### PR TITLE
Check packages and package names.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.9-wip
+
+- `AssetId` now validates package names in addition to paths.
+
 ## 4.0.8
 
 - Allow `analyzer` 14.x, require 13.3.0.

--- a/build/lib/src/asset_id.dart
+++ b/build/lib/src/asset_id.dart
@@ -30,7 +30,18 @@ class AssetId implements Comparable<AssetId> {
   /// thrown.
   ///
   /// The [path] is normalized: `\` is replaced with `/`, then `.` and `..` are removed.
-  AssetId(this.package, String path) : path = _normalizePath(path);
+  ///
+  /// [package] must be a valid Dart package name, or an [ArgumentError] is
+  /// thrown.
+  AssetId(this.package, String path) : path = _normalizePath(path) {
+    if (!_packageRegExp.hasMatch(package)) {
+      throw ArgumentError.value(
+        package,
+        'package',
+        'Package name contains invalid characters.',
+      );
+    }
+  }
 
   /// Creates an [AssetId] from a [uri].
   ///
@@ -155,3 +166,5 @@ Uri _constructUri(AssetId id) {
   final pathSegments = isLib ? originalSegments.skip(1) : originalSegments;
   return Uri(scheme: scheme, pathSegments: [id.package, ...pathSegments]);
 }
+
+final _packageRegExp = RegExp(r'^([a-zA-Z0-9_$-]+(\.[a-zA-Z0-9_$-]+)*)?$');

--- a/build/lib/src/asset_id.dart
+++ b/build/lib/src/asset_id.dart
@@ -113,9 +113,8 @@ class AssetId implements Comparable<AssetId> {
       AssetId(package, p.withoutExtension(path) + newExtension);
 
   /// Deserializes a `List<dynamic>` from [serialize].
-  AssetId.deserialize(List<dynamic> serialized)
-    : package = serialized[0] as String,
-      path = serialized[1] as String;
+  factory AssetId.deserialize(List<dynamic> serialized) =>
+      AssetId(serialized[0] as String, serialized[1] as String);
 
   /// Serializes this [AssetId] to an `Object` that can be sent across isolates.
   ///
@@ -167,4 +166,4 @@ Uri _constructUri(AssetId id) {
   return Uri(scheme: scheme, pathSegments: [id.package, ...pathSegments]);
 }
 
-final _packageRegExp = RegExp(r'^([a-zA-Z0-9_$-]+(\.[a-zA-Z0-9_$-]+)*)?$');
+final _packageRegExp = RegExp(r'^([a-zA-Z0-9_$]+(\.[a-zA-Z0-9_$]+)*)?$');

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 4.0.8
+version: 4.0.9-wip
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace

--- a/build/test/asset_id_test.dart
+++ b/build/test/asset_id_test.dart
@@ -9,6 +9,19 @@ import 'package:test/test.dart';
 
 void main() {
   group('constructor', () {
+    test('validates the package parameter', () {
+      expect(() => AssetId('..', 'a'), throwsArgumentError);
+      expect(() => AssetId('a..b', 'a'), throwsArgumentError);
+      expect(() => AssetId('.a', 'a'), throwsArgumentError);
+      expect(() => AssetId('a.', 'a'), throwsArgumentError);
+      expect(() => AssetId('a/b', 'a'), throwsArgumentError);
+      expect(() => AssetId('a\\b', 'a'), throwsArgumentError);
+      expect(AssetId('', 'a').package, '');
+      expect(AssetId('a.b', 'a').package, 'a.b');
+      expect(AssetId('a\$b', 'a').package, 'a\$b');
+      expect(AssetId('a-b', 'a').package, 'a-b');
+    });
+
     test('normalizes the path', () {
       final id = AssetId('app', r'path/././/to/drop/..//asset.txt');
       expect(id.path, equals('path/to/asset.txt'));

--- a/build/test/asset_id_test.dart
+++ b/build/test/asset_id_test.dart
@@ -16,10 +16,14 @@ void main() {
       expect(() => AssetId('a.', 'a'), throwsArgumentError);
       expect(() => AssetId('a/b', 'a'), throwsArgumentError);
       expect(() => AssetId('a\\b', 'a'), throwsArgumentError);
-      expect(AssetId('', 'a').package, '');
+      expect(() => AssetId('a-b', 'a'), throwsArgumentError);
+
+      // Dots are valid in package names, just not in published packages.
       expect(AssetId('a.b', 'a').package, 'a.b');
-      expect(AssetId('a\$b', 'a').package, 'a\$b');
-      expect(AssetId('a-b', 'a').package, 'a-b');
+
+      // Dollars are not valid in package names, but they are used by
+      // `build_runner` internally.
+      expect(AssetId(r'$sdk', 'a').package, r'$sdk');
     });
 
     test('normalizes the path', () {

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -5,6 +5,8 @@
   deletions: wait until the end of the build.
 - Bug fix: post process builders with `build_to: source` can only write to
   output packages.
+- Bug fix: post process builders with `build_to: cache` can only write output
+  corresponding to known packages.
 - Bug fix: reject incorrect builder config that has duplicate builder keys.
 - Bug fix: reject invalid builder factories in `build.yaml`.
 

--- a/build_runner/lib/src/build/build_step_impl.dart
+++ b/build_runner/lib/src/build/build_step_impl.dart
@@ -16,6 +16,7 @@ import 'package:package_config/package_config_types.dart';
 import 'asset_content.dart';
 import 'builder_filesystem.dart';
 import 'input_tracker.dart';
+import 'resolver/asset_ids.dart';
 import 'resolver/delegating_resolver.dart';
 
 /// A single step in the build processes.
@@ -110,6 +111,7 @@ class BuildStepImpl implements BuildStep {
   @override
   Future<bool> canRead(AssetId id, {bool track = true}) async {
     if (_isComplete) throw BuildStepCompletedException();
+    id = id.normalize();
     final isReadable = await _isReadable(
       id,
       catchInvalidInputs: true,
@@ -132,6 +134,7 @@ class BuildStepImpl implements BuildStep {
   @override
   Future<List<int>> readAsBytes(AssetId id) async {
     if (_isComplete) throw BuildStepCompletedException();
+    id = id.normalize();
     final isReadable = await _isReadable(id);
     if (!isReadable) {
       throw AssetNotFoundException(id);
@@ -150,6 +153,7 @@ class BuildStepImpl implements BuildStep {
     bool track = true,
   }) async {
     if (_isComplete) throw BuildStepCompletedException();
+    id = id.normalize();
     final isReadable = await _isReadable(id, track: track);
     if (!isReadable) {
       throw AssetNotFoundException(id);
@@ -175,6 +179,7 @@ class BuildStepImpl implements BuildStep {
   @override
   Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes) async {
     if (_isComplete) throw BuildStepCompletedException();
+    id = id.normalize();
     _checkOutput(id);
     outputs[id] = AssetContent.bytes(await bytes);
   }
@@ -186,6 +191,7 @@ class BuildStepImpl implements BuildStep {
     Encoding encoding = utf8,
   }) async {
     if (_isComplete) throw BuildStepCompletedException();
+    id = id.normalize();
     _checkOutput(id);
     outputs[id] = AssetContent.string(await content, encoding: encoding);
   }
@@ -193,6 +199,7 @@ class BuildStepImpl implements BuildStep {
   @override
   Future<Digest> digest(AssetId id, {bool track = true}) async {
     if (_isComplete) throw BuildStepCompletedException();
+    id = id.normalize();
     final isReadable = await _isReadable(id, track: track);
 
     if (!isReadable) {

--- a/build_runner/lib/src/build/post_process_build_step_impl.dart
+++ b/build_runner/lib/src/build/post_process_build_step_impl.dart
@@ -10,6 +10,7 @@ import 'package:crypto/crypto.dart' show Digest;
 
 import 'asset_content.dart';
 import 'builder_filesystem.dart';
+import 'resolver/asset_ids.dart';
 
 class PostProcessBuildStepImpl implements PostProcessBuildStep {
   @override
@@ -30,9 +31,12 @@ class PostProcessBuildStepImpl implements PostProcessBuildStep {
        _deleteAsset = deleteAsset;
 
   @override
-  Future<Digest> digest(AssetId id) async => inputId == id
-      ? (await buildFilesystem.contentOf(id)).digest
-      : Future.error(InvalidInputException(id));
+  Future<Digest> digest(AssetId id) async {
+    id = id.normalize();
+    return inputId == id
+        ? (await buildFilesystem.contentOf(id)).digest
+        : Future.error(InvalidInputException(id));
+  }
 
   @override
   Future<List<int>> readInputAsBytes() async {
@@ -48,6 +52,7 @@ class PostProcessBuildStepImpl implements PostProcessBuildStep {
 
   @override
   Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes) async {
+    id = id.normalize();
     _addAsset(id);
     outputs[id] = AssetContent.bytes(await bytes);
   }
@@ -58,6 +63,7 @@ class PostProcessBuildStepImpl implements PostProcessBuildStep {
     FutureOr<String> content, {
     Encoding encoding = utf8,
   }) async {
+    id = id.normalize();
     _addAsset(id);
     outputs[id] = AssetContent.string(await content, encoding: encoding);
   }

--- a/build_runner/lib/src/build/resolver/asset_ids.dart
+++ b/build_runner/lib/src/build/resolver/asset_ids.dart
@@ -8,6 +8,14 @@ import '../../build_plan/build_step_plan.dart';
 import '../build_state/build_state.dart';
 
 extension AssetIdExtension on AssetId {
+  /// Normalizes this [AssetId].
+  ///
+  /// If the type of `this` is exactly `AssetId` then normalization of package
+  /// and path was already done by the constructor and `this` is returned.
+  ///
+  /// Otherwise returns a new `AssetId` constructed from [package] and [path].
+  AssetId normalize() => runtimeType == AssetId ? this : AssetId(package, path);
+
   bool get isDart => extension == '.dart';
 
   /// Whether the asset is hidden.

--- a/build_runner/lib/src/build/resolver/asset_ids.dart
+++ b/build_runner/lib/src/build/resolver/asset_ids.dart
@@ -8,13 +8,10 @@ import '../../build_plan/build_step_plan.dart';
 import '../build_state/build_state.dart';
 
 extension AssetIdExtension on AssetId {
-  /// Normalizes this [AssetId].
+  /// Returns a new [AssetId] constructed from [package] and [path].
   ///
-  /// If the type of `this` is exactly `AssetId` then normalization of package
-  /// and path was already done by the constructor and `this` is returned.
-  ///
-  /// Otherwise returns a new `AssetId` constructed from [package] and [path].
-  AssetId normalize() => runtimeType == AssetId ? this : AssetId(package, path);
+  /// Normalizes the path; throws on invalid package or path.
+  AssetId normalize() => AssetId(package, path);
 
   bool get isDart => extension == '.dart';
 

--- a/build_runner/lib/src/build/resolver/delegating_resolver.dart
+++ b/build_runner/lib/src/build/resolver/delegating_resolver.dart
@@ -9,6 +9,8 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:async/async.dart';
 import 'package:build/build.dart';
 
+import 'asset_ids.dart';
+
 /// [Resolver] implementation that delegates to a `Future<Resolver>`.
 class DelegatingResolver implements Resolver {
   final Future<Resolver> _delegate;
@@ -17,7 +19,7 @@ class DelegatingResolver implements Resolver {
 
   @override
   Future<bool> isLibrary(AssetId assetId) async =>
-      (await _delegate).isLibrary(assetId);
+      (await _delegate).isLibrary(assetId.normalize());
 
   @override
   Stream<LibraryElement> get libraries {
@@ -37,7 +39,7 @@ class DelegatingResolver implements Resolver {
     AssetId assetId, {
     bool allowSyntaxErrors = false,
   }) async => (await _delegate).compilationUnitFor(
-    assetId,
+    assetId.normalize(),
     allowSyntaxErrors: allowSyntaxErrors,
   );
 
@@ -46,7 +48,7 @@ class DelegatingResolver implements Resolver {
     AssetId assetId, {
     bool allowSyntaxErrors = false,
   }) async => (await _delegate).libraryFor(
-    assetId,
+    assetId.normalize(),
     allowSyntaxErrors: allowSyntaxErrors,
   );
 

--- a/build_runner/lib/src/build_plan/build_packages.dart
+++ b/build_runner/lib/src/build_plan/build_packages.dart
@@ -217,13 +217,13 @@ class BuildPackages implements AssetPathProvider {
     required bool hide,
     bool checkWriteAllowed = false,
   }) {
+    if (!packages.containsKey(id.package)) {
+      throw PackageNotFoundException(id.package);
+    }
     if (hide) id = AssetPathProvider.hide(id, outputRoot);
     if (checkWriteAllowed) throwIfReadonly(id);
 
-    final package = packages[id.package];
-    if (package == null) {
-      throw PackageNotFoundException(id.package);
-    }
+    final package = packages[id.package]!;
     var path = id.path;
     if (Platform.pathSeparator != '/') {
       path = path.replaceAll('/', Platform.pathSeparator);

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   analyzer: '>=13.3.0 <15.0.0'
   args: ^2.5.0
   async: ^2.5.0
-  build: ^4.0.7
+  build: ^4.0.9-wip
   build_config: ">=1.3.0 <1.4.0"
   build_daemon: ^4.0.0
   built_collection: ^5.1.1

--- a/build_runner/test/build_plan/build_packages_test.dart
+++ b/build_runner/test/build_plan/build_packages_test.dart
@@ -22,7 +22,7 @@ void main() {
   late BuildPackages buildPackages;
 
   group('BuildPackages', () {
-    group('forThisPackage ', () {
+    group('forThisPackage', () {
       setUp(() async {
         buildPackages = await BuildPackages.forPaths(
           BuildPaths.load(p.current, buildWorkspace: false),
@@ -42,7 +42,7 @@ void main() {
         expect(buildRunner.languageVersion, LanguageVersion(3, 11));
       });
 
-      test('checkWriteAllowed', () {
+      test('pathFor allows write to output package', () {
         expect(
           buildPackages.pathFor(
             AssetId('build_runner', 'lib/a.txt'),
@@ -51,13 +51,57 @@ void main() {
           ),
           isNotNull,
         );
+      });
+
+      test('pathFor prohibits write to known but non-output package', () {
         expect(
           () => buildPackages.pathFor(
-            AssetId('not_build_runner', 'lib/a.txt'),
+            AssetId('test', 'lib/a.txt'),
             hide: false,
             checkWriteAllowed: true,
           ),
           throwsA(isA<InvalidOutputException>()),
+        );
+      });
+
+      test('pathFor prohibits access to unknown package', () {
+        expect(
+          () => buildPackages.pathFor(
+            AssetId('unknown', 'lib/a.txt'),
+            hide: false,
+          ),
+          throwsA(isA<PackageNotFoundException>()),
+        );
+      });
+
+      test('pathFor allows write to cache in output package', () {
+        expect(
+          buildPackages.pathFor(
+            AssetId('build_runner', 'lib/a.txt'),
+            hide: true,
+            checkWriteAllowed: true,
+          ),
+          isNotNull,
+        );
+      });
+      test('pathFor allows write to cache in known but non-output package', () {
+        expect(
+          () => buildPackages.pathFor(
+            AssetId('test', 'lib/a.txt'),
+            hide: true,
+            checkWriteAllowed: true,
+          ),
+          isNotNull,
+        );
+      });
+
+      test('pathFor prohibits access to cache for unknown package', () {
+        expect(
+          () => buildPackages.pathFor(
+            AssetId('unknown', 'lib/a.txt'),
+            hide: true,
+          ),
+          throwsA(isA<PackageNotFoundException>()),
         );
       });
     });


### PR DESCRIPTION
In `package:build`, check package names in `AssetId` are valid.

In `package:build_runner`, check that `AssetId` passed from builder code is actually `AssetId`, if not, copy it. This means the normalization is actually guaranteed to run :)

In `package:build_runner`, check that outputs are to known packages. This catches malformed package names, like the AssetId changes, but additionally catches attempts to "write" to packages not known to the build, which don't make sense.