### PR TITLE
build_web_compilers: require Dart 3.13.0.

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.8.10
+
+- Require Dart `3.13.0`.
+
 ## 4.8.9
 - Fix an issue where `DdcFrontendServerBuilder` accumulates changed files across builds.
 

--- a/builder_pkgs/build_web_compilers/pubspec.yaml
+++ b/builder_pkgs/build_web_compilers/pubspec.yaml
@@ -1,11 +1,11 @@
 name: build_web_compilers
-version: 4.8.9
+version: 4.8.10
 description: Builder implementations wrapping the dart2js and DDC compilers.
 repository: https://github.com/dart-lang/build/tree/master/builder_pkgs/build_web_compilers
 resolution: workspace
 
 environment:
-  sdk: '>=3.13.0-107.0.dev <3.14.0-z'
+  sdk: '>=3.13.0 <3.14.0-z'
 
 dependencies:
   analyzer: '>=13.3.0 <15.0.0'


### PR DESCRIPTION
Fix #5077.

There was a min bound on a dev SDK, put it on the released SDK.