### PR TITLE
Clarify in README.md that generated mock filenames are derived from the source filename.

### DIFF
--- a/builder_pkgs/mockito/CHANGELOG.md
+++ b/builder_pkgs/mockito/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.8.1-wip
+
+* Clarify in `README.md` that generated `.mocks.dart` filenames are based on the
+  source file name.
+  [#4599](https://github.com/dart-lang/build/issues/4599)
+
 ## 5.8.0
 
 * Add support for JS interop extension type mock generation to mockito.

--- a/builder_pkgs/mockito/README.md
+++ b/builder_pkgs/mockito/README.md
@@ -11,15 +11,15 @@ package's `pubspec.yaml` file, under `dev_dependencies`; something like
 
 For alternatives to the code generation API, see the [NULL_SAFETY_README][].
 
-Let's start with a Dart library, `cat.dart`:
+Let's start with a Dart test library, `cat_test.dart`:
 
 ```dart
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
-// Annotation which generates the cat.mocks.dart library and the MockCat class.
+// Annotation which generates the cat_test.mocks.dart library and the MockCat class.
 @GenerateNiceMocks([MockSpec<Cat>()])
-import 'cat.mocks.dart';
+import 'cat_test.mocks.dart';
 
 // Real class
 class Cat {
@@ -49,8 +49,8 @@ dart run build_runner build
 ```
 
 `build_runner` will generate a file with a name based on the file containing the
-`@GenerateNiceMocks` annotation. In the above `cat.dart` example, we import the
-generated library as `cat.mocks.dart`.
+`@GenerateNiceMocks` annotation. In the above `cat_test.dart` example, we import
+the generated library as `cat_test.mocks.dart`.
 
 **NOTE**: by default only annotations in files under `test/` are processed, if
 you want to add Mockito annotations in other places, you will need to add a

--- a/builder_pkgs/mockito/pubspec.yaml
+++ b/builder_pkgs/mockito/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.8.0
+version: 5.8.1-wip
 description: >-
   A mock framework inspired by Mockito with APIs for Fakes, Mocks,
   behavior verification, and stubbing.


### PR DESCRIPTION
Fix #4599.