### PR TITLE
Add build_daemon websocket token.

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -752,6 +752,41 @@ jobs:
       - job_003
       - job_004
   job_018:
+    name: "test; macos; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: macos-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:macos-latest;pub-cache-hosted;sdk:dev;packages:build_daemon;commands:test_0"
+          restore-keys: |
+            os:macos-latest;pub-cache-hosted;sdk:dev;packages:build_daemon
+            os:macos-latest;pub-cache-hosted;sdk:dev
+            os:macos-latest;pub-cache-hosted
+            os:macos-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - id: build_daemon_pub_upgrade
+        name: build_daemon; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: build_daemon
+      - name: "build_daemon; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.build_daemon_pub_upgrade.conclusion == 'success'"
+        working-directory: build_daemon
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_019:
     name: "test; macos; PKG: build_runner; `dart test -t integration1 --test-randomize-ordering-seed=random`"
     runs-on: macos-latest
     steps:
@@ -786,7 +821,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_019:
+  job_020:
     name: "test; macos; PKG: build_runner; `dart test -t integration2 --test-randomize-ordering-seed=random`"
     runs-on: macos-latest
     steps:
@@ -821,7 +856,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_020:
+  job_021:
     name: "test; macos; PKG: build_runner; `dart test -t integration3 --test-randomize-ordering-seed=random`"
     runs-on: macos-latest
     steps:
@@ -856,7 +891,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_021:
+  job_022:
     name: "test; macos; PKG: build_runner; `dart test -t integration4 --test-randomize-ordering-seed=random`"
     runs-on: macos-latest
     steps:
@@ -891,7 +926,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_022:
+  job_023:
     name: "test; windows; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -916,7 +951,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_023:
+  job_024:
     name: "test; windows; PKG: build_runner; `dart test -t integration1 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -941,7 +976,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_024:
+  job_025:
     name: "test; windows; PKG: build_runner; `dart test -t integration2 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -966,7 +1001,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_025:
+  job_026:
     name: "test; windows; PKG: build_runner; `dart test -t integration3 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -991,7 +1026,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_026:
+  job_027:
     name: "test; windows; PKG: build_runner; `dart test -t integration4 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 4.1.3-wip
 
-- Put lock file under `.dart_tool` in the workspace by default. Add
-  `daemonSharedPath` to keep support for other locations.
+- Put lock and config files under `.dart_tool` in the workspace by default.
+  Make them user private. Add `daemonSharedPath` to keep support for other
+  locations.
+- Use a token for websocket authentication.
 - Require Dart 3.11.0.
 
 ## 4.1.2

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -18,8 +18,9 @@ import 'data/serializers.dart';
 import 'data/server_log.dart';
 import 'data/shutdown_notification.dart';
 import 'src/file_wait.dart';
+import 'src/server_info.dart';
 
