### PR TITLE
Fix post process directory filtering.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -7,6 +7,7 @@
   output packages.
 - Bug fix: reject incorrect builder config that has duplicate builder keys.
 - Bug fix: reject invalid builder factories in `build.yaml`.
+- Bug fix: correctly filter served or `--output` post process output.
 
 ## 2.15.2
 

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -172,7 +172,11 @@ class BuildOutputReader {
         result.add(id);
       }
     }
-    result.addAll(_buildState.actualPostOutputs);
+    for (final id in _buildState.actualPostOutputs) {
+      if (!_shouldSkipId(id, rootDir)) {
+        result.add(id);
+      }
+    }
     return result;
   }
 

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -184,5 +184,55 @@ void main() {
             'build filters',
       );
     });
+
+    test('allAssets filters actualPostOutputs by rootDir', () async {
+      final postOutput = AssetId('a', 'test/post_output.txt');
+
+      final postProcessId = PostProcessBuildStepId(
+        input: AssetId('a', 'test/foo.txt'),
+        actionNumber: 0,
+      );
+
+      buildState.addPostProcessBuildStepResult(
+        postProcessId,
+        PostProcessBuildStepResult(
+          hidden: false,
+          deletedPrimaryInput: false,
+          outputs: {
+            postOutput: AssetContent.digest(computeDigest(postOutput, 'a')),
+          },
+        ),
+      );
+
+      final buildPlan = await BuildPlan.load(
+        await BuildSpec.load(
+          builderFactories: BuilderFactories({}),
+          buildOptions: BuildOptions.forTests(
+            buildDirs: {BuildDirectory('web')}.build(),
+          ),
+          testingOverrides: TestingOverrides(
+            buildPhases: buildPhases,
+            readerWriter: readerWriter,
+            buildPackages: buildPackages,
+          ),
+        ),
+      );
+
+      reader = BuildOutputReader(
+        builderFilesystem: BuilderFilesystem(
+          buildPackages: buildPlan.buildSpec.buildPackages,
+          buildConfigs: buildPlan.buildSpec.buildConfigs,
+          buildState: buildState,
+          buildStepPlan: buildPlan.buildStepPlan,
+          readerWriter: buildPlan.readerWriter,
+        ),
+      );
+
+      final webAssets = reader.allAssets(rootDir: 'web');
+      expect(webAssets, isNot(contains(postOutput)));
+
+      final testAssets = reader.allAssets(rootDir: 'test');
+      expect(testAssets, contains(postOutput));
+    });
   });
 }


### PR DESCRIPTION
A few places (serve, `--output`) are supposed to only serve/copy directories you ask for.

This filtering was left off for post process outputs, so it would serve/copy too much.

Fix it :)