### PR TITLE
Restrict incompatibleBuildOutputsToDelete to outputPackages.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Bug fix: in incremental builds, detect and delete conflicting outputs in the
   source directory rather than treating them as sources, which could cause
   builder dependency cycles and hangs; fix #5079.
+- Bug fix: restrict incompatible build output deletion to output packages; do
+  not attempt to delete files in dependency packages.
 
 ## 2.16.0
 

--- a/build_runner/lib/src/build_plan/previous_build.dart
+++ b/build_runner/lib/src/build_plan/previous_build.dart
@@ -260,14 +260,14 @@ Iterable<AssetId> _outputsToDelete({
   for (final stepResult in buildState.buildStepResults.values) {
     if (!stepResult.isHidden) {
       for (final id in stepResult.outputs) {
-        if (buildPackages[id.package] != null) result.add(id);
+        if (buildPackages.outputPackages.contains(id.package)) result.add(id);
       }
     }
   }
   for (final postProcessResult in buildState.postProcessResults.values) {
     if (!postProcessResult.hidden) {
       for (final id in postProcessResult.outputs) {
-        if (buildPackages[id.package] != null) result.add(id);
+        if (buildPackages.outputPackages.contains(id.package)) result.add(id);
       }
     }
   }

--- a/build_runner/test/integration_tests/build_command_workspace_root_test.dart
+++ b/build_runner/test/integration_tests/build_command_workspace_root_test.dart
@@ -39,6 +39,12 @@ ${tester.read('pubspec.yaml')}
 dependencies:
   builder_pkg:
     path: builder_pkg
+  # Make p1 an explicit dependency so it changes between being part of the
+  # build with --workspace and a dep of the build without. This verifies that
+  # the "without" build doesn't try to delete outputs in p1 from the previous
+  # build.
+  p1:
+    path: p1
 ''');
     tester.write('lib/w.txt', '1');
 


### PR DESCRIPTION
When an incompatible build forces a clean build, PreviousBuild._outputsToDelete collects previous non-hidden outputs to delete. Previously, it checked whether id.package was present in buildPackages, which includes all dependencies in the package graph.

In a workspace where a dependency is not an output package, attempting to delete files in that dependency causes ReaderWriter.delete to call BuildPackages.throwIfReadonly, throwing InvalidOutputException and crashing the build.

Checking buildPackages.outputPackages.contains(id.package) ensures outputs from non-output packages are not scheduled for deletion.

Found via the contract programming experiment.