### PR TITLE
Rename `BuildState.isFile` to `isKnownAsset`.

### DIFF
--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -660,12 +660,12 @@ class Build {
       buildFilesystem: _builderFilesystem,
       addAsset: (assetId) {
         if (!outputsToArtifactTree) buildPackages.throwIfReadonly(assetId);
-        if (_isFile(assetId)) {
+        if (buildState.isKnownAsset(assetId)) {
           throw InvalidOutputException(assetId, 'Asset already exists');
         }
       },
       deleteAsset: (assetId) {
-        if (!_isFile(assetId)) {
+        if (!buildState.isKnownAsset(assetId)) {
           throw AssetNotFoundException(assetId);
         }
         if (assetId != input) {
@@ -1114,8 +1114,6 @@ class Build {
       contents: contents,
     );
   }
-
-  bool _isFile(AssetId id) => buildState.isFile(id);
 
   bool _isChangedOutput(AssetId output) {
     final oldDigest = previousBuild.digestOf(output);

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -138,8 +138,8 @@ class BuildSeries {
         continue;
       }
 
-      final isFile = previousBuild.isFile(id);
-      if (!isFile) {
+      final isKnownAsset = previousBuild.isKnownAsset(id);
+      if (!isKnownAsset) {
         // Ignore under `.dart_tool/build`.
         if (id.path.startsWith(hiddenBuildDirectoryPath)) continue;
 

--- a/build_runner/lib/src/build/build_state/build_state.dart
+++ b/build_runner/lib/src/build/build_state/build_state.dart
@@ -90,13 +90,6 @@ class BuildState {
 
   // -- Predicates over IDs and iterables over IDs.
 
-  /// Whether [id] is one of: source, declared output or actual post process
-  /// output.
-  bool isFile(AssetId id) =>
-      isSource(id) ||
-      buildStepPlan.isDeclaredOutput(id) ||
-      isActualPostOutput(id);
-
   /// Sources.
   Iterable<AssetId> get sources => _sources;
 
@@ -105,6 +98,13 @@ class BuildState {
 
   /// Whether [id] is a source file that was accessed but did not exist.
   bool isMissingSource(AssetId id) => _missingSources.contains(id);
+
+  /// Whether [id] is one of: source, declared output or actual post process
+  /// output.
+  bool isKnownAsset(AssetId id) =>
+      isSource(id) ||
+      buildStepPlan.isDeclaredOutput(id) ||
+      isActualPostOutput(id);
 
   /// Actual build step outputs.
   ///

--- a/build_runner/lib/src/build/build_state/finished_build_state.dart
+++ b/build_runner/lib/src/build/build_state/finished_build_state.dart
@@ -97,12 +97,6 @@ class FinishedBuildState {
   bool isInArtifactTree(AssetId id) =>
       buildStepPlan.isDeclaredOutputInArtifactTree(id) ||
       _isArtifactTreePostProcessOutput(id);
-
-  bool isFile(AssetId id) =>
-      isSource(id) ||
-      buildStepPlan.isDeclaredOutput(id) ||
-      isActualPostOutput(id);
-
   AssetContent? contentOf(AssetId id) => contents[id];
 
   Iterable<MapEntry<AssetId, AssetContent>> get sourceContents =>

--- a/build_runner/lib/src/build/builder_filesystem.dart
+++ b/build_runner/lib/src/build/builder_filesystem.dart
@@ -107,10 +107,6 @@ class BuilderFilesystem {
     }
   }
 
-  bool isFile(AssetId id) {
-    return buildState.isFile(id);
-  }
-
   /// Returns the content of [id].
   ///
   /// It must be a known source or an output that has already been generated.
@@ -164,7 +160,7 @@ class BuilderFilesystem {
     }
 
     if (Placeholders.isPlaceholderPath(id.path)) return false;
-    if (!isFile(id)) {
+    if (!buildState.isKnownAsset(id)) {
       buildState.addMissingSource(id);
       return false;
     }
@@ -236,7 +232,7 @@ class BuilderFilesystem {
   /// its content. Note that generation might output nothing, in which case an
   /// empty string is returned for its content.
   Future<PhasedValue<String>> readPhased(int phase, AssetId id) async {
-    if (!isFile(id)) {
+    if (!buildState.isKnownAsset(id)) {
       buildState.addMissingSource(id);
       return PhasedValue.fixed('');
     } else if (buildState.isMissingSource(id)) {

--- a/build_runner/lib/src/build_plan/previous_build.dart
+++ b/build_runner/lib/src/build_plan/previous_build.dart
@@ -135,7 +135,7 @@ abstract class PreviousBuild
       (buildStepPlan?.isDeclaredOutputInArtifactTree(id) ?? false) ||
       _isInArtifactTreePostProcessOutput(id);
 
-  bool isFile(AssetId id) =>
+  bool isKnownAsset(AssetId id) =>
       isSource(id) ||
       (buildStepPlan?.isDeclaredOutput(id) ?? false) ||
       isActualPostOutput(id);

--- a/build_runner/lib/src/io/build_output_reader.dart
+++ b/build_runner/lib/src/io/build_output_reader.dart
@@ -64,9 +64,6 @@ class BuildOutputReader {
 
   /// Returns a reason why [id] is not readable, or null if it is readable.
   Future<UnreadableReason?> _unreadableReason(AssetId id) async {
-    if (!_isFile(id)) {
-      return UnreadableReason.notFound;
-    }
     if (buildState.assetsDeletedByPostProcess.contains(id)) {
       return UnreadableReason.deleted;
     }
@@ -164,7 +161,6 @@ class BuildOutputReader {
   }
 
   bool _shouldSkipId(AssetId id, String? rootDir) {
-    if (!_isFile(id)) return true;
     if (buildState.assetsDeletedByPostProcess.contains(id)) return true;
 
     // Exclude non-lib assets if they're outside of the root directory or not
@@ -193,6 +189,4 @@ class BuildOutputReader {
     if (id.path == '.dart_tool/package_config.json') return true;
     return false;
   }
-
-  bool _isFile(AssetId id) => buildState.isFile(id);
 }


### PR DESCRIPTION
`isFile` was confusing because what it means is not actually a file :)

Remove one use in BuildOutputReader: the explicit handling below was already dealing with all the cases.

Remove from FinishedBuildState because it's no longer used.