### PR TITLE
Use AssetFile for deletes.

### DIFF
--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -17,7 +17,6 @@ import '../build_plan/output_strategy.dart';
 import '../commands/watch/asset_change.dart';
 import '../commands/watch/filtered_changes.dart';
 import '../constants.dart';
-import '../io/asset_path_provider.dart';
 import '../io/asset_tracker.dart';
 import '../io/build_output_reader.dart';
 import '../io/create_merged_dir.dart';
@@ -342,8 +341,12 @@ class BuildSeries {
         inArtifactTree: result.buildState!.isInArtifactTree(output),
       );
     }
-    for (final toDelete in _computeDeletes(result, includeArtifactTree: true)) {
-      _expectedDeletes.add(toDelete);
+    final forceToPackagePathsForTesting =
+        _buildPlan.buildSpec.testingOverrides.forceToPackagePathsForTesting;
+    for (final toDelete in _computeDeletes(result)) {
+      if (toDelete.atPackagePath || forceToPackagePathsForTesting) {
+        _expectedDeletes.add(toDelete.id);
+      }
       await _buildPlan.readerWriter.delete(toDelete);
     }
 
@@ -367,24 +370,9 @@ class BuildSeries {
   /// Files that should be deleted: outputs of the previous build that are no
   /// longer declared outputs, plus files on disk that match declared outputs
   /// that were not actually output.
-  Set<AssetId> _computeDeletes(
-    BuildResult result, {
-    required bool includeArtifactTree,
-  }) {
-    final deletes = <AssetId>{};
+  Set<AssetFile> _computeDeletes(BuildResult result) {
+    final deletes = <AssetFile>{};
     final currentState = result.buildState!;
-    final outputRoot = _buildPlan.buildSpec.buildPackages.outputRoot;
-    // Adds a delete result, unless it is in the artifact tree and
-    // `includeArtifactTree` is false.
-    void maybeAddDelete(AssetId id, {required bool inArtifactTree}) {
-      if (inArtifactTree) {
-        if (includeArtifactTree) {
-          deletes.add(AssetPathProvider.inArtifactTree(id, outputRoot));
-        }
-      } else {
-        deletes.add(id);
-      }
-    }
 
     // If set, artifact tree outputs are forced to package paths for simpler
     // test assertions.
@@ -399,14 +387,14 @@ class BuildSeries {
               currentState.isActualPostOutput(file.id)) &&
           outputInArtifactTree == file.inArtifactTree;
       if (!isMatchingActualOutput) {
-        maybeAddDelete(file.id, inArtifactTree: file.inArtifactTree);
+        deletes.add(file);
       }
     }
     for (final id
         in _buildPlan.previousBuild.incompatibleBuildOutputsToDelete) {
       if (!currentState.isActualOutput(id) &&
           !currentState.isActualPostOutput(id)) {
-        deletes.add(id);
+        deletes.add(AssetFile.atPackagePath(id));
       }
     }
 
@@ -418,12 +406,16 @@ class BuildSeries {
             id,
           );
           if (stepId == null) {
-            maybeAddDelete(id, inArtifactTree: stepResult.inArtifactTree);
+            deletes.add(
+              AssetFile(id, inArtifactTree: stepResult.inArtifactTree),
+            );
           } else {
             final stepResultOrNull = currentState.stepResultOrNull(stepId);
             if (stepResultOrNull != null &&
                 !stepResultOrNull.outputs.contains(id)) {
-              maybeAddDelete(id, inArtifactTree: stepResult.inArtifactTree);
+              deletes.add(
+                AssetFile(id, inArtifactTree: stepResult.inArtifactTree),
+              );
             }
           }
         }
@@ -431,9 +423,8 @@ class BuildSeries {
       for (final postProcessResult in previousBuild.actualPostProcessResults) {
         for (final id in postProcessResult.outputs) {
           if (!currentState.isActualPostOutput(id)) {
-            maybeAddDelete(
-              id,
-              inArtifactTree: postProcessResult.inArtifactTree,
+            deletes.add(
+              AssetFile(id, inArtifactTree: postProcessResult.inArtifactTree),
             );
           }
         }
@@ -472,13 +463,11 @@ class BuildSeries {
       }
     }
 
-    for (final toDelete in _computeDeletes(
-      result,
-      includeArtifactTree: false,
-    )) {
-      final exists = await _buildPlan.readerWriter.canRead(toDelete);
+    for (final toDelete in _computeDeletes(result)) {
+      if (toDelete.inArtifactTree) continue;
+      final exists = await _buildPlan.readerWriter.canRead(toDelete.id);
       if (exists) {
-        unexpected.add(toDelete);
+        unexpected.add(toDelete.id);
       }
     }
 

--- a/build_runner/lib/src/internal.dart
+++ b/build_runner/lib/src/internal.dart
@@ -9,6 +9,7 @@ export 'build/build_series.dart';
 export 'build/input_tracker.dart';
 export 'build/resolver/analysis_driver_model.dart';
 export 'build/resolver/resolvers_impl.dart';
+export 'build_plan/asset_file.dart';
 export 'build_plan/build_configs.dart';
 export 'build_plan/build_directory.dart';
 export 'build_plan/build_filter.dart';

--- a/build_runner/lib/src/io/reader_writer.dart
+++ b/build_runner/lib/src/io/reader_writer.dart
@@ -12,6 +12,7 @@ import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
 import 'package:path/path.dart' as path;
 
+import '../build_plan/asset_file.dart';
 import '../build_plan/build_package.dart';
 import '../build_plan/build_packages.dart';
 import '../logging/timed_activities.dart';
@@ -156,11 +157,11 @@ class ReaderWriter implements AssetReader, AssetWriter {
     return digestSink.events.first;
   }
 
-  Future<void> delete(AssetId id, {bool inArtifactTree = false}) {
+  Future<void> delete(AssetFile file) {
     TimedActivity.write.run(() {
       final path = _pathFor(
-        id,
-        inArtifactTree: inArtifactTree,
+        file.id,
+        inArtifactTree: file.inArtifactTree,
         checkWriteAllowed: true,
       );
       filesystem.deleteSync(path);

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -14,6 +14,7 @@ import 'package:build_config/build_config.dart'
 import 'package:build_runner/src/build/build_result.dart';
 import 'package:build_runner/src/build/build_state/asset_graph_json.dart';
 import 'package:build_runner/src/build/build_state/build_step_id.dart';
+import 'package:build_runner/src/build_plan/asset_file.dart';
 import 'package:build_runner/src/build_plan/build_configs.dart';
 import 'package:build_runner/src/build_plan/build_directory.dart';
 import 'package:build_runner/src/build_plan/build_filter.dart';
@@ -1247,7 +1248,9 @@ targets:
 
     // Delete the `asset_graph.json` file!
     final outputId = makeAssetId('a|$assetGraphJsonPath');
-    await (result.readerWriter as ReaderWriter).delete(outputId);
+    await (result.readerWriter as ReaderWriter).delete(
+      AssetFile.atPackagePath(outputId),
+    );
 
     // Second run, should have no extra outputs.
     await testBuilders(

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -124,7 +124,7 @@ void main() {
       await writeBuildStateAndPlan(buildState, buildPlan);
 
       // Remove source.
-      await readerWriter.delete(assetId);
+      await readerWriter.delete(AssetFile.atPackagePath(assetId));
       // Change source.
       await readerWriter.writeAsString(assetId2, 'changed');
       // Add source.
@@ -132,7 +132,7 @@ void main() {
       await readerWriter.writeAsString(assetId3, '');
 
       // Remove generated.
-      await readerWriter.delete(outputId);
+      await readerWriter.delete(AssetFile.atPackagePath(outputId));
 
       buildPlan = await loadPlan();
 
@@ -314,7 +314,7 @@ void main() {
         );
         await writeBuildStateAndPlan(buildState, buildPlan);
 
-        await readerWriter.delete(assetId);
+        await readerWriter.delete(AssetFile.atPackagePath(assetId));
         final newPlan = await loadPlan();
         expect(newPlan.buildInputs.deletedSources, contains(assetId));
         expect(newPlan.buildInputs.sources, isNot(contains(assetId)));
@@ -342,7 +342,7 @@ void main() {
         );
         await writeBuildStateAndPlan(buildState, buildPlan);
 
-        await readerWriter.delete(outputId);
+        await readerWriter.delete(AssetFile.atPackagePath(outputId));
         final newPlan = await loadPlan();
         expect(newPlan.buildInputs.invalidOutputs, contains(outputId));
       });
@@ -793,7 +793,7 @@ void main() {
         await writeBuildStateAndPlan(buildState, initialPlan);
 
         // Delete the input and create a source file at the old output path.
-        await readerWriter.delete(inputId);
+        await readerWriter.delete(AssetFile.atPackagePath(inputId));
         await readerWriter.writeAsString(postOutputId, '// new source');
 
         final loadedPlan = await loadPlan(postOverrides, postFactories);
@@ -874,8 +874,8 @@ void main() {
         await writeBuildStateAndPlan(buildState, initialPlan);
 
         // Delete the input and the old artifact tree output.
-        await readerWriter.delete(inputId);
-        await readerWriter.delete(postOutputId, inArtifactTree: true);
+        await readerWriter.delete(AssetFile.atPackagePath(inputId));
+        await readerWriter.delete(AssetFile.inArtifactTree(postOutputId));
         await readerWriter.writeAsString(postOutputId, '// new source');
 
         final loadedPlan = await loadPlan(postOverrides, postFactories);
@@ -996,8 +996,8 @@ void main() {
 
         // Delete the input and the artifact tree output, and add a package
         // path source file.
-        await readerWriter.delete(assetId);
-        await readerWriter.delete(outputId, inArtifactTree: true);
+        await readerWriter.delete(AssetFile.atPackagePath(assetId));
+        await readerWriter.delete(AssetFile.inArtifactTree(outputId));
         await readerWriter.writeAsString(outputId, '// source content');
 
         final loadedPlan = await loadPlan();
@@ -1050,7 +1050,7 @@ void main() {
           await writeBuildStateAndPlan(buildState, initialPlan);
 
           // Delete the input source.
-          await readerWriter.delete(assetId);
+          await readerWriter.delete(AssetFile.atPackagePath(assetId));
 
           final loadedPlan = await loadPlan(overrides);
           expect(loadedPlan.buildInputs.deletedSources, contains(assetId));

--- a/build_runner/test/io/reader_writer_test.dart
+++ b/build_runner/test/io/reader_writer_test.dart
@@ -6,6 +6,7 @@ library;
 
 import 'dart:io';
 
+import 'package:build_runner/src/build_plan/asset_file.dart';
 import 'package:build_runner/src/build_plan/build_packages.dart';
 import 'package:build_runner/src/build_plan/build_paths.dart';
 import 'package:build_runner/src/io/reader_writer.dart';
@@ -187,8 +188,18 @@ void main() async {
       expect(await file.exists(), isTrue);
       expect(await file.readAsString(), content);
 
-      await readerWriter.delete(id);
+      await readerWriter.delete(AssetFile.atPackagePath(id));
       expect(await file.exists(), isFalse);
+    });
+
+    test('can output and delete files in the artifact tree', () async {
+      final id = makeAssetId('basic_pkg|test_file.txt');
+      final content = 'test';
+      await readerWriter.writeAsString(id, content, inArtifactTree: true);
+      expect(await readerWriter.canRead(id, inArtifactTree: true), isTrue);
+
+      await readerWriter.delete(AssetFile.inArtifactTree(id));
+      expect(await readerWriter.canRead(id, inArtifactTree: true), isFalse);
     });
   });
 }

--- a/build_test/lib/src/internal_test_reader_writer.dart
+++ b/build_test/lib/src/internal_test_reader_writer.dart
@@ -127,10 +127,16 @@ class InternalTestReaderWriter extends ReaderWriter
     bool inArtifactTree = false,
   }) async {
     assetsWritten.add(id);
-    final type = testing.exists(id) ? ChangeType.MODIFY : ChangeType.ADD;
+    final eventAssetId = _eventAssetId(id, inArtifactTree: inArtifactTree);
+    final type = testing.exists(eventAssetId)
+        ? ChangeType.MODIFY
+        : ChangeType.ADD;
     await super.writeAsBytes(id, bytes, inArtifactTree: inArtifactTree);
     FakeWatcher.notifyWatchers(
-      WatchEvent(type, p.absolute(id.package, p.fromUri(id.path))),
+      WatchEvent(
+        type,
+        p.absolute(eventAssetId.package, p.fromUri(eventAssetId.path)),
+      ),
     );
   }
 
@@ -142,7 +148,10 @@ class InternalTestReaderWriter extends ReaderWriter
     bool inArtifactTree = false,
   }) async {
     assetsWritten.add(id);
-    final type = testing.exists(id) ? ChangeType.MODIFY : ChangeType.ADD;
+    final eventAssetId = _eventAssetId(id, inArtifactTree: inArtifactTree);
+    final type = testing.exists(eventAssetId)
+        ? ChangeType.MODIFY
+        : ChangeType.ADD;
     await super.writeAsString(
       id,
       contents,
@@ -150,17 +159,32 @@ class InternalTestReaderWriter extends ReaderWriter
       inArtifactTree: inArtifactTree,
     );
     FakeWatcher.notifyWatchers(
-      WatchEvent(type, p.absolute(id.package, p.fromUri(id.path))),
+      WatchEvent(
+        type,
+        p.absolute(eventAssetId.package, p.fromUri(eventAssetId.path)),
+      ),
     );
   }
 
   @override
-  Future<void> delete(AssetId id, {bool inArtifactTree = false}) {
-    FakeWatcher.notifyWatchers(
-      WatchEvent(ChangeType.REMOVE, p.absolute(id.package, p.fromUri(id.path))),
+  Future<void> delete(AssetFile file) {
+    final eventAssetId = _eventAssetId(
+      file.id,
+      inArtifactTree: file.inArtifactTree,
     );
-    return super.delete(id, inArtifactTree: inArtifactTree);
+    FakeWatcher.notifyWatchers(
+      WatchEvent(
+        ChangeType.REMOVE,
+        p.absolute(eventAssetId.package, p.fromUri(eventAssetId.path)),
+      ),
+    );
+    return super.delete(file);
   }
+
+  AssetId _eventAssetId(AssetId id, {required bool inArtifactTree}) =>
+      inArtifactTree && !forceToPackagePathsForTesting
+      ? AssetPathProvider.inArtifactTree(id, outputRootPackage)
+      : id;
 }
 
 class InMemoryAssetPathProvider implements AssetPathProvider {

--- a/build_test/test/in_memory_reader_test.dart
+++ b/build_test/test/in_memory_reader_test.dart
@@ -2,10 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:build/build.dart';
+// ignore: implementation_imports
+import 'package:build_runner/src/internal.dart';
+import 'package:build_test/src/fake_watcher.dart';
 import 'package:build_test/src/internal_test_reader_writer.dart';
 import 'package:glob/glob.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+import 'package:watcher/watcher.dart';
 
 void main() {
   group('InMemoryAssetReaderWriter', () {
@@ -65,5 +72,120 @@ void main() {
         ]),
       );
     });
+  });
+
+  group('FakeWatcher events', () {
+    final rootPackage = 'root_pkg';
+    late InternalTestReaderWriter readerWriter;
+    late FakeWatcher rootWatcher;
+    late FakeWatcher depWatcher;
+    late List<WatchEvent> rootEvents;
+    late List<WatchEvent> depEvents;
+    late StreamSubscription<WatchEvent> rootSub;
+    late StreamSubscription<WatchEvent> depSub;
+
+    setUp(() {
+      FakeWatcher.watchers.clear();
+      readerWriter = InternalTestReaderWriter(outputRootPackage: rootPackage);
+      rootWatcher = FakeWatcher(p.absolute(rootPackage));
+      depWatcher = FakeWatcher(p.absolute('dep_pkg'));
+      rootEvents = [];
+      depEvents = [];
+      rootSub = rootWatcher.events.listen(rootEvents.add);
+      depSub = depWatcher.events.listen(depEvents.add);
+    });
+
+    tearDown(() async {
+      await rootSub.cancel();
+      await depSub.cancel();
+      FakeWatcher.watchers.clear();
+    });
+
+    test('notifies package path writes and deletes', () async {
+      final id = AssetId(rootPackage, 'lib/a.txt');
+      await readerWriter.writeAsString(id, 'first');
+      await pumpEventQueue();
+      expect(rootEvents.map((e) => (e.type, e.path)), [
+        (ChangeType.ADD, p.absolute(rootPackage, 'lib/a.txt')),
+      ]);
+
+      await readerWriter.writeAsString(id, 'second');
+      await pumpEventQueue();
+      expect(rootEvents.map((e) => (e.type, e.path)), [
+        (ChangeType.ADD, p.absolute(rootPackage, 'lib/a.txt')),
+        (ChangeType.MODIFY, p.absolute(rootPackage, 'lib/a.txt')),
+      ]);
+
+      await readerWriter.delete(AssetFile.atPackagePath(id));
+      await pumpEventQueue();
+      expect(rootEvents.map((e) => (e.type, e.path)), [
+        (ChangeType.ADD, p.absolute(rootPackage, 'lib/a.txt')),
+        (ChangeType.MODIFY, p.absolute(rootPackage, 'lib/a.txt')),
+        (ChangeType.REMOVE, p.absolute(rootPackage, 'lib/a.txt')),
+      ]);
+    });
+
+    test('notifies artifact tree writes and deletes', () async {
+      final depId = AssetId('dep_pkg', 'lib/dep.txt');
+      final expectedArtifactPath = p.absolute(
+        rootPackage,
+        '.dart_tool/build/generated/dep_pkg/lib/dep.txt',
+      );
+
+      await readerWriter.writeAsString(depId, 'content', inArtifactTree: true);
+      await pumpEventQueue();
+      expect(rootEvents.map((e) => (e.type, e.path)), [
+        (ChangeType.ADD, expectedArtifactPath),
+      ]);
+      expect(depEvents, isEmpty);
+
+      await readerWriter.writeAsString(depId, 'updated', inArtifactTree: true);
+      await pumpEventQueue();
+      expect(rootEvents.map((e) => (e.type, e.path)), [
+        (ChangeType.ADD, expectedArtifactPath),
+        (ChangeType.MODIFY, expectedArtifactPath),
+      ]);
+      expect(depEvents, isEmpty);
+
+      await readerWriter.delete(AssetFile.inArtifactTree(depId));
+      await pumpEventQueue();
+      expect(rootEvents.map((e) => (e.type, e.path)), [
+        (ChangeType.ADD, expectedArtifactPath),
+        (ChangeType.MODIFY, expectedArtifactPath),
+        (ChangeType.REMOVE, expectedArtifactPath),
+      ]);
+      expect(depEvents, isEmpty);
+    });
+
+    test(
+      'notifies package path when forceToPackagePathsForTesting is true',
+      () async {
+        readerWriter = InternalTestReaderWriter(
+          outputRootPackage: rootPackage,
+          forceToPackagePathsForTesting: true,
+        );
+        final depId = AssetId('dep_pkg', 'lib/dep.txt');
+        final expectedPackagePath = p.absolute('dep_pkg', 'lib/dep.txt');
+
+        await readerWriter.writeAsString(
+          depId,
+          'content',
+          inArtifactTree: true,
+        );
+        await pumpEventQueue();
+        expect(depEvents.map((e) => (e.type, e.path)), [
+          (ChangeType.ADD, expectedPackagePath),
+        ]);
+        expect(rootEvents, isEmpty);
+
+        await readerWriter.delete(AssetFile.inArtifactTree(depId));
+        await pumpEventQueue();
+        expect(depEvents.map((e) => (e.type, e.path)), [
+          (ChangeType.ADD, expectedPackagePath),
+          (ChangeType.REMOVE, expectedPackagePath),
+        ]);
+        expect(rootEvents, isEmpty);
+      },
+    );
   });
 }


### PR DESCRIPTION
Use AssetFile for deletes since we want to talk about specific file locations. Simplifies some code.

Fake watcher event handling in `build_test` needs a corresponding change; add previously-missing test coverage.