### PR TITLE
Improve `BuildOutputReader`; add `BuildOutputReadResult`.

### DIFF
--- a/build_runner/lib/src/build/asset_content.dart
+++ b/build_runner/lib/src/build/asset_content.dart
@@ -6,11 +6,14 @@ import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
 
-/// Asset content with bytes or string in memory and an optional cached digest.
+/// Asset content with bytes and/or string in memory and an optional cached digest.
+///
+/// If only bytes are stored, conversion to string with [stringValue] is cached.
+/// If only a string is stored, conversion to bytes with [bytes] is cached.
 class AssetContent {
   List<int>? _bytes;
-  final String? _string;
-  final Encoding? _encoding;
+  String? _string;
+  Encoding? _encoding;
   Digest? _digest;
 
   AssetContent.bytes(List<int> bytes, {Digest? digest})
@@ -28,8 +31,13 @@ class AssetContent {
   List<int> get bytes => _bytes ??= _encoding!.encode(_string!);
 
   String stringValue({Encoding encoding = utf8}) {
-    if (_string != null && _encoding == encoding) return _string;
-    return encoding.decode(bytes);
+    if (_string != null && _encoding == encoding) return _string!;
+    final string = encoding.decode(bytes);
+    if (_string == null) {
+      _string = string;
+      _encoding = encoding;
+    }
+    return string;
   }
 
   /// Returns a copy with [newBytes].

--- a/build_runner/lib/src/commands/serve/server.dart
+++ b/build_runner/lib/src/commands/serve/server.dart
@@ -288,14 +288,14 @@ class AssetHandler {
         result = candidate;
         break;
       }
+      // Ensure some result, if it's not readable then an error will be reported
+      // against it.
       result ??= candidate;
     }
-    // Or if none exists, report an error about the first one.
-    result ??= await reader.read(assetIds.first);
 
     try {
       try {
-        if (!result.canRead) {
+        if (!result!.canRead) {
           switch (result.unreadableReason!) {
             case UnreadableReason.failed:
               return shelf.Response.internalServerError(

--- a/build_runner/lib/src/commands/serve/server.dart
+++ b/build_runner/lib/src/commands/serve/server.dart
@@ -15,6 +15,7 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../../build/build_result.dart';
+import '../../io/build_output_read_result.dart';
 import '../../io/build_output_reader.dart';
 import '../../logging/build_log.dart';
 import '../watch/watcher.dart';
@@ -101,19 +102,19 @@ class ServeHandler {
         rootDir,
         p.url.split(path),
       );
-      AssetId? assetId;
+      BuildOutputReadResult? result;
       for (final id in assetIds) {
-        if (await reader.canRead(id)) {
-          assetId = id;
+        final candidate = await reader.read(id);
+        if (candidate.canRead) {
+          result = candidate;
           break;
         }
       }
 
-      if (assetId == null) {
+      if (result == null) {
         results.remove(path);
       } else {
-        final digest = await reader.digest(assetId);
-        results[path] = digest.toString();
+        results[path] = result.digest.toString();
       }
     }
     return shelf.Response.ok(
@@ -165,12 +166,8 @@ class BuildUpdatesWebSocketHandler {
     final reader = buildResult.buildOutputReader!;
     final digests = <AssetId, String?>{};
     for (final assetId in buildResult.outputs) {
-      try {
-        final digest = await reader.digest(assetId);
-        digests[assetId] = digest.toString();
-      } on AssetNotFoundException {
-        digests[assetId] = null;
-      }
+      final result = await reader.read(assetId);
+      digests[assetId] = result.canRead ? result.digest.toString() : null;
     }
     for (final rootDir in connectionsByRootDir.keys) {
       final resultMap = <String, String?>{};
@@ -284,31 +281,32 @@ class AssetHandler {
     if (reader == null) return shelf.Response.notFound('Not Found');
 
     // Use the first of [assetIds] that exists.
-    AssetId? assetId;
+    BuildOutputReadResult? result;
     for (final id in assetIds) {
-      if (await reader.canRead(id)) {
-        assetId = id;
+      final candidate = await reader.read(id);
+      if (candidate.canRead) {
+        result = candidate;
         break;
       }
+      result ??= candidate;
     }
     // Or if none exists, report an error about the first one.
-    assetId ??= assetIds.first;
+    result ??= await reader.read(assetIds.first);
 
     try {
       try {
-        if (!await reader.canRead(assetId)) {
-          final reason = await reader.unreadableReason(assetId);
-          switch (reason) {
+        if (!result.canRead) {
+          switch (result.unreadableReason!) {
             case UnreadableReason.failed:
               return shelf.Response.internalServerError(
-                body: 'Build failed for $assetId',
+                body: 'Build failed for ${result.id}',
               );
             case UnreadableReason.notOutput:
-              return shelf.Response.notFound('$assetId was not output');
+              return shelf.Response.notFound('${result.id} was not output');
             case UnreadableReason.notFound:
               if (fallbackToDirectoryList) {
                 return shelf.Response.notFound(
-                  await _findDirectoryList(assetId),
+                  await _findDirectoryList(result.id),
                 );
               }
               return shelf.Response.notFound('Not Found');
@@ -321,8 +319,8 @@ class AssetHandler {
         return shelf.Response.notFound('Not Found');
       }
 
-      final etag = base64.encode((await reader.digest(assetId)).bytes);
-      var contentType = _typeResolver.lookup(assetId.path);
+      final etag = base64.encode(result.digest.bytes);
+      var contentType = _typeResolver.lookup(result.id.path);
       if (contentType == 'text/x-dart') {
         contentType = '$contentType; charset=utf-8';
       }
@@ -343,7 +341,7 @@ class AssetHandler {
       }
       List<int>? body;
       if (request.method != 'HEAD') {
-        body = await reader.readAsBytes(assetId);
+        body = result.bytes;
         headers[HttpHeaders.contentLengthHeader] = '${body.length}';
       }
       return shelf.Response.ok(body, headers: headers);

--- a/build_runner/lib/src/io/build_output_read_result.dart
+++ b/build_runner/lib/src/io/build_output_read_result.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:build/build.dart';
+import 'package:crypto/crypto.dart';
+
+import '../build/asset_content.dart';
+
+/// The result of reading an asset from a `BuildOutputReader`.
+class BuildOutputReadResult {
+  final AssetId id;
+  final UnreadableReason? unreadableReason;
+  final AssetContent? _content;
+
+  BuildOutputReadResult.unreadable(
+    this.id,
+    UnreadableReason this.unreadableReason,
+  ) : _content = null;
+
+  BuildOutputReadResult.available(this.id, AssetContent content)
+    : unreadableReason = null,
+      _content = content;
+
+  /// Whether the asset can be read.
+  bool get canRead => unreadableReason == null;
+
+  /// The bytes of the asset.
+  ///
+  /// Throws [AssetNotFoundException] if [canRead] is false.
+  List<int> get bytes {
+    if (unreadableReason != null) {
+      throw AssetNotFoundException(id);
+    }
+    return _content!.bytes;
+  }
+
+  /// Returns the digest of the asset.
+  ///
+  /// Throws [AssetNotFoundException] if [canRead] is false.
+  Digest get digest {
+    if (unreadableReason != null) {
+      throw AssetNotFoundException(id);
+    }
+    return _content!.digest;
+  }
+
+  /// Returns the string contents of the asset.
+  ///
+  /// Throws [AssetNotFoundException] if [canRead] is false.
+  String readAsString({Encoding encoding = utf8}) {
+    if (unreadableReason != null) {
+      throw AssetNotFoundException(id);
+    }
+    return _content!.stringValue(encoding: encoding);
+  }
+}
+
+/// The reason an asset could not be read from a `BuildOutputReader`.
+enum UnreadableReason { notFound, notOutput, deleted, failed }

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -3,26 +3,25 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:build/build.dart';
-import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart' as p;
 
+import '../build/asset_content.dart';
 import '../build/build_file_index.dart';
 import '../build/build_state/finished_build_state.dart';
 import '../build_plan/build_packages.dart';
 import '../build_plan/build_step_plan.dart';
+import 'build_output_read_result.dart';
 import 'reader_writer.dart';
 
-/// A view of the build output.
+/// A view of the build inputs and output.
 ///
-/// If [canRead] returns false, [unreadableReason] explains why the file is
-/// missing; for example, it might say that generation failed.
+/// Build inputs that were used and all outputs are returned from memory.
 ///
-/// Files are only visible if they were a required part of the build, even if
-/// they exist on disk from a previous build.
+/// Build inputs that were not used in the build are not in memory and are
+/// returned directly from disk with no caching.
 class BuildOutputReader {
   final BuildPackages buildPackages;
   final ReaderWriter readerWriter;
@@ -64,7 +63,7 @@ class BuildOutputReader {
   }
 
   /// Returns a reason why [id] is not readable, or null if it is readable.
-  Future<UnreadableReason?> unreadableReason(AssetId id) async {
+  Future<UnreadableReason?> _unreadableReason(AssetId id) async {
     if (!_isFile(id)) {
       return UnreadableReason.notFound;
     }
@@ -102,33 +101,17 @@ class BuildOutputReader {
     return UnreadableReason.notFound;
   }
 
-  Future<bool> canRead(AssetId id) async =>
-      (await unreadableReason(id)) == null;
-
-  Future<Digest> digest(AssetId id) async {
-    final unreadableReason = await this.unreadableReason(id);
-    // Do provide digests for generated files that are known but not output
-    // or known to be deleted. `build serve` uses these digests, which
-    // reflect that the file is missing.
-    if (unreadableReason != null &&
-        unreadableReason != UnreadableReason.notOutput &&
-        unreadableReason != UnreadableReason.deleted) {
-      throw AssetNotFoundException(id);
+  /// Reads [id] from the build output, returning a [BuildOutputReadResult].
+  Future<BuildOutputReadResult> read(AssetId id) async {
+    final reason = await _unreadableReason(id);
+    if (reason != null) {
+      return BuildOutputReadResult.unreadable(id, reason);
     }
-    final digest = await _ensureDigest(id);
-    _recordSourceConsumedOutsideBuild(id);
-    return digest;
-  }
 
-  Future<List<int>> readAsBytes(AssetId id) async {
     final cached = buildState.contentOf(id);
     if (cached != null) {
       _recordSourceConsumedOutsideBuild(id);
-      return cached.bytes;
-    }
-
-    if (!_isFile(id)) {
-      throw AssetNotFoundException(id);
+      return BuildOutputReadResult.available(id, cached);
     }
 
     final bytes = await readerWriter.readAsBytes(
@@ -136,19 +119,11 @@ class BuildOutputReader {
       hidden: buildState.isHidden(id),
     );
     _recordSourceConsumedOutsideBuild(id);
-    return bytes;
+    return BuildOutputReadResult.available(id, AssetContent.bytes(bytes));
   }
 
-  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) async {
-    final cached = buildState.contentOf(id);
-    if (cached != null) {
-      _recordSourceConsumedOutsideBuild(id);
-      return cached.stringValue(encoding: encoding);
-    }
-
-    final bytes = await readAsBytes(id);
-    return encoding.decode(bytes);
-  }
+  Future<bool> canRead(AssetId id) async =>
+      (await _unreadableReason(id)) == null;
 
   void _recordSourceConsumedOutsideBuild(AssetId id) {
     if (buildState.isSource(id) && buildState.contentOf(id) == null) {
@@ -162,16 +137,6 @@ class BuildOutputReader {
         yield id;
       }
     }
-  }
-
-  /// Returns the digest of [id], computing it if necessary.
-  ///
-  /// Note that [id] must exist in the asset graph.
-  FutureOr<Digest> _ensureDigest(AssetId id) async {
-    final content = buildState.contentOf(id);
-    if (content != null) return content.digest;
-    final bytes = await readAsBytes(id);
-    return md5.convert(bytes);
   }
 
   /// A lazily computed view of all the assets available after a build.
@@ -228,5 +193,3 @@ class BuildOutputReader {
 
   bool _isFile(AssetId id) => buildState.isFile(id);
 }
-
-enum UnreadableReason { notFound, notOutput, deleted, failed }

--- a/build_runner/lib/src/io/create_merged_dir.dart
+++ b/build_runner/lib/src/io/create_merged_dir.dart
@@ -247,7 +247,7 @@ Future<String> _writeAsset(
         await _writeAsBytes(
           outputDir,
           assetPath,
-          await buildOutputReader.readAsBytes(id),
+          (await buildOutputReader.read(id)).bytes,
         );
       }
     } on AssetNotFoundException catch (e) {

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -518,6 +518,7 @@ void main() {
       expect(readableResult.canRead, isTrue);
       expect(readableResult.unreadableReason, isNull);
       expect(readableResult.readAsString(), 'content');
+      // The decoded string representation is cached on the result.
       expect(
         identical(readableResult.readAsString(), readableResult.readAsString()),
         isTrue,

--- a/build_runner/test/io/build_output_reader_test.dart
+++ b/build_runner/test/io/build_output_reader_test.dart
@@ -5,6 +5,8 @@
 @TestOn('vm')
 library;
 
+import 'dart:convert';
+
 import 'package:build/build.dart';
 import 'package:build_runner/src/build/asset_content.dart';
 import 'package:build_runner/src/build/build_state/build_state.dart';
@@ -23,8 +25,10 @@ import 'package:build_runner/src/build_plan/build_spec.dart';
 import 'package:build_runner/src/build_plan/builder_factories.dart';
 import 'package:build_runner/src/build_plan/phase.dart';
 import 'package:build_runner/src/build_plan/testing_overrides.dart';
+import 'package:build_runner/src/io/build_output_read_result.dart';
 import 'package:build_runner/src/io/build_output_reader.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:crypto/crypto.dart';
 import 'package:glob/glob.dart';
 import 'package:test/test.dart';
 
@@ -71,10 +75,10 @@ void main() {
           buildState: buildState.toFinishedBuildState(),
         );
 
-        expect(await reader.readAsString(id), 'initial');
+        expect((await reader.read(id)).readAsString(), 'initial');
 
         readerWriter.testing.writeString(id, 'modified');
-        expect(await reader.readAsString(id), 'modified');
+        expect((await reader.read(id)).readAsString(), 'modified');
       },
     );
 
@@ -105,10 +109,10 @@ void main() {
           buildState: buildState.toFinishedBuildState(),
         );
 
-        expect(await reader.readAsString(id), 'initial');
+        expect((await reader.read(id)).readAsString(), 'initial');
 
         readerWriter.testing.writeString(id, 'modified');
-        expect(await reader.readAsString(id), 'initial');
+        expect((await reader.read(id)).readAsString(), 'initial');
       },
     );
 
@@ -210,7 +214,7 @@ void main() {
         buildState: buildState.toFinishedBuildState(),
       );
       expect(
-        await reader.unreadableReason(id),
+        (await reader.read(id)).unreadableReason,
         UnreadableReason.failed,
         reason: 'Should report a failure if no build filters apply',
       );
@@ -244,7 +248,7 @@ void main() {
       );
 
       expect(
-        await reader.unreadableReason(id),
+        (await reader.read(id)).unreadableReason,
         UnreadableReason.notOutput,
         reason:
             'Should report as not output if it doesn\'t match requested '
@@ -327,10 +331,11 @@ void main() {
 
       expect(reader.wasSourceConsumedOutsideBuild(id), isFalse);
       expect(await reader.canRead(id), isTrue);
-      expect(await reader.unreadableReason(id), isNull);
       expect(reader.wasSourceConsumedOutsideBuild(id), isFalse);
 
-      expect(await reader.digest(id), isNotNull);
+      final result = await reader.read(id);
+      expect(result.unreadableReason, isNull);
+      expect(result.digest, isNotNull);
       expect(reader.wasSourceConsumedOutsideBuild(id), isTrue);
     });
 
@@ -382,18 +387,151 @@ void main() {
         );
 
         // Reading an unused source marks it consumed outside the build.
-        await reader.readAsString(unusedSourceId);
+        await reader.read(unusedSourceId);
         expect(reader.wasSourceConsumedOutsideBuild(unusedSourceId), isTrue);
 
         // Reading a used source does not mark it consumed outside the build.
-        await reader.readAsString(usedSourceId);
+        await reader.read(usedSourceId);
         expect(reader.wasSourceConsumedOutsideBuild(usedSourceId), isFalse);
 
         // Reading a generated output does not mark it consumed outside the
         // build.
-        await reader.readAsString(generatedId);
+        await reader.read(generatedId);
         expect(reader.wasSourceConsumedOutsideBuild(generatedId), isFalse);
       },
     );
+
+    test(
+      'BuildOutputReadResult throws for failed step with stale disk output',
+      () async {
+        final id = AssetId('a', 'web/a.txt');
+        final primaryId = AssetId('a', 'web/a.dart');
+        final buildStepId = BuildStepId(
+          primaryInput: primaryId,
+          phaseNumber: 0,
+        );
+
+        readerWriter.testing.writeString(primaryId, '');
+        readerWriter.testing.writeString(id, 'stale content on disk');
+
+        buildPhases = BuildPhases([
+          InBuildPhase(
+            builder: TestBuilder(
+              buildExtensions: replaceExtension('.dart', '.txt'),
+            ),
+            key: 'TestBuilder',
+            package: 'a',
+            isOptional: false,
+          ),
+        ]);
+
+        final buildPlan = await BuildPlan.load(
+          await BuildSpec.load(
+            builderFactories: BuilderFactories({}),
+            buildOptions: BuildOptions.forTests(
+              buildDirs: {BuildDirectory('web')}.build(),
+            ),
+            testingOverrides: TestingOverrides(
+              buildPhases: buildPhases,
+              readerWriter: readerWriter,
+              buildPackages: buildPackages,
+            ),
+          ),
+        );
+        final buildState = BuildState(
+          buildStepPlan: buildPlan.buildStepPlan,
+          sources: const {},
+        );
+        final stepResult = BuildStepResult((b) {
+          b.result = false;
+          b.isHidden = false;
+        });
+        buildState.addBuildStepResult(step: buildStepId, result: stepResult);
+        reader = BuildOutputReader(
+          buildPackages: buildPlan.buildSpec.buildPackages,
+          readerWriter: buildPlan.readerWriter,
+          buildState: buildState.toFinishedBuildState(),
+        );
+
+        expect(await reader.canRead(id), isFalse);
+        final result = await reader.read(id);
+        expect(result.canRead, isFalse);
+        expect(result.unreadableReason, UnreadableReason.failed);
+        expect(result.readAsString, throwsA(isA<AssetNotFoundException>()));
+        expect(() => result.bytes, throwsA(isA<AssetNotFoundException>()));
+      },
+    );
+
+    test('read returns BuildOutputReadResult expressing readability and '
+        'unreadableReason', () async {
+      final readableId = AssetId('a', 'web/readable.txt');
+      final failedId = AssetId('a', 'web/input.txt');
+      final primaryId = AssetId('a', 'web/input.dart');
+      final failedStepId = BuildStepId(primaryInput: primaryId, phaseNumber: 0);
+
+      readerWriter.testing.writeString(primaryId, '');
+      readerWriter.testing.writeString(readableId, 'content');
+      readerWriter.testing.writeString(failedId, 'stale content on disk');
+
+      buildPhases = BuildPhases([
+        InBuildPhase(
+          builder: TestBuilder(
+            buildExtensions: replaceExtension('.dart', '.txt'),
+          ),
+          key: 'TestBuilder',
+          package: 'a',
+          isOptional: false,
+        ),
+      ]);
+
+      final buildPlan = await BuildPlan.load(
+        await BuildSpec.load(
+          builderFactories: BuilderFactories({}),
+          buildOptions: BuildOptions.forTests(
+            buildDirs: {BuildDirectory('web')}.build(),
+          ),
+          testingOverrides: TestingOverrides(
+            buildPhases: buildPhases,
+            readerWriter: readerWriter,
+            buildPackages: buildPackages,
+          ),
+        ),
+      );
+      final buildState = BuildState(
+        buildStepPlan: buildPlan.buildStepPlan,
+        sources: const {},
+      );
+      buildState.addSourceForTest(readableId);
+      final stepResult = BuildStepResult((b) {
+        b.result = false;
+        b.isHidden = false;
+      });
+      buildState.addBuildStepResult(step: failedStepId, result: stepResult);
+      reader = BuildOutputReader(
+        buildPackages: buildPlan.buildSpec.buildPackages,
+        readerWriter: buildPlan.readerWriter,
+        buildState: buildState.toFinishedBuildState(),
+      );
+
+      final readableResult = await reader.read(readableId);
+      expect(readableResult, isA<BuildOutputReadResult>());
+      expect(readableResult.canRead, isTrue);
+      expect(readableResult.unreadableReason, isNull);
+      expect(readableResult.readAsString(), 'content');
+      expect(
+        identical(readableResult.readAsString(), readableResult.readAsString()),
+        isTrue,
+      );
+      expect(readableResult.bytes, utf8.encode('content'));
+      expect(readableResult.digest, md5.convert(utf8.encode('content')));
+
+      final failedResult = await reader.read(failedId);
+      expect(failedResult, isA<BuildOutputReadResult>());
+      expect(failedResult.canRead, isFalse);
+      expect(failedResult.unreadableReason, UnreadableReason.failed);
+      expect(failedResult.readAsString, throwsA(isA<AssetNotFoundException>()));
+      expect(() => failedResult.bytes, throwsA(isA<AssetNotFoundException>()));
+      expect(() => failedResult.digest, throwsA(isA<AssetNotFoundException>()));
+    });
   });
 }


### PR DESCRIPTION
Improve `BuildOutputReader`; add `BuildOutputReadResult`.

Previously, `BuildOutputReader` could return stale data, and all callers did checks to avoid reading it.

Make `BuildOutputReader` throw on stale data, and tidy up the checking work by encapsulating in `BuildOutputReadResult`.

This was found via the contract programming experiment, which identified that the responsibility of avoiding publishing stale data was on the callers of `BuildOutputReader`.