### PR TITLE
chore: harden GitHub Actions workflows against Zizmor findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     labels:
       - autosubmit
     groups:
@@ -20,6 +22,8 @@ updates:
     directory: "build"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: increase-if-necessary
     reviewers:
       - "jakemac53"
@@ -27,6 +31,8 @@ updates:
     directory: "build_modules"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: increase-if-necessary
     reviewers:
       - "jakemac53"
@@ -34,6 +40,8 @@ updates:
     directory: "build_resolvers"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: increase-if-necessary
     reviewers:
       - "jakemac53"
@@ -41,6 +49,8 @@ updates:
     directory: "build_runner"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: increase-if-necessary
     reviewers:
       - "jakemac53"
@@ -48,6 +58,8 @@ updates:
     directory: "build_web_compilers"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: increase-if-necessary
     reviewers:
       - "jakemac53"

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -1,4 +1,7 @@
 name: Health
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ master ]
@@ -6,7 +9,7 @@ on:
 
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@ed9c592c1d35106c0a8a52044426515017a60646
     with:
       checks: "version,changelog,do-not-submit"
       ignore_license: "**.g.dart"

--- a/.github/workflows/markdown_linter.yml
+++ b/.github/workflows/markdown_linter.yml
@@ -1,4 +1,7 @@
 name: markdown_link_check
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -12,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        with:
+          persist-credentials: false
       - uses: tcort/github-action-markdown-link-check@e047c5b37f24ab722bbef1a27b6fab7f96bc4068
         with:
           use-quiet-mode: 'yes'

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,9 +1,11 @@
 name: Comment on the pull request
+permissions:
+  contents: read
 
 on:
   # Trigger this workflow after the Health workflow completes. This workflow will have permissions to
   # do things like create comments on the PR, even if the original workflow couldn't.
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: 
       - Health
       - Publish
@@ -12,6 +14,6 @@ on:
 
 jobs:
   upload:
-    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@ed9c592c1d35106c0a8a52044426515017a60646
     permissions:
       pull-requests: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,8 @@
 # A CI configuration to auto-publish pub packages.
 
 name: Publish
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -12,7 +14,7 @@ on:
 jobs:
   publish:
     if: ${{ github.repository_owner == 'dart-lang' }}
-    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@main
+    uses: dart-lang/ecosystem/.github/workflows/publish.yaml@ed9c592c1d35106c0a8a52044426515017a60646
     with:
       write-comments: false
       sdk: dev


### PR DESCRIPTION
- Pin dart-lang/ecosystem workflows to full commit SHA
- Add top-level permissions: contents: read where missing
- Set persist-credentials: false on actions/checkout
- Add cooldown to dependabot configuration
- Ignore dangerous-triggers for post_summaries workflow_run
