### PR TITLE
Check served paths against subdirectories.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -7,6 +7,7 @@
   output packages.
 - Bug fix: reject incorrect builder config that has duplicate builder keys.
 - Bug fix: reject invalid builder factories in `build.yaml`.
+- Bug fix: `serve` mode only serves the specified package subdirectories.
 
 ## 2.15.2
 

--- a/build_runner/lib/src/commands/serve/path_to_asset_id.dart
+++ b/build_runner/lib/src/commands/serve/path_to_asset_id.dart
@@ -16,14 +16,28 @@ List<AssetId> pathToAssetIds(
   String rootDir,
   List<String> pathSegments,
 ) {
-  final result = <AssetId>[
-    AssetId(outputRootPackage, p.joinAll([rootDir, ...pathSegments])),
-  ];
+  final firstId = AssetId(
+    outputRootPackage,
+    p.joinAll([rootDir, ...pathSegments]),
+  );
+  // AssetId normalizes path, check it didn't normalize upwards.
+  if (rootDir.isNotEmpty &&
+      firstId.path != rootDir &&
+      !firstId.path.startsWith('$rootDir/')) {
+    throw ArgumentError('Path must be within $rootDir.');
+  }
+
+  final result = <AssetId>[firstId];
   final packagesIndex = pathSegments.indexOf('packages');
   if (packagesIndex >= 0 && pathSegments.length - packagesIndex > 2) {
     final package = pathSegments[packagesIndex + 1];
     final path = p.joinAll(pathSegments.sublist(packagesIndex + 2));
-    result.add(AssetId(package, p.join('lib', path)));
+    final secondId = AssetId(package, p.join('lib', path));
+    // AssetId normalizes path, check it didn't normalize upwards.
+    if (secondId.path != 'lib' && !secondId.path.startsWith('lib/')) {
+      throw ArgumentError('Path must be within lib/.');
+    }
+    result.add(secondId);
   }
   return result;
 }

--- a/build_runner/test/commands/serve/path_to_asset_id_test.dart
+++ b/build_runner/test/commands/serve/path_to_asset_id_test.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:build_runner/src/commands/serve/path_to_asset_id.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('pathToAssetIds', () {
+    test('valid path', () {
+      final ids = pathToAssetIds('a', 'web', ['foo', 'bar.dart']);
+      expect(ids.length, 1);
+      expect(ids.first, AssetId('a', 'web/foo/bar.dart'));
+    });
+
+    test('rejects sequences that escape the expected subdir', () {
+      expect(
+        () => pathToAssetIds('a', 'web', ['..', 'foo', 'bar.dart']),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('permits sequences using .. that stay in the expected subdir', () {
+      final ids = pathToAssetIds('a', 'web', ['foo', '..', 'bar.dart']);
+      expect(ids.first.path, 'web/bar.dart');
+    });
+
+    test('handles `packages` mapping', () {
+      final ids = pathToAssetIds('a', 'web', ['packages', 'b', 'foo.dart']);
+      expect(ids.length, 2);
+      expect(ids[0], AssetId('a', 'web/packages/b/foo.dart'));
+      expect(ids[1], AssetId('b', 'lib/foo.dart'));
+    });
+
+    test('rejects packages mapping that escapes the lib directory', () {
+      expect(
+        () => pathToAssetIds('a', 'web', ['packages', 'b', '..', 'foo.dart']),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
The server uses `AssetId` which normalizes, so it will only serve files within a package root.

But it should be slightly stricter, and only serve the _subdirectories_ in the package that you ask it to serve.

Make it slightly stricter :)