### PR TITLE
Add thenAnswerInOrder and support empty lists in in-order stubbing.

### DIFF
--- a/builder_pkgs/mockito/CHANGELOG.md
+++ b/builder_pkgs/mockito/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.8.2-wip
+
+* Add `thenAnswerInOrder` to `PostExpectation`.
+  [#4476](https://github.com/dart-lang/build/issues/4476)
+* Allow empty lists in `thenReturnInOrder` and `thenAnswerInOrder` without
+  throwing `ArgumentError` at stubbing time.
+
 ## 5.8.1
 
 * Cast dummy values for extension types to the extension type so they satisfy

--- a/builder_pkgs/mockito/lib/src/mock.dart
+++ b/builder_pkgs/mockito/lib/src/mock.dart
@@ -572,15 +572,12 @@ class PostExpectation<T> {
   ///
   /// Note: [expects] cannot contain a Future or Stream, due to Zone
   /// considerations.
-  /// To return a Future or Stream from a method stub, use [thenAnswer].
+  /// To return a Future or Stream from a method stub, use [thenAnswer] or
+  /// [thenAnswerInOrder].
   ///
   /// Note: when the method stub is called more times than there are responses
-  /// in [expects], it will throw an StateError in the missing case.
+  /// in [expects], it will throw a [StateError].
   void thenReturnInOrder(List<T> expects) {
-    if (expects.isEmpty) {
-      throw ArgumentError('thenReturnInOrder expects should not be empty');
-    }
-
     expects.forEach(_throwIfInvalid);
 
     final answers = Queue.of(expects);
@@ -607,6 +604,26 @@ class PostExpectation<T> {
   /// The function will be called, and the return value will be returned.
   void thenAnswer(Answering<T> answer) {
     return _completeWhen(answer);
+  }
+
+  /// Store a sequence of functions which are called when this method stub is
+  /// called.
+  ///
+  /// The functions will be called in order, and their return values will be
+  /// returned.
+  ///
+  /// Note: when the method stub is called more times than there are answers
+  /// in [answers], it will throw a [StateError].
+  void thenAnswerInOrder(List<Answering<T>> answers) {
+    final queue = Queue.of(answers);
+
+    thenAnswer((invocation) {
+      if (queue.isEmpty) {
+        throw StateError('thenAnswerInOrder does not have enough answers');
+      }
+
+      return queue.removeFirst()(invocation);
+    });
   }
 
   void _completeWhen(Answering<T> answer) {

--- a/builder_pkgs/mockito/pubspec.yaml
+++ b/builder_pkgs/mockito/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 5.8.1
+version: 5.8.2-wip
 description: >-
   A mock framework inspired by Mockito with APIs for Fakes, Mocks,
   behavior verification, and stubbing.

--- a/builder_pkgs/mockito/test/mockito_test.dart
+++ b/builder_pkgs/mockito/test/mockito_test.dart
@@ -160,7 +160,7 @@ void main() {
       expect(mock.getter, equals('A'));
     });
 
-    test('throws an exception if not enough answers were provided', () {
+    test('thenReturnInOrder throws if not enough answers are provided', () {
       when(mock.methodWithNormalArgs(any)).thenReturnInOrder(['One', 'Two']);
 
       expect(mock.methodWithNormalArgs(100), equals('One'));
@@ -177,6 +177,71 @@ void main() {
         ),
       );
     });
+
+    test(
+      'thenReturnInOrder allows empty list at stubbing and throws when called',
+      () {
+        when(mock.methodWithNormalArgs(any)).thenReturnInOrder([]);
+
+        expect(
+          () => mock.methodWithNormalArgs(100),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains('thenReturnInOrder does not have enough answers'),
+            ),
+          ),
+        );
+      },
+    );
+
+    test('thenAnswerInOrder returns responses in order', () async {
+      when(
+        mock.methodReturningFuture(),
+      ).thenAnswerInOrder([(_) async => 'One', (_) async => 'Two']);
+
+      expect(await mock.methodReturningFuture(), equals('One'));
+      expect(await mock.methodReturningFuture(), equals('Two'));
+    });
+
+    test('thenAnswerInOrder throws if not enough answers are provided', () {
+      when(
+        mock.methodWithNormalArgs(any),
+      ).thenAnswerInOrder([(_) => 'One', (_) => 'Two']);
+
+      expect(mock.methodWithNormalArgs(100), equals('One'));
+      expect(mock.methodWithNormalArgs(100), equals('Two'));
+
+      expect(
+        () => mock.methodWithNormalArgs(100),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('thenAnswerInOrder does not have enough answers'),
+          ),
+        ),
+      );
+    });
+
+    test(
+      'thenAnswerInOrder allows empty list at stubbing and throws when called',
+      () {
+        when(mock.methodWithNormalArgs(any)).thenAnswerInOrder([]);
+
+        expect(
+          () => mock.methodWithNormalArgs(100),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains('thenAnswerInOrder does not have enough answers'),
+            ),
+          ),
+        );
+      },
+    );
 
     test('should have hashCode when it is not mocked', () {
       expect(mock.hashCode, isNotNull);
@@ -249,13 +314,6 @@ void main() {
         () => when(
           mock.methodReturningStream(),
         ).thenReturn(Stream.fromIterable(['stub'])),
-        throwsArgumentError,
-      );
-    });
-
-    test('thenReturn throws if provided expects are empty for inOrder', () {
-      expect(
-        () => when(mock.methodReturningStream()).thenReturnInOrder([]),
         throwsArgumentError,
       );
     });


### PR DESCRIPTION
Fix #4476.

I think it's better to succeed than fail early if someone passes an empty list of answers. If it's a literal, it's clear that it's empty; if it's not a literal, it's created by some code, and it's valid that code decides there will be no answers needed.