### PR TITLE
Support package_config v3 in build_daemon

### DIFF
--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.5
+
+- Support the latest `package_config`.
+
 ## 4.1.4
 
 - In the client, check the workspace build daemon version and throw

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 4.1.4
+version: 4.1.5
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 resolution: workspace
@@ -13,7 +13,7 @@ dependencies:
   crypto: ^3.0.3
   http_multi_server: ^3.0.0
   logging: ^1.0.0
-  package_config: ^2.0.0
+  package_config: '>=2.0.0 <4.0.0'
   path: ^1.8.0
   pool: ^1.5.0
   pub_semver: ^2.0.0


### PR DESCRIPTION
This is causing webdev's tests to fail. The version solve currently forces `package_config` to v3, which downgrades `build_daemon` since it didn't support v2. 