-Future<int> _existingPort(
+Future<ServerInfo> _existingServerInfo(
   String workingDirectory, {
   required String? daemonSharedPath,
 }) async {
@@ -27,7 +28,9 @@ Future<int> _existingPort(
     portFilePath(workingDirectory, daemonSharedPath: daemonSharedPath),
   );
   if (!await waitForFile(portFile)) throw MissingPortFile();
-  return int.parse(portFile.readAsStringSync());
+  final serverInfo = ServerInfo.fromFile(portFile);
+  if (serverInfo == null) throw VersionSkew();
+  return serverInfo;
 }
 
 Future<void> _handleDaemonStartup(
@@ -122,10 +125,10 @@ class BuildDaemonClient {
   final IOWebSocketChannel _channel;
 
   BuildDaemonClient._(
-    int port,
+    Uri serverUrl,
     this._serializers,
     void Function(ServerLog) logHandler,
-  ) : _channel = IOWebSocketChannel.connect('ws://localhost:$port') {
+  ) : _channel = IOWebSocketChannel.connect(serverUrl) {
     _channel.stream
         .listen((data) {
           final message = _serializers.deserialize(jsonDecode(data as String));
@@ -228,8 +231,12 @@ class BuildDaemonClient {
   }) async {
     logHandler ??= (_) {};
     final daemonSerializers = serializersOverride ?? serializers;
+    final serverInfo = await _existingServerInfo(
+      workingDirectory,
+      daemonSharedPath: daemonSharedPath,
+    );
     return BuildDaemonClient._(
-      await _existingPort(workingDirectory, daemonSharedPath: daemonSharedPath),
+      serverInfo.requestUrl,
       daemonSerializers,
       logHandler,
     );

--- a/build_daemon/lib/daemon.dart
+++ b/build_daemon/lib/daemon.dart
@@ -12,8 +12,10 @@ import 'change_provider.dart';
 import 'constants.dart';
 import 'daemon_builder.dart';
 import 'data/build_target.dart';
+import 'src/file_permissions.dart';
 import 'src/file_wait.dart';
 import 'src/server.dart';
+import 'src/server_info.dart';
 
 /// The long running daemon process.
 ///
@@ -115,9 +117,12 @@ class Daemon {
     if (!_doneCompleter.isCompleted) _doneCompleter.complete(exitCode);
   }
 
-  void _createPortFile(int port) => File(
-    portFilePath(_workingDirectory, daemonSharedPath: _daemonSharedPath),
-  ).writeAsStringSync('$port');
+  void _createPortFile(int port) {
+    final portFile = File(
+      portFilePath(_workingDirectory, daemonSharedPath: _daemonSharedPath),
+    );
+    ServerInfo(port, _server!.token).writeToFile(portFile);
+  }
 
   void _createVersionFile() => File(
     versionFilePath(_workingDirectory, daemonSharedPath: _daemonSharedPath),
@@ -162,9 +167,16 @@ void _createDaemonWorkspace(
   required String? daemonSharedPath,
 }) {
   try {
-    Directory(
-      daemonWorkspace(workingDirectory, daemonSharedPath: daemonSharedPath),
-    ).createSync(recursive: true);
+    final workspace = daemonWorkspace(
+      workingDirectory,
+      daemonSharedPath: daemonSharedPath,
+    );
+    final directory = Directory(workspace);
+    final isNew = !directory.existsSync();
+    directory.createSync(recursive: true);
+    if (isNew && daemonSharedPath == null) {
+      FilePermissions.makeUserPrivate(workspace);
+    }
   } catch (e) {
     throw Exception('Unable to create daemon workspace: $e');
   }

--- a/build_daemon/lib/src/file_permissions.dart
+++ b/build_daemon/lib/src/file_permissions.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+class FilePermissions {
+  /// Makes [path] private to the current user.
+  ///
+  /// Throws [FileSystemException] on failure.
+  static void makeUserPrivate(String path) {
+    if (Platform.isWindows) {
+      _makeUserPrivateWindows(path);
+    } else {
+      _makeUserPrivatePosix(path);
+    }
+  }
+
+  static void _makeUserPrivateWindows(String path) {
+    final username = Platform.environment['USERNAME'];
+    if (username == null) {
+      throw FileSystemException(
+        'Failed to get username to make user private: $path',
+      );
+    }
+    final result = Process.runSync('icacls', [
+      path,
+      '/inheritance:r',
+      '/grant:r',
+      '$username:(OI)(CI)F',
+    ]);
+    if (result.exitCode != 0) {
+      throw FileSystemException('Failed to make private: $path');
+    }
+  }
+
+  static void _makeUserPrivatePosix(String path) {
+    final result = Process.runSync('chmod', ['700', path]);
+    if (result.exitCode != 0) {
+      throw FileSystemException('Failed to make user private: $path');
+    }
+  }
+}

--- a/build_daemon/lib/src/server.dart
+++ b/build_daemon/lib/src/server.dart
@@ -6,9 +6,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'dart:math';
+
 import 'package:built_value/serializer.dart';
 import 'package:http_multi_server/http_multi_server.dart';
 import 'package:pool/pool.dart';
+import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart';
 import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:stream_transform/stream_transform.dart';
@@ -45,6 +48,8 @@ class Server {
   final _subs = <StreamSubscription>[];
   final _outputStreamController = StreamController<ServerLog>();
   late final Stream<ServerLog> _logs;
+  final String token;
+
   Server(
     this._builder,
     Duration timeout,
@@ -55,7 +60,8 @@ class Server {
        _serializers = serializersOverride ?? serializers,
        _buildTargetManager = BuildTargetManager(
          shouldBuildOverride: shouldBuild,
-       ) {
+       ),
+       token = _generateToken() {
     _logs = _outputStreamController.stream;
     _forwardData();
     if (changeProvider is AutoChangeProvider) {
@@ -69,51 +75,32 @@ class Server {
     });
   }
 
+  static String _generateToken() {
+    final random = Random.secure();
+    return base64UrlEncode(List<int>.generate(8, (_) => random.nextInt(256)));
+  }
+
+  Handler _checkToken(Handler innerHandler) =>
+      (request) => request.url.queryParameters['token'] == token
+      ? innerHandler(request)
+      : Response.forbidden('');
+
   /// Returns exit code.
   Future<int> get onDone => _isDoneCompleter.future;
 
   /// Starts listening for build daemon clients.
   Future<int> listen() async {
-    // The client does not set the Origin header. Reject any client that does,
-    // which includes all browsers.
-    final handler = webSocketHandler(allowedOrigins: const [], (
-      WebSocketChannel channel,
-      _,
-    ) async {
-      channel.stream.listen(
-        (message) async {
-          dynamic request;
-          try {
-            request = _serializers.deserialize(jsonDecode(message as String));
-          } catch (e, s) {
-            _logMessage(
-              Level.WARNING,
-              'Unable to parse message: $message',
-              e,
-              s,
-            );
-            return;
-          }
-          if (request is BuildTargetRequest) {
-            _buildTargetManager.addBuildTarget(request.target, channel);
-          } else if (request is BuildRequest) {
-            // We can only get explicit build requests if we have a manual
-            // change provider.
-            final changeProvider = _changeProvider;
-            final changes = changeProvider is ManualChangeProvider
-                ? await changeProvider.collectChanges()
-                : <WatchEvent>[];
-            final targets = changes.isEmpty
-                ? _buildTargetManager.targets
-                : _buildTargetManager.targetsForChanges(changes);
-            await _build(targets, changes);
-          }
-        },
-        onDone: () {
-          _removeChannel(channel);
-        },
-      );
-    });
+    final handler = const Pipeline()
+        .addMiddleware(_checkToken)
+        .addHandler(
+          webSocketHandler(
+            _handleWebsocket,
+            // The client does not set the Origin header. Reject any client that
+            // does, which includes all browsers.
+            allowedOrigins: const [],
+          ),
+        );
+
     final server = _server = await HttpMultiServer.loopback(0);
     // Serve requests in an error zone to prevent failures
     // when running from another error zone.
@@ -121,6 +108,37 @@ class Server {
       _logMessage(Level.WARNING, 'Error serving requests', e, s);
     });
     return server.port;
+  }
+
+  void _handleWebsocket(WebSocketChannel channel, _) {
+    channel.stream.listen(
+      (message) async {
+        dynamic request;
+        try {
+          request = _serializers.deserialize(jsonDecode(message as String));
+        } catch (e, s) {
+          _logMessage(Level.WARNING, 'Unable to parse message: $message', e, s);
+          return;
+        }
+        if (request is BuildTargetRequest) {
+          _buildTargetManager.addBuildTarget(request.target, channel);
+        } else if (request is BuildRequest) {
+          // We can only get explicit build requests if we have a manual
+          // change provider.
+          final changeProvider = _changeProvider;
+          final changes = changeProvider is ManualChangeProvider
+              ? await changeProvider.collectChanges()
+              : <WatchEvent>[];
+          final targets = changes.isEmpty
+              ? _buildTargetManager.targets
+              : _buildTargetManager.targetsForChanges(changes);
+          await _build(targets, changes);
+        }
+      },
+      onDone: () {
+        _removeChannel(channel);
+      },
+    );
   }
 
   Future<void> stop({String message = '', int failureType = 0}) async {

--- a/build_daemon/lib/src/server_info.dart
+++ b/build_daemon/lib/src/server_info.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+/// The port and access token of the `build_daemon` server.
+class ServerInfo {
+  final int port;
+  final String token;
+
+  ServerInfo(this.port, this.token);
+
+  void writeToFile(File file) {
+    file.writeAsStringSync('$port\n$token');
+  }
+
+  /// Reads and parses from [file].
+  ///
+  /// Returns `null` on parse failure.
+  static ServerInfo? fromFile(File file) {
+    try {
+      final lines = file.readAsLinesSync();
+      return ServerInfo(int.parse(lines[0]), lines[1]);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// The websocket URI with token.
+  Uri get requestUrl => Uri(
+    scheme: 'ws',
+    host: 'localhost',
+    port: port,
+    queryParameters: {'token': token},
+  );
+}

--- a/build_daemon/mono_pkg.yaml
+++ b/build_daemon/mono_pkg.yaml
@@ -13,3 +13,4 @@ stages:
     os:
     - linux
     - windows
+    - macos

--- a/build_daemon/test/file_permissions_test.dart
+++ b/build_daemon/test/file_permissions_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:build_daemon/src/file_permissions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  group('FilePermissions', () {
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('build_daemon_test_');
+    });
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('makeUserPrivate restricts directory access', () {
+      FilePermissions.makeUserPrivate(tempDir.path);
+
+      if (Platform.isWindows) {
+        // Shell out to PowerShell to verify the ACL has severed inheritance,
+        // which verifies that only the explicitly granted user has access.
+        final result = Process.runSync('powershell', [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          '(Get-Acl "${tempDir.path}").AreAccessRulesProtected',
+        ]);
+        expect(result.exitCode, 0);
+        expect(result.stdout.toString().trim(), 'True');
+      } else {
+        final stat = tempDir.statSync();
+        final mode = stat.mode & (7 * 8 * 8 + 7 * 8 + 7); // 0777 octal
+        expect(
+          mode,
+          7 * 8 * 8, // 0700 octal
+        );
+      }
+    });
+  });
+}

--- a/build_daemon/test/server_test.dart
+++ b/build_daemon/test/server_test.dart
@@ -9,6 +9,7 @@ library;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:build_daemon/data/build_request.dart';
 import 'package:build_daemon/data/build_status.dart';
@@ -19,6 +20,7 @@ import 'package:build_daemon/data/server_log.dart';
 import 'package:build_daemon/src/fakes/fake_change_provider.dart';
 import 'package:build_daemon/src/fakes/fake_test_builder.dart';
 import 'package:build_daemon/src/server.dart';
+import 'package:build_daemon/src/server_info.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:test/test.dart';
 import 'package:web_socket_channel/io.dart';
@@ -39,7 +41,7 @@ void main() {
       port = await server.listen();
 
       // Connect the client and redirect its logs.
-      client = _createClient(controller, port);
+      client = _createClient(controller, ServerInfo(port, server.token));
     });
 
     tearDown(() async {
@@ -91,8 +93,11 @@ void main() {
 
     test('forwards changed assets to interested clients', () async {
       final interestedEvents = StreamController<Object?>();
-      final interstedClient = _createClient(interestedEvents, port);
-      addTearDown(interstedClient.sink.close);
+      final interestedClient = _createClient(
+        interestedEvents,
+        ServerInfo(port, server.token),
+      );
+      addTearDown(interestedClient.sink.close);
       addTearDown(interestedEvents.close);
 
       // Register default client, not intersted in changes
@@ -110,7 +115,7 @@ void main() {
           ..target = ''
           ..reportChangedAssets = true,
       );
-      interstedClient.sink.add(
+      interestedClient.sink.add(
         jsonEncode(
           serializers.serialize(
             BuildTargetRequest((b) => b.target = targetWithChanges),
@@ -146,6 +151,33 @@ void main() {
       );
     });
   });
+
+  group('token check', () {
+    late Server server;
+    late int port;
+
+    setUp(() async {
+      server = _createServer();
+      port = await server.listen();
+    });
+
+    tearDown(() async {
+      await server.stop();
+      await expectLater(server.onDone, completes);
+    });
+
+    test('rejects invalid connections', () async {
+      await expectLater(
+        WebSocket.connect('ws://localhost:$port'),
+        throwsA(isA<WebSocketException>()),
+      );
+
+      await expectLater(
+        WebSocket.connect('ws://localhost:$port?token=invalid_token'),
+        throwsA(isA<WebSocketException>()),
+      );
+    });
+  });
 }
 
 Server _createServer() {
@@ -158,9 +190,9 @@ Server _createServer() {
 
 IOWebSocketChannel _createClient(
   StreamController<Object?> controller,
-  int port,
+  ServerInfo serverInfo,
 ) {
-  final client = IOWebSocketChannel.connect('ws://localhost:$port');
+  final client = IOWebSocketChannel.connect(serverInfo.requestUrl);
   client.stream.listen((data) {
     final message = serializers.deserialize(jsonDecode(data as String));
     controller.add(message);


### PR DESCRIPTION
Add an auth token to build_daemon's websocket.

Write the token to the same file to which we currently write the port.

The previous build_daemon PR moved that from being under `/tmp` to being under `.dart_tool`, so it's in a user-owned location.

Also set that dir user private. Now the websocket is only accessible to the user who ran the daemon.

The tests were already running on Linux+Windows, run them on MacOS as well; this didn't uncover anything new but it's nice to have.