### PR TITLE
Set default test timeout to 3m in build_runner/dart_test.yaml.

### DIFF
--- a/build_runner/dart_test.yaml
+++ b/build_runner/dart_test.yaml
@@ -1,11 +1,8 @@
 reporter: failures-only
+timeout: 3m
 
 tags:
   integration1:
-    timeout: 3m
   integration2:
-    timeout: 3m
   integration3:
-    timeout: 3m
   integration4:
-    timeout: 3m


### PR DESCRIPTION
Use the 3m timeout for all tests, not just integration tests.

Some tests approach the 30s default timeout under load; the timeouts don't add much value, so just increase it.

Tags are still needed, even with no configuration, as they are used to ... well, tag tests :)