### PR TITLE
Set default test reporter to `failures-only` across all packages.

### DIFF
--- a/_benchmark/dart_test.yaml
+++ b/_benchmark/dart_test.yaml
@@ -1,2 +1,1 @@
 reporter: failures-only
-timeout: 2x

--- a/build/dart_test.yaml
+++ b/build/dart_test.yaml
@@ -1,2 +1,1 @@
 reporter: failures-only
-timeout: 2x

--- a/build_config/dart_test.yaml
+++ b/build_config/dart_test.yaml
@@ -1,2 +1,1 @@
 reporter: failures-only
-timeout: 2x

--- a/build_daemon/dart_test.yaml
+++ b/build_daemon/dart_test.yaml
@@ -1,2 +1,1 @@
 reporter: failures-only
-timeout: 2x

--- a/build_runner/dart_test.yaml
+++ b/build_runner/dart_test.yaml
@@ -1,3 +1,5 @@
+reporter: failures-only
+
 tags:
   integration1:
     timeout: 3m

--- a/build_test/dart_test.yaml
+++ b/build_test/dart_test.yaml
@@ -1,2 +1,1 @@
 reporter: failures-only
-timeout: 2x

--- a/builder_pkgs/mockito/dart_test.yaml
+++ b/builder_pkgs/mockito/dart_test.yaml
@@ -1,2 +1,1 @@
 reporter: failures-only
-timeout: 2x

--- a/builder_pkgs/scratch_space/dart_test.yaml
+++ b/builder_pkgs/scratch_space/dart_test.yaml
@@ -1,2 +1,1 @@
 reporter: failures-only
-timeout: 2x

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,2 +1,1 @@
 reporter: failures-only
-timeout: 2x

--- a/example/dart_test.yaml
+++ b/example/dart_test.yaml
@@ -1,2 +1,1 @@
 reporter: failures-only
-timeout: 2x

--- a/tool/dart_test.yaml
+++ b/tool/dart_test.yaml
@@ -1,2 +1,1 @@
 reporter: failures-only
-timeout: 2x


### PR DESCRIPTION
This stops `dart test` from outputting one line per successful test, which

 - makes CI output easier to read
 - significantly reduces the amount of text that agents have to read when iterating on tests

Markdown link checker is failing because dartdoc didn't run yet for the recently-published package:mockito.
