### PR TITLE
Introduce AssetFile to differentiate source and cache locations

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Bug fix: make post-process output behavior match normal outputs: by default,
   rebuild if deleted or incorrect. Follow `--keep-modified-outputs` and
   `--only-check`.
+- Bug fix: in incremental builds, detect and delete conflicting outputs in the
+  source directory rather than treating them as sources, which could cause
+  builder dependency cycles and hangs; fix #5079.
 
 ## 2.16.0
 

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -383,10 +383,12 @@ class BuildSeries {
       }
     }
 
-    final forceVisible =
+    // With `forceVisibleForTesting` all hidden outputs are forced to non-hidden
+    // outputs for simpler test assertions.
+    final forceVisibleForTesting =
         _buildPlan.buildSpec.testingOverrides.forceVisibleForTesting;
     for (final file in _buildPlan.conflictingOutputs) {
-      final outputIsHidden = forceVisible
+      final outputIsHidden = forceVisibleForTesting
           ? false
           : currentState.isHidden(file.id);
       final isMatchingActualOutput =

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -9,6 +9,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:crypto/crypto.dart';
 import 'package:watcher/watcher.dart';
 
+import '../build_plan/asset_file.dart';
 import '../build_plan/build_directory.dart';
 import '../build_plan/build_filter.dart';
 import '../build_plan/build_plan.dart';
@@ -106,13 +107,19 @@ class BuildSeries {
         if ((change.type == .ADD || change.type == .MODIFY) &&
             _buildPlan.buildStepPlan.isDeclaredOutput(id)) {
           final expectedDigest = previousBuild.digestOf(id);
+          final isHidden = _buildPlan.buildStepPlan.isHidden(id);
           if (expectedDigest != null) {
             try {
               final bytes = await _buildPlan.readerWriter.readAsBytes(
                 id,
-                hidden: _buildPlan.buildStepPlan.isHidden(id),
+                hidden: isHidden,
               );
-              if (md5.convert(bytes) == expectedDigest) {
+              // TODO(davidmorgan): alternative is to track location in events.
+              final conflictingExists = await _buildPlan.readerWriter.canRead(
+                id,
+                hidden: !isHidden,
+              );
+              if (!conflictingExists && md5.convert(bytes) == expectedDigest) {
                 continue;
               }
             } catch (_) {}
@@ -146,10 +153,10 @@ class BuildSeries {
 
       // Changes to files that are part of the build.
 
-      // If not copying to a merged output directory, ignore changes to files
+      // If not copying to a merged output directory, ignore changes to sources
       // with no outputs.
       if (!_buildPlan.buildSpec.buildOptions.anyMergedOutputDirectory &&
-          !previousBuild.isMissingSource(id) &&
+          previousBuild.isSource(id) &&
           previousBuild.digestOf(id) == null) {
         rejected.add(change);
         continue;
@@ -177,18 +184,16 @@ class BuildSeries {
               'build.${_buildPlan.buildSpec.buildOptions.configKey}.yaml');
 
   Future<List<WatchEvent>> checkForChanges() async {
-    final updates =
-        await AssetTracker(
-          _buildPlan.readerWriter,
-          _buildPlan.buildSpec.buildPackages,
-          _buildPlan.buildSpec.buildConfigs,
-        ).collectChanges(
-          buildStepPlan: _buildPlan.buildStepPlan,
-          previousBuild: _buildPlan.previousBuild,
-        );
+    final updates = await AssetTracker(
+      _buildPlan.readerWriter,
+      _buildPlan.buildSpec.buildPackages,
+      _buildPlan.buildSpec.buildConfigs,
+    ).collectChanges(previousBuild: _buildPlan.previousBuild);
 
     return List.of(
-      updates.entries.map((entry) => WatchEvent(entry.value, '${entry.key}')),
+      updates.entries.map(
+        (entry) => WatchEvent(entry.value, '${entry.key.id}'),
+      ),
     );
   }
 
@@ -259,7 +264,11 @@ class BuildSeries {
     );
 
     if (!firstBuild || updates.isNotEmpty) {
-      _buildPlan = await _buildPlan.updateForFileChanges(updates);
+      final filesToCheck = <AssetFile>{
+        for (final id in updates) AssetFile.source(id),
+        for (final id in updates) AssetFile.cache(id),
+      };
+      _buildPlan = await _buildPlan.updateForFileChanges(filesToCheck);
     }
 
     final build = Build(
@@ -361,20 +370,6 @@ class BuildSeries {
   Set<AssetId> _computeDeletes(BuildResult result, {bool onlyVisible = false}) {
     final deletes = <AssetId>{};
     final currentState = result.buildState!;
-    for (final id in _buildPlan.conflictingOutputs) {
-      if (!currentState.isActualOutput(id) &&
-          !currentState.isActualPostOutput(id)) {
-        deletes.add(id);
-      }
-    }
-    for (final id
-        in _buildPlan.previousBuild.incompatibleBuildOutputsToDelete) {
-      if (!currentState.isActualOutput(id) &&
-          !currentState.isActualPostOutput(id)) {
-        deletes.add(id);
-      }
-    }
-
     final outputRoot = _buildPlan.buildSpec.buildPackages.outputRoot;
     // Adds a delete result, unless it's a hidden file and `onlyVisible` was
     // requested.
@@ -384,6 +379,28 @@ class BuildSeries {
           deletes.add(AssetPathProvider.hide(id, outputRoot));
         }
       } else {
+        deletes.add(id);
+      }
+    }
+
+    final forceVisible =
+        _buildPlan.buildSpec.testingOverrides.forceVisibleForTesting;
+    for (final file in _buildPlan.conflictingOutputs) {
+      final outputIsHidden = forceVisible
+          ? false
+          : currentState.isHidden(file.id);
+      final isMatchingActualOutput =
+          (currentState.isActualOutput(file.id) ||
+              currentState.isActualPostOutput(file.id)) &&
+          outputIsHidden == file.hidden;
+      if (!isMatchingActualOutput) {
+        maybeAddDelete(file.id, file.hidden);
+      }
+    }
+    for (final id
+        in _buildPlan.previousBuild.incompatibleBuildOutputsToDelete) {
+      if (!currentState.isActualOutput(id) &&
+          !currentState.isActualPostOutput(id)) {
         deletes.add(id);
       }
     }

--- a/build_runner/lib/src/build_plan/asset_file.dart
+++ b/build_runner/lib/src/build_plan/asset_file.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart' hide Builder;
+import 'package:built_value/built_value.dart';
+
+part 'asset_file.g.dart';
+
+/// An asset with its physical location on disk: either in the source directory
+/// or in the hidden cache directory.
+abstract class AssetFile implements Built<AssetFile, AssetFileBuilder> {
+  /// The logical asset identifier.
+  AssetId get id;
+
+  /// Whether the file is located in the hidden cache directory.
+  bool get hidden;
+
+  factory AssetFile(AssetId id, {required bool hidden}) =>
+      _$AssetFile._(id: id, hidden: hidden);
+
+  /// An asset in the source directory.
+  factory AssetFile.source(AssetId id) => _$AssetFile._(id: id, hidden: false);
+
+  /// An asset in the hidden cache directory.
+  factory AssetFile.cache(AssetId id) => _$AssetFile._(id: id, hidden: true);
+
+  AssetFile._();
+}

--- a/build_runner/lib/src/build_plan/asset_file.g.dart
+++ b/build_runner/lib/src/build_plan/asset_file.g.dart
@@ -1,0 +1,102 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'asset_file.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$AssetFile extends AssetFile {
+  @override
+  final AssetId id;
+  @override
+  final bool hidden;
+
+  factory _$AssetFile([void Function(AssetFileBuilder)? updates]) =>
+      (AssetFileBuilder()..update(updates))._build();
+
+  _$AssetFile._({required this.id, required this.hidden}) : super._();
+  @override
+  AssetFile rebuild(void Function(AssetFileBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AssetFileBuilder toBuilder() => AssetFileBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AssetFile && id == other.id && hidden == other.hidden;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, hidden.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AssetFile')
+          ..add('id', id)
+          ..add('hidden', hidden))
+        .toString();
+  }
+}
+
+class AssetFileBuilder implements Builder<AssetFile, AssetFileBuilder> {
+  _$AssetFile? _$v;
+
+  AssetId? _id;
+  AssetId? get id => _$this._id;
+  set id(AssetId? id) => _$this._id = id;
+
+  bool? _hidden;
+  bool? get hidden => _$this._hidden;
+  set hidden(bool? hidden) => _$this._hidden = hidden;
+
+  AssetFileBuilder();
+
+  AssetFileBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
+      _hidden = $v.hidden;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(AssetFile other) {
+    _$v = other as _$AssetFile;
+  }
+
+  @override
+  void update(void Function(AssetFileBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AssetFile build() => _build();
+
+  _$AssetFile _build() {
+    final _$result =
+        _$v ??
+        _$AssetFile._(
+          id: BuiltValueNullFieldError.checkNotNull(id, r'AssetFile', 'id'),
+          hidden: BuiltValueNullFieldError.checkNotNull(
+            hidden,
+            r'AssetFile',
+            'hidden',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -206,10 +206,9 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
     final result = BuildInputsBuilder()..cleanBuild = true;
 
     for (final file in filesToCheck) {
-      if (await readerWriter.canRead(file.id, hidden: file.hidden)) {
-        if (!file.hidden) {
-          result.sources.add(file.id);
-        }
+      if (file.hidden) continue;
+      if (await readerWriter.canRead(file.id, hidden: false)) {
+        result.sources.add(file.id);
       }
     }
 
@@ -299,20 +298,20 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
     for (final file in filesToCheck) {
       final id = file.id;
       final oldIsSource = previousBuild.isSource(id);
-      final oldExisted =
-          oldIsSource ||
-          previousBuild.isActualOutput(id) ||
-          previousBuild.isActualPostOutput(id);
-      final oldFile = !oldExisted
-          ? null
-          : oldIsSource
-          ? AssetFile.source(id)
-          : AssetFile(id, hidden: previousBuild.isHidden(id));
-      final oldExistedHere = oldExisted && oldFile == file;
-      final oldDigest = oldExistedHere ? previousBuild.digestOf(id) : null;
+      AssetFile? oldFile;
+      if (oldIsSource) {
+        oldFile = AssetFile.source(id);
+      } else if (previousBuild.isActualOutput(id) ||
+          previousBuild.isActualPostOutput(id)) {
+        oldFile = AssetFile(id, hidden: previousBuild.isHidden(id));
+      }
+      final oldExistedSameLocation = oldFile == file;
+      final oldDigest = oldExistedSameLocation
+          ? previousBuild.digestOf(id)
+          : null;
+
       var exists = false;
       AssetContent? newContent;
-
       if (await readerWriter.canRead(id, hidden: file.hidden)) {
         exists = true;
         if (oldDigest != null) {
@@ -329,7 +328,7 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
       }
 
       if (!exists) {
-        if (oldExistedHere) {
+        if (oldExistedSameLocation) {
           if (oldIsSource) {
             buildInputs.deletedSources.add(id);
             buildInputs.sources.remove(id);
@@ -342,7 +341,7 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         continue;
       }
 
-      if (!oldExistedHere) {
+      if (!oldExistedSameLocation) {
         if (file.hidden) {
           newCacheFiles.add(id);
           conflictingOutputs.add(file);

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -14,6 +14,7 @@ import '../exceptions.dart';
 import '../io/asset_tracker.dart';
 import '../io/reader_writer.dart';
 import '../logging/build_log.dart';
+import 'asset_file.dart';
 import 'build_directory.dart';
 import 'build_filter.dart';
 import 'build_inputs.dart';
@@ -33,9 +34,8 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
 
   /// Callback that gets notified of deletes.
 
-  /// Inputs in the source tree that conflict with declared outputs and must be
-  /// deleted.
-  BuiltList<AssetId> get conflictingOutputs;
+  /// Files on disk that conflict with declared outputs and must be deleted.
+  BuiltList<AssetFile> get conflictingOutputs;
 
   /// Sources and changes to sources before the build.
   BuildInputs get buildInputs;
@@ -68,15 +68,17 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
       buildPackages,
       buildSpec.buildConfigs,
     );
-    final assetTrackerInputSources = await assetTracker.findInputSources();
-    final cacheDirSources = await assetTracker.findCacheDirSources();
+    final diskFiles = await assetTracker.findFiles();
 
     final hasCompatiblePreviousBuild = previousBuild.incrementalState != null;
     if (!hasCompatiblePreviousBuild) {
       // If there is no compatible previous build, compute inputs with files
       // that look like old generation outputs removed.
 
-      final inputSources = assetTrackerInputSources.toSet();
+      final inputSources = diskFiles
+          .where((f) => !f.hidden)
+          .map((f) => f.id)
+          .toSet();
 
       // Remove files from the incompatible build.
       inputSources.removeAll(previousBuild.incompatibleBuildOutputsToDelete);
@@ -98,18 +100,21 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         previousBuild: previousBuild,
         buildDirs: buildSpec.buildOptions.buildDirs,
         buildFilters: buildSpec.buildOptions.buildFilters,
-        filesToCheck: inputSources,
-        assetTrackerInputSources: assetTrackerInputSources,
+        filesToCheck: inputSources.map(AssetFile.source).toSet(),
+        diskFiles: diskFiles,
       );
     } else {
       // If there is a compatible previous build, check all previous build files
       // and all discovered files on disk.
-      final filesToCheck = {
-        ...assetTrackerInputSources,
-        ...cacheDirSources,
-        ...previousBuild.sources,
-        ...previousBuild.actualOutputs,
-        ...previousBuild.actualPostOutputs,
+      final filesToCheck = <AssetFile>{
+        ...diskFiles,
+        ...previousBuild.sources.map(AssetFile.source),
+        ...previousBuild.actualOutputs.map(
+          (id) => AssetFile(id, hidden: previousBuild.isHidden(id)),
+        ),
+        ...previousBuild.actualPostOutputs.map(
+          (id) => AssetFile(id, hidden: previousBuild.isHidden(id)),
+        ),
       };
 
       final previousBuildStepPlan = previousBuild.buildStepPlan!;
@@ -147,7 +152,7 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
       ..conflictingOutputs.clear(),
   );
 
-  Future<BuildPlan> updateForFileChanges(Set<AssetId> filesToCheck) {
+  Future<BuildPlan> updateForFileChanges(Set<AssetFile> filesToCheck) {
     if (previousBuild.incrementalState == null) {
       return _createClean(
         buildSpec: buildSpec,
@@ -158,7 +163,7 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         // Updates are being made to a `BuildPlan` that didn't actually run.
         // That means the conflicting file check was already done when that
         // `BuildPlan` was created, don't repeat it.
-        assetTrackerInputSources: null,
+        diskFiles: null,
       );
     } else {
       return _createIncremental(
@@ -185,24 +190,26 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
 
   /// Creates a [BuildPlan] for a clean build.
   ///
-  /// Pass [assetTrackerInputSources] to check if any files that builders
-  /// will generate conflict with files already on disk. Conflicts in
-  /// dependencies cause an exception to be thrown, conflicts in writable
-  /// packages are added to [conflictingOutputs] so they will be deleted.
+  /// Pass [diskFiles] to check if any files that builders will generate
+  /// conflict with files already on disk. Conflicts in dependencies cause an
+  /// exception to be thrown, conflicts in writable packages are added to
+  /// [conflictingOutputs] so they will be deleted.
   static Future<BuildPlan> _createClean({
     required BuildSpec buildSpec,
     required PreviousBuild previousBuild,
     required BuiltSet<BuildDirectory> buildDirs,
     required BuiltSet<BuildFilter> buildFilters,
-    required Set<AssetId> filesToCheck,
-    Set<AssetId>? assetTrackerInputSources,
+    required Set<AssetFile> filesToCheck,
+    Set<AssetFile>? diskFiles,
   }) async {
     final readerWriter = buildSpec.readerWriter;
     final result = BuildInputsBuilder()..cleanBuild = true;
 
-    for (final id in filesToCheck) {
-      if (await readerWriter.canRead(id)) {
-        result.sources.add(id);
+    for (final file in filesToCheck) {
+      if (await readerWriter.canRead(file.id, hidden: file.hidden)) {
+        if (!file.hidden) {
+          result.sources.add(file.id);
+        }
       }
     }
 
@@ -212,13 +219,13 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
       sources: result.sources.build(),
     );
 
-    final conflictingOutputs = <AssetId>{};
+    final conflictingOutputs = <AssetFile>{};
     final buildPackages = buildSpec.buildPackages;
 
-    if (assetTrackerInputSources != null) {
+    if (diskFiles != null) {
       final conflictsInDeps = buildStepPlan.declaredOutputs
           .where((n) => !buildPackages.outputPackages.contains(n.package))
-          .where(assetTrackerInputSources.contains)
+          .where((n) => diskFiles.contains(AssetFile.source(n)))
           .toSet();
       if (conflictsInDeps.isNotEmpty) {
         buildLog.error(
@@ -230,12 +237,16 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         throw const CannotBuildException();
       }
 
-      conflictingOutputs.addAll(
-        buildStepPlan.declaredOutputs
-            .where((n) => buildPackages.outputPackages.contains(n.package))
-            .where(assetTrackerInputSources.contains)
-            .toSet(),
-      );
+      for (final file in diskFiles) {
+        if (buildStepPlan.isDeclaredOutput(file.id)) {
+          if (!file.hidden &&
+              buildPackages.outputPackages.contains(file.id.package)) {
+            conflictingOutputs.add(file);
+          } else if (file.hidden && !buildStepPlan.isHidden(file.id)) {
+            conflictingOutputs.add(file);
+          }
+        }
+      }
     }
 
     for (final id in result.sources.build()) {
@@ -267,7 +278,7 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
     BuildInputs? previousBuildInputs,
     required BuiltSet<BuildDirectory> buildDirs,
     required BuiltSet<BuildFilter> buildFilters,
-    required Set<AssetId> filesToCheck,
+    required Set<AssetFile> filesToCheck,
   }) async {
     final readerWriter = buildSpec.readerWriter;
     final buildInputs = BuildInputsBuilder()..cleanBuild = false;
@@ -282,20 +293,33 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
 
     buildInputs.sources.addAll(previousBuild.sources);
 
-    for (final id in filesToCheck) {
+    final conflictingOutputs = <AssetFile>{};
+    final newCacheFiles = <AssetId>{};
+
+    for (final file in filesToCheck) {
+      final id = file.id;
       final oldIsSource = previousBuild.isSource(id);
-      final oldExisted = previousBuild.isFile(id);
-      final oldDigest = previousBuild.digestOf(id);
+      final oldExisted =
+          oldIsSource ||
+          previousBuild.isActualOutput(id) ||
+          previousBuild.isActualPostOutput(id);
+      final oldFile = !oldExisted
+          ? null
+          : oldIsSource
+          ? AssetFile.source(id)
+          : AssetFile(id, hidden: previousBuild.isHidden(id));
+      final oldExistedHere = oldExisted && oldFile == file;
+      final oldDigest = oldExistedHere ? previousBuild.digestOf(id) : null;
       var exists = false;
       AssetContent? newContent;
 
-      if (await readerWriter.canRead(id, hidden: previousBuild.isHidden(id))) {
+      if (await readerWriter.canRead(id, hidden: file.hidden)) {
         exists = true;
         if (oldDigest != null) {
           try {
             final bytes = await readerWriter.readAsBytes(
               id,
-              hidden: previousBuild.isHidden(id),
+              hidden: file.hidden,
             );
             newContent = AssetContent.bytes(bytes);
           } catch (_) {
@@ -305,7 +329,7 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
       }
 
       if (!exists) {
-        if (oldExisted) {
+        if (oldExistedHere) {
           if (oldIsSource) {
             buildInputs.deletedSources.add(id);
             buildInputs.sources.remove(id);
@@ -318,9 +342,14 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         continue;
       }
 
-      if (!oldExisted) {
-        buildInputs.updatedSources.add(id);
-        buildInputs.sources.add(id);
+      if (!oldExistedHere) {
+        if (file.hidden) {
+          newCacheFiles.add(id);
+          conflictingOutputs.add(file);
+        } else {
+          buildInputs.updatedSources.add(id);
+          buildInputs.sources.add(id);
+        }
         continue;
       }
 
@@ -361,7 +390,71 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
       sources: buildInputs.sources.build(),
     );
 
-    for (final id in buildInputs.sources.build()) {
+    final declaredOutputs = buildStepPlan.declaredOutputs;
+    final currentSources = buildInputs.sources.build();
+    final postBuildActions =
+        buildSpec.buildPhases.postBuildPhase.builderActions;
+    // Outputs that were misclassified as sources.
+    final misclassifiedSources = <AssetId>{};
+    for (final id in currentSources) {
+      if (declaredOutputs.contains(id)) {
+        misclassifiedSources.add(id);
+      } else {
+        final postStepId = previousBuild.postProcessOutputs[id];
+        if (postStepId != null) {
+          final producingInput = postStepId.input;
+          final inputExists =
+              currentSources.contains(producingInput) ||
+              buildStepPlan.isDeclaredOutput(producingInput);
+          if (inputExists &&
+              postStepId.actionNumber < postBuildActions.length &&
+              buildStepPlan.actionMatches(
+                postBuildActions[postStepId.actionNumber],
+                producingInput,
+              )) {
+            misclassifiedSources.add(id);
+          }
+        }
+      }
+    }
+    if (misclassifiedSources.isNotEmpty) {
+      final buildPackages = buildSpec.buildPackages;
+      final conflictsInDeps = misclassifiedSources
+          .where((n) => !buildPackages.outputPackages.contains(n.package))
+          .toSet();
+      if (conflictsInDeps.isNotEmpty) {
+        buildLog.error(
+          'There are existing files in dependencies which conflict '
+          'with files that a Builder may produce. These must be removed or '
+          'the Builders disabled before a build can continue: '
+          '${conflictsInDeps.map((a) => a.uri).join('\n')}',
+        );
+        throw const CannotBuildException();
+      }
+
+      buildInputs.sources.removeAll(misclassifiedSources);
+      buildInputs.sourceContents.removeWhere(
+        (id, _) => misclassifiedSources.contains(id),
+      );
+      buildInputs.updatedSources.removeWhere(misclassifiedSources.contains);
+      for (final id in misclassifiedSources) {
+        conflictingOutputs.add(AssetFile.source(id));
+      }
+      buildStepPlan = BuildStepPlan.compute(
+        buildPhases: buildSpec.buildPhases,
+        placeholderIds: buildSpec.buildPackages.placeholderIds,
+        sources: buildInputs.sources.build(),
+      );
+    }
+
+    final finalSources = buildInputs.sources.build();
+    for (final id in newCacheFiles) {
+      if (!finalSources.contains(id)) {
+        buildInputs.invalidOutputs.add(id);
+      }
+    }
+
+    for (final id in finalSources) {
       if (buildInputs.sourceContents[id] == null &&
           buildStepPlan.declaredOutputsOf(id).isNotEmpty) {
         try {
@@ -379,11 +472,13 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         .transitiveDeclaredOutputsOf(buildInputs.deletedSources.build())
         .toSet();
     buildInputs.invalidOutputs.addAll(invalidOutputs);
+    buildInputs.invalidOutputs.removeAll(finalSources);
 
     return BuildPlan((b) {
       b.buildSpec.replace(buildSpec);
       b.previousBuild.replace(previousBuild);
       b.buildStepPlan.replace(buildStepPlan);
+      b.conflictingOutputs.replace(conflictingOutputs);
       b.buildInputs = buildInputs;
       b.buildDirs.replace(buildDirs);
       b.buildFilters.replace(buildFilters);

--- a/build_runner/lib/src/build_plan/build_plan.g.dart
+++ b/build_runner/lib/src/build_plan/build_plan.g.dart
@@ -14,7 +14,7 @@ class _$BuildPlan extends BuildPlan {
   @override
   final BuildStepPlan buildStepPlan;
   @override
-  final BuiltList<AssetId> conflictingOutputs;
+  final BuiltList<AssetFile> conflictingOutputs;
   @override
   final BuildInputs buildInputs;
   @override
@@ -101,10 +101,10 @@ class BuildPlanBuilder implements Builder<BuildPlan, BuildPlanBuilder> {
   set buildStepPlan(BuildStepPlanBuilder? buildStepPlan) =>
       _$this._buildStepPlan = buildStepPlan;
 
-  ListBuilder<AssetId>? _conflictingOutputs;
-  ListBuilder<AssetId> get conflictingOutputs =>
-      _$this._conflictingOutputs ??= ListBuilder<AssetId>();
-  set conflictingOutputs(ListBuilder<AssetId>? conflictingOutputs) =>
+  ListBuilder<AssetFile>? _conflictingOutputs;
+  ListBuilder<AssetFile> get conflictingOutputs =>
+      _$this._conflictingOutputs ??= ListBuilder<AssetFile>();
+  set conflictingOutputs(ListBuilder<AssetFile>? conflictingOutputs) =>
       _$this._conflictingOutputs = conflictingOutputs;
 
   BuildInputsBuilder? _buildInputs;

--- a/build_runner/lib/src/build_plan/previous_build.dart
+++ b/build_runner/lib/src/build_plan/previous_build.dart
@@ -116,7 +116,13 @@ abstract class PreviousBuild
       buildStepResults.values.expand((r) => r.outputs);
   Iterable<AssetId> get actualPostOutputs => postProcessOutputs.keys;
 
-  bool _isActualPostOutput(AssetId id) => postProcessOutputs.containsKey(id);
+  bool isActualPostOutput(AssetId id) => postProcessOutputs.containsKey(id);
+
+  bool isActualOutput(AssetId id) {
+    final step = buildStepPlan?.stepForDeclaredOutputOrNull(id);
+    if (step == null) return false;
+    return stepResultOrNull(step)?.outputs.contains(id) ?? false;
+  }
 
   bool _isHiddenPostProcessOutput(AssetId id) {
     final step = postProcessOutputs[id];
@@ -130,7 +136,7 @@ abstract class PreviousBuild
   bool isFile(AssetId id) =>
       isSource(id) ||
       (buildStepPlan?.isDeclaredOutput(id) ?? false) ||
-      _isActualPostOutput(id);
+      isActualPostOutput(id);
 
   Digest? digestOf(AssetId id) => digests[id];
 

--- a/build_runner/lib/src/io/asset_tracker.dart
+++ b/build_runner/lib/src/io/asset_tracker.dart
@@ -10,9 +10,9 @@ import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 import 'package:watcher/watcher.dart';
 
+import '../build_plan/asset_file.dart';
 import '../build_plan/build_configs.dart';
 import '../build_plan/build_packages.dart';
-import '../build_plan/build_step_plan.dart';
 import '../build_plan/build_target.dart';
 import '../build_plan/previous_build.dart';
 import '../constants.dart';
@@ -27,25 +27,27 @@ class AssetTracker {
 
   AssetTracker(this._readerWriter, this._buildPackages, this._buildConfigs);
 
-  /// Checks for and returns any file system changes compared to the current
-  /// build step plan and previous build.
-  Future<Map<AssetId, ChangeType>> collectChanges({
-    required BuildStepPlan buildStepPlan,
+  /// Checks for and returns any file system changes compared to the previous
+  /// build.
+  Future<Map<AssetFile, ChangeType>> collectChanges({
     required PreviousBuild previousBuild,
   }) async {
-    final inputSources = await findInputSources();
-    final generatedSources = await findCacheDirSources();
-    final declaredAndActualOutputs = [
-      ...buildStepPlan.declaredOutputs,
+    final diskFiles = await findFiles();
+    final actualOutputs = [
+      ...previousBuild.actualOutputs,
       ...previousBuild.actualPostOutputs,
     ];
-    return computeSourceUpdates(
-      inputSources,
-      generatedSources,
-      previousBuild,
-      declaredAndActualOutputs,
-      buildStepPlan: buildStepPlan,
-    );
+    return computeSourceUpdates(diskFiles, previousBuild, actualOutputs);
+  }
+
+  /// Returns all assets found on disk: both source files and cache files.
+  Future<Set<AssetFile>> findFiles() async {
+    final inputSources = await findInputSources();
+    final cacheSources = await findCacheDirSources();
+    return {
+      ...inputSources.map(AssetFile.source),
+      ...cacheSources.map(AssetFile.cache),
+    };
   }
 
   /// Returns the all the sources found in the cache directory.
@@ -65,61 +67,41 @@ class AssetTracker {
   /// Finds the asset changes which have happened while unwatched between builds
   /// by taking a difference between the assets in the previous build and the
   /// assets on disk.
-  Future<Map<AssetId, ChangeType>> computeSourceUpdates(
-    Set<AssetId> inputSources,
-    Set<AssetId> generatedSources,
+  Future<Map<AssetFile, ChangeType>> computeSourceUpdates(
+    Set<AssetFile> diskFiles,
     PreviousBuild previousBuild,
-    Iterable<AssetId> declaredAndActualOutputs, {
-    required BuildStepPlan buildStepPlan,
-  }) async {
-    final allSources = <AssetId>{}
-      ..addAll(inputSources)
-      ..addAll(generatedSources);
-    final updates = <AssetId, ChangeType>{};
-    void addUpdates(Iterable<AssetId> assets, ChangeType type) {
-      for (final asset in assets) {
-        updates[asset] = type;
-      }
+    Iterable<AssetId> actualOutputs,
+  ) async {
+    final previousFiles = <AssetFile>{
+      ...previousBuild.sources.map(AssetFile.source),
+      ...actualOutputs.map(
+        (id) => AssetFile(id, hidden: previousBuild.isHidden(id)),
+      ),
+    };
+
+    final updates = <AssetFile, ChangeType>{};
+
+    for (final file in diskFiles.difference(previousFiles)) {
+      updates[file] = ChangeType.ADD;
     }
 
-    final newSources = inputSources.difference(previousBuild.sources.toSet());
-    addUpdates(newSources, ChangeType.ADD);
-    final removedAssets = [
-      for (final id in previousBuild.sources)
-        if (!allSources.contains(id)) id,
-      for (final id in declaredAndActualOutputs)
-        if (!allSources.contains(id)) id,
-    ];
-
-    addUpdates(removedAssets, ChangeType.REMOVE);
-
-    final originalGraphSources = previousBuild.sources.toSet();
-    final preExistingSources = originalGraphSources.intersection(inputSources);
-    for (final id in preExistingSources) {
-      final originalDigest = previousBuild.digestOf(id);
-      if (originalDigest == null) continue;
-
-      final currentDigest = await _readerWriter.digest(id);
-      if (currentDigest != originalDigest) {
-        updates[id] = ChangeType.MODIFY;
-      }
+    for (final file in previousFiles.difference(diskFiles)) {
+      updates[file] = ChangeType.REMOVE;
     }
 
-    final preExistingOutputs = declaredAndActualOutputs.toSet().intersection(
-      allSources,
-    );
-    for (final id in preExistingOutputs) {
-      final originalDigest = previousBuild.digestOf(id);
+    for (final file in previousFiles.intersection(diskFiles)) {
+      final originalDigest = previousBuild.digestOf(file.id);
       if (originalDigest == null) continue;
 
       final currentDigest = await _readerWriter.digest(
-        id,
-        hidden: previousBuild.isHidden(id),
+        file.id,
+        hidden: file.hidden,
       );
       if (currentDigest != originalDigest) {
-        updates[id] = ChangeType.MODIFY;
+        updates[file] = ChangeType.MODIFY;
       }
     }
+
     return updates;
   }
 

--- a/build_runner/test/build/build_series_test.dart
+++ b/build_runner/test/build/build_series_test.dart
@@ -1,0 +1,362 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:build_runner/src/build/asset_content.dart';
+import 'package:build_runner/src/build/build_result.dart';
+import 'package:build_runner/src/build/build_series.dart';
+import 'package:build_runner/src/build/build_state/asset_graph_json.dart';
+import 'package:build_runner/src/build/build_state/build_state.dart';
+import 'package:build_runner/src/build/build_state/build_step_result.dart';
+import 'package:build_runner/src/build/library_cycle_graph/phased_asset_deps.dart';
+import 'package:build_runner/src/build_plan/build_options.dart';
+import 'package:build_runner/src/build_plan/build_package.dart';
+import 'package:build_runner/src/build_plan/build_packages.dart';
+import 'package:build_runner/src/build_plan/build_plan.dart';
+import 'package:build_runner/src/build_plan/build_spec.dart';
+import 'package:build_runner/src/build_plan/builder_definition.dart';
+import 'package:build_runner/src/build_plan/builder_factories.dart';
+import 'package:build_runner/src/build_plan/testing_overrides.dart';
+import 'package:build_runner/src/commands/watch/asset_change.dart';
+import 'package:build_runner/src/constants.dart';
+import 'package:build_runner/src/io/reader_writer.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:test/test.dart';
+import 'package:watcher/watcher.dart';
+
+import '../common/common.dart';
+
+void main() {
+  setUpTestLogging();
+
+  group('BuildSeries', () {
+    final assetId = AssetId('a', 'lib/a.dart');
+    final outputId = AssetId('a', 'lib/a.dart.copy');
+    final assetGraphJsonId = AssetId('a', assetGraphJsonPath);
+
+    late BuildPackages buildPackages;
+    late ReaderWriter readerWriter;
+    late BuildOptions buildOptions;
+    late BuilderFactories builderFactories;
+    late TestingOverrides testingOverrides;
+    late BuildPlan buildPlan;
+
+    Future<BuildPlan> loadPlan([TestingOverrides? overrides]) async {
+      return BuildPlan.load(
+        await BuildSpec.load(
+          builderFactories: builderFactories,
+          buildOptions: buildOptions,
+          testingOverrides: overrides ?? testingOverrides,
+        ),
+      );
+    }
+
+    Future<void> writeBuildStateAndPlan(
+      BuildState buildState,
+      BuildPlan buildPlan,
+    ) async {
+      await readerWriter.writeAsBytes(
+        assetGraphJsonId,
+        AssetGraphJson.serialize(
+          buildPlanDigest: buildPlan.buildSpec.buildPlanDigest,
+          buildState: buildState.toIncrementalBuildState(),
+          phasedAssetDeps: PhasedAssetDeps(),
+        ),
+      );
+    }
+
+    setUp(() async {
+      buildPackages = BuildPackages.singlePackageBuild('a', [
+        BuildPackage.forTesting(name: 'a', watch: true, isOutput: true),
+      ]);
+      readerWriter = InternalTestReaderWriter(outputRootPackage: 'a');
+      await readerWriter.writeAsString(assetId, '// a.dart');
+      buildOptions = BuildOptions.forTests();
+      builderFactories = BuilderFactories({
+        '': [
+          (_) => TestBuilder(
+            buildExtensions: const {
+              '.dart': ['.dart.copy'],
+            },
+          ),
+        ],
+      });
+      testingOverrides = TestingOverrides(
+        builderDefinitions: [BuilderDefinition('', hideOutput: false)].build(),
+        readerWriter: readerWriter,
+        buildPackages: buildPackages,
+        checkBuilderFreshness: false,
+      );
+      buildPlan = await loadPlan();
+    });
+
+    group('filterChanges', () {
+      test('rejects change to unread source', () async {
+        final unreadSourceId = AssetId('a', 'lib/no_outputs.txt');
+        await readerWriter.writeAsString(unreadSourceId, '// no outputs');
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null, unreadSourceId: null},
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+        final loadedPlan = await loadPlan();
+        final buildSeries = BuildSeries(loadedPlan);
+
+        final change = AssetChange(unreadSourceId, ChangeType.MODIFY);
+        final filtered = await buildSeries.filterChanges([change]);
+
+        expect(filtered.accepted, isEmpty);
+        expect(filtered.rejected, [change]);
+      });
+
+      test('accepts change to read source', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        buildState.updateSourceContent(
+          assetId,
+          AssetContent.string('// a.dart'),
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+        final loadedPlan = await loadPlan();
+        final buildSeries = BuildSeries(loadedPlan);
+
+        final change = AssetChange(assetId, ChangeType.MODIFY);
+        final filtered = await buildSeries.filterChanges([change]);
+
+        expect(filtered.accepted, [change]);
+        expect(filtered.rejected, isEmpty);
+      });
+
+      test(
+        'accepts change to declared output that was not generated',
+        () async {
+          final buildState = BuildState(
+            buildStepPlan: buildPlan.buildStepPlan,
+            sources: {assetId: null},
+          );
+          await writeBuildStateAndPlan(buildState, buildPlan);
+          final loadedPlan = await loadPlan();
+          final buildSeries = BuildSeries(loadedPlan);
+
+          final change = AssetChange(outputId, ChangeType.ADD);
+          final filtered = await buildSeries.filterChanges([change]);
+
+          expect(filtered.accepted, [change]);
+          expect(filtered.rejected, isEmpty);
+        },
+      );
+
+      test(
+        'accepts modification to declared output that was not generated',
+        () async {
+          final buildState = BuildState(
+            buildStepPlan: buildPlan.buildStepPlan,
+            sources: {assetId: null},
+          );
+          await writeBuildStateAndPlan(buildState, buildPlan);
+          final loadedPlan = await loadPlan();
+          final buildSeries = BuildSeries(loadedPlan);
+
+          final change = AssetChange(outputId, ChangeType.MODIFY);
+          final filtered = await buildSeries.filterChanges([change]);
+
+          expect(filtered.accepted, [change]);
+          expect(filtered.rejected, isEmpty);
+        },
+      );
+
+      test('ignores write to generated output matching digest', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        final outputContent = '// output';
+        await readerWriter.writeAsString(outputId, outputContent);
+        final stepId = buildPlan.buildStepPlan.stepForDeclaredOutput(outputId);
+        buildState.addBuildStepResult(
+          step: stepId,
+          result: BuildStepResult((b) {
+            b.result = true;
+            b.isHidden = false;
+            b.outputs.add(outputId);
+          }),
+          contents: {outputId: AssetContent.string(outputContent)},
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+        final loadedPlan = await loadPlan();
+        final buildSeries = BuildSeries(loadedPlan);
+
+        final change = AssetChange(outputId, ChangeType.MODIFY);
+        final filtered = await buildSeries.filterChanges([change]);
+
+        expect(filtered.accepted, isEmpty);
+        expect(filtered.rejected, isEmpty);
+      });
+
+      test('accepts write to generated output differing in digest', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        await readerWriter.writeAsString(outputId, '// different content');
+        final stepId = buildPlan.buildStepPlan.stepForDeclaredOutput(outputId);
+        buildState.addBuildStepResult(
+          step: stepId,
+          result: BuildStepResult((b) {
+            b.result = true;
+            b.isHidden = false;
+            b.outputs.add(outputId);
+          }),
+          contents: {outputId: AssetContent.string('// previous content')},
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+        final loadedPlan = await loadPlan();
+        final buildSeries = BuildSeries(loadedPlan);
+
+        final change = AssetChange(outputId, ChangeType.MODIFY);
+        final filtered = await buildSeries.filterChanges([change]);
+
+        expect(filtered.accepted, [change]);
+        expect(filtered.rejected, isEmpty);
+      });
+
+      test(
+        'accepts conflicting visible file when hidden output is unchanged',
+        () async {
+          final hiddenPlan = await loadPlan(
+            TestingOverrides(
+              builderDefinitions: [
+                BuilderDefinition('', hideOutput: true),
+              ].build(),
+              readerWriter: readerWriter,
+              buildPackages: buildPackages,
+              checkBuilderFreshness: false,
+            ),
+          );
+          final buildState = BuildState(
+            buildStepPlan: hiddenPlan.buildStepPlan,
+            sources: {assetId: null},
+          );
+          final outputContent = '// output';
+          await readerWriter.writeAsString(
+            outputId,
+            outputContent,
+            hidden: true,
+          );
+          final stepId = hiddenPlan.buildStepPlan.stepForDeclaredOutput(
+            outputId,
+          );
+          buildState.addBuildStepResult(
+            step: stepId,
+            result: BuildStepResult((b) {
+              b.result = true;
+              b.isHidden = true;
+              b.outputs.add(outputId);
+            }),
+            contents: {outputId: AssetContent.string(outputContent)},
+          );
+          await writeBuildStateAndPlan(buildState, hiddenPlan);
+          final loadedPlan = await loadPlan(
+            TestingOverrides(
+              builderDefinitions: [
+                BuilderDefinition('', hideOutput: true),
+              ].build(),
+              readerWriter: readerWriter,
+              buildPackages: buildPackages,
+              checkBuilderFreshness: false,
+            ),
+          );
+          final buildSeries = BuildSeries(loadedPlan);
+
+          // A conflicting visible file is added.
+          await readerWriter.writeAsString(
+            outputId,
+            '// visible conflict',
+            hidden: false,
+          );
+
+          final change = AssetChange(outputId, ChangeType.ADD);
+          final filtered = await buildSeries.filterChanges([change]);
+
+          expect(filtered.accepted, [change]);
+          expect(filtered.rejected, isEmpty);
+        },
+      );
+
+      test(
+        'accepts conflicting cache file when visible output is unchanged',
+        () async {
+          final buildState = BuildState(
+            buildStepPlan: buildPlan.buildStepPlan,
+            sources: {assetId: null},
+          );
+          final outputContent = '// output';
+          await readerWriter.writeAsString(
+            outputId,
+            outputContent,
+            hidden: false,
+          );
+          final stepId = buildPlan.buildStepPlan.stepForDeclaredOutput(
+            outputId,
+          );
+          buildState.addBuildStepResult(
+            step: stepId,
+            result: BuildStepResult((b) {
+              b.result = true;
+              b.isHidden = false;
+              b.outputs.add(outputId);
+            }),
+            contents: {outputId: AssetContent.string(outputContent)},
+          );
+          await writeBuildStateAndPlan(buildState, buildPlan);
+          final loadedPlan = await loadPlan();
+          final buildSeries = BuildSeries(loadedPlan);
+
+          // A conflicting cache file is found by manual scanning.
+          await readerWriter.writeAsString(
+            outputId,
+            '// cache conflict',
+            hidden: true,
+          );
+
+          final change = AssetChange(outputId, ChangeType.ADD);
+          final filtered = await buildSeries.filterChanges([change]);
+
+          expect(filtered.accepted, [change]);
+          expect(filtered.rejected, isEmpty);
+        },
+      );
+
+      test('runs build step for existing source when unexpected cache file '
+          'appears', () async {
+        final series = BuildSeries(buildPlan);
+        final firstResult = await series.run({}, recentlyBootstrapped: true);
+        expect(firstResult.status, BuildStatus.success);
+        expect(firstResult.outputs, contains(outputId));
+
+        // An unexpected cache file appears at the source ID, and the source
+        // is updated.
+        await readerWriter.writeAsString(
+          assetId,
+          '// unexpected cache',
+          hidden: true,
+        );
+        await readerWriter.writeAsString(assetId, '// updated source');
+
+        final change = AssetChange(assetId, ChangeType.MODIFY);
+        final filtered = await series.filterChanges([change]);
+        expect(filtered.accepted, [change]);
+
+        final secondResult = await series.run({
+          assetId,
+        }, recentlyBootstrapped: false);
+
+        expect(secondResult.status, BuildStatus.success);
+        expect(secondResult.outputs, contains(outputId));
+      });
+    });
+  });
+}

--- a/build_runner/test/build/build_state/build_state_test.dart
+++ b/build_runner/test/build/build_state/build_state_test.dart
@@ -108,6 +108,16 @@ void main() {
         );
       });
 
+      test('clash between source and declared output throws', () {
+        expect(
+          () => BuildState(
+            buildStepPlan: buildStepPlan,
+            sources: {primaryOutputId: null},
+          ),
+          throwsArgumentError,
+        );
+      });
+
       test('overlapping build phases cause an error', () async {
         expect(
           () => BuildStepPlan.compute(

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -5,12 +5,16 @@
 import 'dart:convert';
 
 import 'package:build/build.dart';
-import 'package:build_config/build_config.dart' hide BuilderDefinition;
+import 'package:build_config/build_config.dart'
+    hide BuilderDefinition, PostProcessBuilderDefinition;
 import 'package:build_runner/src/build/asset_content.dart';
 import 'package:build_runner/src/build/build_state/asset_graph_json.dart';
 import 'package:build_runner/src/build/build_state/build_state.dart';
 import 'package:build_runner/src/build/build_state/build_step_result.dart';
+import 'package:build_runner/src/build/build_state/post_process_build_step_id.dart';
+import 'package:build_runner/src/build/build_state/post_process_build_step_result.dart';
 import 'package:build_runner/src/build/library_cycle_graph/phased_asset_deps.dart';
+import 'package:build_runner/src/build_plan/asset_file.dart';
 import 'package:build_runner/src/build_plan/build_options.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
@@ -46,10 +50,13 @@ void main() {
     late TestingOverrides testingOverrides;
     late BuildPlan buildPlan;
 
-    Future<BuildPlan> loadPlan([TestingOverrides? overrides]) async {
+    Future<BuildPlan> loadPlan([
+      TestingOverrides? overrides,
+      BuilderFactories? factories,
+    ]) async {
       return BuildPlan.load(
         await BuildSpec.load(
-          builderFactories: builderFactories,
+          builderFactories: factories ?? builderFactories,
           buildOptions: buildOptions,
           testingOverrides: overrides ?? testingOverrides,
         ),
@@ -291,6 +298,682 @@ void main() {
         ),
         throwsA(const TypeMatcher<CannotBuildException>()),
       );
+    });
+
+    group('incremental planning', () {
+      test('deleted source is marked as deleted', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        buildState.updateSourceContent(
+          assetId,
+          AssetContent.string('// a.dart'),
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+
+        await readerWriter.delete(assetId);
+        final newPlan = await loadPlan();
+        expect(newPlan.buildInputs.deletedSources, contains(assetId));
+        expect(newPlan.buildInputs.sources, isNot(contains(assetId)));
+      });
+
+      test('deleted output is marked as invalid output', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        await readerWriter.writeAsString(outputId, '// output');
+        final stepId = buildPlan.buildStepPlan.stepForDeclaredOutput(outputId);
+        buildState.addBuildStepResult(
+          step: stepId,
+          result: BuildStepResult((b) {
+            b.result = true;
+            b.isHidden = false;
+            b.outputs.add(outputId);
+          }),
+          contents: {outputId: AssetContent.string('// output')},
+        );
+        buildState.updateSourceContent(
+          assetId,
+          AssetContent.string('// a.dart'),
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+
+        await readerWriter.delete(outputId);
+        final newPlan = await loadPlan();
+        expect(newPlan.buildInputs.invalidOutputs, contains(outputId));
+      });
+
+      test('new source file is marked as updated source', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        buildState.updateSourceContent(
+          assetId,
+          AssetContent.string('// a.dart'),
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+
+        final newSourceId = AssetId('a', 'lib/new_file.dart');
+        await readerWriter.writeAsString(newSourceId, '// new');
+        final newPlan = await loadPlan();
+        expect(newPlan.buildInputs.updatedSources, contains(newSourceId));
+        expect(newPlan.buildInputs.sources, contains(newSourceId));
+      });
+
+      test('stale cache file is marked as invalid output', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        buildState.updateSourceContent(
+          assetId,
+          AssetContent.string('// a.dart'),
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+
+        final staleCacheId = AssetId('a', 'lib/stale.dart.copy');
+        await readerWriter.writeAsString(
+          staleCacheId,
+          '// stale',
+          hidden: true,
+        );
+        final newPlan = await loadPlan();
+        expect(newPlan.buildInputs.invalidOutputs, contains(staleCacheId));
+      });
+
+      test('modified source is marked as updated source', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        buildState.updateSourceContent(
+          assetId,
+          AssetContent.string('// a.dart'),
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+
+        await readerWriter.writeAsString(assetId, '// modified content');
+        final newPlan = await loadPlan();
+        expect(newPlan.buildInputs.updatedSources, contains(assetId));
+      });
+
+      test('modified output is marked as invalid output', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        await readerWriter.writeAsString(outputId, '// output');
+        final stepId = buildPlan.buildStepPlan.stepForDeclaredOutput(outputId);
+        buildState.addBuildStepResult(
+          step: stepId,
+          result: BuildStepResult((b) {
+            b.result = true;
+            b.isHidden = false;
+            b.outputs.add(outputId);
+          }),
+          contents: {outputId: AssetContent.string('// output')},
+        );
+        buildState.updateSourceContent(
+          assetId,
+          AssetContent.string('// a.dart'),
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+
+        await readerWriter.writeAsString(outputId, '// modified output');
+        final newPlan = await loadPlan();
+        expect(newPlan.buildInputs.invalidOutputs, contains(outputId));
+      });
+
+      test(
+        'displaced location where source conflicts with cache output marks '
+        'conflicting source output to delete and keeps hidden output valid',
+        () async {
+          final buildState = BuildState(
+            buildStepPlan: buildPlan.buildStepPlan,
+            sources: {assetId: null, assetId2: null},
+          );
+          final hiddenOutputId = AssetId('a', 'lib/a.dart.copy');
+          await readerWriter.writeAsString(
+            hiddenOutputId,
+            '// hidden output',
+            hidden: true,
+          );
+          final stepId = buildPlan.buildStepPlan.stepForDeclaredOutput(
+            hiddenOutputId,
+          );
+          buildState.addBuildStepResult(
+            step: stepId,
+            result: BuildStepResult((b) {
+              b.result = true;
+              b.isHidden = true;
+              b.outputs.add(hiddenOutputId);
+            }),
+            contents: {hiddenOutputId: AssetContent.string('// hidden output')},
+          );
+          buildState.updateSourceContent(
+            assetId,
+            AssetContent.string('// a.dart'),
+          );
+          buildState.updateSourceContent(
+            assetId2,
+            AssetContent.string('// other'),
+          );
+          await writeBuildStateAndPlan(buildState, buildPlan);
+
+          // Now user creates a source file with the same ID in the source tree.
+          await readerWriter.writeAsString(
+            hiddenOutputId,
+            '// conflicting source',
+          );
+          final newPlan = await loadPlan();
+          expect(
+            newPlan.conflictingOutputs,
+            contains(AssetFile.source(hiddenOutputId)),
+          );
+          expect(
+            newPlan.buildInputs.invalidOutputs,
+            isNot(contains(hiddenOutputId)),
+          );
+          expect(newPlan.buildInputs.sources, isNot(contains(hiddenOutputId)));
+        },
+      );
+
+      test('throws CannotBuildException if incremental build encounters '
+          'conflicting outputs in dependencies', () async {
+        final buildPackages = BuildPackages.singlePackageBuild('a', [
+          BuildPackage.forTesting(
+            name: 'a',
+            watch: true,
+            isOutput: true,
+            dependencies: ['dep'],
+          ),
+          BuildPackage.forTesting(name: 'dep', watch: true, isOutput: false),
+        ]);
+        final readerWriter = InternalTestReaderWriter(outputRootPackage: 'a');
+        final aId = AssetId('a', 'lib/a.dart');
+        final depSourceId = AssetId('dep', 'lib/a.dart');
+        await readerWriter.writeAsString(aId, '// a.dart');
+        await readerWriter.writeAsString(depSourceId, '// dep a.dart');
+
+        final testingOverrides = TestingOverrides(
+          builderDefinitions: [
+            BuilderDefinition(
+              '',
+              hideOutput: true,
+              autoApply: AutoApply.allPackages,
+            ),
+          ].build(),
+          readerWriter: readerWriter,
+          buildPackages: buildPackages,
+          checkBuilderFreshness: false,
+        );
+
+        final initialPlan = await BuildPlan.load(
+          await BuildSpec.load(
+            builderFactories: builderFactories,
+            buildOptions: buildOptions,
+            testingOverrides: testingOverrides,
+          ),
+        );
+        final buildState = BuildState(
+          buildStepPlan: initialPlan.buildStepPlan,
+          sources: {aId: null, depSourceId: null},
+        );
+        await readerWriter.writeAsBytes(
+          AssetId('a', assetGraphJsonPath),
+          AssetGraphJson.serialize(
+            buildPlanDigest: initialPlan.buildSpec.buildPlanDigest,
+            buildState: buildState.toIncrementalBuildState(),
+            phasedAssetDeps: PhasedAssetDeps(),
+          ),
+        );
+
+        // Create a conflicting source file in the dependency.
+        final depConflictId = AssetId('dep', 'lib/a.dart.copy');
+        await readerWriter.writeAsString(depConflictId, '// conflict in dep');
+
+        expect(
+          () async => await BuildPlan.load(
+            await BuildSpec.load(
+              builderFactories: builderFactories,
+              buildOptions: buildOptions,
+              testingOverrides: testingOverrides,
+            ),
+          ),
+          throwsA(const TypeMatcher<CannotBuildException>()),
+        );
+      });
+
+      test('declared output that was never generated is not marked as invalid '
+          'output when missing from disk', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null, assetId2: null},
+        );
+        buildState.updateSourceContent(
+          assetId,
+          AssetContent.string('// a.dart'),
+        );
+        buildState.updateSourceContent(
+          assetId2,
+          AssetContent.string('// other'),
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+
+        final loadedPlan = await loadPlan();
+        final updatedPlan = await loadedPlan.updateForFileChanges({
+          AssetFile.source(outputId),
+          AssetFile.cache(outputId),
+        });
+        expect(
+          updatedPlan.buildInputs.invalidOutputs,
+          isNot(contains(outputId)),
+        );
+        expect(
+          updatedPlan.buildInputs.deletedSources,
+          isNot(contains(outputId)),
+        );
+      });
+
+      test(
+        'declared output that was never generated is marked as invalid output '
+        'and conflicting output when created in cache',
+        () async {
+          final buildState = BuildState(
+            buildStepPlan: buildPlan.buildStepPlan,
+            sources: {assetId: null, assetId2: null},
+          );
+          buildState.updateSourceContent(
+            assetId,
+            AssetContent.string('// a.dart'),
+          );
+          buildState.updateSourceContent(
+            assetId2,
+            AssetContent.string('// other'),
+          );
+          await writeBuildStateAndPlan(buildState, buildPlan);
+
+          await readerWriter.writeAsString(
+            outputId,
+            '// unexpected cache file',
+            hidden: true,
+          );
+
+          final loadedPlan = await loadPlan();
+          expect(
+            loadedPlan.conflictingOutputs,
+            contains(AssetFile.cache(outputId)),
+          );
+          expect(loadedPlan.buildInputs.invalidOutputs, contains(outputId));
+        },
+      );
+
+      test(
+        'existing source is not marked as invalid output when unexpected cache '
+        'file is created',
+        () async {
+          final buildState = BuildState(
+            buildStepPlan: buildPlan.buildStepPlan,
+            sources: {assetId: null, assetId2: null},
+          );
+          buildState.updateSourceContent(
+            assetId,
+            AssetContent.string('// a.dart'),
+          );
+          buildState.updateSourceContent(
+            assetId2,
+            AssetContent.string('// other'),
+          );
+          await writeBuildStateAndPlan(buildState, buildPlan);
+
+          // An unexpected cache file appears with the same ID as an existing
+          // source.
+          await readerWriter.writeAsString(
+            assetId,
+            '// unexpected cache file',
+            hidden: true,
+          );
+
+          final loadedPlan = await loadPlan();
+          expect(
+            loadedPlan.conflictingOutputs,
+            contains(AssetFile.cache(assetId)),
+          );
+          expect(
+            loadedPlan.buildInputs.invalidOutputs,
+            isNot(contains(assetId)),
+          );
+          expect(loadedPlan.buildInputs.sources, contains(assetId));
+        },
+      );
+
+      test(
+        'incremental build discovers an input and its output simultaneously',
+        () async {
+          final buildState = BuildState(
+            buildStepPlan: buildPlan.buildStepPlan,
+            sources: {assetId2: null},
+          );
+          buildState.updateSourceContent(
+            assetId2,
+            AssetContent.string('// other'),
+          );
+          await writeBuildStateAndPlan(buildState, buildPlan);
+
+          // Write both a new input and a conflicting output simultaneously.
+          final newInputId = AssetId('a', 'lib/new_input.dart');
+          final newOutputId = AssetId('a', 'lib/new_input.dart.copy');
+          await readerWriter.writeAsString(newInputId, '// new input');
+          await readerWriter.writeAsString(
+            newOutputId,
+            '// conflicting output',
+          );
+
+          final loadedPlan = await loadPlan();
+
+          // Input is marked as a source.
+          expect(loadedPlan.buildInputs.sources, contains(newInputId));
+          expect(loadedPlan.buildInputs.updatedSources, contains(newInputId));
+
+          // Output is marked conflicting and not retained as a source.
+          expect(
+            loadedPlan.conflictingOutputs,
+            contains(AssetFile.source(newOutputId)),
+          );
+          expect(loadedPlan.buildInputs.sources, isNot(contains(newOutputId)));
+
+          // Output is not used as a primary input.
+          expect(
+            loadedPlan.buildStepPlan.declaredOutputsByPrimaryInput[newOutputId],
+            isEmpty,
+          );
+        },
+      );
+
+      test('newly discovered source with unexpected cache file does not mark '
+          'source as invalid output', () async {
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        buildState.updateSourceContent(
+          assetId,
+          AssetContent.string('// a.dart'),
+        );
+        await writeBuildStateAndPlan(buildState, buildPlan);
+
+        final newSourceId = AssetId('a', 'lib/new_source.dart');
+        await readerWriter.writeAsString(newSourceId, '// new source');
+        await readerWriter.writeAsString(
+          newSourceId,
+          '// unexpected cache',
+          hidden: true,
+        );
+
+        final loadedPlan = await loadPlan();
+        expect(
+          loadedPlan.conflictingOutputs,
+          contains(AssetFile.cache(newSourceId)),
+        );
+        expect(
+          loadedPlan.buildInputs.invalidOutputs,
+          isNot(contains(newSourceId)),
+        );
+        expect(loadedPlan.buildInputs.sources, contains(newSourceId));
+        expect(loadedPlan.buildInputs.updatedSources, contains(newSourceId));
+      });
+
+      test('deleted input with hidden post process output does not mark new '
+          'source as conflicting output', () async {
+        final inputId = AssetId('a', 'lib/input.txt');
+        final postOutputId = AssetId('a', 'lib/input.txt.post');
+        await readerWriter.writeAsString(inputId, '// input');
+        await readerWriter.writeAsString(postOutputId, '// post', hidden: true);
+
+        final postBuilderDef = PostProcessBuilderDefinition('a:post');
+        final postOverrides = TestingOverrides(
+          builderDefinitions: [
+            BuilderDefinition(
+              '',
+              appliesBuilders: ['a:post'],
+              autoApply: AutoApply.rootPackage,
+            ),
+            postBuilderDef,
+          ].build(),
+          readerWriter: readerWriter,
+          buildPackages: buildPackages,
+          checkBuilderFreshness: false,
+        );
+        final postFactories = BuilderFactories(
+          {
+            '': [(_) => TestBuilder()],
+          },
+          postProcessBuilderFactories: {
+            'a:post': (_) =>
+                CopyingPostProcessBuilder(outputExtension: '.post'),
+          },
+        );
+
+        final initialPlan = await loadPlan(postOverrides, postFactories);
+        final postStepId = PostProcessBuildStepId(
+          input: inputId,
+          actionNumber: 0,
+        );
+        final buildState = BuildState(
+          buildStepPlan: initialPlan.buildStepPlan,
+          sources: {inputId: null, assetId: null},
+        );
+        buildState.addPostProcessBuildStepResult(
+          step: postStepId,
+          result: PostProcessBuildStepResult(
+            hidden: true,
+            outputs: [postOutputId],
+          ),
+          contents: {postOutputId: AssetContent.string('// post')},
+        );
+        buildState.updateSourceContent(
+          inputId,
+          AssetContent.string('// input'),
+        );
+        await writeBuildStateAndPlan(buildState, initialPlan);
+
+        // Delete the input and create a source file at the old output path.
+        await readerWriter.delete(inputId);
+        await readerWriter.writeAsString(postOutputId, '// new source');
+
+        final loadedPlan = await loadPlan(postOverrides, postFactories);
+        expect(loadedPlan.buildInputs.sources, contains(postOutputId));
+        expect(loadedPlan.buildInputs.updatedSources, contains(postOutputId));
+        expect(
+          loadedPlan.conflictingOutputs,
+          isNot(contains(AssetFile.source(postOutputId))),
+        );
+        expect(
+          loadedPlan.buildInputs.invalidOutputs,
+          isNot(contains(postOutputId)),
+        );
+      });
+
+      test('deleted input and deleted hidden post process output does not mark '
+          'new source as invalid output', () async {
+        final inputId = AssetId('a', 'lib/input.txt');
+        final postOutputId = AssetId('a', 'lib/input.txt.post');
+        await readerWriter.writeAsString(inputId, '// input');
+        await readerWriter.writeAsString(postOutputId, '// post', hidden: true);
+
+        final postBuilderDef = PostProcessBuilderDefinition('a:post');
+        final postOverrides = TestingOverrides(
+          builderDefinitions: [
+            BuilderDefinition(
+              '',
+              appliesBuilders: ['a:post'],
+              autoApply: AutoApply.rootPackage,
+            ),
+            postBuilderDef,
+          ].build(),
+          readerWriter: readerWriter,
+          buildPackages: buildPackages,
+          checkBuilderFreshness: false,
+        );
+        final postFactories = BuilderFactories(
+          {
+            '': [(_) => TestBuilder()],
+          },
+          postProcessBuilderFactories: {
+            'a:post': (_) =>
+                CopyingPostProcessBuilder(outputExtension: '.post'),
+          },
+        );
+
+        final initialPlan = await loadPlan(postOverrides, postFactories);
+        final postStepId = PostProcessBuildStepId(
+          input: inputId,
+          actionNumber: 0,
+        );
+        final buildState = BuildState(
+          buildStepPlan: initialPlan.buildStepPlan,
+          sources: {inputId: null, assetId: null},
+        );
+        buildState.addPostProcessBuildStepResult(
+          step: postStepId,
+          result: PostProcessBuildStepResult(
+            hidden: true,
+            outputs: [postOutputId],
+          ),
+          contents: {postOutputId: AssetContent.string('// post')},
+        );
+        buildState.updateSourceContent(
+          inputId,
+          AssetContent.string('// input'),
+        );
+        await writeBuildStateAndPlan(buildState, initialPlan);
+
+        // Delete the input and the old hidden output.
+        await readerWriter.delete(inputId);
+        await readerWriter.delete(postOutputId, hidden: true);
+        await readerWriter.writeAsString(postOutputId, '// new source');
+
+        final loadedPlan = await loadPlan(postOverrides, postFactories);
+        expect(loadedPlan.buildInputs.sources, contains(postOutputId));
+        expect(loadedPlan.buildInputs.updatedSources, contains(postOutputId));
+        expect(
+          loadedPlan.conflictingOutputs,
+          isNot(contains(AssetFile.source(postOutputId))),
+        );
+        expect(
+          loadedPlan.buildInputs.invalidOutputs,
+          isNot(contains(postOutputId)),
+        );
+      });
+
+      test('existing input with hidden post process output marks new visible '
+          'source as conflicting output', () async {
+        final inputId = AssetId('a', 'lib/input.txt');
+        final postOutputId = AssetId('a', 'lib/input.txt.post');
+        await readerWriter.writeAsString(inputId, '// input');
+        await readerWriter.writeAsString(postOutputId, '// post', hidden: true);
+
+        final postBuilderDef = PostProcessBuilderDefinition('a:post');
+        final postOverrides = TestingOverrides(
+          builderDefinitions: [
+            BuilderDefinition(
+              '',
+              appliesBuilders: ['a:post'],
+              autoApply: AutoApply.rootPackage,
+            ),
+            postBuilderDef,
+          ].build(),
+          readerWriter: readerWriter,
+          buildPackages: buildPackages,
+          checkBuilderFreshness: false,
+        );
+        final postFactories = BuilderFactories(
+          {
+            '': [(_) => TestBuilder()],
+          },
+          postProcessBuilderFactories: {
+            'a:post': (_) =>
+                CopyingPostProcessBuilder(outputExtension: '.post'),
+          },
+        );
+
+        final initialPlan = await loadPlan(postOverrides, postFactories);
+        final postStepId = PostProcessBuildStepId(
+          input: inputId,
+          actionNumber: 0,
+        );
+        final buildState = BuildState(
+          buildStepPlan: initialPlan.buildStepPlan,
+          sources: {inputId: null, assetId: null},
+        );
+        buildState.addPostProcessBuildStepResult(
+          step: postStepId,
+          result: PostProcessBuildStepResult(
+            hidden: true,
+            outputs: [postOutputId],
+          ),
+          contents: {postOutputId: AssetContent.string('// post')},
+        );
+        buildState.updateSourceContent(
+          inputId,
+          AssetContent.string('// input'),
+        );
+        await writeBuildStateAndPlan(buildState, initialPlan);
+
+        // Create a visible file at the post-process output location.
+        await readerWriter.writeAsString(postOutputId, '// visible collision');
+
+        final loadedPlan = await loadPlan(postOverrides, postFactories);
+        expect(
+          loadedPlan.conflictingOutputs,
+          contains(AssetFile.source(postOutputId)),
+        );
+        expect(loadedPlan.buildInputs.sources, isNot(contains(postOutputId)));
+        expect(
+          loadedPlan.buildInputs.updatedSources,
+          isNot(contains(postOutputId)),
+        );
+      });
+
+      test('deleted input with transitive declared output replaced by visible '
+          'source does not mark source as invalid output', () async {
+        final stepId = buildPlan.buildStepPlan.stepForDeclaredOutput(outputId);
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: {assetId: null},
+        );
+        buildState.addBuildStepResult(
+          step: stepId,
+          result: BuildStepResult((b) {
+            b.result = true;
+            b.isHidden = true;
+            b.outputs.add(outputId);
+          }),
+          contents: {outputId: AssetContent.string('// copy')},
+        );
+        buildState.updateSourceContent(
+          assetId,
+          AssetContent.string('// a.dart'),
+        );
+        await readerWriter.writeAsString(outputId, '// copy', hidden: true);
+        await writeBuildStateAndPlan(buildState, buildPlan);
+
+        // Delete the input and the hidden output, and add a visible source
+        // file.
+        await readerWriter.delete(assetId);
+        await readerWriter.delete(outputId, hidden: true);
+        await readerWriter.writeAsString(outputId, '// source content');
+
+        final loadedPlan = await loadPlan();
+        expect(loadedPlan.buildInputs.sources, contains(outputId));
+        expect(
+          loadedPlan.buildInputs.invalidOutputs,
+          isNot(contains(outputId)),
+        );
+      });
     });
   });
 }

--- a/build_runner/test/integration_tests/build_command_invalidation_test.dart
+++ b/build_runner/test/integration_tests/build_command_invalidation_test.dart
@@ -118,5 +118,74 @@ void main() async {
     tester.delete('root_pkg/web/a.txt');
     await tester.run('root_pkg', 'dart run build_runner build --force-jit');
     expect(tester.read('root_pkg/web/a.txt.copy2'), null);
+
+    // Conflicting logical ID exists in both source and cache.
+    tester.writeFixturePackage(
+      FixturePackages.copyBuilder(
+        buildToCache: true,
+        outputExtension: '.hidden',
+      ),
+    );
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {'web/a.txt': 'a'},
+    );
+
+    // Initial build creates hidden output in cache.
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    final cacheFile =
+        'root_pkg/.dart_tool/build/generated/root_pkg/web/a.txt.hidden';
+    expect(tester.read(cacheFile), 'a');
+
+    // Create a source file with the exact same logical ID.
+    tester.write('root_pkg/web/a.txt.hidden', 'source content');
+
+    // Next build recognizes the new source file and handles the conflict:
+    // the conflicting source file is deleted and hidden output remains in
+    // cache.
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    expect(tester.read('root_pkg/web/a.txt.hidden'), null);
+    expect(tester.read(cacheFile), 'a');
+
+    // Conflicts in cache deleted when builder outputs to source tree.
+    tester.writeFixturePackage(
+      FixturePackages.copyBuilder(buildToCache: false),
+    );
+    tester.writePackage(
+      name: 'root_pkg',
+      dependencies: ['build_runner'],
+      pathDependencies: ['builder_pkg'],
+      files: {
+        'web/a.txt': 'a',
+        'web/a.txt.copy': 'visible conflict',
+        '.dart_tool/build/generated/root_pkg/web/a.txt.copy': 'hidden conflict',
+      },
+    );
+    // Both locations conflict, builder writes visible: hidden is deleted.
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'a');
+    expect(
+      tester.read(
+        'root_pkg/.dart_tool/build/generated/root_pkg/web/a.txt.copy',
+      ),
+      null,
+    );
+
+    // Previous visible actual output plus new hidden conflict: hidden is
+    // deleted.
+    tester.write(
+      'root_pkg/.dart_tool/build/generated/root_pkg/web/a.txt.copy',
+      'new hidden conflict',
+    );
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    expect(
+      tester.read(
+        'root_pkg/.dart_tool/build/generated/root_pkg/web/a.txt.copy',
+      ),
+      null,
+    );
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'a');
   });
 }

--- a/build_runner/test/io/asset_tracker_test.dart
+++ b/build_runner/test/io/asset_tracker_test.dart
@@ -9,7 +9,11 @@ import 'package:build/build.dart';
 import 'package:build_runner/src/build/asset_content.dart';
 import 'package:build_runner/src/build/build_state/build_state.dart';
 import 'package:build_runner/src/build/build_state/build_step_id.dart';
+import 'package:build_runner/src/build/build_state/build_step_result.dart';
 import 'package:build_runner/src/build/build_state/finished_build_state.dart';
+import 'package:build_runner/src/build/build_state/post_process_build_step_id.dart';
+import 'package:build_runner/src/build/build_state/post_process_build_step_result.dart';
+import 'package:build_runner/src/build_plan/asset_file.dart';
 import 'package:build_runner/src/build_plan/build_configs.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
@@ -85,16 +89,15 @@ void main() {
       assetTracker = AssetTracker(reader, buildPackages, buildConfigs);
       final updates = await assetTracker.collectChanges(
         previousBuild: PreviousBuild.fromFinishedBuildState(finishedBuildState),
-        buildStepPlan: buildStepPlan,
       );
       // Advance buildState for the next tests so these initial sources are
       // known.
       final newSources = finishedBuildState.sources.toSet();
       for (final entry in updates.entries) {
         if (entry.value != ChangeType.REMOVE) {
-          newSources.add(entry.key);
+          newSources.add(entry.key.id);
         } else {
-          newSources.remove(entry.key);
+          newSources.remove(entry.key.id);
         }
       }
       final nextState = BuildState(
@@ -112,7 +115,7 @@ void main() {
       // We should see no changes initially other than new sdk sources
       expect(
         updates..removeWhere(
-          (id, type) => id.package == r'$sdk' && type == ChangeType.ADD,
+          (file, type) => file.id.package == r'$sdk' && type == ChangeType.ADD,
         ),
         isEmpty,
       );
@@ -126,9 +129,8 @@ void main() {
           previousBuild: PreviousBuild.fromFinishedBuildState(
             finishedBuildState,
           ),
-          buildStepPlan: buildStepPlan,
         ),
-        {AssetId('a', 'web/a.txt'): ChangeType.MODIFY},
+        {AssetFile.source(AssetId('a', 'web/a.txt')): ChangeType.MODIFY},
       );
     });
 
@@ -140,11 +142,58 @@ void main() {
           previousBuild: PreviousBuild.fromFinishedBuildState(
             finishedBuildState,
           ),
-          buildStepPlan: buildStepPlan,
         ),
-        {AssetId('a', 'web/b.txt'): ChangeType.ADD},
+        {AssetFile.source(AssetId('a', 'web/b.txt')): ChangeType.ADD},
       );
     });
+
+    test('Collects new cache files', () async {
+      final generatedDir = Directory(
+        p.join(d.sandbox, 'a', '.dart_tool', 'build', 'generated', 'a', 'web'),
+      );
+      generatedDir.createSync(recursive: true);
+      File(p.join(generatedDir.path, 'cache.txt')).writeAsStringSync('cached');
+
+      expect(
+        await assetTracker.collectChanges(
+          previousBuild: PreviousBuild.fromFinishedBuildState(
+            finishedBuildState,
+          ),
+        ),
+        {AssetFile.cache(AssetId('a', 'web/cache.txt')): ChangeType.ADD},
+      );
+    });
+
+    test(
+      'Collects new cache file for declared-but-not-actual hidden output',
+      () async {
+        final outputId = AssetId('a', 'web/a.txt.hidden');
+
+        final generatedDir = Directory(
+          p.join(
+            d.sandbox,
+            'a',
+            '.dart_tool',
+            'build',
+            'generated',
+            'a',
+            'web',
+          ),
+        );
+        generatedDir.createSync(recursive: true);
+        File(
+          p.join(generatedDir.path, 'a.txt.hidden'),
+        ).writeAsStringSync('hidden');
+
+        final changes = await assetTracker.collectChanges(
+          previousBuild: PreviousBuild.fromFinishedBuildState(
+            finishedBuildState,
+          ),
+        );
+        changes.removeWhere((file, type) => file.id.package == r'$sdk');
+        expect(changes, {AssetFile.cache(outputId): ChangeType.ADD});
+      },
+    );
 
     test('Collects deleted files', () async {
       File(p.join(d.sandbox, 'a', 'web', 'a.txt')).deleteSync();
@@ -154,17 +203,27 @@ void main() {
           previousBuild: PreviousBuild.fromFinishedBuildState(
             finishedBuildState,
           ),
-          buildStepPlan: buildStepPlan,
         ),
-        {AssetId('a', 'web/a.txt'): ChangeType.REMOVE},
+        {AssetFile.source(AssetId('a', 'web/a.txt')): ChangeType.REMOVE},
       );
     });
 
-    test('Collects deleted declared outputs', () async {
-      // Create a buildState with no sources (so web/a.txt is not in sources).
-      final emptyBuildState = FinishedBuildState.empty();
+    test(
+      'Does not collect absent declared outputs that were not generated',
+      () async {
+        final emptyBuildState = FinishedBuildState.empty();
 
-      // Delete the file from disk so it's actually missing.
+        File(p.join(d.sandbox, 'a', 'web', 'a.txt')).deleteSync();
+
+        final changes = await assetTracker.collectChanges(
+          previousBuild: PreviousBuild.fromFinishedBuildState(emptyBuildState),
+        );
+        changes.removeWhere((file, type) => file.id.package == r'$sdk');
+        expect(changes, isEmpty);
+      },
+    );
+
+    test('Collects deleted actual outputs', () async {
       File(p.join(d.sandbox, 'a', 'web', 'a.txt')).deleteSync();
 
       final outputId = AssetId('a', 'web/a.txt');
@@ -175,16 +234,144 @@ void main() {
 
       final planWithOutput = BuildStepPlan(
         (BuildStepPlanBuilder b) => b
-          ..buildPhases = BuildPhases(const <InBuildPhase>[])
+          ..buildPhases = BuildPhases([
+            InBuildPhase(
+              builder: TestBuilder(),
+              key: 'a:builder',
+              package: 'a',
+              hideOutput: false,
+            ),
+          ])
           ..buildStepsByDeclaredOutput.addAll({outputId: buildStepId}),
       );
 
-      final changes = await assetTracker.collectChanges(
-        previousBuild: PreviousBuild.fromFinishedBuildState(emptyBuildState),
-        buildStepPlan: planWithOutput,
+      final buildState = BuildState(buildStepPlan: planWithOutput, sources: {});
+      buildState.addBuildStepResult(
+        step: buildStepId,
+        result: BuildStepResult((b) {
+          b.result = true;
+          b.isHidden = false;
+          b.outputs.add(outputId);
+        }),
+        contents: {
+          outputId: AssetContent.bytes([1, 2, 3]),
+        },
       );
-      changes.removeWhere((id, type) => id.package == r'$sdk');
-      expect(changes, {outputId: ChangeType.REMOVE});
+
+      final changes = await assetTracker.collectChanges(
+        previousBuild: PreviousBuild.fromFinishedBuildState(
+          buildState.toFinishedBuildState(),
+        ),
+      );
+      changes.removeWhere((file, type) => file.id.package == r'$sdk');
+      expect(changes, {AssetFile.source(outputId): ChangeType.REMOVE});
+    });
+
+    test('Collects deleted actual post process outputs', () async {
+      File(p.join(d.sandbox, 'a', 'web', 'a.txt')).deleteSync();
+
+      final outputId = AssetId('a', 'web/a.txt');
+      final postStepId = PostProcessBuildStepId(
+        input: AssetId('a', 'web/a.dart'),
+        actionNumber: 0,
+      );
+
+      final buildState = BuildState(buildStepPlan: buildStepPlan, sources: {});
+      buildState.addPostProcessBuildStepResult(
+        step: postStepId,
+        result: PostProcessBuildStepResult(hidden: false, outputs: [outputId]),
+        contents: {
+          outputId: AssetContent.bytes([1, 2, 3]),
+        },
+      );
+
+      final changes = await assetTracker.collectChanges(
+        previousBuild: PreviousBuild.fromFinishedBuildState(
+          buildState.toFinishedBuildState(),
+        ),
+      );
+      changes.removeWhere((file, type) => file.id.package == r'$sdk');
+      expect(changes, {AssetFile.source(outputId): ChangeType.REMOVE});
+    });
+  });
+
+  group('AssetTracker.findCacheDirSources()', () {
+    test('discovers cache files using IoFilesystem', () async {
+      await d.dir('pkg', [
+        d.dir('.dart_tool', [
+          d.dir('build', [
+            d.dir('generated', [
+              d.dir('pkg', [
+                d.dir('lib', [d.file('a.g.dart', '// generated')]),
+              ]),
+              d.dir('other_pkg', [
+                d.dir('lib', [d.file('b.g.dart', '// dep generated')]),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]).create();
+
+      final buildPackages = BuildPackages.singlePackageBuild('pkg', [
+        BuildPackage(
+          name: 'pkg',
+          path: p.join(d.sandbox, 'pkg'),
+          languageVersion: LanguageVersion(2, 6),
+          watch: true,
+          isOutput: true,
+        ),
+      ]);
+      final reader = ReaderWriter(buildPackages);
+      final buildConfigs = await BuildConfigs.load(
+        buildPackages: buildPackages,
+        testingOverrides: TestingOverrides(
+          defaultRootPackageSources: ['lib/**'].build(),
+        ),
+      );
+      final tracker = AssetTracker(reader, buildPackages, buildConfigs);
+      final cacheSources = await tracker.findCacheDirSources();
+
+      expect(
+        cacheSources,
+        unorderedEquals({
+          AssetId('pkg', 'lib/a.g.dart'),
+          AssetId('other_pkg', 'lib/b.g.dart'),
+        }),
+      );
+    });
+
+    test('discovers cache files using InMemoryFilesystem', () async {
+      final buildPackages = BuildPackages.singlePackageBuild('pkg', [
+        BuildPackage.forTesting(name: 'pkg', watch: true, isOutput: true),
+      ]);
+      final readerWriter = InternalTestReaderWriter(outputRootPackage: 'pkg');
+      await readerWriter.writeAsString(
+        AssetId('pkg', 'lib/a.g.dart'),
+        '// generated',
+        hidden: true,
+      );
+      await readerWriter.writeAsString(
+        AssetId('other_pkg', 'lib/b.g.dart'),
+        '// dep generated',
+        hidden: true,
+      );
+
+      final buildConfigs = await BuildConfigs.load(
+        buildPackages: buildPackages,
+        testingOverrides: TestingOverrides(
+          defaultRootPackageSources: ['lib/**'].build(),
+        ),
+      );
+      final tracker = AssetTracker(readerWriter, buildPackages, buildConfigs);
+      final cacheSources = await tracker.findCacheDirSources();
+
+      expect(
+        cacheSources,
+        unorderedEquals({
+          AssetId('pkg', 'lib/a.g.dart'),
+          AssetId('other_pkg', 'lib/b.g.dart'),
+        }),
+      );
     });
   });
 }

--- a/builder_pkgs/mockito/example/build_extensions/mocks/example.mocks.dart
+++ b/builder_pkgs/mockito/example/build_extensions/mocks/example.mocks.dart
@@ -4,6 +4,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;

--- a/builder_pkgs/mockito/example/example.mocks.dart
+++ b/builder_pkgs/mockito/example/example.mocks.dart
@@ -4,6 +4,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i3;
 
 import 'package:mockito/mockito.dart' as _i1;

--- a/builder_pkgs/mockito/example/iss/iss_test.mocks.dart
+++ b/builder_pkgs/mockito/example/iss/iss_test.mocks.dart
@@ -4,6 +4,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i5;
 import 'dart:math' as _i3;
 

--- a/builder_pkgs/mockito/test/end2end/dart_js_interop_test.mocks.dart
+++ b/builder_pkgs/mockito/test/end2end/dart_js_interop_test.mocks.dart
@@ -4,6 +4,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:js_interop' as _i1;
 
 import 'package:mockito/mockito.dart' as _i2;

--- a/builder_pkgs/mockito/test/end2end/generated_mocks_test.mocks.dart
+++ b/builder_pkgs/mockito/test/end2end/generated_mocks_test.mocks.dart
@@ -4,6 +4,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+
 import 'dart:async' as _i2;
 
 import 'package:mockito/mockito.dart' as _i1;


### PR DESCRIPTION
Introduce AssetFile to differentiate source and cache locations.

Fix #5079. Track asset locations in AssetTracker and BuildPlan so that source+cache conflicts are correctly cleaned up.

Add unit tests for AssetFile and incremental planning.

Add tests verifying that BuildState content resolution respects physical location and that incremental planning detects displaced outputs and changes.