### PR TITLE
Suppress experimental_member_use warnings in generated mock files.

### DIFF
--- a/builder_pkgs/mockito/CHANGELOG.md
+++ b/builder_pkgs/mockito/CHANGELOG.md
@@ -1,5 +1,9 @@
-## 5.8.0
+## 5.8.1-wip
 
+* Suppress `experimental_member_use` warnings in generated mock files.
+  [#4602](https://github.com/dart-lang/build/issues/4602)
+
+## 5.8.0
 * Add support for JS interop extension type mock generation to mockito.
 * It is now an error to generate mocks for non-JS interop extension types.
   Instead, mock the representation type and cast to the extension type where

--- a/builder_pkgs/mockito/example/build_extensions/mocks/example.mocks.dart
+++ b/builder_pkgs/mockito/example/build_extensions/mocks/example.mocks.dart
@@ -16,6 +16,7 @@ import '../example.dart' as _i2;
 // ignore_for_file: comment_references
 // ignore_for_file: deprecated_member_use
 // ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: experimental_member_use
 // ignore_for_file: implementation_imports
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 // ignore_for_file: must_be_immutable

--- a/builder_pkgs/mockito/example/example.mocks.dart
+++ b/builder_pkgs/mockito/example/example.mocks.dart
@@ -15,6 +15,7 @@ import 'example.dart' as _i2;
 // ignore_for_file: comment_references
 // ignore_for_file: deprecated_member_use
 // ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: experimental_member_use
 // ignore_for_file: implementation_imports
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 // ignore_for_file: must_be_immutable

--- a/builder_pkgs/mockito/example/iss/iss_test.mocks.dart
+++ b/builder_pkgs/mockito/example/iss/iss_test.mocks.dart
@@ -17,6 +17,7 @@ import 'iss.dart' as _i4;
 // ignore_for_file: comment_references
 // ignore_for_file: deprecated_member_use
 // ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: experimental_member_use
 // ignore_for_file: implementation_imports
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 // ignore_for_file: must_be_immutable

--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -125,6 +125,9 @@ class MockBuilder implements Builder {
       b.body.add(
         Code('// ignore_for_file: deprecated_member_use_from_same_package\n'),
       );
+      // We might import an experimental library, or implement an experimental
+      // class.
+      b.body.add(Code('// ignore_for_file: experimental_member_use\n'));
       // We might import a package's 'src' directory.
       b.body.add(Code('// ignore_for_file: implementation_imports\n'));
       // `Mock.noSuchMethod` is `@visibleForTesting`, but the generated code is

--- a/builder_pkgs/mockito/pubspec.yaml
+++ b/builder_pkgs/mockito/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.8.0
+version: 5.8.1-wip
 description: >-
   A mock framework inspired by Mockito with APIs for Fakes, Mocks,
   behavior verification, and stubbing.

--- a/builder_pkgs/mockito/test/end2end/dart_js_interop_test.mocks.dart
+++ b/builder_pkgs/mockito/test/end2end/dart_js_interop_test.mocks.dart
@@ -16,6 +16,7 @@ import 'uses_js_interop.dart' as _i3;
 // ignore_for_file: comment_references
 // ignore_for_file: deprecated_member_use
 // ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: experimental_member_use
 // ignore_for_file: implementation_imports
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 // ignore_for_file: must_be_immutable

--- a/builder_pkgs/mockito/test/end2end/generated_mocks_test.mocks.dart
+++ b/builder_pkgs/mockito/test/end2end/generated_mocks_test.mocks.dart
@@ -17,6 +17,7 @@ import 'foo_sub.dart' as _i5;
 // ignore_for_file: comment_references
 // ignore_for_file: deprecated_member_use
 // ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: experimental_member_use
 // ignore_for_file: implementation_imports
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 // ignore_for_file: must_be_immutable


### PR DESCRIPTION
Fix #4602.