### PR TITLE
Add a cast for extension type with generic.

### DIFF
--- a/builder_pkgs/mockito/CHANGELOG.md
+++ b/builder_pkgs/mockito/CHANGELOG.md
@@ -1,13 +1,17 @@
 ## 5.8.1-wip
 
+* Cast dummy values for extension types to the extension type so they satisfy
+  static type checking in generic return types like `Future<ExtensionType>`.
+  [#4590](https://github.com/dart-lang/build/issues/4590)
+* Use canonical asset path in generated header comments so symlink paths are
+  excluded.
+  [#4545](https://github.com/dart-lang/build/issues/4545)
 * Deterministically select library to import when multiple libraries export the
   same type.
   [#4549](https://github.com/dart-lang/build/issues/4549)
 * Prefer importing public entrypoints over `/src/` implementation libraries
   when multiple libraries export the same type.
   [#4551](https://github.com/dart-lang/build/issues/4551)
-  excluded.
-  [#4545](https://github.com/dart-lang/build/issues/4545)
 * Throw `InvalidMockitoAnnotationException` with a clear message when
   `@GenerateMocks` `customMocks` or `@GenerateNiceMocks` `mocks` is not a list
   literal, instead of crashing with a type cast exception.

--- a/builder_pkgs/mockito/lib/src/builder.dart
+++ b/builder_pkgs/mockito/lib/src/builder.dart
@@ -2227,7 +2227,7 @@ class _MockClassInfo {
     _dummyFakedValue(dartType, invocation),
     ExtensionTypeElement(:final typeErasure)
         when !typeErasure.containsPrivateName =>
-      _dummyValue(typeErasure, invocation),
+      _dummyValue(typeErasure, invocation).asA(_typeReference(dartType)),
     ExtensionTypeElement() => _dummyValueFallbackToRuntime(
       dartType,
       invocation,

--- a/builder_pkgs/mockito/test/builder/auto_mocks_test.dart
+++ b/builder_pkgs/mockito/test/builder/auto_mocks_test.dart
@@ -4255,7 +4255,24 @@ void main() {
           E get v;
         }
         '''),
-        decodedMatches(allOf(contains('E get v'), contains('returnValue: 0'))),
+        decodedMatches(
+          allOf(contains('E get v'), contains('returnValue: (0 as _i2.E)')),
+        ),
+      );
+    });
+
+    test('are supported as type arguments in return types', () async {
+      await expectSingleNonNullableOutput(
+        dedent('''
+        extension type E(int v) {}
+        class Foo {
+          Future<E> get v;
+        }
+        '''),
+        _containsAllOf(
+          'Future<_i2.E> get v',
+          'returnValue: _i3.Future<_i2.E>.value((0 as _i2.E))',
+        ),
       );
     });
   });

--- a/builder_pkgs/mockito/test/end2end/generated_mocks_test.mocks.dart
+++ b/builder_pkgs/mockito/test/end2end/generated_mocks_test.mocks.dart
@@ -1002,8 +1002,8 @@ class MockUsesExtTypes extends _i1.Mock implements _i3.UsesExtTypes {
   _i3.Ext extTypeReturn(int? _0) =>
       (super.noSuchMethod(
             Invocation.method(#extTypeReturn, [_0]),
-            returnValue: 0,
-            returnValueForMissingStub: 0,
+            returnValue: (0 as _i3.Ext),
+            returnValueForMissingStub: (0 as _i3.Ext),
           )
           as _i3.Ext);
 


### PR DESCRIPTION
Code was generated that did not type check for a return value `Future<ExtensionType>`, add a cast.

Fix #4495.

Fix CHANGELOG.md which got mangled in a merge. (Sigh).