### PR TITLE
Evict deleted and displaced outputs from retainedOutputContents in BuildPlan._createIncremental.

### DIFF
--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -447,6 +447,9 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
     }
 
     final finalSources = buildInputs.sources.build();
+    for (final id in finalSources) {
+      buildInputs.retainedOutputContents.remove(id);
+    }
     for (final id in newCacheFiles) {
       if (!finalSources.contains(id)) {
         buildInputs.invalidOutputs.add(id);
@@ -472,6 +475,9 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
         .toSet();
     buildInputs.invalidOutputs.addAll(invalidOutputs);
     buildInputs.invalidOutputs.removeAll(finalSources);
+    for (final invalid in invalidOutputs) {
+      buildInputs.retainedOutputContents.remove(invalid);
+    }
 
     return BuildPlan((b) {
       b.buildSpec.replace(buildSpec);

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -795,6 +795,12 @@ void main() {
           loadedPlan.buildInputs.invalidOutputs,
           isNot(contains(postOutputId)),
         );
+        expect(
+          loadedPlan.buildInputs.retainedOutputContents.containsKey(
+            postOutputId,
+          ),
+          isFalse,
+        );
       });
 
       test('deleted input and deleted hidden post process output does not mark '
@@ -974,6 +980,60 @@ void main() {
           isNot(contains(outputId)),
         );
       });
+
+      test(
+        'outputs of deleted sources are evicted from retainedOutputContents',
+        () async {
+          final overrides = TestingOverrides(
+            builderDefinitions: [
+              BuilderDefinition('', hideOutput: false),
+            ].build(),
+            readerWriter: readerWriter,
+            buildPackages: buildPackages,
+            checkBuilderFreshness: false,
+          );
+          final initialPlan = await loadPlan(overrides);
+          final buildState = BuildState(
+            buildStepPlan: initialPlan.buildStepPlan,
+            sources: {assetId: null, assetId2: null},
+          );
+          await readerWriter.writeAsString(outputId, '// copy');
+          final stepId = initialPlan.buildStepPlan.stepForDeclaredOutput(
+            outputId,
+          );
+          final initialDigest = md5.convert(utf8.encode('// copy'));
+          buildState.addBuildStepResult(
+            step: stepId,
+            result: BuildStepResult((b) {
+              b.result = true;
+              b.isHidden = false;
+              b.outputs.add(outputId);
+            }),
+            contents: {
+              outputId: AssetContent.bytes(
+                utf8.encode('// copy'),
+                digest: initialDigest,
+              ),
+            },
+          );
+          buildState.updateSourceContent(
+            assetId,
+            AssetContent.bytes(utf8.encode('// a.dart')),
+          );
+          await writeBuildStateAndPlan(buildState, initialPlan);
+
+          // Delete the input source.
+          await readerWriter.delete(assetId);
+
+          final loadedPlan = await loadPlan(overrides);
+          expect(loadedPlan.buildInputs.deletedSources, contains(assetId));
+          expect(loadedPlan.buildInputs.invalidOutputs, contains(outputId));
+          expect(
+            loadedPlan.buildInputs.retainedOutputContents.containsKey(outputId),
+            isFalse,
+          );
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Stop tracking files that have disappeared.

This doesn't cause any user-visible problems, but leaks memory due to keeping useless state.

Found via the contract programming experiment.