### PR TITLE
Do not invalidate retained package path outputs on artifact tree conflicts.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -14,6 +14,8 @@
   builder dependency cycles and hangs; fix #5079.
 - Bug fix: restrict incompatible build output deletion to output packages; do
   not attempt to delete files in dependency packages.
+- Bug fix: do not invalidate retained package path outputs when conflicting
+  artifact tree files appear; avoid unnecessary build step reruns.
 
 ## 2.16.0
 

--- a/build_runner/lib/src/build_plan/build_plan.dart
+++ b/build_runner/lib/src/build_plan/build_plan.dart
@@ -461,7 +461,8 @@ abstract class BuildPlan implements Built<BuildPlan, BuildPlanBuilder> {
       buildInputs.retainedOutputContents.remove(id);
     }
     for (final id in newArtifactTreeFiles) {
-      if (!finalSources.contains(id)) {
+      if (!finalSources.contains(id) &&
+          buildInputs.retainedOutputContents[id] == null) {
         buildInputs.invalidOutputs.add(id);
       }
     }

--- a/build_runner/test/integration_tests/build_command_invalidation_test.dart
+++ b/build_runner/test/integration_tests/build_command_invalidation_test.dart
@@ -182,7 +182,13 @@ void main() async {
       'root_pkg/.dart_tool/build/generated/root_pkg/web/a.txt.copy',
       'new artifact tree conflict',
     );
-    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+    );
+    // The conflicting artifact tree file was deleted and the existing package
+    // path output is still valid, so there is no rerun.
+    expect(output, contains('wrote 0 outputs'));
     expect(
       tester.read(
         'root_pkg/.dart_tool/build/generated/root_pkg/web/a.txt.copy',


### PR DESCRIPTION
When a builder writes outputs to package paths, those outputs are retained in incremental builds. If a conflicting file appears in the artifact tree, it will be cleaned up before build phases. Invalidate the output only if it was not already retained, avoiding an unnecessary build step rerun.

Found via contract programming experiment.