### PR TITLE
Reset cleanBuild and change tracking sets in BuildPlan.withCompatiblePreviousBuild.

### DIFF
--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -143,12 +143,16 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
           finishedBuildState: previousBuildState,
         ),
       )
+      ..buildInputs.cleanBuild = false
       ..buildInputs.sourceContents.clear()
       ..buildInputs.sourceContents.addEntries(previousBuildState.sourceContents)
       ..buildInputs.retainedOutputContents.clear()
       ..buildInputs.retainedOutputContents.addEntries(
         previousBuildState.outputContents,
       )
+      ..buildInputs.deletedSources.clear()
+      ..buildInputs.updatedSources.clear()
+      ..buildInputs.invalidOutputs.clear()
       ..conflictingOutputs.clear(),
   );
 

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -974,6 +974,31 @@ void main() {
           isNot(contains(outputId)),
         );
       });
+
+      test('withCompatiblePreviousBuild resets change tracking sets and '
+          'cleanBuild', () async {
+        final buildPlan = await loadPlan();
+        final updatedPlan = buildPlan.rebuild(
+          (b) => b
+            ..buildInputs.cleanBuild = true
+            ..buildInputs.deletedSources.add(assetId)
+            ..buildInputs.updatedSources.add(assetId2)
+            ..buildInputs.invalidOutputs.add(outputId),
+        );
+
+        final nextPlan = updatedPlan.withCompatiblePreviousBuild(
+          previousBuildState: BuildState(
+            buildStepPlan: buildPlan.buildStepPlan,
+            sources: {assetId2: null},
+          ).toFinishedBuildState(),
+          previousPhasedAssetDeps: PhasedAssetDeps(),
+        );
+
+        expect(nextPlan.buildInputs.cleanBuild, isFalse);
+        expect(nextPlan.buildInputs.deletedSources, isEmpty);
+        expect(nextPlan.buildInputs.updatedSources, isEmpty);
+        expect(nextPlan.buildInputs.invalidOutputs, isEmpty);
+      });
     });
   });
 }


### PR DESCRIPTION
`withCompatiblePreviousBuild` returns partly invalid state; not user visible because it's currently dropped later, but could easily cause confusion.

Return valid state :)

Found via the contract programming experiment.