### PR TITLE
Fix AssetId path validation.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.0.9-wip
 
 - `AssetId` now validates package names in addition to paths.
+- Bug fix: more strictly prohibit absolute paths in `AssetId` path validation.
 
 ## 4.0.8
 

--- a/build/lib/src/asset_id.dart
+++ b/build/lib/src/asset_id.dart
@@ -9,12 +9,14 @@ class AssetId implements Comparable<AssetId> {
   /// The package containing the file.
   final String package;
 
-  /// The relative path of the file under the root of [package].
+  /// The relative path within [package].
   ///
-  /// The path is relative and contains no parent references `..`, guaranteeing
-  /// that it is under [package].
+  /// The `AssetId` contructor guarantees that it's a POSIX-formatted relative
+  /// path: it uses `/` for separators, does not start with `/`, does not
+  /// contain `..`.
   ///
-  /// The path segment separator is `/` on all platforms.
+  /// Additionally, the `AssetId` constructor guarantees that it does not
+  /// contain any backslashes.
   final String path;
 
   /// The segments of [path].
@@ -26,10 +28,9 @@ class AssetId implements Comparable<AssetId> {
 
   /// An [AssetId] with the specified [path] under [package].
   ///
-  /// The [path] must be relative and under [package], or an [ArgumentError] is
-  /// thrown.
-  ///
-  /// The [path] is normalized: `\` is replaced with `/`, then `.` and `..` are removed.
+  /// Backslashes in [path] are converted to forward slashes, then it is
+  /// normalized. After normalization it must be relative and contain no `..` or
+  /// an [ArgumentError] is thrown.
   ///
   /// [package] must be a valid Dart package name, or an [ArgumentError] is
   /// thrown.
@@ -142,14 +143,13 @@ class AssetId implements Comparable<AssetId> {
 }
 
 String _normalizePath(String path) {
-  if (p.isAbsolute(path)) {
+  final normalized = path.replaceAll(r'\', '/');
+  final result = p.posix.normalize(normalized);
+
+  if (p.posix.isAbsolute(result)) {
     throw ArgumentError.value(path, 'Asset paths must be relative.');
   }
-  path = path.replaceAll(r'\', '/');
-
-  // Collapse "." and "..".
-  final result = p.posix.normalize(path);
-  if (result.startsWith('../')) {
+  if (result.startsWith('../') || result == '..') {
     throw ArgumentError.value(
       path,
       'Asset paths must be within the specified the package.',

--- a/build/test/asset_id_test.dart
+++ b/build/test/asset_id_test.dart
@@ -39,6 +39,17 @@ void main() {
     test('allows empty package and path', () {
       AssetId('', '');
     });
+
+    test('throws for absolute paths', () {
+      expect(() => AssetId('app', '/tmp/asset.txt'), throwsArgumentError);
+      expect(() => AssetId('app', r'\tmp\asset.txt'), throwsArgumentError);
+    });
+
+    test('throws for paths that escape the package root', () {
+      expect(() => AssetId('app', '../asset.txt'), throwsArgumentError);
+      expect(() => AssetId('app', '..'), throwsArgumentError);
+      expect(() => AssetId('app', 'foo/../../asset.txt'), throwsArgumentError);
+    });
   });
 
   group('parse', () {

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bug fix: `serve` mode only serves the specified package subdirectories.
 - Bug fix: `serve` live reload websocket checks for localhost origin.
 - Bug fix: don't follow symlinks when cleaning up output folders.
+- Bug fix: catch Windows-specific absolute paths.
 
 ## 2.15.2
 

--- a/build_runner/lib/src/build/resolver/asset_ids.dart
+++ b/build_runner/lib/src/build/resolver/asset_ids.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:build/build.dart';
 
 import '../../build_plan/build_step_plan.dart';
@@ -30,5 +32,24 @@ extension AssetIdExtension on AssetId {
   bool isHidden({BuildStepPlan? buildStepPlan, BuildState? buildState}) {
     return buildStepPlan?.isHidden(this) == true ||
         buildState?.isHiddenPostProcessOutput(this) == true;
+  }
+
+  /// Returns [path] for the current platform.
+  String get platformPath => Platform.isWindows ? windowsPath : path;
+
+  /// Returns [path] for Windows.
+  ///
+  /// Throws an [ArgumentError] if the path contains a colon. This prevents
+  /// paths that are relative on POSIX becoming absolute on Windows due to
+  /// starting with a drive letter and a colon.
+  String get windowsPath {
+    if (path.contains(':')) {
+      throw ArgumentError.value(
+        path,
+        'path',
+        'Windows paths cannot contain colons.',
+      );
+    }
+    return path.replaceAll('/', '\\');
   }
 }

--- a/build_runner/lib/src/build_plan/build_packages.dart
+++ b/build_runner/lib/src/build_plan/build_packages.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:build/build.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:graphs/graphs.dart';
@@ -11,6 +9,7 @@ import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 
+import '../build/resolver/asset_ids.dart';
 import '../constants.dart';
 import '../io/asset_path_provider.dart';
 import 'build_package.dart';
@@ -222,13 +221,8 @@ class BuildPackages implements AssetPathProvider {
     }
     if (hide) id = AssetPathProvider.hide(id, outputRoot);
     if (checkWriteAllowed) throwIfReadonly(id);
-
     final package = packages[id.package]!;
-    var path = id.path;
-    if (Platform.pathSeparator != '/') {
-      path = path.replaceAll('/', Platform.pathSeparator);
-    }
-    return p.join(package.path, path);
+    return p.join(package.path, id.platformPath);
   }
 
   /// Throws if [id] is not allowed to be written or deleted.

--- a/build_runner/test/build/resolver/asset_ids_test.dart
+++ b/build_runner/test/build/resolver/asset_ids_test.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:build_runner/src/build/resolver/asset_ids.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AssetIdExtension', () {
+    group('windowsPath', () {
+      test('converts slashes to backslashes', () {
+        final id = AssetId('a', 'lib/a.dart');
+        expect(id.windowsPath, r'lib\a.dart');
+      });
+
+      test('throws if path contains a colon', () {
+        final id = AssetId('a', 'lib/foo:a.dart');
+        expect(() => id.windowsPath, throwsArgumentError);
+      });
+    });
+  });
+}


### PR DESCRIPTION
The path in `AssetId` must be relative; close a couple of holes in validation.