### PR TITLE
Document missing stub behavior for void/Future<void> with @GenerateMocks

### DIFF
--- a/builder_pkgs/mockito/CHANGELOG.md
+++ b/builder_pkgs/mockito/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.8.1-wip
+
+* Document missing stub behavior for `void` and `Future<void>`.
+
 ## 5.8.0
 
 * Add support for JS interop extension type mock generation to mockito.

--- a/builder_pkgs/mockito/NULL_SAFETY_README.md
+++ b/builder_pkgs/mockito/NULL_SAFETY_README.md
@@ -152,8 +152,9 @@ legal default value is returned. This is the default and recommended
 "missing stub" behavior.
 
 There is a "classic" "missing stub" behavior, which is to throw an exception
-when such a method call is received. To generate a mock class with this
-behavior, use `@GenerateMocks`:
+when such a method call is received, except for methods returning `void` or
+`Future<void>`, which return normally without a stub. To generate a mock class
+with this behavior, use `@GenerateMocks`:
 
 ```dart
 @GenerateMocks([Foo])

--- a/builder_pkgs/mockito/README.md
+++ b/builder_pkgs/mockito/README.md
@@ -340,7 +340,8 @@ with `when(cat.sound())`, so what should the code do? What is the "missing stub"
 behavior?
 
 * The "missing stub" behavior of a mock class generated with `@GenerateMocks` is
-  to throw an exception.
+  to throw an exception, except for methods returning `void` or `Future<void>`,
+  which return normally without a stub.
 * The "missing stub" behavior of a mock class generated with
   `@GenerateNiceMocks` is to return a "simple" legal value (for example, a
   non-`null` value for a non-nullable return type). The value should not be used

--- a/builder_pkgs/mockito/pubspec.yaml
+++ b/builder_pkgs/mockito/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.8.0
+version: 5.8.1-wip
 description: >-
   A mock framework inspired by Mockito with APIs for Fakes, Mocks,
   behavior verification, and stubbing.


### PR DESCRIPTION
Fix #4431.