### PR TITLE
Check project build_daemon version in connect and release 4.1.4.

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.1.4
+
+- In the client, check the workspace build daemon version and throw
+  `VersionSkew` if there is a mismatch.
+- Add descriptive messages and custom `toString` overrides to
+  `MissingPortFile`, `OptionsSkew`, and `VersionSkew`.
+
 ## 4.1.3
 
 - Bug fix: fix race condition when a new daemon immediately starts after

--- a/build_daemon/lib/client.dart
+++ b/build_daemon/lib/client.dart
@@ -19,6 +19,7 @@ import 'data/server_log.dart';
 import 'data/shutdown_notification.dart';
 import 'src/file_wait.dart';
 import 'src/server_info.dart';
+import 'src/version_check.dart';
 
 Future<ServerInfo> _existingServerInfo(
   String workingDirectory, {
@@ -27,9 +28,13 @@ Future<ServerInfo> _existingServerInfo(
   final portFile = File(
     portFilePath(workingDirectory, daemonSharedPath: daemonSharedPath),
   );
-  if (!await waitForFile(portFile)) throw MissingPortFile();
+  if (!await waitForFile(portFile)) {
+    throw MissingPortFile('Timeout waiting for port file at ${portFile.path}.');
+  }
   final serverInfo = ServerInfo.fromFile(portFile);
-  if (serverInfo == null) throw VersionSkew();
+  if (serverInfo == null) {
+    throw VersionSkew('Unable to read ServerInfo from ${portFile.path}.');
+  }
   return serverInfo;
 }
 
@@ -100,9 +105,9 @@ Future<void> _handleDaemonStartup(
   );
 
   if (daemonAction == versionSkew) {
-    throw VersionSkew();
+    throw VersionSkew('Running daemon version does not match client version.');
   } else if (daemonAction == optionsSkew) {
-    throw OptionsSkew();
+    throw OptionsSkew('Requested options do not match running daemon options.');
   }
   await sub.cancel();
 }
@@ -189,6 +194,7 @@ class BuildDaemonClient {
     BuildMode buildMode = BuildMode.Auto,
     String? daemonSharedPath,
   }) async {
+    await checkProjectBuildDaemonVersion(workingDirectory);
     logHandler ??= (_) {};
     final daemonArgs = daemonCommand.sublist(1)
       ..add('--$buildModeFlag=$buildMode');
@@ -244,12 +250,36 @@ class BuildDaemonClient {
 }
 
 /// Thrown when the port file for the running daemon instance can't be found.
-class MissingPortFile implements Exception {}
+class MissingPortFile implements Exception {
+  final String? details;
+
+  MissingPortFile([this.details]);
+
+  @override
+  String toString() =>
+      details == null ? 'MissingPortFile' : 'MissingPortFile: $details';
+}
 
 /// Thrown if the client requests conflicting options with the current daemon
 /// instance.
-class OptionsSkew implements Exception {}
+class OptionsSkew implements Exception {
+  final String? details;
+
+  OptionsSkew([this.details]);
+
+  @override
+  String toString() =>
+      details == null ? 'OptionsSkew' : 'OptionsSkew: $details';
+}
 
 /// Thrown if the current daemon instance version does not match that of the
 /// client.
-class VersionSkew implements Exception {}
+class VersionSkew implements Exception {
+  final String? details;
+
+  VersionSkew([this.details]);
+
+  @override
+  String toString() =>
+      details == null ? 'VersionSkew' : 'VersionSkew: $details';
+}

--- a/build_daemon/lib/src/version_check.dart
+++ b/build_daemon/lib/src/version_check.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:package_config/package_config.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart';
+
+import '../client.dart';
+
+/// Checks the workspace `build_daemon` version, if any.
+///
+/// Throws [VersionSkew] if the version is too old.
+Future<void> checkProjectBuildDaemonVersion(String workingDirectory) async {
+  final packageConfigFile = _findPackageConfigFile(workingDirectory);
+  if (packageConfigFile == null) return;
+  Version resolvedVersion;
+  try {
+    final packageConfig = await loadPackageConfig(packageConfigFile);
+    final package = packageConfig['build_daemon']!;
+    final pubspecFile = File(p.join(package.root.toFilePath(), 'pubspec.yaml'));
+    final pubspecYaml = loadYaml(pubspecFile.readAsStringSync());
+    if (pubspecYaml is! Map) return;
+    final versionString = pubspecYaml['version'] as String?;
+    if (versionString == null) return;
+    resolvedVersion = Version.parse(versionString);
+  } catch (_) {
+    return;
+  }
+  final minVersion = Version.parse('4.1.3');
+  if (resolvedVersion < minVersion) {
+    throw VersionSkew(
+      'Project resolved build_daemon $resolvedVersion which is incompatible '
+      'with client requiring >=4.1.3.',
+    );
+  }
+}
+
+/// Finds the `package_config.json` for [workingDirectory].
+///
+/// It might be in `.dart_tool` or in the workspace `.dart_tool`.
+///
+/// Returns `null` on failure to find any `package_config.json`.
+File? _findPackageConfigFile(String workingDirectory) {
+  var rootPath = workingDirectory;
+  final workspaceRefFile = File(
+    p.join(workingDirectory, '.dart_tool', 'pub', 'workspace_ref.json'),
+  );
+  if (workspaceRefFile.existsSync()) {
+    try {
+      final workspaceRef =
+          (jsonDecode(workspaceRefFile.readAsStringSync())
+                  as Map<String, dynamic>)['workspaceRoot']
+              as String?;
+      if (workspaceRef != null) {
+        rootPath = p.canonicalize(
+          p.join(p.dirname(workspaceRefFile.path), workspaceRef),
+        );
+      }
+    } catch (_) {}
+  }
+  final file = File(p.join(rootPath, '.dart_tool', 'package_config.json'));
+  return file.existsSync() ? file : null;
+}

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 4.1.3
+version: 4.1.4
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 resolution: workspace
@@ -13,13 +13,16 @@ dependencies:
   crypto: ^3.0.3
   http_multi_server: ^3.0.0
   logging: ^1.0.0
+  package_config: ^2.0.0
   path: ^1.8.0
   pool: ^1.5.0
+  pub_semver: ^2.0.0
   shelf: ^1.0.0
   shelf_web_socket: ">=1.0.0 <4.0.0"
   stream_transform: ^2.0.0
   watcher: ^1.0.0
   web_socket_channel: ">=2.3.0 <4.0.0"
+  yaml: ^3.0.0
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/build_daemon/test/version_check_test.dart
+++ b/build_daemon/test/version_check_test.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:build_daemon/client.dart';
+import 'package:build_daemon/src/version_check.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('package_config version skew check', () {
+    late Directory workspace;
+
+    setUp(() {
+      workspace = Directory.systemTemp.createTempSync('build_daemon_test');
+    });
+
+    tearDown(() {
+      workspace.deleteSync(recursive: true);
+    });
+
+    void writePackageConfig(String version) {
+      final pkgDir = Directory(p.join(workspace.path, 'pkg'))..createSync();
+      File(
+        p.join(pkgDir.path, 'pubspec.yaml'),
+      ).writeAsStringSync('name: build_daemon\nversion: $version\n');
+      final dartTool = Directory(p.join(workspace.path, '.dart_tool'))
+        ..createSync();
+      File(p.join(dartTool.path, 'package_config.json')).writeAsStringSync('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "build_daemon",
+      "rootUri": "../pkg",
+      "packageUri": "lib/",
+      "languageVersion": "3.11"
+    }
+  ]
+}
+''');
+    }
+
+    test(
+      'throws VersionSkew when project resolved older build_daemon',
+      () async {
+        writePackageConfig('4.1.2');
+        expect(
+          () => checkProjectBuildDaemonVersion(workspace.path),
+          throwsA(isA<VersionSkew>()),
+        );
+      },
+    );
+
+    test('does not throw VersionSkew for compatible build_daemon', () async {
+      writePackageConfig('4.1.3');
+      expect(checkProjectBuildDaemonVersion(workspace.path), completes);
+    });
+
+    test(
+      'resolves workspace_ref.json in workspace package directory',
+      () async {
+        writePackageConfig('4.1.2');
+        final subPkg = Directory(p.join(workspace.path, 'sub_pkg'))
+          ..createSync();
+        final subPub = Directory(p.join(subPkg.path, '.dart_tool', 'pub'))
+          ..createSync(recursive: true);
+        File(
+          p.join(subPub.path, 'workspace_ref.json'),
+        ).writeAsStringSync('{"workspaceRoot": "../../.."}');
+        expect(
+          () => checkProjectBuildDaemonVersion(subPkg.path),
+          throwsA(isA<VersionSkew>()),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
For https://github.com/dart-lang/build/issues/5052; one possible improvement we can make+release.

This catches the case where the client is ahead of the current workspace, and fails with a version error.

Add detail to the various errors.