### PR TITLE
Import built_value into built_types/.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,7 @@ jobs:
     with:
       write-comments: false
       sdk: dev
+      ignore-packages: 'built_types/**'
     permissions:
       id-token: write
       pull-requests: write

--- a/built_types/.github/dependabot.yaml
+++ b/built_types/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+# Dependabot configuration file.
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/built_types/.github/workflows/build.yaml
+++ b/built_types/.github/workflows/build.yaml
@@ -1,0 +1,23 @@
+name: Build
+
+on:
+  schedule:
+    # “At 00:00 (UTC) on Sunday.”
+    - cron: '0 0 * * 0'
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+        with:
+          sdk: dev
+      - name: Run Presubmits
+        run: tool/presubmit

--- a/built_types/.gitignore
+++ b/built_types/.gitignore
@@ -1,0 +1,11 @@
+.buildlog
+.dart_tool/
+.DS_Store
+.idea
+.pub/
+.settings/
+*.iml
+**/build
+**/packages
+**/pubspec.lock
+**/.packages

--- a/built_types/AUTHORS
+++ b/built_types/AUTHORS
@@ -1,0 +1,15 @@
+# Below is a list of people and organizations that have contributed
+# to the project. Names should be added to the list like so:
+#
+#   Name/Organization <email address>
+
+Abhijeeth Padarthi <rkinabhi@gmail.com>
+David Morgan/Google Inc. <davidmorgan@google.com>
+Ivan Inozemtsev/Google Inc. <iinozemtsev@google.com>
+John Dengis <jadengis@gmail.com>
+Resul Alkan/MetGlobal <me@resulalkan.com>
+Dao Hoang Son <dao@hoangson.vn>
+Ahmed Fwela/Bdaya Development <ahmednfwela@bdaya-dev.com>
+Max Härtwig/Google Inc. <maxhaertwig@google.com>
+Nikolas Rimikis <rimikis.nikolas@gmail.com>
+Dusty Holmes <dusty.holmes@workiva.com>

--- a/built_types/CHANGELOG.md
+++ b/built_types/CHANGELOG.md
@@ -1,0 +1,1058 @@
+# Changelog
+
+## 8.13.0
+
+- Support generating from classes and enums that use the `new` syntax for
+  constructors.
+
+# 8.12.7
+
+- Allow `analyzer 13.0.0` and `analyzer 14.0.0`
+
+# 8.12.6
+
+- Require `analyzer 13.0.0`.
+
+# 8.12.5
+
+- Allow `analyzer 11.0.0` and `analyzer 12.0.0`.
+
+# 8.12.4
+
+- Reduce use of dynamic calls in generated `operator==` when there are
+  functions: only use dynamic calls if the class also has type parameters.
+
+# 8.12.3
+
+- Require `analyzer ^10.0.0`, stop using removed and deprecated methods from
+  earlier versions.
+
+# 8.12.2
+
+- Allow `analyzer 10.0.0`.
+
+# 8.12.1
+
+- Allow `analyzer 9.0.0`.
+
+# 8.12.0
+
+- Enable `build_runner 2.7.0` "triggers" optimization.
+- `built_value` will now only run in libraries that directly import
+  `package:built_value/built_value.dart` or use an annotation called
+  `@SerializersFor`. Other files will be quickly skipped and show in
+  `build_runner` output as "not triggered" or "skipped".
+- If you need to run `built_value` on other source files, see
+  https://pub.dev/packages/build_config#triggers for how to configure your own
+  additional triggers for `built_value`.
+
+# 8.11.2
+
+- Require `analyzer ^8.0.0`.
+- Allow `built_value_generator` to use `build 4.0.0`.
+- Allow `built_value_generator` to use `source_gen 4.0.0`.
+
+# 8.11.1
+
+- Allow `built_value_generator` to use `analyzer 8.0.0`.
+
+# 8.11.0
+
+- Use `build ^3.0.0`.
+- Use `source_gen ^3.0.0`.
+
+# 8.11.0-dev
+
+- Use `build ^3.0.0-dev`.
+- Use `source_gen ^3.0.0-dev`.
+
+# 8.10.1
+
+- Add mutable collection serializers so `built_value` can serialize `List`,
+  `Set` and `Map`. It's still recommended to avoid mutable collections inside
+  value types as they break hashing, comparison and caching; the intended use
+  case is that you have one top level mutable collection of your immutable
+  value types.
+
+# 8.10.0
+
+- Stop generating unnecessary `new` keywords.
+- Stop generating explicit null checks in constructors: these are not needed
+  with sound null safety.
+- Stop generating checks for `dynamic` in generics in constructors: accidental
+  use of `dynamic` is better avoided with lints than a runtime check.
+
+# 8.9.5
+
+- Allow `built_value_generator` to use `analyzer 7.0.0`.
+
+# 8.9.4
+
+- Allow `built_value_generator` to use `source_gen 2.0.0`.
+
+# 8.9.3
+
+- Generate code that formats faster with current "short" style. Both versions
+  are fast with the coming "tall" style.
+- Mark `@nullable` deprecated: it does nothing and should not be used.
+
+# 8.9.2
+
+- Improve build performance when there are lots of `built_value` classes.
+
+# 8.9.1
+
+- Fix for new warning about `operator==` param type.
+
+# 8.9.0
+
+- In `StandardJsonPlugin`, add support for specifying types that should be left
+  as `List`.
+- Allow non alphanumeric characters in `EnumClass` names.
+
+# 8.8.1
+
+- Fix codegen for enum wire keys when there is a `$` in the field name.
+- Remove support for generating legacy (<2.12) Dart code.
+
+# 8.8.0
+
+- Allow classes with record fields to be serialized if they use a typedef for
+  the record type and install a custom `Serializer` for it.
+
+# 8.7.0
+
+- Add `Int32` serializer.
+
+# 8.6.3
+
+- Bump version of `analyzer`.
+
+# 8.6.2
+
+- Remove JSON from `DeserializationError` message to prevent data accidentally
+  leaking into logs. The JSON is still available on the `DeserializationError`
+  object.
+- Fix generation for fields that are `Function` types that are declared
+  separately, for example in a `mixin` defined in another source file, and use
+  named or positional parameters.
+
+# 8.6.1
+
+- Fix support for generating enum mixins for Dart 3. Instead of triggering
+  mixin generation with `abstract class TestEnumMixin = Object with
+  _$TestEnumMixin` it must now be triggered with `typedef TestEnumMixin =
+  _$TestEnumMixin`.
+
+# 8.6.0
+
+- Add support for value types with record fields. Serialization with records
+  is not yet supported.
+- Fix generator failure due to top level record field.
+- Migrate benchmark and examples to null safety.
+- Remove pre-null-safe test cases.
+- Remove analyzer plugin.
+- Remove reference to `@nullable` annotation from failure-to-instantiate
+  message.
+
+# 8.5.0
+
+- Add `Uint8ListSerializer`.
+- Generate Dart-3-compatible code if needed.
+- Stop using deprecated analyzer API.
+- Fix codegen for optional fields with `$` in the name.
+
+# 8.4.4
+
+- Increase minimum version of `analyzer`.
+- Fix generation with the type `Never`.
+
+# 8.4.3
+
+- Fix generated deserialization code when there is a manually written builder
+  with nullable fields.
+- Drop dev dependency on `quiver`.
+- Disable all linting of generated code.
+- Change generated hash code implementation so it formats better when there are
+  many fields.
+
+# 8.4.2
+
+- Prepare for breaking analyzer changes.
+- Bump version of `analyzer`.
+
+# 8.4.1
+
+- Bump version of `analyzer`.
+
+# 8.4.0
+
+- Fix custom builders in null safe code: allow nested builder fields to be
+  nullable.
+- Improve custom builders for null safe code: allow abstract setter/getter
+  pairs instead of fields. This allows nested builders to have a setter that
+  accepts `null` and a getter that guarantees not to return `null`, which is
+  what auto instantiation of nested builders already provides.
+- Allow use of super field initialization in `EnumClass`.
+
+# 8.3.3
+
+- Fix erroneously generated null check for fields with generic bounds.
+
+# 8.3.2
+
+- Migrate `built_value_test` to null safety.
+
+# 8.3.1
+
+- Fix generation support for optional generic bounds, e.g. 
+  `class Foo<T extends Object?>`.
+- Fix generation for classes with names starting `$`.
+- Ignore lint `unnecessary_lambdas` in generated code.
+
+# 8.3.0
+
+- Change generated `build` methods to return only public types, creating
+  `_build` methods that return the generated impl types. This means dartdoc
+  will no longer reference the generated types.
+- Ignore the `no_leading_underscores_for_local_identifiers` lint in generated
+  code.
+- Migrated `built_value_generator` to null safety. This is purely an internal
+  change, the generator can still generate legacy code as and when needed.
+
+# 8.2.3
+
+- Bug fix: fix a corner case with generics that had incorrect serializer generation.
+
+# 8.2.2
+
+- Bug fix: remove a `print` from the enum generator.
+
+# 8.2.1
+
+- Fix deps: allow `built_value_generator` to use `built_value 8.2.0`.
+
+# 8.2.0
+
+- Allow writing final parameters in EnumClass constructor and valueOf method.
+- Make generator output additional explicit null checks so the generated code complies with the `cast_nullable_to_non_nullable` lint.
+- Bump version of `analyzer`.
+
+# 8.1.4
+
+- Bump version of `analyzer`.
+
+# 8.1.3
+
+- Bump version of `analyzer`, fix deprecation warnings.
+
+# 8.1.2
+
+- Bump version of `analyzer`.
+
+# 8.1.1
+
+- Bug fix: allow constructors to have annotations. Previously, annotations
+  would cause codegen to fail.
+
+# 8.1.0
+
+New features:
+
+- Add `@BuiltValueHook` annotation. It provides the same functionality as
+  `_initializeBuilder` and `_finalizeBuilder`, but in a more visible way:
+  annotate a static method on the value class with `@BuiltValueHook` to
+  have it called on builder creation or finalization.
+- Add back `serializeNulls` to `BuiltValueSerializer` annotation. By default
+  generated serializers skip null fields instead of writing them; set
+  `serializeNulls` to write the nulls.
+
+New minor functionality:
+
+- Support use of nulls in collections when the key or value types are
+  explicitly nullable.
+- Allow `JsonObject` to be instantiated from a `Map<dynamic, dynamic>`.
+- Mark nested builder getters in `instantiable: false` classes not nullable,
+  to match the implementations. Use `autoCreateNestedBuilders: false` to get
+  the old behaviour.
+- Allow explicit nulls in JSON for nullable fields when deserializing.
+- Specify annotation targets; the analyzer will now hint if a `built_value`
+  annotation is used where it has no effect.
+- Support polymorphism with mixed in parent value type: generated builder
+  now mixes in parent builder.
+
+Bug fixes:
+
+- Fix support for serializing and deserializing nulls.
+- Fix `nestedBuilders: false` with `instantiable: false`.
+- Fix enum deserialization fallback for `int`.
+- Annotating a wrong type getter with `@SerializersFor` is now an error,
+  instead of just generating nothing.
+
+Cleanup:
+
+- Removed Angular mixin from example, as this feature is no longer needed:
+  Angular now directly supports using static members in templates.
+
+# 8.0.6
+
+- Bump versions of `build_config` and `build_runner`.
+
+# 8.0.5
+
+- Bump version of `analyzer`.
+
+# 8.0.4
+
+- Bump version of `source_gen`.
+
+# 8.0.3
+
+- Fix error message for builder factory not installed.
+- Bump version of `build`.
+
+# 8.0.2
+
+- Bump versions of `analyzer`, `quiver`.
+
+# 8.0.1
+
+- Update `chat` example to webdev.
+- Allow nulls when serializing/deserializing for better JSON interop.
+- Fix generation bugs around enum wire name and polymorphism.
+- Fix generation with generics for analysis with `strict-raw-types`.
+- Add test coverage around generation for generic serialization.
+- Add test coverage around initialization with generics.
+
+# 8.0.0
+
+- Stable null safe release.
+- Add `toJson` and `fromJson` convenience methods to `Serializers`.
+
+# 8.0.0-nullsafety.0
+
+- Migrate to NNBD.
+- Remove dependency on `package:quiver`.
+- Remove support for serializing nulls using
+  `BuiltValueSerializer(serializeNulls: true)`.
+- Make installed plugins public in `Serializers` as `serializerPlugins`.
+- `@memoized` fields can now memoize `null`; previously, nulls would not be
+  cached, causing the computation to rerun.
+
+# 7.1.1
+
+- Support analyzer `^0.40.0`.
+- Workaround https://github.com/google/built_value.dart/issues/941.
+
+# 7.1.0
+
+- Support private `Built` classes. Note that private classes cannot be made
+  serializable.
+- Support serializing enums to ints: add `wireNumber` to
+  `@BuiltValueEnumConst`.
+- Support memoizing `hashCode`, so it's computed lazily once. Write an abstract
+  getter `int get hashCode;` then annotate it with `@memoized` to turn this on
+  for a `built_value` class.
+- Trim `built_value_test` dependencies: depend on `matcher` instead of `test`.
+- Fix enum generator error messages when `value` and `valueOf` are missing.
+
+# 7.0.9
+
+- Fix unescaped string usages while generating `ValueSourceClass`.
+- Fix analyzer use: don't rely on `toString` on types.
+
+# 7.0.8
+
+- Fix `analyzer` lower bound: was `0.39.0`, needs to be `0.39.3`.
+
+# 7.0.7
+
+- Fix regression in a corner case when determining which fields to generate
+  based on mixins.
+- Tweak generation changes for `implicit-casts: false` and
+  `implicit-dynamic: false`. Relax casts again where possible.
+
+# 7.0.6
+
+- Make generated code comply with analyzer option `strict-raw-types`.
+- Allow `Serialiers` declaration to comply with `strict-raw-types`, or to
+  continue to use raw types as before.
+- Make generated code comply with analyzer options `implicit-casts: false`
+  and `implicit-dynamic: false`.
+
+# 7.0.5
+
+- Internal: fix analyzer deprecation warnings.
+
+# 7.0.4
+
+- Split analysis plugin out into new package, `built_value_analyzer_plugin`.
+  Bump `built_value_generator` dependency on `analyzer` to `0.39.0` so it
+  supports extension methods.
+
+# 7.0.3
+
+- Add `example` folders with `README.md` pointing to examples.
+
+# 7.0.2
+
+- Internal: cleanup for pedantic v1.9.0 lints.
+
+# 7.0.1
+
+- Internal: cleanup for pedantic v1.9.0 lints.
+
+# 7.0.0
+
+- Internal: clean up `built_value_generator` -> `built_value` dependency;
+  depend on minor instead of major version so we can in future handle tight
+  coupling between the two without a major version bump to `built_value`.
+
+# 6.8.2
+
+- Fix `_finalizeBuilder` generation so it uses the correct class name.
+
+# 6.8.1
+
+- Fix missing `README.md` in `package:built_value`.
+
+# 6.8.0
+
+- Support `_initializeBuilder` hook in value types. If found, it's executed
+  when a `Builder` is created and can be used to set defaults.
+- Support `_finalizeBuilder` hook in value types. If found, it's executed
+  when `build` is called and can be used to apply processing to fields.
+- Add `defaultCompare` and `defaultSerialize` to `@BuiltValue`. They
+  control the defaults for `compare` and `serialize` in `@BuiltValueField`.
+- Add facility to merge `Serializers` instances via `Serializers.merge`,
+  `SerializersBuilder.merge` and `SerializersBuilder.mergeAll`.
+- Bug fix: fix generated code with polymorphism and more than one level of
+  non-instantiable classes.
+- Bug fix: fix generated `operator==` when a field is called `other`.
+- Fix `num` deserialization so it does not always convert to `double`.
+- Bump version of `analyzer`.
+- Internal: replace analyzer's `DartType.displayName` with custom code
+  generator.
+
+# 6.7.1
+
+- Fix codegen for custom builders when fields use types that have an import
+  prefix.
+- Bump version of `analyzer_plugin`.
+
+# 6.7.0
+
+- Generate code compatible with 'no raw types'.
+
+# 6.6.0
+
+- Allow providing your own `toString` via a mixin.
+- Fix `BuiltValueSerializer(serializeNulls: true)` for non-primitive fields.
+- Stop using old analyzer API; require analyzer `0.34.0`.
+
+# 6.5.0
+
+- Add `Iso8601DurationSerializer` for use when you want ISO8601 serialization
+  instead of the default microseconds serialization.
+- Bump versions of `analyzer`, `analyzer_plugin` and `build_config`.
+
+# 6.4.0
+
+- Add `@BuiltValue(generateBuilderOnSetField: true)` which provides a way to
+  listen for `set` calls on generated builders.
+- Add `@BuiltValueEnumConst(fallback: true)` as a way to mark an enum const
+  as the fallback when `valueOf` or deserialization fails.
+- Add `@BuiltValueSerializer(serializeNulls: true` as a way to modify the wire
+  format to explicitly contain `null` values.
+- Make it possible to merge `Serializers` instances: add a `builderFactories`
+  getter that returns installed builder factories.
+- Use new `Function` syntax everywhere.
+- Bug fix: only generate builder factories for fields that are `Built`
+  types or `built_collection` collections.
+
+# 6.3.2
+
+- Allow `analyzer` 0.35.0.
+
+# 6.3.1
+
+- Fix `BuiltList` serialization when using `StandardJsonPlugin` with
+  unspecified type and when list length is 1.
+
+# 6.3.0
+
+- Allow custom builders to use setter/getter pairs instead of normal fields.
+- Add an option to `@BuiltValue` to turn off auto instantiation of nested
+  builders.
+- Add `@BuiltValueSerializer` annotation which gives the option to specify a
+  custom serializer for a class.
+- Make it possible to merge `Serializers` instances: add a `serializers`
+  getter that returns the installed serializers.
+- Add serializer for `RegExp` fields.
+- Allow `analyzer` 0.34.0.
+
+# 6.2.0
+
+New features:
+
+- Add an option to `@BuiltValue` to generate comparable builders.
+- Add serializer for `Duration` fields.
+- Add `serializerForType` and `serializerForWireName` methods to `Serializers`.
+
+Improvements:
+
+- Add ignore for `avoid_as` lint to generated code.
+- Put ignored lints on a single line at the end of the generated output.
+- Stop checking for import of `built_value.dart` when `EnumClass` is used; this
+  was expensive.
+
+Fixes:
+
+- Fix tests following changes to source_gen error output.
+- Fix generation when new `mixin` declarations are used.
+- Support dollar signs in enum value names.
+- Fix nested collections when using a custom builder.
+
+# 6.1.6
+
+- Switch to new analyzer API in version `0.33.3`.
+
+# 6.1.5
+
+- Bump versions of `analyzer`, `analyzer_plugin`, `build`, `build_runner`.
+
+# 6.1.4
+
+- Allow polymorphic base classes to omit implementing `Built` while still
+  implementing any other interface(s).
+- Allow the dollar character in `wireName` settings.
+- Allow `build` version 1.0.
+
+# 6.1.3
+
+- Add `built_value_test` support for remaining built collections.
+
+# 6.1.2
+
+- Fix generated `operator==` when a type uses generic functions.
+- Fix generated code for `curly_braces_in_control_flow` lint.
+
+# 6.1.1
+
+- Allow `build_runner` 0.10.0.
+
+# 6.1.0
+
+- Improve generation for `operator==`, don't use `dynamic`.
+- Improve error message and documentation for missing builder factory.
+- Allow built_collection 4.0.0.
+- Fix code generation stack overflow when there is a loop in serializable
+  types.
+- Fix library name output in generation error messages.
+- Add ignores for lints 'unnecessary_const' and 'unnecessary_new' to generated
+  code.
+
+# 6.0.0
+
+- Update to the latest `source_gen`. This generator can now be used with other
+  generators that want to write to `.g.dart` files without a manual build
+  script.
+- Breaking change: The "header" configuration on this builder is now ignored.
+
+# 5.5.5
+
+- Allow SDK 2.0.0.
+
+# 5.5.4
+
+- Add ignores for lints 'lines_longer_than_80_chars' and
+  'avoid_catches_without_on_clauses' to generated code.
+- Bump version of quiver.
+
+# 5.5.3
+
+- Bump versions of build_runner, build_config and shelf.
+
+# 5.5.2
+
+- Fix violations of `prefer_equal_for_default_values` lint.
+
+# 5.5.1
+
+- Bump versions of `analyzer`, `analyzer_plugin`.
+
+# 5.5.0
+
+- Support serializing `BuiltSet` with `StandardJsonPlugin`. It's serialized to
+  a JSON list.
+- Add `Iso8601DateTimeSerializer` for use when you want ISO8601 serialization
+  instead of microseconds since epoch.
+- Fix code generation when inherited generic fields are made non-generic.
+
+# 5.4.5
+
+- Improve error message on failure to deserialize.
+- Move check forbidding instantiation with `dynamic` type parameters from
+  builder to value class. Previously, you could avoid the check by using the
+  generated constructor called `_`.
+
+# 5.4.4
+
+- Removed dependency on `build_config` from `built_value` and added it to
+  `built_value_generator`.
+
+# 5.4.3
+
+- Allow source_gen 0.8.0.
+
+# 5.4.2
+
+- Make `StandardJsonPlugin` return `Map<String, Object>`, as the firebase
+  libraries expect, instead of `Map<Object, Object>`.
+
+# 5.4.1
+
+- Fix analyzer plugin loading. It should now work, provided you modify your
+  `analysis_options.yaml` as suggested.
+
+# 5.4.0
+
+- Add an experimental analyzer plugin that surfaces compile time generation
+  errors as suggestions in your IDE. Turn it on by modifying your
+  `analysis_options.yaml` file to add `plugins` entries,
+  [example](https://github.com/google/built_value.dart/blob/master/analysis_options.yaml).
+
+# 5.3.0
+
+- Support serializing `BigInt`.
+- Add support for setting the generated header in a `build.yaml` file in your
+  project. See `example/build.yaml` for an example.
+- Explicitly forbid serialization of `Function` and `typedef` types; these
+  fields need to be marked `@BuiltValueField(serialize: false)`.
+- Fix generation when a field picked up via inheritance is a function type
+  defined in another source file.
+- Fail with a helpful error message if `@SerializersFor` annotation list
+  contains an undefined symbol.
+
+# 5.2.2
+
+- Fix built_value_generator/build.yaml to run generator on self package.
+- Fix end_to_end_test/pubspec.yaml to include build_runner.
+- Fix internal use of deprecated SDK constants.
+- Remove polymorphism examples that no longer work in Dart 2. Proper fix to come.
+- Allow quiver 0.29.
+
+# 5.2.1
+
+- Type fixes for DDC.
+
+# 5.2.0
+
+- Upgrade to latest `built_runner`. You no longer need `build.dart` or
+  `watch.dart`. Instead, make sure you have a dev dependency on
+  `built_value_generator` and `build_runner`, then run
+  `pub run build_runner build` or `pub run build_runner watch`.
+- Note: this version requires the pre release of the Dart 2 SDK.
+
+# 5.1.3
+
+- Generate simpler deserialization code for `built_collection` instances.
+
+# 5.1.2
+
+- Fix generated serialization code when a manually declared builder causes
+  a field to not use a nested builder.
+
+# 5.1.1
+
+- Workaround for analyzer issue when `implement`ing multiple classes that
+  use `@BuiltValue(instantiable: false)`.
+
+## 5.1.0
+
+- Relax restriction on `extends` to allow for one special case: sharing of
+  code between `built_value` and `const` classes. The base class in question
+  must be abstract, have no fields, have no abstract getters and must not
+  implement `operator==`, `hashCode` or `toString`.
+
+## 5.0.1
+
+- Allow quiver 0.28.
+
+## 5.0.0
+
+Introduce restrictions on using `built_value` in unsupported ways:
+
+- Prohibit use of `extends` in `built_value` classes. Classes should inherit
+  API using `implements` and API+implementation using `extends Object with`.
+- Prohibit use of `show` or `as` when importing
+  'package:built_value/built_value.dart'. The generated code needs access to
+  all symbols in the package with no import prefix.
+- Prohibit use of the mutable collection types `List`, `Set`, `Map`,
+  `ListMultimap` and `SetMultimap`. Suggest `built_collection` equivalents
+  instead.
+
+If any of these restrictions causes problem for you, please file an issue
+on github: https://github.com/google/built_value.dart/issues
+
+## 4.6.1
+
+- Allow hand-coded base builders, that is, builders for classes with
+  `@BuiltValue(instantaible: false)`. They are now allowed to not
+  implement `Builder` (as a workaround for a dart2js issue); they are
+  allowed to omit fields; and they must omit constructor and factory.
+
+## 4.6.0
+
+- Add custom `Error` classes: `BuiltValueNullFieldError`,
+  `BuiltValueMissingGenericsError` and `BuiltValueNestedFieldError`. These
+  provide clearer error messages on failure. In particular, errors in nested
+  builders now report the enclosing class and field name, making them much
+  more useful.
+- Fix serialization when using polymorphism with StandardJsonPlugin.
+
+## 4.5.2
+
+- Allow built_collection 3.0.0.
+- Allow quiver 0.27.
+
+## 4.5.1
+
+- Fix generation when analyzing using summaries.
+
+## 4.5.0
+
+New features:
+
+- Add `serialize` field to `@BuiltValueField`. Use this to tag fields to skip
+  when serializing.
+- Add `wireName` field to `@BuiltValue` and `@BuiltValueField`. Use this to
+  override the wire name for classes and fields when serializing.
+- Add `@BuiltValueEnum` and `@BuiltValueEnumConst` annotations for specifying
+  settings for enums. Add `wireName` field to these to override the wire names
+  in enums when serializing.
+- Add support for polymorphism to `StandardJsonPlugin`. It will now specify
+  type names as needed via a `discriminator` field, which by defualt is
+  called `$`. This can be changed in the `StandardJsonPlugin` constructor.
+- Add `BuiltListAsyncDeserializer`. It provides a way to deserialize large
+  responses without blocking, provided the top level serialized type is
+  `BuiltList`.
+- Add built in serializer for `Uri`.
+
+Improvements:
+
+- Allow declaration of multiple `Serializers` in the same file.
+- Explicitly disallow private fields; fail with an error during generation if
+  one is found.
+- Improve error message for field without type.
+
+Fixes:
+
+- Fix generated builder when fields hold function types.
+- Fix checks and generated builder when manually maintained builder has
+  generics.
+- Fix name of classes generated from a private class.
+- Fix builder and serializer generation when importing with a prefix.
+
+## 4.4.1
+
+- Use build 0.11.1 and build_runner 0.6.0.
+
+## 4.4.0
+
+- New annotation, `BuiltValueField`, for configuring fields. First
+  setting available is `compare`. Set to `false` to ignore a particular field
+  for `operator==` and `hashCode`.
+- Generator now has a `const` constructor.
+
+## 4.3.4
+
+- Fix for built_collection 2.0.0.
+
+## 4.3.3
+
+- Allow quiver 0.26.
+
+## 4.3.2
+
+- Fix generation when a field is found via two levels of inheritance.
+
+## 4.3.1
+
+- Fix generation when a field comes from an interface but is also implemented
+  by a mixin.
+
+## 4.3.0
+
+- Support serializing Int64.
+
+## 4.2.1
+
+- Correct handling of import prefixes; fixes some corner cases in
+  generation.
+
+## 4.2.0
+
+- Generated code ignores more lints.
+- Add a workaround so "polymorphism" features can be used with dart2js.
+  See example/lib/polymorphism.dart.
+- Deal explicitly with the user defining their own operator==, hashCode
+  and/or toString(). Previously, they would just not work. Now, custom
+  operator== and hashCode are forbidden at compile time, but custom
+  toString() is supported.
+
+## 4.1.1
+
+- Generated code now tells the analyzer to ignore
+  prefer_expression_function_bodies and sort_constructors_first.
+- Remove an unneeded use of computeNode in generator; improves generator
+  performance.
+
+## 4.1.0
+
+- Improved annotation handling for corner cases.
+- Pick up field declarations from mixins as well as interfaces.
+
+## 4.0.0
+
+- Fix generated polymorphic builders for the analyzer. Mark the `rebuild`
+  method with `covariant` so the analyzer knows that, for example, a
+  `CatBuilder` cannot accept an `Animal`.
+- Update to build 0.10.0 and build_runner 0.4.0. Please update your
+  `build.dart` and `watch.dart` as shown in the examples.
+
+## 3.0.0
+
+- Fix DateTime serialization; include microseconds. This is a breaking change
+  to the JSON format.
+- Add SerializersFor annotation. Classes to serialize are no longer found by
+  scanning all available libraries, as this was slow and hard to control.
+  Instead, specify which classes you need to serialize using the new
+  annotation on your "serializers" declaration. You only need to specify the
+  "root" classes; the classes needed for the fields of classes you specify
+  are included, transitively.
+
+## 2.1.0
+
+- Add "nestedBuilders" setting. Defaults to true; set to false to stop
+  using nested builders by default in fully generated builders.
+- Allow fields to be called 'result'.
+- Fix generation when a field is a noninstantiable built value: don't try to
+  instantiate the abstract builder.
+
+## 2.0.0
+
+- Update to source_gen 0.7.0.
+- Please make the following trivial update to your `build.dart` and
+  `watch.dart`: replace the string `GeneratorBuilder` with `PartBuilder`.
+
+## 1.2.1
+
+- Fix generated code when implementing generic non-instantiable Built class.
+
+## 1.2.0
+
+- Fix depending on a fully generated builder from a manually maintained builder.
+- Pick up fields on implemented interfaces, so you don't have to @override them.
+- Add BuiltValue annotation for specifying settings.
+- Add "instantiable" setting. When false, no implementation is generated, only
+  a builder interface.
+- Polymorphism support: you can now "implement" a non-instantiable Built class.
+  The generated builder will implement its builder, so the types all work.
+
+## 1.1.4
+
+- Require SDK 1.21 and use the non-comment syntax for generics again.
+
+## 1.1.3
+
+- Removed dependency on now-unneeded package:meta.
+- Fixed a few lints/hints in enum generated code.
+- Use comment syntax for generics; using the non-comment syntax requires
+  SDK 1.21 which is not specified in pubspec.yaml.
+
+## 1.1.2
+
+- Significantly improve build performance by using @memoized instead of
+  precomputed fields.
+
+## 1.1.1
+
+- Update analyzer and build dependencies.
+
+## 1.1.0
+
+- Add "built_value_test" library. It provides a matcher which gives good
+  mismatch messages for built_value instances.
+
+## 1.0.1
+
+- Allow quiver 0.25.
+
+## 1.0.0
+
+- Version bump to 1.0.0. Three minor features are marked as experimental and
+  may change without a major version increase: BuiltValueToStringHelper,
+  JsonObject and SerializerPlugin.
+- Made toString() output customizable.
+- Made the default toString() output use indentation and omit nulls.
+- Sort serializers in generated output.
+
+## 0.5.7
+
+- Ignore nulls when deserializing with StandardJsonPlugin.
+
+## 0.5.6
+
+- Add serializer for "DateTime" fields.
+- Add JsonObject class and serializer.
+- Add convenience methods Seralizers.serializeWith and deserializeWith.
+- Add example for using StandardJsonPlugin.
+- Support serializing NaN, INF and -INF for double and num.
+
+## 0.5.5
+
+- Add serializer for "num" fields.
+- Better error message for missing serializer.
+- Fix generation when there are nested multi-parameter generics.
+- Use cascades in generated code as suggested by lint.
+- Allow users to define any factory that references the generated
+  implementation.
+- Add example of a simpler factory for a one-field class.
+
+## 0.5.4
+
+- Enforce that serializer declarations refer to the right generated name.
+- Streamline generation for classes with no fields.
+- Add identical check to generated operator==.
+- Make generated code compatible with strong mode implicit-dynamic:false
+  and implicit-cast:false.
+
+## 0.5.3
+
+- Add null check to generated builder "replace" methods.
+- Fail with error on abstract enum classes.
+- Update to `build` 0.7.0 , `build_runner` 0.3.0, and `build_test` 0.4.0.
+
+## 0.5.2
+
+- Support "import ... as" for field types.
+
+## 0.5.1
+
+- Add @memoized. Annotate getters on built_value classes with @memoized
+  to memoize their result. That means it's computed on first access then
+  stored in the instance.
+- Support generics, in value types and in serialization.
+- Add support for "standard" JSON via StandardJsonPlugin.
+
+## 0.5.0
+
+- Update dependency on analyzer, build, quiver.
+- Breaking change: your build.dart and watch.dart now need to import
+  build_runner/build_runner.dart instead of build/build.dart.
+
+## 0.4.3
+
+- Fix builder getters to be available before a set is used.
+
+## 0.4.2
+
+- Fix lints.
+- Allow "updates" in value type factory to have explicit void return type.
+
+## 0.4.1
+
+- Fix some analyzer hints.
+- Fix exception from serializer generator if builder field is incorrect.
+
+## 0.4.0
+
+- Add benchmark for updating deeply nested data structures.
+- Make builders copy lazily. This makes updates to deeply nested structures
+  much faster: only the classes on the path to the update are copied, instead
+  of the entire tree.
+- Breaking change: if you hand-code the builder then you must mark the fields
+  @virtual so they can be overriden in the generated code.
+- Auto-create nested nullable builders when they're accessed. Fixes
+  deserialization with nested nullable builder.
+
+## 0.3.0
+
+- Merged built_json and built_json_generator into built_value and
+  built_value_generator. These are intended to be used together, and make
+  more sense as a single package.
+- Fix generation when class extends multiple interfaces.
+- Add serialization of BuiltListMultimap and BuiltSetMultimap.
+
+## 0.2.0
+
+- Merged enum_class and enum_class_generator into built_value and
+  built_value_generator. These are intended to be used together, and make
+  more sense as a single package.
+
+## 0.1.6
+
+- Add checking for correct type arguments for Built and Builder interfaces.
+- Generate empty constructor with semicolon instead of {}.
+- Use ArgumentError.notNull for null errors.
+- Reject dynamic fields.
+- Add simple benchmark for hashing. Improve hashing performance.
+
+## 0.1.5
+
+- Allow quiver 0.23.
+
+## 0.1.4
+
+- Upgrade analyzer, build and source_gen dependencies.
+
+## 0.1.3
+
+- Generate builder if it's not written by hand.
+- Make toString append commas for improved clarity.
+- Improve examples and tests.
+- Fix double null checking.
+
+## 0.1.2
+
+- Refactor generator to split into logical classes.
+
+## 0.1.1
+
+- Improve error output on failure to generate.
+
+## 0.1.0
+
+- Upgrade to source_gen 0.5.0.
+- Breaking change; see example for required changes to build.dart.
+
+## 0.0.6
+
+- Move null checks to "build" method for compatibility with Strong Mode
+  analyzer.
+- Allow (and ignore) setters.
+- Allow custom factories on value classes.
+
+## 0.0.5
+
+- Fix for changes to analyzer library.
+
+## 0.0.4
+
+- Support @nullable for fields using builders.
+- Fix constraints for source_gen.
+
+## 0.0.3
+
+- Allow static fields in value class.
+- Allow custom setters in builder.
+
+## 0.0.2
+
+- Fix error message for missing builder class.
+- Allow non-abstract getters in value class.
+
+## 0.0.1
+
+- Generator, tests and example.

--- a/built_types/CHANGELOG.md
+++ b/built_types/CHANGELOG.md
@@ -619,8 +619,7 @@ Fixes:
 
 - Add an experimental analyzer plugin that surfaces compile time generation
   errors as suggestions in your IDE. Turn it on by modifying your
-  `analysis_options.yaml` file to add `plugins` entries,
-  [example](https://github.com/google/built_value.dart/blob/master/analysis_options.yaml).
+  `analysis_options.yaml` file to add `plugins` entries.
 
 # 5.3.0
 

--- a/built_types/CONTRIBUTING.md
+++ b/built_types/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+Want to contribute? Great! First, read this page (including the small print at
+the end).
+
+### Before you contribute
+Before we can use your code, you must sign the
+[Google Individual Contributor License Agreement](https://cla.developers.google.com/about/google-individual)
+(CLA), which you can do online. The CLA is necessary mainly because you own the
+copyright to your changes, even after your contribution becomes part of our
+codebase, so we need your permission to use and distribute your code. We also
+need to be sure of various other things—for instance that you'll tell us if you
+know that your code infringes on other people's patents. You don't have to sign
+the CLA until after you've submitted your code for review and a member has
+approved it, but you must do it before we can put your code into our codebase.
+
+Before you start working on a larger contribution, you should get in touch with
+us first through the issue tracker with your idea so that we can help out and
+possibly guide you. Coordinating up front makes it much easier to avoid
+frustration later on.
+
+### Code reviews
+All submissions, including submissions by project members, require review. We
+use Github pull requests for this purpose.
+
+### File headers
+All files in the project must start with the following header.
+
+    // Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+    // All rights reserved. Use of this source code is governed by a BSD-style
+    // license that can be found in the LICENSE file.
+
+### The small print
+Contributions made by corporations are covered by a different agreement than the
+one above, the
+[Software Grant and Corporate Contributor License Agreement](https://developers.google.com/open-source/cla/corporate).

--- a/built_types/LICENSE
+++ b/built_types/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2015, Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/built_types/README.md
+++ b/built_types/README.md
@@ -1,0 +1,282 @@
+[![Build](https://github.com/google/built_value.dart/actions/workflows/build.yaml/badge.svg)](https://github.com/google/built_value.dart/actions/workflows/build.yaml)
+
+## Built Values for Dart - Introduction
+
+Built Value provides:
+
+- Immutable value types;
+- EnumClass, classes that behave like enums;
+- JSON serialization.
+
+Immutable collections are from
+[built_collection](https://github.com/google/built_collection.dart#built-collections-for-dart).
+
+See the [API docs](https://pub.dev/documentation/built_value/latest/built_value/built_value-library.html).
+
+## Articles
+
+- [`built_value` for Immutable Object Models](https://medium.com/@davidmorgan_14314/darts-built-value-for-immutable-object-models-83e2497922d4#.48dyezxcl)
+- [`built_value` for Serialization](https://medium.com/@davidmorgan_14314/darts-built-value-for-serialization-f5db9d0f4159#.h12y94wu7)
+- [Building a Chat App in Dart](https://medium.com/@davidmorgan_14314/building-a-chat-app-in-dart-815fcd0e5a31#.ku4vtbmk2)
+- [End to End Testing in One Short Second with Dart](https://medium.com/@davidmorgan_14314/end-to-end-testing-in-one-short-second-with-dart-e699c8146fd6#.c7xfxohg4)
+- [Moving Fast with Dart Immutable Values](https://medium.com/@davidmorgan_14314/moving-fast-with-dart-immutable-values-1e717925fafb)
+- [Flutter JSON Serialization](https://aloisdeniel.github.io/flutter-json-serialization/)
+- [Flutter TODO App Example](https://gitlab.com/brianegan/flutter_architecture_samples/tree/master/example/built_redux)
+  using `built_value`, [built_redux](https://pub.dev/packages/built_redux), and [flutter_built_redux](https://pub.dev/packages/flutter_built_redux)
+- [Building a (large) Flutter app with Redux](https://hillelcoren.com/2018/06/01/building-a-large-flutter-app-with-redux/)
+- [Some Options for Deserializing JSON with Flutter](https://medium.com/flutter-io/some-options-for-deserializing-json-with-flutter-7481325a4450)
+
+## Tutorials
+
+ - [Custom Serializers](https://medium.com/@solid.goncalo/creating-custom-built-value-serializers-with-builtvalueserializer-46a52c75d4c5)
+ - [Flutter + built_value + Reddit Tutorial](https://steemit.com/utopian-io/@tensor/building-immutable-models-with-built-value-and-built-collection-in-dart-s-flutter-framework);
+   [video](https://www.youtube.com/watch?v=hNbOSSgpneI);
+   [source code](https://github.com/tensor-programming/built_flutter_tutorial)
+
+## Tools
+
+ - [Json to Dart built_value class converter](https://charafau.github.io/json2builtvalue/)
+ - [Json or js Object to Dart built_value class converter](https://januwa.github.io/p5_object_2_builtvalue/index.html)
+- [VSCode extension](https://marketplace.visualstudio.com/items?itemName=GiancarloCode.built-value-snippets)
+ - [IntelliJ plugin](https://plugins.jetbrains.com/plugin/13786-built-value-snippets)
+
+## Examples
+
+For an end to end example see the
+[chat example](https://github.com/google/built_value.dart/tree/master/chat_example), which was
+[demoed](https://www.youtube.com/watch?v=TMeJxWltoVo) at the Dart Summit 2016.
+The
+[data model](https://github.com/google/built_value.dart/blob/master/chat_example/lib/data_model/data_model.dart),
+used both client and server side, uses value types, enums and serialization from
+built_value.
+
+Simple examples are
+[here](https://github.com/google/built_value.dart/tree/master/example/lib/example.dart).
+
+## Codegen
+
+Codegen is done using `dart run build_runner build` for one-off builds. 
+
+To continuously watch your source and update the generated output when it changes, use `dart run build_runner watch`.
+
+Note that you need a dev dependency on `built_value_generator` and `build_runner`. See the example
+[pubspec.yaml](https://github.com/google/built_value.dart/blob/master/example/pubspec.yaml).
+
+## Value Types
+
+Value types are, for our purposes, classes that are considered
+interchangeable if their fields have the same values.
+
+Common examples include `Date`, `Money` and `Url`. Most code introduces
+its own value types. For example, every web app probably has some
+version of `Account` and `User`.
+
+Value types are very commonly sent by RPC and/or stored for later
+retrieval.
+
+The problems that led to the creation of the Built Value library have
+been
+[discussed at great length](https://docs.google.com/presentation/d/14u_h-lMn7f1rXE1nDiLX0azS3IkgjGl5uxp5jGJ75RE/edit)
+in the context of
+[AutoValue](https://github.com/google/auto/tree/master/value#autovalue)
+for Java.
+
+In short: creating and maintaining value types by hand requires a lot of
+boilerplate. It's boring to write, and if you make a mistake, you very
+likely create a bug that's hard to track down.
+
+Any solution for value types needs to allow them to participate in object
+oriented design. `Date`, for example, is the right place for code that
+does simple date manipulation.
+
+[AutoValue](https://github.com/google/auto/tree/master/value#autovalue)
+solves the problem for Java with code generation, and Built Values does
+the same for Dart. The boilerplate is generated for you, leaving you to
+specify which fields you need and to add code for the behaviour of the
+class.
+
+### Generating boilerplate for Value Types
+
+Value types require a bit of boilerplate in order to connect it to generated
+code. Luckily, even this bit of boilerplate can be automated using code
+snippets support in your favourite text editor. For example, in IntelliJ you
+can use the following live template:
+
+```dart
+abstract class $CLASS_NAME$ implements Built<$CLASS_NAME$, $CLASS_NAME$Builder> {
+  $CLASS_NAME$._();
+  factory $CLASS_NAME$([void Function($CLASS_NAME$Builder) updates]) = _$$$CLASS_NAME$;
+}
+```
+
+Using this template, you would only have to manually enter a name for your data
+class, which is something that can't be automated.
+
+## Enum Class
+
+Enum Classes provide classes with enum features.
+
+Enums are very helpful in modelling the real world: whenever there are a
+small fixed set of options, an enum is a natural choice. For an object
+oriented design, though, enums need to be classes. Dart falls short here,
+so Enum Classes provide what's missing!
+
+Design:
+
+- Constants have `name` and `toString`, can be used in `switch` statements,
+  and are real classes that can hold code and implement interfaces
+- Generated `values` method that returns all the enum values in a `BuiltSet` (immutable set)
+- Generated `valueOf` method that takes a `String`
+
+## Serialization
+
+Built Values comes with JSON serialization support which allows you to
+serialize a complete data model of Built Values, Enum Classes and
+Built Collections. The
+[chat example](https://github.com/google/built_value.dart/tree/master/chat_example) shows 
+how easy this makes building a full application with Dart on the server and
+client.
+
+Here are the major features of the serialization support:
+
+It _fully supports object oriented design_: any object model that you can 
+design can be serialized, including full use of generics and interfaces.
+Some other libraries require concrete types or do not fully support generics.
+
+It _allows different object oriented models over the same data_. For
+example, in a client server application, it's likely that the client and server
+want different functionality from their data model. So, they are allowed to have
+different classes that map to the same data. Most other libraries enforce a 1:1
+mapping between classes and types on the wire.
+
+It _requires well behaved types_. They must be immutable, can use
+interface but not concrete inheritance, must have predictable nullability,
+`hashCode`, `equals` and `toString`. In fact, they must be Enum Classes, Built
+Collections or Built Values. Some other libraries allow badly behaved types to
+be serialized.
+
+It _supports changes to the data model_. Optional fields can be added or
+removed, and fields can be switched from optional to required, allowing your
+data model to evolve without breaking compatbility. Some other libraries break
+compatibility on any change to any serializable class.
+
+It's _modular_. Each endpoint can choose which classes to know about;
+for example, you can have multiple clients that each know about only a subset of
+the classes the server knows. Most other libraries are monolithic, requiring all
+endpoints to know all types.
+
+It _has first class support for validation_ via Built Values. An important 
+part of a powerful data model is ensuring it's valid, so classes can make
+guarantees about what they can do. Other libraries also support validation
+but usually in a less prominent way.
+
+It's _pluggable_. You can add serializers for your own types, and you can add
+[plugins](https://github.com/google/built_value.dart/blob/master/built_value/lib/standard_json_plugin.dart)
+which run before and after all serializers. This could be used to
+interoperate with other tools or to add hand coded high performance serializers
+for specific classes. Some other libraries are not so extensible.
+
+It was designed to be _multi language_, mapping to equivalent object models in
+Java and other languages. Currently only Dart is supported. The need for other
+languages didn't materialize as servers are typically either written in Dart
+or owned by third parties. Please open an issue if you'd like to explore
+support in more languages.
+
+## Common Usage
+
+While full, compiled examples are available in
+[`example/lib`](https://github.com/google/built_value.dart/tree/master/example/lib),
+a common usage example is shown here. This example assumes that you are writing
+a client for a JSON API representing a person that looks like the following:
+
+```json
+{
+  "id": 12345,
+  "age": 35,
+  "first_name": "Jimmy",
+  "hobbies": ["jumping", "basketball"]
+}
+```
+
+The corresponding dart class employing `built_value` might look like this. Note
+that it is using the
+[`@BuiltValueField`](https://pub.dev/documentation/built_value/latest/built_value/BuiltValueField-class.html)
+annotation to map between the property name on the response and the name of the
+member variable in the `Person` class.
+
+```dart
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:built_collection/built_collection.dart';
+
+part 'person.g.dart';
+
+abstract class Person implements Built<Person, PersonBuilder> {
+  static Serializer<Person> get serializer => _$personSerializer;
+
+  int get id;
+
+  int? get age;
+
+  @BuiltValueField(wireName: 'first_name')
+  String? get firstName;
+
+  BuiltList<String> get hobbies;
+
+  Person._();
+  factory Person([void Function(PersonBuilder) updates]) = _$Person;
+}
+```
+
+## FAQ
+
+### How do I check a field is valid on instantiation?
+
+The value class private constructor runs when all fields are initialized and
+can do arbitrary checks:
+
+```dart
+abstract class MyValue {
+  MyValue._() {
+    if (field < 0) {
+      throw ArgumentError(field, 'field', 'Must not be negative.');
+    }
+  }
+```
+
+### How do I process a field on instantiation?
+
+Add a hook that runs immediately before a builder is built. For example, you
+could sort a list, so it's always sorted directly before the value is created:
+
+```dart
+abstract class MyValue {
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _sortItems(MyValueBuilder b) =>
+      b..items.sort();
+```
+
+### How do I set a default for a field?
+
+Add a hook that runs whenever a builder is created:
+
+```dart
+abstract class MyValue {
+  @BuiltValueHook(initializeBuilder: true)
+  static void _setDefaults(MyValueBuilder b) =>
+      b
+        ..name = 'defaultName'
+        ..count = 0;
+```
+
+### Should I check in and/or publish in the generated `.g.dart` files?
+
+See the [build_runner](https://pub.dev/packages/build_runner#source-control)
+docs. You usually should not check in generated files, but you _do_ need to publish
+them.
+
+## Features and bugs
+
+Please file feature requests and bugs at the [issue tracker][tracker].
+
+[tracker]: https://github.com/google/built_value.dart/issues

--- a/built_types/benchmark/analysis_options.yaml
+++ b/built_types/benchmark/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/built_types/benchmark/bin/main.dart
+++ b/built_types/benchmark/bin/main.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:benchmark/benchmark.dart';
+
+void main() => benchmark();

--- a/built_types/benchmark/lib/benchmark.dart
+++ b/built_types/benchmark/lib/benchmark.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:benchmark/node.dart';
+import 'package:benchmark/simple_value.dart';
+
+void benchmark() {
+  benchmarkHashCode();
+  benchmarkNestedRebuilds();
+}
+
+void benchmarkHashCode() {
+  final value = SimpleValue((b) => b
+    ..anInt = 0
+    ..aString = 'zero');
+  _benchmark('hashCode', () => value.hashCode);
+}
+
+void benchmarkNestedRebuilds() {
+  for (var depth = 0; depth != 10; ++depth) {
+    final value = Node((b) => _buildNested(b, depth));
+
+    _benchmark('nested rebuild $depth', () {
+      final topBuilder = value.toBuilder();
+      var leafBuilder = topBuilder;
+      for (var i = 0; i != depth; ++i) {
+        leafBuilder = leafBuilder.left;
+      }
+      leafBuilder.label = 'updatedLeaf';
+      topBuilder.build();
+    });
+  }
+}
+
+void _buildNested(NodeBuilder nodeBuilder, int depth) {
+  if (depth == 0) {
+    nodeBuilder.label = 'leaf';
+  } else {
+    _buildNested(nodeBuilder.left, depth - 1);
+    _buildNested(nodeBuilder.right, depth - 1);
+  }
+}
+
+void _benchmark(String name, Function() function) {
+  // Warm up.
+  for (var i = 0; i != 1000; ++i) {
+    function();
+  }
+
+  // Time.
+  for (var i = 0; i != 3; ++i) {
+    final stopwatch = Stopwatch()..start();
+    final reps = 10000000;
+    for (var i = 0; i != reps; ++i) {
+      function();
+    }
+    final perSecond =
+        (reps / (stopwatch.elapsedMicroseconds / 1000000.0)).round();
+    print('$name: $perSecond/s');
+  }
+}

--- a/built_types/benchmark/lib/node.dart
+++ b/built_types/benchmark/lib/node.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library node;
+
+import 'package:built_value/built_value.dart';
+
+part 'node.g.dart';
+
+abstract class Node implements Built<Node, NodeBuilder> {
+  String? get label;
+
+  Node? get left;
+
+  Node? get right;
+
+  factory Node([Function(NodeBuilder) updates]) = _$Node;
+  Node._();
+}

--- a/built_types/benchmark/lib/node.g.dart
+++ b/built_types/benchmark/lib/node.g.dart
@@ -1,0 +1,124 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'node.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$Node extends Node {
+  @override
+  final String? label;
+  @override
+  final Node? left;
+  @override
+  final Node? right;
+
+  factory _$Node([void Function(NodeBuilder)? updates]) =>
+      (NodeBuilder()..update(updates))._build();
+
+  _$Node._({this.label, this.left, this.right}) : super._();
+  @override
+  Node rebuild(void Function(NodeBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  NodeBuilder toBuilder() => NodeBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Node &&
+        label == other.label &&
+        left == other.left &&
+        right == other.right;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, label.hashCode);
+    _$hash = $jc(_$hash, left.hashCode);
+    _$hash = $jc(_$hash, right.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Node')
+          ..add('label', label)
+          ..add('left', left)
+          ..add('right', right))
+        .toString();
+  }
+}
+
+class NodeBuilder implements Builder<Node, NodeBuilder> {
+  _$Node? _$v;
+
+  String? _label;
+  String? get label => _$this._label;
+  set label(String? label) => _$this._label = label;
+
+  NodeBuilder? _left;
+  NodeBuilder get left => _$this._left ??= NodeBuilder();
+  set left(NodeBuilder? left) => _$this._left = left;
+
+  NodeBuilder? _right;
+  NodeBuilder get right => _$this._right ??= NodeBuilder();
+  set right(NodeBuilder? right) => _$this._right = right;
+
+  NodeBuilder();
+
+  NodeBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _label = $v.label;
+      _left = $v.left?.toBuilder();
+      _right = $v.right?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Node other) {
+    _$v = other as _$Node;
+  }
+
+  @override
+  void update(void Function(NodeBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Node build() => _build();
+
+  _$Node _build() {
+    _$Node _$result;
+    try {
+      _$result = _$v ??
+          _$Node._(
+            label: label,
+            left: _left?.build(),
+            right: _right?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'left';
+        _left?.build();
+        _$failedField = 'right';
+        _right?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'Node', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/benchmark/lib/simple_value.dart
+++ b/built_types/benchmark/lib/simple_value.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library simple_value;
+
+import 'package:built_value/built_value.dart';
+
+part 'simple_value.g.dart';
+
+abstract class SimpleValue implements Built<SimpleValue, SimpleValueBuilder> {
+  int get anInt;
+
+  String get aString;
+
+  factory SimpleValue([Function(SimpleValueBuilder) updates]) = _$SimpleValue;
+  SimpleValue._();
+}

--- a/built_types/benchmark/lib/simple_value.g.dart
+++ b/built_types/benchmark/lib/simple_value.g.dart
@@ -1,0 +1,101 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'simple_value.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$SimpleValue extends SimpleValue {
+  @override
+  final int anInt;
+  @override
+  final String aString;
+
+  factory _$SimpleValue([void Function(SimpleValueBuilder)? updates]) =>
+      (SimpleValueBuilder()..update(updates))._build();
+
+  _$SimpleValue._({required this.anInt, required this.aString}) : super._();
+  @override
+  SimpleValue rebuild(void Function(SimpleValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SimpleValueBuilder toBuilder() => SimpleValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SimpleValue &&
+        anInt == other.anInt &&
+        aString == other.aString;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, aString.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SimpleValue')
+          ..add('anInt', anInt)
+          ..add('aString', aString))
+        .toString();
+  }
+}
+
+class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
+  _$SimpleValue? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  String? _aString;
+  String? get aString => _$this._aString;
+  set aString(String? aString) => _$this._aString = aString;
+
+  SimpleValueBuilder();
+
+  SimpleValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _aString = $v.aString;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SimpleValue other) {
+    _$v = other as _$SimpleValue;
+  }
+
+  @override
+  void update(void Function(SimpleValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SimpleValue build() => _build();
+
+  _$SimpleValue _build() {
+    final _$result = _$v ??
+        _$SimpleValue._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'SimpleValue', 'anInt'),
+          aString: BuiltValueNullFieldError.checkNotNull(
+              aString, r'SimpleValue', 'aString'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/benchmark/pubspec.yaml
+++ b/built_types/benchmark/pubspec.yaml
@@ -1,0 +1,20 @@
+name: benchmark
+version: 8.13.0
+publish_to: none
+description: >
+  Benchmark, not for publishing.
+homepage: https://github.com/google/built_value.dart
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  built_collection: ^5.0.0
+  built_value: ^8.8.0
+
+dev_dependencies:
+  build_runner: '>=1.0.0 <3.0.0'
+  built_value_generator: ^8.13.0
+  pedantic: ^1.4.0
+  quiver: '>=0.21.0 <4.0.0'
+  test: ^1.0.0

--- a/built_types/benchmark/test/node_test.dart
+++ b/built_types/benchmark/test/node_test.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:benchmark/node.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Node', () {
+    test('can be instantiated', () {
+      Node();
+    });
+
+    test('label can be updated', () {
+      final node = Node((b) => b.label = 'updated');
+      expect(node.label, 'updated');
+    });
+
+    test('label update does not affect original', () {
+      final node = Node();
+      node.rebuild((b) => b.label = 'updated');
+      expect(node.label, isNull);
+    });
+
+    test('builder use after build does not affect original', () {
+      final builder = NodeBuilder();
+      final node = builder.build();
+      builder.label = 'updated';
+      expect(node.label, isNull);
+    });
+
+    test('nested label can be updated', () {
+      final node = Node((b) => b.left.label = 'updated');
+      expect(node.left!.label, 'updated');
+    });
+
+    test('nested label update does not affect original', () {
+      final node = Node();
+      node.rebuild((b) => b.left.label = 'updated');
+      expect(node.left, null);
+    });
+
+    test('nested builder use after build does not affect original', () {
+      final builder = NodeBuilder();
+      final nestedBuilder = builder.left;
+      nestedBuilder.label = 'leaf';
+      final node = builder.build();
+      nestedBuilder.label = 'updated';
+      expect(node.left!.label, 'leaf');
+    });
+
+    test('doubly nested label can be updated', () {
+      final node = Node((b) => b.left.left.label = 'updated');
+      expect(node.left!.left!.label, 'updated');
+    });
+
+    test('doubly nested label update does not affect original', () {
+      final node = Node();
+      node.rebuild((b) => b.left.left.label = 'updated');
+      expect(node.left, null);
+    });
+
+    test('doubly nested builder use after build does not affect original', () {
+      final builder = NodeBuilder();
+      final nestedBuilder = builder.left.left;
+      nestedBuilder.label = 'leaf';
+      final node = builder.build();
+      nestedBuilder.label = 'updated';
+      expect(node.left!.left!.label, 'leaf');
+    });
+
+    test('structure can be created', () {
+      final node = Node((b) => b
+        ..left.left.label = 'one'
+        ..left.right.left.label = 'two'
+        ..right.right.right.label = 'three');
+      expect(node.left!.left!.label, 'one');
+      expect(node.left!.right!.left!.label, 'two');
+      expect(node.right!.right!.right!.label, 'three');
+    });
+
+    test('derived structure can be created without affecting original', () {
+      final node = Node((b) => b
+        ..left.left.label = 'one'
+        ..left.right.left.label = 'two'
+        ..right.right.right.label = 'three');
+
+      final updatedNode = node.rebuild((b) => b
+        ..left.left.label = '1'
+        ..left.right.left.label = '2'
+        ..right.right.right.right.label = 'below 3');
+
+      // Original is unchanged.
+      expect(node.left!.left!.label, 'one');
+      expect(node.left!.right!.left!.label, 'two');
+      expect(node.right!.right!.right!.label, 'three');
+
+      // Derived structure is correct.
+      expect(updatedNode.left!.left!.label, '1');
+      expect(updatedNode.left!.right!.left!.label, '2');
+      expect(updatedNode.right!.right!.right!.label, 'three');
+      expect(updatedNode.right!.right!.right!.right!.label, 'below 3');
+    });
+
+    test('supports setting builders to null to clear', () {
+      final node = Node((b) => b..left.left.label = 'leaf');
+      final updatedNode = node.rebuild((b) => b..left = null);
+      expect(updatedNode.left, null);
+    });
+
+    test(
+        'derived structure including deletes can be created without affecting '
+        'original', () {
+      final node = Node((b) => b
+        ..left.left.label = 'one'
+        ..left.right.left.label = 'two'
+        ..right.right.right.label = 'three');
+
+      final updatedNode = node.rebuild((b) => b
+        ..left.left.label = '1'
+        ..left.right.left = null);
+
+      // Original is unchanged.
+      expect(node.left!.left!.label, 'one');
+      expect(node.left!.right!.left!.label, 'two');
+      expect(node.right!.right!.right!.label, 'three');
+
+      // Derived structure is correct.
+      expect(updatedNode.left!.left!.label, '1');
+      expect(updatedNode.left!.right!.left, null);
+      expect(updatedNode.right!.right!.right!.label, 'three');
+    });
+  });
+}

--- a/built_types/benchmark/web/index.html
+++ b/built_types/benchmark/web/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<head>
+  <title>built_value benchmark</title>
+</head>
+<body>
+
+<html>
+<head>
+  <script type="application/dart" src="main.dart"></script>
+  <script src="packages/browser/dart.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/built_types/benchmark/web/main.dart
+++ b/built_types/benchmark/web/main.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:benchmark/benchmark.dart';
+
+void main() => benchmark();

--- a/built_types/built_value/LICENSE
+++ b/built_types/built_value/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2015, Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/built_types/built_value/analysis_options.yaml
+++ b/built_types/built_value/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/built_types/built_value/example/README.md
+++ b/built_types/built_value/example/README.md
@@ -1,0 +1,4 @@
+ - [Basic usage](https://github.com/google/built_value.dart/blob/master/example/lib/example.dart)
+ - [Client and server](https://github.com/google/built_value.dart/tree/master/chat_example)
+ - [End to end tests](https://github.com/google/built_value.dart/tree/master/end_to_end_test)
+ - [API documentation](https://pub.dev/documentation/built_value/latest/)

--- a/built_types/built_value/lib/async_serializer.dart
+++ b/built_types/built_value/lib/async_serializer.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/serializer.dart';
+
+/// Deserializer for `BuiltList` that runs asynchronously.
+///
+/// If you need to deserialize large payloads without blocking, arrange that
+/// the top level serialized object is a `BuiltList`. Then use this class to
+/// deserialize to a [Stream] of objects.
+class BuiltListAsyncDeserializer {
+  Stream<Object?> deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) async* {
+    var elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    for (var item in serialized) {
+      yield serializers.deserialize(item, specifiedType: elementType);
+    }
+  }
+}

--- a/built_types/built_value/lib/built_value.dart
+++ b/built_types/built_value/lib/built_value.dart
@@ -1,0 +1,455 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:meta/meta_meta.dart';
+
+/// Implement this for a Built Value.
+///
+/// Then use built_value_generator.dart code generation functionality to
+/// provide the rest of the implementation.
+///
+/// See https://github.com/google/built_value.dart/tree/master/example
+abstract class Built<V extends Built<V, B>, B extends Builder<V, B>> {
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [B].
+  ///
+  /// The implementation of this method will be generated for you by the
+  /// built_value generator.
+  V rebuild(Function(B) updates);
+
+  /// Converts the instance to a builder [B].
+  ///
+  /// The implementation of this method will be generated for you by the
+  /// built_value generator.
+  B toBuilder();
+}
+
+/// Every [Built] class has a corresponding [Builder] class.
+///
+/// Usually you don't need to create one by hand; it will be generated
+/// for you.
+///
+/// See <https://github.com/google/built_value.dart/tree/master/example>
+abstract class Builder<V extends Built<V, B>, B extends Builder<V, B>> {
+  /// Replaces the value in the builder with a new one.
+  ///
+  /// The implementation of this method will be generated for you by the
+  /// built_value generator.
+  void replace(V value);
+
+  /// Applies updates.
+  ///
+  /// [updates] is a function that takes a builder [B].
+  void update(Function(B)? updates);
+
+  /// Builds.
+  ///
+  /// The implementation of this method will be generated for you by the
+  /// built_value generator.
+  V build();
+}
+
+/// Optionally, annotate a Built Value with this to specify settings. This is
+/// only needed for advanced use.
+class BuiltValue {
+  /// Whether the Built Value is instantiable. Defaults to `true`.
+  ///
+  /// A non-instantiable Built Value has no constructor or factory. No
+  /// implementation will be generated. But, an abstract builder will be
+  /// generated, or you may write one yourself.
+  ///
+  /// Other Built Values may choose to `implement` a non-instantiable Built
+  /// Value, pulling in fields and methods from it. Their generated builders
+  /// will automatically `implement` the corresponding builder, so you can
+  /// access and modify the common inherited fields without knowing the
+  /// concrete type.
+  final bool instantiable;
+
+  /// Whether to use nested builders. Defaults to `true`.
+  ///
+  /// If the builder class is fully generated, controls whether nested builders
+  /// are used. This means builder fields are themselves builders if there is a
+  /// builder available for each field type.
+  ///
+  /// If you write the builder class by hand, this has no effect; simply
+  /// declare each field as the type you want, either the built type or the
+  /// builder.
+  final bool nestedBuilders;
+
+  /// Whether to auto create nested builders. Defaults to `true`.
+  ///
+  /// When this is enabled, accessing a nested builder via a getter causes it
+  /// to be instantiated if it's `null`. In most cases this is convenient, but
+  /// if you are using builders for data processing then you might need to
+  /// check for `null`. If so you should set this to `false`.
+  final bool autoCreateNestedBuilders;
+
+  /// Whether builders should implement `operator==` and `hashCode`, making
+  /// them comparable.
+  ///
+  /// May only be used with `nestedBuilders: false` and if the builder class
+  /// is fully generated.
+  final bool comparableBuilders;
+
+  /// Whether to generate an `onSet` field in the builder.
+  ///
+  /// Defaults to `false`.
+  ///
+  /// If generated the `onSet` field will have type `void Function()`, and will
+  /// be called after any setter is called. Assign your own function to
+  /// `onSet` to respond to changes to the builder.
+  final bool generateBuilderOnSetField;
+
+  /// The wire name when the class is serialized. Defaults to `null` which
+  /// indicates that the name is to be taken from the literal class name.
+  final String? wireName;
+
+  /// The default for [BuiltValueField.compare]. Set to `false` if you want to
+  /// ignore most fields when comparing, then mark the ones you do want to
+  /// compare on with `@BuiltValueField(compare: true)`.
+  final bool defaultCompare;
+
+  /// The default for [BuiltValueField.serialize]. Set to `false` if you want
+  /// to ignore most fields when serializing, then mark the ones you do want
+  /// to serialize with `@BuiltValueField(serialize: true)`.
+  final bool defaultSerialize;
+
+  const BuiltValue(
+      {this.instantiable = true,
+      this.nestedBuilders = true,
+      this.autoCreateNestedBuilders = true,
+      this.comparableBuilders = false,
+      this.generateBuilderOnSetField = false,
+      this.wireName,
+      this.defaultCompare = true,
+      this.defaultSerialize = true});
+}
+
+/// Annotation that was used to mark nullable Built Value fields.
+///
+/// Now it does nothing or causes an error whenever used.
+@Deprecated('Add `?` to the field type to make it nullable instead')
+const String nullable = 'nullable';
+
+/// Optionally, annotate a Built Value field with this to specify settings.
+/// This is only needed for advanced use.
+@Target({TargetKind.getter})
+class BuiltValueField {
+  /// Whether the field is compared and hashed. Defaults to `null` which means
+  /// [BuiltValue.defaultCompare] is used.
+  ///
+  /// Set to `false` to ignore the field when calculating `hashCode` and when
+  /// comparing with `operator==`.
+  final bool? compare;
+
+  /// Whether the field is serialized. Defaults to `null` which means
+  /// [BuiltValue.defaultSerialize] is used.
+  ///
+  /// If a field is not serialized, it must either be nullable or specify a
+  /// default for deserialization to succeed.
+  final bool? serialize;
+
+  /// The wire name when the field is serialized. Defaults to `null` which
+  /// indicates the name is to be taken from the literal field name.
+  final String? wireName;
+
+  /// Whether the field overrides the `nestedBuilders` setting from the class. Defaults to `null` which
+  /// indicates the setting is to be taken from the `nestedBuilders` setting on the class.
+  final bool? nestedBuilder;
+
+  /// Whether the field overrides the `autoCreateNestedBuilders` setting from the class. Defaults to `null` which
+  /// indicates the setting is to be taken from the `autoCreateNestedBuilders` setting on the class.
+  final bool? autoCreateNestedBuilder;
+
+  const BuiltValueField(
+      {this.compare,
+      this.serialize,
+      this.wireName,
+      this.nestedBuilder,
+      this.autoCreateNestedBuilder});
+}
+
+/// Optionally, annotate a Built Value `Serializer` getters with this to
+/// specify settings. This is only needed for advanced use.
+@Target({TargetKind.getter})
+class BuiltValueSerializer {
+  /// Set this to `true` to stop Built Value from generating a serializer for
+  /// you. The getter may then return any compatible `Serializer`. Defaults
+  /// to `false`.
+  final bool custom;
+
+  /// Whether the generated serializer should output `null`s.
+  ///
+  /// By default this is `false` and nulls are omitted from the output.
+
+  final bool serializeNulls;
+
+  const BuiltValueSerializer(
+      {this.custom = false, this.serializeNulls = false});
+}
+
+/// Memoized annotation for Built Value getters.
+///
+/// Getters marked with this annotation are memoized: the result is calculated
+/// once on first access and stored in the instance.
+const String memoized = 'memoized';
+
+/// Optionally, annotate an `EnumClass` with this to specify settings. This
+/// is only needed for advanced use.
+@Target({TargetKind.classType})
+class BuiltValueEnum {
+  /// The wire name when the enum is serialized. Defaults to `null` which
+  /// indicates that the name is to be taken from the literal class name.
+  final String? wireName;
+
+  const BuiltValueEnum({this.wireName});
+}
+
+/// Optionally, annotate an `EnumClass` constant with this to specify settings.
+/// This is only needed for advanced use.
+@Target({TargetKind.field})
+class BuiltValueEnumConst {
+  /// The wire name when the constant is serialized. Defaults to `null` which
+  /// indicates the name is to be taken from the literal field name.
+  ///
+  /// Or, set [wireNumber] to serialize to an `int`. Only one of the two may be
+  /// used.
+  final String? wireName;
+
+  /// The wire name when the constant is serialized. Defaults to `null` which
+  /// indicates the name is to be taken from the literal field name.
+  ///
+  /// Or, set [wireName] to serialize to a `String`. Only one of the two may
+  /// be used.
+  final int? wireNumber;
+
+  /// Marks a value that is used as a fallback when an unrecognized value
+  /// is encountered.
+  ///
+  /// Defaults to `false`. At most one fallback is allowed per `EnumClass`.
+  ///
+  /// Applies to the `valueOf` method and to deserialization; both will use
+  /// the fallback, if available, rather than throwing an exception.
+  final bool fallback;
+
+  const BuiltValueEnumConst(
+      {this.wireName, this.wireNumber, this.fallback = false});
+}
+
+/// Optionally, annotate methods with this to cause them to be called by
+/// generated code.
+@Target({TargetKind.method})
+class BuiltValueHook {
+  /// Marks a static method that will be called when the builder for the
+  /// enclosing value type is initialized.
+  ///
+  /// The method must accept a builder of the enclosing value type.
+  ///
+  /// This example uses it to set a default value:
+  ///
+  /// ```
+  /// @BuiltValueHook(initializeBuilder: true)
+  /// static void _initialize(MyClassBuilder b) =>
+  ///    b..name = 'defaultName';
+  ///
+  /// Defaults to `false`.
+  /// ```
+  final bool initializeBuilder;
+
+  /// Marks a static method that will be called immediately before the builder
+  /// for the enclosing value type is built.
+  ///
+  /// The method must accept a builder of the enclosing value type.
+  ///
+  /// This example uses it to make `items` sorted:
+  ///
+  /// ```
+  /// @BuiltValueHook(finalizeBuilder: true)
+  /// static void _finalize(MyClassBuilder b) =>
+  ///    b..items.sort();
+  ///
+  /// Defaults to `false`.
+  /// ```
+  final bool finalizeBuilder;
+
+  const BuiltValueHook(
+      {this.initializeBuilder = false, this.finalizeBuilder = false});
+}
+
+/// Enum Class base class.
+///
+/// Extend this class then use the built_value.dart code generation
+/// functionality to provide the rest of the implementation.
+///
+/// See https://github.com/google/built_value.dart/tree/master/example
+class EnumClass {
+  final String name;
+
+  const EnumClass(this.name);
+
+  @override
+  String toString() => name;
+}
+
+/// For use by generated code in calculating hash codes. Do not use directly.
+int $jc(int hash, int value) {
+  // Jenkins hash "combine".
+  hash = 0x1fffffff & (hash + value);
+  hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+  return hash ^ (hash >> 6);
+}
+
+/// For use by generated code in calculating hash codes. Do not use directly.
+int $jf(int hash) {
+  // Jenkins hash "finish".
+  hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+  hash = hash ^ (hash >> 11);
+  return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+}
+
+/// Function that returns a [BuiltValueToStringHelper].
+typedef BuiltValueToStringHelperProvider = BuiltValueToStringHelper Function(
+    String className);
+
+/// Function used by generated code to get a [BuiltValueToStringHelper].
+/// Set this to change built_value class toString() output. Built-in examples
+/// are [IndentingBuiltValueToStringHelper], which is the default, and
+/// [FlatBuiltValueToStringHelper].
+BuiltValueToStringHelperProvider newBuiltValueToStringHelper =
+    (String className) => IndentingBuiltValueToStringHelper(className);
+
+/// Interface for built_value toString() output helpers.
+///
+/// Note: this is an experimental feature. API may change without a major
+/// version increase.
+abstract class BuiltValueToStringHelper {
+  /// Add a field and its value.
+  void add(String field, Object? value);
+
+  /// Returns to completed toString(). The helper may not be used after this
+  /// method is called.
+  @override
+  String toString();
+}
+
+/// A [BuiltValueToStringHelper] that produces multi-line indented output.
+class IndentingBuiltValueToStringHelper implements BuiltValueToStringHelper {
+  StringBuffer? _result = StringBuffer();
+
+  IndentingBuiltValueToStringHelper(String className) {
+    _result!
+      ..write(className)
+      ..write(' {\n');
+    _indentingBuiltValueToStringHelperIndent += 2;
+  }
+
+  @override
+  void add(String field, Object? value) {
+    if (value != null) {
+      _result!
+        ..write(' ' * _indentingBuiltValueToStringHelperIndent)
+        ..write(field)
+        ..write('=')
+        ..write(value)
+        ..write(',\n');
+    }
+  }
+
+  @override
+  String toString() {
+    _indentingBuiltValueToStringHelperIndent -= 2;
+    _result!
+      ..write(' ' * _indentingBuiltValueToStringHelperIndent)
+      ..write('}');
+    var stringResult = _result.toString();
+    _result = null;
+    return stringResult;
+  }
+}
+
+int _indentingBuiltValueToStringHelperIndent = 0;
+
+/// A [BuiltValueToStringHelper] that produces single line output.
+class FlatBuiltValueToStringHelper implements BuiltValueToStringHelper {
+  StringBuffer? _result = StringBuffer();
+  bool _previousField = false;
+
+  FlatBuiltValueToStringHelper(String className) {
+    _result!
+      ..write(className)
+      ..write(' {');
+  }
+
+  @override
+  void add(String field, Object? value) {
+    if (value != null) {
+      if (_previousField) _result!.write(',');
+      _result!
+        ..write(field)
+        ..write('=')
+        ..write(value);
+      _previousField = true;
+    }
+  }
+
+  @override
+  String toString() {
+    _result!.write('}');
+    var stringResult = _result.toString();
+    _result = null;
+    return stringResult;
+  }
+}
+
+/// [Error] indicating that a built_value class constructor was called with
+/// a `null` value for a field not marked nullable.
+class BuiltValueNullFieldError extends Error {
+  final String type;
+  final String field;
+
+  BuiltValueNullFieldError(this.type, this.field);
+
+  /// Throws a [BuiltValueNullFieldError] if [value] is `null`.
+  static T checkNotNull<T>(T? value, String type, String field) {
+    if (value == null) {
+      throw BuiltValueNullFieldError(type, field);
+    }
+    return value;
+  }
+
+  @override
+  String toString() =>
+      'Tried to construct class "$type" with null for non-nullable field "$field".';
+}
+
+/// [Error] indicating that a built_value class constructor was called with
+/// a missing or `dynamic` type parameter.
+class BuiltValueMissingGenericsError extends Error {
+  final String type;
+  final String parameter;
+
+  BuiltValueMissingGenericsError(this.type, this.parameter);
+
+  @override
+  String toString() =>
+      'Tried to construct class "$type" with missing or dynamic '
+      'type argument "$parameter". All type arguments must be specified.';
+}
+
+/// [Error] indicating that a built_value `build` method failed because a
+/// nested field builder failed.
+class BuiltValueNestedFieldError extends Error {
+  final String type;
+  final String field;
+  final String error;
+
+  BuiltValueNestedFieldError(this.type, this.field, this.error);
+
+  @override
+  String toString() =>
+      'Tried to build class "$type" but nested builder for field "$field" '
+      'threw: $error';
+}

--- a/built_types/built_value/lib/iso_8601_date_time_serializer.dart
+++ b/built_types/built_value/lib/iso_8601_date_time_serializer.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+/// Alternative serializer for [DateTime].
+///
+/// Install this to use ISO8601 format instead of the default (microseconds
+/// since epoch). Use [SerializersBuilder.add] to install it.
+///
+/// An exception will be thrown on attempt to serialize local DateTime
+/// instances; you must use UTC.
+class Iso8601DateTimeSerializer implements PrimitiveSerializer<DateTime> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([DateTime]);
+  @override
+  final String wireName = 'DateTime';
+
+  @override
+  Object serialize(Serializers serializers, DateTime dateTime,
+      {FullType specifiedType = FullType.unspecified}) {
+    if (!dateTime.isUtc) {
+      throw ArgumentError.value(
+          dateTime, 'dateTime', 'Must be in utc for serialization.');
+    }
+
+    return dateTime.toIso8601String();
+  }
+
+  @override
+  DateTime deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return DateTime.parse(serialized as String).toUtc();
+  }
+}

--- a/built_types/built_value/lib/iso_8601_duration_serializer.dart
+++ b/built_types/built_value/lib/iso_8601_duration_serializer.dart
@@ -1,0 +1,103 @@
+// Copyright (c) 2019, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+/// Alternative serializer for [Duration].
+///
+/// Install this to use ISO8601 compatible format instead of the default
+/// (microseconds). Use [SerializersBuilder.add] to install it.
+///
+/// Note that this serializer is not 100% compatible with the ISO8601 format
+/// due to limitations of the [Duration] class, but is designed to produce and
+/// consume reasonable strings that match the standard.
+class Iso8601DurationSerializer extends PrimitiveSerializer<Duration> {
+  @override
+  Duration deserialize(Serializers serializers, Object? serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      _parseDuration(serialized as String);
+
+  @override
+  Object serialize(Serializers serializers, Duration object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      _writeIso8601Duration(object);
+
+  @override
+  Iterable<Type> get types => BuiltList(const [Duration]);
+
+  @override
+  String get wireName => 'Duration';
+
+  Duration _parseDuration(String value) {
+    final match = _parseFormat.firstMatch(value);
+    if (match == null) {
+      throw FormatException('Invalid duration format', value);
+    }
+    // Iterate through the capture groups to build the unit mappings.
+    final unitMappings = <String, int>{};
+
+    // Start iterating at 1, because match[0] is the full match.
+    for (var i = 1; i <= match.groupCount; i++) {
+      final group = match[i];
+      if (group == null) continue;
+
+      // Get all but last character in group.
+      // The RegExp ensures this must be an int.
+      final value = int.parse(group.substring(0, group.length - 1));
+      // Get last character.
+      final unit = group.substring(group.length - 1);
+      unitMappings[unit] = value;
+    }
+    return Duration(
+      days: unitMappings[_dayToken] ?? 0,
+      hours: unitMappings[_hourToken] ?? 0,
+      minutes: unitMappings[_minuteToken] ?? 0,
+      seconds: unitMappings[_secondToken] ?? 0,
+    );
+  }
+
+  String _writeIso8601Duration(Duration duration) {
+    if (duration == Duration.zero) {
+      return 'PT0S';
+    }
+    final days = duration.inDays;
+    final hours = (duration - Duration(days: days)).inHours;
+    final minutes = (duration - Duration(days: days, hours: hours)).inMinutes;
+    final seconds =
+        (duration - Duration(days: days, hours: hours, minutes: minutes))
+            .inSeconds;
+    final remainder = duration -
+        Duration(days: days, hours: hours, minutes: minutes, seconds: seconds);
+
+    if (remainder != Duration.zero) {
+      throw ArgumentError.value(duration, 'duration',
+          'Contains sub-second data which cannot be serialized.');
+    }
+    final buffer = StringBuffer(_durationToken)
+      ..write(days == 0 ? '' : '$days$_dayToken');
+    if (!(hours == 0 && minutes == 0 && seconds == 0)) {
+      buffer
+        ..write(_timeToken)
+        ..write(hours == 0 ? '' : '$hours$_hourToken')
+        ..write(minutes == 0 ? '' : '$minutes$_minuteToken')
+        ..write(seconds == 0 ? '' : '$seconds$_secondToken');
+    }
+    return buffer.toString();
+  }
+
+  // The unit tokens.
+  static const _durationToken = 'P';
+  static const _dayToken = 'D';
+  static const _timeToken = 'T';
+  static const _hourToken = 'H';
+  static const _minuteToken = 'M';
+  static const _secondToken = 'S';
+
+  // The parse format for ISO8601 durations.
+  static final _parseFormat = RegExp(
+    '^P(?!\$)(0D|[1-9][0-9]*D)?'
+    '(?:T(?!\$)(0H|[1-9][0-9]*H)?(0M|[1-9][0-9]*M)?(0S|[1-9][0-9]*S)?)?\$',
+  );
+}

--- a/built_types/built_value/lib/json_object.dart
+++ b/built_types/built_value/lib/json_object.dart
@@ -1,0 +1,208 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+
+/// A JSON value.
+///
+/// This class is suitable for use in built_value fields. When serialized it
+/// maps directly onto JSON values.
+///
+/// Deep operator== and hashCode are provided, meaning the contents of a
+/// List or Map is used for equality and hashing.
+///
+/// List and Map classes are wrapped in [UnmodifiableListView] and
+/// [UnmodifiableMapView] so they won't be modifiable via this object. You
+/// must ensure that no updates are made via the original reference, as a
+/// copy is not made.
+///
+/// Note: this is an experimental feature. API may change without a major
+/// version increase.
+abstract class JsonObject {
+  /// The value, which may be a bool, a List, a Map, a num or a String.
+  Object get value;
+
+  /// Whether the value is a [bool].
+  bool get isBool => false;
+
+  /// The value as a [bool], or throw if not.
+  bool get asBool => throw StateError('Not a bool.');
+
+  /// Whether the value is a [List].
+  bool get isList => false;
+
+  /// The value as a [List], or throw if not.
+  List get asList => throw StateError('Not a List.');
+
+  /// Whether the value is a [Map].
+  bool get isMap => false;
+
+  /// The value as a [Map], or throw if not.
+  Map get asMap => throw StateError('Not a Map.');
+
+  /// Whether the value is a [num].
+  bool get isNum => false;
+
+  /// The value as a [num], or throw if not.
+  num get asNum => throw StateError('Not a num.');
+
+  /// Whether the value is a [String].
+  bool get isString => false;
+
+  /// The value as a [String], or throw if not.
+  String get asString => throw StateError('Not a String.');
+
+  /// Instantiates with [value], which must be a bool, a List, a Map, a num
+  /// or a String. Otherwise, an [ArgumentError] is thrown.
+  factory JsonObject(Object? value) {
+    if (value is num) {
+      return NumJsonObject(value);
+    } else if (value is String) {
+      return StringJsonObject(value);
+    } else if (value is bool) {
+      return BoolJsonObject(value);
+    } else if (value is List<Object?>) {
+      return ListJsonObject(value);
+    } else if (value is Map<String, Object?>) {
+      return MapJsonObject(value);
+    } else if (value is Map) {
+      // Allow wrong type map, check individual values.
+      return MapJsonObject(value.cast());
+    } else {
+      throw ArgumentError.value(value, 'value',
+          'Must be bool, List<Object?>, Map<String?, Object?>, num or String');
+    }
+  }
+
+  JsonObject._();
+
+  @override
+  String toString() {
+    return value.toString();
+  }
+}
+
+/// A [JsonObject] holding a bool.
+class BoolJsonObject extends JsonObject {
+  @override
+  final bool value;
+
+  BoolJsonObject(this.value) : super._();
+
+  @override
+  bool get isBool => true;
+
+  @override
+  bool get asBool => value;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    if (other is! BoolJsonObject) return false;
+    return value == other.value;
+  }
+
+  @override
+  int get hashCode => value.hashCode;
+}
+
+/// A [JsonObject] holding a List.
+class ListJsonObject extends JsonObject {
+  @override
+  final List<Object?> value;
+
+  ListJsonObject(List<Object?> value)
+      : value = UnmodifiableListView<Object?>(value),
+        super._();
+
+  @override
+  bool get isList => true;
+
+  @override
+  List<Object?> get asList => value;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    if (other is! ListJsonObject) return false;
+    return const DeepCollectionEquality().equals(value, other.value);
+  }
+
+  @override
+  int get hashCode => const DeepCollectionEquality().hash(value);
+}
+
+/// A [JsonObject] holding a Map.
+class MapJsonObject extends JsonObject {
+  @override
+  final Map<String, Object?> value;
+
+  MapJsonObject(Map<String, Object?> value)
+      : value = UnmodifiableMapView(value),
+        super._();
+
+  @override
+  bool get isMap => true;
+
+  @override
+  Map<String, Object?> get asMap => value;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    if (other is! MapJsonObject) return false;
+    return const DeepCollectionEquality().equals(value, other.value);
+  }
+
+  @override
+  int get hashCode => const DeepCollectionEquality().hash(value);
+}
+
+/// A [JsonObject] holding a num.
+class NumJsonObject extends JsonObject {
+  @override
+  final num value;
+
+  NumJsonObject(this.value) : super._();
+
+  @override
+  bool get isNum => true;
+
+  @override
+  num get asNum => value;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    if (other is! NumJsonObject) return false;
+    return value == other.value;
+  }
+
+  @override
+  int get hashCode => value.hashCode;
+}
+
+/// A [JsonObject] holding a String.
+class StringJsonObject extends JsonObject {
+  @override
+  final String value;
+
+  StringJsonObject(this.value) : super._();
+
+  @override
+  bool get isString => true;
+
+  @override
+  String get asString => value;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    if (other is! StringJsonObject) return false;
+    return value == other.value;
+  }
+
+  @override
+  int get hashCode => value.hashCode;
+}

--- a/built_types/built_value/lib/serializer.dart
+++ b/built_types/built_value/lib/serializer.dart
@@ -1,0 +1,406 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_collection/src/internal/hash.dart';
+import 'package:built_value/src/big_int_serializer.dart';
+import 'package:built_value/src/date_time_serializer.dart';
+import 'package:built_value/src/duration_serializer.dart';
+import 'package:built_value/src/int32_serializer.dart';
+import 'package:built_value/src/int64_serializer.dart';
+import 'package:built_value/src/json_object_serializer.dart';
+import 'package:built_value/src/list_serializer.dart';
+import 'package:built_value/src/map_serializer.dart';
+import 'package:built_value/src/num_serializer.dart';
+import 'package:built_value/src/set_serializer.dart';
+import 'package:built_value/src/uint8_list_serializer.dart';
+import 'package:built_value/src/uri_serializer.dart';
+
+import 'src/bool_serializer.dart';
+import 'src/built_json_serializers.dart';
+import 'src/built_list_multimap_serializer.dart';
+import 'src/built_list_serializer.dart';
+import 'src/built_map_serializer.dart';
+import 'src/built_set_multimap_serializer.dart';
+import 'src/built_set_serializer.dart';
+import 'src/double_serializer.dart';
+import 'src/int_serializer.dart';
+import 'src/null_serializer.dart';
+import 'src/regexp_serializer.dart';
+import 'src/string_serializer.dart';
+
+/// Annotation to trigger code generation of a [Serializers] instance.
+///
+/// Use like this:
+///
+/// ```
+/// @SerializersFor(const [
+///   MySerializableClass,
+///   MyOtherSerializableClass,
+/// ])
+/// final Serializers serializers = _$serializers;
+/// ```
+///
+/// The `_$serializers` value will be generated for you in a part file next
+/// to the current source file. It will hold serializers for the types
+/// specified plus any types used in their fields, transitively.
+class SerializersFor {
+  final List<Type> types;
+
+  const SerializersFor(this.types);
+}
+
+/// Serializes all known classes.
+///
+/// See: https://github.com/google/built_value.dart/tree/master/example
+abstract class Serializers {
+  /// Default [Serializers] that can serialize primitives and collections.
+  ///
+  /// Use [toBuilder] to add more serializers.
+  factory Serializers() {
+    return (SerializersBuilder()
+          ..add(BigIntSerializer())
+          ..add(BoolSerializer())
+          ..add(ListSerializer())
+          ..add(MapSerializer())
+          ..add(SetSerializer())
+          ..add(BuiltListSerializer())
+          ..add(BuiltListMultimapSerializer())
+          ..add(BuiltMapSerializer())
+          ..add(BuiltSetSerializer())
+          ..add(BuiltSetMultimapSerializer())
+          ..add(DateTimeSerializer())
+          ..add(DoubleSerializer())
+          ..add(DurationSerializer())
+          ..add(IntSerializer())
+          ..add(Int32Serializer())
+          ..add(Int64Serializer())
+          ..add(JsonObjectSerializer())
+          ..add(NullSerializer())
+          ..add(NumSerializer())
+          ..add(RegExpSerializer())
+          ..add(StringSerializer())
+          ..add(Uint8ListSerializer())
+          ..add(UriSerializer())
+          ..addBuilderFactory(const FullType(BuiltList, [FullType.object]),
+              () => ListBuilder<Object>())
+          ..addBuilderFactory(
+              const FullType(
+                  BuiltListMultimap, [FullType.object, FullType.object]),
+              () => ListMultimapBuilder<Object, Object>())
+          ..addBuilderFactory(
+              const FullType(BuiltMap, [FullType.object, FullType.object]),
+              () => MapBuilder<Object, Object>())
+          ..addBuilderFactory(const FullType(BuiltSet, [FullType.object]),
+              () => SetBuilder<Object>())
+          ..addBuilderFactory(
+              const FullType(
+                  BuiltSetMultimap, [FullType.object, FullType.object]),
+              () => SetMultimapBuilder<Object, Object>()))
+        .build();
+  }
+
+  /// Merges iterable of [Serializers] into a single [Serializers].
+  ///
+  /// [Serializer] and builder factories are accumulated. Plugins are not.
+  static Serializers merge(Iterable<Serializers> serializersIterable) =>
+      (Serializers().toBuilder()..mergeAll(serializersIterable)).build();
+
+  /// The installed [Serializer]s.
+  Iterable<Serializer> get serializers;
+
+  /// The installed builder factories.
+  BuiltMap<FullType, Function> get builderFactories;
+
+  /// The installed serializer plugins.
+  Iterable<SerializerPlugin> get serializerPlugins;
+
+  /// Serializes [object].
+  ///
+  /// A [Serializer] must have been provided for every type the object uses.
+  ///
+  /// Types that are known statically can be provided via [specifiedType]. This
+  /// will reduce the amount of data needed on the wire. The exact same
+  /// [specifiedType] will be needed to deserialize.
+  ///
+  /// Create one using [SerializersBuilder].
+  ///
+  /// TODO(davidmorgan): document the wire format.
+  Object? serialize(Object? object,
+      {FullType specifiedType = FullType.unspecified});
+
+  /// Convenience method for when you know the type you're serializing.
+  /// Specify the type by specifying its [Serializer] class. Equivalent to
+  /// calling [serialize] with a `specifiedType`.
+  Object? serializeWith<T>(Serializer<T> serializer, T? object);
+
+  /// Convenience method for when you want a JSON string and know the type
+  /// you're serializing. Specify the type by specifying its [Serializer]
+  /// class. Equivalent to calling [serialize] with a `specifiedType` then
+  /// calling `json.encode`.
+  String toJson<T>(Serializer<T> serializer, T? object);
+
+  /// Deserializes [serialized].
+  ///
+  /// A [Serializer] must have been provided for every type the object uses.
+  ///
+  /// If [serialized] was produced by calling [serialize] with [specifiedType],
+  /// the exact same [specifiedType] must be provided to deserialize.
+  Object? deserialize(Object? serialized,
+      {FullType specifiedType = FullType.unspecified});
+
+  /// Convenience method for when you know the type you're deserializing.
+  /// Specify the type by specifying its [Serializer] class. Equivalent to
+  /// calling [deserialize] with a `specifiedType`.
+  T? deserializeWith<T>(Serializer<T> serializer, Object? serialized);
+
+  /// Convenience method for when you have a JSON string and know the type
+  /// you're deserializing. Specify the type by specifying its [Serializer]
+  /// class. Equivalent to calling [deserialize] with a `specifiedType` then
+  /// calling `json.decode`.
+  T? fromJson<T>(Serializer<T> serializer, String serialized);
+
+  /// Gets a serializer; returns `null` if none is found. For use in plugins
+  /// and other extension code.
+  Serializer? serializerForType(Type type);
+
+  /// Gets a serializer; returns `null` if none is found. For use in plugins
+  /// and other extension code.
+  Serializer? serializerForWireName(String wireName);
+
+  /// Creates a new builder for the type represented by [fullType].
+  ///
+  /// For example, if [fullType] is `BuiltList<int, String>`, returns a
+  /// `ListBuilder<int, String>`. This helps serializers to instantiate with
+  /// correct generic type parameters.
+  ///
+  /// Throws a [StateError] if no matching builder factory has been added.
+  Object newBuilder(FullType fullType);
+
+  /// Whether a builder for [fullType] is available via [newBuilder].
+  bool hasBuilder(FullType fullType);
+
+  /// Throws if a builder for [fullType] is not available via [newBuilder].
+  void expectBuilder(FullType fullType);
+
+  SerializersBuilder toBuilder();
+}
+
+/// Note: this is an experimental feature. API may change without a major
+/// version increase.
+abstract class SerializerPlugin {
+  Object? beforeSerialize(Object? object, FullType specifiedType);
+
+  Object? afterSerialize(Object? object, FullType specifiedType);
+
+  Object? beforeDeserialize(Object? object, FullType specifiedType);
+
+  Object? afterDeserialize(Object? object, FullType specifiedType);
+}
+
+/// Builder for [Serializers].
+abstract class SerializersBuilder {
+  factory SerializersBuilder() = BuiltJsonSerializersBuilder;
+
+  /// Adds a [Serializer]. It will be used to handle the type(s) it declares
+  /// via its `types` property.
+  void add(Serializer serializer);
+
+  /// Merges a [Serializers], adding all of its [Serializer] instances and
+  /// builder factories. Does _not_ add plugins.
+  void merge(Serializers serializers);
+
+  /// Adds an iterable of [Serializer].
+  void addAll(Iterable<Serializer> serializers);
+
+  /// Merges an iterable of [Serializers].
+  void mergeAll(Iterable<Serializers> serializersIterable);
+
+  /// Adds a builder factory.
+  ///
+  /// Builder factories are needed when deserializing to types that use
+  /// generics. For example, to deserialize a `BuiltList<Foo>`, `built_value`
+  /// needs a builder factory for `BuiltList<Foo>`.
+  ///
+  /// `built_value` tries to generate code that will install all the builder
+  /// factories you need, but this support is incomplete. So you may need to
+  /// add your own. For example:
+  ///
+  /// ```dart
+  /// serializers = (serializers.toBuilder()
+  ///       ..addBuilderFactory(
+  ///         const FullType(BuiltList, [FullType(Foo)]),
+  ///         () => ListBuilder<Foo>(),
+  ///       ))
+  ///     .build();
+  /// ```
+  void addBuilderFactory(FullType specifiedType, Function function);
+
+  /// Installs a [SerializerPlugin] that applies to all serialization and
+  /// deserialization.
+  void addPlugin(SerializerPlugin plugin);
+
+  Serializers build();
+}
+
+/// A [Type] with, optionally, [FullType] generic type parameters.
+///
+/// May also be [unspecified], indicating that no type information is
+/// available.
+class FullType {
+  /// An unspecified type.
+  static const FullType unspecified = FullType(null);
+
+  /// The [Object] type.
+  static const FullType object = FullType(Object);
+
+  /// The root of the type.
+  final Type? root;
+
+  /// Type parameters of the type.
+  final List<FullType> parameters;
+
+  /// Whether the type is nullable.
+  final bool nullable;
+
+  const FullType(this.root, [this.parameters = const []]) : nullable = false;
+  const FullType.nullable(this.root, [this.parameters = const []])
+      : nullable = true;
+
+  bool get isUnspecified => identical(root, null);
+
+  FullType withNullability(bool nullability) => nullability
+      ? FullType.nullable(root, parameters)
+      : FullType(root, parameters);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    if (other is! FullType) return false;
+    if (root != other.root) return false;
+    if (nullable != other.nullable) return false;
+    if (parameters.length != other.parameters.length) return false;
+    for (var i = 0; i != parameters.length; ++i) {
+      if (parameters[i] != other.parameters[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    return hash2(root, hashObjects(parameters)) ^ (nullable ? 0x696eefd9 : 0);
+  }
+
+  @override
+  String toString() => isUnspecified
+      ? 'unspecified'
+      : (parameters.isEmpty
+              ? _getRawName(root)
+              : '${_getRawName(root)}<${parameters.join(", ")}>') +
+          _nullabilitySuffix;
+
+  String get _nullabilitySuffix => nullable ? '?' : '';
+
+  static String _getRawName(Type? type) {
+    var name = type.toString();
+    var genericsStart = name.indexOf('<');
+    return genericsStart == -1 ? name : name.substring(0, genericsStart);
+  }
+}
+
+/// Serializes a single type.
+///
+/// You should not usually need to implement this interface. Implementations
+/// are provided for collections and primitives in `built_json`. Classes using
+/// `built_value` and enums using `EnumClass` can have implementations
+/// generated using `built_json_generator`.
+///
+/// Implementations must extend either [PrimitiveSerializer] or
+/// [StructuredSerializer].
+abstract class Serializer<T> {
+  /// The [Type]s that can be serialized.
+  ///
+  /// They must all be equal to T or a subclass of T. Subclasses are used when
+  /// T is an abstract class, which is the case with built_value generated
+  /// serializers.
+  Iterable<Type> get types;
+
+  /// The wire name of the serializable type. For most classes, the class name.
+  /// For primitives and collections a lower-case name is defined as part of
+  /// the `built_json` wire format.
+  String get wireName;
+}
+
+/// A [Serializer] that serializes to and from primitive JSON values.
+abstract class PrimitiveSerializer<T> implements Serializer<T> {
+  /// Serializes [object].
+  ///
+  /// Use [serializers] as needed for nested serialization. Information about
+  /// the type being serialized is provided in [specifiedType].
+  ///
+  /// Returns a value that can be represented as a JSON primitive: a boolean,
+  /// an integer, a double, a String or a List.
+  ///
+  /// TODO(davidmorgan): document the wire format.
+  Object serialize(Serializers serializers, T object,
+      {FullType specifiedType = FullType.unspecified});
+
+  /// Deserializes [serialized].
+  ///
+  /// [serialized] is a boolean, an integer, a double or a String.
+  ///
+  /// Use [serializers] as needed for nested deserialization. Information about
+  /// the type being deserialized is provided in [specifiedType].
+  T deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType = FullType.unspecified});
+}
+
+/// A [Serializer] that serializes to and from an [Iterable] of primitive JSON
+/// values.
+abstract class StructuredSerializer<T> implements Serializer<T> {
+  /// Serializes [object].
+  ///
+  /// Use [serializers] as needed for nested serialization. Information about
+  /// the type being serialized is provided in [specifiedType].
+  ///
+  /// Returns an [Iterable] of values that can be represented as structured
+  /// JSON: booleans, integers, doubles, Strings and [Iterable]s.
+  ///
+  /// TODO(davidmorgan): document the wire format.
+  Iterable<Object?> serialize(Serializers serializers, T object,
+      {FullType specifiedType = FullType.unspecified});
+
+  /// Deserializes [serialized].
+  ///
+  /// [serialized] is an [Iterable] that may contain booleans, integers,
+  /// doubles, Strings and/or [Iterable]s.
+  ///
+  /// Use [serializers] as needed for nested deserialization. Information about
+  /// the type being deserialized is provided in [specifiedType].
+  T deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified});
+}
+
+/// [Error] conveying why deserialization failed.
+///
+/// The Object that failed to deseralize is included as [json] but is not displayed
+/// in the error message to prevent accidental inclusion in logs.
+class DeserializationError extends Error {
+  final String? json;
+  final FullType type;
+  final Error error;
+
+  factory DeserializationError(Object? json, FullType type, Error error) {
+    var limitedJson = json.toString();
+    if (limitedJson.length > 80) {
+      limitedJson = limitedJson.replaceRange(77, limitedJson.length, '...');
+    }
+    return DeserializationError._(limitedJson, type, error);
+  }
+
+  DeserializationError._(this.json, this.type, this.error);
+
+  @override
+  String toString() => "Deserializing to '$type' failed due to: $error";
+}

--- a/built_types/built_value/lib/src/big_int_serializer.dart
+++ b/built_types/built_value/lib/src/big_int_serializer.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BigIntSerializer implements PrimitiveSerializer<BigInt> {
+  final bool structured = false;
+
+  // [BigInt] has a private implementation type; register it via [BigInt.zero].
+  @override
+  final Iterable<Type> types =
+      BuiltList<Type>([BigInt, BigInt.zero.runtimeType]);
+  @override
+  final String wireName = 'BigInt';
+
+  @override
+  Object serialize(Serializers serializers, BigInt bigInt,
+      {FullType specifiedType = FullType.unspecified}) {
+    return bigInt.toString();
+  }
+
+  @override
+  BigInt deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return BigInt.parse(serialized as String);
+  }
+}

--- a/built_types/built_value/lib/src/bool_serializer.dart
+++ b/built_types/built_value/lib/src/bool_serializer.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BoolSerializer implements PrimitiveSerializer<bool> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([bool]);
+  @override
+  final String wireName = 'bool';
+
+  @override
+  Object serialize(Serializers serializers, bool boolean,
+      {FullType specifiedType = FullType.unspecified}) {
+    return boolean;
+  }
+
+  @override
+  bool deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return serialized as bool;
+  }
+}

--- a/built_types/built_value/lib/src/built_json_serializers.dart
+++ b/built_types/built_value/lib/src/built_json_serializers.dart
@@ -1,0 +1,333 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+/// Default implementation of [Serializers].
+class BuiltJsonSerializers implements Serializers {
+  final BuiltMap<Type, Serializer> _typeToSerializer;
+
+  // Implementation note: wire name is what gets sent in the JSON, type name is
+  // the runtime type name. Type name is complicated for two reasons:
+  //
+  // 1. Built Value classes have two types, the abstract class and the
+  // generated implementation.
+  //
+  // 2. When compiled to javascript the runtime type names are obfuscated.
+  final BuiltMap<String, Serializer> _wireNameToSerializer;
+  final BuiltMap<String, Serializer> _typeNameToSerializer;
+
+  @override
+  final BuiltMap<FullType, Function> builderFactories;
+
+  @override
+  final BuiltList<SerializerPlugin> serializerPlugins;
+
+  BuiltJsonSerializers._(
+      this._typeToSerializer,
+      this._wireNameToSerializer,
+      this._typeNameToSerializer,
+      this.builderFactories,
+      this.serializerPlugins);
+
+  @override
+  Iterable<Serializer> get serializers => _wireNameToSerializer.values;
+
+  @override
+  T? deserializeWith<T>(Serializer<T> serializer, Object? serialized) {
+    return deserialize(serialized,
+        specifiedType: FullType(serializer.types.first)) as T?;
+  }
+
+  @override
+  T? fromJson<T>(Serializer<T> serializer, String serialized) {
+    return deserializeWith<T>(serializer, json.decode(serialized));
+  }
+
+  @override
+  Object? serializeWith<T>(Serializer<T> serializer, T? object) {
+    return serialize(object, specifiedType: FullType(serializer.types.first));
+  }
+
+  @override
+  String toJson<T>(Serializer<T> serializer, T? object) {
+    return json.encode(serializeWith<T>(serializer, object));
+  }
+
+  @override
+  Object? serialize(Object? object,
+      {FullType specifiedType = FullType.unspecified}) {
+    var transformedObject = object;
+    for (var plugin in serializerPlugins) {
+      transformedObject =
+          plugin.beforeSerialize(transformedObject, specifiedType);
+    }
+    var result = _serialize(transformedObject, specifiedType);
+    for (var plugin in serializerPlugins) {
+      result = plugin.afterSerialize(result, specifiedType);
+    }
+    return result;
+  }
+
+  Object? _serialize(Object? object, FullType specifiedType) {
+    if (specifiedType.isUnspecified) {
+      final serializer = serializerForType(object.runtimeType);
+      if (serializer == null) {
+        throw StateError(
+            _noSerializerMessageFor(object.runtimeType.toString()));
+      }
+      if (serializer is StructuredSerializer) {
+        final result = <Object?>[serializer.wireName];
+        return result..addAll(serializer.serialize(this, object));
+      } else if (serializer is PrimitiveSerializer) {
+        return object == null
+            ? <Object?>[serializer.wireName, null]
+            : <Object>[serializer.wireName, serializer.serialize(this, object)];
+      } else {
+        throw StateError(
+            'serializer must be StructuredSerializer or PrimitiveSerializer');
+      }
+    } else {
+      final serializer = serializerForType(specifiedType.root);
+      if (serializer == null) {
+        // Might be an interface; try resolving using the runtime type.
+        return serialize(object);
+      }
+      if (serializer is StructuredSerializer) {
+        return object == null
+            ? null
+            : serializer
+                .serialize(this, object, specifiedType: specifiedType)
+                .toList();
+      } else if (serializer is PrimitiveSerializer) {
+        return object == null
+            ? null
+            : serializer.serialize(this, object, specifiedType: specifiedType);
+      } else {
+        throw StateError(
+            'serializer must be StructuredSerializer or PrimitiveSerializer');
+      }
+    }
+  }
+
+  @override
+  Object? deserialize(Object? object,
+      {FullType specifiedType = FullType.unspecified}) {
+    var transformedObject = object;
+    for (var plugin in serializerPlugins) {
+      transformedObject =
+          plugin.beforeDeserialize(transformedObject, specifiedType);
+    }
+    var result = _deserialize(object, transformedObject, specifiedType);
+    for (var plugin in serializerPlugins) {
+      result = plugin.afterDeserialize(result, specifiedType);
+    }
+    return result;
+  }
+
+  Object? _deserialize(
+      Object? objectBeforePlugins, Object? object, FullType specifiedType) {
+    if (specifiedType.isUnspecified) {
+      final wireName = (object as List<Object?>).first as String;
+
+      final serializer = serializerForWireName(wireName);
+      if (serializer == null) {
+        throw StateError(_noSerializerMessageFor(wireName));
+      }
+
+      if (serializer is StructuredSerializer) {
+        try {
+          return serializer.deserialize(this, object.sublist(1));
+        } on Error catch (error) {
+          throw DeserializationError(object, specifiedType, error);
+        }
+      } else if (serializer is PrimitiveSerializer) {
+        try {
+          var primitive = object[1];
+          return primitive == null
+              ? null
+              : serializer.deserialize(this, primitive);
+        } on Error catch (error) {
+          throw DeserializationError(object, specifiedType, error);
+        }
+      } else {
+        throw StateError(
+            'serializer must be StructuredSerializer or PrimitiveSerializer');
+      }
+    } else {
+      final serializer = serializerForType(specifiedType.root);
+      if (serializer == null) {
+        if (object is List && object.first is String) {
+          // Might be an interface; try resolving using the type on the wire.
+          return deserialize(objectBeforePlugins);
+        } else {
+          throw StateError(
+              _noSerializerMessageFor(specifiedType.root.toString()));
+        }
+      }
+
+      if (serializer is StructuredSerializer) {
+        try {
+          return object == null
+              ? null
+              : serializer.deserialize(this, object as Iterable<Object?>,
+                  specifiedType: specifiedType);
+        } on Error catch (error) {
+          throw DeserializationError(object, specifiedType, error);
+        }
+      } else if (serializer is PrimitiveSerializer) {
+        try {
+          return object == null
+              ? null
+              : serializer.deserialize(this, object,
+                  specifiedType: specifiedType);
+        } on Error catch (error) {
+          throw DeserializationError(object, specifiedType, error);
+        }
+      } else {
+        throw StateError(
+            'serializer must be StructuredSerializer or PrimitiveSerializer');
+      }
+    }
+  }
+
+  @override
+  Serializer? serializerForType(Type? type) =>
+      _typeToSerializer[type] ?? _typeNameToSerializer[_getRawName(type)];
+
+  @override
+  Serializer? serializerForWireName(String wireName) =>
+      _wireNameToSerializer[wireName];
+
+  @override
+  Object newBuilder(FullType fullType) {
+    var builderFactory = builderFactories[fullType];
+    if (builderFactory == null) _throwMissingBuilderFactory(fullType);
+    return builderFactory();
+  }
+
+  @override
+  void expectBuilder(FullType fullType) {
+    if (!hasBuilder(fullType)) _throwMissingBuilderFactory(fullType);
+  }
+
+  Never _throwMissingBuilderFactory(FullType fullType) {
+    throw StateError('No builder factory for $fullType. '
+        'Fix by adding one, see SerializersBuilder.addBuilderFactory.');
+  }
+
+  @override
+  bool hasBuilder(FullType fullType) {
+    return builderFactories.containsKey(fullType);
+  }
+
+  @override
+  SerializersBuilder toBuilder() {
+    return BuiltJsonSerializersBuilder._(
+        _typeToSerializer.toBuilder(),
+        _wireNameToSerializer.toBuilder(),
+        _typeNameToSerializer.toBuilder(),
+        builderFactories.toBuilder(),
+        serializerPlugins.toBuilder());
+  }
+}
+
+/// Default implementation of [SerializersBuilder].
+class BuiltJsonSerializersBuilder implements SerializersBuilder {
+  final MapBuilder<Type, Serializer> _typeToSerializer;
+  final MapBuilder<String, Serializer> _wireNameToSerializer;
+  final MapBuilder<String, Serializer> _typeNameToSerializer;
+
+  final MapBuilder<FullType, Function> _builderFactories;
+
+  final ListBuilder<SerializerPlugin> _plugins;
+
+  factory BuiltJsonSerializersBuilder() => BuiltJsonSerializersBuilder._(
+      MapBuilder<Type, Serializer>(),
+      MapBuilder<String, Serializer>(),
+      MapBuilder<String, Serializer>(),
+      MapBuilder<FullType, Function>(),
+      ListBuilder<SerializerPlugin>());
+
+  BuiltJsonSerializersBuilder._(
+      this._typeToSerializer,
+      this._wireNameToSerializer,
+      this._typeNameToSerializer,
+      this._builderFactories,
+      this._plugins);
+
+  @override
+  void add(Serializer serializer) {
+    if (serializer is! StructuredSerializer &&
+        serializer is! PrimitiveSerializer) {
+      throw ArgumentError(
+          'serializer must be StructuredSerializer or PrimitiveSerializer');
+    }
+
+    _wireNameToSerializer[serializer.wireName] = serializer;
+    for (var type in serializer.types) {
+      _typeToSerializer[type] = serializer;
+      _typeNameToSerializer[_getRawName(type)] = serializer;
+    }
+  }
+
+  @override
+  void addAll(Iterable<Serializer> serializers) {
+    serializers.forEach(add);
+  }
+
+  @override
+  void addBuilderFactory(FullType types, Function function) {
+    _builderFactories[types] = function;
+    // Nullability of the top level type is irrelevant to serialization, but
+    // lookup might be done with either nullable or not nullable depending
+    // on the context. So, store both for fast lookup.
+    _builderFactories[types.withNullability(!types.nullable)] = function;
+  }
+
+  @override
+  void merge(Serializers serializers) {
+    addAll(serializers.serializers);
+    _builderFactories.addAll(serializers.builderFactories.asMap());
+  }
+
+  @override
+  void mergeAll(Iterable<Serializers> serializersIterable) {
+    for (var serializers in serializersIterable) {
+      merge(serializers);
+    }
+  }
+
+  @override
+  void addPlugin(SerializerPlugin plugin) {
+    _plugins.add(plugin);
+  }
+
+  @override
+  Serializers build() {
+    return BuiltJsonSerializers._(
+        _typeToSerializer.build(),
+        _wireNameToSerializer.build(),
+        _typeNameToSerializer.build(),
+        _builderFactories.build(),
+        _plugins.build());
+  }
+}
+
+String _getRawName(Type? type) {
+  var name = type.toString();
+  var genericsStart = name.indexOf('<');
+  return genericsStart == -1 ? name : name.substring(0, genericsStart);
+}
+
+String _noSerializerMessageFor(String typeName) {
+  final maybeRecordAdvice = typeName.contains('(')
+      ? ' Note that record types are not automatically serializable, '
+          'please write and install your own `Serializer`.'
+      : '';
+  return "No serializer for '$typeName'.$maybeRecordAdvice";
+}

--- a/built_types/built_value/lib/src/built_list_multimap_serializer.dart
+++ b/built_types/built_value/lib/src/built_list_multimap_serializer.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BuiltListMultimapSerializer
+    implements StructuredSerializer<BuiltListMultimap> {
+  final bool structured = true;
+  @override
+  final Iterable<Type> types = BuiltList<Type>(
+      [BuiltListMultimap, BuiltListMultimap<Object, Object>().runtimeType]);
+  @override
+  final String wireName = 'listMultimap';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, BuiltListMultimap builtListMultimap,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+
+    var keyType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    var valueType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[1];
+
+    var result = <Object?>[];
+    for (var key in builtListMultimap.keys) {
+      result.add(serializers.serialize(key, specifiedType: keyType));
+      result.add(builtListMultimap[key]
+          .map(
+              (value) => serializers.serialize(value, specifiedType: valueType))
+          .toList());
+    }
+    return result;
+  }
+
+  @override
+  BuiltListMultimap deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    var keyType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    var valueType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[1];
+
+    var result = isUnderspecified
+        ? ListMultimapBuilder<Object, Object>()
+        : serializers.newBuilder(specifiedType) as ListMultimapBuilder;
+
+    if (serialized.length % 2 == 1) {
+      throw ArgumentError('odd length');
+    }
+
+    for (var i = 0; i != serialized.length; i += 2) {
+      final key = serializers.deserialize(serialized.elementAt(i),
+          specifiedType: keyType);
+      final values = (serialized.elementAt(i + 1) as Iterable<Object?>).map(
+          (value) => serializers.deserialize(value, specifiedType: valueType));
+      for (var value in values) {
+        result.add(key, value);
+      }
+    }
+
+    return result.build();
+  }
+}

--- a/built_types/built_value/lib/src/built_list_serializer.dart
+++ b/built_types/built_value/lib/src/built_list_serializer.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BuiltListSerializer implements StructuredSerializer<BuiltList> {
+  final bool structured = true;
+  @override
+  final Iterable<Type> types =
+      BuiltList<Type>([BuiltList, BuiltList<Object>().runtimeType]);
+  @override
+  final String wireName = 'list';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, BuiltList builtList,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+
+    var elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    return builtList
+        .map((item) => serializers.serialize(item, specifiedType: elementType));
+  }
+
+  @override
+  BuiltList deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    var elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    var result = isUnderspecified
+        ? ListBuilder<Object>()
+        : serializers.newBuilder(specifiedType) as ListBuilder;
+
+    result.replace(serialized.map(
+        (item) => serializers.deserialize(item, specifiedType: elementType)));
+    return result.build();
+  }
+}

--- a/built_types/built_value/lib/src/built_map_serializer.dart
+++ b/built_types/built_value/lib/src/built_map_serializer.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BuiltMapSerializer implements StructuredSerializer<BuiltMap> {
+  final bool structured = true;
+  @override
+  final Iterable<Type> types =
+      BuiltList<Type>([BuiltMap, BuiltMap<Object, Object>().runtimeType]);
+  @override
+  final String wireName = 'map';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, BuiltMap builtMap,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+
+    var keyType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    var valueType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[1];
+
+    var result = <Object?>[];
+    for (var key in builtMap.keys) {
+      result.add(serializers.serialize(key, specifiedType: keyType));
+      final value = builtMap[key];
+      result.add(serializers.serialize(value, specifiedType: valueType));
+    }
+    return result;
+  }
+
+  @override
+  BuiltMap deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    var keyType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    var valueType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[1];
+
+    var result = isUnderspecified
+        ? MapBuilder<Object, Object>()
+        : serializers.newBuilder(specifiedType) as MapBuilder;
+
+    if (serialized.length % 2 == 1) {
+      throw ArgumentError('odd length');
+    }
+
+    for (var i = 0; i != serialized.length; i += 2) {
+      final key = serializers.deserialize(serialized.elementAt(i),
+          specifiedType: keyType);
+      final value = serializers.deserialize(serialized.elementAt(i + 1),
+          specifiedType: valueType);
+      result[key] = value;
+    }
+
+    return result.build();
+  }
+}

--- a/built_types/built_value/lib/src/built_set_multimap_serializer.dart
+++ b/built_types/built_value/lib/src/built_set_multimap_serializer.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BuiltSetMultimapSerializer
+    implements StructuredSerializer<BuiltSetMultimap> {
+  final bool structured = true;
+  @override
+  final Iterable<Type> types = BuiltSet<Type>([BuiltSetMultimap]);
+  @override
+  final String wireName = 'setMultimap';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, BuiltSetMultimap builtSetMultimap,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+
+    var keyType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    var valueType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[1];
+
+    var result = <Object?>[];
+    for (var key in builtSetMultimap.keys) {
+      result.add(serializers.serialize(key, specifiedType: keyType));
+      result.add(builtSetMultimap[key]!
+          .map(
+              (value) => serializers.serialize(value, specifiedType: valueType))
+          .toList());
+    }
+    return result;
+  }
+
+  @override
+  BuiltSetMultimap deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    var keyType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    var valueType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[1];
+
+    var result = isUnderspecified
+        ? SetMultimapBuilder<Object, Object>()
+        : serializers.newBuilder(specifiedType) as SetMultimapBuilder;
+
+    if (serialized.length % 2 == 1) {
+      throw ArgumentError('odd length');
+    }
+
+    for (var i = 0; i != serialized.length; i += 2) {
+      final key = serializers.deserialize(serialized.elementAt(i),
+          specifiedType: keyType);
+      final values = serialized.elementAt(i + 1).map(
+          (value) => serializers.deserialize(value, specifiedType: valueType));
+      for (var value in values) {
+        result.add(key, value);
+      }
+    }
+
+    return result.build();
+  }
+}

--- a/built_types/built_value/lib/src/built_set_serializer.dart
+++ b/built_types/built_value/lib/src/built_set_serializer.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class BuiltSetSerializer implements StructuredSerializer<BuiltSet> {
+  final bool structured = true;
+  @override
+  final Iterable<Type> types =
+      BuiltList<Type>([BuiltSet, BuiltSet<Object>().runtimeType]);
+  @override
+  final String wireName = 'set';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, BuiltSet builtSet,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+
+    var elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    return builtSet
+        .map((item) => serializers.serialize(item, specifiedType: elementType));
+  }
+
+  @override
+  BuiltSet deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    var elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    var result = isUnderspecified
+        ? SetBuilder<Object>()
+        : serializers.newBuilder(specifiedType) as SetBuilder;
+
+    result.replace(serialized.map(
+        (item) => serializers.deserialize(item, specifiedType: elementType)));
+    return result.build();
+  }
+}

--- a/built_types/built_value/lib/src/date_time_serializer.dart
+++ b/built_types/built_value/lib/src/date_time_serializer.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+/// Serializer for [DateTime].
+///
+/// An exception will be thrown on attempt to serialize local DateTime
+/// instances; you must use UTC.
+class DateTimeSerializer implements PrimitiveSerializer<DateTime> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([DateTime]);
+  @override
+  final String wireName = 'DateTime';
+
+  @override
+  Object serialize(Serializers serializers, DateTime dateTime,
+      {FullType specifiedType = FullType.unspecified}) {
+    if (!dateTime.isUtc) {
+      throw ArgumentError.value(
+          dateTime, 'dateTime', 'Must be in utc for serialization.');
+    }
+
+    return dateTime.microsecondsSinceEpoch;
+  }
+
+  @override
+  DateTime deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    var microsecondsSinceEpoch = serialized as int;
+    return DateTime.fromMicrosecondsSinceEpoch(microsecondsSinceEpoch,
+        isUtc: true);
+  }
+}

--- a/built_types/built_value/lib/src/double_serializer.dart
+++ b/built_types/built_value/lib/src/double_serializer.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class DoubleSerializer implements PrimitiveSerializer<double> {
+  // Constant names match those in [double].
+  // ignore_for_file: non_constant_identifier_names
+  static final String nan = 'NaN';
+  static final String infinity = 'INF';
+  static final String negativeInfinity = '-INF';
+
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([double]);
+  @override
+  final String wireName = 'double';
+
+  @override
+  Object serialize(Serializers serializers, double aDouble,
+      {FullType specifiedType = FullType.unspecified}) {
+    if (aDouble.isNaN) {
+      return nan;
+    } else if (aDouble.isInfinite) {
+      return aDouble.isNegative ? negativeInfinity : infinity;
+    } else {
+      return aDouble;
+    }
+  }
+
+  @override
+  double deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    if (serialized == nan) {
+      return double.nan;
+    } else if (serialized == negativeInfinity) {
+      return double.negativeInfinity;
+    } else if (serialized == infinity) {
+      return double.infinity;
+    } else {
+      return (serialized as num).toDouble();
+    }
+  }
+}

--- a/built_types/built_value/lib/src/duration_serializer.dart
+++ b/built_types/built_value/lib/src/duration_serializer.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+/// Serializer for [Duration].
+///
+/// [Duration] is implemented as an `int` number of microseconds, so just
+/// store that `int`.
+class DurationSerializer implements PrimitiveSerializer<Duration> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([Duration]);
+  @override
+  final String wireName = 'Duration';
+
+  @override
+  Object serialize(Serializers serializers, Duration duration,
+      {FullType specifiedType = FullType.unspecified}) {
+    return duration.inMicroseconds;
+  }
+
+  @override
+  Duration deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return Duration(microseconds: serialized as int);
+  }
+}

--- a/built_types/built_value/lib/src/int32_serializer.dart
+++ b/built_types/built_value/lib/src/int32_serializer.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2023, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:fixnum/fixnum.dart';
+
+class Int32Serializer implements PrimitiveSerializer<Int32> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([Int32]);
+  @override
+  final String wireName = 'Int32';
+
+  @override
+  Object serialize(Serializers serializers, Int32 int32,
+      {FullType specifiedType = FullType.unspecified}) {
+    return int32.toInt();
+  }
+
+  @override
+  Int32 deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return Int32(serialized as int);
+  }
+}

--- a/built_types/built_value/lib/src/int64_serializer.dart
+++ b/built_types/built_value/lib/src/int64_serializer.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:fixnum/fixnum.dart';
+
+class Int64Serializer implements PrimitiveSerializer<Int64> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([Int64]);
+  @override
+  final String wireName = 'Int64';
+
+  @override
+  Object serialize(Serializers serializers, Int64 int64,
+      {FullType specifiedType = FullType.unspecified}) {
+    return int64.toString();
+  }
+
+  @override
+  Int64 deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return Int64.parseInt(serialized as String);
+  }
+}

--- a/built_types/built_value/lib/src/int_serializer.dart
+++ b/built_types/built_value/lib/src/int_serializer.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class IntSerializer implements PrimitiveSerializer<int> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([int]);
+  @override
+  final String wireName = 'int';
+
+  @override
+  Object serialize(Serializers serializers, int integer,
+      {FullType specifiedType = FullType.unspecified}) {
+    return integer;
+  }
+
+  @override
+  int deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return serialized as int;
+  }
+}

--- a/built_types/built_value/lib/src/json_object_serializer.dart
+++ b/built_types/built_value/lib/src/json_object_serializer.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+
+class JsonObjectSerializer implements PrimitiveSerializer<JsonObject> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([
+    JsonObject,
+    BoolJsonObject,
+    ListJsonObject,
+    MapJsonObject,
+    NumJsonObject,
+    StringJsonObject,
+  ]);
+  @override
+  final String wireName = 'JsonObject';
+
+  @override
+  Object serialize(Serializers serializers, JsonObject jsonObject,
+      {FullType specifiedType = FullType.unspecified}) {
+    return jsonObject.value;
+  }
+
+  @override
+  JsonObject deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return JsonObject(serialized);
+  }
+}

--- a/built_types/built_value/lib/src/list_serializer.dart
+++ b/built_types/built_value/lib/src/list_serializer.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2025, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class ListSerializer implements StructuredSerializer<List> {
+  final bool structured = true;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([List, <Object>[].runtimeType]);
+  @override
+  final String wireName = 'List';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, List list,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+
+    var elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    return list
+        .map((item) => serializers.serialize(item, specifiedType: elementType));
+  }
+
+  @override
+  List deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    var elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    var result = isUnderspecified
+        ? <Object>[]
+        : serializers.newBuilder(specifiedType) as List;
+
+    for (final item in serialized) {
+      result.add(serializers.deserialize(item, specifiedType: elementType));
+    }
+    return result;
+  }
+}

--- a/built_types/built_value/lib/src/map_serializer.dart
+++ b/built_types/built_value/lib/src/map_serializer.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2025, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class MapSerializer implements StructuredSerializer<Map> {
+  final bool structured = true;
+  @override
+  final Iterable<Type> types =
+      BuiltList<Type>([Map, <Object, Object>{}.runtimeType]);
+  @override
+  final String wireName = 'Map';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Map Map,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+
+    var keyType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    var valueType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[1];
+
+    var result = <Object?>[];
+    for (var key in Map.keys) {
+      result.add(serializers.serialize(key, specifiedType: keyType));
+      final value = Map[key];
+      result.add(serializers.serialize(value, specifiedType: valueType));
+    }
+    return result;
+  }
+
+  @override
+  Map deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    var keyType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+    var valueType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[1];
+
+    var result = isUnderspecified
+        ? <Object, Object>{}
+        : serializers.newBuilder(specifiedType) as Map;
+
+    if (serialized.length % 2 == 1) {
+      throw ArgumentError('odd length');
+    }
+
+    for (var i = 0; i != serialized.length; i += 2) {
+      final key = serializers.deserialize(serialized.elementAt(i),
+          specifiedType: keyType);
+      final value = serializers.deserialize(serialized.elementAt(i + 1),
+          specifiedType: valueType);
+      result[key] = value;
+    }
+
+    return result;
+  }
+}

--- a/built_types/built_value/lib/src/null_serializer.dart
+++ b/built_types/built_value/lib/src/null_serializer.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2021, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class NullSerializer implements PrimitiveSerializer<Null> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([Null]);
+  @override
+  final String wireName = 'Null';
+
+  @override
+  Object serialize(Serializers serializers, Null value,
+      {FullType specifiedType = FullType.unspecified}) {
+    // Never actually called; `built_json_serializer.dart` handles nulls.
+    throw UnimplementedError();
+  }
+
+  @override
+  Null deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    // Never actually called; `built_json_serializer.dart` handles nulls.
+    throw UnimplementedError();
+  }
+}

--- a/built_types/built_value/lib/src/num_serializer.dart
+++ b/built_types/built_value/lib/src/num_serializer.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:built_value/src/double_serializer.dart';
+
+class NumSerializer implements PrimitiveSerializer<num> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([num]);
+  @override
+  final String wireName = 'num';
+
+  @override
+  Object serialize(Serializers serializers, num number,
+      {FullType specifiedType = FullType.unspecified}) {
+    if (number.isNaN) {
+      return DoubleSerializer.nan;
+    } else if (number.isInfinite) {
+      return number.isNegative
+          ? DoubleSerializer.negativeInfinity
+          : DoubleSerializer.infinity;
+    } else {
+      return number;
+    }
+  }
+
+  @override
+  num deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    if (serialized == DoubleSerializer.nan) {
+      return double.nan;
+    } else if (serialized == DoubleSerializer.negativeInfinity) {
+      return double.negativeInfinity;
+    } else if (serialized == DoubleSerializer.infinity) {
+      return double.infinity;
+    } else {
+      return serialized as num;
+    }
+  }
+}

--- a/built_types/built_value/lib/src/regexp_serializer.dart
+++ b/built_types/built_value/lib/src/regexp_serializer.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2019, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+/// Runtime type for [RegExp] private implementation.
+final _runtimeType = RegExp('').runtimeType;
+
+class RegExpSerializer implements PrimitiveSerializer<RegExp> {
+  @override
+  final Iterable<Type> types = BuiltList<Type>([RegExp, _runtimeType]);
+  @override
+  final String wireName = 'RegExp';
+
+  @override
+  Object serialize(Serializers serializers, RegExp value,
+      {FullType specifiedType = FullType.unspecified}) {
+    return value.pattern;
+  }
+
+  @override
+  RegExp deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return RegExp(serialized as String);
+  }
+}

--- a/built_types/built_value/lib/src/set_serializer.dart
+++ b/built_types/built_value/lib/src/set_serializer.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2025, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class SetSerializer implements StructuredSerializer<Set> {
+  final bool structured = true;
+  @override
+  final Iterable<Type> types = BuiltSet<Type>([Set, <Object>{}.runtimeType]);
+  @override
+  final String wireName = 'Set';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Set set,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+
+    var elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    return set
+        .map((item) => serializers.serialize(item, specifiedType: elementType));
+  }
+
+  @override
+  Set deserialize(Serializers serializers, Iterable serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    var isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+
+    var elementType = specifiedType.parameters.isEmpty
+        ? FullType.unspecified
+        : specifiedType.parameters[0];
+
+    var result = isUnderspecified
+        ? <Object>{}
+        : serializers.newBuilder(specifiedType) as Set;
+
+    for (final item in serialized) {
+      result.add(serializers.deserialize(item, specifiedType: elementType));
+    }
+    return result;
+  }
+}

--- a/built_types/built_value/lib/src/string_serializer.dart
+++ b/built_types/built_value/lib/src/string_serializer.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class StringSerializer implements PrimitiveSerializer<String> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([String]);
+  @override
+  final String wireName = 'String';
+
+  @override
+  Object serialize(Serializers serializers, String string,
+      {FullType specifiedType = FullType.unspecified}) {
+    return string;
+  }
+
+  @override
+  String deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return serialized as String;
+  }
+}

--- a/built_types/built_value/lib/src/uint8_list_serializer.dart
+++ b/built_types/built_value/lib/src/uint8_list_serializer.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2023, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class Uint8ListSerializer implements PrimitiveSerializer<Uint8List> {
+  @override
+  final String wireName = 'UInt8List';
+
+  @override
+  Object serialize(Serializers serializers, Uint8List uint8list,
+      {FullType specifiedType = FullType.unspecified}) {
+    return base64Encode(uint8list);
+  }
+
+  @override
+  Uint8List deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return base64Decode(serialized as String);
+  }
+
+  @override
+  Iterable<Type> get types => BuiltList<Type>([Uint8List]);
+}

--- a/built_types/built_value/lib/src/uri_serializer.dart
+++ b/built_types/built_value/lib/src/uri_serializer.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+class UriSerializer implements PrimitiveSerializer<Uri> {
+  final bool structured = false;
+  @override
+  final Iterable<Type> types = BuiltList<Type>([
+    Uri,
+    // `Uri` is just an interface. Need to record actual implementation types
+    // here. This is a `_SimpleUri`:
+    Uri.parse('http://example.com').runtimeType,
+    // And this is a `_Uri`:
+    Uri.parse('http://example.com:').runtimeType,
+  ]);
+  @override
+  final String wireName = 'Uri';
+
+  @override
+  Object serialize(Serializers serializers, Uri uri,
+      {FullType specifiedType = FullType.unspecified}) {
+    return uri.toString();
+  }
+
+  @override
+  Uri deserialize(Serializers serializers, Object? serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return Uri.parse(serialized as String);
+  }
+}

--- a/built_types/built_value/lib/standard_json_plugin.dart
+++ b/built_types/built_value/lib/standard_json_plugin.dart
@@ -1,0 +1,227 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+import 'dart:convert' show json;
+
+/// Switches to "standard" JSON format.
+///
+/// The default serialization format is more powerful, with better performance
+/// and support for more collection types. But, you may need to interact with
+/// other systems that use simple map-based JSON. If so, use
+/// [SerializersBuilder.addPlugin] to install this plugin.
+///
+/// When using this plugin you may wish to also install
+/// `Iso8601DateTimeSerializer` which switches serialization of `DateTime`
+/// from microseconds since epoch to ISO 8601 format.
+class StandardJsonPlugin implements SerializerPlugin {
+  static final BuiltSet<Type> _unsupportedTypes =
+      BuiltSet<Type>([BuiltListMultimap, BuiltSetMultimap]);
+
+  /// The field used to specify the value type if needed. Defaults to `$`.
+  final String discriminator;
+
+  /// The key used when there is just a single value, for example if serializing
+  /// an `int`.
+  final String valueKey;
+
+  /// The types to leave as a list when converting into json.
+  final BuiltSet<Type> typesToLeaveAsList;
+
+  StandardJsonPlugin({
+    this.discriminator = r'$',
+    this.valueKey = '',
+    Iterable<Type>? typesToLeaveAsList,
+  }) : typesToLeaveAsList = BuiltSet<Type>(
+            {BuiltList, BuiltSet, JsonObject, ...?typesToLeaveAsList});
+
+  @override
+  Object? beforeSerialize(Object? object, FullType specifiedType) {
+    if (_unsupportedTypes.contains(specifiedType.root)) {
+      throw ArgumentError(
+          'Standard JSON cannot serialize type ${specifiedType.root}.');
+    }
+    return object;
+  }
+
+  @override
+  Object? afterSerialize(Object? object, FullType specifiedType) {
+    if (object is List && !typesToLeaveAsList.contains(specifiedType.root)) {
+      if (specifiedType.isUnspecified) {
+        return _toMapWithDiscriminator(object);
+      } else {
+        return _toMap(object, _needsEncodedKeys(specifiedType));
+      }
+    } else {
+      return object;
+    }
+  }
+
+  @override
+  Object? beforeDeserialize(Object? object, FullType specifiedType) {
+    if (object is Map && specifiedType.root != JsonObject) {
+      if (specifiedType.isUnspecified) {
+        return _toListUsingDiscriminator(object);
+      } else {
+        return _toList(object, _needsEncodedKeys(specifiedType),
+            keepNulls: specifiedType.root == BuiltMap);
+      }
+    } else {
+      return object;
+    }
+  }
+
+  @override
+  Object? afterDeserialize(Object? object, FullType specifiedType) {
+    return object;
+  }
+
+  /// Returns whether a type has keys that aren't supported by JSON maps; this
+  /// only applies to `BuiltMap` with non-String keys.
+  bool _needsEncodedKeys(FullType specifiedType) =>
+      specifiedType.root == BuiltMap &&
+      specifiedType.parameters[0].root != String;
+
+  /// Converts serialization output, a `List`, to a `Map`, when the serialized
+  /// type is known statically.
+  Map _toMap(List list, bool needsEncodedKeys) {
+    var result = <String, Object?>{};
+    for (var i = 0; i != list.length ~/ 2; ++i) {
+      final key = list[i * 2];
+      final value = list[i * 2 + 1];
+      result[needsEncodedKeys ? _encodeKey(key) : key as String] = value;
+    }
+    return result;
+  }
+
+  /// Converts serialization output, a `List`, to a `Map`, when the serialized
+  /// type is not known statically. The type will be specified in the
+  /// [discriminator] field.
+  Map _toMapWithDiscriminator(List list) {
+    var type = list[0];
+
+    if (type == 'list') {
+      // Embed the list in the map.
+      return <String, Object>{discriminator: type, valueKey: list.sublist(1)};
+    }
+
+    // Length is at least two because we have one entry for type and one for
+    // the value.
+    if (list.length == 2) {
+      // Just a type and a primitive value. Encode the value in the map.
+      return <String, Object?>{discriminator: type, valueKey: list[1]};
+    }
+
+    // If a map has non-String keys then they need encoding to strings before
+    // it can be converted to JSON. Because we don't know the type, we also
+    // won't know the type on deserialization, and signal this by changing the
+    // type name on the wire to `encoded_map`.
+    var needToEncodeKeys = false;
+    if (type == 'map') {
+      for (var i = 0; i != (list.length - 1) ~/ 2; ++i) {
+        if (list[i * 2 + 1] is! String) {
+          needToEncodeKeys = true;
+          type = 'encoded_map';
+          break;
+        }
+      }
+    }
+
+    var result = <String, Object>{discriminator: type};
+    for (var i = 0; i != (list.length - 1) ~/ 2; ++i) {
+      final key = needToEncodeKeys
+          ? _encodeKey(list[i * 2 + 1])
+          : list[i * 2 + 1] as String;
+      final value = list[i * 2 + 2];
+      result[key] = value;
+    }
+    return result;
+  }
+
+  /// JSON-encodes an `Object` key so it can be stored as a `String`. Needed
+  /// because JSON maps are only allowed strings as keys.
+  String _encodeKey(Object key) {
+    return json.encode(key);
+  }
+
+  /// Converts [StandardJsonPlugin] serialization output, a `Map`, to a `List`,
+  /// when the serialized type is known statically.
+  ///
+  /// By default keys with null values are dropped, pass [keepNulls] true when
+  /// the map is an actual map with nullable values, so they should be kept.
+  List<Object?> _toList(Map map, bool hasEncodedKeys,
+      {bool keepNulls = false}) {
+    var nullValueCount =
+        keepNulls ? 0 : map.values.where((value) => value == null).length;
+    var result = List<Object?>.filled(
+        (map.length - nullValueCount) * 2, 0 /* Will be overwritten. */);
+    var i = 0;
+    map.forEach((key, value) {
+      // Drop null values, they are represented by missing keys.
+      if (!keepNulls && value == null) return;
+
+      result[i] = hasEncodedKeys ? _decodeKey(key as String) : key;
+      result[i + 1] = value;
+      i += 2;
+    });
+    return result;
+  }
+
+  /// Converts [StandardJsonPlugin] serialization output, a `Map`, to a `List`,
+  /// when the serialized type is not known statically. The type is retrieved
+  /// from the [discriminator] field.
+  List<Object?> _toListUsingDiscriminator(Map map) {
+    var type = map[discriminator];
+
+    if (type == null) {
+      throw ArgumentError('Unknown type on deserialization. '
+          'Need either specifiedType or discriminator field.');
+    }
+
+    if (type == 'list') {
+      return [type, ...(map[valueKey] as Iterable)];
+    }
+
+    if (map.containsKey(valueKey)) {
+      // Just a type and a primitive value. Retrieve the value in the map.
+      final result = List<Object?>.filled(2, 0 /* Will be overwritten. */);
+      result[0] = type;
+      result[1] = map[valueKey];
+      return result;
+    }
+
+    // A type name of `encoded_map` indicates that the map has non-String keys
+    // that have been serialized and JSON-encoded; decode the keys when
+    // converting back to a `List`.
+    var needToDecodeKeys = type == 'encoded_map';
+    if (needToDecodeKeys) {
+      type = 'map';
+    }
+
+    var nullValueCount = map.values.where((value) => value == null).length;
+    var result = List<Object>.filled(
+        (map.length - nullValueCount) * 2 - 1, 0 /* Will be overwritten. */);
+    result[0] = type;
+
+    var i = 1;
+    map.forEach((key, value) {
+      if (key == discriminator) return;
+
+      // Drop null values, they are represented by missing keys.
+      if (value == null) return;
+
+      result[i] = needToDecodeKeys ? _decodeKey(key as String) : key;
+      result[i + 1] = value;
+      i += 2;
+    });
+    return result;
+  }
+
+  /// JSON-decodes a `String` encoded using [_encodeKey].
+  Object? _decodeKey(String key) {
+    return json.decode(key);
+  }
+}

--- a/built_types/built_value/pubspec.yaml
+++ b/built_types/built_value/pubspec.yaml
@@ -1,0 +1,21 @@
+name: built_value
+version: 8.13.0
+description: >
+  Value types with builders, Dart classes as enums, and serialization.
+  This library is the runtime dependency.
+repository: https://github.com/google/built_value.dart/tree/master/built_value
+topics:
+ - built-value
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  built_collection: ^5.0.0
+  collection: ^1.15.0
+  fixnum: ^1.0.0
+  meta: ^1.3.0
+
+dev_dependencies:
+  pedantic: ^1.4.0
+  test: ^1.16.0

--- a/built_types/built_value/test/big_int_serializer_test.dart
+++ b/built_types/built_value/test/big_int_serializer_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('BigInt with known specifiedType', () {
+    var data = BigInt.parse('123456789012345678901234567890');
+    var serialized = '123456789012345678901234567890';
+    var specifiedType = const FullType(BigInt);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BigInt with unknown specifiedType', () {
+    var data = BigInt.parse('123456789012345678901234567890');
+    var serialized =
+        json.decode(json.encode(['BigInt', '123456789012345678901234567890']))
+            as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/bool_serializer_test.dart
+++ b/built_types/built_value/test/bool_serializer_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('bool with known specifiedType', () {
+    var data = true;
+    var serialized = true;
+    var specifiedType = const FullType(bool);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('bool with unknown specifiedType', () {
+    var data = true;
+    var serialized = json.decode(json.encode(['bool', true])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/builder_factory_test.dart
+++ b/built_types/built_value/test/builder_factory_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2021, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Missing builder factory', () {
+    var data = BuiltList<int>([1, 2, 3]);
+    var specifiedType = const FullType(BuiltList, [FullType(int)]);
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+    test('serialize throws with nice message', () {
+      expect(
+          () => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(predicate((e) =>
+              e.toString().contains('No builder factory for BuiltList<int>'))));
+    });
+
+    test('deserialize throws with nice message', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throwsA(predicate((e) =>
+              e.toString().contains('No builder factory for BuiltList<int>'))));
+    });
+  });
+}

--- a/built_types/built_value/test/built_list_async_deserializer_test.dart
+++ b/built_types/built_value/test/built_list_async_deserializer_test.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/async_serializer.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuiltList', () {
+    var data = BuiltList<int>([1, 2, 3]);
+    var specifiedType = const FullType(BuiltList, [FullType(int)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => ListBuilder<int>()))
+        .build();
+    var serialized = json.decode(json.encode([1, 2, 3])) as Iterable;
+
+    test('can be deserialized asynchronously', () async {
+      final deserialized = await BuiltListAsyncDeserializer()
+          .deserialize(serializers, serialized, specifiedType: specifiedType)
+          .toList();
+
+      expect(deserialized, data);
+    });
+  });
+}

--- a/built_types/built_value/test/built_list_multimap_serializer_test.dart
+++ b/built_types/built_value/test/built_list_multimap_serializer_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuiltListMultimap with known specifiedType and correct builder', () {
+    var data = BuiltListMultimap<int, String>({
+      1: ['one'],
+      2: ['two'],
+      3: ['three', '3hree']
+    });
+    var specifiedType =
+        const FullType(BuiltListMultimap, [FullType(int), FullType(String)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => ListMultimapBuilder<int, String>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      1,
+      ['one'],
+      2,
+      ['two'],
+      3,
+      ['three', '3hree']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType,
+          BuiltListMultimap<int, String>().runtimeType);
+    });
+  });
+}

--- a/built_types/built_value/test/built_list_serializer_test.dart
+++ b/built_types/built_value/test/built_list_serializer_test.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuiltList with known specifiedType but missing builder', () {
+    var data = BuiltList<int>([1, 2, 3]);
+    var specifiedType = const FullType(BuiltList, [FullType(int)]);
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+    test('serialize throws', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<StateError>()));
+    });
+
+    test('deserialize throws', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<DeserializationError>()));
+    });
+  });
+
+  group('BuiltList with known specifiedType and correct builder', () {
+    var data = BuiltList<int>([1, 2, 3]);
+    var specifiedType = const FullType(BuiltList, [FullType(int)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => ListBuilder<int>()))
+        .build();
+    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType,
+          BuiltList<int>().runtimeType);
+    });
+  });
+
+  group('BuiltList nested with known specifiedType and correct builders', () {
+    var data = BuiltList<BuiltList<int>>([
+      BuiltList<int>([1, 2, 3]),
+      BuiltList<int>([4, 5, 6]),
+      BuiltList<int>([7, 8, 9])
+    ]);
+    var specifiedType = const FullType(BuiltList, [
+      FullType(BuiltList, [FullType(int)])
+    ]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => ListBuilder<BuiltList<int>>())
+          ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]),
+              () => ListBuilder<int>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltList with unknown specifiedType and no builders', () {
+    var data = BuiltList<int>([1, 2, 3]);
+    var specifiedType = FullType.unspecified;
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([
+      'list',
+      ['int', 1],
+      ['int', 2],
+      ['int', 3]
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/built_map_serializer_test.dart
+++ b/built_types/built_value/test/built_map_serializer_test.dart
@@ -1,0 +1,285 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuiltMap with known specifiedType but missing builder', () {
+    var data = BuiltMap<int, String>({1: 'one', 2: 'two', 3: 'three'});
+    var specifiedType =
+        const FullType(BuiltMap, [FullType(int), FullType(String)]);
+    var serializers = Serializers();
+    var serialized =
+        json.decode(json.encode([1, 'one', 2, 'two', 3, 'three'])) as Object;
+
+    test('cannot be serialized', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<StateError>()));
+    });
+
+    test('cannot be deserialized', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<DeserializationError>()));
+    });
+  });
+
+  group('BuiltMap with known specifiedType and correct builder', () {
+    var data = BuiltMap<int, String>({1: 'one', 2: 'two', 3: 'three'});
+    var specifiedType =
+        const FullType(BuiltMap, [FullType(int), FullType(String)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => MapBuilder<int, String>()))
+        .build();
+    var serialized =
+        json.decode(json.encode([1, 'one', 2, 'two', 3, 'three'])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType,
+          BuiltMap<int, String>().runtimeType);
+    });
+  });
+
+  group('BuiltMap nested left with known specifiedType', () {
+    var data = BuiltMap<BuiltMap<int, String>, String>({
+      BuiltMap<int, String>({1: 'one'}): 'one!',
+      BuiltMap<int, String>({2: 'two'}): 'two!'
+    });
+    const innerTypeLeft = FullType(BuiltMap, [FullType(int), FullType(String)]);
+    var specifiedType =
+        const FullType(BuiltMap, [innerTypeLeft, FullType(String)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(innerTypeLeft, () => MapBuilder<int, String>())
+          ..addBuilderFactory(
+              specifiedType, () => MapBuilder<BuiltMap<int, String>, String>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      [1, 'one'],
+      'one!',
+      [2, 'two'],
+      'two!'
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltMap nested right with known specifiedType', () {
+    var data = BuiltMap<int, BuiltMap<String, String>>({
+      1: BuiltMap<String, String>({'one': 'one!'}),
+      2: BuiltMap<String, String>({'two': 'two!'})
+    });
+    const innerTypeRight =
+        FullType(BuiltMap, [FullType(String), FullType(String)]);
+    var specifiedType =
+        const FullType(BuiltMap, [FullType(int), innerTypeRight]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(
+              innerTypeRight, () => MapBuilder<String, String>())
+          ..addBuilderFactory(
+              specifiedType, () => MapBuilder<int, BuiltMap<String, String>>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      1,
+      ['one', 'one!'],
+      2,
+      ['two', 'two!']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltMap nested both with known specifiedType', () {
+    var data = BuiltMap<BuiltMap<int, int>, BuiltMap<String, String>>({
+      BuiltMap<int, int>({1: 1}): BuiltMap<String, String>({'one': 'one!'}),
+      BuiltMap<int, int>({2: 2}): BuiltMap<String, String>({'two': 'two!'})
+    });
+    const builtMapOfIntIntGenericType =
+        FullType(BuiltMap, [FullType(int), FullType(int)]);
+    const builtMapOfStringStringGenericType =
+        FullType(BuiltMap, [FullType(String), FullType(String)]);
+    var specifiedType = const FullType(BuiltMap,
+        [builtMapOfIntIntGenericType, builtMapOfStringStringGenericType]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(
+              builtMapOfIntIntGenericType, () => MapBuilder<int, int>())
+          ..addBuilderFactory(builtMapOfStringStringGenericType,
+              () => MapBuilder<String, String>())
+          ..addBuilderFactory(specifiedType,
+              () => MapBuilder<BuiltMap<int, int>, BuiltMap<String, String>>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      [1, 1],
+      ['one', 'one!'],
+      [2, 2],
+      ['two', 'two!']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type on deserialization', () {
+      final genericSerializer = (serializers.toBuilder()
+            ..addBuilderFactory(
+                specifiedType,
+                () =>
+                    MapBuilder<BuiltMap<int, int>, BuiltMap<String, String>>())
+            ..addBuilderFactory(
+                builtMapOfIntIntGenericType, () => MapBuilder<int, int>())
+            ..addBuilderFactory(builtMapOfStringStringGenericType,
+                () => MapBuilder<String, String>()))
+          .build();
+
+      expect(
+          genericSerializer
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType,
+          BuiltMap<BuiltMap<int, int>, BuiltMap<String, String>>().runtimeType);
+    });
+  });
+
+  group('BuiltMap with Object values', () {
+    var data = BuiltMap<int, Object>({1: 'one', 2: 2, 3: 'three'});
+    var specifiedType =
+        const FullType(BuiltMap, [FullType(int), FullType.unspecified]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => MapBuilder<int, Object>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      1,
+      ['String', 'one'],
+      2,
+      ['int', 2],
+      3,
+      ['String', 'three']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltMap with Object keys', () {
+    var data = BuiltMap<Object, String>({1: 'one', 'two': 'two', 3: 'three'});
+    var specifiedType =
+        const FullType(BuiltMap, [FullType.unspecified, FullType(String)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => MapBuilder<Object, String>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      ['int', 1],
+      'one',
+      ['String', 'two'],
+      'two',
+      ['int', 3],
+      'three'
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltMap with Object keys and values', () {
+    var data = BuiltMap<Object, Object>({1: 'one', 'two': 2, 3: 'three'});
+    var specifiedType = const FullType(BuiltMap);
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([
+      ['int', 1],
+      ['String', 'one'],
+      ['String', 'two'],
+      ['int', 2],
+      ['int', 3],
+      ['String', 'three']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltMap with unknown specifiedType', () {
+    var data = BuiltMap<Object, Object>({1: 'one', 'two': 2, 3: 'three'});
+    var specifiedType = FullType.unspecified;
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([
+      'map',
+      ['int', 1],
+      ['String', 'one'],
+      ['String', 'two'],
+      ['int', 2],
+      ['int', 3],
+      ['String', 'three']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/built_set_multimap_serializer_test.dart
+++ b/built_types/built_value/test/built_set_multimap_serializer_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BuiltSetMultimap with known specifiedType and correct builder', () {
+    var data = BuiltSetMultimap<int, String>({
+      1: ['one'],
+      2: ['two'],
+      3: ['three', '3hree']
+    });
+    var specifiedType =
+        const FullType(BuiltSetMultimap, [FullType(int), FullType(String)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => SetMultimapBuilder<int, String>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      1,
+      ['one'],
+      2,
+      ['two'],
+      3,
+      ['three', '3hree']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType,
+          BuiltSetMultimap<int, String>().runtimeType);
+    });
+  });
+}

--- a/built_types/built_value/test/built_set_serializer_test.dart
+++ b/built_types/built_value/test/built_set_serializer_test.dart
@@ -1,0 +1,113 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+// Note: BuiltSet preserves order, so comparisons in these tests can assume a
+// specific ordering. In fact, these tests are exactly the BuiltListSerializer
+// tests with "list" replaced by "set".
+void main() {
+  group('BuiltSet with known specifiedType but missing builder', () {
+    var data = BuiltSet<int>([1, 2, 3]);
+    var specifiedType = const FullType(BuiltSet, [FullType(int)]);
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+    test('serialize throws', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<StateError>()));
+    });
+
+    test('deserialize throws', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<DeserializationError>()));
+    });
+  });
+
+  group('BuiltSet with known specifiedType and correct builder', () {
+    var data = BuiltSet<int>([1, 2, 3]);
+    var specifiedType = const FullType(BuiltSet, [FullType(int)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => SetBuilder<int>()))
+        .build();
+    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType,
+          BuiltSet<int>().runtimeType);
+    });
+  });
+
+  group('BuiltSet nested with known specifiedType and correct builders', () {
+    var data = BuiltSet<BuiltSet<int>>([
+      BuiltSet<int>([1, 2, 3]),
+      BuiltSet<int>([4, 5, 6]),
+      BuiltSet<int>([7, 8, 9])
+    ]);
+    var specifiedType = const FullType(BuiltSet, [
+      FullType(BuiltSet, [FullType(int)])
+    ]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => SetBuilder<BuiltSet<int>>())
+          ..addBuilderFactory(const FullType(BuiltSet, [FullType(int)]),
+              () => SetBuilder<int>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('BuiltSet with unknown specifiedType and no builders', () {
+    var data = BuiltSet<int>([1, 2, 3]);
+    var specifiedType = FullType.unspecified;
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([
+      'set',
+      ['int', 1],
+      ['int', 2],
+      ['int', 3]
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/built_value_test.dart
+++ b/built_types/built_value/test/built_value_test.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/built_value.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EnumClass', () {
+    test('can be used in switch', () {
+      final yes = YesNoEnum.yes;
+      switch (yes) {
+        case YesNoEnum.yes:
+          break;
+        case YesNoEnum.no:
+          break;
+      }
+    });
+  });
+}
+
+// Note: this is not the right way to use EnumClass!
+//
+// See https://github.com/google/built_value.dart/tree/master/example
+class YesNoEnum extends EnumClass {
+  static const YesNoEnum yes = YesNoEnum._('yes');
+  static const YesNoEnum no = YesNoEnum._('no');
+
+  const YesNoEnum._(String name) : super(name);
+}

--- a/built_types/built_value/test/date_time_serializer_test.dart
+++ b/built_types/built_value/test/date_time_serializer_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('DateTime with known specifiedType', () {
+    var data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
+    var serialized = data.microsecondsSinceEpoch;
+    var specifiedType = const FullType(DateTime);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('serialize throws if not UTC', () {
+      expect(() => serializers.serialize(DateTime.now()),
+          throwsA(const TypeMatcher<ArgumentError>()));
+    });
+  });
+
+  group('DateTime with unknown specifiedType', () {
+    var data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
+    var serialized =
+        json.decode(json.encode(['DateTime', data.microsecondsSinceEpoch]))
+            as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/double_serializer_test.dart
+++ b/built_types/built_value/test/double_serializer_test.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('double with known specifiedType', () {
+    var data = 3.141592653589793;
+    var serialized = data;
+    var specifiedType = const FullType(double);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('double with unknown specifiedType', () {
+    var data = 3.141592653589793;
+    var serialized = json.decode(json.encode(['double', data])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('double with NaN value', () {
+    var data = double.nan;
+    var serialized = 'NaN';
+    var specifiedType = const FullType(double);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      // Compare using toString as NaN != NaN.
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .toString(),
+          data.toString());
+    });
+  });
+
+  group('double with -INF value', () {
+    var data = double.negativeInfinity;
+    var serialized = '-INF';
+    var specifiedType = const FullType(double);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('double with INF value', () {
+    var data = double.infinity;
+    var serialized = 'INF';
+    var specifiedType = const FullType(double);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/duration_serializer_test.dart
+++ b/built_types/built_value/test/duration_serializer_test.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('Duration with known specifiedType', () {
+    var data = Duration(
+        days: 1,
+        hours: 2,
+        minutes: 3,
+        seconds: 4,
+        milliseconds: 5,
+        microseconds: 6);
+    var serialized = 1 * 1000 * 1000 * 60 * 60 * 24 +
+        2 * 1000 * 1000 * 60 * 60 +
+        3 * 1000 * 1000 * 60 +
+        4 * 1000 * 1000 +
+        5 * 1000 +
+        6;
+    var specifiedType = const FullType(Duration);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('Duration with unknown specifiedType', () {
+    var data = Duration(
+        days: 1,
+        hours: 2,
+        minutes: 3,
+        seconds: 4,
+        milliseconds: 5,
+        microseconds: 6);
+    var serialized = json.decode(json.encode([
+      'Duration',
+      1 * 1000 * 1000 * 60 * 60 * 24 +
+          2 * 1000 * 1000 * 60 * 60 +
+          3 * 1000 * 1000 * 60 +
+          4 * 1000 * 1000 +
+          5 * 1000 +
+          6,
+    ])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/int32_serializer_test.dart
+++ b/built_types/built_value/test/int32_serializer_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2023, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('int32 with known specifiedType', () {
+    var data = Int32.MAX_VALUE;
+    var serialized = Int32.MAX_VALUE.toInt();
+    var specifiedType = const FullType(Int32);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('int32 with unknown specifiedType', () {
+    var data = Int32.MIN_VALUE;
+    var serialized =
+        json.decode(json.encode(['Int32', Int32.MIN_VALUE.toInt()])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/int64_serializer_test.dart
+++ b/built_types/built_value/test/int64_serializer_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('int64 with known specifiedType', () {
+    var data = Int64.MAX_VALUE;
+    var serialized = Int64.MAX_VALUE.toString();
+    var specifiedType = const FullType(Int64);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('int64 with unknown specifiedType', () {
+    var data = Int64.MIN_VALUE;
+    var serialized = json
+        .decode(json.encode(['Int64', Int64.MIN_VALUE.toString()])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/int_serializer_test.dart
+++ b/built_types/built_value/test/int_serializer_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('int with known specifiedType', () {
+    var data = 42;
+    var serialized = 42;
+    var specifiedType = const FullType(int);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('int with unknown specifiedType', () {
+    var data = 42;
+    var serialized = json.decode(json.encode(['int', 42])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/iso_8601_date_time_serializer_test.dart
+++ b/built_types/built_value/test/iso_8601_date_time_serializer_test.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/iso_8601_date_time_serializer.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers =
+      (Serializers().toBuilder()..add(Iso8601DateTimeSerializer())).build();
+
+  group('DateTime with known specifiedType', () {
+    var data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
+    var serialized = '1980-01-02T03:04:05.006007Z';
+    var specifiedType = const FullType(DateTime);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('serialize throws if not UTC', () {
+      expect(() => serializers.serialize(DateTime.now()),
+          throwsA(const TypeMatcher<ArgumentError>()));
+    });
+  });
+
+  group('DateTime with unknown specifiedType', () {
+    var data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
+    var serialized =
+        json.decode(json.encode(['DateTime', '1980-01-02T03:04:05.006007Z']))
+            as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/iso_8601_duration_serializer_test.dart
+++ b/built_types/built_value/test/iso_8601_duration_serializer_test.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2019, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/iso_8601_duration_serializer.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers =
+      (Serializers().toBuilder()..add(Iso8601DurationSerializer())).build();
+
+  const testTable = [
+    {
+      #s: 'P1DT2H3M4S',
+      #d: Duration(days: 1, hours: 2, minutes: 3, seconds: 4),
+    },
+    {
+      #s: 'PT0S',
+      #d: Duration.zero,
+    },
+    {
+      #s: 'PT2H',
+      #d: Duration(hours: 2),
+    },
+    {
+      #s: 'PT2H3M',
+      #d: Duration(hours: 2, minutes: 3),
+    },
+    {
+      #s: 'P2D',
+      #d: Duration(days: 2),
+    },
+  ];
+  const badOnes = [
+    'P',
+    'P0',
+    'PT2S567',
+  ];
+
+  group('Duration with known specifiedType', () {
+    final specifiedType = const FullType(Duration);
+    testTable.forEach((testValue) {
+      test('can be serialized', () {
+        expect(
+            serializers.serialize(testValue[#d]!, specifiedType: specifiedType),
+            testValue[#s]);
+      });
+
+      test('can be deserialized', () {
+        expect(
+            serializers.deserialize(testValue[#s]!,
+                specifiedType: specifiedType),
+            testValue[#d]);
+      });
+    });
+    badOnes.forEach((badOne) {
+      test('deserialize throws if not ISO format', () {
+        expect(
+            () => serializers.deserialize(badOne, specifiedType: specifiedType),
+            throwsA(const TypeMatcher<FormatException>()));
+      });
+    });
+  });
+
+  group('Duration with unknown specifiedType', () {
+    final specifiedType = FullType.unspecified;
+    testTable.forEach((testValue) {
+      test('can be serialized', () {
+        expect(
+            serializers.serialize(testValue[#d]!, specifiedType: specifiedType),
+            ['Duration', testValue[#s]]);
+      });
+
+      test('can be deserialized', () {
+        expect(
+            serializers.deserialize(['Duration', testValue[#s]],
+                specifiedType: specifiedType),
+            testValue[#d]);
+      });
+    });
+
+    group('Duration with subsecond data', () {
+      final data = Duration(seconds: 2, milliseconds: 4);
+      final specifiedType = const FullType(Duration);
+      test('throws an error upon serialization', () {
+        expect(() => serializers.serialize(data, specifiedType: specifiedType),
+            throwsArgumentError);
+      });
+    });
+  });
+}

--- a/built_types/built_value/test/json_object_serializer_test.dart
+++ b/built_types/built_value/test/json_object_serializer_test.dart
@@ -1,0 +1,211 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('JsonObject with known specifiedType holding bool', () {
+    var data = JsonObject(true);
+    var serialized = true;
+    var specifiedType = const FullType(JsonObject);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with unknown specifiedType holding bool', () {
+    var data = JsonObject(true);
+    var serialized = json.decode(json.encode(['JsonObject', true])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with known specifiedType holding double', () {
+    var data = JsonObject(42.5);
+    var serialized = 42.5;
+    var specifiedType = const FullType(JsonObject);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with unknown specifiedType holding double', () {
+    var data = JsonObject(42.5);
+    var serialized = json.decode(json.encode(['JsonObject', 42.5])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with known specifiedType holding list', () {
+    var data = JsonObject([1, 2, 3]);
+    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    var specifiedType = const FullType(JsonObject);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with unknown specifiedType holding list', () {
+    var data = JsonObject([1, 2, 3]);
+    var serialized = json.decode(json.encode([
+      'JsonObject',
+      [1, 2, 3],
+    ])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with known specifiedType holding map', () {
+    var data = JsonObject({'one': 1, 'two': 2, 'three': 3});
+    var serialized = {'one': 1, 'two': 2, 'three': 3};
+    var specifiedType = const FullType(JsonObject);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with unknown specifiedType holding map', () {
+    var data = JsonObject({'one': 1, 'two': 2, 'three': 3});
+    var serialized = json.decode(json.encode([
+      'JsonObject',
+      {'one': 1, 'two': 2, 'three': 3},
+    ])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with known specifiedType holding int', () {
+    var data = JsonObject(42);
+    var serialized = 42;
+    var specifiedType = const FullType(JsonObject);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with unknown specifiedType holding int', () {
+    var data = JsonObject(42);
+    var serialized = json.decode(json.encode(['JsonObject', 42])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with known specifiedType holding String', () {
+    var data = JsonObject('test');
+    var serialized = 'test';
+    var specifiedType = const FullType(JsonObject);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('JsonObject with unknown specifiedType holding String', () {
+    var data = JsonObject('test');
+    var serialized = json.decode(json.encode(['JsonObject', 'test'])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/json_object_test.dart
+++ b/built_types/built_value/test/json_object_test.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2021, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/json_object.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(JsonObject, () {
+    test('can be instantiated from Map<dynamic, dynamic>', () {
+      JsonObject({});
+    });
+
+    test('allows access to Map<String?, dynamic>', () {
+      var map = JsonObject(<String?, dynamic>{'one': 1});
+      expect(map.asMap['one'], 1);
+    });
+  });
+}

--- a/built_types/built_value/test/list_serializer_test.dart
+++ b/built_types/built_value/test/list_serializer_test.dart
@@ -1,0 +1,109 @@
+// Copyright (c) 2025, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('List with known specifiedType but missing builder', () {
+    var data = <int>[1, 2, 3];
+    var specifiedType = const FullType(List, [FullType(int)]);
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+    test('serialize throws', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<StateError>()));
+    });
+
+    test('deserialize throws', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<DeserializationError>()));
+    });
+  });
+
+  group('List with known specifiedType and correct builder', () {
+    var data = <int>[1, 2, 3];
+    var specifiedType = const FullType(List, [FullType(int)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => <int>[]))
+        .build();
+    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType,
+          <int>[].runtimeType);
+    });
+  });
+
+  group('List nested with known specifiedType and correct builders', () {
+    var data = <List<int>>[
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ];
+    var specifiedType = const FullType(List, [
+      FullType(List, [FullType(int)])
+    ]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => <List<int>>[])
+          ..addBuilderFactory(
+              const FullType(List, [FullType(int)]), () => <int>[]))
+        .build();
+    var serialized = json.decode(json.encode([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('List with unknown specifiedType and no builders', () {
+    var data = <int>[1, 2, 3];
+    var specifiedType = FullType.unspecified;
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([
+      'List',
+      ['int', 1],
+      ['int', 2],
+      ['int', 3]
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/map_serializer_test.dart
+++ b/built_types/built_value/test/map_serializer_test.dart
@@ -1,0 +1,283 @@
+// Copyright (c) 2025, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Map with known specifiedType but missing builder', () {
+    var data = <int, String>{1: 'one', 2: 'two', 3: 'three'};
+    var specifiedType = const FullType(Map, [FullType(int), FullType(String)]);
+    var serializers = Serializers();
+    var serialized =
+        json.decode(json.encode([1, 'one', 2, 'two', 3, 'three'])) as Object;
+
+    test('cannot be serialized', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<StateError>()));
+    });
+
+    test('cannot be deserialized', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<DeserializationError>()));
+    });
+  });
+
+  group('Map with known specifiedType and correct builder', () {
+    var data = <int, String>{1: 'one', 2: 'two', 3: 'three'};
+    var specifiedType = const FullType(Map, [FullType(int), FullType(String)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => <int, String>{}))
+        .build();
+    var serialized =
+        json.decode(json.encode([1, 'one', 2, 'two', 3, 'three'])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType,
+          <int, String>{}.runtimeType);
+    });
+  });
+
+  group('Map nested left with known specifiedType', () {
+    var data = <Map<int, String>, String>{
+      <int, String>{1: 'one'}: 'one!',
+      <int, String>{2: 'two'}: 'two!'
+    };
+    const innerTypeLeft = FullType(Map, [FullType(int), FullType(String)]);
+    var specifiedType = const FullType(Map, [innerTypeLeft, FullType(String)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(innerTypeLeft, () => <int, String>{})
+          ..addBuilderFactory(
+              specifiedType, () => <Map<int, String>, String>{}))
+        .build();
+    var serialized = json.decode(json.encode([
+      [1, 'one'],
+      'one!',
+      [2, 'two'],
+      'two!'
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      // `expect` does not deep compare `Map` by key, `toString` is close
+      // enough.
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .toString(),
+          data.toString());
+    });
+  });
+
+  group('Map nested right with known specifiedType', () {
+    var data = <int, Map<String, String>>{
+      1: <String, String>{'one': 'one!'},
+      2: <String, String>{'two': 'two!'}
+    };
+    const innerTypeRight = FullType(Map, [FullType(String), FullType(String)]);
+    var specifiedType = const FullType(Map, [FullType(int), innerTypeRight]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(innerTypeRight, () => <String, String>{})
+          ..addBuilderFactory(
+              specifiedType, () => <int, Map<String, String>>{}))
+        .build();
+    var serialized = json.decode(json.encode([
+      1,
+      ['one', 'one!'],
+      2,
+      ['two', 'two!']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('Map nested both with known specifiedType', () {
+    var data = <Map<int, int>, Map<String, String>>{
+      <int, int>{1: 1}: <String, String>{'one': 'one!'},
+      <int, int>{2: 2}: <String, String>{'two': 'two!'}
+    };
+    const MapOfIntIntGenericType =
+        FullType(Map, [FullType(int), FullType(int)]);
+    const MapOfStringStringGenericType =
+        FullType(Map, [FullType(String), FullType(String)]);
+    var specifiedType = const FullType(
+        Map, [MapOfIntIntGenericType, MapOfStringStringGenericType]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(MapOfIntIntGenericType, () => <int, int>{})
+          ..addBuilderFactory(
+              MapOfStringStringGenericType, () => <String, String>{})
+          ..addBuilderFactory(
+              specifiedType, () => <Map<int, int>, Map<String, String>>{}))
+        .build();
+    var serialized = json.decode(json.encode([
+      [1, 1],
+      ['one', 'one!'],
+      [2, 2],
+      ['two', 'two!']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      // `expect` does not deep compare `Map` by key, `toString` is close
+      // enough.
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .toString(),
+          data.toString());
+    });
+
+    test('keeps generic type on deserialization', () {
+      final genericSerializer = (serializers.toBuilder()
+            ..addBuilderFactory(
+                specifiedType, () => <Map<int, int>, Map<String, String>>{})
+            ..addBuilderFactory(MapOfIntIntGenericType, () => <int, int>{})
+            ..addBuilderFactory(
+                MapOfStringStringGenericType, () => <String, String>{}))
+          .build();
+
+      expect(
+          genericSerializer
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType,
+          <Map<int, int>, Map<String, String>>{}.runtimeType);
+    });
+  });
+
+  group('Map with Object values', () {
+    var data = <int, Object>{1: 'one', 2: 2, 3: 'three'};
+    var specifiedType =
+        const FullType(Map, [FullType(int), FullType.unspecified]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => <int, Object>{}))
+        .build();
+    var serialized = json.decode(json.encode([
+      1,
+      ['String', 'one'],
+      2,
+      ['int', 2],
+      3,
+      ['String', 'three']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('Map with Object keys', () {
+    var data = <Object, String>{1: 'one', 'two': 'two', 3: 'three'};
+    var specifiedType =
+        const FullType(Map, [FullType.unspecified, FullType(String)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => <Object, String>{}))
+        .build();
+    var serialized = json.decode(json.encode([
+      ['int', 1],
+      'one',
+      ['String', 'two'],
+      'two',
+      ['int', 3],
+      'three'
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('Map with Object keys and values', () {
+    var data = <Object, Object>{1: 'one', 'two': 2, 3: 'three'};
+    var specifiedType = const FullType(Map);
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([
+      ['int', 1],
+      ['String', 'one'],
+      ['String', 'two'],
+      ['int', 2],
+      ['int', 3],
+      ['String', 'three']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('Map with unknown specifiedType', () {
+    var data = <Object, Object>{1: 'one', 'two': 2, 3: 'three'};
+    var specifiedType = FullType.unspecified;
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([
+      'Map',
+      ['int', 1],
+      ['String', 'one'],
+      ['String', 'two'],
+      ['int', 2],
+      ['int', 3],
+      ['String', 'three']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/num_serializer_test.dart
+++ b/built_types/built_value/test/num_serializer_test.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('num with known specifiedType', () {
+    var data = 42;
+    var serialized = 42;
+    var specifiedType = const FullType(num);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('num with NaN value', () {
+    var data = double.nan;
+    var serialized = 'NaN';
+    var specifiedType = const FullType(num);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      // Compare using toString as NaN != NaN.
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .toString(),
+          data.toString());
+    });
+  });
+
+  group('num with -INF value', () {
+    var data = double.negativeInfinity;
+    var serialized = '-INF';
+    var specifiedType = const FullType(num);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('num with INF value', () {
+    var data = double.infinity;
+    var serialized = 'INF';
+    var specifiedType = const FullType(num);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/regexp_serializer_test.dart
+++ b/built_types/built_value/test/regexp_serializer_test.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2019, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('RegExp with known specifiedType', () {
+    var data = RegExp(r'\d+, [A-Z](foo)?');
+    var serialized = r'\d+, [A-Z](foo)?';
+    var specifiedType = const FullType(RegExp);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('String with unknown specifiedType', () {
+    var data = RegExp('testing, testing');
+    var serialized =
+        json.decode(json.encode(['RegExp', 'testing, testing'])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/serializers_test.dart
+++ b/built_types/built_value/test/serializers_test.dart
@@ -1,0 +1,114 @@
+// Copyright (c) 2019, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/serializer.dart';
+import 'package:built_value/src/date_time_serializer.dart';
+import 'package:built_value/src/int_serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+  final moreSerializers = (serializers.toBuilder()
+        ..addAll([TestSerializer()])
+        ..addBuilderFactory(FullType(TestSerializer), () => null))
+      .build();
+  final serializersWithPlugin =
+      (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
+
+  group(Serializers, () {
+    test('exposes iterable of serializer', () {
+      expect(serializers.serializers, contains(TypeMatcher<IntSerializer>()));
+    });
+
+    test('can be added to', () {
+      expect(
+          moreSerializers.serializers, contains(TypeMatcher<TestSerializer>()));
+    });
+
+    test('can be merged', () {
+      var mergedSerializers =
+          (serializers.toBuilder()..mergeAll([moreSerializers])).build();
+      expect(mergedSerializers.serializers,
+          contains(TypeMatcher<TestSerializer>()));
+      expect(mergedSerializers.builderFactories.keys,
+          contains(FullType(TestSerializer)));
+    });
+
+    test('can be merged by static method', () {
+      var mergedSerializers = Serializers.merge([serializers, moreSerializers]);
+      expect(mergedSerializers.serializers,
+          contains(TypeMatcher<TestSerializer>()));
+      expect(mergedSerializers.builderFactories.keys,
+          contains(FullType(TestSerializer)));
+    });
+
+    test('provides convenience toJson method', () {
+      expect(serializers.toJson(DateTimeSerializer(), DateTime.utc(2020, 1, 1)),
+          '1577836800000000');
+    });
+
+    test('provides convenience fromJson method', () {
+      expect(serializers.fromJson(DateTimeSerializer(), '1577836800000000'),
+          DateTime.utc(2020, 1, 1));
+    });
+
+    test('serializes null int to null', () {
+      expect(serializers.serialize(null, specifiedType: FullType(int)), null);
+    });
+
+    test('deserializes null int from null', () {
+      expect(serializers.deserialize(null, specifiedType: FullType(int)), null);
+    });
+
+    test('serializes null int to null when plugin is installed', () {
+      expect(
+          serializersWithPlugin.serialize(null, specifiedType: FullType(int)),
+          null);
+    });
+
+    test('deserializes null int from null when plugin is installed', () {
+      expect(
+          serializersWithPlugin.deserialize(null, specifiedType: FullType(int)),
+          null);
+    });
+
+    test('serializes unknown type null to null', () {
+      expect(serializers.serialize(null), ['Null', null]);
+    });
+
+    test('deserializes null from unknown type null', () {
+      expect(serializers.deserialize(['Null', null]), null);
+    });
+
+    test('serializes unknown type null to null when plugin is installed', () {
+      expect(serializersWithPlugin.serialize(null), {r'$': 'Null', '': null});
+    });
+
+    test('deserializes null from unknown type null when plugin is installed',
+        () {
+      expect(serializersWithPlugin.deserialize({r'$': 'Null', '': null}), null);
+    });
+  });
+}
+
+class TestSerializer implements PrimitiveSerializer<Object?> {
+  @override
+  Iterable<Type> get types => [];
+
+  @override
+  String get wireName => '';
+
+  @override
+  Object? deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return null;
+  }
+
+  @override
+  Object serialize(Serializers serializers, Object? object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return '';
+  }
+}

--- a/built_types/built_value/test/set_serializer_test.dart
+++ b/built_types/built_value/test/set_serializer_test.dart
@@ -1,0 +1,113 @@
+// Copyright (c) 2025, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+// Note: Set preserves order, so comparisons in these tests can assume a
+// specific ordering. In fact, these tests are exactly the ListSerializer
+// tests with "list" replaced by "set".
+
+void main() {
+  group('Set with known specifiedType but missing builder', () {
+    var data = <int>{1, 2, 3};
+    var specifiedType = const FullType(Set, [FullType(int)]);
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+    test('serialize throws', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<StateError>()));
+    });
+
+    test('deserialize throws', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<DeserializationError>()));
+    });
+  });
+
+  group('Set with known specifiedType and correct builder', () {
+    var data = <int>{1, 2, 3};
+    var specifiedType = const FullType(Set, [FullType(int)]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => <int>{}))
+        .build();
+    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type when deserialized', () {
+      expect(
+          serializers
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType,
+          <int>{}.runtimeType);
+    });
+  });
+
+  group('Set nested with known specifiedType and correct builders', () {
+    var data = <Set<int>>{
+      {1, 2, 3},
+      {4, 5, 6},
+      {7, 8, 9}
+    };
+    var specifiedType = const FullType(Set, [
+      FullType(Set, [FullType(int)])
+    ]);
+    var serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, () => <Set<int>>{})
+          ..addBuilderFactory(
+              const FullType(Set, [FullType(int)]), () => <int>{}))
+        .build();
+    var serialized = json.decode(json.encode([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9]
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('Set with unknown specifiedType and no builders', () {
+    var data = <int>{1, 2, 3};
+    var specifiedType = FullType.unspecified;
+    var serializers = Serializers();
+    var serialized = json.decode(json.encode([
+      'Set',
+      ['int', 1],
+      ['int', 2],
+      ['int', 3]
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/standard_json_plugin_test.dart
+++ b/built_types/built_value/test/standard_json_plugin_test.dart
@@ -1,0 +1,364 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/standard_json_plugin.dart';
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = (Serializers().toBuilder()
+        ..addPlugin(StandardJsonPlugin())
+        ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]),
+            () => ListBuilder<int>())
+        ..addBuilderFactory(
+            const FullType(BuiltList, [
+              FullType(BuiltList, [FullType(int)])
+            ]),
+            () => ListBuilder<BuiltList<int>>())
+        ..addBuilderFactory(
+            const FullType(BuiltSet, [FullType(int)]), () => SetBuilder<int>())
+        ..addBuilderFactory(
+            const FullType(BuiltMap, [FullType(int), FullType(String)]),
+            () => MapBuilder<int, String>())
+        ..addBuilderFactory(
+            const FullType(BuiltMap, [FullType(String), FullType(String)]),
+            () => MapBuilder<String, String>())
+        ..addBuilderFactory(
+            const FullType(BuiltMap, [
+              FullType(BuiltMap, [FullType(int), FullType(String)]),
+              FullType(BuiltMap, [FullType(int), FullType(String)])
+            ]),
+            () => MapBuilder<BuiltMap<int, String>, BuiltMap<int, String>>()))
+      .build();
+
+  group('Serializers with StandardJsonPlugin', () {
+    test('throws on serialize of list multimaps', () {
+      final data = BuiltListMultimap<int, String>({
+        1: ['one'],
+        2: ['two'],
+        3: ['three']
+      });
+      final specifiedType =
+          const FullType(BuiltListMultimap, [FullType(int), FullType(String)]);
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<ArgumentError>()));
+    });
+
+    test('throws on serialize of set multimaps', () {
+      final data = BuiltSetMultimap<int, String>({
+        1: ['one'],
+        2: ['two'],
+        3: ['three']
+      });
+      final specifiedType =
+          const FullType(BuiltSetMultimap, [FullType(int), FullType(String)]);
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<ArgumentError>()));
+    });
+
+    group('and known specifiedType', () {
+      group('can take an int and', () {
+        final data = 1;
+        final specifiedType = const FullType(int);
+        final serialized = 1;
+
+        test('serialize it', () {
+          expect(serializers.serialize(data, specifiedType: specifiedType),
+              serialized);
+        });
+
+        test('deserialize it', () {
+          expect(
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+              data);
+        });
+      });
+
+      group('can take a list and', () {
+        final data = BuiltList<int>([1, 2, 3]);
+        final specifiedType = const FullType(BuiltList, [FullType(int)]);
+        final serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+        test('serialize it', () {
+          expect(serializers.serialize(data, specifiedType: specifiedType),
+              serialized);
+        });
+
+        test('deserialize it', () {
+          expect(
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+              data);
+        });
+      });
+
+      group('can take a set and', () {
+        final data = BuiltSet<int>([1, 2, 3]);
+        final specifiedType = const FullType(BuiltSet, [FullType(int)]);
+        final serialized = json.decode(json.encode([1, 2, 3])) as Object;
+
+        test('serialize it', () {
+          expect(serializers.serialize(data, specifiedType: specifiedType),
+              serialized);
+        });
+
+        test('deserialize it', () {
+          expect(
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+              data);
+        });
+      });
+
+      group('can take a nested list and', () {
+        final data = BuiltList<BuiltList<int>>([
+          BuiltList<int>([1, 2, 3]),
+          BuiltList<int>([4, 5, 6]),
+          BuiltList<int>([7, 8, 9])
+        ]);
+        final specifiedType = const FullType(BuiltList, [
+          FullType(BuiltList, [FullType(int)])
+        ]);
+        final serialized = json.decode(json.encode([
+          [1, 2, 3],
+          [4, 5, 6],
+          [7, 8, 9]
+        ])) as Object;
+
+        test('serialize it', () {
+          expect(serializers.serialize(data, specifiedType: specifiedType),
+              serialized);
+        });
+
+        test('deserialize it', () {
+          expect(
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+              data);
+        });
+      });
+
+      group('can take a map and', () {
+        final data = BuiltMap<int, String>({1: 'one', 2: 'two', 3: 'three'});
+        final specifiedType =
+            const FullType(BuiltMap, [FullType(int), FullType(String)]);
+        final serialized = {'1': 'one', '2': 'two', '3': 'three'};
+
+        test('serialize it', () {
+          expect(serializers.serialize(data, specifiedType: specifiedType),
+              serialized);
+        });
+
+        test('deserialize it', () {
+          expect(
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+              data);
+        });
+      });
+
+      group('can take a map with String keys and', () {
+        final data =
+            BuiltMap<String, String>({'1': 'one', '2': 'two', '3': 'three'});
+        final specifiedType =
+            const FullType(BuiltMap, [FullType(String), FullType(String)]);
+        final serialized = {'1': 'one', '2': 'two', '3': 'three'};
+
+        test('serialize it', () {
+          expect(serializers.serialize(data, specifiedType: specifiedType),
+              serialized);
+        });
+
+        test('deserialize it', () {
+          expect(
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+              data);
+        });
+      });
+
+      group('can take a nested map and', () {
+        final data = BuiltMap<BuiltMap<int, String>, BuiltMap<int, String>>({
+          BuiltMap<int, String>({1: 'one'}):
+              BuiltMap<int, String>({2: 'two', 3: 'three'})
+        });
+        final specifiedType = const FullType(BuiltMap, [
+          FullType(BuiltMap, [FullType(int), FullType(String)]),
+          FullType(BuiltMap, [FullType(int), FullType(String)])
+        ]);
+        final serialized = {
+          '{"1":"one"}': {'2': 'two', '3': 'three'}
+        };
+
+        test('serialize it', () {
+          expect(serializers.serialize(data, specifiedType: specifiedType),
+              serialized);
+        });
+
+        test('deserialize it', () {
+          expect(
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+              data);
+        });
+      });
+    });
+
+    group('and unknown specifiedType', () {
+      group('can take an int and', () {
+        final data = 1;
+        final serialized = {r'$': 'int', '': 1};
+
+        test('serialize it', () {
+          expect(serializers.serialize(data), serialized);
+        });
+
+        test('deserialize it', () {
+          expect(serializers.deserialize(serialized), data);
+        });
+      });
+
+      group('can take a list and', () {
+        final data = BuiltList<int>([1, 2, 3]);
+        final serialized = {
+          r'$': 'list',
+          '': [
+            {r'$': 'int', '': 1},
+            {r'$': 'int', '': 2},
+            {r'$': 'int', '': 3}
+          ]
+        };
+
+        test('serialize it', () {
+          expect(serializers.serialize(data), serialized);
+        });
+
+        test('deserialize it', () {
+          expect(serializers.deserialize(serialized), data);
+        });
+      });
+
+      group('can take a list of length 1 and', () {
+        final data = BuiltList<int>([1]);
+        final serialized = {
+          r'$': 'list',
+          '': [
+            {r'$': 'int', '': 1},
+          ]
+        };
+
+        test('serialize it', () {
+          expect(serializers.serialize(data), serialized);
+        });
+
+        test('deserialize it', () {
+          expect(serializers.deserialize(serialized), data);
+        });
+      });
+
+      group('can take a nested list and', () {
+        final data = BuiltList<BuiltList<int>>([
+          BuiltList<int>([1, 2, 3]),
+          BuiltList<int>([4, 5, 6]),
+          BuiltList<int>([7, 8, 9])
+        ]);
+        final serialized = {
+          r'$': 'list',
+          '': [
+            {
+              r'$': 'list',
+              '': [
+                {r'$': 'int', '': 1},
+                {r'$': 'int', '': 2},
+                {r'$': 'int', '': 3}
+              ]
+            },
+            {
+              r'$': 'list',
+              '': [
+                {r'$': 'int', '': 4},
+                {r'$': 'int', '': 5},
+                {r'$': 'int', '': 6}
+              ]
+            },
+            {
+              r'$': 'list',
+              '': [
+                {r'$': 'int', '': 7},
+                {r'$': 'int', '': 8},
+                {r'$': 'int', '': 9}
+              ]
+            }
+          ]
+        };
+
+        test('serialize it', () {
+          expect(serializers.serialize(data), serialized);
+        });
+
+        test('deserialize it', () {
+          expect(serializers.deserialize(serialized), data);
+        });
+      });
+
+      group('can take a map and', () {
+        final data = BuiltMap<int, String>({1: 'one', 2: 'two', 3: 'three'});
+        final serialized = {
+          r'$': 'encoded_map',
+          r'{"$":"int","":1}': {r'$': 'String', '': 'one'},
+          r'{"$":"int","":2}': {r'$': 'String', '': 'two'},
+          r'{"$":"int","":3}': {r'$': 'String', '': 'three'}
+        };
+
+        test('serialize it', () {
+          expect(serializers.serialize(data), serialized);
+        });
+
+        test('deserialize it', () {
+          expect(serializers.deserialize(serialized), data);
+        });
+      });
+
+      group('can take a map with String keys and', () {
+        final data =
+            BuiltMap<String, String>({'1': 'one', '2': 'two', '3': 'three'});
+        final serialized = {
+          r'$': 'encoded_map',
+          r'{"$":"String","":"1"}': {r'$': 'String', '': 'one'},
+          r'{"$":"String","":"2"}': {r'$': 'String', '': 'two'},
+          r'{"$":"String","":"3"}': {r'$': 'String', '': 'three'}
+        };
+
+        test('serialize it', () {
+          expect(serializers.serialize(data), serialized);
+        });
+
+        test('deserialize it', () {
+          expect(serializers.deserialize(serialized), data);
+        });
+      });
+
+      group('can take a nested map and', () {
+        final data = BuiltMap<BuiltMap<int, String>, BuiltMap<int, String>>({
+          BuiltMap<int, String>({1: 'one'}):
+              BuiltMap<int, String>({2: 'two', 3: 'three'})
+        });
+        final serialized = {
+          r'$': 'encoded_map',
+          r'{"$":"encoded_map",'
+              r'"{\"$\":\"int\",\"\":1}":{"$":"String","":"one"}}': {
+            r'$': 'encoded_map',
+            r'{"$":"int","":2}': {r'$': 'String', '': 'two'},
+            r'{"$":"int","":3}': {r'$': 'String', '': 'three'}
+          }
+        };
+
+        test('serialize it', () {
+          expect(serializers.serialize(data), serialized);
+        });
+
+        test('deserialize it', () {
+          expect(serializers.deserialize(serialized), data);
+        });
+      });
+    });
+  });
+}

--- a/built_types/built_value/test/string_serializer_test.dart
+++ b/built_types/built_value/test/string_serializer_test.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('String with known specifiedType', () {
+    var data = 'testing, testing';
+    var serialized = 'testing, testing';
+    var specifiedType = const FullType(String);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('String with unknown specifiedType', () {
+    var data = 'testing, testing';
+    var serialized =
+        json.decode(json.encode(['String', 'testing, testing'])) as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/uint8_list_serializer_test.dart
+++ b/built_types/built_value/test/uint8_list_serializer_test.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2023, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('Uint8List with known specifiedType', () {
+    var serialized =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+    var data = base64Decode(serialized);
+    var specifiedType = const FullType(Uint8List);
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('UInt8List with unknown specifiedType', () {
+    var rawData =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+    var serialized = json.decode(json.encode(['UInt8List', rawData])) as Object;
+    var data = base64Decode(rawData.toString());
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      var serialized_by =
+          serializers.serialize(data, specifiedType: specifiedType);
+      expect(serialized_by, serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value/test/uri_serializer_test.dart
+++ b/built_types/built_value/test/uri_serializer_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var serializers = Serializers();
+
+  group('SimpleUri with known specifiedType', () {
+    var data = Uri.parse('https://github.com');
+    var serialized = 'https://github.com';
+    var specifiedType = const FullType(Uri);
+
+    test('has expected type', () {
+      expect(data.runtimeType.toString(), '_SimpleUri');
+    });
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('Uri with known specifiedType', () {
+    var data = Uri.parse('https://github.com:0/google/built_value.dart');
+    var serialized = 'https://github.com:0/google/built_value.dart';
+    var specifiedType = const FullType(Uri);
+
+    test('has expected type', () {
+      expect(data.runtimeType.toString(), '_Uri');
+    });
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('Uri with unknown specifiedType', () {
+    var data = Uri.parse('https://github.com/google/built_value.dart');
+    var serialized = json.decode(
+            json.encode(['Uri', 'https://github.com/google/built_value.dart']))
+        as Object;
+    var specifiedType = FullType.unspecified;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized, specifiedType: specifiedType),
+          data);
+    });
+  });
+}

--- a/built_types/built_value_generator/LICENSE
+++ b/built_types/built_value_generator/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2015, Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/built_types/built_value_generator/analysis_options.yaml
+++ b/built_types/built_value_generator/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/built_types/built_value_generator/build.yaml
+++ b/built_types/built_value_generator/build.yaml
@@ -1,0 +1,23 @@
+targets:
+  $default:
+    builders:
+      built_value_generator|built_value:
+        enabled: true
+
+builders:
+  built_value:
+    target: ":built_value_generator"
+    import: "package:built_value_generator/builder.dart"
+    builder_factories: ["builtValue"]
+    build_extensions: {".dart": [".built_value.g.part"]}
+    auto_apply: dependents
+    build_to: cache
+    applies_builders: ["source_gen|combining_builder"]
+    defaults:
+      options:
+        run_only_if_triggered: true
+
+triggers:
+  built_value_generator:built_value:
+    - import built_value/built_value.dart
+    - annotation SerializersFor

--- a/built_types/built_value_generator/example/README.md
+++ b/built_types/built_value_generator/example/README.md
@@ -1,0 +1,4 @@
+ - [Basic usage](https://github.com/google/built_value.dart/blob/master/example/lib/example.dart)
+ - [Client and server](https://github.com/google/built_value.dart/tree/master/chat_example)
+ - [End to end tests](https://github.com/google/built_value.dart/tree/master/end_to_end_test)
+ - [API documentation](https://pub.dev/documentation/built_value/latest/)

--- a/built_types/built_value_generator/lib/builder.dart
+++ b/built_types/built_value_generator/lib/builder.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:build/build.dart';
+
+import 'package:built_value_generator/built_value_generator.dart';
+import 'package:source_gen/source_gen.dart';
+
+Builder builtValue(BuilderOptions _) =>
+    SharedPartBuilder([BuiltValueGenerator()], 'built_value');

--- a/built_types/built_value_generator/lib/built_value_generator.dart
+++ b/built_types/built_value_generator/lib/built_value_generator.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build/build.dart';
+import 'package:built_value_generator/src/enum_source_library.dart';
+import 'package:built_value_generator/src/parsed_library_results.dart';
+import 'package:built_value_generator/src/serializer_source_library.dart';
+import 'package:built_value_generator/src/value_source_class.dart';
+import 'package:source_gen/source_gen.dart';
+
+/// Generator for Enum Class and Built Values.
+///
+/// See https://github.com/google/built_value.dart/tree/master/example
+class BuiltValueGenerator extends Generator {
+  // Allow creating via `const` as well as enforces immutability here.
+  const BuiltValueGenerator();
+
+  @override
+  Future<String?> generate(LibraryReader library, BuildStep buildStep) async {
+    var parsedLibraryResults = ParsedLibraryResults();
+
+    // Workaround for https://github.com/google/built_value.dart/issues/941.
+    LibraryElement libraryElement;
+    var attempts = 0;
+    while (true) {
+      try {
+        libraryElement = await buildStep.resolver.libraryFor(
+          await buildStep.resolver.assetIdForElement(library.element),
+        );
+        parsedLibraryResults.parsedLibraryResultOrThrowingMock(libraryElement);
+        break;
+      } catch (_) {
+        ++attempts;
+        if (attempts == 10) {
+          log.severe('Analysis session did not stabilize after ten tries!');
+          return null;
+        }
+      }
+    }
+
+    var result = StringBuffer();
+    try {
+      final enumCode = EnumSourceLibrary(
+        parsedLibraryResults,
+        libraryElement,
+      ).generateCode();
+      if (enumCode != null) result.writeln(enumCode);
+      final serializerSourceLibrary = SerializerSourceLibrary(
+        parsedLibraryResults,
+        libraryElement,
+      );
+      if (serializerSourceLibrary.needsBuiltJson ||
+          serializerSourceLibrary.hasSerializers) {
+        result.writeln(serializerSourceLibrary.generateCode());
+      }
+    } on InvalidGenerationSourceError catch (e, st) {
+      result.writeln(_error(e.message));
+      log.severe(
+        'Error in BuiltValueGenerator for '
+        '${libraryElement.firstFragment.source.fullName}.',
+        e,
+        st,
+      );
+    } catch (e, st) {
+      result.writeln(_error(e.toString()));
+      log.severe(
+        'Unknown error in BuiltValueGenerator for '
+        '${libraryElement.firstFragment.source.fullName}.',
+        e,
+        st,
+      );
+    }
+
+    for (var element in libraryElement.classes) {
+      if (ValueSourceClass.needsBuiltValue(element)) {
+        try {
+          result.writeln(
+            ValueSourceClass(parsedLibraryResults, element).generateCode(),
+          );
+        } catch (e, st) {
+          result.writeln(_error(e));
+          log.severe('Error in BuiltValueGenerator for $element.', e, st);
+        }
+      }
+    }
+
+    if (result.isNotEmpty) {
+      return '$result'
+          '\n'
+          '// ignore_for_file: '
+          'deprecated_member_use_from_same_package,'
+          'type=lint';
+    } else {
+      return null;
+    }
+  }
+}
+
+String _error(Object error) {
+  var lines = '$error'.split('\n');
+  var indented = lines.skip(1).map((l) => '//        $l'.trim()).join('\n');
+  return '// Error: ${lines.first}\n$indented';
+}

--- a/built_types/built_value_generator/lib/src/dart_types.dart
+++ b/built_types/built_value_generator/lib/src/dart_types.dart
@@ -1,0 +1,148 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value_generator/src/parsed_library_results.dart';
+import 'package:built_value_generator/src/value_source_class.dart';
+
+BuiltSet<String> _builtCollectionNames = BuiltSet<String>([
+  'BuiltList',
+  'BuiltListMultimap',
+  'BuiltMap',
+  'BuiltSet',
+  'BuiltSetMultimap',
+]);
+
+class DartTypes {
+  static bool needsNestedBuilder(
+    ParsedLibraryResults parsedLibraryResults,
+    DartType type,
+  ) {
+    return isInstantiableBuiltValue(parsedLibraryResults, type) ||
+        isBuiltCollection(type);
+  }
+
+  static bool isInstantiableBuiltValue(
+    ParsedLibraryResults parsedLibraryResults,
+    DartType type,
+  ) {
+    return isBuiltValue(type) &&
+        ValueSourceClass(
+          parsedLibraryResults,
+          type.element as ClassElement,
+        ).settings.instantiable;
+  }
+
+  static bool isBuiltValue(DartType type) =>
+      type is InterfaceType &&
+      type.element.allSupertypes.any(
+        (interfaceType) => interfaceType.element.name == 'Built',
+      );
+
+  static bool isBuiltCollection(DartType type) {
+    return _builtCollectionNames.any(
+      (name) => getName(type).startsWith('$name<'),
+    );
+  }
+
+  static bool isBuilt(DartType type) =>
+      isBuiltValue(type) || isBuiltCollection(type);
+
+  static bool isBuiltCollectionTypeName(String name) =>
+      _builtCollectionNames.contains(name);
+
+  /// As [getName] but allows `dartType` to be `null`.
+  ///
+  /// If it's `null`, returns `null`.
+  static String? tryGetName(
+    DartType? dartType, {
+    bool withNullabilitySuffix = false,
+  }) {
+    if (dartType == null) {
+      return null;
+    }
+    return getName(dartType, withNullabilitySuffix: withNullabilitySuffix);
+  }
+
+  /// Gets the name of a `DartType`. Supports `Function` types, which will
+  /// be returned using the `Function()` syntax.
+  static String getName(
+    DartType dartType, {
+    bool withNullabilitySuffix = false,
+  }) {
+    var suffix = withNullabilitySuffix &&
+            dartType.nullabilitySuffix == NullabilitySuffix.question
+        ? '?'
+        : '';
+
+    if (dartType is InvalidType) {
+      // InvalidType might indicate a type that has not yet been generated,
+      // handle as if the type is unknown.
+      return 'dynamic';
+    } else if (dartType is DynamicType) {
+      return 'dynamic';
+    } else if (dartType is FunctionType) {
+      final parameters = StringBuffer();
+
+      parameters.write(
+        dartType.normalParameterTypes.map((t) => getName(t)).join(', '),
+      );
+
+      if (dartType.optionalParameterTypes.isNotEmpty) {
+        if (parameters.isNotEmpty) parameters.write(', ');
+        parameters.write('[');
+        parameters.write(
+          dartType.optionalParameterTypes.map((t) => getName(t)).join(', '),
+        );
+        parameters.write(']');
+      }
+
+      if (dartType.namedParameterTypes.isNotEmpty) {
+        if (parameters.isNotEmpty) parameters.write(', ');
+        parameters.write('{');
+        parameters.write(
+          dartType.formalParameters
+              .where((p) => p.isOptionalNamed || p.isRequiredNamed)
+              .map(
+                (p) => '${p.isRequiredNamed ? 'required ' : ''}'
+                    '${getName(p.type)} ${p.name}',
+              )
+              .join(', '),
+        );
+        parameters.write('}');
+      }
+
+      return getName(dartType.returnType) + ' Function($parameters)$suffix';
+    } else if (dartType is InterfaceType) {
+      var typeArguments = dartType.typeArguments;
+      if (typeArguments.isEmpty) {
+        return dartType.element.name! + suffix;
+      } else {
+        final typeArgumentsStr = typeArguments
+            .map((type) => getName(type, withNullabilitySuffix: true))
+            .join(', ');
+        return '${dartType.element.name}<$typeArgumentsStr>$suffix';
+      }
+    } else if (dartType is TypeParameterType) {
+      return dartType.element.name! + suffix;
+    } else if (dartType is RecordType) {
+      return dartType.getDisplayString();
+    } else if (dartType is VoidType) {
+      return 'void';
+    } else if (dartType.isBottom) {
+      return 'Never' + suffix;
+    } else {
+      throw UnimplementedError('(${dartType.runtimeType}) $dartType');
+    }
+  }
+
+  /// Turns a type name, optionally with generics, into just the type name.
+  static String stripGenerics(String name) {
+    var genericsStart = name.indexOf('<');
+    return genericsStart == -1 ? name : name.substring(0, genericsStart);
+  }
+}

--- a/built_types/built_value_generator/lib/src/enum_source_class.dart
+++ b/built_types/built_value_generator/lib/src/enum_source_class.dart
@@ -1,0 +1,288 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.enum_source_class;
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/dart_types.dart';
+import 'package:built_value_generator/src/enum_source_field.dart';
+import 'package:built_value_generator/src/parsed_library_results.dart';
+import 'package:built_value_generator/src/strings.dart';
+import 'package:collection/collection.dart' show IterableExtension;
+
+import 'library_elements.dart';
+
+part 'enum_source_class.g.dart';
+
+abstract class EnumSourceClass
+    implements Built<EnumSourceClass, EnumSourceClassBuilder> {
+  ParsedLibraryResults get parsedLibraryResults;
+
+  InterfaceElement get element;
+
+  factory EnumSourceClass(
+    ParsedLibraryResults parsedLibraryResults,
+    InterfaceElement element,
+  ) =>
+      _$EnumSourceClass._(
+        parsedLibraryResults: parsedLibraryResults,
+        element: element,
+      );
+  EnumSourceClass._();
+
+  @memoized
+  ParsedLibraryResult get parsedLibrary =>
+      parsedLibraryResults.parsedLibraryResultOrThrowingMock(element.library);
+
+  @memoized
+  String get name => element.name!;
+
+  /// Returns `mixin` if class modifiers are available, `abstract class`
+  /// otherwise.
+  ///
+  /// The two are equivalent as class modifiers change the meaning of `class`.
+  String get _mixin => LibraryElements.areClassMixinsEnabled(element.library)
+      ? 'mixin'
+      : 'abstract class';
+
+  @memoized
+  String get wireName => settings.wireName ?? name;
+
+  @memoized
+  BuiltValueEnum get settings {
+    var annotations = element.metadata.annotations
+        .map((annotation) => annotation.computeConstantValue())
+        .where(
+          (value) => DartTypes.tryGetName(value?.type) == 'BuiltValueEnum',
+        );
+    if (annotations.isEmpty) return const BuiltValueEnum();
+    var annotation = annotations.single!;
+    return BuiltValueEnum(
+      wireName: annotation.getField('wireName')?.toStringValue(),
+    );
+  }
+
+  @memoized
+  bool get isAbstract {
+    final element = this.element;
+    return element is ClassElement && element.isAbstract;
+  }
+
+  @memoized
+  BuiltList<EnumSourceField> get fields =>
+      EnumSourceField.fromClassElement(parsedLibrary, element);
+
+  @memoized
+  BuiltList<String> get constructors => BuiltList<String>(
+        element.constructors.map((element) {
+          final declaration = parsedLibrary.getFragmentDeclaration(
+            element.firstFragment,
+          );
+          return declaration?.node.toSource() ?? '';
+        }),
+      );
+
+  @memoized
+  String? get valuesIdentifier {
+    var getter = element.getGetter('values');
+    if (getter == null) return null;
+    var source = parsedLibrary
+        .getFragmentDeclaration(getter.firstFragment)!
+        .node
+        .toSource();
+    var matches = RegExp(
+      r'static BuiltSet<' +
+          RegExp.escape(element.displayName) +
+          r'> get values => (_\$[\w$]+)\;',
+    ).allMatches(source);
+    return matches.isEmpty ? null : matches.first.group(1);
+  }
+
+  @memoized
+  String? get valueOfIdentifier {
+    var getter = element.getMethod('valueOf');
+    if (getter == null) return null;
+    var source = parsedLibrary
+        .getFragmentDeclaration(getter.firstFragment)!
+        .node
+        .toSource();
+    var matches = RegExp(
+      r'static ' +
+          RegExp.escape(element.displayName) +
+          r' valueOf\((?:final )?String name\) \=\> (\_\$[\w$]+)\(name\)\;',
+    ).allMatches(source);
+    return matches.isEmpty ? null : matches.first.group(1);
+  }
+
+  @memoized
+  bool get usesMixin =>
+      element.library.getClass(name + 'Mixin') != null ||
+      element.library.firstFragment.typeAliases.any(
+        (a) => a.name == name + 'Mixin',
+      );
+
+  @memoized
+  Iterable<String> get identifiers {
+    return [
+      valuesIdentifier,
+      valueOfIdentifier,
+      for (var field in fields) field.generatedIdentifier,
+    ].nonNulls.toList();
+  }
+
+  static bool needsEnumClass(ClassElement classElement) {
+    // `Object` and mixins return `null` for `supertype`.
+    return DartTypes.tryGetName(classElement.supertype) == 'EnumClass';
+  }
+
+  Iterable<String> computeErrors() {
+    return [
+      ..._checkAbstract(),
+      ..._checkFields(),
+      ..._checkFallbackFields(),
+      ..._checkConstructor(),
+      ..._checkValuesGetter(),
+      ..._checkValueOf(),
+    ];
+  }
+
+  Iterable<String> _checkAbstract() {
+    return isAbstract ? ['Make $name concrete; remove "abstract".'] : [];
+  }
+
+  Iterable<String> _checkFields() {
+    return fields.expand((field) => field.errors);
+  }
+
+  Iterable<String> _checkFallbackFields() {
+    var result = <String>[];
+
+    var fallbackFields =
+        fields.where((field) => field.settings.fallback).toList();
+    if (fallbackFields.length > 1) {
+      result.add(
+        'Remove `fallback = true` '
+        'so that at most one constant is the fallback. '
+        'Currently on "$name" fields '
+        '${fallbackFields.map((field) => '"${field.name}"').join(', ')}.',
+      );
+    }
+    return result;
+  }
+
+  Iterable<String> _checkConstructor() {
+    var expectedCode = RegExp(
+      'const ${RegExp.escape(name)}._\\((?:final )?String name\\) : super\\(name\\);',
+    );
+    var expectedCode217 = RegExp(
+      'const (?:${RegExp.escape(name)}\\.|new )_\\(super\\.name\\);',
+    );
+    var expectedCodeNew = RegExp(
+      'const new _\\((?:final )?String name\\) : super\\(name\\);',
+    );
+    return constructors.length == 1 &&
+            (constructors.single.contains(expectedCode) ||
+                constructors.single.contains(expectedCode217) ||
+                constructors.single.contains(expectedCodeNew))
+        ? <String>[]
+        : <String>[
+            'Have exactly one constructor: '
+                'const $name._(String name) : super(name); or in Dart>=2.17: const $name._(super.name);',
+          ];
+  }
+
+  Iterable<String> _checkValuesGetter() {
+    var result = <String>[];
+    if (valuesIdentifier == null) {
+      result.add('Add getter: static BuiltSet<$name> get values => _\$values');
+    }
+    return result;
+  }
+
+  Iterable<String> _checkValueOf() {
+    var result = <String>[];
+    if (valueOfIdentifier == null) {
+      result.add(
+        'Add method: '
+        'static $name valueOf(String name) => _\$valueOf(name)',
+      );
+    }
+    return result;
+  }
+
+  String generateCode() {
+    var result = StringBuffer();
+
+    for (var field in fields) {
+      result.writeln(
+        'const $name ${field.generatedIdentifier} = '
+        'const $name._(\'${escapeString(field.name)}\');',
+      );
+    }
+
+    result.writeln('');
+
+    result.writeln(
+      '$name $valueOfIdentifier(String name) {'
+      'switch (name) {',
+    );
+    for (var field in fields) {
+      result.writeln(
+        "case '${escapeString(field.name)}':"
+        ' return ${field.generatedIdentifier};',
+      );
+    }
+
+    var fallback = fields.firstWhereOrNull((field) => field.settings.fallback);
+    if (fallback == null) {
+      result.writeln('default: throw ArgumentError(name);');
+    } else {
+      result.writeln('default: return ${fallback.generatedIdentifier};');
+    }
+    result.writeln('}}');
+
+    result.writeln('');
+
+    result.writeln(
+      'final BuiltSet<$name> $valuesIdentifier ='
+      'BuiltSet<$name>(const <$name>[',
+    );
+    for (var field in fields) {
+      result.writeln('${field.generatedIdentifier},');
+    }
+    result.writeln(']);');
+
+    if (usesMixin) {
+      result.write(_generateMixin());
+    }
+
+    return result.toString();
+  }
+
+  String _generateMixin() {
+    var result = StringBuffer();
+
+    result
+      ..writeln('class _\$${name}Meta {')
+      ..writeln('const _\$${name}Meta();');
+    for (var field in fields) {
+      result.writeln(
+        '$name get ${field.name} => ${field.generatedIdentifier};',
+      );
+    }
+    result
+      ..writeln('$name valueOf(String name) => $valueOfIdentifier(name);')
+      ..writeln('BuiltSet<$name> get values => $valuesIdentifier;')
+      ..writeln('}')
+      ..writeln('$_mixin _\$${name}Mixin {')
+      ..writeln('  // ignore: non_constant_identifier_names')
+      ..writeln('_\$${name}Meta get $name => const _\$${name}Meta();')
+      ..writeln('}');
+
+    return result.toString();
+  }
+}

--- a/built_types/built_value_generator/lib/src/enum_source_class.g.dart
+++ b/built_types/built_value_generator/lib/src/enum_source_class.g.dart
@@ -1,0 +1,165 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'enum_source_class.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$EnumSourceClass extends EnumSourceClass {
+  @override
+  final ParsedLibraryResults parsedLibraryResults;
+  @override
+  final InterfaceElement element;
+  ParsedLibraryResult? __parsedLibrary;
+  String? __name;
+  String? __wireName;
+  BuiltValueEnum? __settings;
+  bool? __isAbstract;
+  BuiltList<EnumSourceField>? __fields;
+  BuiltList<String>? __constructors;
+  String? __valuesIdentifier;
+  bool ___valuesIdentifier = false;
+  String? __valueOfIdentifier;
+  bool ___valueOfIdentifier = false;
+  bool? __usesMixin;
+  Iterable<String>? __identifiers;
+
+  factory _$EnumSourceClass([void Function(EnumSourceClassBuilder)? updates]) =>
+      (EnumSourceClassBuilder()..update(updates))._build();
+
+  _$EnumSourceClass._(
+      {required this.parsedLibraryResults, required this.element})
+      : super._();
+  @override
+  ParsedLibraryResult get parsedLibrary =>
+      __parsedLibrary ??= super.parsedLibrary;
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get wireName => __wireName ??= super.wireName;
+
+  @override
+  BuiltValueEnum get settings => __settings ??= super.settings;
+
+  @override
+  bool get isAbstract => __isAbstract ??= super.isAbstract;
+
+  @override
+  BuiltList<EnumSourceField> get fields => __fields ??= super.fields;
+
+  @override
+  BuiltList<String> get constructors => __constructors ??= super.constructors;
+
+  @override
+  String? get valuesIdentifier {
+    if (!___valuesIdentifier) {
+      __valuesIdentifier = super.valuesIdentifier;
+      ___valuesIdentifier = true;
+    }
+    return __valuesIdentifier;
+  }
+
+  @override
+  String? get valueOfIdentifier {
+    if (!___valueOfIdentifier) {
+      __valueOfIdentifier = super.valueOfIdentifier;
+      ___valueOfIdentifier = true;
+    }
+    return __valueOfIdentifier;
+  }
+
+  @override
+  bool get usesMixin => __usesMixin ??= super.usesMixin;
+
+  @override
+  Iterable<String> get identifiers => __identifiers ??= super.identifiers;
+
+  @override
+  EnumSourceClass rebuild(void Function(EnumSourceClassBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  EnumSourceClassBuilder toBuilder() => EnumSourceClassBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is EnumSourceClass &&
+        parsedLibraryResults == other.parsedLibraryResults &&
+        element == other.element;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, parsedLibraryResults.hashCode);
+    _$hash = $jc(_$hash, element.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'EnumSourceClass')
+          ..add('parsedLibraryResults', parsedLibraryResults)
+          ..add('element', element))
+        .toString();
+  }
+}
+
+class EnumSourceClassBuilder
+    implements Builder<EnumSourceClass, EnumSourceClassBuilder> {
+  _$EnumSourceClass? _$v;
+
+  ParsedLibraryResults? _parsedLibraryResults;
+  ParsedLibraryResults? get parsedLibraryResults =>
+      _$this._parsedLibraryResults;
+  set parsedLibraryResults(ParsedLibraryResults? parsedLibraryResults) =>
+      _$this._parsedLibraryResults = parsedLibraryResults;
+
+  InterfaceElement? _element;
+  InterfaceElement? get element => _$this._element;
+  set element(InterfaceElement? element) => _$this._element = element;
+
+  EnumSourceClassBuilder();
+
+  EnumSourceClassBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _parsedLibraryResults = $v.parsedLibraryResults;
+      _element = $v.element;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(EnumSourceClass other) {
+    _$v = other as _$EnumSourceClass;
+  }
+
+  @override
+  void update(void Function(EnumSourceClassBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  EnumSourceClass build() => _build();
+
+  _$EnumSourceClass _build() {
+    final _$result = _$v ??
+        _$EnumSourceClass._(
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults, r'EnumSourceClass', 'parsedLibraryResults'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'EnumSourceClass', 'element'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/built_value_generator/lib/src/enum_source_field.dart
+++ b/built_types/built_value_generator/lib/src/enum_source_field.dart
@@ -1,0 +1,107 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.enum_source_field;
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+
+import 'dart_types.dart';
+
+part 'enum_source_field.g.dart';
+
+abstract class EnumSourceField
+    implements Built<EnumSourceField, EnumSourceFieldBuilder> {
+  ParsedLibraryResult get parsedLibrary;
+  FieldElement get element;
+
+  factory EnumSourceField(
+    ParsedLibraryResult parsedLibrary,
+    FieldElement element,
+  ) =>
+      _$EnumSourceField._(parsedLibrary: parsedLibrary, element: element);
+  EnumSourceField._();
+
+  @memoized
+  String get name => element.displayName;
+
+  @memoized
+  String? get type => DartTypes.tryGetName(element.getter?.returnType);
+
+  @memoized
+  BuiltValueEnumConst get settings {
+    var annotations = element.metadata.annotations
+        .map((annotation) => annotation.computeConstantValue())
+        .where(
+          (value) => DartTypes.tryGetName(value?.type) == 'BuiltValueEnumConst',
+        );
+    if (annotations.isEmpty) return const BuiltValueEnumConst();
+    var annotation = annotations.single!;
+    return BuiltValueEnumConst(
+      fallback: annotation.getField('fallback')?.toBoolValue() ?? false,
+      wireName: annotation.getField('wireName')!.toStringValue(),
+      // Field added in version `7.1.0`, might be missing.
+      wireNumber: annotation.getField('wireNumber')?.toIntValue(),
+    );
+  }
+
+  @memoized
+  String get generatedIdentifier {
+    var fieldName = element.displayName;
+    return parsedLibrary
+        .getFragmentDeclaration(element.firstFragment)!
+        .node
+        .toSource()
+        .substring('$fieldName = '.length);
+  }
+
+  @memoized
+  bool get isConst => element.isConst;
+
+  @memoized
+  bool get isStatic => element.isStatic;
+
+  static BuiltList<EnumSourceField> fromClassElement(
+    ParsedLibraryResult parsedLibrary,
+    InterfaceElement classElement,
+  ) {
+    var result = ListBuilder<EnumSourceField>();
+
+    var enumName = classElement.displayName;
+    for (var fieldElement in classElement.fields) {
+      final type = DartTypes.tryGetName(fieldElement.getter?.returnType);
+      if (fieldElement.isOriginDeclaration &&
+          (type == enumName || type == 'dynamic')) {
+        result.add(EnumSourceField(parsedLibrary, fieldElement));
+      }
+    }
+
+    return result.build();
+  }
+
+  Iterable<String> get errors {
+    var result = <String>[];
+
+    if (type == 'dynamic') {
+      result.add('Specify a type for field "$name".');
+    } else if (!isConst && !isStatic) {
+      result.add('Make field "$name" static const.');
+    } else if (!isConst) {
+      result.add('Make field "$name" const.');
+    } else if (!generatedIdentifier.startsWith('_\$')) {
+      result.add('Initialize field "$name" with a value starting "_\$".');
+    }
+
+    if (settings.wireName != null && settings.wireNumber != null) {
+      result.add(
+        'Specify either `wireName` or `wireNumber`, not both, on '
+        'field "$name".',
+      );
+    }
+
+    return result;
+  }
+}

--- a/built_types/built_value_generator/lib/src/enum_source_field.g.dart
+++ b/built_types/built_value_generator/lib/src/enum_source_field.g.dart
@@ -1,0 +1,136 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'enum_source_field.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$EnumSourceField extends EnumSourceField {
+  @override
+  final ParsedLibraryResult parsedLibrary;
+  @override
+  final FieldElement element;
+  String? __name;
+  String? __type;
+  bool ___type = false;
+  BuiltValueEnumConst? __settings;
+  String? __generatedIdentifier;
+  bool? __isConst;
+  bool? __isStatic;
+
+  factory _$EnumSourceField([void Function(EnumSourceFieldBuilder)? updates]) =>
+      (EnumSourceFieldBuilder()..update(updates))._build();
+
+  _$EnumSourceField._({required this.parsedLibrary, required this.element})
+      : super._();
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String? get type {
+    if (!___type) {
+      __type = super.type;
+      ___type = true;
+    }
+    return __type;
+  }
+
+  @override
+  BuiltValueEnumConst get settings => __settings ??= super.settings;
+
+  @override
+  String get generatedIdentifier =>
+      __generatedIdentifier ??= super.generatedIdentifier;
+
+  @override
+  bool get isConst => __isConst ??= super.isConst;
+
+  @override
+  bool get isStatic => __isStatic ??= super.isStatic;
+
+  @override
+  EnumSourceField rebuild(void Function(EnumSourceFieldBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  EnumSourceFieldBuilder toBuilder() => EnumSourceFieldBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is EnumSourceField &&
+        parsedLibrary == other.parsedLibrary &&
+        element == other.element;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, parsedLibrary.hashCode);
+    _$hash = $jc(_$hash, element.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'EnumSourceField')
+          ..add('parsedLibrary', parsedLibrary)
+          ..add('element', element))
+        .toString();
+  }
+}
+
+class EnumSourceFieldBuilder
+    implements Builder<EnumSourceField, EnumSourceFieldBuilder> {
+  _$EnumSourceField? _$v;
+
+  ParsedLibraryResult? _parsedLibrary;
+  ParsedLibraryResult? get parsedLibrary => _$this._parsedLibrary;
+  set parsedLibrary(ParsedLibraryResult? parsedLibrary) =>
+      _$this._parsedLibrary = parsedLibrary;
+
+  FieldElement? _element;
+  FieldElement? get element => _$this._element;
+  set element(FieldElement? element) => _$this._element = element;
+
+  EnumSourceFieldBuilder();
+
+  EnumSourceFieldBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _parsedLibrary = $v.parsedLibrary;
+      _element = $v.element;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(EnumSourceField other) {
+    _$v = other as _$EnumSourceField;
+  }
+
+  @override
+  void update(void Function(EnumSourceFieldBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  EnumSourceField build() => _build();
+
+  _$EnumSourceField _build() {
+    final _$result = _$v ??
+        _$EnumSourceField._(
+          parsedLibrary: BuiltValueNullFieldError.checkNotNull(
+              parsedLibrary, r'EnumSourceField', 'parsedLibrary'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'EnumSourceField', 'element'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/built_value_generator/lib/src/enum_source_library.dart
+++ b/built_types/built_value_generator/lib/src/enum_source_library.dart
@@ -1,0 +1,116 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.enum_source_library;
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/enum_source_class.dart';
+import 'package:built_value_generator/src/parsed_library_results.dart';
+import 'package:source_gen/source_gen.dart';
+
+part 'enum_source_library.g.dart';
+
+abstract class EnumSourceLibrary
+    implements Built<EnumSourceLibrary, EnumSourceLibraryBuilder> {
+  ParsedLibraryResults get parsedLibraryResults;
+  LibraryElement get element;
+
+  factory EnumSourceLibrary(
+    ParsedLibraryResults parsedLibraryResults,
+    LibraryElement element,
+  ) =>
+      _$EnumSourceLibrary._(
+        parsedLibraryResults: parsedLibraryResults,
+        element: element,
+      );
+  EnumSourceLibrary._();
+
+  @memoized
+  ParsedLibraryResult get parsedLibrary =>
+      parsedLibraryResults.parsedLibraryResultOrThrowingMock(element.library);
+
+  @memoized
+  String get name => element.name!;
+
+  @memoized
+  String get fileName =>
+      element.firstFragment.source.shortName.replaceAll('.dart', '');
+
+  @memoized
+  String get source => element.firstFragment.source.contents.data;
+
+  @memoized
+  BuiltList<EnumSourceClass> get classes {
+    var result = ListBuilder<EnumSourceClass>();
+
+    for (var classElement in element.classes) {
+      if (EnumSourceClass.needsEnumClass(classElement)) {
+        result.add(EnumSourceClass(parsedLibraryResults, classElement));
+      }
+    }
+    return result.build();
+  }
+
+  String? generateCode() {
+    if (classes.isEmpty) return null;
+
+    var errors = _computeErrors();
+    if (errors.isNotEmpty) throw _makeError(errors);
+
+    return classes.map((c) => c.generateCode()).join('\n');
+  }
+
+  Iterable<String> _computeErrors() {
+    return [
+      ..._checkPart(),
+      ..._checkIdentifiers(),
+      for (var c in classes) ...c.computeErrors(),
+    ];
+  }
+
+  Iterable<String> _checkPart() {
+    var expectedCode = "part '$fileName.g.dart';";
+    var alternativeExpectedCode = 'part "$fileName.g.dart";';
+    return source.contains(expectedCode) ||
+            source.contains(alternativeExpectedCode)
+        ? <String>[]
+        : <String>['Import generated part: $expectedCode'];
+  }
+
+  Iterable<String> _checkIdentifiers() {
+    var result = <String>[];
+    var seenIdentifiers = <String>{};
+    var reportedIdentifiers = <String>{};
+
+    for (var sourceClass in classes) {
+      for (var identifier in sourceClass.identifiers) {
+        if (seenIdentifiers.contains(identifier) &&
+            !reportedIdentifiers.contains(identifier)) {
+          reportedIdentifiers.add(identifier);
+          result.add(
+            'Generated identifier "$identifier" is used multiple times in'
+            ' $name, change to something else.',
+          );
+        }
+        seenIdentifiers.add(identifier);
+      }
+    }
+
+    return result;
+  }
+}
+
+InvalidGenerationSourceError _makeError(Iterable<String> todos) {
+  final message = StringBuffer(
+    'Please make the following changes to use EnumClass:\n',
+  );
+  for (var i = 0; i != todos.length; ++i) {
+    message.write('\n${i + 1}. ${todos.elementAt(i)}');
+  }
+
+  return InvalidGenerationSourceError(message.toString());
+}

--- a/built_types/built_value_generator/lib/src/enum_source_library.g.dart
+++ b/built_types/built_value_generator/lib/src/enum_source_library.g.dart
@@ -1,0 +1,131 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'enum_source_library.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$EnumSourceLibrary extends EnumSourceLibrary {
+  @override
+  final ParsedLibraryResults parsedLibraryResults;
+  @override
+  final LibraryElement element;
+  ParsedLibraryResult? __parsedLibrary;
+  String? __name;
+  String? __fileName;
+  String? __source;
+  BuiltList<EnumSourceClass>? __classes;
+
+  factory _$EnumSourceLibrary(
+          [void Function(EnumSourceLibraryBuilder)? updates]) =>
+      (EnumSourceLibraryBuilder()..update(updates))._build();
+
+  _$EnumSourceLibrary._(
+      {required this.parsedLibraryResults, required this.element})
+      : super._();
+  @override
+  ParsedLibraryResult get parsedLibrary =>
+      __parsedLibrary ??= super.parsedLibrary;
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get fileName => __fileName ??= super.fileName;
+
+  @override
+  String get source => __source ??= super.source;
+
+  @override
+  BuiltList<EnumSourceClass> get classes => __classes ??= super.classes;
+
+  @override
+  EnumSourceLibrary rebuild(void Function(EnumSourceLibraryBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  EnumSourceLibraryBuilder toBuilder() =>
+      EnumSourceLibraryBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is EnumSourceLibrary &&
+        parsedLibraryResults == other.parsedLibraryResults &&
+        element == other.element;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, parsedLibraryResults.hashCode);
+    _$hash = $jc(_$hash, element.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'EnumSourceLibrary')
+          ..add('parsedLibraryResults', parsedLibraryResults)
+          ..add('element', element))
+        .toString();
+  }
+}
+
+class EnumSourceLibraryBuilder
+    implements Builder<EnumSourceLibrary, EnumSourceLibraryBuilder> {
+  _$EnumSourceLibrary? _$v;
+
+  ParsedLibraryResults? _parsedLibraryResults;
+  ParsedLibraryResults? get parsedLibraryResults =>
+      _$this._parsedLibraryResults;
+  set parsedLibraryResults(ParsedLibraryResults? parsedLibraryResults) =>
+      _$this._parsedLibraryResults = parsedLibraryResults;
+
+  LibraryElement? _element;
+  LibraryElement? get element => _$this._element;
+  set element(LibraryElement? element) => _$this._element = element;
+
+  EnumSourceLibraryBuilder();
+
+  EnumSourceLibraryBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _parsedLibraryResults = $v.parsedLibraryResults;
+      _element = $v.element;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(EnumSourceLibrary other) {
+    _$v = other as _$EnumSourceLibrary;
+  }
+
+  @override
+  void update(void Function(EnumSourceLibraryBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  EnumSourceLibrary build() => _build();
+
+  _$EnumSourceLibrary _build() {
+    final _$result = _$v ??
+        _$EnumSourceLibrary._(
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'EnumSourceLibrary',
+              'parsedLibraryResults'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'EnumSourceLibrary', 'element'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/built_value_generator/lib/src/field_mixin.dart
+++ b/built_types/built_value_generator/lib/src/field_mixin.dart
@@ -1,0 +1,56 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/dart_types.dart';
+
+/// Common logic between `ValueSourceField` and `SerializerSourceField`.
+mixin FieldMixin {
+  PropertyInducingElement? get builderElement;
+  ParsedLibraryResult get parsedLibrary;
+
+  bool get builderFieldExists => builderElement != null;
+
+  /// Gets the type of the field in a manually written builder.
+  ///
+  /// Returns `dynamic` if there is no such field.
+  ///
+  /// Goes via the AST if needed. This happens if the type has not been
+  /// generated yet, which will be the case for a nested builder field if the
+  /// builder is in this same library.
+  @memoized
+  String get fullBuildElementType {
+    if (!builderFieldExists) return 'dynamic';
+
+    // Try to get a resolved type first, it's faster.
+    var result = DartTypes.tryGetName(
+      builderElement!.getter?.returnType,
+      withNullabilitySuffix: true,
+    );
+
+    if (result != null && result != 'dynamic') return result;
+    // Go via AST to allow use of unresolvable types not yet generated;
+    // this includes generated Builder types.
+    result = parsedLibrary
+        .getFragmentDeclaration(builderElement!.firstFragment)
+        ?.node
+        .parent
+        ?.childEntities
+        .first
+        .toString();
+
+    if (result != null) return result;
+
+    result = builderElement!.getter != null
+        ? (parsedLibrary
+                .getFragmentDeclaration(
+                  builderElement!.getter!.firstFragment,
+                )
+                ?.node as MethodDeclaration?)
+            ?.returnType
+            .toString()
+        : null;
+
+    return result ?? 'dynamic';
+  }
+}

--- a/built_types/built_value_generator/lib/src/fields.dart
+++ b/built_types/built_value_generator/lib/src/fields.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:collection';
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:built_collection/built_collection.dart';
+
+/// Gets fields, including from interfaces. Fields from interfaces are only
+/// returned if they are not also implemented by a mixin.
+///
+/// If a field is overridden then just the closest (overriding) field is
+/// returned.
+BuiltList<PropertyInducingElement> collectFields(InterfaceElement element) =>
+    collectFieldsForType(element.thisType);
+
+/// Gets fields, including from interfaces. Fields from interfaces are only
+/// returned if they are not also implemented by a mixin.
+///
+/// If a field is overridden then just the closest (overriding) field is
+/// returned.
+BuiltList<PropertyInducingElement> collectFieldsForType(InterfaceType type) {
+  var fields = <PropertyInducingElement>[];
+  // Add fields from this class before interfaces, so they're added to the set
+  // first below. Re-added fields from interfaces are ignored.
+  fields.addAll(_fieldElementsForType(type));
+
+  Set<InterfaceType>.from(type.interfaces)
+    ..addAll(type.mixins)
+    ..forEach((interface) => fields.addAll(collectFieldsForType(interface)));
+
+  // Overridden fields have multiple declarations, so deduplicate by adding
+  // to a set that compares on field name.
+  var fieldSet = LinkedHashSet<PropertyInducingElement>(
+    equals: (a, b) => a.displayName == b.displayName,
+    hashCode: (a) => a.displayName.hashCode,
+  );
+  fieldSet.addAll(fields);
+
+  // Filter to fields that are not implemented by a mixin.
+  return BuiltList<PropertyInducingElement>.build(
+    (b) => b
+      ..addAll(fieldSet)
+      ..where(
+        (field) =>
+            type
+                .lookUpGetter(
+                  field.name!,
+                  field.library,
+                  inherited: true,
+                  concrete: true,
+                )
+                ?.isAbstract ??
+            true,
+      ),
+  );
+}
+
+BuiltList<PropertyInducingElement> _fieldElementsForType(InterfaceType type) {
+  var result = ListBuilder<PropertyInducingElement>();
+  for (var accessor in type.getters) {
+    result.add(accessor.variable);
+  }
+  return result.build();
+}

--- a/built_types/built_value_generator/lib/src/fixes.dart
+++ b/built_types/built_value_generator/lib/src/fixes.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/built_value.dart';
+
+part 'fixes.g.dart';
+
+/// An error in input source detected by the generator.
+///
+/// Optionally specifies the location of the error and the source code to
+/// replace it to fix the error.
+abstract class GeneratorError
+    implements Built<GeneratorError, GeneratorErrorBuilder> {
+  /// Error message for the user.
+  String get message;
+
+  /// Optionally, the offset of the incorrect code.
+  int? get offset;
+
+  /// Optionally, the length of the incorrect code.
+  int? get length;
+
+  /// Optionally, the fix for the incorrect code.
+  String? get fix;
+
+  factory GeneratorError([void Function(GeneratorErrorBuilder) updates]) =
+      _$GeneratorError;
+  GeneratorError._() {
+    if (((offset == null) != (length == null)) ||
+        ((offset == null) != (fix == null))) {
+      throw ArgumentError(
+          'Offset, length and fix must either all be null or all non-null. '
+          'Got: offset $offset, length $length, fix $fix');
+    }
+  }
+}

--- a/built_types/built_value_generator/lib/src/fixes.g.dart
+++ b/built_types/built_value_generator/lib/src/fixes.g.dart
@@ -1,0 +1,125 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'fixes.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$GeneratorError extends GeneratorError {
+  @override
+  final String message;
+  @override
+  final int? offset;
+  @override
+  final int? length;
+  @override
+  final String? fix;
+
+  factory _$GeneratorError([void Function(GeneratorErrorBuilder)? updates]) =>
+      (GeneratorErrorBuilder()..update(updates))._build();
+
+  _$GeneratorError._(
+      {required this.message, this.offset, this.length, this.fix})
+      : super._();
+  @override
+  GeneratorError rebuild(void Function(GeneratorErrorBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GeneratorErrorBuilder toBuilder() => GeneratorErrorBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GeneratorError &&
+        message == other.message &&
+        offset == other.offset &&
+        length == other.length &&
+        fix == other.fix;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jc(_$hash, offset.hashCode);
+    _$hash = $jc(_$hash, length.hashCode);
+    _$hash = $jc(_$hash, fix.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GeneratorError')
+          ..add('message', message)
+          ..add('offset', offset)
+          ..add('length', length)
+          ..add('fix', fix))
+        .toString();
+  }
+}
+
+class GeneratorErrorBuilder
+    implements Builder<GeneratorError, GeneratorErrorBuilder> {
+  _$GeneratorError? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  int? _offset;
+  int? get offset => _$this._offset;
+  set offset(int? offset) => _$this._offset = offset;
+
+  int? _length;
+  int? get length => _$this._length;
+  set length(int? length) => _$this._length = length;
+
+  String? _fix;
+  String? get fix => _$this._fix;
+  set fix(String? fix) => _$this._fix = fix;
+
+  GeneratorErrorBuilder();
+
+  GeneratorErrorBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _offset = $v.offset;
+      _length = $v.length;
+      _fix = $v.fix;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GeneratorError other) {
+    _$v = other as _$GeneratorError;
+  }
+
+  @override
+  void update(void Function(GeneratorErrorBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GeneratorError build() => _build();
+
+  _$GeneratorError _build() {
+    final _$result = _$v ??
+        _$GeneratorError._(
+          message: BuiltValueNullFieldError.checkNotNull(
+              message, r'GeneratorError', 'message'),
+          offset: offset,
+          length: length,
+          fix: fix,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/built_value_generator/lib/src/library_elements.dart
+++ b/built_types/built_value_generator/lib/src/library_elements.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/dart/analysis/experiments.dart';
+
+/// Tools for [LibraryElement]s.
+class LibraryElements {
+  static bool areClassMixinsEnabled(LibraryElement element) =>
+      ExperimentStatus.knownFeatures.containsKey('class-modifiers') &&
+      element.featureSet.isEnabled(
+        ExperimentStatus.knownFeatures['class-modifiers']!,
+      );
+}

--- a/built_types/built_value_generator/lib/src/memoized_getter.dart
+++ b/built_types/built_value_generator/lib/src/memoized_getter.dart
@@ -1,0 +1,46 @@
+library built_value_generator.memoized_getter;
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/dart_types.dart';
+import 'package:built_value_generator/src/metadata.dart'
+    show metadataToStringValue;
+
+part 'memoized_getter.g.dart';
+
+abstract class MemoizedGetter
+    implements Built<MemoizedGetter, MemoizedGetterBuilder> {
+  String get returnType;
+  NullabilitySuffix get nullabilitySuffix;
+  String get name;
+
+  factory MemoizedGetter([void Function(MemoizedGetterBuilder) updates]) =
+      _$MemoizedGetter;
+  MemoizedGetter._();
+
+  bool get isNullable => nullabilitySuffix == NullabilitySuffix.question;
+
+  static Iterable<MemoizedGetter> fromClassElement(
+    InterfaceElement classElement,
+  ) {
+    return classElement.fields
+        .where(
+          (field) =>
+              field.getter != null &&
+              !field.getter!.isAbstract &&
+              field.getter!.metadata.annotations.any(
+                (metadata) => metadataToStringValue(metadata) == 'memoized',
+              ),
+        )
+        .map(
+          (field) => MemoizedGetter(
+            (b) => b
+              ..returnType = DartTypes.getName(field.getter!.returnType)
+              ..nullabilitySuffix = field.getter!.returnType.nullabilitySuffix
+              ..name = field.displayName,
+          ),
+        )
+        .toList();
+  }
+}

--- a/built_types/built_value_generator/lib/src/memoized_getter.g.dart
+++ b/built_types/built_value_generator/lib/src/memoized_getter.g.dart
@@ -1,0 +1,119 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'memoized_getter.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$MemoizedGetter extends MemoizedGetter {
+  @override
+  final String returnType;
+  @override
+  final NullabilitySuffix nullabilitySuffix;
+  @override
+  final String name;
+
+  factory _$MemoizedGetter([void Function(MemoizedGetterBuilder)? updates]) =>
+      (MemoizedGetterBuilder()..update(updates))._build();
+
+  _$MemoizedGetter._(
+      {required this.returnType,
+      required this.nullabilitySuffix,
+      required this.name})
+      : super._();
+  @override
+  MemoizedGetter rebuild(void Function(MemoizedGetterBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  MemoizedGetterBuilder toBuilder() => MemoizedGetterBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is MemoizedGetter &&
+        returnType == other.returnType &&
+        nullabilitySuffix == other.nullabilitySuffix &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, returnType.hashCode);
+    _$hash = $jc(_$hash, nullabilitySuffix.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'MemoizedGetter')
+          ..add('returnType', returnType)
+          ..add('nullabilitySuffix', nullabilitySuffix)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class MemoizedGetterBuilder
+    implements Builder<MemoizedGetter, MemoizedGetterBuilder> {
+  _$MemoizedGetter? _$v;
+
+  String? _returnType;
+  String? get returnType => _$this._returnType;
+  set returnType(String? returnType) => _$this._returnType = returnType;
+
+  NullabilitySuffix? _nullabilitySuffix;
+  NullabilitySuffix? get nullabilitySuffix => _$this._nullabilitySuffix;
+  set nullabilitySuffix(NullabilitySuffix? nullabilitySuffix) =>
+      _$this._nullabilitySuffix = nullabilitySuffix;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  MemoizedGetterBuilder();
+
+  MemoizedGetterBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _returnType = $v.returnType;
+      _nullabilitySuffix = $v.nullabilitySuffix;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(MemoizedGetter other) {
+    _$v = other as _$MemoizedGetter;
+  }
+
+  @override
+  void update(void Function(MemoizedGetterBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  MemoizedGetter build() => _build();
+
+  _$MemoizedGetter _build() {
+    final _$result = _$v ??
+        _$MemoizedGetter._(
+          returnType: BuiltValueNullFieldError.checkNotNull(
+              returnType, r'MemoizedGetter', 'returnType'),
+          nullabilitySuffix: BuiltValueNullFieldError.checkNotNull(
+              nullabilitySuffix, r'MemoizedGetter', 'nullabilitySuffix'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'MemoizedGetter', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/built_value_generator/lib/src/metadata.dart
+++ b/built_types/built_value_generator/lib/src/metadata.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:source_gen/source_gen.dart';
+
+DartObject getConstantValueFromAnnotation(ElementAnnotation annotation) {
+  final value = annotation.computeConstantValue();
+  if (value == null) {
+    throw InvalidGenerationSourceError(
+        'Can’t process annotation “${annotation.toSource()}” in '
+        '“${annotation.libraryFragment.source.uri}”. '
+        'Please check for a missing import.');
+  }
+  return value;
+}
+
+/// Gets the `String` value of an annotation. Throws a descriptive
+/// [InvalidGenerationSourceError] if the annotation can't be resolved.
+String? metadataToStringValue(ElementAnnotation annotation) {
+  final value = getConstantValueFromAnnotation(annotation);
+  return value.toStringValue();
+}
+
+/// Gets a field from an annotation. Throws a descriptive
+/// [InvalidGenerationSourceError] if the annotation can't be resolved.
+DartObject? getMetadataField(ElementAnnotation annotation, String name) {
+  final value = getConstantValueFromAnnotation(annotation);
+  return value.getField(name);
+}

--- a/built_types/built_value_generator/lib/src/parsed_library_results.dart
+++ b/built_types/built_value_generator/lib/src/parsed_library_results.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2021, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/element/element.dart';
+
+/// Caches parsed library results across one generation.
+///
+/// Substitutes a "throwing mock" if no parsed library is available.
+class ParsedLibraryResults {
+  final Map<Uri, ParsedLibraryResult> _results = {};
+
+  ParsedLibraryResult parsedLibraryResultOrThrowingMock(
+    LibraryElement element,
+  ) {
+    var uri = element.uri;
+    return _results[uri] ??= _parsedLibraryResultOrThrowingMock(element);
+  }
+
+  ParsedLibraryResult _parsedLibraryResultOrThrowingMock(
+    LibraryElement element,
+  ) {
+    var result = element.session.getParsedLibraryByElement(element);
+    if (result is ParsedLibraryResult) {
+      return result;
+    }
+    return _ParsedLibraryResultMock();
+  }
+}
+
+class _ParsedLibraryResultMock implements ParsedLibraryResult {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/built_types/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_types/built_value_generator/lib/src/serializer_source_class.dart
@@ -1,0 +1,638 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.source_class;
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/enum_source_class.dart';
+import 'package:built_value_generator/src/enum_source_field.dart';
+import 'package:built_value_generator/src/fields.dart' show collectFields;
+import 'package:built_value_generator/src/parsed_library_results.dart';
+import 'package:built_value_generator/src/serializer_source_field.dart';
+import 'package:built_value_generator/src/strings.dart';
+import 'package:built_value_generator/src/value_source_class.dart';
+
+import 'dart_types.dart';
+
+part 'serializer_source_class.g.dart';
+
+abstract class SerializerSourceClass
+    implements Built<SerializerSourceClass, SerializerSourceClassBuilder> {
+  ParsedLibraryResults get parsedLibraryResults;
+  InterfaceElement get element;
+
+  ClassElement? get builderElement;
+
+  factory SerializerSourceClass(
+    ParsedLibraryResults parsedLibraryResults,
+    InterfaceElement element,
+  ) =>
+      _$SerializerSourceClass._(
+        parsedLibraryResults: parsedLibraryResults,
+        element: element,
+        builderElement:
+            element.library.getClass(element.displayName + 'Builder'),
+      );
+
+  SerializerSourceClass._();
+
+  @memoized
+  ParsedLibraryResult get parsedLibrary =>
+      parsedLibraryResults.parsedLibraryResultOrThrowingMock(element.library);
+
+  // TODO(davidmorgan): share common code in a nicer way.
+  @memoized
+  BuiltValue get builtValueSettings =>
+      ValueSourceClass(parsedLibraryResults, element).settings;
+
+  @memoized
+  bool get hasBuilder => builderElement != null;
+
+  @memoized
+  BuiltValueSerializer get serializerSettings {
+    var serializerFields =
+        element.fields.where((field) => field.name == 'serializer').toList();
+    if (serializerFields.isEmpty) return const BuiltValueSerializer();
+    var serializerField = serializerFields.single;
+    if (serializerField.getter == null) return const BuiltValueSerializer();
+
+    var annotations = serializerField.getter!.metadata.annotations
+        .map((annotation) => annotation.computeConstantValue())
+        .where(
+          (value) =>
+              DartTypes.tryGetName(value?.type) == 'BuiltValueSerializer',
+        );
+    if (annotations.isEmpty) return const BuiltValueSerializer();
+
+    var annotation = annotations.single!;
+    // If a field does not exist, that means an old `built_value` version; use
+    // the default.
+    return BuiltValueSerializer(
+      custom: annotation.getField('custom')?.toBoolValue() ?? false,
+      serializeNulls:
+          annotation.getField('serializeNulls')?.toBoolValue() ?? false,
+    );
+  }
+
+  // TODO(davidmorgan): share common code in a nicer way.
+  @memoized
+  BuiltValueEnum get enumClassSettings =>
+      EnumSourceClass(parsedLibraryResults, element).settings;
+
+  @memoized
+  String get name => element.name!;
+
+  @memoized
+  String get wireName {
+    if (isBuiltValue) {
+      return builtValueSettings.wireName ?? name;
+    } else if (isEnumClass) {
+      return enumClassSettings.wireName ?? name;
+    } else {
+      return name;
+    }
+  }
+
+  @memoized
+  String get serializerDeclaration {
+    var serializerFields =
+        element.fields.where((field) => field.name == 'serializer').toList();
+    if (serializerFields.isEmpty) return '';
+    var serializerField = serializerFields.single;
+    var result = parsedLibrary
+            .getFragmentDeclaration(serializerField.getter!.firstFragment)
+            ?.node
+            .toSource() ??
+        '';
+    // Strip off annotations.
+    if (result.startsWith('@')) {
+      // First thing after the annotations should be `static`.
+      if (result.contains(' static ')) {
+        result = result.substring(result.indexOf(' static ') + 1);
+      }
+    }
+    return result;
+  }
+
+  @memoized
+  BuiltList<String> get genericParameters =>
+      BuiltList<String>(element.typeParameters.map((e) => e.name!));
+
+  @memoized
+  BuiltList<String> get genericBounds => BuiltList<String>(
+        element.typeParameters.map(
+          (element) => DartTypes.tryGetName(element.bound) ?? '',
+        ),
+      );
+
+  @memoized
+  String get genericBoundsOrObjectString => genericBounds.isEmpty
+      ? ''
+      : '<' +
+          genericBounds
+              .map((bound) => bound.isEmpty ? 'Object?' : bound)
+              .join(', ') +
+          '>';
+
+  String get genericName => '$name$genericBoundsOrObjectString';
+
+  // TODO(davidmorgan): better check.
+  @memoized
+  bool get isBuiltValue =>
+      element.allSupertypes
+          .map((type) => type.element.name!)
+          .any((name) => name.startsWith('Built')) &&
+      !element.name!.startsWith(r'_$') &&
+      element.fields.any((field) => field.name == 'serializer');
+
+  // TODO(davidmorgan): better check.
+  @memoized
+  bool get isEnumClass =>
+      element.allSupertypes
+          .map((type) => type.element.name)
+          .any((name) => name == 'EnumClass') &&
+      !element.name!.startsWith(r'_$') &&
+      element.fields.any((field) => field.name == 'serializer');
+
+  @memoized
+  BuiltList<SerializerSourceField> get fields {
+    var result = ListBuilder<SerializerSourceField>();
+    for (var fieldElement in collectFields(element)) {
+      final builderFieldElement = builderElement?.getField(
+        fieldElement.displayName,
+      );
+      final sourceField = SerializerSourceField(
+        parsedLibraryResults,
+        builtValueSettings,
+        parsedLibrary,
+        fieldElement,
+        builderFieldElement,
+      );
+      if (sourceField.isSerializable) {
+        result.add(sourceField);
+      }
+    }
+    return result.build();
+  }
+
+  /// Returns all the serializable classes used, transitively, by fields of
+  /// this class.
+  @memoized
+  BuiltSet<SerializerSourceClass> get fieldClasses =>
+      _fieldClassesWith(BuiltSet<SerializerSourceClass>());
+
+  /// Returns all the serializable classes used, transitively, by fields of
+  /// this class.
+  ///
+  /// [initialClasses] may be empty, or may include classes that are already
+  /// being evaluated. These will not be re-evaluated, preventing infinite
+  /// recursion when there is a loop in field types. For example, when `FooA`
+  /// has a field of type `FooB`, and `FooB `has a field of type `FooA`.
+  BuiltSet<SerializerSourceClass> _fieldClassesWith(
+    BuiltSet<SerializerSourceClass> initialClasses,
+  ) {
+    var result = initialClasses.toBuilder();
+    for (var fieldElement in collectFields(element)) {
+      if (fieldElement.isStatic) continue;
+      if (fieldElement.setter != null) continue;
+
+      final fieldType = fieldElement.type;
+      final fieldTypeElement = fieldType.element;
+
+      // Type is not fully specified, ignore.
+      if (fieldTypeElement is! ClassElement) continue;
+
+      // Also find classes used as generic parameters; for example a field
+      // of type List<Foo> means we need to be able to serialize Foo.
+      if (fieldType is ParameterizedType) {
+        for (final type in fieldType.typeArguments) {
+          final typeElement = type.element;
+
+          // Type is not fully specified, ignore.
+          if (typeElement is! ClassElement) continue;
+
+          final sourceClass = SerializerSourceClass(
+            parsedLibraryResults,
+            typeElement,
+          );
+
+          if (sourceClass != this &&
+              !result.build().contains(sourceClass) &&
+              sourceClass.isSerializable) {
+            result.add(sourceClass);
+            result.replace(sourceClass._fieldClassesWith(result.build()));
+          }
+        }
+      }
+
+      final sourceClass = SerializerSourceClass(
+        parsedLibraryResults,
+        fieldTypeElement,
+      );
+      if (sourceClass != this &&
+          !result.build().contains(sourceClass) &&
+          sourceClass.isSerializable) {
+        result.add(sourceClass);
+        result.replace(sourceClass._fieldClassesWith(result.build()));
+      }
+    }
+
+    return result.build();
+  }
+
+  @memoized
+  LibraryFragment get libraryFragment => element.library.firstFragment;
+
+  /// Returns the serializer class name for the generated implementation.
+  @memoized
+  String get serializerImplName => '_\$${name}Serializer';
+
+  /// Returns the serializer instance name for the generated implementation,
+  /// referenced by the user as a `static serializer` attribute.
+  @memoized
+  String get serializerInstanceName => '_\$${_toCamelCase(name)}Serializer';
+
+  Iterable<String> computeErrors() {
+    var result = <String>[];
+
+    if (!serializerSettings.custom) {
+      final expectedSerializerDeclaration =
+          'static Serializer<$genericName> get serializer => $serializerInstanceName;';
+      // We used to recommend raw types; recommend the full type now, but still
+      // allow raw types.
+      final expectedSerializerDeclarationRaw =
+          'static Serializer<$name> get serializer => $serializerInstanceName;';
+      if (serializerDeclaration != expectedSerializerDeclaration &&
+          serializerDeclaration != expectedSerializerDeclarationRaw) {
+        result.add(
+          'Declare $name.serializer as: '
+          '$expectedSerializerDeclaration got $serializerDeclaration',
+        );
+      }
+      if (name.startsWith('_')) {
+        result.add('Cannot generate serializers for private class $name');
+      }
+    }
+
+    for (var field in fields) {
+      result.addAll(field.computeErrors());
+    }
+
+    return result;
+  }
+
+  @memoized
+  bool get isSerializable => isBuiltValue || isEnumClass;
+
+  @memoized
+  bool get needsGeneratedSerializer => !serializerSettings.custom;
+
+  String generateTransitiveSerializerAdder() {
+    return '..add($name.serializer)';
+  }
+
+  /// Returns a string with `addBuilderFactory` calls to add the needed builder
+  /// factories. Specify the [libraryFragment] the code will run in, so the
+  /// code can be generated correctly (with or without import prefixes).
+  String generateBuilderFactoryAdders(LibraryFragment libraryFragment) {
+    return fields
+        .where(
+          (field) =>
+              field.needsBuilder &&
+              field
+                  .generateFullType(
+                    libraryFragment,
+                    genericParameters.toBuiltSet(),
+                  )
+                  .startsWith('const '),
+        )
+        .map(
+          (field) =>
+              '..addBuilderFactory(${field.generateFullType(libraryFragment)}, '
+              ' () => ${field.generateBuilder()})',
+        )
+        .join('\n');
+  }
+
+  String generateSerializerDeclaration() =>
+      'Serializer<$genericName> $serializerInstanceName = $serializerImplName();';
+
+  /// Returns the class name for the generated implementation. If the manually
+  /// maintained class is private then we ignore the underscore here, to avoid
+  /// returning a class name starting `_$_`.
+  @memoized
+  String get implName =>
+      name.startsWith('_') ? '_\$${name.substring(1)}' : '_\$$name';
+
+  String generateSerializer() {
+    if (isBuiltValue) {
+      // Add local $cast function if it will be used in code generated by
+      // _generateFieldDeserializers.
+      var needsCastFn = hasBuilder &&
+          fields.any(
+            (f) => f.builderFieldUsesNestedBuilder && f.builderFieldIsNullable,
+          );
+      var maybeCastFn = needsCastFn
+          ? r'''
+T $cast<T>(dynamic any) => any as T;
+'''
+          : '';
+
+      return '''
+class $serializerImplName implements StructuredSerializer<$genericName> {
+  @override
+  final Iterable<Type> types = const [$name, $implName];
+  @override
+  final String wireName = '${escapeString(wireName)}';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, $genericName object,
+      {FullType specifiedType = FullType.unspecified}) {
+    ${fields.isEmpty ? 'return <Object?>[];' : '''
+    ${_generateGenericsSerializerPreamble()}
+    final result = <Object?>[${_generateRequiredFieldSerializers()}];
+    ${_generateNullableFieldSerializers()}
+    return result;
+    '''}
+  }
+
+  @override
+  $genericName deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    ${_generateGenericsSerializerPreamble()}
+    $maybeCastFn
+    ${fields.isEmpty ? 'return ${_generateNewBuilder()}.build();' : '''
+    final result = ${_generateNewBuilder()};
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        ${_generateFieldDeserializers()}
+      }
+    }
+
+    return result.build();
+    '''}
+  }
+}
+''';
+    } else if (isEnumClass) {
+      final wireNameMapping = BuiltMap<String, Object>.build(
+        (b) => element.fields
+            .where((field) => field.isConst && field.isStatic)
+            .forEach((field) {
+          final enumSourceField = EnumSourceField(parsedLibrary, field);
+          if (enumSourceField.settings.wireName != null) {
+            b[field.name!] = enumSourceField.settings.wireName!;
+          } else if (enumSourceField.settings.wireNumber != null) {
+            b[field.name!] = enumSourceField.settings.wireNumber!;
+          }
+        }),
+      );
+
+      if (wireNameMapping.isEmpty) {
+        // No wire names. Just use the enum names directly.
+        return '''
+class $serializerImplName implements PrimitiveSerializer<$genericName> {
+  @override
+  final Iterable<Type> types = const <Type>[$name];
+  @override
+  final String wireName = '${escapeString(wireName)}';
+
+  @override
+  Object serialize(Serializers serializers, $genericName object,
+      {FullType specifiedType = FullType.unspecified}) =>
+    object.name;
+
+  @override
+  $name deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType = FullType.unspecified}) =>
+    $name.valueOf(serialized as String);
+}''';
+      } else {
+        // Generate maps between enum names and wire names.
+        final toWire = '''
+         static const Map<String, Object> _toWire = const <String, Object>{
+           ${wireNameMapping.keys.map((key) => "'${escapeString(key)}': ${_toCode(wireNameMapping[key])},").join('\n')}
+         };''';
+        final fromWire = '''
+         static const Map<Object, String> _fromWire = const <Object, String>{
+           ${wireNameMapping.keys.map((key) => "${_toCode(wireNameMapping[key])}: '${escapeString(key)}',").join('\n')}
+         };''';
+
+        return '''
+class $serializerImplName implements PrimitiveSerializer<$genericName> {
+  $toWire
+  $fromWire
+
+  @override
+  final Iterable<Type> types = const <Type>[$name];
+  @override
+  final String wireName = '${escapeString(wireName)}';
+
+  @override
+  Object serialize(Serializers serializers, $genericName object,
+      {FullType specifiedType = FullType.unspecified}) =>
+    _toWire[object.name] ?? object.name;
+
+  @override
+  $genericName deserialize(Serializers serializers, Object serialized,
+      {FullType specifiedType = FullType.unspecified}) =>
+    $name.valueOf(_fromWire[serialized] ?? (
+        serialized is String ? serialized : ''));
+}''';
+      }
+    } else {
+      throw UnsupportedError('not serializable');
+    }
+  }
+
+  static String _toCode(Object? object) {
+    if (object is String) {
+      return "'${escapeString(object)}'";
+    } else if (object is int) {
+      return object.toString();
+    } else {
+      throw UnsupportedError('$object');
+    }
+  }
+
+  String _generateNewBuilder() {
+    var parameters = _genericParametersUsedInFields;
+    if (parameters.isEmpty) {
+      return '${name}Builder$genericBoundsOrObjectString()';
+    }
+    return 'isUnderspecified ? '
+        '${name}Builder$genericBoundsOrObjectString() : '
+        'serializers.newBuilder(specifiedType) as '
+        '${name}Builder$genericBoundsOrObjectString';
+  }
+
+  BuiltList<String> get _genericParametersUsedInFields => BuiltList<String>(
+        genericParameters.where(
+          (parameter) => fields.any(
+            (field) =>
+                field.rawType == parameter ||
+                field.type.contains(RegExp('[<, \n]$parameter[>, \n]')),
+          ),
+        ),
+      );
+
+  String _generateGenericsSerializerPreamble() {
+    var parameters = _genericParametersUsedInFields;
+    if (parameters.isEmpty) return '';
+    var result = StringBuffer();
+    result.writeln(
+      'final isUnderspecified = specifiedType.isUnspecified || '
+      'specifiedType.parameters.isEmpty;',
+    );
+    result.writeln(
+      'if (!isUnderspecified) serializers.expectBuilder(specifiedType);',
+    );
+    for (var parameter in parameters) {
+      final index = genericParameters.indexOf(parameter);
+      result.writeln(
+        'final parameter$parameter = '
+        'isUnderspecified '
+        '? FullType.object : '
+        'specifiedType.parameters[$index];',
+      );
+    }
+    result.writeln();
+    return result.toString();
+  }
+
+  String _generateRequiredFieldSerializers() {
+    return fields
+        .where((field) => !field.isNullable)
+        .map(
+          (field) => "'${escapeString(field.wireName)}', "
+              'serializers.serialize(object.${field.name}, '
+              'specifiedType: '
+              '${field.generateFullType(libraryFragment, genericParameters.toBuiltSet())}),',
+        )
+        .join('');
+  }
+
+  String _generateNullableFieldSerializers() {
+    var nullableFields = fields.where((field) => field.isNullable).toList();
+    if (nullableFields.isEmpty) return '';
+
+    return 'Object? value;' +
+        nullableFields.map((field) {
+          var serializeField = '''serializers.serialize(
+          value,
+          specifiedType:
+          ${field.generateFullType(libraryFragment, genericParameters.toBuiltSet())})''';
+
+          return '''
+          value = object.${field.name};
+          ${serializerSettings.serializeNulls ? '' : 'if (value != null) {'}
+            result
+              ..add('${escapeString(field.wireName)}')
+              ..add($serializeField);
+          ${serializerSettings.serializeNulls ? '' : '}'}''';
+        }).join('');
+  }
+
+  /// Gets a map from generic parameter to its bound.
+  ///
+  /// 'Object' is substituted where there is no bound.
+  BuiltMap<String, String> get _genericBoundsAsMap {
+    var genericBoundsOrObject =
+        genericBounds.map((bound) => bound.isEmpty ? 'Object' : bound).toList();
+    var result = MapBuilder<String, String>();
+    for (var i = 0; i != genericParameters.length; ++i) {
+      result[genericParameters[i]] = genericBoundsOrObject[i];
+    }
+    return result.build();
+  }
+
+  String _generateFieldDeserializers() {
+    return fields.map((field) {
+      final fullType = field.generateFullType(
+        libraryFragment,
+        genericParameters.toBuiltSet(),
+      );
+      final cast = field.generateCast(libraryFragment, _genericBoundsAsMap);
+      // If cast exists and is not nullable.
+      var maybeNotNull = !field.isNullable && cast.isNotEmpty ? '!' : '';
+      if (field.builderFieldUsesNestedBuilder) {
+        if (hasBuilder && field.builderFieldIsNullable) {
+          // The manually implemented builder might or might not return a
+          // builder. If it does, use `replace` as usual. If not, use `$cast`
+          // to avoid computing a new type of static cast.
+          return '''
+case '${escapeString(field.wireName)}':
+  var maybeBuilder = result.${field.name};
+  var fieldValue = serializers.deserialize(
+      value, specifiedType: $fullType)! $cast;
+  if (maybeBuilder == null) {
+    result.${field.name} = \$cast(fieldValue.toBuilder());
+  } else {
+    maybeBuilder.replace(fieldValue);
+  }
+  break;
+''';
+        } else if (field.builderFieldAutoCreatesNestedBuilder) {
+          // Use a looser cast where possible for calls to `replace`.
+          final looseCast = field.generateCast(
+            libraryFragment,
+            _genericBoundsAsMap,
+            forReplace: true,
+          );
+          return '''
+case '${escapeString(field.wireName)}':
+  result.${field.name}.replace(serializers.deserialize(
+      value, specifiedType: $fullType)! $looseCast);
+  break;
+''';
+        } else {
+          return '''
+case '${escapeString(field.wireName)}':
+  result.${field.name} = (serializers.deserialize(
+      value, specifiedType: $fullType)$maybeNotNull $cast).toBuilder();
+  break;
+''';
+        }
+      } else {
+        // `cast` is empty if no cast is needed.
+        var maybeOrNull = field.isNullable && cast.isNotEmpty ? '?' : '';
+        return '''
+case '${escapeString(field.wireName)}':
+  result.${field.name} = serializers.deserialize(
+      value, specifiedType: $fullType)$maybeNotNull $cast$maybeOrNull;
+  break;
+''';
+      }
+    }).join('');
+  }
+
+  static String _toCamelCase(String name) {
+    var result = '';
+    var upperCase = false;
+    var firstCharacter = true;
+    for (var char in name.split('')) {
+      if (char == '_') {
+        upperCase = true;
+      } else if (char == '\$') {
+        result += '\$';
+      } else {
+        result += firstCharacter
+            ? char.toLowerCase()
+            : (upperCase ? char.toUpperCase() : char);
+        upperCase = false;
+        firstCharacter = false;
+      }
+    }
+    return result;
+  }
+}

--- a/built_types/built_value_generator/lib/src/serializer_source_class.g.dart
+++ b/built_types/built_value_generator/lib/src/serializer_source_class.g.dart
@@ -1,0 +1,222 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'serializer_source_class.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$SerializerSourceClass extends SerializerSourceClass {
+  @override
+  final ParsedLibraryResults parsedLibraryResults;
+  @override
+  final InterfaceElement element;
+  @override
+  final ClassElement? builderElement;
+  ParsedLibraryResult? __parsedLibrary;
+  BuiltValue? __builtValueSettings;
+  bool? __hasBuilder;
+  BuiltValueSerializer? __serializerSettings;
+  BuiltValueEnum? __enumClassSettings;
+  String? __name;
+  String? __wireName;
+  String? __serializerDeclaration;
+  BuiltList<String>? __genericParameters;
+  BuiltList<String>? __genericBounds;
+  String? __genericBoundsOrObjectString;
+  bool? __isBuiltValue;
+  bool? __isEnumClass;
+  BuiltList<SerializerSourceField>? __fields;
+  BuiltSet<SerializerSourceClass>? __fieldClasses;
+  LibraryFragment? __libraryFragment;
+  String? __serializerImplName;
+  String? __serializerInstanceName;
+  bool? __isSerializable;
+  bool? __needsGeneratedSerializer;
+  String? __implName;
+
+  factory _$SerializerSourceClass(
+          [void Function(SerializerSourceClassBuilder)? updates]) =>
+      (SerializerSourceClassBuilder()..update(updates))._build();
+
+  _$SerializerSourceClass._(
+      {required this.parsedLibraryResults,
+      required this.element,
+      this.builderElement})
+      : super._();
+  @override
+  ParsedLibraryResult get parsedLibrary =>
+      __parsedLibrary ??= super.parsedLibrary;
+
+  @override
+  BuiltValue get builtValueSettings =>
+      __builtValueSettings ??= super.builtValueSettings;
+
+  @override
+  bool get hasBuilder => __hasBuilder ??= super.hasBuilder;
+
+  @override
+  BuiltValueSerializer get serializerSettings =>
+      __serializerSettings ??= super.serializerSettings;
+
+  @override
+  BuiltValueEnum get enumClassSettings =>
+      __enumClassSettings ??= super.enumClassSettings;
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get wireName => __wireName ??= super.wireName;
+
+  @override
+  String get serializerDeclaration =>
+      __serializerDeclaration ??= super.serializerDeclaration;
+
+  @override
+  BuiltList<String> get genericParameters =>
+      __genericParameters ??= super.genericParameters;
+
+  @override
+  BuiltList<String> get genericBounds =>
+      __genericBounds ??= super.genericBounds;
+
+  @override
+  String get genericBoundsOrObjectString =>
+      __genericBoundsOrObjectString ??= super.genericBoundsOrObjectString;
+
+  @override
+  bool get isBuiltValue => __isBuiltValue ??= super.isBuiltValue;
+
+  @override
+  bool get isEnumClass => __isEnumClass ??= super.isEnumClass;
+
+  @override
+  BuiltList<SerializerSourceField> get fields => __fields ??= super.fields;
+
+  @override
+  BuiltSet<SerializerSourceClass> get fieldClasses =>
+      __fieldClasses ??= super.fieldClasses;
+
+  @override
+  LibraryFragment get libraryFragment =>
+      __libraryFragment ??= super.libraryFragment;
+
+  @override
+  String get serializerImplName =>
+      __serializerImplName ??= super.serializerImplName;
+
+  @override
+  String get serializerInstanceName =>
+      __serializerInstanceName ??= super.serializerInstanceName;
+
+  @override
+  bool get isSerializable => __isSerializable ??= super.isSerializable;
+
+  @override
+  bool get needsGeneratedSerializer =>
+      __needsGeneratedSerializer ??= super.needsGeneratedSerializer;
+
+  @override
+  String get implName => __implName ??= super.implName;
+
+  @override
+  SerializerSourceClass rebuild(
+          void Function(SerializerSourceClassBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SerializerSourceClassBuilder toBuilder() =>
+      SerializerSourceClassBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SerializerSourceClass &&
+        parsedLibraryResults == other.parsedLibraryResults &&
+        element == other.element &&
+        builderElement == other.builderElement;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, parsedLibraryResults.hashCode);
+    _$hash = $jc(_$hash, element.hashCode);
+    _$hash = $jc(_$hash, builderElement.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SerializerSourceClass')
+          ..add('parsedLibraryResults', parsedLibraryResults)
+          ..add('element', element)
+          ..add('builderElement', builderElement))
+        .toString();
+  }
+}
+
+class SerializerSourceClassBuilder
+    implements Builder<SerializerSourceClass, SerializerSourceClassBuilder> {
+  _$SerializerSourceClass? _$v;
+
+  ParsedLibraryResults? _parsedLibraryResults;
+  ParsedLibraryResults? get parsedLibraryResults =>
+      _$this._parsedLibraryResults;
+  set parsedLibraryResults(ParsedLibraryResults? parsedLibraryResults) =>
+      _$this._parsedLibraryResults = parsedLibraryResults;
+
+  InterfaceElement? _element;
+  InterfaceElement? get element => _$this._element;
+  set element(InterfaceElement? element) => _$this._element = element;
+
+  ClassElement? _builderElement;
+  ClassElement? get builderElement => _$this._builderElement;
+  set builderElement(ClassElement? builderElement) =>
+      _$this._builderElement = builderElement;
+
+  SerializerSourceClassBuilder();
+
+  SerializerSourceClassBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _parsedLibraryResults = $v.parsedLibraryResults;
+      _element = $v.element;
+      _builderElement = $v.builderElement;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SerializerSourceClass other) {
+    _$v = other as _$SerializerSourceClass;
+  }
+
+  @override
+  void update(void Function(SerializerSourceClassBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SerializerSourceClass build() => _build();
+
+  _$SerializerSourceClass _build() {
+    final _$result = _$v ??
+        _$SerializerSourceClass._(
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'SerializerSourceClass',
+              'parsedLibraryResults'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'SerializerSourceClass', 'element'),
+          builderElement: builderElement,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/built_value_generator/lib/src/serializer_source_field.dart
+++ b/built_types/built_value_generator/lib/src/serializer_source_field.dart
@@ -1,0 +1,391 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.source_field;
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/dart_types.dart';
+import 'package:built_value_generator/src/field_mixin.dart';
+import 'package:built_value_generator/src/metadata.dart'
+    show metadataToStringValue;
+import 'package:built_value_generator/src/parsed_library_results.dart';
+import 'package:built_value_generator/src/strings.dart';
+
+part 'serializer_source_field.g.dart';
+
+abstract class SerializerSourceField
+    with FieldMixin
+    implements Built<SerializerSourceField, SerializerSourceFieldBuilder> {
+  static final BuiltMap<String, String> typesWithBuilder =
+      BuiltMap<String, String>({
+    'BuiltList': 'ListBuilder',
+    'BuiltListMultimap': 'ListMultimapBuilder',
+    'BuiltMap': 'MapBuilder',
+    'BuiltSet': 'SetBuilder',
+    'BuiltSetMultimap': 'SetMultimapBuilder',
+  });
+  ParsedLibraryResults get parsedLibraryResults;
+  BuiltValue get settings;
+  @override
+  ParsedLibraryResult get parsedLibrary;
+  PropertyInducingElement get element;
+  @override
+  PropertyInducingElement? get builderElement;
+
+  factory SerializerSourceField(
+    ParsedLibraryResults parsedLibraryResults,
+    BuiltValue settings,
+    ParsedLibraryResult parsedLibrary,
+    PropertyInducingElement element,
+    PropertyInducingElement? builderElement,
+  ) =>
+      _$SerializerSourceField._(
+        parsedLibraryResults: parsedLibraryResults,
+        settings: settings,
+        parsedLibrary: parsedLibrary,
+        element: element,
+        builderElement: builderElement,
+      );
+  SerializerSourceField._();
+
+  @memoized
+  bool get isSerializable =>
+      element.getter != null &&
+      element.getter!.isAbstract &&
+      !element.isStatic &&
+      (builtValueField.serialize ?? settings.defaultSerialize);
+
+  @memoized
+  BuiltValueField get builtValueField {
+    var annotations = element.getter!.metadata.annotations
+        .map((annotation) => annotation.computeConstantValue())
+        .where(
+          (value) => DartTypes.tryGetName(value?.type) == 'BuiltValueField',
+        );
+    if (annotations.isEmpty) return const BuiltValueField();
+    var annotation = annotations.single!;
+    return BuiltValueField(
+      compare: annotation.getField('compare')?.toBoolValue(),
+      serialize: annotation.getField('serialize')?.toBoolValue(),
+      wireName: annotation.getField('wireName')?.toStringValue(),
+      nestedBuilder: annotation.getField('nestedBuilder')?.toBoolValue(),
+      autoCreateNestedBuilder:
+          annotation.getField('autoCreateNestedBuilder')?.toBoolValue(),
+    );
+  }
+
+  @memoized
+  bool get hasNullableAnnotation => element.getter!.metadata.annotations.any(
+        (metadata) => metadataToStringValue(metadata) == 'nullable',
+      );
+
+  @memoized
+  bool get hasNullableType =>
+      element.getter?.returnType.nullabilitySuffix ==
+      NullabilitySuffix.question;
+
+  @memoized
+  bool get isNullable => hasNullableAnnotation || hasNullableType;
+
+  @memoized
+  String get name => element.displayName;
+
+  @memoized
+  String get wireName => builtValueField.wireName ?? name;
+
+  @memoized
+  String get type => stripNullabilitySuffix(typeWithNullabilitySuffix);
+
+  @memoized
+  String get typeWithNullabilitySuffix => DartTypes.getName(
+        element.getter!.returnType,
+        withNullabilitySuffix: true,
+      );
+
+  /// The [type] plus any import prefix, with any nullability suffix.
+  @memoized
+  String get typeWithPrefix =>
+      stripNullabilitySuffix(typeWithPrefixAndNullabilitySuffix);
+
+  /// The [type] plus any import prefix, without any nullability suffix.
+  @memoized
+  String get typeWithPrefixAndNullabilitySuffix {
+    var declaration =
+        parsedLibrary.getFragmentDeclaration(element.getter!.firstFragment)!;
+    var typeFromAst =
+        (declaration.node as MethodDeclaration).returnType?.toString() ??
+            'dynamic';
+    var typeFromElement = typeWithNullabilitySuffix;
+
+    // If the type is a function, we can't use the element result; it is
+    // formatted incorrectly.
+    if (typeFromElement.contains('(')) return typeFromAst;
+
+    // If the type does not have an import prefix, prefer the element result.
+    // It handles inherited generics correctly.
+    if (!typeFromAst.contains('.')) return typeFromElement;
+
+    return typeFromAst;
+  }
+
+  /// Returns the type with import prefix if the compilation unit matches,
+  /// otherwise the type with no import prefix.
+  String typeInLibraryFragment(LibraryFragment libraryFragment) =>
+      stripNullabilitySuffix(
+        typeInLibraryFragmentWithNullabilitySuffix(libraryFragment),
+      );
+
+  /// Returns the type with import prefix if the compilation unit matches,
+  /// otherwise the type with no import prefix.
+  String typeInLibraryFragmentWithNullabilitySuffix(
+    LibraryFragment libraryFragment,
+  ) {
+    return libraryFragment == element.library.firstFragment
+        ? typeWithPrefixAndNullabilitySuffix
+        : typeWithNullabilitySuffix;
+  }
+
+  @memoized
+  bool get builderFieldElementIsValid =>
+      (builderElement?.getter?.isAbstract == false) &&
+      !builderElement!.isStatic;
+
+  @memoized
+  bool get builderFieldUsesNestedBuilder {
+    // If the builder is present, check it to determine whether a nested
+    // builder is needed. Otherwise, use the same logic as built_value when
+    // it decides whether to use a nested builder.
+    return builderFieldElementIsValid
+        ? DartTypes.getName(element.getter!.returnType) !=
+            DartTypes.getName(builderElement!.getter!.returnType)
+        : (builtValueField.nestedBuilder ?? settings.nestedBuilders) &&
+            DartTypes.needsNestedBuilder(
+              parsedLibraryResults,
+              element.getter!.returnType,
+            );
+  }
+
+  @memoized
+  @override
+  String get fullBuildElementType => super.fullBuildElementType;
+
+  @memoized
+  bool get builderFieldIsNullable {
+    if (!builderFieldElementIsValid) return true;
+
+    return fullBuildElementType == 'dynamic' ||
+        fullBuildElementType.endsWith('?');
+  }
+
+  @memoized
+  bool get builderFieldAutoCreatesNestedBuilder =>
+      builtValueField.autoCreateNestedBuilder ??
+      settings.autoCreateNestedBuilders;
+
+  @memoized
+  String get rawType => _getBareType(type);
+
+  String generateFullType(
+    LibraryFragment libraryFragment, [
+    BuiltSet<String>? classGenericParameters,
+  ]) {
+    return _generateFullType(
+      typeInLibraryFragmentWithNullabilitySuffix(libraryFragment),
+      classGenericParameters ?? BuiltSet<String>(),
+    );
+  }
+
+  @memoized
+  bool get needsBuilder =>
+      DartTypes.getName(element.getter!.returnType).contains('<') &&
+      DartTypes.isBuilt(element.getter!.returnType);
+
+  Iterable<String> computeErrors() {
+    if (isSerializable && element.getter!.returnType is FunctionType) {
+      return [
+        'Function fields are not serializable. '
+            'Remove "$name" or mark it "@BuiltValueField(serialize: false)".',
+      ];
+    }
+
+    if (isSerializable &&
+        element.getter!.returnType is RecordType &&
+        typeWithPrefix.contains('(')) {
+      return [
+        'Fields declared with record types are not automatically serializable. '
+            'To allow the class to be serialized, modify "$name" by: '
+            'a) removing it,  or '
+            'b) marking it "@BuiltValueField(serialize: false)", or '
+            'c) creating a `typedef` to represent the record type then '
+            'writing and installing a custom `Serializer` for it.',
+      ];
+    }
+
+    return [];
+  }
+
+  /// Generates a cast using 'as' to this field type.
+  ///
+  /// Generics are cast to the bound of the generic. If there is no bound,
+  /// no cast is needed, and an empty string is returned.
+  ///
+  /// Set [forReplace] to loosen generics of cast where possible for calling
+  /// a `replace` method.
+  String generateCast(
+    LibraryFragment libraryFragment,
+    BuiltMap<String, String> classGenericBounds, {
+    bool forReplace = false,
+  }) {
+    var result = _generateCast(
+      typeInLibraryFragment(libraryFragment),
+      classGenericBounds,
+      forReplace: forReplace,
+    );
+    return result == 'Object' ? '' : 'as $result';
+  }
+
+  String generateBuilder() {
+    var bareType = _getBareType(type);
+    if (typesWithBuilder.containsKey(bareType)) {
+      return '${typesWithBuilder[bareType]}<${_getGenerics(type)}>()';
+    } else {
+      return '${bareType}Builder<${_getGenerics(type)}>()';
+    }
+  }
+
+  static String _generateFullType(
+    String type,
+    BuiltSet<String> classGenericParameters, {
+    bool includeNullability = false,
+  }) {
+    var bareType = _getBareType(type);
+    var generics = _getGenerics(type);
+    var genericItems = _splitOnTopLevelCommas(generics);
+    var maybeNullability =
+        includeNullability && type.endsWith('?') ? '.nullable' : '';
+
+    if (generics.isEmpty) {
+      if (classGenericParameters.contains(bareType)) {
+        return 'parameter$bareType';
+      }
+      return 'const FullType$maybeNullability($bareType)';
+    } else {
+      final parameterFullTypes = genericItems.map(
+        (item) => _generateFullType(
+          item,
+          classGenericParameters,
+          includeNullability: true,
+        ),
+      );
+      final canUseConst = parameterFullTypes.every(
+        (param) => param.startsWith('const '),
+      );
+      final constOrEmpty = canUseConst ? 'const ' : '';
+      return '${constOrEmpty}FullType$maybeNullability('
+          '$bareType, $constOrEmpty[${parameterFullTypes.join(', ')}])';
+    }
+  }
+
+  String _generateCast(
+    String type,
+    BuiltMap<String, String> classGenericBounds, {
+    bool topLevel = true,
+    bool forReplace = false,
+  }) {
+    var resultNullabilitySuffix = (!topLevel && type.endsWith('?')) ? '?' : '';
+    var bareType = _getBareType(type);
+
+    // `built_collection` `replace` methods don't care about the full generic
+    // type, so we can be less precise about the cast. This doesn't add any
+    // particular value for vanilla `built_value` but it allows plugging in
+    // serializers that don't get the generic types correct.
+    //
+    // Only if `forReplace` was passed.
+    String generics;
+    if (forReplace &&
+        topLevel &&
+        DartTypes.isBuiltCollectionTypeName(bareType) &&
+        builderFieldUsesNestedBuilder) {
+      if (bareType == 'BuiltList' || bareType == 'BuiltSet') {
+        generics = 'Object?';
+      } else if (bareType == 'BuiltMap' ||
+          bareType == 'BuiltListMultimap' ||
+          bareType == 'BuiltSetMultimap') {
+        // Map `replace` methods are even more generous so that they can accept
+        // a `Map` or a `BuiltMap`. So, we can just pass `Object`.
+        return 'Object';
+      } else {
+        throw UnsupportedError(
+          'Bare type is a built_collection type, but not '
+          'one of the known built_collection types: $bareType.',
+        );
+      }
+    } else {
+      generics = _getGenerics(type);
+    }
+
+    var genericItems = _splitOnTopLevelCommas(generics);
+
+    if (generics.isEmpty) {
+      if (classGenericBounds.keys.contains(bareType)) {
+        return classGenericBounds[bareType]!;
+      }
+      return bareType + resultNullabilitySuffix;
+    } else {
+      final parameterFullTypes = genericItems
+          .map(
+            (item) => _generateCast(item, classGenericBounds, topLevel: false),
+          )
+          .join(', ');
+      return '$bareType<$parameterFullTypes>$resultNullabilitySuffix';
+    }
+  }
+
+  static String _getBareType(String name) {
+    var genericsStart = name.indexOf('<');
+    var result = genericsStart == -1 ? name : name.substring(0, genericsStart);
+    if (result.endsWith('?')) result = result.substring(0, result.length - 1);
+    return result;
+  }
+
+  static String _getGenerics(String name) {
+    var genericsStart = name.indexOf('<');
+    var hasNullableSuffix = name.endsWith('?');
+    return genericsStart == -1
+        ? ''
+        : name.substring(genericsStart + 1).substring(
+              0,
+              name.length - genericsStart - 2 - (hasNullableSuffix ? 1 : 0),
+            );
+  }
+
+  /// Splits a generic parameter string on top level commas; that means
+  /// commas nested inside '<' and '>' are ignored.
+  static BuiltList<String> _splitOnTopLevelCommas(String string) {
+    var result = ListBuilder<String>();
+    var accumulator = StringBuffer();
+    var depth = 0;
+    for (var i = 0; i != string.length; ++i) {
+      if (string[i] == '<') ++depth;
+      if (string[i] == '>') --depth;
+
+      if (string[i] == ',' && depth == 0) {
+        result.add(accumulator.toString().trim());
+        accumulator.clear();
+      } else {
+        accumulator.write(string[i]);
+      }
+    }
+    if (accumulator.isNotEmpty) {
+      result.add(accumulator.toString().trim());
+    }
+    return result.build();
+  }
+}

--- a/built_types/built_value_generator/lib/src/serializer_source_field.g.dart
+++ b/built_types/built_value_generator/lib/src/serializer_source_field.g.dart
@@ -1,0 +1,235 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'serializer_source_field.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$SerializerSourceField extends SerializerSourceField {
+  @override
+  final ParsedLibraryResults parsedLibraryResults;
+  @override
+  final BuiltValue settings;
+  @override
+  final ParsedLibraryResult parsedLibrary;
+  @override
+  final PropertyInducingElement element;
+  @override
+  final PropertyInducingElement? builderElement;
+  bool? __isSerializable;
+  BuiltValueField? __builtValueField;
+  bool? __hasNullableAnnotation;
+  bool? __hasNullableType;
+  bool? __isNullable;
+  String? __name;
+  String? __wireName;
+  String? __type;
+  String? __typeWithNullabilitySuffix;
+  String? __typeWithPrefix;
+  String? __typeWithPrefixAndNullabilitySuffix;
+  bool? __builderFieldElementIsValid;
+  bool? __builderFieldUsesNestedBuilder;
+  String? __fullBuildElementType;
+  bool? __builderFieldIsNullable;
+  bool? __builderFieldAutoCreatesNestedBuilder;
+  String? __rawType;
+  bool? __needsBuilder;
+
+  factory _$SerializerSourceField(
+          [void Function(SerializerSourceFieldBuilder)? updates]) =>
+      (SerializerSourceFieldBuilder()..update(updates))._build();
+
+  _$SerializerSourceField._(
+      {required this.parsedLibraryResults,
+      required this.settings,
+      required this.parsedLibrary,
+      required this.element,
+      this.builderElement})
+      : super._();
+  @override
+  bool get isSerializable => __isSerializable ??= super.isSerializable;
+
+  @override
+  BuiltValueField get builtValueField =>
+      __builtValueField ??= super.builtValueField;
+
+  @override
+  bool get hasNullableAnnotation =>
+      __hasNullableAnnotation ??= super.hasNullableAnnotation;
+
+  @override
+  bool get hasNullableType => __hasNullableType ??= super.hasNullableType;
+
+  @override
+  bool get isNullable => __isNullable ??= super.isNullable;
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get wireName => __wireName ??= super.wireName;
+
+  @override
+  String get type => __type ??= super.type;
+
+  @override
+  String get typeWithNullabilitySuffix =>
+      __typeWithNullabilitySuffix ??= super.typeWithNullabilitySuffix;
+
+  @override
+  String get typeWithPrefix => __typeWithPrefix ??= super.typeWithPrefix;
+
+  @override
+  String get typeWithPrefixAndNullabilitySuffix =>
+      __typeWithPrefixAndNullabilitySuffix ??=
+          super.typeWithPrefixAndNullabilitySuffix;
+
+  @override
+  bool get builderFieldElementIsValid =>
+      __builderFieldElementIsValid ??= super.builderFieldElementIsValid;
+
+  @override
+  bool get builderFieldUsesNestedBuilder =>
+      __builderFieldUsesNestedBuilder ??= super.builderFieldUsesNestedBuilder;
+
+  @override
+  String get fullBuildElementType =>
+      __fullBuildElementType ??= super.fullBuildElementType;
+
+  @override
+  bool get builderFieldIsNullable =>
+      __builderFieldIsNullable ??= super.builderFieldIsNullable;
+
+  @override
+  bool get builderFieldAutoCreatesNestedBuilder =>
+      __builderFieldAutoCreatesNestedBuilder ??=
+          super.builderFieldAutoCreatesNestedBuilder;
+
+  @override
+  String get rawType => __rawType ??= super.rawType;
+
+  @override
+  bool get needsBuilder => __needsBuilder ??= super.needsBuilder;
+
+  @override
+  SerializerSourceField rebuild(
+          void Function(SerializerSourceFieldBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SerializerSourceFieldBuilder toBuilder() =>
+      SerializerSourceFieldBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SerializerSourceField &&
+        parsedLibraryResults == other.parsedLibraryResults &&
+        settings == other.settings &&
+        parsedLibrary == other.parsedLibrary &&
+        element == other.element &&
+        builderElement == other.builderElement;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, parsedLibraryResults.hashCode);
+    _$hash = $jc(_$hash, settings.hashCode);
+    _$hash = $jc(_$hash, parsedLibrary.hashCode);
+    _$hash = $jc(_$hash, element.hashCode);
+    _$hash = $jc(_$hash, builderElement.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SerializerSourceField')
+          ..add('parsedLibraryResults', parsedLibraryResults)
+          ..add('settings', settings)
+          ..add('parsedLibrary', parsedLibrary)
+          ..add('element', element)
+          ..add('builderElement', builderElement))
+        .toString();
+  }
+}
+
+class SerializerSourceFieldBuilder
+    implements Builder<SerializerSourceField, SerializerSourceFieldBuilder> {
+  _$SerializerSourceField? _$v;
+
+  ParsedLibraryResults? _parsedLibraryResults;
+  ParsedLibraryResults? get parsedLibraryResults =>
+      _$this._parsedLibraryResults;
+  set parsedLibraryResults(ParsedLibraryResults? parsedLibraryResults) =>
+      _$this._parsedLibraryResults = parsedLibraryResults;
+
+  BuiltValue? _settings;
+  BuiltValue? get settings => _$this._settings;
+  set settings(BuiltValue? settings) => _$this._settings = settings;
+
+  ParsedLibraryResult? _parsedLibrary;
+  ParsedLibraryResult? get parsedLibrary => _$this._parsedLibrary;
+  set parsedLibrary(ParsedLibraryResult? parsedLibrary) =>
+      _$this._parsedLibrary = parsedLibrary;
+
+  PropertyInducingElement? _element;
+  PropertyInducingElement? get element => _$this._element;
+  set element(PropertyInducingElement? element) => _$this._element = element;
+
+  PropertyInducingElement? _builderElement;
+  PropertyInducingElement? get builderElement => _$this._builderElement;
+  set builderElement(PropertyInducingElement? builderElement) =>
+      _$this._builderElement = builderElement;
+
+  SerializerSourceFieldBuilder();
+
+  SerializerSourceFieldBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _parsedLibraryResults = $v.parsedLibraryResults;
+      _settings = $v.settings;
+      _parsedLibrary = $v.parsedLibrary;
+      _element = $v.element;
+      _builderElement = $v.builderElement;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SerializerSourceField other) {
+    _$v = other as _$SerializerSourceField;
+  }
+
+  @override
+  void update(void Function(SerializerSourceFieldBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SerializerSourceField build() => _build();
+
+  _$SerializerSourceField _build() {
+    final _$result = _$v ??
+        _$SerializerSourceField._(
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'SerializerSourceField',
+              'parsedLibraryResults'),
+          settings: BuiltValueNullFieldError.checkNotNull(
+              settings, r'SerializerSourceField', 'settings'),
+          parsedLibrary: BuiltValueNullFieldError.checkNotNull(
+              parsedLibrary, r'SerializerSourceField', 'parsedLibrary'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'SerializerSourceField', 'element'),
+          builderElement: builderElement,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/built_value_generator/lib/src/serializer_source_library.dart
+++ b/built_types/built_value_generator/lib/src/serializer_source_library.dart
@@ -1,0 +1,263 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.source_library;
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/parsed_library_results.dart';
+import 'package:built_value_generator/src/serializer_source_class.dart';
+import 'package:source_gen/source_gen.dart';
+
+import 'dart_types.dart';
+
+part 'serializer_source_library.g.dart';
+
+abstract class SerializerSourceLibrary
+    implements Built<SerializerSourceLibrary, SerializerSourceLibraryBuilder> {
+  ParsedLibraryResults get parsedLibraryResults;
+  LibraryElement get element;
+
+  factory SerializerSourceLibrary(
+    ParsedLibraryResults parsedLibraryResults,
+    LibraryElement element,
+  ) =>
+      _$SerializerSourceLibrary._(
+        parsedLibraryResults: parsedLibraryResults,
+        element: element,
+      );
+  SerializerSourceLibrary._();
+
+  @memoized
+  ParsedLibraryResult get parsedLibrary =>
+      parsedLibraryResults.parsedLibraryResultOrThrowingMock(element.library);
+
+  @memoized
+  bool get hasSerializers => serializersForAnnotations.isNotEmpty;
+
+  /// Returns a map of `Serializers` declarations; the keys are field names
+  /// and the values are the `@SerializersFor` annotations.
+  @memoized
+  BuiltMap<String, ElementAnnotation> get serializersForAnnotations {
+    var result = MapBuilder<String, ElementAnnotation>();
+    var accessors = element.library.topLevelVariables
+        .where(
+          (element) =>
+              element.getter != null &&
+              DartTypes.getName(element.getter!.returnType) == 'Serializers',
+        )
+        .toList();
+
+    for (var accessor in accessors) {
+      final annotations = accessor.metadata.annotations
+          .where(
+            (annotation) =>
+                DartTypes.tryGetName(
+                  annotation.computeConstantValue()?.type,
+                ) ==
+                'SerializersFor',
+          )
+          .toList();
+      if (annotations.isEmpty) continue;
+
+      result[accessor.name!] = annotations.single;
+    }
+
+    return result.build();
+  }
+
+  /// Returns a list of getters annotated `SerializersFor` that have the wrong
+  /// return type.
+  @memoized
+  BuiltList<String> get wrongSerializersDeclarations {
+    var result = ListBuilder<String>();
+    var accessors = element.topLevelVariables
+        .where(
+          (element) =>
+              element.getter != null &&
+              DartTypes.getName(element.getter!.returnType) != 'Serializers',
+        )
+        .toList();
+
+    for (var accessor in accessors) {
+      final annotations = accessor.metadata.annotations
+          .where(
+            (annotation) =>
+                DartTypes.tryGetName(
+                  annotation.computeConstantValue()?.type,
+                ) ==
+                'SerializersFor',
+          )
+          .toList();
+      if (annotations.isEmpty) continue;
+
+      result.add(accessor.name!);
+    }
+
+    return result.build();
+  }
+
+  /// Returns the set of serializable classes in this library. A serializer
+  /// needs to be installed for each of these. A serialized needs to be
+  /// generated for each, except where the serializer is marked `custom`.
+  @memoized
+  BuiltSet<SerializerSourceClass> get sourceClasses {
+    var result = SetBuilder<SerializerSourceClass>();
+    var classElements = element.classes;
+    for (var classElement in classElements) {
+      final sourceClass = SerializerSourceClass(
+        parsedLibraryResults,
+        classElement,
+      );
+      if (sourceClass.isSerializable) {
+        result.add(sourceClass);
+      }
+    }
+    return result.build();
+  }
+
+  /// Returns a map from `Serializers` declaration field names to the classes
+  /// that each serializer is required to be able to serialize.
+  @memoized
+  BuiltSetMultimap<String, SerializerSourceClass> get serializeForClasses {
+    var result = SetMultimapBuilder<String, SerializerSourceClass>();
+
+    for (var field in serializersForAnnotations.keys) {
+      final serializersForAnnotation = serializersForAnnotations[field]!;
+
+      final types = serializersForAnnotation
+          .computeConstantValue()!
+          .getField('types')!
+          .toListValue()
+          ?.map((dartObject) => dartObject.toTypeValue());
+
+      if (types == null) {
+        // This only happens if the source code is invalid.
+        throw InvalidGenerationSourceError(
+          'Broken @SerializersFor annotation. Are all the types imported?',
+        );
+      }
+
+      result.addValues(
+        field,
+        types.map(
+          (type) => SerializerSourceClass(
+            parsedLibraryResults,
+            type!.element as InterfaceElement,
+          ),
+        ),
+      );
+    }
+    return result.build();
+  }
+
+  /// Returns a map from `Serializers` declaration field names to the
+  /// transitive set of serializable classes implied by `serializeForClasses`.
+  @memoized
+  BuiltSetMultimap<String, SerializerSourceClass>
+      get serializeForTransitiveClasses {
+    var result = SetMultimapBuilder<String, SerializerSourceClass>();
+
+    for (var field in serializersForAnnotations.keys) {
+      var currentResult = BuiltSet<SerializerSourceClass>(
+        serializeForClasses[field]!.where(
+          (serializerSourceClass) => serializerSourceClass.isSerializable,
+        ),
+      );
+      BuiltSet<SerializerSourceClass>? expandedResult;
+
+      while (currentResult != expandedResult) {
+        currentResult = expandedResult ?? currentResult;
+        expandedResult = currentResult.rebuild(
+          (b) => b
+            ..addAll(
+              currentResult.expand(
+                (sourceClass) => sourceClass.fieldClasses.where(
+                  (fieldClass) => fieldClass.isSerializable,
+                ),
+              ),
+            ),
+        );
+      }
+
+      result.addValues(field, currentResult);
+    }
+
+    return result.build();
+  }
+
+  bool get needsBuiltJson => sourceClasses.isNotEmpty;
+
+  Iterable<String> computeErrors() {
+    var result = <String>[];
+
+    if (wrongSerializersDeclarations.isNotEmpty) {
+      result.add(
+        'These top level getters are annotated @SerializersFor but do not '
+        'have the required type Serializers, please fix the type or remove '
+        'the annotation: ${wrongSerializersDeclarations.join(', ')}',
+      );
+    }
+
+    return result;
+  }
+
+  /// Generates serializer source for this library.
+  String generateCode() {
+    var errors = [
+      ...computeErrors(),
+      for (var sourceClass in sourceClasses) ...sourceClass.computeErrors(),
+    ];
+
+    if (errors.isNotEmpty) throw _makeError(errors);
+
+    return _generateSerializersTopLevelFields() +
+        sourceClasses
+            .where((sourceClass) => sourceClass.needsGeneratedSerializer)
+            .map((sourceClass) => sourceClass.generateSerializerDeclaration())
+            .join('\n') +
+        sourceClasses
+            .where((sourceClass) => sourceClass.needsGeneratedSerializer)
+            .map((sourceClass) => sourceClass.generateSerializer())
+            .join('\n');
+  }
+
+  String _generateSerializersTopLevelFields() => serializersForAnnotations.keys
+      .map(
+        (field) =>
+            'Serializers _\$$field = (Serializers().toBuilder()' +
+            (serializeForTransitiveClasses[field]!
+                    .map(
+                      (sourceClass) =>
+                          sourceClass.generateTransitiveSerializerAdder(),
+                    )
+                    .toList()
+                  ..sort())
+                .join('\n') +
+            (serializeForTransitiveClasses[field]!
+                    .map(
+                      (sourceClass) => sourceClass.generateBuilderFactoryAdders(
+                        element.library.firstFragment,
+                      ),
+                    )
+                    .toList()
+                  ..sort())
+                .join('\n') +
+            ').build();',
+      )
+      .join('\n');
+}
+
+InvalidGenerationSourceError _makeError(Iterable<String> todos) {
+  var message = StringBuffer(
+    'Please make the following changes to use built_value serialization:\n',
+  );
+  for (var i = 0; i != todos.length; ++i) {
+    message.write('\n${i + 1}. ${todos.elementAt(i)}');
+  }
+
+  return InvalidGenerationSourceError(message.toString());
+}

--- a/built_types/built_value_generator/lib/src/serializer_source_library.g.dart
+++ b/built_types/built_value_generator/lib/src/serializer_source_library.g.dart
@@ -1,0 +1,148 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'serializer_source_library.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$SerializerSourceLibrary extends SerializerSourceLibrary {
+  @override
+  final ParsedLibraryResults parsedLibraryResults;
+  @override
+  final LibraryElement element;
+  ParsedLibraryResult? __parsedLibrary;
+  bool? __hasSerializers;
+  BuiltMap<String, ElementAnnotation>? __serializersForAnnotations;
+  BuiltList<String>? __wrongSerializersDeclarations;
+  BuiltSet<SerializerSourceClass>? __sourceClasses;
+  BuiltSetMultimap<String, SerializerSourceClass>? __serializeForClasses;
+  BuiltSetMultimap<String, SerializerSourceClass>?
+      __serializeForTransitiveClasses;
+
+  factory _$SerializerSourceLibrary(
+          [void Function(SerializerSourceLibraryBuilder)? updates]) =>
+      (SerializerSourceLibraryBuilder()..update(updates))._build();
+
+  _$SerializerSourceLibrary._(
+      {required this.parsedLibraryResults, required this.element})
+      : super._();
+  @override
+  ParsedLibraryResult get parsedLibrary =>
+      __parsedLibrary ??= super.parsedLibrary;
+
+  @override
+  bool get hasSerializers => __hasSerializers ??= super.hasSerializers;
+
+  @override
+  BuiltMap<String, ElementAnnotation> get serializersForAnnotations =>
+      __serializersForAnnotations ??= super.serializersForAnnotations;
+
+  @override
+  BuiltList<String> get wrongSerializersDeclarations =>
+      __wrongSerializersDeclarations ??= super.wrongSerializersDeclarations;
+
+  @override
+  BuiltSet<SerializerSourceClass> get sourceClasses =>
+      __sourceClasses ??= super.sourceClasses;
+
+  @override
+  BuiltSetMultimap<String, SerializerSourceClass> get serializeForClasses =>
+      __serializeForClasses ??= super.serializeForClasses;
+
+  @override
+  BuiltSetMultimap<String, SerializerSourceClass>
+      get serializeForTransitiveClasses => __serializeForTransitiveClasses ??=
+          super.serializeForTransitiveClasses;
+
+  @override
+  SerializerSourceLibrary rebuild(
+          void Function(SerializerSourceLibraryBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SerializerSourceLibraryBuilder toBuilder() =>
+      SerializerSourceLibraryBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SerializerSourceLibrary &&
+        parsedLibraryResults == other.parsedLibraryResults &&
+        element == other.element;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, parsedLibraryResults.hashCode);
+    _$hash = $jc(_$hash, element.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SerializerSourceLibrary')
+          ..add('parsedLibraryResults', parsedLibraryResults)
+          ..add('element', element))
+        .toString();
+  }
+}
+
+class SerializerSourceLibraryBuilder
+    implements
+        Builder<SerializerSourceLibrary, SerializerSourceLibraryBuilder> {
+  _$SerializerSourceLibrary? _$v;
+
+  ParsedLibraryResults? _parsedLibraryResults;
+  ParsedLibraryResults? get parsedLibraryResults =>
+      _$this._parsedLibraryResults;
+  set parsedLibraryResults(ParsedLibraryResults? parsedLibraryResults) =>
+      _$this._parsedLibraryResults = parsedLibraryResults;
+
+  LibraryElement? _element;
+  LibraryElement? get element => _$this._element;
+  set element(LibraryElement? element) => _$this._element = element;
+
+  SerializerSourceLibraryBuilder();
+
+  SerializerSourceLibraryBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _parsedLibraryResults = $v.parsedLibraryResults;
+      _element = $v.element;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SerializerSourceLibrary other) {
+    _$v = other as _$SerializerSourceLibrary;
+  }
+
+  @override
+  void update(void Function(SerializerSourceLibraryBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SerializerSourceLibrary build() => _build();
+
+  _$SerializerSourceLibrary _build() {
+    final _$result = _$v ??
+        _$SerializerSourceLibrary._(
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'SerializerSourceLibrary',
+              'parsedLibraryResults'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'SerializerSourceLibrary', 'element'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/built_value_generator/lib/src/strings.dart
+++ b/built_types/built_value_generator/lib/src/strings.dart
@@ -1,0 +1,6 @@
+/// Escapes dollar signs in a string with backslashes.
+String escapeString(String string) => string.replaceAll(r'$', r'\$');
+
+/// Strips off any trailing `?`.
+String stripNullabilitySuffix(String string) =>
+    string.endsWith('?') ? string.substring(0, string.length - 1) : string;

--- a/built_types/built_value_generator/lib/src/value_source_class.dart
+++ b/built_types/built_value_generator/lib/src/value_source_class.dart
@@ -1,0 +1,1522 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.source_class;
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/fixes.dart';
+import 'package:built_value_generator/src/memoized_getter.dart';
+import 'package:built_value_generator/src/metadata.dart';
+import 'package:built_value_generator/src/parsed_library_results.dart';
+import 'package:built_value_generator/src/strings.dart';
+import 'package:built_value_generator/src/value_source_field.dart';
+import 'package:collection/collection.dart';
+import 'package:source_gen/source_gen.dart';
+
+import 'dart_types.dart';
+import 'library_elements.dart';
+
+part 'value_source_class.g.dart';
+
+const String _importWithSingleQuotes =
+    "import 'package:built_value/built_value.dart'";
+const String _importWithDoubleQuotes =
+    'import "package:built_value/built_value.dart"';
+
+abstract class ValueSourceClass
+    implements Built<ValueSourceClass, ValueSourceClassBuilder> {
+  ParsedLibraryResults get parsedLibraryResults;
+  InterfaceElement get element;
+
+  factory ValueSourceClass(
+    ParsedLibraryResults parsedLibraryResults,
+    InterfaceElement element,
+  ) =>
+      _$ValueSourceClass._(
+        parsedLibraryResults: parsedLibraryResults,
+        element: element,
+      );
+  ValueSourceClass._();
+
+  @memoized
+  ParsedLibraryResult get parsedLibrary =>
+      parsedLibraryResults.parsedLibraryResultOrThrowingMock(element.library);
+
+  @memoized
+  String get name => element.displayName;
+
+  /// Returns `mixin class` if class modifiers are available, `class` otherwise.
+  ///
+  /// The two are equivalent as class modifiers change the meaning of `class`.
+  String get _class => LibraryElements.areClassMixinsEnabled(element.library)
+      ? 'mixin class'
+      : 'class';
+
+  /// Returns the class name for the generated implementation. If the manually
+  /// maintained class is private then we ignore the underscore here, to avoid
+  /// returning a class name starting `_$_`.
+  @memoized
+  String get implName =>
+      name.startsWith('_') ? '_\$${name.substring(1)}' : '_\$$name';
+
+  @memoized
+  ClassElement? get builderElement {
+    var result = element.library.getClass(name + 'Builder');
+    if (result == null) return null;
+    // If the builder is in a generated file, then we're analyzing _after_ code
+    // generation. Ignore it. This happens when running as an analyzer plugin.
+    if (result.library.firstFragment.source.fullName.endsWith('.g.dart')) {
+      return null;
+    }
+    return result;
+  }
+
+  @memoized
+  bool get implementsBuilt => element.allSupertypes.any(
+        (interfaceType) => interfaceType.element.name == 'Built',
+      );
+
+  @memoized
+  bool get extendsIsAllowed {
+    // Usually `extends` is not allowed. But, allow one special case:
+    //
+    // A `built_value` class may share code with a `const` class by extending
+    // a `const` base class. There's no other way to do this sharing because
+    // a `const` class is not allowed to use a mixin.
+    //
+    // To avoid causing problems for `built_value` the base class must be
+    // abstract, must have no fields, must have no abstract getters, and
+    // must not implement `operator==`, `hashCode` or `toString`.
+    // This means it _is_ allowed to have concrete getters as well as
+    // concrete and abstract methods.
+
+    for (var supertype in [
+      element.supertype,
+      ...element.supertype!.element.allSupertypes,
+    ]) {
+      if (DartTypes.tryGetName(supertype) == 'Object') continue;
+
+      // Base class must be abstract.
+      final superElement = supertype!.element;
+      if (superElement is! ClassElement || !superElement.isAbstract) {
+        return false;
+      }
+
+      // Base class must have no fields.
+      if (supertype.element.fields.any(
+        (field) => !field.isStatic && field.isOriginDeclaration,
+      )) {
+        return false;
+      }
+
+      // Base class must have no abstract getters.
+      if (supertype.getters.any(
+        (accessor) => !accessor.isStatic && accessor.isAbstract,
+      )) {
+        return false;
+      }
+
+      // Base class must not implement operator==, hashCode or toString.
+      if (supertype.element.getMethod('hashCode') != null) return false;
+      if (supertype.element.getMethod('==') != null) return false;
+      if (supertype.element.getMethod('toString') != null) return false;
+    }
+
+    return true;
+  }
+
+  @memoized
+  BuiltValue get settings {
+    var annotations = element.metadata.annotations
+        .map((annotation) => annotation.computeConstantValue())
+        .where((value) => DartTypes.tryGetName(value?.type) == 'BuiltValue');
+    if (annotations.isEmpty) return const BuiltValue();
+    var annotation = annotations.single!;
+    // If a field does not exist, that means an old `built_value` version; use
+    // the default.
+    return BuiltValue(
+      comparableBuilders:
+          annotation.getField('comparableBuilders')?.toBoolValue() ?? false,
+      instantiable: annotation.getField('instantiable')?.toBoolValue() ?? true,
+      nestedBuilders:
+          annotation.getField('nestedBuilders')?.toBoolValue() ?? true,
+      autoCreateNestedBuilders:
+          annotation.getField('autoCreateNestedBuilders')?.toBoolValue() ??
+              true,
+      generateBuilderOnSetField:
+          annotation.getField('generateBuilderOnSetField')?.toBoolValue() ??
+              false,
+      defaultCompare:
+          annotation.getField('defaultCompare')?.toBoolValue() ?? true,
+      defaultSerialize:
+          annotation.getField('defaultSerialize')?.toBoolValue() ?? true,
+      wireName: annotation.getField('wireName')?.toStringValue(),
+    );
+  }
+
+  @memoized
+  BuiltList<String> get genericParameters =>
+      BuiltList<String>(element.typeParameters.map((e) => e.name));
+
+  @memoized
+  BuiltList<String> get genericBounds => BuiltList<String>(
+        element.typeParameters.map((element) {
+          var bound = element.bound;
+          if (bound == null) return '';
+          return DartTypes.getName(bound) +
+              (element.bound!.nullabilitySuffix == NullabilitySuffix.question
+                  ? '?'
+                  : '');
+        }),
+      );
+
+  @memoized
+  ClassDeclaration get classDeclaration {
+    return parsedLibrary.getFragmentDeclaration(element.firstFragment)!.node
+        as ClassDeclaration;
+  }
+
+  @memoized
+  bool get hasBuilder => builderElement != null;
+
+  // The `initializer` methods are no longer recommended, see hooks below.
+
+  @memoized
+  bool get hasBuilderInitializer => builderInitializer != null;
+
+  @memoized
+  MethodElement? get builderInitializer =>
+      element.getMethod('_initializeBuilder');
+
+  @memoized
+  bool get hasBuilderFinalizer => builderFinalizer != null;
+
+  @memoized
+  MethodElement? get builderFinalizer => element.getMethod('_finalizeBuilder');
+
+  @memoized
+  BuiltMap<String, BuiltValueHook> get hooks {
+    var result = MapBuilder<String, BuiltValueHook>();
+    for (var method in element.methods) {
+      var annotations = method.metadata.annotations
+          .map((annotation) => annotation.computeConstantValue())
+          .where(
+            (value) => DartTypes.tryGetName(value?.type) == 'BuiltValueHook',
+          );
+      if (annotations.isEmpty) continue;
+      var annotation = annotations.single!;
+      // If a field does not exist, that means an old `built_value` version; use
+      // the default.
+      result[method.name!] = BuiltValueHook(
+        initializeBuilder:
+            annotation.getField('initializeBuilder')?.toBoolValue() ?? false,
+        finalizeBuilder:
+            annotation.getField('finalizeBuilder')?.toBoolValue() ?? true,
+      );
+    }
+    return result.build();
+  }
+
+  @memoized
+  String get builderParameters {
+    return builderElement!.allSupertypes
+        .where((interfaceType) => interfaceType.element.name == 'Builder')
+        .single
+        .typeArguments
+        .map((type) => DartTypes.getName(type))
+        .join(', ');
+  }
+
+  @memoized
+  BuiltList<ValueSourceField> get fields => ValueSourceField.fromClassElements(
+        parsedLibraryResults,
+        settings,
+        parsedLibrary,
+        element,
+        builderElement,
+      );
+
+  @memoized
+  String get source => element.library.firstFragment.source.contents.data;
+
+  @memoized
+  String get partStatement {
+    var fileName = element.library.firstFragment.source.shortName.replaceAll(
+      '.dart',
+      '',
+    );
+    return "part '$fileName.g.dart';";
+  }
+
+  @memoized
+  bool get hasPartStatement {
+    var expectedCode = partStatement;
+    return source.contains(expectedCode);
+  }
+
+  @memoized
+  bool get hasBuiltValueImportWithShow {
+    // It would be more accurate to check using the AST, but this is
+    // potentially expensive. We already have the source for the "part of"
+    // check, use that.
+    return source.contains('$_importWithSingleQuotes show') ||
+        source.contains('$_importWithDoubleQuotes show');
+  }
+
+  @memoized
+  bool get hasBuiltValueImportWithAs {
+    // It would be more accurate to check using the AST, but this is
+    // potentially expensive. We already have the source for the "part of"
+    // check, use that.
+    return source.contains('$_importWithSingleQuotes as') ||
+        source.contains('$_importWithDoubleQuotes as');
+  }
+
+  @memoized
+  bool get valueClassIsAbstract {
+    final element = this.element;
+    return element is ClassElement && element.isAbstract;
+  }
+
+  @memoized
+  BuiltList<AstNode> get valueClassConstructors => BuiltList<AstNode>(
+        element.constructors
+            .where(
+              (constructor) =>
+                  !constructor.isFactory && constructor.isOriginDeclaration,
+            )
+            .map(
+              (constructor) => parsedLibrary
+                  .getFragmentDeclaration(constructor.firstFragment)!
+                  .node,
+            ),
+      );
+
+  @memoized
+  BuiltList<AstNode> get valueClassFactories => BuiltList<AstNode>(
+        element.constructors.where((constructor) => constructor.isFactory).map(
+              (factory) => parsedLibrary
+                  .getFragmentDeclaration(factory.firstFragment)!
+                  .node,
+            ),
+      );
+
+  @memoized
+  bool get builderClassIsAbstract => builderElement!.isAbstract;
+
+  @memoized
+  BuiltList<AstNode> get builderClassConstructors => BuiltList<AstNode>(
+        builderElement!.constructors
+            .where(
+              (constructor) =>
+                  !constructor.isFactory && constructor.isOriginDeclaration,
+            )
+            .map(
+              (constructor) => parsedLibrary
+                  .getFragmentDeclaration(constructor.firstFragment)!
+                  .node,
+            ),
+      );
+
+  @memoized
+  BuiltList<String> get builderClassFactories => BuiltList<String>(
+        builderElement!.constructors
+            .where((constructor) => constructor.isFactory)
+            .map(
+              (factory) => parsedLibrary
+                  .getFragmentDeclaration(factory.firstFragment)!
+                  .node
+                  .toSource(),
+            ),
+      );
+
+  @memoized
+  BuiltList<MemoizedGetter> get memoizedGetters =>
+      BuiltList<MemoizedGetter>(MemoizedGetter.fromClassElement(element));
+
+  /// Returns the `implements` clause for the builder.
+  ///
+  /// All builders implement `Builder`.
+  ///
+  /// Additionally, if the value class implements other value classes, the
+  /// builder implements the corresponding builders.
+  @memoized
+  BuiltList<String> get builderImplements => BuiltList<String>.build(
+        (b) => b
+          ..add('Builder<$name$_generics, ${name}Builder$_generics>')
+          ..addAll(
+            element.interfaces
+                .where((interface) => needsBuiltValue(interface.element))
+                .map(_parentBuilderInterfaceName),
+          ),
+      );
+
+  /// Returns the `with` clause for the builder.
+  ///
+  /// If the value class mixes in other value classes, the builder mixes in
+  /// the corresponding builders.
+  @memoized
+  BuiltList<String> get builderMixins => element.mixins
+      .where((interface) => needsBuiltValue(interface.element))
+      .map(_parentBuilderInterfaceName)
+      .toBuiltList();
+
+  String _parentBuilderInterfaceName(InterfaceType interface) {
+    final displayName = DartTypes.getName(interface);
+    if (!displayName.contains('<')) return displayName + 'Builder';
+    final index = displayName.indexOf('<');
+    return displayName.substring(0, index) +
+        'Builder' +
+        displayName.substring(index);
+  }
+
+  bool get _implementsParentBuilder =>
+      builderImplements.length + builderMixins.length > 1;
+
+  @memoized
+  bool get implementsHashCode {
+    var getter = element.getGetter('hashCode');
+    return getter != null && !getter.isAbstract;
+  }
+
+  @memoized
+  bool get declaresMemoizedHashCode {
+    var getter = element.getGetter('hashCode');
+    return getter != null &&
+        getter.isAbstract &&
+        getter.metadata.annotations.any(
+          (metadata) => metadataToStringValue(metadata) == 'memoized',
+        );
+  }
+
+  @memoized
+  bool get implementsOperatorEquals => element.getMethod('==') != null;
+
+  @memoized
+  bool get implementsToString {
+    // Check for any `toString` implementation apart from the one defined on
+    // `Object`.
+    var method = element.lookUpConcreteMethod('toString', element.library)!;
+    var clazz = method.enclosingElement;
+    return clazz is! ClassElement || clazz.name != 'Object';
+  }
+
+  @memoized
+  LibraryFragment get libraryFragment => element.library.firstFragment;
+
+  static bool needsBuiltValue(InterfaceElement classElement) {
+    // TODO(davidmorgan): more exact type check.
+    return !classElement.displayName.startsWith('_\$') &&
+        (classElement.allSupertypes.any(
+              (interfaceType) => interfaceType.element.name == 'Built',
+            ) ||
+            classElement.metadata.annotations
+                .map((annotation) => annotation.computeConstantValue())
+                .any(
+                  (value) => DartTypes.tryGetName(value?.type) == 'BuiltValue',
+                ));
+  }
+
+  Iterable<GeneratorError> computeErrors() {
+    return [
+      ..._checkPart(),
+      ..._checkSettings(),
+      ..._checkValueClass(),
+      ..._checkBuilderClass(),
+      ..._checkFieldList(),
+      for (var field in fields) ...field.computeErrors(),
+    ];
+  }
+
+  Iterable<GeneratorError> _checkPart() {
+    if (hasPartStatement) return [];
+
+    var directives = (classDeclaration.parent as CompilationUnit).directives;
+    if (directives.isEmpty) {
+      return [
+        GeneratorError(
+          (b) => b
+            ..message = 'Import generated part: $partStatement'
+            ..offset = 0
+            ..length = 0
+            ..fix = '$partStatement\n\n',
+        ),
+      ];
+    } else {
+      return [
+        GeneratorError(
+          (b) => b
+            ..message = 'Import generated part: $partStatement'
+            ..offset = directives.last.offset + directives.last.length
+            ..length = 0
+            ..fix = '\n\n$partStatement\n\n',
+        ),
+      ];
+    }
+  }
+
+  Iterable<GeneratorError> _checkSettings() {
+    // Not allowed to have comparable builders with nested builders; this
+    // would break comparing because the nested builders may not be comparable.
+    // (Collection builders, in particularly, are definitely not comparable).
+    if (settings.comparableBuilders && settings.nestedBuilders) {
+      return [
+        GeneratorError(
+          (b) => b
+            ..message = 'Set `nestedBuilders: false`'
+                ' in order to use `comparableBuilders: true`.',
+        ),
+      ];
+    } else {
+      return [];
+    }
+  }
+
+  Iterable<GeneratorError> _checkValueClass() {
+    var result = <GeneratorError>[];
+
+    if (!valueClassIsAbstract) {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message = 'Make class abstract.'
+            ..offset = classDeclaration.offset
+            ..length = 0
+            ..fix = 'abstract ',
+        ),
+      );
+    }
+
+    if (hasBuiltValueImportWithShow) {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message = 'Stop using "show" when importing '
+                '"package:built_value/built_value.dart". It prevents the '
+                'generated code from finding helper methods.',
+        ),
+      );
+    }
+
+    if (hasBuiltValueImportWithAs) {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message = 'Stop using "as" when importing '
+                '"package:built_value/built_value.dart". It prevents the generated '
+                'code from finding helper methods.',
+        ),
+      );
+    }
+
+    var implementsClause = classDeclaration.implementsClause;
+    var expectedInterface = 'Built<$name$_generics, ${name}Builder$_generics>';
+
+    var implementsClauseIsCorrect = implementsClause != null &&
+        implementsClause.interfaces.any(
+          (type) => type.toSource() == expectedInterface,
+        );
+
+    // Built parameters need fixing if they are not as expected, unless 1) the
+    // class is marked `@BuiltValue(instantiable: false)` and 2) there is no
+    // case of the `Built` interface being implemented. This is to allow
+    // omitting the `Built` interface to work around having to implement the
+    // same interface twice with different type parameters.
+    var implementsClauseIsAllowedToBeIncorrect = !settings.instantiable &&
+        (implementsClause == null ||
+            !implementsClause.interfaces.any(
+              (type) =>
+                  type.toSource() == 'Built' ||
+                  type.toSource().startsWith('Built<'),
+            ));
+
+    if (!implementsClauseIsCorrect && !implementsClauseIsAllowedToBeIncorrect) {
+      if (implementsClause == null) {
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message = 'Make class implement $expectedInterface.'
+              ..offset = classDeclaration.body.offset - 1
+              ..length = 0
+              ..fix = 'implements $expectedInterface',
+          ),
+        );
+      } else {
+        var found = false;
+        final interfaces = implementsClause.interfaces.map((type) {
+          if (type.name.lexeme == 'Built') {
+            found = true;
+            return expectedInterface;
+          } else {
+            return type.toSource();
+          }
+        }).toList();
+        if (!found) interfaces.add(expectedInterface);
+
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message = 'Make class implement $expectedInterface.'
+              ..offset = implementsClause.offset
+              ..length = implementsClause.length
+              ..fix = 'implements ${interfaces.join(", ")}',
+          ),
+        );
+      }
+    }
+
+    if (!extendsIsAllowed) {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message = 'Stop class extending other classes. '
+                'Only "implements" and "extends Object with" are allowed.',
+        ),
+      );
+    }
+
+    bool isStaticBuilderHook(MethodElement method) {
+      return method.isStatic &&
+          method.returnType is VoidType &&
+          method.formalParameters.length == 1 &&
+          parsedLibrary
+              .getFragmentDeclaration(
+                method.formalParameters[0].firstFragment,
+              )!
+              .node is RegularFormalParameter &&
+          DartTypes.stripGenerics(
+                (parsedLibrary
+                        .getFragmentDeclaration(
+                          method.formalParameters[0].firstFragment,
+                        )!
+                        .node as RegularFormalParameter)
+                    .type!
+                    .toSource(),
+              ) ==
+              '${name}Builder';
+    }
+
+    if (settings.instantiable) {
+      if (hasBuilderInitializer) {
+        if (!isStaticBuilderHook(builderInitializer!)) {
+          result.add(
+            GeneratorError(
+              (b) => b
+                ..message = 'Fix _initializeBuilder signature: '
+                    'static void _initializeBuilder(${name}Builder b)',
+            ),
+          );
+        }
+        if (hooks.containsKey('_initializeBuilder')) {
+          result.add(
+            GeneratorError(
+              (b) => b
+                ..message = 'Remove @BuiltValueHook from _initializeBuilder. '
+                    'It is a magic method name that is always a hook. '
+                    'Or, to use the annotation, please rename the method.',
+            ),
+          );
+        }
+      }
+      if (hasBuilderFinalizer) {
+        if (!isStaticBuilderHook(builderFinalizer!)) {
+          result.add(
+            GeneratorError(
+              (b) => b
+                ..message = 'Fix _finalizeBuilder signature: '
+                    'static void _finalizeBuilder(${name}Builder b)',
+            ),
+          );
+        }
+        if (hooks.containsKey('_finalizeBuilder')) {
+          result.add(
+            GeneratorError(
+              (b) => b
+                ..message = 'Remove @BuiltValueHook from _finalizeBuilder. '
+                    'It is a magic method name that is always a hook. '
+                    'Or, to use the annotation, please rename the method.',
+            ),
+          );
+        }
+      }
+      for (var hook in hooks.entries.where(
+        (hook) => hook.value.initializeBuilder || hook.value.finalizeBuilder,
+      )) {
+        if (hook.key == '_initializeBuilder') continue;
+        if (hook.key == '_finalizeBuilder') continue;
+        var method =
+            element.methods.where((method) => method.name == hook.key).single;
+        if (!isStaticBuilderHook(method)) {
+          result.add(
+            GeneratorError(
+              (b) => b
+                ..message =
+                    'Fix ${hook.key} signature to use it with @BuiltValueHook: '
+                        'static void ${hook.key}(${name}Builder b)',
+            ),
+          );
+        }
+      }
+
+      final expectedConstructor = '$name._()';
+      bool constructorCheck(AstNode c) {
+        if (c is! ConstructorDeclaration) return false;
+        if (c.name?.lexeme != '_') return false;
+        if (c.parameters.parameters.isNotEmpty) return false;
+        if (c.typeName != null && c.typeName!.toSource() != name) return false;
+        return true;
+      }
+
+      if (valueClassConstructors.isEmpty) {
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message =
+                  'Make class have exactly one constructor: $expectedConstructor;'
+              ..offset = classDeclaration.body.endToken.offset
+              ..length = 0
+              ..fix = '  $expectedConstructor;\n',
+          ),
+        );
+      } else if (valueClassConstructors.length > 1) {
+        var found = false;
+        for (var constructor in valueClassConstructors) {
+          if (constructorCheck(constructor)) {
+            found = true;
+          } else {
+            result.add(
+              GeneratorError(
+                (b) => b
+                  ..message = 'Remove invalid constructor.'
+                  ..offset = constructor.offset
+                  ..length = constructor.length
+                  ..fix = '',
+              ),
+            );
+          }
+        }
+        if (!found) {
+          result.add(
+            GeneratorError(
+              (b) => b
+                ..message =
+                    'Make class have exactly one constructor: $expectedConstructor;'
+                ..offset = classDeclaration.body.endToken.offset
+                ..length = 0
+                ..fix = '  $expectedConstructor;\n',
+            ),
+          );
+        }
+      } else if (!constructorCheck(valueClassConstructors.single)) {
+        final isExactPrimary = valueClassConstructors.single
+                is! ConstructorDeclaration &&
+            (valueClassConstructors.single.toSource() == expectedConstructor ||
+                valueClassConstructors.single.toSource() == '._()' ||
+                valueClassConstructors.single.toSource() == '_()');
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message = isExactPrimary
+                  ? '$expectedConstructor must go in the body.'
+                  : 'Make class have exactly one constructor: $expectedConstructor'
+              ..offset = valueClassConstructors.single.offset
+              ..length = valueClassConstructors.single.length
+              ..fix = expectedConstructor + ';',
+          ),
+        );
+      }
+    } else {
+      if (valueClassConstructors.isNotEmpty) {
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message =
+                  'Remove all constructors or remove "instantiable: false".',
+          ),
+        );
+      }
+    }
+
+    if (settings.instantiable) {
+      if (!valueClassFactories.any(
+        (factory) => factory.toSource().contains('$implName$_generics'),
+      )) {
+        final exampleFactory = 'factory $name('
+            '[void Function(${name}Builder$_generics)? updates]) = '
+            '$implName$_generics;';
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message =
+                  'Add a factory so your class can be instantiated. Example:\n\n'
+                      '$exampleFactory'
+              ..offset = classDeclaration.body.endToken.offset
+              ..length = 0
+              ..fix = '  $exampleFactory\n',
+          ),
+        );
+      }
+    } else {
+      if (valueClassFactories.isNotEmpty) {
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message =
+                  'Remove all factories or remove "instantiable: false".',
+          ),
+        );
+      }
+    }
+
+    if (implementsHashCode) {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message =
+                'Stop implementing hashCode; it will be generated for you.',
+        ),
+      );
+    }
+
+    if (implementsOperatorEquals) {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message =
+                'Stop implementing operator==; it will be generated for you.',
+        ),
+      );
+    }
+
+    return result;
+  }
+
+  Iterable<GeneratorError> _checkBuilderClass() {
+    var result = <GeneratorError>[];
+    if (!hasBuilder) return result;
+
+    if (!builderClassIsAbstract) {
+      result.add(
+        GeneratorError((b) => b..message = 'Make builder class abstract.'),
+      );
+    }
+
+    if (settings.instantiable) {
+      final expectedBuilderParameters =
+          '$name$_generics, ${name}Builder$_generics';
+      if (builderParameters != expectedBuilderParameters) {
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message =
+                  'Make builder class implement Builder<$expectedBuilderParameters>. '
+                      'Currently: Builder<$builderParameters>',
+          ),
+        );
+      }
+    }
+
+    if (settings.instantiable) {
+      final expectedConstructor = '${name}Builder._()';
+      bool builderConstructorCheck(AstNode c) {
+        if (c is! ConstructorDeclaration) return false;
+        if (c.name?.lexeme != '_') return false;
+        if (c.parameters.parameters.isNotEmpty) return false;
+        if (c.typeName != null && c.typeName!.toSource() != '${name}Builder') {
+          return false;
+        }
+        return true;
+      }
+
+      if (builderClassConstructors.length == 1 &&
+          !builderConstructorCheck(builderClassConstructors.single)) {
+        final isExactPrimary =
+            builderClassConstructors.single is! ConstructorDeclaration &&
+                (builderClassConstructors.single.toSource() ==
+                        expectedConstructor ||
+                    builderClassConstructors.single.toSource() == '._()' ||
+                    builderClassConstructors.single.toSource() == '_()');
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message = isExactPrimary
+                  ? '$expectedConstructor must go in the body.'
+                  : 'Make builder class have exactly one constructor: $expectedConstructor;',
+          ),
+        );
+      } else if (builderClassConstructors.length != 1) {
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message =
+                  'Make builder class have exactly one constructor: $expectedConstructor;',
+          ),
+        );
+      }
+    } else {
+      if (builderClassConstructors.isNotEmpty) {
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message = 'Remove all builder constructors '
+                  'or remove "instantiable: false".',
+          ),
+        );
+      }
+    }
+
+    if (settings.instantiable) {
+      final expectedFactory =
+          'factory ${name}Builder() = ${implName}Builder$_generics;';
+      final expectedFactoryNew =
+          'factory ${name}Builder.new() = ${implName}Builder$_generics;';
+      if (builderClassFactories.length != 1 ||
+          (!builderClassFactories.single.contains(expectedFactory) &&
+              !builderClassFactories.single.contains(expectedFactoryNew))) {
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message =
+                  'Make builder class have exactly one factory: $expectedFactory',
+          ),
+        );
+      }
+    } else {
+      if (builderClassFactories.isNotEmpty) {
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message =
+                  'Remove all builder factories or remove "instantiable: false".',
+          ),
+        );
+      }
+    }
+
+    return result;
+  }
+
+  Iterable<GeneratorError> _checkFieldList() {
+    if (!hasBuilder || !settings.instantiable) return <GeneratorError>[];
+    return fields.any((field) => !field.builderFieldExists)
+        ? [
+            GeneratorError(
+              (b) => b
+                ..message = 'Make builder have exactly these fields: ' +
+                    fields.map((field) => field.name).join(', '),
+            ),
+          ]
+        : [];
+  }
+
+  String get _generics =>
+      genericParameters.isEmpty ? '' : '<' + genericParameters.join(', ') + '>';
+
+  String get _boundedGenerics => genericParameters.isEmpty
+      ? ''
+      : '<' +
+          IterableZip([genericParameters, genericBounds]).map((zipped) {
+            final parameter = zipped[0];
+            final bound = zipped[1];
+            return bound.isEmpty ? parameter : '$parameter extends $bound';
+          }).join(', ') +
+          '>';
+
+  String generateCode() {
+    var errors = computeErrors();
+    if (errors.isNotEmpty) throw _makeError(errors);
+
+    var result = StringBuffer();
+    if (settings.instantiable) result.write(_generateImpl());
+    if (settings.instantiable) {
+      result.write(_generateBuilder());
+    } else if (!hasBuilder) {
+      result.write(_generateAbstractBuilder());
+    }
+    return result.toString();
+  }
+
+  /// Generates the value class implementation.
+  String _generateImpl() {
+    var result = StringBuffer();
+    result.writeln(
+      'class $implName$_boundedGenerics '
+      'extends $name$_generics {',
+    );
+    for (var field in fields) {
+      final type = field.typeInLibraryFragment(libraryFragment);
+      result.writeln('@override');
+      result.writeln(
+        'final $type${field.isNullable ? '?' : ''} ${field.name};',
+      );
+    }
+    for (var memoizedGetter in memoizedGetters) {
+      result.writeln('${memoizedGetter.returnType}? __${memoizedGetter.name};');
+      if (memoizedGetter.isNullable) {
+        // Nullable memoiozed getters needs a field to store whether they are
+        // initialized.
+        result.writeln('bool ___${memoizedGetter.name} = false;');
+      }
+    }
+    result.writeln();
+
+    // If there is a manually maintained builder we have to cast the "build()"
+    // result to the generated value class. If the builder is generated, that
+    // returns the right type directly in private `_build` so there is no need
+    // to cast.
+    if (hasBuilder) {
+      result.writeln(
+        'factory $implName(['
+        'void Function(${name}Builder$_generics)? updates]) '
+        '=> (${name}Builder$_generics()..update(updates)).build()'
+        ' as $implName$_generics;',
+      );
+    } else {
+      result.writeln(
+        'factory $implName(['
+        'void Function(${name}Builder$_generics)? updates]) '
+        '=> (${name}Builder$_generics()..update(updates))._build();',
+      );
+    }
+
+    result.writeln();
+
+    if (fields.isEmpty) {
+      result.write('$implName._() : super._();');
+    } else {
+      result.write('$implName._({');
+      result.write(
+        fields.map((field) {
+          var maybeRequired = field.isNullable ? '' : 'required ';
+          return '${maybeRequired}this.${field.name}';
+        }).join(', '),
+      );
+      result.write('}) : super._();');
+    }
+    result.writeln();
+
+    for (var memoizedGetter in memoizedGetters) {
+      result.writeln('@override');
+      if (memoizedGetter.isNullable) {
+        result.writeln(
+          '${memoizedGetter.returnType}? get ${memoizedGetter.name} {',
+        );
+        result.writeln('if (!___${memoizedGetter.name}) {');
+        result.writeln(
+          '__${memoizedGetter.name} = super.${memoizedGetter.name};',
+        );
+        result.writeln('___${memoizedGetter.name} = true;');
+        result.writeln('}');
+        result.writeln('return __${memoizedGetter.name};');
+        result.writeln('}');
+      } else {
+        result.writeln(
+          '${memoizedGetter.returnType} get ${memoizedGetter.name} =>',
+        );
+        result.writeln(
+          '__${memoizedGetter.name} ??= super.${memoizedGetter.name};',
+        );
+      }
+      result.writeln();
+    }
+
+    result.writeln('@override');
+    result.writeln(
+      '$name$_generics rebuild(void Function(${name}Builder$_generics) updates) '
+      '=> (toBuilder()..update(updates)).build();',
+    );
+    result.writeln();
+
+    result.writeln('@override');
+    if (hasBuilder) {
+      result.writeln(
+        '${implName}Builder$_generics toBuilder() '
+        '=> ${implName}Builder$_generics()..replace(this);',
+      );
+    } else {
+      result.writeln(
+        '${name}Builder$_generics toBuilder() '
+        '=> ${name}Builder$_generics()..replace(this);',
+      );
+    }
+    result.writeln();
+
+    result.write(_generateEqualsAndHashcode());
+
+    // Only generate toString() if there wasn't one already.
+    if (!implementsToString) {
+      result.writeln('@override');
+      result.writeln('String toString() {');
+      if (fields.isEmpty) {
+        result.writeln(
+          "return newBuiltValueToStringHelper(r'$name').toString();",
+        );
+      } else {
+        result.writeln("return (newBuiltValueToStringHelper(r'$name')");
+        result.writeln(
+          fields
+              .map(
+                (field) =>
+                    "..add('${escapeString(field.name)}',  ${field.name})",
+              )
+              .join(''),
+        );
+        result.writeln(').toString();');
+      }
+      result.writeln('}');
+      result.writeln();
+    }
+
+    result.writeln('}');
+    return result.toString();
+  }
+
+  /// Generates the builder implementation.
+  String _generateBuilder() {
+    var result = StringBuffer();
+    if (hasBuilder) {
+      result.writeln(
+        'class ${implName}Builder$_boundedGenerics '
+        'extends ${name}Builder$_generics {',
+      );
+    } else if (builderMixins.isNotEmpty) {
+      result.writeln(
+        'class ${name}Builder$_boundedGenerics '
+        'with ${builderMixins.join(", ")} '
+        'implements ${builderImplements.join(", ")} {',
+      );
+    } else {
+      result.writeln(
+        'class ${name}Builder$_boundedGenerics '
+        'implements ${builderImplements.join(", ")} {',
+      );
+    }
+
+    // Builder holds a reference to a value, copies from it lazily.
+    result.writeln('$implName$_generics? _\$v;');
+    result.writeln('');
+
+    for (var field in fields) {
+      late final String type;
+
+      if (field.isNestedBuilder) {
+        type = hasBuilder
+            ? field.builderElementTypeWithPrefix
+            : field.typeInBuilder(libraryFragment)!;
+      } else {
+        type = field.typeInLibraryFragment(libraryFragment);
+      }
+
+      final name = field.name;
+
+      final isNullableNestedBuilder = field.isAutoCreateNestedBuilder &&
+          field.isNestedBuilder &&
+          (!hasBuilder || field.builderElementSetterIsNullable);
+      final hasNullableSetter = !hasBuilder ||
+          isNullableNestedBuilder ||
+          field.builderElementSetterIsNullable;
+      final getterMaybeOrNull = hasNullableSetter &&
+              (!field.isNestedBuilder || !field.isAutoCreateNestedBuilder)
+          ? '?'
+          : '';
+      final setterMaybeOrNull = hasNullableSetter ? '?' : '';
+      final maybeLate = !hasNullableSetter ? 'late ' : '';
+
+      late String trackedVariable;
+
+      if (field.builderFieldExists && !field.builderFieldIsAbstract) {
+        trackedVariable = 'super.$name';
+      } else {
+        result.writeln('$maybeLate$type$setterMaybeOrNull _$name;');
+        trackedVariable = hasBuilder ? '_$name' : '_\$this._$name';
+      }
+
+      if (hasBuilder) result.writeln('@override');
+      result.write('$type$getterMaybeOrNull get $name ');
+      if (hasBuilder) {
+        result.writeln('{');
+        result.writeln('_\$this;');
+        result.write('return');
+      } else {
+        result.writeln('=>');
+      }
+      result.write(' $trackedVariable');
+      if (isNullableNestedBuilder) {
+        result.write('??= $type()');
+      }
+      result.writeln(';');
+      if (hasBuilder) result.writeln('}');
+
+      final shouldGenerateOnSet =
+          !hasBuilder && settings.generateBuilderOnSetField;
+      // Add `covariant` if we're implementing one or more parent builders.
+      final maybeCovariant =
+          !hasBuilder && _implementsParentBuilder ? 'covariant ' : '';
+
+      if (shouldGenerateOnSet) {
+        result.writeln('void Function() onSet = () {};');
+        result.writeln();
+      }
+
+      final isMultilineSetter = hasBuilder || shouldGenerateOnSet;
+      if (hasBuilder) result.writeln('@override');
+      result.write('set $name($maybeCovariant$type$setterMaybeOrNull $name) ');
+      result.writeln(isMultilineSetter ? '{' : '=>');
+      if (hasBuilder) result.writeln('_\$this;');
+      result.writeln('$trackedVariable = $name;');
+      if (shouldGenerateOnSet) {
+        result.writeln('onSet();');
+      }
+      if (isMultilineSetter) result.writeln('}');
+
+      result.writeln();
+    }
+
+    result.writeln();
+
+    if (hasBuilder) {
+      result.writeln('${implName}Builder() : super._()');
+    } else {
+      result.writeln('${name}Builder()');
+    }
+    if (hasBuilderInitializer ||
+        hooks.values.any((hook) => hook.initializeBuilder)) {
+      result.writeln('{');
+      if (hasBuilderInitializer) {
+        result.writeln('$name._initializeBuilder(this);');
+      }
+      for (var hook in hooks.entries) {
+        if (hook.value.initializeBuilder) {
+          result.writeln('$name.${hook.key}(this);');
+        }
+      }
+      result.writeln('}');
+    } else {
+      result.writeln(';');
+    }
+    result.writeln('');
+
+    // Getter for "this" that does lazy copying if needed.
+    if (fields.isNotEmpty) {
+      result.writeln('${name}Builder$_generics get _\$this {');
+      result.writeln('final \$v = _\$v;');
+      result.writeln('if (\$v != null) {');
+      for (var field in fields) {
+        final name = field.name;
+        final nameInBuilder =
+            field.builderFieldExists && !field.builderFieldIsAbstract
+                ? 'super.$name'
+                : '_$name';
+        if (field.isNestedBuilder) {
+          var maybeOrNull = field.isNullable ? '?' : '';
+          result.writeln(
+            '$nameInBuilder = '
+            '\$v.$name$maybeOrNull.toBuilder();',
+          );
+        } else {
+          result.writeln('$nameInBuilder = \$v.$name;');
+        }
+      }
+      result.writeln('_\$v = null;');
+      result.writeln('}');
+      result.writeln('return this;');
+      result.writeln('}');
+    }
+
+    result.writeln('@override');
+    if (_implementsParentBuilder) {
+      // If we're overriding `replace` from other builders, tell the analyzer
+      // that this builder only accepts values of exactly the right type, by
+      // marking the value `covariant`.
+
+      if (builderImplements.length + builderMixins.length > 2) {
+        // Add this `ignore` as a workaround for analyzer issue:
+        // https://github.com/dart-lang/sdk/issues/32025
+        result.writeln('// ignore: override_on_non_overriding_method');
+      }
+      result.writeln('void replace(covariant $name$_generics other) {');
+    } else {
+      result.writeln('void replace($name$_generics other) {');
+    }
+
+    result.writeln('_\$v = other as $implName$_generics;');
+    result.writeln('}');
+
+    result.writeln('@override');
+    result.writeln(
+      'void update(void Function(${name}Builder$_generics)? updates) {'
+      ' if (updates != null) updates(this); }',
+    );
+    result.writeln();
+
+    result.writeln('@override');
+    result.writeln('$name$_generics build() => _build();');
+    result.writeln();
+    result.writeln('$implName$_generics _build() {');
+
+    if (hasBuilderFinalizer) {
+      result.writeln('$name._finalizeBuilder(this);');
+    }
+    for (var hook in hooks.entries) {
+      if (hook.value.finalizeBuilder) {
+        result.writeln('$name.${hook.key}(this);');
+      }
+    }
+
+    // Construct a map from field to how it's built. If it's a normal field,
+    // this is just the field name; if it's a nested builder, this is an
+    // invocation of the nested builder taking into account nullability.
+    var fieldBuilders = <String, String>{};
+    var needsNullCheck = <String>{};
+    var genericFields = <String, String>{};
+    fields.forEach((field) {
+      final name = field.name;
+      if (!field.isNestedBuilder) {
+        fieldBuilders[name] = name;
+        if (!field.isNullable) {
+          needsNullCheck.add(name);
+        }
+        if (field.hasNullableGenericType) {
+          genericFields[name] =
+              field.element.getter!.returnType.element!.displayName;
+        }
+      } else if (!field.isNullable && field.isAutoCreateNestedBuilder) {
+        // If not nullable, go via the public accessor, which instantiates
+        // if needed provided `autoCreateNestedBuilders` is true.
+        fieldBuilders[name] = '$name.build()';
+      } else if (hasBuilder && !field.builderFieldIsAbstract) {
+        // Otherwise access the private field: in super if there's a manually
+        // maintained builder.
+        fieldBuilders[name] = 'super.$name?.build()';
+        if (!field.isNullable) needsNullCheck.add(name);
+      } else {
+        // Or, directly if there is no manually maintained builder.
+        fieldBuilders[name] = '_$name?.build()';
+        if (!field.isNullable) needsNullCheck.add(name);
+      }
+    });
+
+    // If there are nested builders then wrap the build in a try/catch so we
+    // can add information should a nested builder fail.
+    var needsTryCatchOnBuild = fieldBuilders.keys.any(
+      (field) => fieldBuilders[field] != field,
+    );
+
+    if (needsTryCatchOnBuild) {
+      result.writeln('$implName$_generics _\$result;');
+      result.writeln('try {');
+    } else {
+      result.write('final ');
+    }
+    result.writeln('_\$result = _\$v ?? ');
+    result.writeln('$implName$_generics._(');
+    result.write(
+      fieldBuilders.keys
+          .map((field) {
+            final fieldBuilder = fieldBuilders[field];
+            if (needsNullCheck.contains(field)) {
+              if (genericFields.containsKey(field)) {
+                final genericType = genericFields[field];
+                return '$field: null is $genericType ? $fieldBuilder as $genericType '
+                    ': BuiltValueNullFieldError.checkNotNull($fieldBuilder'
+                    ", r'$name', '${escapeString(field)}')";
+              }
+              return '$field: BuiltValueNullFieldError.checkNotNull($fieldBuilder, '
+                  "r'$name', '${escapeString(field)}')";
+            }
+            return '$field: $fieldBuilder';
+          })
+          .map((fieldBuilder) => '$fieldBuilder,')
+          .join(''),
+    );
+    result.writeln(');');
+
+    if (needsTryCatchOnBuild) {
+      // Handle errors by re-running all nested builders; if there's an error
+      // in a nested builder then throw with more information. Otherwise,
+      // just rethrow.
+      result.writeln('} catch (_) {');
+      result.writeln('late String _\$failedField;');
+      result.writeln('try {');
+      result.write(
+        fieldBuilders.keys.map((field) {
+          final fieldBuilder = fieldBuilders[field];
+          if (fieldBuilder == field) return '';
+          return "_\$failedField = '${escapeString(field)}'; $fieldBuilder;";
+        }).join('\n'),
+      );
+
+      result.writeln('} catch (e) {');
+      result.writeln(
+        'throw BuiltValueNestedFieldError('
+        "r'$name', _\$failedField, e.toString());",
+      );
+      result.writeln('}');
+      result.writeln('rethrow;');
+      result.writeln('}');
+    }
+
+    // Set _$v to the built value, so it will be lazily copied if needed.
+    result.writeln('replace(_\$result);');
+    result.writeln('return _\$result;');
+    result.writeln('}');
+
+    if (settings.comparableBuilders) {
+      result.write(_generateEqualsAndHashcode(forBuilder: true));
+    }
+
+    result.writeln('}');
+
+    return result.toString();
+  }
+
+  String _generateEqualsAndHashcode({bool forBuilder = false}) {
+    var result = StringBuffer();
+
+    var comparedFields = fields
+        .where(
+          (field) => field.builtValueField.compare ?? settings.defaultCompare,
+        )
+        .toList();
+    var comparedFunctionFields =
+        comparedFields.where((field) => field.isFunctionType).toList();
+    result.writeln('@override');
+    result.writeln('bool operator==(Object other) {');
+    result.writeln('  if (identical(other, this)) return true;');
+
+    var needsDynamic =
+        comparedFunctionFields.isNotEmpty && genericParameters.isNotEmpty;
+
+    if (needsDynamic) {
+      result.writeln('  final dynamic _\$dynamicOther = other;');
+    }
+    result.writeln('  return other is $name${forBuilder ? 'Builder' : ''}');
+    if (comparedFields.isNotEmpty) {
+      result.writeln('&&');
+      result.writeln(
+        comparedFields.map((field) {
+          var nameOrThisDotName =
+              field.name == 'other' ? 'this.other' : field.name;
+          return needsDynamic && field.isFunctionType
+              ? '$nameOrThisDotName == _\$dynamicOther.${field.name}'
+              : '$nameOrThisDotName == other.${field.name}';
+        }).join('&&'),
+      );
+    }
+    result.writeln(';');
+    result.writeln('}');
+    result.writeln();
+
+    var generateMemoizedHashCode =
+        declaresMemoizedHashCode && comparedFields.isNotEmpty;
+    if (generateMemoizedHashCode) {
+      result.writeln('int? __hashCode;');
+    }
+
+    result.writeln('@override');
+    result.writeln('int get hashCode {');
+
+    if (comparedFields.isEmpty) {
+      result.writeln('return ${name.hashCode};');
+    } else {
+      if (generateMemoizedHashCode) {
+        result.writeln('if (__hashCode != null) return __hashCode!;');
+      }
+
+      // Use a different seed for builders than for values, so they do not have
+      // identical hashCodes if the values are identical.
+      final seed = forBuilder ? 1 : 0;
+      result.writeln('var _\$hash  = $seed;');
+
+      for (var field in comparedFields) {
+        result.writeln('_\$hash = \$jc(_\$hash, ${field.name}.hashCode);');
+      }
+
+      result.writeln('_\$hash = \$jf(_\$hash);');
+
+      if (generateMemoizedHashCode) {
+        result.writeln('return __hashCode ??= _\$hash;');
+      } else {
+        result.writeln('return _\$hash;');
+      }
+    }
+    result.writeln('}');
+    result.writeln();
+
+    return result.toString();
+  }
+
+  /// Generates an abstract builder with just abstract setters and getters.
+  String _generateAbstractBuilder() {
+    var result = StringBuffer();
+
+    // The "Built" interface has been omitted to work around dart2js issue
+    // https://github.com/dart-lang/sdk/issues/14729. So, we can't implement
+    // "Builder". Add the methods explicitly. We can however implement any
+    // other built_value interfaces.
+    var interfaces = [...builderImplements.skip(1), ...builderMixins];
+
+    if (implementsBuilt) {
+      result.writeln(
+        'abstract $_class ${name}Builder$_boundedGenerics '
+        'implements ${builderImplements.join(", ")} {',
+      );
+    } else {
+      result.writeln(
+        'abstract $_class ${name}Builder$_boundedGenerics '
+        '${interfaces.isEmpty ? '' : 'implements ' + interfaces.join(', ')}'
+        '{',
+      );
+
+      // Add `covariant` if we're implementing one or more parent builders.
+      result.writeln(
+        'void replace(${interfaces.isEmpty ? '' : 'covariant '}'
+        '$name$_generics other);',
+      );
+      result.writeln(
+        'void update(void Function(${name}Builder$_generics) updates);',
+      );
+    }
+
+    for (var field in fields) {
+      var type = field.isNestedBuilder
+          ? field.typeInBuilder(libraryFragment)
+          : field.typeInLibraryFragment(libraryFragment);
+      final name = field.name;
+
+      final autoCreatedNestedBuilder =
+          field.isNestedBuilder && settings.autoCreateNestedBuilders;
+      final maybeOrNull = autoCreatedNestedBuilder ? '' : '?';
+
+      result.writeln('$type$maybeOrNull get $name;');
+      // Add `covariant` if we're implementing one or more parent builders.
+      result.writeln(
+        'set $name(${interfaces.isEmpty ? '' : 'covariant '} '
+        '$type? $name);',
+      );
+
+      result.writeln();
+    }
+
+    result.writeln('}');
+    return result.toString();
+  }
+}
+
+InvalidGenerationSourceError _makeError(Iterable<GeneratorError> todos) {
+  var message = StringBuffer(
+    'Please make the following changes to use BuiltValue:\n',
+  );
+  for (var i = 0; i != todos.length; ++i) {
+    message.write('\n${i + 1}. ${todos.elementAt(i).message}');
+  }
+
+  return InvalidGenerationSourceError(message.toString());
+}

--- a/built_types/built_value_generator/lib/src/value_source_class.g.dart
+++ b/built_types/built_value_generator/lib/src/value_source_class.g.dart
@@ -1,0 +1,302 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'value_source_class.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$ValueSourceClass extends ValueSourceClass {
+  @override
+  final ParsedLibraryResults parsedLibraryResults;
+  @override
+  final InterfaceElement element;
+  ParsedLibraryResult? __parsedLibrary;
+  String? __name;
+  String? __implName;
+  ClassElement? __builderElement;
+  bool ___builderElement = false;
+  bool? __implementsBuilt;
+  bool? __extendsIsAllowed;
+  BuiltValue? __settings;
+  BuiltList<String>? __genericParameters;
+  BuiltList<String>? __genericBounds;
+  ClassDeclaration? __classDeclaration;
+  bool? __hasBuilder;
+  bool? __hasBuilderInitializer;
+  MethodElement? __builderInitializer;
+  bool ___builderInitializer = false;
+  bool? __hasBuilderFinalizer;
+  MethodElement? __builderFinalizer;
+  bool ___builderFinalizer = false;
+  BuiltMap<String, BuiltValueHook>? __hooks;
+  String? __builderParameters;
+  BuiltList<ValueSourceField>? __fields;
+  String? __source;
+  String? __partStatement;
+  bool? __hasPartStatement;
+  bool? __hasBuiltValueImportWithShow;
+  bool? __hasBuiltValueImportWithAs;
+  bool? __valueClassIsAbstract;
+  BuiltList<AstNode>? __valueClassConstructors;
+  BuiltList<AstNode>? __valueClassFactories;
+  bool? __builderClassIsAbstract;
+  BuiltList<AstNode>? __builderClassConstructors;
+  BuiltList<String>? __builderClassFactories;
+  BuiltList<MemoizedGetter>? __memoizedGetters;
+  BuiltList<String>? __builderImplements;
+  BuiltList<String>? __builderMixins;
+  bool? __implementsHashCode;
+  bool? __declaresMemoizedHashCode;
+  bool? __implementsOperatorEquals;
+  bool? __implementsToString;
+  LibraryFragment? __libraryFragment;
+
+  factory _$ValueSourceClass(
+          [void Function(ValueSourceClassBuilder)? updates]) =>
+      (ValueSourceClassBuilder()..update(updates))._build();
+
+  _$ValueSourceClass._(
+      {required this.parsedLibraryResults, required this.element})
+      : super._();
+  @override
+  ParsedLibraryResult get parsedLibrary =>
+      __parsedLibrary ??= super.parsedLibrary;
+
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get implName => __implName ??= super.implName;
+
+  @override
+  ClassElement? get builderElement {
+    if (!___builderElement) {
+      __builderElement = super.builderElement;
+      ___builderElement = true;
+    }
+    return __builderElement;
+  }
+
+  @override
+  bool get implementsBuilt => __implementsBuilt ??= super.implementsBuilt;
+
+  @override
+  bool get extendsIsAllowed => __extendsIsAllowed ??= super.extendsIsAllowed;
+
+  @override
+  BuiltValue get settings => __settings ??= super.settings;
+
+  @override
+  BuiltList<String> get genericParameters =>
+      __genericParameters ??= super.genericParameters;
+
+  @override
+  BuiltList<String> get genericBounds =>
+      __genericBounds ??= super.genericBounds;
+
+  @override
+  ClassDeclaration get classDeclaration =>
+      __classDeclaration ??= super.classDeclaration;
+
+  @override
+  bool get hasBuilder => __hasBuilder ??= super.hasBuilder;
+
+  @override
+  bool get hasBuilderInitializer =>
+      __hasBuilderInitializer ??= super.hasBuilderInitializer;
+
+  @override
+  MethodElement? get builderInitializer {
+    if (!___builderInitializer) {
+      __builderInitializer = super.builderInitializer;
+      ___builderInitializer = true;
+    }
+    return __builderInitializer;
+  }
+
+  @override
+  bool get hasBuilderFinalizer =>
+      __hasBuilderFinalizer ??= super.hasBuilderFinalizer;
+
+  @override
+  MethodElement? get builderFinalizer {
+    if (!___builderFinalizer) {
+      __builderFinalizer = super.builderFinalizer;
+      ___builderFinalizer = true;
+    }
+    return __builderFinalizer;
+  }
+
+  @override
+  BuiltMap<String, BuiltValueHook> get hooks => __hooks ??= super.hooks;
+
+  @override
+  String get builderParameters =>
+      __builderParameters ??= super.builderParameters;
+
+  @override
+  BuiltList<ValueSourceField> get fields => __fields ??= super.fields;
+
+  @override
+  String get source => __source ??= super.source;
+
+  @override
+  String get partStatement => __partStatement ??= super.partStatement;
+
+  @override
+  bool get hasPartStatement => __hasPartStatement ??= super.hasPartStatement;
+
+  @override
+  bool get hasBuiltValueImportWithShow =>
+      __hasBuiltValueImportWithShow ??= super.hasBuiltValueImportWithShow;
+
+  @override
+  bool get hasBuiltValueImportWithAs =>
+      __hasBuiltValueImportWithAs ??= super.hasBuiltValueImportWithAs;
+
+  @override
+  bool get valueClassIsAbstract =>
+      __valueClassIsAbstract ??= super.valueClassIsAbstract;
+
+  @override
+  BuiltList<AstNode> get valueClassConstructors =>
+      __valueClassConstructors ??= super.valueClassConstructors;
+
+  @override
+  BuiltList<AstNode> get valueClassFactories =>
+      __valueClassFactories ??= super.valueClassFactories;
+
+  @override
+  bool get builderClassIsAbstract =>
+      __builderClassIsAbstract ??= super.builderClassIsAbstract;
+
+  @override
+  BuiltList<AstNode> get builderClassConstructors =>
+      __builderClassConstructors ??= super.builderClassConstructors;
+
+  @override
+  BuiltList<String> get builderClassFactories =>
+      __builderClassFactories ??= super.builderClassFactories;
+
+  @override
+  BuiltList<MemoizedGetter> get memoizedGetters =>
+      __memoizedGetters ??= super.memoizedGetters;
+
+  @override
+  BuiltList<String> get builderImplements =>
+      __builderImplements ??= super.builderImplements;
+
+  @override
+  BuiltList<String> get builderMixins =>
+      __builderMixins ??= super.builderMixins;
+
+  @override
+  bool get implementsHashCode =>
+      __implementsHashCode ??= super.implementsHashCode;
+
+  @override
+  bool get declaresMemoizedHashCode =>
+      __declaresMemoizedHashCode ??= super.declaresMemoizedHashCode;
+
+  @override
+  bool get implementsOperatorEquals =>
+      __implementsOperatorEquals ??= super.implementsOperatorEquals;
+
+  @override
+  bool get implementsToString =>
+      __implementsToString ??= super.implementsToString;
+
+  @override
+  LibraryFragment get libraryFragment =>
+      __libraryFragment ??= super.libraryFragment;
+
+  @override
+  ValueSourceClass rebuild(void Function(ValueSourceClassBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ValueSourceClassBuilder toBuilder() =>
+      ValueSourceClassBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueSourceClass &&
+        parsedLibraryResults == other.parsedLibraryResults &&
+        element == other.element;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, parsedLibraryResults.hashCode);
+    _$hash = $jc(_$hash, element.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueSourceClass')
+          ..add('parsedLibraryResults', parsedLibraryResults)
+          ..add('element', element))
+        .toString();
+  }
+}
+
+class ValueSourceClassBuilder
+    implements Builder<ValueSourceClass, ValueSourceClassBuilder> {
+  _$ValueSourceClass? _$v;
+
+  ParsedLibraryResults? _parsedLibraryResults;
+  ParsedLibraryResults? get parsedLibraryResults =>
+      _$this._parsedLibraryResults;
+  set parsedLibraryResults(ParsedLibraryResults? parsedLibraryResults) =>
+      _$this._parsedLibraryResults = parsedLibraryResults;
+
+  InterfaceElement? _element;
+  InterfaceElement? get element => _$this._element;
+  set element(InterfaceElement? element) => _$this._element = element;
+
+  ValueSourceClassBuilder();
+
+  ValueSourceClassBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _parsedLibraryResults = $v.parsedLibraryResults;
+      _element = $v.element;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueSourceClass other) {
+    _$v = other as _$ValueSourceClass;
+  }
+
+  @override
+  void update(void Function(ValueSourceClassBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueSourceClass build() => _build();
+
+  _$ValueSourceClass _build() {
+    final _$result = _$v ??
+        _$ValueSourceClass._(
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'ValueSourceClass',
+              'parsedLibraryResults'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'ValueSourceClass', 'element'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/built_value_generator/lib/src/value_source_field.dart
+++ b/built_types/built_value_generator/lib/src/value_source_field.dart
@@ -1,0 +1,435 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_value_generator.source_field;
+
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value_generator/src/dart_types.dart';
+import 'package:built_value_generator/src/field_mixin.dart';
+import 'package:built_value_generator/src/fields.dart' show collectFields;
+import 'package:built_value_generator/src/fixes.dart';
+import 'package:built_value_generator/src/metadata.dart'
+    show metadataToStringValue;
+import 'package:built_value_generator/src/parsed_library_results.dart';
+
+part 'value_source_field.g.dart';
+
+const _suggestedTypes = <String, String>{
+  'List<dynamic>': 'BuiltList',
+  'Map<dynamic, dynamic>': 'BuiltMap',
+  'Set<dynamic>': 'BuiltSet',
+  'ListMultimap<dynamic, dynamic>': 'BuiltListMultimap',
+  'SetMultimap<dynamic, dynamic>': 'BuiltSetMultimap',
+};
+
+abstract class ValueSourceField
+    with FieldMixin
+    implements Built<ValueSourceField, ValueSourceFieldBuilder> {
+  ParsedLibraryResults get parsedLibraryResults;
+  BuiltValue get settings;
+  @override
+  ParsedLibraryResult get parsedLibrary;
+  PropertyInducingElement get element;
+  @override
+  PropertyInducingElement? get builderElement;
+
+  factory ValueSourceField(
+    ParsedLibraryResults parsedLibraryResults,
+    BuiltValue settings,
+    ParsedLibraryResult parsedLibrary,
+    PropertyInducingElement element,
+    PropertyInducingElement? builderElement,
+  ) =>
+      _$ValueSourceField._(
+        parsedLibraryResults: parsedLibraryResults,
+        settings: settings,
+        parsedLibrary: parsedLibrary,
+        element: element,
+        builderElement: builderElement,
+      );
+  ValueSourceField._();
+
+  @memoized
+  String get name => element.displayName;
+
+  @memoized
+  String get type => DartTypes.getName(element.getter!.returnType);
+
+  @memoized
+  bool get isFunctionType => type.contains('(');
+
+  /// The [type] plus any import prefix, without any nullability suffix.
+  @memoized
+  String get typeWithPrefix {
+    var typeFromAst = (parsedLibrary
+                .getFragmentDeclaration(element.getter!.firstFragment)!
+                .node as MethodDeclaration)
+            .returnType
+            ?.toSource() ??
+        'dynamic';
+    if (typeFromAst.endsWith('?')) {
+      typeFromAst = typeFromAst.substring(0, typeFromAst.length - 1);
+    }
+    var typeFromElement = type;
+
+    // If the type is a function, we can't use the element result; it is
+    // formatted incorrectly.
+    if (isFunctionType) return typeFromAst;
+
+    // If the type does not have an import prefix, prefer the element result.
+    // It handles inherited generics correctly.
+    if (!typeFromAst.contains('.')) return typeFromElement;
+
+    return typeFromAst;
+  }
+
+  /// Returns the type with import prefix if the library fragment matches,
+  /// otherwise the type with no import prefix.
+  String typeInLibraryFragment(LibraryFragment? libraryFragment) {
+    return libraryFragment == element.library.firstFragment
+        ? typeWithPrefix
+        : type;
+  }
+
+  @memoized
+  bool get isGetter =>
+      element.getter != null && element.getter!.isOriginDeclaration;
+
+  @memoized
+  bool get hasNullableAnnotation => element.getter!.metadata.annotations.any(
+        (metadata) => metadataToStringValue(metadata) == 'nullable',
+      );
+
+  @memoized
+  bool get hasNullableType =>
+      element.getter?.returnType.nullabilitySuffix ==
+      NullabilitySuffix.question;
+
+  @memoized
+  bool get hasNullableGenericType =>
+      element.getter?.returnType is TypeParameterType &&
+      (element.getter!.returnType as TypeParameterType)
+              .bound
+              .nullabilitySuffix ==
+          NullabilitySuffix.question;
+
+  @memoized
+  bool get isNullable => hasNullableAnnotation || hasNullableType;
+
+  @memoized
+  BuiltValueField get builtValueField {
+    var annotations = element.getter!.metadata.annotations
+        .map((annotation) => annotation.computeConstantValue())
+        .where(
+          (value) => DartTypes.tryGetName(value?.type) == 'BuiltValueField',
+        );
+    if (annotations.isEmpty) return const BuiltValueField();
+    var annotation = annotations.single!;
+    return BuiltValueField(
+      compare: annotation.getField('compare')?.toBoolValue(),
+      serialize: annotation.getField('serialize')?.toBoolValue(),
+      wireName: annotation.getField('wireName')?.toStringValue(),
+      nestedBuilder: annotation.getField('nestedBuilder')?.toBoolValue(),
+      autoCreateNestedBuilder:
+          annotation.getField('autoCreateNestedBuilder')?.toBoolValue(),
+    );
+  }
+
+  @memoized
+  bool get builderFieldIsNormalField =>
+      builderFieldExists &&
+      builderElement!.getter != null &&
+      !builderElement!.getter!.isAbstract &&
+      !builderElement!.getter!.isOriginDeclaration;
+
+  @memoized
+  bool get builderFieldIsGetterSetterPair =>
+      builderFieldExists &&
+      (builderElement!.getter != null && builderElement!.setter != null);
+
+  @memoized
+  bool get builderFieldIsAbstract =>
+      builderFieldExists &&
+      builderElement!.getter != null &&
+      builderElement!.getter!.isAbstract;
+
+  @memoized
+  @override
+  String get fullBuildElementType => super.fullBuildElementType;
+
+  @memoized
+  String get buildElementType {
+    var result = fullBuildElementType;
+    // If we went via the AST there may be an import prefix, but we don't
+    // want one here. Strip it off.
+    if (result.contains('.')) {
+      result = result.substring(result.indexOf('.') + 1);
+    }
+    return _removeNullabilitySuffix(result);
+  }
+
+  bool get builderElementTypeIsNullable => fullBuildElementType.endsWith('?');
+
+  bool get builderElementSetterIsNullable {
+    if (!builderFieldExists) return false;
+
+    // Try to get a resolved type first, it's faster.
+    var result = DartTypes.tryGetName(
+      builderElement!.setter?.formalParameters.first.type,
+      withNullabilitySuffix: true,
+    );
+
+    if (result == null || result == 'dynamic') {
+      // Go via AST to allow use of unresolvable types not yet generated;
+      // this includes generated Builder types.
+      result = parsedLibrary
+          .getFragmentDeclaration(builderElement!.firstFragment)
+          ?.node
+          .parent
+          ?.childEntities
+          .first
+          .toString();
+    }
+
+    if (result == null || result == 'dynamic') {
+      result = builderElement!.setter != null
+          ? (parsedLibrary
+                  .getFragmentDeclaration(
+                    builderElement!.setter!.firstFragment,
+                  )
+                  ?.node as MethodDeclaration?)
+              ?.parameters!
+              .parameters
+              .first
+              .childEntities
+              .first
+              .toString()
+          : null;
+    }
+
+    return result?.endsWith('?') ?? false;
+  }
+
+  /// The [builderElementType] plus any import prefix.
+  @memoized
+  String get builderElementTypeWithPrefix {
+    // If it's a real field, it's a [VariableDeclaration] which is guaranteed
+    // to have parent node [VariableDeclarationList] giving the type.
+    var fieldDeclaration = parsedLibrary.getFragmentDeclaration(
+      builderElement!.firstFragment,
+    );
+    if (fieldDeclaration != null) {
+      return _removeNullabilitySuffix(
+        (((fieldDeclaration.node as VariableDeclaration).parent)
+                    as VariableDeclarationList?)
+                ?.type
+                ?.toSource() ??
+            'dynamic',
+      );
+    } else {
+      // Otherwise it's an explicit getter/setter pair; get the type from the getter.
+      return _removeNullabilitySuffix(
+        (parsedLibrary
+                    .getFragmentDeclaration(
+                      builderElement!.getter!.firstFragment,
+                    )!
+                    .node as MethodDeclaration)
+                .returnType
+                ?.toSource() ??
+            'dynamic',
+      );
+    }
+  }
+
+  String _removeNullabilitySuffix(String type) {
+    return type.endsWith('?') ? type.substring(0, type.length - 1) : type;
+  }
+
+  /// Gets the type name for the builder. Specify the library fragment to
+  /// get the name for as [libraryFragment]; this affects whether an import
+  /// prefix is used. Pass `null` for [libraryFragment] to just omit the prefix.
+  String? typeInBuilder(LibraryFragment? libraryFragment) => builderFieldExists
+      ? buildElementType
+      : _toBuilderType(
+          parsedLibraryResults,
+          element.getter!.returnType,
+          typeInLibraryFragment(libraryFragment),
+        );
+
+  @memoized
+  bool get isNestedBuilder => builderFieldExists
+      ? typeInBuilder(null)?.contains('Builder') ?? false
+      : (builtValueField.nestedBuilder ?? settings.nestedBuilders) &&
+          DartTypes.needsNestedBuilder(
+            parsedLibraryResults,
+            element.getter!.returnType,
+          );
+
+  @memoized
+  bool get isAutoCreateNestedBuilder =>
+      builtValueField.autoCreateNestedBuilder ??
+      settings.autoCreateNestedBuilders;
+
+  static BuiltList<ValueSourceField> fromClassElements(
+    ParsedLibraryResults parsedLibraryResults,
+    BuiltValue settings,
+    ParsedLibraryResult parsedLibrary,
+    InterfaceElement classElement,
+    ClassElement? builderClassElement,
+  ) {
+    var result = ListBuilder<ValueSourceField>();
+
+    for (var field in collectFields(classElement)) {
+      if (!field.isStatic &&
+          field.getter != null &&
+          (field.getter!.isAbstract || !field.getter!.isOriginDeclaration)) {
+        final builderField = builderClassElement?.getField(field.name!);
+        result.add(
+          ValueSourceField(
+            parsedLibraryResults,
+            settings,
+            parsedLibrary,
+            field,
+            builderField,
+          ),
+        );
+      }
+    }
+
+    return result.build();
+  }
+
+  static String? _toBuilderType(
+    ParsedLibraryResults parsedLibraryResults,
+    DartType type,
+    String displayName,
+  ) {
+    if (DartTypes.isBuiltCollection(type)) {
+      return displayName
+          .replaceFirst('Built', '')
+          .replaceFirst('<', 'Builder<');
+    } else if (DartTypes.isInstantiableBuiltValue(parsedLibraryResults, type)) {
+      return displayName.contains('<')
+          ? displayName.replaceFirst('<', 'Builder<')
+          : '${displayName}Builder';
+    } else {
+      return displayName;
+    }
+  }
+
+  Iterable<GeneratorError> computeErrors() {
+    var result = <GeneratorError>[];
+
+    if (!isGetter) {
+      result.add(
+        GeneratorError((b) => b..message = 'Make field $name a getter.'),
+      );
+    }
+
+    if (type == 'dynamic') {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message = 'Make field $name have non-dynamic type. '
+                'If you are already specifying a type, '
+                'please make sure the type is correctly imported.',
+        ),
+      );
+    }
+
+    if (name.startsWith('_')) {
+      result.add(
+        GeneratorError(
+          (b) => b..message = 'Make field $name public; remove the underscore.',
+        ),
+      );
+    }
+
+    // TODO(davidmorgan): tighten this up to apply to any generics.
+    if (_suggestedTypes.keys.contains(type)) {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message = 'Make field "$name" have type "${_suggestedTypes[type]}". '
+                'The current type, "$type", is not allowed because it is mutable.',
+        ),
+      );
+    }
+
+    if (hasNullableAnnotation) {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message = 'Remove "@nullable" from field "$name". '
+                'Add "?" to the field type instead.',
+        ),
+      );
+    }
+
+    if (builderFieldExists) {
+      var builderElementTypeOrNull = buildElementType;
+      if (builderElementTypeIsNullable) builderElementTypeOrNull += '?';
+      final builderType = _toBuilderType(
+        parsedLibraryResults,
+        element.type,
+        type,
+      );
+      if (builderElementTypeOrNull != type + '?' &&
+          (builderType == null ||
+              (builderElementTypeOrNull != builderType &&
+                  builderElementTypeOrNull != builderType + '?'))) {
+        result.add(
+          GeneratorError(
+            (b) => b
+              ..message = 'Make builder field $name have type: '
+                  '$type? (or, if applicable, builder)',
+          ),
+        );
+      }
+    }
+
+    if (builderFieldExists &&
+        !builderFieldIsNormalField &&
+        !builderFieldIsGetterSetterPair) {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message =
+                'Make builder field $name a normal field or a getter/setter '
+                    'pair.',
+        ),
+      );
+    }
+
+    if (builderFieldExists &&
+        builderFieldIsGetterSetterPair &&
+        (builderElement!.getter!.isAbstract ^
+            builderElement!.setter!.isAbstract)) {
+      result.add(
+        GeneratorError(
+          (b) =>
+              b..message = 'Explicit getter/setter pair must both be defined.',
+        ),
+      );
+    }
+
+    if (settings.comparableBuilders && builtValueField.nestedBuilder == true) {
+      result.add(
+        GeneratorError(
+          (b) => b
+            ..message = 'Make builder field $name have `nestedBuilder: false`'
+                ' in order to use `comparableBuilders: true`.',
+        ),
+      );
+    }
+
+    return result;
+  }
+}

--- a/built_types/built_value_generator/lib/src/value_source_field.g.dart
+++ b/built_types/built_value_generator/lib/src/value_source_field.g.dart
@@ -1,0 +1,232 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'value_source_field.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$ValueSourceField extends ValueSourceField {
+  @override
+  final ParsedLibraryResults parsedLibraryResults;
+  @override
+  final BuiltValue settings;
+  @override
+  final ParsedLibraryResult parsedLibrary;
+  @override
+  final PropertyInducingElement element;
+  @override
+  final PropertyInducingElement? builderElement;
+  String? __name;
+  String? __type;
+  bool? __isFunctionType;
+  String? __typeWithPrefix;
+  bool? __isGetter;
+  bool? __hasNullableAnnotation;
+  bool? __hasNullableType;
+  bool? __hasNullableGenericType;
+  bool? __isNullable;
+  BuiltValueField? __builtValueField;
+  bool? __builderFieldIsNormalField;
+  bool? __builderFieldIsGetterSetterPair;
+  bool? __builderFieldIsAbstract;
+  String? __fullBuildElementType;
+  String? __buildElementType;
+  String? __builderElementTypeWithPrefix;
+  bool? __isNestedBuilder;
+  bool? __isAutoCreateNestedBuilder;
+
+  factory _$ValueSourceField(
+          [void Function(ValueSourceFieldBuilder)? updates]) =>
+      (ValueSourceFieldBuilder()..update(updates))._build();
+
+  _$ValueSourceField._(
+      {required this.parsedLibraryResults,
+      required this.settings,
+      required this.parsedLibrary,
+      required this.element,
+      this.builderElement})
+      : super._();
+  @override
+  String get name => __name ??= super.name;
+
+  @override
+  String get type => __type ??= super.type;
+
+  @override
+  bool get isFunctionType => __isFunctionType ??= super.isFunctionType;
+
+  @override
+  String get typeWithPrefix => __typeWithPrefix ??= super.typeWithPrefix;
+
+  @override
+  bool get isGetter => __isGetter ??= super.isGetter;
+
+  @override
+  bool get hasNullableAnnotation =>
+      __hasNullableAnnotation ??= super.hasNullableAnnotation;
+
+  @override
+  bool get hasNullableType => __hasNullableType ??= super.hasNullableType;
+
+  @override
+  bool get hasNullableGenericType =>
+      __hasNullableGenericType ??= super.hasNullableGenericType;
+
+  @override
+  bool get isNullable => __isNullable ??= super.isNullable;
+
+  @override
+  BuiltValueField get builtValueField =>
+      __builtValueField ??= super.builtValueField;
+
+  @override
+  bool get builderFieldIsNormalField =>
+      __builderFieldIsNormalField ??= super.builderFieldIsNormalField;
+
+  @override
+  bool get builderFieldIsGetterSetterPair =>
+      __builderFieldIsGetterSetterPair ??= super.builderFieldIsGetterSetterPair;
+
+  @override
+  bool get builderFieldIsAbstract =>
+      __builderFieldIsAbstract ??= super.builderFieldIsAbstract;
+
+  @override
+  String get fullBuildElementType =>
+      __fullBuildElementType ??= super.fullBuildElementType;
+
+  @override
+  String get buildElementType => __buildElementType ??= super.buildElementType;
+
+  @override
+  String get builderElementTypeWithPrefix =>
+      __builderElementTypeWithPrefix ??= super.builderElementTypeWithPrefix;
+
+  @override
+  bool get isNestedBuilder => __isNestedBuilder ??= super.isNestedBuilder;
+
+  @override
+  bool get isAutoCreateNestedBuilder =>
+      __isAutoCreateNestedBuilder ??= super.isAutoCreateNestedBuilder;
+
+  @override
+  ValueSourceField rebuild(void Function(ValueSourceFieldBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ValueSourceFieldBuilder toBuilder() =>
+      ValueSourceFieldBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueSourceField &&
+        parsedLibraryResults == other.parsedLibraryResults &&
+        settings == other.settings &&
+        parsedLibrary == other.parsedLibrary &&
+        element == other.element &&
+        builderElement == other.builderElement;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, parsedLibraryResults.hashCode);
+    _$hash = $jc(_$hash, settings.hashCode);
+    _$hash = $jc(_$hash, parsedLibrary.hashCode);
+    _$hash = $jc(_$hash, element.hashCode);
+    _$hash = $jc(_$hash, builderElement.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueSourceField')
+          ..add('parsedLibraryResults', parsedLibraryResults)
+          ..add('settings', settings)
+          ..add('parsedLibrary', parsedLibrary)
+          ..add('element', element)
+          ..add('builderElement', builderElement))
+        .toString();
+  }
+}
+
+class ValueSourceFieldBuilder
+    implements Builder<ValueSourceField, ValueSourceFieldBuilder> {
+  _$ValueSourceField? _$v;
+
+  ParsedLibraryResults? _parsedLibraryResults;
+  ParsedLibraryResults? get parsedLibraryResults =>
+      _$this._parsedLibraryResults;
+  set parsedLibraryResults(ParsedLibraryResults? parsedLibraryResults) =>
+      _$this._parsedLibraryResults = parsedLibraryResults;
+
+  BuiltValue? _settings;
+  BuiltValue? get settings => _$this._settings;
+  set settings(BuiltValue? settings) => _$this._settings = settings;
+
+  ParsedLibraryResult? _parsedLibrary;
+  ParsedLibraryResult? get parsedLibrary => _$this._parsedLibrary;
+  set parsedLibrary(ParsedLibraryResult? parsedLibrary) =>
+      _$this._parsedLibrary = parsedLibrary;
+
+  PropertyInducingElement? _element;
+  PropertyInducingElement? get element => _$this._element;
+  set element(PropertyInducingElement? element) => _$this._element = element;
+
+  PropertyInducingElement? _builderElement;
+  PropertyInducingElement? get builderElement => _$this._builderElement;
+  set builderElement(PropertyInducingElement? builderElement) =>
+      _$this._builderElement = builderElement;
+
+  ValueSourceFieldBuilder();
+
+  ValueSourceFieldBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _parsedLibraryResults = $v.parsedLibraryResults;
+      _settings = $v.settings;
+      _parsedLibrary = $v.parsedLibrary;
+      _element = $v.element;
+      _builderElement = $v.builderElement;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueSourceField other) {
+    _$v = other as _$ValueSourceField;
+  }
+
+  @override
+  void update(void Function(ValueSourceFieldBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueSourceField build() => _build();
+
+  _$ValueSourceField _build() {
+    final _$result = _$v ??
+        _$ValueSourceField._(
+          parsedLibraryResults: BuiltValueNullFieldError.checkNotNull(
+              parsedLibraryResults,
+              r'ValueSourceField',
+              'parsedLibraryResults'),
+          settings: BuiltValueNullFieldError.checkNotNull(
+              settings, r'ValueSourceField', 'settings'),
+          parsedLibrary: BuiltValueNullFieldError.checkNotNull(
+              parsedLibrary, r'ValueSourceField', 'parsedLibrary'),
+          element: BuiltValueNullFieldError.checkNotNull(
+              element, r'ValueSourceField', 'element'),
+          builderElement: builderElement,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/built_value_generator/pubspec.yaml
+++ b/built_types/built_value_generator/pubspec.yaml
@@ -1,0 +1,29 @@
+name: built_value_generator
+version: 8.13.0
+description: >
+  Value types with builders, Dart classes as enums, and serialization.
+  This library is the dev dependency.
+repository: https://github.com/google/built_value.dart/tree/master/built_value_generator
+topics:
+ - built-value
+ - codegen
+ - build-runner
+
+environment:
+  sdk: '>=3.6.0 <4.0.0'
+
+dependencies:
+  analyzer: '>=13.0.0 <15.0.0'
+  build: '>=3.0.0 <5.0.0'
+  build_config: ^1.2.0
+  built_collection: ^5.0.0
+  built_value: '>=8.1.0 <8.14.0'
+  collection: ^1.15.0
+  source_gen: '>=3.0.0 <5.0.0'
+
+dev_dependencies:
+  build_test: ^3.0.0
+  build_runner: '>=1.0.0 <3.0.0'
+  logging: ^1.3.0
+  pedantic: ^1.4.0
+  test: ^1.0.0

--- a/built_types/built_value_generator/test/built_value_generator_test.dart
+++ b/built_types/built_value_generator/test/built_value_generator_test.dart
@@ -1,0 +1,1154 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:built_value_generator/built_value_generator.dart';
+import 'package:logging/logging.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('generator', () {
+    group('rejects', () {
+      test('import with "show"', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart' show Built, Builder;
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Stop using "show" when importing '
+                '"package:built_value/built_value.dart".'));
+      });
+
+      test('double quoted import with "show"', () async {
+        expect(
+            await generate('''library value;
+import "package:built_value/built_value.dart" show Built, Builder;
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Stop using "show" when importing '
+                '"package:built_value/built_value.dart".'));
+      });
+
+      test('import with "as"', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart' as bv;
+part 'value.g.dart';
+abstract class Value implements bv.Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements bv.Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Stop using "as" when importing '
+                '"package:built_value/built_value.dart".'));
+      });
+
+      test('double quoted import with "as"', () async {
+        expect(
+            await generate('''library value;
+import "package:built_value/built_value.dart" as bv;
+part 'value.g.dart';
+abstract class Value implements bv.Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements bv.Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Stop using "as" when importing '
+                '"package:built_value/built_value.dart".'));
+      });
+
+      test('"extends" with concrete base', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+class Foo {}
+abstract class Value extends Foo implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Stop class extending other classes. '
+                'Only "implements" and "extends Object with" are allowed.'));
+      });
+
+      test('"extends" with base with fields', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Foo {
+  final int x;
+}
+abstract class Value extends Foo implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Stop class extending other classes. '
+                'Only "implements" and "extends Object with" are allowed.'));
+      });
+
+      test('"extends" with base with abstract getter', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Foo {
+  int get x;
+}
+abstract class Value extends Foo implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Stop class extending other classes. '
+                'Only "implements" and "extends Object with" are allowed.'));
+      });
+
+      test('"extends" with base with operator==', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Foo {
+  bool operator ==(other) => true;
+}
+abstract class Value extends Foo implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Stop class extending other classes. '
+                'Only "implements" and "extends Object with" are allowed.'));
+      });
+
+      test('"extends Built"', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value extends Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), allOf(contains('Make class implement Built<Value, ValueBuilder>.')));
+      });
+
+      test('hashCode', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  int get hashCode => 0;
+}'''), contains('1. Stop implementing hashCode; it will be generated for you.'));
+      });
+
+      test('operator==', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  bool operator==(other) => false;
+}'''), contains('1. Stop implementing operator==; it will be generated for you.'));
+      });
+
+      test('dynamic fields', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  get foo;
+}'''),
+            contains('1. Make field foo have non-dynamic type. If you are '
+                'already specifying a type, please make sure the type is correctly imported.'));
+      });
+
+      test('2.12 rejects @nullable annotation', () async {
+        expect(
+            await generate('''// @dart=2.12
+library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+
+  @nullable
+  int get x;
+}'''),
+            contains('1. Remove "@nullable" from field "x". '
+                'Add "?" to the field type instead.'));
+      });
+    });
+
+    group('suggests', () {
+      test('to import part file', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains("1. Import generated part: part 'value.g.dart';"));
+      });
+
+      test('to make value class abstract', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class abstract.'));
+      });
+
+      test('correct Built type parameters for implements', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Foo, Bar> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class implement Built<Value, ValueBuilder>.'));
+      });
+
+      test('making builder initializer static', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  void _initializeBuilder(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _initializeBuilder signature: '
+                'static void _initializeBuilder(ValueBuilder b)'));
+      });
+
+      test('making builder initializer return void', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  static String _initializeBuilder(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _initializeBuilder signature: '
+                'static void _initializeBuilder(ValueBuilder b)'));
+      });
+
+      test('making builder initializer accept a builder', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  static void _initializeBuilder(String b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _initializeBuilder signature: '
+                'static void _initializeBuilder(ValueBuilder b)'));
+      });
+
+      test('making builder finalizer static', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  void _finalizeBuilder(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _finalizeBuilder signature: '
+                'static void _finalizeBuilder(ValueBuilder b)'));
+      });
+
+      test('making builder finalizer return void', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  static String _finalizeBuilder(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _finalizeBuilder signature: '
+                'static void _finalizeBuilder(ValueBuilder b)'));
+      });
+
+      test('making builder finalizer accept a builder', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  static void _finalizeBuilder(String b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix _finalizeBuilder signature: '
+                'static void _finalizeBuilder(ValueBuilder b)'));
+      });
+
+      test('removing annotation from _initializeBuilder', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  @BuiltValueHook(initializeBuilder: true)
+  static void _initializeBuilder(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Remove @BuiltValueHook from _initializeBuilder. '
+                'It is a magic method name that is always a hook. Or, to use '
+                'the annotation, please rename the method.'));
+      });
+
+      test('fixing signature of @BuiltValueHook(initializeBuilder: true)',
+          () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  @BuiltValueHook(initializeBuilder: true)
+  static String hook(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix hook signature to use it with @BuiltValueHook: '
+                'static void hook(ValueBuilder b)'));
+      });
+
+      test('removing annotation from _finalizeBuilder', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _finalizeBuilder(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Remove @BuiltValueHook from _finalizeBuilder. '
+                'It is a magic method name that is always a hook. Or, to use '
+                'the annotation, please rename the method.'));
+      });
+
+      test('fixing signature of @BuiltValueHook(finalizeBuilder: true)',
+          () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  @BuiltValueHook(finalizeBuilder: true)
+  static String hook(ValueBuilder b) {}
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Fix hook signature to use it with @BuiltValueHook: '
+                'static void hook(ValueBuilder b)'));
+      });
+
+      test('to add constructor to value class', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class have exactly one constructor: Value._();'));
+      });
+
+      test('to fix invalid primary constructor on value class', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value.other() implements Built<Value, ValueBuilder> {
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class have exactly one constructor: Value._()'));
+      });
+
+      test('to reject exact Value._() primary constructor', () async {
+        final result = await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value._() implements Built<Value, ValueBuilder> {
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}''');
+        expect(result, contains('1. Value._() must go in the body.'));
+      });
+
+      test('to reject exact ValueBuilder._() primary constructor', () async {
+        final result = await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder._() implements Builder<Value, ValueBuilder> {
+  factory ValueBuilder() = _\$ValueBuilder;
+}''');
+        expect(result, contains('1. ValueBuilder._() must go in the body.'));
+      });
+
+      test('to fix primary constructor with parameters on value class',
+          () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value._(int x) implements Built<Value, ValueBuilder> {
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class have exactly one constructor: Value._()'));
+      });
+
+      test('to fix new constructor with parameters on value class', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  new _(int x);
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class have exactly one constructor: Value._()'));
+      });
+
+      test('to remove primary constructor from non-instantiable value class',
+          () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+@BuiltValue(instantiable: false)
+abstract class Value._() implements Built<Value, ValueBuilder> {
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+}'''), contains('1. Remove all constructors or remove "instantiable: false".'));
+      });
+
+      test(
+          'to remove extra constructor when value class has primary constructor',
+          () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value._() implements Built<Value, ValueBuilder> {
+  Value.other();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Remove invalid constructor.'));
+      });
+
+      test('to add constructor when there is synthetic constructor', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make class have exactly one constructor: Value._();'));
+      });
+
+      test('to remove constructor from non-instantiable value class', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+@BuiltValue(instantiable: false)
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value() {}
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Remove all constructors or remove "instantiable: false".'));
+      });
+
+      test('to add factory to value class', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains(
+                '1. Add a factory so your class can be instantiated. Example:\n'
+                '\n'
+                'factory Value([void Function(ValueBuilder)? updates]) = _\$Value;'));
+      });
+
+      test('to remove factory from non-instantiable value class', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+@BuiltValue(instantiable: false)
+abstract class Value implements Built<Value, ValueBuilder> {
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Remove all factories or remove "instantiable: false".'));
+      });
+
+      test('to make builder class abstract', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make builder class abstract'));
+      });
+
+      test('correct Builder type parameters', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Foo, Bar> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains(
+                '1. Make builder class implement Builder<Value, ValueBuilder>. '
+                'Currently: Builder<dynamic, dynamic>'));
+      });
+
+      test('to add constructor to builder class', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Make builder class '
+                'have exactly one constructor: ValueBuilder._();'));
+      });
+
+      test('to fix invalid primary constructor on builder class', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder.other() implements Builder<Value, ValueBuilder> {
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Make builder class '
+                'have exactly one constructor: ValueBuilder._();'));
+      });
+
+      test('to fix primary constructor with parameters on builder class',
+          () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder._(int x) implements Builder<Value, ValueBuilder> {
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Make builder class '
+                'have exactly one constructor: ValueBuilder._();'));
+      });
+
+      test('to fix new constructor with parameters on builder class', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  new _(int x);
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+            contains('1. Make builder class '
+                'have exactly one constructor: ValueBuilder._();'));
+      });
+
+      test('constructor for builder class with synthetic constructor',
+          () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+}'''),
+            contains('1. Make builder class '
+                'have exactly one constructor: ValueBuilder._();'));
+      });
+
+      test('to add factory to builder class', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+}'''),
+            contains('1. Make builder class have exactly one factory: '
+                'factory ValueBuilder() = _\$ValueBuilder;'));
+      });
+
+      test('value fields must be getters', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  int foo;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+  int foo;
+}'''), contains('1. Make field foo a getter.'));
+      });
+
+      test('value fields must be public', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  int get _foo;
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}'''), contains('1. Make field _foo public; remove the underscore.'));
+      });
+
+      test('builder fields must be normal fields or getter/setter pairs',
+          () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  int get foo;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+  int get foo;
+}'''),
+            contains('1. Make builder field foo a normal field or a '
+                'getter/setter pair.'));
+      });
+
+      test('builder field getter/setter pairs must both be abstract or defined',
+          () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  int get foo;
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  int get foo;
+  set foo(int value) {
+    print('hi');
+  }
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Explicit getter/setter pair must both be defined.'));
+      });
+
+      test('builder fields must be in sync', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  int get foo;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), contains('1. Make builder have exactly these fields: foo'));
+      });
+
+      test('builder fields must be same type', () async {
+        expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  int get foo;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+  String foo;
+}'''), contains('1. Make builder field foo have type: int'));
+      });
+
+      test('built_collection fields instead of SDK fields', () async {
+        expect(
+            await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  List get list;
+  Set get set;
+  Map get map;
+}'''),
+            allOf(
+                contains('1. Make field "list" have type "BuiltList". '
+                    'The current type, "List<dynamic>", is not allowed '
+                    'because it is mutable.'),
+                contains('2. Make field "set" have type "BuiltSet". '
+                    'The current type, "Set<dynamic>", is not allowed '
+                    'because it is mutable.')));
+      });
+    });
+
+    test(
+        'allows "extends" with base with abstract and concrete methods '
+        'and concrete getters', () async {
+      expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Foo {
+  int foo();
+  int bar() => 3;
+  int get baz => foo();
+}
+abstract class Value extends Foo implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''), isNot(contains('1.')));
+    });
+
+    test('works with multiple implements', () async {
+      expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder>, Object {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}'''), isNot(contains('1.')));
+    });
+
+    test('allows updates to have return type', () async {
+      expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder>, Object {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}'''), isNot(contains('1.')));
+    });
+
+    test('handles unresolved Built type parameters', () async {
+      expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}'''), isNot(contains('1.')));
+    });
+
+    test('allows code in constructor of value class', () async {
+      expect(
+          await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._() {
+    print("hi");
+  }
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}'''),
+          isNot(contains(
+              '1. Make class have exactly one constructor: Value._();')));
+    });
+
+    test('ignores setters', () async {
+      expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  set foo(int foo) => print(foo);
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+  set foo(int foo) => print(foo);
+}'''), isNot(contains('1.')));
+    });
+
+    test('generates empty constructor with semicolon not braces', () async {
+      final generated = await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+}
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  ValueBuilder._();
+  factory ValueBuilder() = _\$ValueBuilder;
+}
+''');
+      expect(generated, isNot(contains('super._() {}')));
+      expect(generated, contains('super._();'));
+    });
+
+    test('uses toString()', () async {
+      expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  String toString() => 'hi!';
+}'''), isNot(contains('String toString()')));
+    });
+
+    test('comparableBuilders with nestedBuilders', () async {
+      expect(
+          await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+@BuiltValue(comparableBuilders: true)
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  }'''),
+          contains(
+              '1. Set `nestedBuilders: false` in order to use `comparableBuilders: true`.'));
+    });
+
+    test('comparableBuilders with field nestedBuilder', () async {
+      expect(
+          await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+@BuiltValue(comparableBuilders: true, nestedBuilders: false)
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+
+  @BuiltValueField(nestedBuilder: true)
+  NestedValue get nestedValue;
+}
+abstract class NestedValue implements Built<NestedValue, NestedValueBuilder> {
+  NestedValue._();
+  factory NestedValue([void Function(NestedValueBuilder) updates]) = _\$NestedValue;
+}
+'''),
+          contains(
+              '1. Make builder field nestedValue have `nestedBuilder: false` in order to use `comparableBuilders: true`.'));
+    });
+
+    test('uses dynamic for equality check on function fields with generics',
+        () async {
+      expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value<T> implements Built<Value<T>, ValueBuilder<T>> {
+  Value._();
+  factory Value([void Function(ValueBuilder<T>) updates]) = _\$Value<T>;
+  void Function(T) get callback;
+}
+'''), contains(r'final dynamic _$dynamicOther = other;'));
+    });
+
+    test(
+        'does not use dynamic for equality check on function fields without generics',
+        () async {
+      expect(await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class Value implements Built<Value, ValueBuilder> {
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _\$Value;
+  void Function(int) get callback;
+}
+'''), isNot(contains(r'dynamicOther')));
+    });
+
+    test('cleans generated class names for private classes', () async {
+      expect(
+          await generate('''library value;
+import 'package:built_value/built_value.dart';
+part 'value.g.dart';
+abstract class _Value implements Built<_Value, _ValueBuilder> {
+  _Value._();
+  factory _Value([void Function(_ValueBuilder) updates]) = _\$Value;
+}'''),
+          allOf(
+            isNot(contains(r'_$_')),
+            isNot(contains(r'1.')),
+          ));
+    });
+  });
+}
+
+// Test setup.
+
+final String pkgName = 'pkg';
+
+final Builder builder = PartBuilder([BuiltValueGenerator()], '.g.dart');
+
+Future<String> generate(String source) async {
+  var srcs = <String, String>{
+    'built_value|lib/built_value.dart': builtValueSource,
+    '$pkgName|lib/value.dart': source,
+  };
+
+  // Capture any error from generation; if there is one, return that instead of
+  // the generated output.
+  String? error;
+  void captureError(LogRecord logRecord) {
+    if (logRecord.level != Level.SEVERE) return;
+    if (error != null) throw StateError('Expected at most one error.');
+    error = logRecord.message;
+  }
+
+  final result = await testBuilder(builder, srcs,
+      rootPackage: pkgName, onLog: captureError);
+  return error ??
+      result.readerWriter.testing.readString(AssetId(
+          pkgName, '.dart_tool/build/generated/$pkgName/lib/value.g.dart'));
+}
+
+const String builtValueSource = r'''
+library built_value;
+
+const nullable = 'nullable';
+
+abstract class Built<V extends Built<V, B>, B extends Builder<V, B>> {
+  V rebuild(updates(B builder));
+  B toBuilder();
+}
+
+abstract class Builder<V extends Built<V, B>, B extends Builder<V, B>> {
+  void replace(V value);
+  void update(updates(B builder));
+  V build();
+}
+
+class BuiltValue {
+  final bool comparableBuilders;
+  final bool instantiable;
+  final bool nestedBuilders;
+  final String? wireName;
+
+  const BuiltValue({
+      this.comparableBuilders = false,
+      this.instantiable = true,
+      this.nestedBuilders = true,
+      this.wireName});
+}
+
+class BuiltValueField {
+  final bool? compare;
+  final bool? serialize;
+  final String? wireName;
+  final bool? nestedBuilder;
+  final bool? autoCreateNestedBuilder;
+
+  const BuiltValueField(
+      {this.compare,
+      this.serialize,
+      this.wireName,
+      this.nestedBuilder,
+      this.autoCreateNestedBuilder});
+}
+
+class BuiltValueHook {
+  final bool initializeBuilder;
+  final bool finalizeBuilder;
+
+  const BuiltValueHook(
+      {this.initializeBuilder = false,
+      this.finalizeBuilder = false});
+}
+''';

--- a/built_types/built_value_generator/test/enum_class_generator_test.dart
+++ b/built_types/built_value_generator/test/enum_class_generator_test.dart
@@ -1,0 +1,698 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:built_value_generator/built_value_generator.dart';
+import 'package:logging/logging.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+final String correctInput = r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+
+abstract class TestEnumMixin = Object with _$TestEnumMixin;
+''';
+
+final String correctOutput = r'''
+const TestEnum _$yes = const TestEnum._('yes');
+const TestEnum _$no = const TestEnum._('no');
+const TestEnum _$maybe = const TestEnum._('maybe');
+
+TestEnum _$valueOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$yes;
+    case 'no':
+      return _$no;
+    case 'maybe':
+      return _$maybe;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<TestEnum> _$values = BuiltSet<TestEnum>(const <TestEnum>[
+  _$yes,
+  _$no,
+  _$maybe,
+]);
+
+class _$TestEnumMeta {
+  const _$TestEnumMeta();
+  TestEnum get yes => _$yes;
+  TestEnum get no => _$no;
+  TestEnum get maybe => _$maybe;
+  TestEnum valueOf(String name) => _$valueOf(name);
+  BuiltSet<TestEnum> get values => _$values;
+}
+
+abstract class _$TestEnumMixin {
+  // ignore: non_constant_identifier_names
+  _$TestEnumMeta get TestEnum => const _$TestEnumMeta();
+}
+''';
+
+void main() {
+  group('generator', () {
+    group('fails', () {
+      test('on dynamic fields', () async {
+        expect(
+            await generate(correctInput.replaceAll(
+                'class TestEnum extends EnumClass {',
+                'class TestEnum extends EnumClass {\n'
+                    '  static const aNull = null;')),
+            contains(r'''Please make the following changes to use EnumClass:
+
+1. Specify a type for field "aNull".'''));
+      });
+
+      test('with error on missing part statement', () async {
+        expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'src_par.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''), contains(r'''Please make the following changes to use EnumClass:
+
+1. Import generated part: part 'test_enum.g.dart';'''));
+      });
+
+      test('with error on non-const static fields', () async {
+        expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static TestEnum yes = _$yes;
+  static TestEnum no = _$no;
+  static TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''), contains(r'''Please make the following changes to use EnumClass:
+
+1. Make field "yes" const.
+2. Make field "no" const.
+3. Make field "maybe" const.'''));
+      });
+
+      test('with error on non-const non-static fields', () async {
+        expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  TestEnum yes = _$yes;
+  TestEnum no = _$no;
+  TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''), contains(r'''Please make the following changes to use EnumClass:
+
+1. Make field "yes" static const.
+2. Make field "no" static const.
+3. Make field "maybe" static const.'''));
+      });
+
+      test('with error on name clash for field rhs', () async {
+        expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$no;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$yes;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''), contains(r'''Please make the following changes to use EnumClass:
+
+1. Generated identifier "_$no" is used multiple times in test_enum, change to something else.'''));
+      });
+
+      test('with error on name clash for values', () async {
+        expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$no;
+  static const TestEnum no = _$maybe;
+  static const TestEnum maybe = _$yes;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$no;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''), contains(r'''Please make the following changes to use EnumClass:
+
+1. Generated identifier "_$no" is used multiple times in test_enum, change to something else.'''));
+      });
+
+      test('with error on missing constructor', () async {
+        expect(
+            await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''),
+            contains(r'''Please make the following changes to use EnumClass:
+
+1. Have exactly one constructor: const TestEnum._(String name) : super(name); '''
+                'or in Dart>=2.17: const TestEnum._(super.name);'));
+      });
+
+      test('with error on incorrect constructor', () async {
+        expect(
+            await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''),
+            contains(r'''Please make the following changes to use EnumClass:
+
+1. Have exactly one constructor: const TestEnum._(String name) : super(name); '''
+                'or in Dart>=2.17: const TestEnum._(super.name);'));
+      });
+
+      test('with error on primary constructor for EnumClass', () async {
+        expect(
+            await generate(r'''
+// @dart=3.14
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum._(super.name) extends EnumClass {
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''),
+            contains(r'''Please make the following changes to use EnumClass:
+
+1. Have exactly one constructor: const TestEnum._(String name) : super(name); '''
+                'or in Dart>=2.17: const TestEnum._(super.name);'));
+      });
+
+      test('with error on too many constructors', () async {
+        expect(
+            await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+  TestEnum._create(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+
+abstract class BuiltSet<T> {
+}
+'''),
+            contains(r'''Please make the following changes to use EnumClass:
+
+1. Have exactly one constructor: const TestEnum._(String name) : super(name); '''
+                'or in Dart>=2.17: const TestEnum._(super.name);'));
+      });
+
+      test('with error on missing values getter', () async {
+        expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''), contains(r'''Please make the following changes to use EnumClass:
+
+1. Add getter: static BuiltSet<TestEnum> get values => _$values'''));
+      });
+
+      test('with error on missing valueOf', () async {
+        expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+}
+'''), contains(r'''Please make the following changes to use EnumClass:
+
+1. Add method: static TestEnum valueOf(String name) => _$valueOf(name)'''));
+      });
+
+      test('with error on abstract class', () async {
+        expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+abstract class TestEnum extends EnumClass {
+  static const TestEnum yes = _$yes;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''), contains(r'''Please make the following changes to use EnumClass:
+
+1. Make TestEnum concrete; remove "abstract".'''));
+      });
+
+      test('if there is more than one fallback field', () async {
+        expect(
+            await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  @BuiltValueEnumConst(fallback: true)
+  static const TestEnum yes = _$yes;
+  @BuiltValueEnumConst(fallback: true)
+  static const TestEnum no = _$no;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''),
+            contains(r'''Please make the following changes to use EnumClass:
+
+1. Remove `fallback = true` so that at most one constant is the fallback.'''
+                ' Currently on "TestEnum" fields "yes", "no".'));
+      });
+
+      test('if both `wireName` and `wireNumber` are used', () async {
+        expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  @BuiltValueEnumConst(wireName: 'yes', wireNumber: 1)
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''), contains(r'''Please make the following changes to use EnumClass:
+
+1. Specify either `wireName` or `wireNumber`, not both, on field "yes".'''));
+      });
+    });
+
+    test('produces correct output for correct input', () async {
+      expect(await generate(correctInput), contains(correctOutput));
+    });
+
+    test('produces two correct output for two correct inputs', () async {
+      expect(
+          await generateTwo(correctInput,
+              correctInput.replaceAll('test_enum', 'test_enum_two')),
+          contains(correctOutput.replaceAll('test_enum', 'test_enum_two')));
+    });
+
+    test('allows part statement with double quotes', () async {
+      expect(
+          await generate(correctInput.replaceAll(
+              "part 'test_enum.g.dart'", 'part "test_enum.g.dart"')),
+          contains(correctOutput));
+    });
+
+    test('allows new constructor naming syntax with string parameter',
+        () async {
+      expect(
+          await generate('// @dart=3.14\n' +
+              correctInput.replaceAll(
+                  'const TestEnum._(String name) : super(name);',
+                  'const new _(String name) : super(name);')),
+          contains(correctOutput.replaceFirst(
+              'abstract class _\$TestEnumMixin', 'mixin _\$TestEnumMixin')));
+    });
+
+    test('ignores fields of different type', () async {
+      expect(
+          await generate(correctInput.replaceAll(
+              'class TestEnum extends EnumClass {',
+              'class TestEnum extends EnumClass {\n'
+                  '  static const int anInt = 3;')),
+          contains(correctOutput));
+    });
+
+    test('ignores static const fields of wrong type', () async {
+      expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const int count = 0;
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+
+abstract class TestEnumMixin = Object with _$TestEnumMixin;
+'''), contains(correctOutput));
+    });
+
+    test('matches generated names to rhs for field names', () async {
+      expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$no;
+  static const TestEnum no = _$maybe;
+  static const TestEnum maybe = _$yes;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+'''), contains(r'''
+const TestEnum _$no = const TestEnum._('yes');
+const TestEnum _$maybe = const TestEnum._('no');
+const TestEnum _$yes = const TestEnum._('maybe');
+
+TestEnum _$valueOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$no;
+    case 'no':
+      return _$maybe;
+    case 'maybe':
+      return _$yes;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<TestEnum> _$values = BuiltSet<TestEnum>(const <TestEnum>[
+  _$no,
+  _$maybe,
+  _$yes,
+]);
+'''));
+    });
+
+    test('matches generated names to values and valueOf', () async {
+      expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$vls;
+  static TestEnum valueOf(String name) => _$vlOf(name);
+}
+'''), contains(r'''
+const TestEnum _$yes = const TestEnum._('yes');
+const TestEnum _$no = const TestEnum._('no');
+const TestEnum _$maybe = const TestEnum._('maybe');
+
+TestEnum _$vlOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$yes;
+    case 'no':
+      return _$no;
+    case 'maybe':
+      return _$maybe;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<TestEnum> _$vls = BuiltSet<TestEnum>(const <TestEnum>[
+  _$yes,
+  _$no,
+  _$maybe,
+]);
+'''));
+    });
+
+    test('does not fail with clash across multiple files', () async {
+      expect(
+          await generateTwo(correctInput,
+              correctInput.replaceAll('test_enum', 'test_enum_two')),
+          contains(correctOutput.replaceAll('test_enum', 'test_enum_two')));
+    });
+
+    test('does not report name clash on null', () async {
+      expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$no;
+  static const TestEnum no = _$maybe;
+  static const TestEnum maybe = _$yes;
+
+  const TestEnum._(String name) : super(name);
+}
+'''), isNot(contains('null')));
+    });
+
+    test('is robust to newlines in input', () async {
+      expect(await generate(r'''
+library test_enum;
+
+import 'package:built_value/built_value.dart';
+
+part 'test_enum.g.dart';
+
+class TestEnum extends EnumClass {
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name)
+      : super(name);
+
+  static BuiltSet<TestEnum> get values =>
+      _$values;
+  static TestEnum valueOf(String name) =>
+      _$valueOf(name);
+}
+
+abstract class TestEnumMixin = Object with _$TestEnumMixin;
+'''), contains(correctOutput));
+    });
+  });
+}
+
+// Test setup.
+
+final String pkgName = 'pkg';
+
+// Recreate BuiltValueGenerator for each test because we repeatedly create
+// enums with the same name in the same library, which will clash.
+Builder get builder => PartBuilder([BuiltValueGenerator()], '.g.dart');
+
+Future<String> generate(String source) async {
+  final srcs = <String, String>{
+    'built_value|lib/built_value.dart': builtValueSource,
+    '$pkgName|lib/test_enum.dart':
+        source.startsWith('// @dart') ? source : '// @dart=2.19\n$source',
+  };
+
+  // Capture any error from generation; if there is one, return that instead of
+  // the generated output.
+  String? error;
+  void captureError(LogRecord logRecord) {
+    if (logRecord.level != Level.SEVERE) return;
+    if (error != null) throw StateError('Expected at most one error.');
+    error = logRecord.message;
+  }
+
+  final result = await testBuilder(builder, srcs,
+      rootPackage: pkgName, onLog: captureError);
+  return error ??
+      result.readerWriter.testing.readString(AssetId(
+          pkgName, '.dart_tool/build/generated/$pkgName/lib/test_enum.g.dart'));
+}
+
+Future<String> generateTwo(String source, String source2) async {
+  final srcs = {
+    'built_value|lib/built_value.dart': builtValueSource,
+    '$pkgName|lib/test_enum.dart': '// @dart=2.19\n$source',
+    '$pkgName|lib/test_enum_two.dart': '// @dart=2.19\n$source2',
+  };
+
+  final result = await testBuilder(builder, srcs, rootPackage: pkgName);
+  return result.readerWriter.testing.readString(AssetId(pkgName,
+          '.dart_tool/build/generated/$pkgName/lib/test_enum.g.dart')) +
+      result.readerWriter.testing.readString(AssetId(pkgName,
+          '.dart_tool/build/generated/$pkgName/lib/test_enum_two.g.dart'));
+}
+
+const String builtValueSource = r'''
+library built_value;
+
+class EnumClass {
+  final String name;
+
+  const EnumClass(this.name);
+
+  @override
+  String toString() => name;
+}
+
+class BuiltValueEnumConst {
+  final String? wireName;
+  final int? wireNumber;
+  final bool fallback;
+
+  const BuiltValueEnumConst({
+      this.wireName,
+      this.wireNumber,
+      this.fallback = false});
+}
+''';

--- a/built_types/built_value_generator/test/serializer_generator_test.dart
+++ b/built_types/built_value_generator/test/serializer_generator_test.dart
@@ -1,0 +1,315 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:built_value_generator/built_value_generator.dart';
+import 'package:logging/logging.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('generator', () {
+    test('ignores empty library', () async {
+      expect(await generate('library value;'), isEmpty);
+    });
+
+    test('ignores normal class', () async {
+      expect(await generate(r'''
+library value;
+
+class EmptyClass {}
+'''), isEmpty);
+    });
+
+    test('ignores built_value class without serializer', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {}
+'''), isNot(contains('implements StructuredSerializer<Value>')));
+    });
+
+    test('generates for built_value class with serializer', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+part 'value.g.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static Serializer<Value> get serializer => _$valueSerializer;
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _$Value;
+}
+'''), contains('implements StructuredSerializer<Value>'));
+    });
+
+    test('ignores EnumClass without serializer', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+class Enum extends EnumClass {}
+'''), isNot(contains('Serializer<Enum>')));
+    });
+
+    test('generates for EnumClass with serializer', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+class Enum extends EnumClass {
+  static Serializer<Enum> get serializer => _$serializer;
+}
+'''), isNotEmpty);
+    });
+
+    test('does not generate for serializers without annotation', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+final Serializers serializers = _$serializers;
+'''), isEmpty);
+    });
+
+    test('generates for serializers with annotation', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+part 'value.g.dart';
+
+@SerializersFor(const [Value])
+final Serializers serializers = _$serializers;
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static Serializer<Value> get serializer => _$valueSerializer;
+  bool get aBool;
+
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _$Value;
+}
+'''), contains(r'_$serializers'));
+    });
+
+    test('errors on annotation on wrong declaration', () async {
+      expect(
+          await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+part 'value.g.dart';
+
+@SerializersFor(const [Value])
+final serializers = _$serializers;
+
+@SerializersFor(const [Value])
+final int moreSerializers = _$moreSerializers;
+
+@SerializersFor(const [Value])
+final Serializers correctSerializers = _$correctSerializers;
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static Serializer<Value> get serializer => _$valueSerializer;
+  bool get aBool;
+
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _$Value;
+}
+'''),
+          contains(
+              r'1. These top level getters are annotated @SerializersFor but '
+              'do not have the required type Serializers, please fix the type '
+              'or remove the annotation: serializers, moreSerializers'));
+    });
+
+    test('does not crash for incorrect builder getter', () async {
+      expect(
+          await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+part 'value.g.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static Serializer<Value> get serializer => _$valueSerializer;
+  bool get aBool;
+
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _$Value;
+}
+
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {
+  set aBool(bool aBool);
+
+  ValueBuilder._();
+  factory ValueBuilder() = _$ValueBuilder;
+}
+'''),
+          contains(
+              'Make builder field aBool a normal field or a getter/setter pair.'));
+    });
+
+    test('checks serializer declarations use correct values', () async {
+      expect(
+          await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+part 'value.g.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static Serializer<Value> get serializer => _$valueSerializer;
+  bool get aBool;
+
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _$Value;
+}
+
+abstract class OtherValue implements Built<OtherValue, OtherValueBuilder> {
+  static Serializer<Value> get serializer => _$serializer;
+  bool get aBool;
+
+  OtherValue._();
+  factory OtherValue([void Function(OtherValueBuilder) updates]) = _$OtherValue;
+}
+'''),
+          contains(r'1. Declare OtherValue.serializer as: '
+              'static Serializer<OtherValue> get serializer => '
+              '_\$otherValueSerializer;'));
+    });
+
+    test('suggests Function fields be marked not serializable', () async {
+      expect(
+          await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+part 'value.g.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static Serializer<Value> get serializer => _$valueSerializer;
+  Function() get function;
+
+  factory Value() => _$Value();
+  Value._();
+}
+'''),
+          contains(r'1. Function fields are not serializable. Remove '
+              '"function" or mark it "@BuiltValueField(serialize: false)".'));
+    });
+
+    test('cannot generate serializer for private classes', () async {
+      expect(await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+part 'value.g.dart';
+
+abstract class _Value implements Built<_Value, _ValueBuilder> {
+  static Serializer<_Value> get serializer => _$valueSerializer;
+  bool get aBool;
+
+  _Value._();
+  factory _Value([void Function(ValueBuilder) updates]) = _$Value;
+}
+'''), contains(r'1. Cannot generate serializers for private class _Value'));
+    });
+
+    test('cannot generate serializer if there are record fields', () async {
+      expect(
+          await generate(r'''
+library value;
+
+import 'package:test_support/test_support.dart';
+
+part 'value.g.dart';
+
+abstract class Value implements Built<Value, ValueBuilder> {
+  static Serializer<Value> get serializer => _$valueSerializer;
+  (int, int) get record;
+
+  Value._();
+  factory Value([void Function(ValueBuilder) updates]) = _$Value;
+}
+'''),
+          contains(r'1. Fields declared with record types are not '
+              'automatically serializable. '
+              'To allow the class to be serialized, modify "record" by'));
+    });
+  });
+}
+
+// Test setup.
+
+final String pkgName = 'pkg';
+
+final Builder builder = PartBuilder([BuiltValueGenerator()], '.g.dart');
+
+Future<String> generate(String source) async {
+  var srcs = <String, String>{
+    'test_support|lib/test_support.dart': testSupportSource,
+    '$pkgName|lib/value.dart': source,
+  };
+
+  // Capture any error from generation; if there is one, return that instead of
+  // the generated output.
+  String? error;
+  void captureError(LogRecord logRecord) {
+    if (logRecord.level != Level.SEVERE) return;
+    if (error != null) throw StateError('Expected at most one error.');
+    error = logRecord.message;
+  }
+
+  final id =
+      AssetId(pkgName, '.dart_tool/build/generated/$pkgName/lib/value.g.dart');
+  final result = await testBuilder(builder, srcs,
+      rootPackage: pkgName, onLog: captureError);
+  return error ??
+      (result.readerWriter.testing.exists(id)
+          ? result.readerWriter.testing.readString(id)
+          : '');
+}
+
+// Classes mentioned in the test input need to exist, but we don't need the
+// real versions. So just use minimal ones.
+const String testSupportSource = r'''
+const String nullable = 'nullable';
+
+class Built<V, B> {}
+
+class Builder<V, B> {}
+
+class BuiltList<E> {}
+
+class BuiltMap<K, V> {}
+
+class EnumClass {}
+
+class SerializersFor {
+  final List<Type> types;
+
+  const SerializersFor(this.types);
+}
+
+class Serializer<T> {}
+
+class Serializers {}
+''';

--- a/built_types/built_value_test/LICENSE
+++ b/built_types/built_value_test/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2017, Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/built_types/built_value_test/analysis_options.yaml
+++ b/built_types/built_value_test/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/built_types/built_value_test/lib/matcher.dart
+++ b/built_types/built_value_test/lib/matcher.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:matcher/matcher.dart';
+
+/// Returns a matcher that matches if the value is structurally equal to
+/// [expected].
+///
+/// Improves on a simple equality test by offering a detailed mismatch message.
+Matcher equalsBuilt(Built expected) => _BuiltValueMatcher(expected);
+
+/// Matcher for [Built] instances.
+///
+/// Converts instances to maps using [_CapturingToStringHelper] then compares
+/// using [equals], which does deep comparison on maps.
+class _BuiltValueMatcher implements Matcher {
+  final Built _expected;
+  final Matcher _delegate;
+
+  _BuiltValueMatcher(this._expected) : _delegate = equals(_toMap(_expected));
+
+  @override
+  Description describe(Description description) =>
+      _delegate.describe(description);
+
+  @override
+  Description describeMismatch(dynamic item, Description mismatchDescription,
+      Map matchState, bool verbose) {
+    if (_expected.runtimeType != item.runtimeType) {
+      return mismatchDescription.add('is the wrong type');
+    }
+
+    return _delegate.describeMismatch(
+        _toMap(item), mismatchDescription, matchState, verbose);
+  }
+
+  @override
+  bool matches(dynamic item, Map matchState) {
+    if (_expected.runtimeType != item.runtimeType) return false;
+
+    return _delegate.matches(_toMap(item), matchState);
+  }
+}
+
+/// Converts a Built to a map.
+Map<String, Object?> _toMap(Object? built) {
+  // Save the current newBuiltValueToStringHelper so we can restore it on
+  // return.
+  final previousNewBuiltValueToStringHelper = newBuiltValueToStringHelper;
+
+  // Create a ToStringHelper that will capture values instead of converting
+  // them to String.
+  final capturingToStringHelper = _CapturingToStringHelper();
+  newBuiltValueToStringHelper = (String className) {
+    // Store the class name in the map, so we check types as well as fields
+    // and values.
+    capturingToStringHelper.map[r'$class'] = className;
+    return capturingToStringHelper;
+  };
+
+  // Call toString() on the value to do capture.
+  built.toString();
+
+  // Reset to what it was on method entry.
+  newBuiltValueToStringHelper = previousNewBuiltValueToStringHelper;
+
+  return capturingToStringHelper.map;
+}
+
+/// Captures values in a Map instead of converting to a String.
+class _CapturingToStringHelper implements BuiltValueToStringHelper {
+  final Map<String, Object?> map = <String, Object?>{};
+
+  @override
+  void add(String field, Object? value) {
+    if (value is Built) {
+      map[field] = _toMap(value);
+    } else if (value is BuiltList) {
+      map[field] = value.asList();
+    } else if (value is BuiltListMultimap) {
+      map[field] = value.asMap();
+    } else if (value is BuiltMap) {
+      map[field] = value.asMap();
+    } else if (value is BuiltSet) {
+      map[field] = value.asSet();
+    } else if (value is BuiltSetMultimap) {
+      map[field] = value.asMap();
+    } else {
+      map[field] = value;
+    }
+  }
+}

--- a/built_types/built_value_test/pubspec.yaml
+++ b/built_types/built_value_test/pubspec.yaml
@@ -1,0 +1,27 @@
+name: built_value_test
+version: 8.13.0
+description: >
+  Value types with builders, Dart classes as enums, and serialization.
+  This library provides test support.
+repository: https://github.com/google/built_value.dart/tree/master/built_value_test
+topics:
+ - testing
+ - built-value
+ - codegen
+ - build-runner
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  built_value: ^8.7.0
+  built_collection: ^5.0.0
+  collection: ^1.0.0
+  matcher: ^0.12.0
+  quiver: '>=0.21.0 <4.0.0'
+
+dev_dependencies:
+  built_value_generator: ^8.13.0
+  build_runner: '>=1.0.0 <3.0.0'
+  pedantic: ^1.4.0
+  test: ^1.0.0

--- a/built_types/built_value_test/test/matcher_test.dart
+++ b/built_types/built_value_test/test/matcher_test.dart
@@ -1,0 +1,142 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value_test/matcher.dart';
+import 'package:test/test.dart';
+
+import 'values.dart';
+
+void main() {
+  group('built_value matcher', () {
+    test('matches if same', () {
+      final value = CompoundValue((b) => b
+        ..simpleValue.anInt = 3
+        ..string = 'str');
+
+      expect(value, equalsBuilt(value));
+    });
+
+    test('reports if not same', () {
+      final value = CompoundValue((b) => b
+        ..simpleValue.anInt = 3
+        ..string = 'str');
+      final otherValue = value.rebuild((b) => b..simpleValue.anInt = 5);
+
+      _expectMismatch(value, otherValue,
+          "at location ['simpleValue']['anInt'] is <3> instead of <5>");
+    });
+
+    test('reports deep match on lists if not same', () {
+      final value = CompoundValue((b) => b
+        ..simpleValue.anInt = 3
+        ..simpleValue.list.add('foo')
+        ..string = 'str');
+      final otherValue = value.rebuild((b) => b..simpleValue.list.add('bar'));
+
+      _expectMismatch(value, otherValue, 'shorter than expected');
+      _expectMismatch(value, otherValue, "['simpleValue']['list'][1]");
+    });
+
+    test('reports deep match on list multimaps if not same', () {
+      final value = CompoundValue((b) => b
+        ..simpleValue.anInt = 3
+        ..simpleValue.multimap.add(42, true)
+        ..string = 'str');
+      final otherValue =
+          value.rebuild((b) => b..simpleValue.multimap.add(42, false));
+
+      _expectMismatch(
+          value, otherValue, " ['simpleValue']['multimap']['42'][1]");
+      _expectMismatch(value, otherValue, 'shorter than expected');
+    });
+
+    test('reports deep match on maps if not same', () {
+      final value = CompoundValue((b) => b
+        ..simpleValue.anInt = 3
+        ..simpleValue.map['foo'] = 3
+        ..simpleValue.map['bar'] = 4
+        ..string = 'str');
+      final otherValue = value.rebuild((b) => b..simpleValue.map['bar'] = 5);
+
+      _expectMismatch(value, otherValue,
+          "at location ['simpleValue']['map']['bar'] is <4> instead of <5>");
+    });
+
+    test('reports deep match on sets if not same', () {
+      final value = CompoundValue((b) => b
+        ..simpleValue.anInt = 3
+        ..simpleValue.aSet.add(42)
+        ..string = 'str');
+      final otherValue = value.rebuild((b) => b..simpleValue.aSet.remove(42));
+
+      _expectMismatch(value, otherValue, "['simpleValue']['aSet']");
+      _expectMismatch(value, otherValue, 'larger than expected');
+    });
+
+    test('reports deep match on set multimaps if not same', () {
+      final value = CompoundValue((b) => b
+        ..simpleValue.anInt = 3
+        ..simpleValue.setMultimap.add(42, true)
+        ..string = 'str');
+      final otherValue =
+          value.rebuild((b) => b..simpleValue.setMultimap.add(42, false));
+
+      _expectMismatch(
+          value, otherValue, "['simpleValue']['setMultimap']['42'][1]");
+      _expectMismatch(value, otherValue, 'shorter than expected');
+    });
+
+    test('reports if the wrong type', () {
+      final value = 42;
+      final otherValue = CompoundValue((b) => b..simpleValue.anInt = 5);
+
+      _expectMismatch(value, otherValue, 'is the wrong type');
+    });
+
+    test('compared value matcher', () {
+      final value = ComparedValue((b) => b
+        ..name = 'foo'
+        ..onChanged = () => 'Change happened!');
+      final otherValue = ComparedValue((b) => b
+        ..name = 'foo'
+        ..onChanged = () => 'Change happened!');
+
+      expect(value, otherValue);
+    });
+
+    test('compared value matcher with different onChanged outcomes', () {
+      final value = ComparedValue((b) => b
+        ..name = 'foo'
+        ..onChanged = () => 'Change happened!');
+      final otherValue = ComparedValue((b) => b
+        ..name = 'foo'
+        ..onChanged = () => 'Change did not happen!');
+
+      expect(value, otherValue);
+    });
+
+    test('compared value matcher with different names', () {
+      final value = ComparedValue((b) => b
+        ..name = 'foo'
+        ..onChanged = () => 'Change happened!');
+      final otherValue = ComparedValue((b) => b
+        ..name = 'bar'
+        ..onChanged = () => 'Change did not happen!');
+
+      _expectMismatch(value, otherValue, 'is \'foo\' instead of \'bar\'');
+    });
+  });
+}
+
+void _expectMismatch(
+    Object value, Built otherValue, String expectedMismatchMessage) {
+  try {
+    expect(value, equalsBuilt(otherValue));
+  } catch (exception) {
+    expect(exception.toString(), contains(expectedMismatchMessage));
+    return;
+  }
+  throw StateError('Expected mismatch.');
+}

--- a/built_types/built_value_test/test/values.dart
+++ b/built_types/built_value_test/test/values.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library values;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+
+part 'values.g.dart';
+
+abstract class SimpleValue implements Built<SimpleValue, SimpleValueBuilder> {
+  int get anInt;
+  BuiltList<String> get list;
+  BuiltListMultimap<int, bool> get multimap;
+  BuiltMap<String, int> get map;
+  BuiltSet<int> get aSet;
+  BuiltSetMultimap<int, bool> get setMultimap;
+
+  factory SimpleValue([Function(SimpleValueBuilder) updates]) = _$SimpleValue;
+  SimpleValue._();
+}
+
+abstract class CompoundValue
+    implements Built<CompoundValue, CompoundValueBuilder> {
+  SimpleValue get simpleValue;
+  String? get string;
+
+  factory CompoundValue([Function(CompoundValueBuilder) updates]) =
+      _$CompoundValue;
+  CompoundValue._();
+}
+
+abstract class ComparedValue
+    implements Built<ComparedValue, ComparedValueBuilder> {
+  String get name;
+
+  @BuiltValueField(compare: false)
+  Function get onChanged;
+
+  factory ComparedValue([Function(ComparedValueBuilder) updates]) =
+      _$ComparedValue;
+  ComparedValue._();
+}

--- a/built_types/built_value_test/test/values.g.dart
+++ b/built_types/built_value_test/test/values.g.dart
@@ -1,0 +1,372 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'values.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$SimpleValue extends SimpleValue {
+  @override
+  final int anInt;
+  @override
+  final BuiltList<String> list;
+  @override
+  final BuiltListMultimap<int, bool> multimap;
+  @override
+  final BuiltMap<String, int> map;
+  @override
+  final BuiltSet<int> aSet;
+  @override
+  final BuiltSetMultimap<int, bool> setMultimap;
+
+  factory _$SimpleValue([void Function(SimpleValueBuilder)? updates]) =>
+      (SimpleValueBuilder()..update(updates))._build();
+
+  _$SimpleValue._(
+      {required this.anInt,
+      required this.list,
+      required this.multimap,
+      required this.map,
+      required this.aSet,
+      required this.setMultimap})
+      : super._();
+  @override
+  SimpleValue rebuild(void Function(SimpleValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SimpleValueBuilder toBuilder() => SimpleValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SimpleValue &&
+        anInt == other.anInt &&
+        list == other.list &&
+        multimap == other.multimap &&
+        map == other.map &&
+        aSet == other.aSet &&
+        setMultimap == other.setMultimap;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, list.hashCode);
+    _$hash = $jc(_$hash, multimap.hashCode);
+    _$hash = $jc(_$hash, map.hashCode);
+    _$hash = $jc(_$hash, aSet.hashCode);
+    _$hash = $jc(_$hash, setMultimap.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SimpleValue')
+          ..add('anInt', anInt)
+          ..add('list', list)
+          ..add('multimap', multimap)
+          ..add('map', map)
+          ..add('aSet', aSet)
+          ..add('setMultimap', setMultimap))
+        .toString();
+  }
+}
+
+class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
+  _$SimpleValue? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  ListBuilder<String>? _list;
+  ListBuilder<String> get list => _$this._list ??= ListBuilder<String>();
+  set list(ListBuilder<String>? list) => _$this._list = list;
+
+  ListMultimapBuilder<int, bool>? _multimap;
+  ListMultimapBuilder<int, bool> get multimap =>
+      _$this._multimap ??= ListMultimapBuilder<int, bool>();
+  set multimap(ListMultimapBuilder<int, bool>? multimap) =>
+      _$this._multimap = multimap;
+
+  MapBuilder<String, int>? _map;
+  MapBuilder<String, int> get map => _$this._map ??= MapBuilder<String, int>();
+  set map(MapBuilder<String, int>? map) => _$this._map = map;
+
+  SetBuilder<int>? _aSet;
+  SetBuilder<int> get aSet => _$this._aSet ??= SetBuilder<int>();
+  set aSet(SetBuilder<int>? aSet) => _$this._aSet = aSet;
+
+  SetMultimapBuilder<int, bool>? _setMultimap;
+  SetMultimapBuilder<int, bool> get setMultimap =>
+      _$this._setMultimap ??= SetMultimapBuilder<int, bool>();
+  set setMultimap(SetMultimapBuilder<int, bool>? setMultimap) =>
+      _$this._setMultimap = setMultimap;
+
+  SimpleValueBuilder();
+
+  SimpleValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _list = $v.list.toBuilder();
+      _multimap = $v.multimap.toBuilder();
+      _map = $v.map.toBuilder();
+      _aSet = $v.aSet.toBuilder();
+      _setMultimap = $v.setMultimap.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SimpleValue other) {
+    _$v = other as _$SimpleValue;
+  }
+
+  @override
+  void update(void Function(SimpleValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SimpleValue build() => _build();
+
+  _$SimpleValue _build() {
+    _$SimpleValue _$result;
+    try {
+      _$result = _$v ??
+          _$SimpleValue._(
+            anInt: BuiltValueNullFieldError.checkNotNull(
+                anInt, r'SimpleValue', 'anInt'),
+            list: list.build(),
+            multimap: multimap.build(),
+            map: map.build(),
+            aSet: aSet.build(),
+            setMultimap: setMultimap.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'list';
+        list.build();
+        _$failedField = 'multimap';
+        multimap.build();
+        _$failedField = 'map';
+        map.build();
+        _$failedField = 'aSet';
+        aSet.build();
+        _$failedField = 'setMultimap';
+        setMultimap.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'SimpleValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CompoundValue extends CompoundValue {
+  @override
+  final SimpleValue simpleValue;
+  @override
+  final String? string;
+
+  factory _$CompoundValue([void Function(CompoundValueBuilder)? updates]) =>
+      (CompoundValueBuilder()..update(updates))._build();
+
+  _$CompoundValue._({required this.simpleValue, this.string}) : super._();
+  @override
+  CompoundValue rebuild(void Function(CompoundValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CompoundValueBuilder toBuilder() => CompoundValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValue &&
+        simpleValue == other.simpleValue &&
+        string == other.string;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, string.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CompoundValue')
+          ..add('simpleValue', simpleValue)
+          ..add('string', string))
+        .toString();
+  }
+}
+
+class CompoundValueBuilder
+    implements Builder<CompoundValue, CompoundValueBuilder> {
+  _$CompoundValue? _$v;
+
+  SimpleValueBuilder? _simpleValue;
+  SimpleValueBuilder get simpleValue =>
+      _$this._simpleValue ??= SimpleValueBuilder();
+  set simpleValue(SimpleValueBuilder? simpleValue) =>
+      _$this._simpleValue = simpleValue;
+
+  String? _string;
+  String? get string => _$this._string;
+  set string(String? string) => _$this._string = string;
+
+  CompoundValueBuilder();
+
+  CompoundValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _simpleValue = $v.simpleValue.toBuilder();
+      _string = $v.string;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValue other) {
+    _$v = other as _$CompoundValue;
+  }
+
+  @override
+  void update(void Function(CompoundValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValue build() => _build();
+
+  _$CompoundValue _build() {
+    _$CompoundValue _$result;
+    try {
+      _$result = _$v ??
+          _$CompoundValue._(
+            simpleValue: simpleValue.build(),
+            string: string,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        simpleValue.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'CompoundValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ComparedValue extends ComparedValue {
+  @override
+  final String name;
+  @override
+  final Function onChanged;
+
+  factory _$ComparedValue([void Function(ComparedValueBuilder)? updates]) =>
+      (ComparedValueBuilder()..update(updates))._build();
+
+  _$ComparedValue._({required this.name, required this.onChanged}) : super._();
+  @override
+  ComparedValue rebuild(void Function(ComparedValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ComparedValueBuilder toBuilder() => ComparedValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ComparedValue && name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ComparedValue')
+          ..add('name', name)
+          ..add('onChanged', onChanged))
+        .toString();
+  }
+}
+
+class ComparedValueBuilder
+    implements Builder<ComparedValue, ComparedValueBuilder> {
+  _$ComparedValue? _$v;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  Function? _onChanged;
+  Function? get onChanged => _$this._onChanged;
+  set onChanged(Function? onChanged) => _$this._onChanged = onChanged;
+
+  ComparedValueBuilder();
+
+  ComparedValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _name = $v.name;
+      _onChanged = $v.onChanged;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ComparedValue other) {
+    _$v = other as _$ComparedValue;
+  }
+
+  @override
+  void update(void Function(ComparedValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ComparedValue build() => _build();
+
+  _$ComparedValue _build() {
+    final _$result = _$v ??
+        _$ComparedValue._(
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'ComparedValue', 'name'),
+          onChanged: BuiltValueNullFieldError.checkNotNull(
+              onChanged, r'ComparedValue', 'onChanged'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/chat_example/README.md
+++ b/built_types/chat_example/README.md
@@ -1,0 +1,18 @@
+# built_value chat example
+
+A simple chat client (dart2js) and server (Dart VM).
+
+Launch pub serve and the server, in separate terminals:
+
+`pub serve`
+
+`dart bin/main.dart`
+
+You can now load the app in Dartium or any modern browser at
+http://localhost:26199.
+
+When developing, run
+
+`dart tool/watch.dart`
+
+to continuously update generated source.

--- a/built_types/chat_example/README.md
+++ b/built_types/chat_example/README.md
@@ -9,7 +9,7 @@ Launch pub serve and the server, in separate terminals:
 `dart bin/main.dart`
 
 You can now load the app in Dartium or any modern browser at
-http://localhost:26199.
+`http://localhost:26199`.
 
 When developing, run
 

--- a/built_types/chat_example/analysis_options.yaml
+++ b/built_types/chat_example/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/built_types/chat_example/bin/main.dart
+++ b/built_types/chat_example/bin/main.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:chat_example/server/http_server_connection.dart';
+import 'package:chat_example/server/resource_server.dart';
+import 'package:chat_example/server/server.dart';
+
+void main() {
+  final server = Server();
+  ResourceServer().start(
+      (webSocket) => server.addConnection(HttpServerConnection(webSocket)));
+}

--- a/built_types/chat_example/lib/client/client.dart
+++ b/built_types/chat_example/lib/client/client.dart
@@ -1,0 +1,127 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:chat_example/client/client_connection.dart';
+import 'package:chat_example/client/display.dart';
+import 'package:chat_example/data_model/data_model.dart';
+import 'package:chat_example/data_model/serializers.dart';
+
+typedef CommandRunner = void Function(String command);
+
+/// Client-side logic for built_value chat example.
+class Client {
+  final Stream<String> _keyboardInput;
+  final Display _display;
+  final ClientConnection _connection;
+
+  /// A chat client needs a keyboard, a display and a connection.
+  Client(this._keyboardInput, this._display, this._connection) {
+    _keyboardInput.listen(_runLocalCommand);
+    _connection.dataFromServer.listen(_handleServerData);
+  }
+
+  void _handleServerData(String data) {
+    final response = serializers.deserialize(json.decode(data));
+
+    if (response is Response) {
+      _display.add(response.render());
+    } else {
+      throw StateError('Invalid data from server: $response');
+    }
+  }
+
+  void _runLocalCommand(String command) {
+    final handlers = <String, CommandRunner>{
+      '/away': _runAway,
+      '/help': _runHelp,
+      '/list': _runList,
+      '/login': _runLogin,
+      '/quit': _runQuit,
+      '/status': _runStatus,
+      '/tell': _runTell,
+    };
+
+    var found = false;
+    handlers.forEach((prefix, commandRunner) {
+      if (command.startsWith(prefix)) {
+        commandRunner(command);
+        found = true;
+      }
+    });
+    if (found) return;
+
+    if (command.startsWith('/')) {
+      _display.addLocal(command);
+      _display.add('Unknown command.');
+      return;
+    }
+
+    _send(Chat((b) => b..text = command));
+  }
+
+  void _runAway(String command) {
+    _display.addLocal(command);
+    _send(Status((b) => b
+      ..message = command.substring('/away '.length)
+      ..type = StatusType.away));
+  }
+
+  void _runHelp(String command) {
+    _display.addLocal(command);
+    _display.addLocal('''Commands:
+
+/away <message> -- sets away message
+/help -- for help
+/list -- list online users
+/login <username> <password> -- log in or create new user
+/quit <message> -- quits with message
+/status <message> -- sets status message
+/tell <username> <message> -- private message
+''');
+  }
+
+  void _runList(String command) {
+    _display.addLocal(command);
+    _send(ListUsers(
+        (b) => b..statusTypes.replace([StatusType.online, StatusType.away])));
+  }
+
+  void _runLogin(String command) {
+    final words = command.split(' ');
+    _display.addLocal('/login ${words[1]} ********');
+    _send(Login((b) => b
+      ..username = words[1]
+      ..password = words[2]));
+  }
+
+  void _runQuit(String command) {
+    _display.addLocal(command);
+    _send(Status((b) => b
+      ..message = command.substring('/quit '.length)
+      ..type = StatusType.offline));
+  }
+
+  void _runStatus(String command) {
+    _display.addLocal(command);
+    _send(Status((b) => b
+      ..message = command.substring('/status '.length)
+      ..type = StatusType.online));
+  }
+
+  void _runTell(String command) {
+    _display.addLocal(command);
+    final words = command.split(' ');
+    final targets = words[1].split(',');
+    _send(Chat((b) => b
+      ..text = words.sublist(2).join(' ')
+      ..targets.replace(targets)));
+  }
+
+  void _send(Command command) {
+    _connection.sendToServer(json.encode(serializers.serialize(command)));
+  }
+}

--- a/built_types/chat_example/lib/client/client_connection.dart
+++ b/built_types/chat_example/lib/client/client_connection.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+/// Two-way connection between client and server; the client.
+abstract class ClientConnection {
+  Stream<String> get dataFromServer;
+
+  void sendToServer(String string);
+}

--- a/built_types/chat_example/lib/client/display.dart
+++ b/built_types/chat_example/lib/client/display.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/// Chat window main text display.
+abstract class Display {
+  /// Adds [text] to the display, coloured to indicate a local command.
+  void addLocal(String text);
+
+  /// Adds [text] to the display.
+  void add(String text);
+}

--- a/built_types/chat_example/lib/client/html_display.dart
+++ b/built_types/chat_example/lib/client/html_display.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:js_interop';
+
+import 'package:chat_example/client/display.dart';
+import 'package:web/web.dart';
+
+/// [Display] using `dart:html`.
+class HtmlDisplay implements Display {
+  final Element _element;
+  final HtmlEscape _htmlEscape = const HtmlEscape();
+
+  factory HtmlDisplay() {
+    return HtmlDisplay._(document.querySelector('#text')!);
+  }
+
+  HtmlDisplay._(this._element) {
+    add('Welcome to the built_value chat example. For help, type /help.');
+  }
+
+  @override
+  void addLocal(String text) {
+    _element.textContent = _element.textContent! +
+        '<div class="local">'
+            '${_htmlEscape.convert(text).replaceAll('\n', '<br>')}</div>';
+    window.scrollTo(0.toJS, document.body!.scrollHeight);
+  }
+
+  @override
+  void add(String text) {
+    _element.textContent = _element.textContent! +
+        '${_htmlEscape.convert(text).replaceAll('\n', '<br>')}<br>';
+    window.scrollTo(0.toJS, document.body!.scrollHeight);
+  }
+}

--- a/built_types/chat_example/lib/client/http_client_connection.dart
+++ b/built_types/chat_example/lib/client/http_client_connection.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:chat_example/client/client_connection.dart';
+import 'package:web/web.dart';
+
+/// [ClientConnection] using a web socket.
+class HttpClientConnection implements ClientConnection {
+  final WebSocket _websocket;
+  final StreamController<String> _streamController = StreamController<String>();
+
+  factory HttpClientConnection() {
+    return HttpClientConnection._(WebSocket('ws://${window.location.host}/ws'));
+  }
+
+  HttpClientConnection._(this._websocket) {
+    _websocket.onMessage.listen((message) {
+      _streamController.add(message.data as String);
+    });
+  }
+
+  @override
+  Stream<String> get dataFromServer => _streamController.stream;
+
+  @override
+  void sendToServer(String data) {
+    _websocket.send(data.toJS);
+  }
+}

--- a/built_types/chat_example/lib/client/input.dart
+++ b/built_types/chat_example/lib/client/input.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:web/web.dart';
+
+/// An input box using `dart:html`.
+class Input {
+  final StreamController<String> _streamController = StreamController<String>();
+
+  Input() {
+    final input = document.querySelector('#input')! as HTMLInputElement;
+
+    input.onKeyPress.listen((keyEvent) {
+      if (keyEvent.keyCode == KeyCode.ENTER) {
+        _streamController.add(input.value);
+        input.value = '';
+      }
+    });
+  }
+
+  Stream<String> get keyboardInput => _streamController.stream;
+}

--- a/built_types/chat_example/lib/client/layout.dart
+++ b/built_types/chat_example/lib/client/layout.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:web/web.dart';
+
+/// Forces focus to the input box.
+class Layout {
+  Layout() {
+    final screen = document.querySelector('#screen')!;
+    final text = document.querySelector('#text')!;
+    final input = document.querySelector('#input')! as HTMLInputElement;
+
+    input.focus();
+
+    for (final element in [screen, text]) {
+      element.onClick.listen((e) {
+        input.focus();
+      });
+    }
+  }
+}

--- a/built_types/chat_example/lib/data_model/data_model.dart
+++ b/built_types/chat_example/lib/data_model/data_model.dart
@@ -1,0 +1,170 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/// Data model for the built_value chat example.
+library data_model;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'data_model.g.dart';
+
+/// Marker interface for classes sent from client to server.
+abstract class Command {}
+
+/// Sends a chat.
+abstract class Chat implements Built<Chat, ChatBuilder>, Command {
+  static Serializer<Chat> get serializer => _$chatSerializer;
+
+  // Chat text.
+  String get text;
+
+  /// Set of usernames to send the chat to, or empty to send to everyone.
+  BuiltSet<String> get targets;
+
+  factory Chat([Function(ChatBuilder) updates]) = _$Chat;
+  Chat._();
+}
+
+/// Logs in.
+abstract class Login implements Built<Login, LoginBuilder>, Command {
+  static Serializer<Login> get serializer => _$loginSerializer;
+  String get username;
+  String get password;
+
+  factory Login([Function(LoginBuilder) updates]) = _$Login;
+  Login._();
+}
+
+/// User status: online, away or offline, and a message.
+///
+/// Sent as a command, sets the current user status.
+abstract class Status implements Built<Status, StatusBuilder>, Command {
+  static Serializer<Status> get serializer => _$statusSerializer;
+  String get message;
+  StatusType get type;
+
+  factory Status([Function(StatusBuilder) updates]) = _$Status;
+  Status._();
+}
+
+/// User status: online, away or offline.
+class StatusType extends EnumClass {
+  static Serializer<StatusType> get serializer => _$statusTypeSerializer;
+
+  static const StatusType online = _$online;
+  static const StatusType away = _$away;
+  static const StatusType offline = _$offline;
+
+  const StatusType._(String name) : super(name);
+
+  static BuiltSet<StatusType> get values => _$stValues;
+  static StatusType valueOf(String name) => _$stValueOf(name);
+}
+
+/// Lists users, filtered by status.
+abstract class ListUsers
+    implements Built<ListUsers, ListUsersBuilder>, Command {
+  static Serializer<ListUsers> get serializer => _$listUsersSerializer;
+
+  /// Set of statuses to filter by.
+  BuiltSet<StatusType> get statusTypes;
+
+  factory ListUsers([Function(ListUsersBuilder) updates]) = _$ListUsers;
+  ListUsers._();
+}
+
+/// Classes sent from server to client.
+abstract class Response {
+  String render();
+}
+
+/// Response to a login attempt.
+class LoginResponse extends EnumClass implements Response {
+  static Serializer<LoginResponse> get serializer => _$loginResponseSerializer;
+  static const LoginResponse success = _$success;
+  static const LoginResponse badPassword = _$badPassword;
+  static const LoginResponse reset = _$reset;
+
+  const LoginResponse._(String name) : super(name);
+
+  static BuiltSet<LoginResponse> get values => _$lrValues;
+  static LoginResponse valueOf(String name) => _$lrValueOf(name);
+
+  @override
+  String render() {
+    switch (this) {
+      case success:
+        return 'You have logged in successfully.';
+      case badPassword:
+        return 'Incorrect password.';
+      case reset:
+        return 'You have been logged out.';
+      default:
+        throw StateError(name);
+    }
+  }
+}
+
+/// Displays a chat message.
+abstract class ShowChat implements Built<ShowChat, ShowChatBuilder>, Response {
+  static Serializer<ShowChat> get serializer => _$showChatSerializer;
+
+  /// Originator of the message.
+  String get username;
+
+  /// Whether the message is a /tell or a general message.
+  bool get private;
+
+  /// Message text.
+  String get text;
+
+  factory ShowChat([Function(ShowChatBuilder) updates]) = _$ShowChat;
+  ShowChat._();
+
+  @override
+  String render() => '$username${private ? " (private)" : ""}: $text';
+}
+
+abstract class Welcome implements Built<Welcome, WelcomeBuilder>, Response {
+  static Serializer<Welcome> get serializer => _$welcomeSerializer;
+
+  BuiltList<Response> get log;
+
+  String get message;
+
+  factory Welcome([Function(WelcomeBuilder) updates]) = _$Welcome;
+  Welcome._();
+
+  @override
+  String render() =>
+      log.map((response) => response.render()).join('\n') + '\n' + message;
+}
+
+/// Displays a list of users and their status messages.
+abstract class ListUsersResponse
+    implements Built<ListUsersResponse, ListUsersResponseBuilder>, Response {
+  static Serializer<ListUsersResponse> get serializer =>
+      _$listUsersResponseSerializer;
+
+  /// Map from username to status.
+  BuiltMap<String, Status> get statuses;
+
+  factory ListUsersResponse([Function(ListUsersResponseBuilder) updates]) =
+      _$ListUsersResponse;
+  ListUsersResponse._();
+
+  @override
+  String render() {
+    final result = StringBuffer('The following users are online:\n\n');
+    for (final username in statuses.keys) {
+      final status = statuses[username]!;
+      result.write(
+          status.message.isEmpty ? username : '$username ${status.message}');
+      result.write('\n');
+    }
+    return result.toString();
+  }
+}

--- a/built_types/chat_example/lib/data_model/data_model.g.dart
+++ b/built_types/chat_example/lib/data_model/data_model.g.dart
@@ -1,0 +1,1113 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'data_model.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+const StatusType _$online = const StatusType._('online');
+const StatusType _$away = const StatusType._('away');
+const StatusType _$offline = const StatusType._('offline');
+
+StatusType _$stValueOf(String name) {
+  switch (name) {
+    case 'online':
+      return _$online;
+    case 'away':
+      return _$away;
+    case 'offline':
+      return _$offline;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<StatusType> _$stValues = BuiltSet<StatusType>(const <StatusType>[
+  _$online,
+  _$away,
+  _$offline,
+]);
+
+const LoginResponse _$success = const LoginResponse._('success');
+const LoginResponse _$badPassword = const LoginResponse._('badPassword');
+const LoginResponse _$reset = const LoginResponse._('reset');
+
+LoginResponse _$lrValueOf(String name) {
+  switch (name) {
+    case 'success':
+      return _$success;
+    case 'badPassword':
+      return _$badPassword;
+    case 'reset':
+      return _$reset;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<LoginResponse> _$lrValues =
+    BuiltSet<LoginResponse>(const <LoginResponse>[
+  _$success,
+  _$badPassword,
+  _$reset,
+]);
+
+Serializer<Chat> _$chatSerializer = _$ChatSerializer();
+Serializer<Login> _$loginSerializer = _$LoginSerializer();
+Serializer<Status> _$statusSerializer = _$StatusSerializer();
+Serializer<StatusType> _$statusTypeSerializer = _$StatusTypeSerializer();
+Serializer<ListUsers> _$listUsersSerializer = _$ListUsersSerializer();
+Serializer<LoginResponse> _$loginResponseSerializer =
+    _$LoginResponseSerializer();
+Serializer<ShowChat> _$showChatSerializer = _$ShowChatSerializer();
+Serializer<Welcome> _$welcomeSerializer = _$WelcomeSerializer();
+Serializer<ListUsersResponse> _$listUsersResponseSerializer =
+    _$ListUsersResponseSerializer();
+
+class _$ChatSerializer implements StructuredSerializer<Chat> {
+  @override
+  final Iterable<Type> types = const [Chat, _$Chat];
+  @override
+  final String wireName = 'Chat';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Chat object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'text',
+      serializers.serialize(object.text, specifiedType: const FullType(String)),
+      'targets',
+      serializers.serialize(object.targets,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  Chat deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'text':
+          result.text = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'targets':
+          result.targets.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltSet, const [const FullType(String)]))!
+              as BuiltSet<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$LoginSerializer implements StructuredSerializer<Login> {
+  @override
+  final Iterable<Type> types = const [Login, _$Login];
+  @override
+  final String wireName = 'Login';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Login object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'username',
+      serializers.serialize(object.username,
+          specifiedType: const FullType(String)),
+      'password',
+      serializers.serialize(object.password,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Login deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = LoginBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'username':
+          result.username = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'password':
+          result.password = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$StatusSerializer implements StructuredSerializer<Status> {
+  @override
+  final Iterable<Type> types = const [Status, _$Status];
+  @override
+  final String wireName = 'Status';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Status object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'message',
+      serializers.serialize(object.message,
+          specifiedType: const FullType(String)),
+      'type',
+      serializers.serialize(object.type,
+          specifiedType: const FullType(StatusType)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Status deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = StatusBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'message':
+          result.message = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'type':
+          result.type = serializers.deserialize(value,
+              specifiedType: const FullType(StatusType))! as StatusType;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$StatusTypeSerializer implements PrimitiveSerializer<StatusType> {
+  @override
+  final Iterable<Type> types = const <Type>[StatusType];
+  @override
+  final String wireName = 'StatusType';
+
+  @override
+  Object serialize(Serializers serializers, StatusType object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
+
+  @override
+  StatusType deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      StatusType.valueOf(serialized as String);
+}
+
+class _$ListUsersSerializer implements StructuredSerializer<ListUsers> {
+  @override
+  final Iterable<Type> types = const [ListUsers, _$ListUsers];
+  @override
+  final String wireName = 'ListUsers';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ListUsers object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'statusTypes',
+      serializers.serialize(object.statusTypes,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(StatusType)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  ListUsers deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ListUsersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'statusTypes':
+          result.statusTypes.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltSet, const [const FullType(StatusType)]))!
+              as BuiltSet<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$LoginResponseSerializer implements PrimitiveSerializer<LoginResponse> {
+  @override
+  final Iterable<Type> types = const <Type>[LoginResponse];
+  @override
+  final String wireName = 'LoginResponse';
+
+  @override
+  Object serialize(Serializers serializers, LoginResponse object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
+
+  @override
+  LoginResponse deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      LoginResponse.valueOf(serialized as String);
+}
+
+class _$ShowChatSerializer implements StructuredSerializer<ShowChat> {
+  @override
+  final Iterable<Type> types = const [ShowChat, _$ShowChat];
+  @override
+  final String wireName = 'ShowChat';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ShowChat object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'username',
+      serializers.serialize(object.username,
+          specifiedType: const FullType(String)),
+      'private',
+      serializers.serialize(object.private,
+          specifiedType: const FullType(bool)),
+      'text',
+      serializers.serialize(object.text, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ShowChat deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ShowChatBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'username':
+          result.username = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'private':
+          result.private = serializers.deserialize(value,
+              specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'text':
+          result.text = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$WelcomeSerializer implements StructuredSerializer<Welcome> {
+  @override
+  final Iterable<Type> types = const [Welcome, _$Welcome];
+  @override
+  final String wireName = 'Welcome';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Welcome object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'log',
+      serializers.serialize(object.log,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(Response)])),
+      'message',
+      serializers.serialize(object.message,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Welcome deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = WelcomeBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'log':
+          result.log.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(Response)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'message':
+          result.message = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ListUsersResponseSerializer
+    implements StructuredSerializer<ListUsersResponse> {
+  @override
+  final Iterable<Type> types = const [ListUsersResponse, _$ListUsersResponse];
+  @override
+  final String wireName = 'ListUsersResponse';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ListUsersResponse object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'statuses',
+      serializers.serialize(object.statuses,
+          specifiedType: const FullType(BuiltMap,
+              const [const FullType(String), const FullType(Status)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  ListUsersResponse deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ListUsersResponseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'statuses':
+          result.statuses.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap,
+                  const [const FullType(String), const FullType(Status)]))!);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$Chat extends Chat {
+  @override
+  final String text;
+  @override
+  final BuiltSet<String> targets;
+
+  factory _$Chat([void Function(ChatBuilder)? updates]) =>
+      (ChatBuilder()..update(updates))._build();
+
+  _$Chat._({required this.text, required this.targets}) : super._();
+  @override
+  Chat rebuild(void Function(ChatBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatBuilder toBuilder() => ChatBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Chat && text == other.text && targets == other.targets;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, text.hashCode);
+    _$hash = $jc(_$hash, targets.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Chat')
+          ..add('text', text)
+          ..add('targets', targets))
+        .toString();
+  }
+}
+
+class ChatBuilder implements Builder<Chat, ChatBuilder> {
+  _$Chat? _$v;
+
+  String? _text;
+  String? get text => _$this._text;
+  set text(String? text) => _$this._text = text;
+
+  SetBuilder<String>? _targets;
+  SetBuilder<String> get targets => _$this._targets ??= SetBuilder<String>();
+  set targets(SetBuilder<String>? targets) => _$this._targets = targets;
+
+  ChatBuilder();
+
+  ChatBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _text = $v.text;
+      _targets = $v.targets.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Chat other) {
+    _$v = other as _$Chat;
+  }
+
+  @override
+  void update(void Function(ChatBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Chat build() => _build();
+
+  _$Chat _build() {
+    _$Chat _$result;
+    try {
+      _$result = _$v ??
+          _$Chat._(
+            text: BuiltValueNullFieldError.checkNotNull(text, r'Chat', 'text'),
+            targets: targets.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'targets';
+        targets.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'Chat', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$Login extends Login {
+  @override
+  final String username;
+  @override
+  final String password;
+
+  factory _$Login([void Function(LoginBuilder)? updates]) =>
+      (LoginBuilder()..update(updates))._build();
+
+  _$Login._({required this.username, required this.password}) : super._();
+  @override
+  Login rebuild(void Function(LoginBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  LoginBuilder toBuilder() => LoginBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Login &&
+        username == other.username &&
+        password == other.password;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, username.hashCode);
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Login')
+          ..add('username', username)
+          ..add('password', password))
+        .toString();
+  }
+}
+
+class LoginBuilder implements Builder<Login, LoginBuilder> {
+  _$Login? _$v;
+
+  String? _username;
+  String? get username => _$this._username;
+  set username(String? username) => _$this._username = username;
+
+  String? _password;
+  String? get password => _$this._password;
+  set password(String? password) => _$this._password = password;
+
+  LoginBuilder();
+
+  LoginBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _username = $v.username;
+      _password = $v.password;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Login other) {
+    _$v = other as _$Login;
+  }
+
+  @override
+  void update(void Function(LoginBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Login build() => _build();
+
+  _$Login _build() {
+    final _$result = _$v ??
+        _$Login._(
+          username: BuiltValueNullFieldError.checkNotNull(
+              username, r'Login', 'username'),
+          password: BuiltValueNullFieldError.checkNotNull(
+              password, r'Login', 'password'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$Status extends Status {
+  @override
+  final String message;
+  @override
+  final StatusType type;
+
+  factory _$Status([void Function(StatusBuilder)? updates]) =>
+      (StatusBuilder()..update(updates))._build();
+
+  _$Status._({required this.message, required this.type}) : super._();
+  @override
+  Status rebuild(void Function(StatusBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  StatusBuilder toBuilder() => StatusBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Status && message == other.message && type == other.type;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jc(_$hash, type.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Status')
+          ..add('message', message)
+          ..add('type', type))
+        .toString();
+  }
+}
+
+class StatusBuilder implements Builder<Status, StatusBuilder> {
+  _$Status? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  StatusType? _type;
+  StatusType? get type => _$this._type;
+  set type(StatusType? type) => _$this._type = type;
+
+  StatusBuilder();
+
+  StatusBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _type = $v.type;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Status other) {
+    _$v = other as _$Status;
+  }
+
+  @override
+  void update(void Function(StatusBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Status build() => _build();
+
+  _$Status _build() {
+    final _$result = _$v ??
+        _$Status._(
+          message: BuiltValueNullFieldError.checkNotNull(
+              message, r'Status', 'message'),
+          type: BuiltValueNullFieldError.checkNotNull(type, r'Status', 'type'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ListUsers extends ListUsers {
+  @override
+  final BuiltSet<StatusType> statusTypes;
+
+  factory _$ListUsers([void Function(ListUsersBuilder)? updates]) =>
+      (ListUsersBuilder()..update(updates))._build();
+
+  _$ListUsers._({required this.statusTypes}) : super._();
+  @override
+  ListUsers rebuild(void Function(ListUsersBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ListUsersBuilder toBuilder() => ListUsersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ListUsers && statusTypes == other.statusTypes;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, statusTypes.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ListUsers')
+          ..add('statusTypes', statusTypes))
+        .toString();
+  }
+}
+
+class ListUsersBuilder implements Builder<ListUsers, ListUsersBuilder> {
+  _$ListUsers? _$v;
+
+  SetBuilder<StatusType>? _statusTypes;
+  SetBuilder<StatusType> get statusTypes =>
+      _$this._statusTypes ??= SetBuilder<StatusType>();
+  set statusTypes(SetBuilder<StatusType>? statusTypes) =>
+      _$this._statusTypes = statusTypes;
+
+  ListUsersBuilder();
+
+  ListUsersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _statusTypes = $v.statusTypes.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ListUsers other) {
+    _$v = other as _$ListUsers;
+  }
+
+  @override
+  void update(void Function(ListUsersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ListUsers build() => _build();
+
+  _$ListUsers _build() {
+    _$ListUsers _$result;
+    try {
+      _$result = _$v ??
+          _$ListUsers._(
+            statusTypes: statusTypes.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'statusTypes';
+        statusTypes.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'ListUsers', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ShowChat extends ShowChat {
+  @override
+  final String username;
+  @override
+  final bool private;
+  @override
+  final String text;
+
+  factory _$ShowChat([void Function(ShowChatBuilder)? updates]) =>
+      (ShowChatBuilder()..update(updates))._build();
+
+  _$ShowChat._(
+      {required this.username, required this.private, required this.text})
+      : super._();
+  @override
+  ShowChat rebuild(void Function(ShowChatBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ShowChatBuilder toBuilder() => ShowChatBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ShowChat &&
+        username == other.username &&
+        private == other.private &&
+        text == other.text;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, username.hashCode);
+    _$hash = $jc(_$hash, private.hashCode);
+    _$hash = $jc(_$hash, text.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ShowChat')
+          ..add('username', username)
+          ..add('private', private)
+          ..add('text', text))
+        .toString();
+  }
+}
+
+class ShowChatBuilder implements Builder<ShowChat, ShowChatBuilder> {
+  _$ShowChat? _$v;
+
+  String? _username;
+  String? get username => _$this._username;
+  set username(String? username) => _$this._username = username;
+
+  bool? _private;
+  bool? get private => _$this._private;
+  set private(bool? private) => _$this._private = private;
+
+  String? _text;
+  String? get text => _$this._text;
+  set text(String? text) => _$this._text = text;
+
+  ShowChatBuilder();
+
+  ShowChatBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _username = $v.username;
+      _private = $v.private;
+      _text = $v.text;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ShowChat other) {
+    _$v = other as _$ShowChat;
+  }
+
+  @override
+  void update(void Function(ShowChatBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ShowChat build() => _build();
+
+  _$ShowChat _build() {
+    final _$result = _$v ??
+        _$ShowChat._(
+          username: BuiltValueNullFieldError.checkNotNull(
+              username, r'ShowChat', 'username'),
+          private: BuiltValueNullFieldError.checkNotNull(
+              private, r'ShowChat', 'private'),
+          text:
+              BuiltValueNullFieldError.checkNotNull(text, r'ShowChat', 'text'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$Welcome extends Welcome {
+  @override
+  final BuiltList<Response> log;
+  @override
+  final String message;
+
+  factory _$Welcome([void Function(WelcomeBuilder)? updates]) =>
+      (WelcomeBuilder()..update(updates))._build();
+
+  _$Welcome._({required this.log, required this.message}) : super._();
+  @override
+  Welcome rebuild(void Function(WelcomeBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WelcomeBuilder toBuilder() => WelcomeBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Welcome && log == other.log && message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, log.hashCode);
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Welcome')
+          ..add('log', log)
+          ..add('message', message))
+        .toString();
+  }
+}
+
+class WelcomeBuilder implements Builder<Welcome, WelcomeBuilder> {
+  _$Welcome? _$v;
+
+  ListBuilder<Response>? _log;
+  ListBuilder<Response> get log => _$this._log ??= ListBuilder<Response>();
+  set log(ListBuilder<Response>? log) => _$this._log = log;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(String? message) => _$this._message = message;
+
+  WelcomeBuilder();
+
+  WelcomeBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _log = $v.log.toBuilder();
+      _message = $v.message;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Welcome other) {
+    _$v = other as _$Welcome;
+  }
+
+  @override
+  void update(void Function(WelcomeBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Welcome build() => _build();
+
+  _$Welcome _build() {
+    _$Welcome _$result;
+    try {
+      _$result = _$v ??
+          _$Welcome._(
+            log: log.build(),
+            message: BuiltValueNullFieldError.checkNotNull(
+                message, r'Welcome', 'message'),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'log';
+        log.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'Welcome', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ListUsersResponse extends ListUsersResponse {
+  @override
+  final BuiltMap<String, Status> statuses;
+
+  factory _$ListUsersResponse(
+          [void Function(ListUsersResponseBuilder)? updates]) =>
+      (ListUsersResponseBuilder()..update(updates))._build();
+
+  _$ListUsersResponse._({required this.statuses}) : super._();
+  @override
+  ListUsersResponse rebuild(void Function(ListUsersResponseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ListUsersResponseBuilder toBuilder() =>
+      ListUsersResponseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ListUsersResponse && statuses == other.statuses;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, statuses.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ListUsersResponse')
+          ..add('statuses', statuses))
+        .toString();
+  }
+}
+
+class ListUsersResponseBuilder
+    implements Builder<ListUsersResponse, ListUsersResponseBuilder> {
+  _$ListUsersResponse? _$v;
+
+  MapBuilder<String, Status>? _statuses;
+  MapBuilder<String, Status> get statuses =>
+      _$this._statuses ??= MapBuilder<String, Status>();
+  set statuses(MapBuilder<String, Status>? statuses) =>
+      _$this._statuses = statuses;
+
+  ListUsersResponseBuilder();
+
+  ListUsersResponseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _statuses = $v.statuses.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ListUsersResponse other) {
+    _$v = other as _$ListUsersResponse;
+  }
+
+  @override
+  void update(void Function(ListUsersResponseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ListUsersResponse build() => _build();
+
+  _$ListUsersResponse _build() {
+    _$ListUsersResponse _$result;
+    try {
+      _$result = _$v ??
+          _$ListUsersResponse._(
+            statuses: statuses.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'statuses';
+        statuses.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'ListUsersResponse', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/chat_example/lib/data_model/serializers.dart
+++ b/built_types/chat_example/lib/data_model/serializers.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library serializers;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:chat_example/data_model/data_model.dart';
+
+part 'serializers.g.dart';
+
+/// Collection of generated serializers for the built_value chat example.
+@SerializersFor([
+  Chat,
+  ListUsers,
+  ListUsersResponse,
+  Login,
+  LoginResponse,
+  ShowChat,
+  Status,
+  Welcome,
+])
+final Serializers serializers = _$serializers;

--- a/built_types/chat_example/lib/data_model/serializers.g.dart
+++ b/built_types/chat_example/lib/data_model/serializers.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'serializers.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializers _$serializers = (Serializers().toBuilder()
+      ..add(Chat.serializer)
+      ..add(ListUsers.serializer)
+      ..add(ListUsersResponse.serializer)
+      ..add(Login.serializer)
+      ..add(LoginResponse.serializer)
+      ..add(ShowChat.serializer)
+      ..add(Status.serializer)
+      ..add(StatusType.serializer)
+      ..add(Welcome.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(Response)]),
+          () => ListBuilder<Response>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltMap, const [const FullType(String), const FullType(Status)]),
+          () => MapBuilder<String, Status>())
+      ..addBuilderFactory(
+          const FullType(BuiltSet, const [const FullType(StatusType)]),
+          () => SetBuilder<StatusType>())
+      ..addBuilderFactory(
+          const FullType(BuiltSet, const [const FullType(String)]),
+          () => SetBuilder<String>()))
+    .build();
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/chat_example/lib/server/http_server_connection.dart
+++ b/built_types/chat_example/lib/server/http_server_connection.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:chat_example/server/server_connection.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// [ServerConnection] using a web socket.
+class HttpServerConnection implements ServerConnection {
+  final WebSocketChannel _webSocketChannel;
+  final StreamController<String> _streamController = StreamController<String>();
+
+  @override
+  late String username;
+
+  HttpServerConnection(this._webSocketChannel) {
+    _webSocketChannel.stream.listen((data) {
+      _streamController.add(data as String);
+    });
+  }
+
+  @override
+  Stream<String> get dataFromClient => _streamController.stream;
+
+  @override
+  void sendToClient(String data) {
+    _webSocketChannel.sink.add(data);
+  }
+
+  @override
+  void close() {
+    _webSocketChannel.sink.close();
+  }
+}

--- a/built_types/chat_example/lib/server/resource_server.dart
+++ b/built_types/chat_example/lib/server/resource_server.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:shelf_proxy/shelf_proxy.dart';
+import 'package:shelf_web_socket/shelf_web_socket.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+typedef SocketReceiver = void Function(WebSocketChannel webSocket);
+
+/// Resource server for the built_value chat example.
+///
+/// Proxies to webdev for most requests. Accepts web socket connections.
+class ResourceServer {
+  /// Serves resources, passing new sockets to [socketReceiver].
+  Future start(SocketReceiver socketReceiver) async {
+    final cascade = Cascade()
+        // Web socket handler will do nothing for non-websocket requests, so
+        // just add it in the cascade at the top.
+        .add(webSocketHandler(socketReceiver))
+        // Anything else goes to webdev.
+        .add(proxyHandler(Uri.parse('http://localhost:8080')))
+        // If that didn't work, must be a problem with webdev.
+        .add((_) {
+      print('Request failed. Check webdev output for errors.');
+      return Response.notFound('');
+    });
+
+    await io.serve(cascade.handler, 'localhost', 26199).then((server) {
+      print('Serving at http://${server.address.host}:${server.port}. Please '
+          'also run webdev on port 8080.');
+    });
+  }
+}

--- a/built_types/chat_example/lib/server/server.dart
+++ b/built_types/chat_example/lib/server/server.dart
@@ -1,0 +1,130 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:chat_example/data_model/data_model.dart';
+import 'package:chat_example/data_model/serializers.dart';
+import 'package:chat_example/server/server_connection.dart';
+
+/// Server-side logic for the built_value chat example.
+class Server {
+  final Random random = Random();
+  final Set<ServerConnection> _connections = <ServerConnection>{};
+  final Map<String, String> _passwords = <String, String>{};
+  final Map<String, Status> _statuses = <String, Status>{};
+  final List<Response> _log = <Response>[];
+
+  /// Adds a new connection to the server.
+  ///
+  /// A random username is assigned.
+  void addConnection(ServerConnection connection) {
+    final username = 'anon${random.nextInt(10000)}';
+    connection.username = username;
+    _connections.add(connection);
+    _send(
+        connection,
+        Welcome((b) => b
+          ..log.addAll(_log)
+          ..message = 'You are connected as $username.'));
+    connection.dataFromClient
+        .listen((string) => _handleDataFromClient(connection, string));
+  }
+
+  void _handleDataFromClient(ServerConnection connection, String data) {
+    final command = serializers.deserialize(json.decode(data));
+
+    if (command is Chat) {
+      _chat(connection, command);
+    } else if (command is Login) {
+      _login(connection, command);
+    } else if (command is Status) {
+      _status(connection, command);
+    } else if (command is ListUsers) {
+      _listUsers(connection, command);
+    } else {
+      throw StateError('Invalid data from client: $command');
+    }
+  }
+
+  void _chat(ServerConnection connection, Chat chat) {
+    if (chat.targets.isEmpty) {
+      _sendToAll(ShowChat((b) => b
+        ..username = connection.username
+        ..private = false
+        ..text = chat.text));
+    } else {
+      _sendTo(
+          chat.targets,
+          ShowChat((b) => b
+            ..username = connection.username
+            ..private = true
+            ..text = chat.text));
+    }
+  }
+
+  void _listUsers(ServerConnection connection, ListUsers listUsers) {
+    _send(
+        connection,
+        ListUsersResponse((b) => _statuses.forEach((username, status) {
+              if (listUsers.statusTypes.contains(status.type)) {
+                b.statuses[username] = status;
+              }
+            })));
+  }
+
+  void _login(ServerConnection connection, Login login) {
+    if (_passwords.containsKey(login.username)) {
+      if (_passwords[login.username] != login.password) {
+        _send(connection, LoginResponse.badPassword);
+        return;
+      }
+    } else {
+      _passwords[login.username] = login.password;
+    }
+
+    for (final existingConnection in _connections) {
+      if (existingConnection.username == login.username) {
+        existingConnection.username = 'anon${random.nextInt(10000)}';
+        _send(existingConnection, LoginResponse.reset);
+      }
+    }
+
+    _statuses[login.username] = Status((b) => b
+      ..message = ''
+      ..type = StatusType.online);
+
+    connection.username = login.username;
+    _send(connection, LoginResponse.success);
+  }
+
+  void _status(ServerConnection connection, Status status) {
+    _statuses[connection.username] = status;
+    if (status.type == StatusType.offline) {
+      _connections.remove(connection);
+      connection.close();
+    }
+  }
+
+  void _sendTo(BuiltSet<String> usernames, Response response) {
+    for (final connection in _connections) {
+      if (usernames.contains(connection.username)) {
+        _send(connection, response);
+      }
+    }
+  }
+
+  void _sendToAll(Response response) {
+    _log.add(response);
+    for (final connection in _connections) {
+      _send(connection, response);
+    }
+  }
+
+  static void _send(ServerConnection connection, Response response) {
+    connection.sendToClient(json.encode(serializers.serialize(response)));
+  }
+}

--- a/built_types/chat_example/lib/server/server_connection.dart
+++ b/built_types/chat_example/lib/server/server_connection.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+/// Two-way connection between client and server; the server.
+abstract class ServerConnection {
+  /// The username associated with this connection.
+  String get username;
+  set username(String username);
+
+  Stream<String> get dataFromClient;
+  void sendToClient(String data);
+  void close();
+}

--- a/built_types/chat_example/lib/testing/fake_client_connection.dart
+++ b/built_types/chat_example/lib/testing/fake_client_connection.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:chat_example/client/client_connection.dart';
+
+/// Fake [ClientConnection] that exposes stream controllers.
+class FakeClientConnection implements ClientConnection {
+  final StreamController<String> toServerStreamController =
+      StreamController<String>(sync: true);
+  final StreamController<String> fromServerStreamController =
+      StreamController<String>(sync: true);
+
+  @override
+  void sendToServer(String string) {
+    toServerStreamController.add(string);
+  }
+
+  @override
+  Stream<String> get dataFromServer => fromServerStreamController.stream;
+}

--- a/built_types/chat_example/lib/testing/fake_display.dart
+++ b/built_types/chat_example/lib/testing/fake_display.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:chat_example/client/display.dart';
+
+/// Fake [Display] that stores added text.
+class FakeDisplay implements Display {
+  List<String> text = <String>[];
+  List<String> localText = <String>[];
+
+  @override
+  void add(String text) {
+    this.text.add(text);
+  }
+
+  @override
+  void addLocal(String text) {
+    localText.add(text);
+  }
+}

--- a/built_types/chat_example/lib/testing/fake_environment.dart
+++ b/built_types/chat_example/lib/testing/fake_environment.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:chat_example/client/client.dart';
+import 'package:chat_example/server/server.dart';
+import 'package:chat_example/testing/fake_client_connection.dart';
+import 'package:chat_example/testing/fake_display.dart';
+import 'package:chat_example/testing/fake_server_connection.dart';
+import 'package:chat_example/testing/test_user.dart';
+
+/// Environment for testing server and client logic together.
+///
+/// The HTML display and input are faked, as are the HTTP connections. This
+/// leaves the client logic and server logic available for testing.
+class FakeEnvironment {
+  final Server server;
+
+  factory FakeEnvironment() {
+    final server = Server();
+
+    return FakeEnvironment._(server);
+  }
+
+  FakeEnvironment._(this.server);
+
+  /// Creates a new user connected to this environment.
+  TestUser newUser() {
+    final clientConnection = FakeClientConnection();
+    final serverConnection = FakeServerConnection();
+
+    clientConnection.toServerStreamController.stream.listen((string) {
+      serverConnection.fromClientStreamController.add(string);
+    });
+    serverConnection.toClientStreamController.stream.listen((string) {
+      clientConnection.fromServerStreamController.add(string);
+    });
+
+    final keyboardInputController = StreamController<String>(sync: true);
+    final display = FakeDisplay();
+    Client(keyboardInputController.stream, display, clientConnection);
+    server.addConnection(serverConnection);
+    return TestUser(display, keyboardInputController);
+  }
+}

--- a/built_types/chat_example/lib/testing/fake_server_connection.dart
+++ b/built_types/chat_example/lib/testing/fake_server_connection.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:chat_example/server/server_connection.dart';
+
+/// Fake [ServerConnection] that exposes stream controllers.
+class FakeServerConnection implements ServerConnection {
+  final StreamController<String> toClientStreamController =
+      StreamController<String>(sync: true);
+  final StreamController<String> fromClientStreamController =
+      StreamController<String>(sync: true);
+
+  @override
+  late String username;
+
+  @override
+  void sendToClient(String data) {
+    toClientStreamController.add(data);
+  }
+
+  @override
+  Stream<String> get dataFromClient => fromClientStreamController.stream;
+
+  @override
+  void close() {}
+}

--- a/built_types/chat_example/lib/testing/test_user.dart
+++ b/built_types/chat_example/lib/testing/test_user.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:chat_example/testing/fake_display.dart';
+import 'package:test/test.dart';
+
+/// A test user connected to the fake environment.
+class TestUser {
+  final FakeDisplay _display;
+  final StreamController<String> _inputController;
+
+  TestUser(this._display, this._inputController);
+
+  /// Types text as this user.
+  void type(String text) {
+    _inputController.add(text);
+  }
+
+  /// Checks server responses to this user.
+  void expectMatch(Pattern pattern) {
+    expect(_display.text, anyElement(matches(pattern)));
+  }
+
+  /// Checks server responses to this user.
+  void expectNoMatch(Pattern pattern) {
+    expect(_display.text, isNot(anyElement(matches(pattern))));
+  }
+
+  /// Checks local text for this user.
+  void expectLocalMatch(Pattern pattern) {
+    expect(_display.localText, anyElement(matches(pattern)));
+  }
+}

--- a/built_types/chat_example/pubspec.yaml
+++ b/built_types/chat_example/pubspec.yaml
@@ -1,0 +1,26 @@
+name: chat_example
+version: 8.13.0
+publish_to: none
+description: >
+  Just an example, not for publishing.
+homepage: https://github.com/google/built_value.dart
+
+environment:
+  sdk: '>=3.4.0 <4.0.0'
+
+dependencies:
+  built_collection: ^5.0.0
+  built_value: ^8.7.0
+  shelf: ^1.0.0
+  shelf_proxy: ^1.0.0
+  shelf_web_socket: ^1.0.0
+  web: ^1.1.1
+  web_socket_channel: ^2.0.0
+
+dev_dependencies:
+  build_runner: any
+  build_test: any
+  build_web_compilers: any
+  built_value_generator: ^8.13.0
+  pedantic: ^1.4.0
+  test: ^1.0.0

--- a/built_types/chat_example/test/chat_test.dart
+++ b/built_types/chat_example/test/chat_test.dart
@@ -1,0 +1,201 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:chat_example/data_model/data_model.dart';
+import 'package:chat_example/testing/fake_environment.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late FakeEnvironment environment;
+
+  setUp(() {
+    environment = FakeEnvironment();
+  });
+
+  group('on connect', () {
+    test('client sees login message', () async {
+      final alice = environment.newUser();
+
+      alice.expectMatch('.*You are connected as .*');
+    });
+
+    test('clients can exchange messages', () async {
+      final alice = environment.newUser();
+      final bob = environment.newUser();
+
+      alice.type('Hi, Bob!');
+      bob.expectMatch('anon.*: Hi, Bob!');
+
+      bob.type('Hi, Alice!');
+      alice.expectMatch('anon.*: Hi, Alice!');
+    });
+
+    test('clients can see log', () async {
+      final alice = environment.newUser();
+      alice.type('Hi, Bob!');
+
+      final bob = environment.newUser();
+      bob.expectMatch('anon.*: Hi, Bob!');
+    });
+  });
+
+  group('help', () {
+    test('echoes locally', () async {
+      environment.newUser()
+        ..type('/help')
+        ..expectLocalMatch(r'/help');
+    });
+  });
+
+  group('login', () {
+    test('echoes without password', () async {
+      environment.newUser()
+        ..type('/login Alice letmein')
+        ..expectLocalMatch(r'/login Alice \*\*\*\*\*\*\*\*');
+    });
+
+    test('announces success to self', () async {
+      final alice = environment.newUser();
+
+      alice
+        ..type('/login Alice letmein')
+        ..expectMatch(LoginResponse.success.render());
+    });
+
+    test('changes name', () async {
+      final alice = environment.newUser();
+      final bob = environment.newUser();
+
+      alice
+        ..type('/login Alice letmein')
+        ..type('Hi, Bob!');
+      bob.expectMatch('Alice: Hi, Bob!');
+    });
+
+    test('fails with wrong password', () async {
+      final alice = environment.newUser();
+      final bob = environment.newUser();
+
+      alice.type('/login Alice letmein');
+      bob.type('/login Alice wrongpassword');
+      bob.expectMatch(LoginResponse.badPassword.render());
+    });
+
+    test('logs out existing user', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+      environment.newUser().type('/login Alice letmein');
+
+      alice.expectMatch(LoginResponse.reset.render());
+    });
+  });
+
+  group('list', () {
+    test('echoes locally', () async {
+      environment.newUser()
+        ..type('/list')
+        ..expectLocalMatch(r'/list');
+    });
+
+    test('shows online users', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+      environment.newUser().type('/login Bob letmein');
+
+      alice
+        ..type('/list')
+        ..expectMatch('''The following users are online:
+
+Alice
+Bob
+''');
+    });
+  });
+
+  group('status', () {
+    test('echoes locally', () async {
+      environment.newUser()
+        ..type('/status Waiting around.')
+        ..expectLocalMatch(r'/status Waiting around\.');
+    });
+
+    test('changes message in user list', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+
+      alice
+        ..type('/status Waiting around.')
+        ..type('/list')
+        ..expectMatch('''The following users are online:
+
+Alice Waiting around.
+''');
+    });
+  });
+
+  group('away', () {
+    test('echoes locally', () async {
+      environment.newUser()
+        ..type('/away Not here.')
+        ..expectLocalMatch(r'/away Not here\.');
+    });
+
+    test('changes message in user list', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+
+      alice
+        ..type('/away Not here.')
+        ..type('/list')
+        ..expectMatch('''The following users are online:
+
+Alice Not here.
+''');
+    });
+  });
+
+  group('quit', () {
+    test('echoes locally', () async {
+      environment.newUser()
+        ..type('/quit Gone.')
+        ..expectLocalMatch(r'/quit Gone\.');
+    });
+
+    test('removes from online list', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+      final bob = environment.newUser()..type('/login Bob letmein');
+
+      alice.type('/quit Gone.');
+      bob
+        ..type('/list')
+        ..expectMatch('''The following users are online:
+
+Bob
+''');
+    });
+
+    test('stops getting messages', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+      final bob = environment.newUser()..type('/login Bob letmein');
+
+      alice.type('/quit Gone.');
+      bob.type('Hi Alice.');
+      alice.expectNoMatch('Hi Alice.');
+    });
+  });
+
+  group('tell', () {
+    test('echoes locally', () async {
+      environment.newUser()
+        ..type('/tell someone something.')
+        ..expectLocalMatch(r'/tell someone something.');
+    });
+
+    test('goes to a single user', () async {
+      final alice = environment.newUser()..type('/login Alice letmein');
+      final bob = environment.newUser()..type('/login Bob letmein');
+      final eve = environment.newUser();
+
+      alice.type('/tell Bob Hi there.');
+      bob.expectMatch(r'Alice \(private\): Hi there.');
+      eve.expectNoMatch('Hi there.');
+    });
+  });
+}

--- a/built_types/chat_example/web/index.html
+++ b/built_types/chat_example/web/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <link rel="stylesheet" href="main.css">
+</head>
+<body class="screen" id="screen">
+<div class="text" id="text"></div>
+<input class="input" id="input">
+<script defer src="main.dart.js"></script>
+</body>
+</html>

--- a/built_types/chat_example/web/main.css
+++ b/built_types/chat_example/web/main.css
@@ -1,0 +1,38 @@
+body {
+  overflow-y: scroll;
+}
+
+.input:focus {
+  outline: 0;
+}
+
+.screen {
+  background-color: black;
+  color: gray;
+  padding: 0px;
+  width: 48em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.text {
+  width: 100%;
+  font-family: Ariel, sans-serif;
+  font-size: 16px;
+}
+
+.local {
+  color: green;
+}
+
+.input {
+  position: relative;
+  top: 0px;
+  left: 0px;
+  font-family: Ariel, sans-serif;
+  font-size: 16px;
+  background-color: black;
+  color: green;
+  border-style: none;
+  width: 100%;
+}

--- a/built_types/chat_example/web/main.dart
+++ b/built_types/chat_example/web/main.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:chat_example/client/client.dart';
+import 'package:chat_example/client/html_display.dart';
+import 'package:chat_example/client/http_client_connection.dart';
+import 'package:chat_example/client/input.dart';
+import 'package:chat_example/client/layout.dart';
+
+void main() {
+  Layout();
+  final input = Input();
+  Client(input.keyboardInput, HtmlDisplay(), HttpClientConnection());
+}

--- a/built_types/end_to_end_test/analysis_options.yaml
+++ b/built_types/end_to_end_test/analysis_options.yaml
@@ -1,0 +1,10 @@
+include: package:pedantic/analysis_options.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-raw-types: true
+
+linter:
+  rules:
+    - cast_nullable_to_non_nullable

--- a/built_types/end_to_end_test/lib/collections.dart
+++ b/built_types/end_to_end_test/lib/collections.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'collections.g.dart';
+
+abstract class Collections implements Built<Collections, CollectionsBuilder> {
+  static Serializer<Collections> get serializer => _$collectionsSerializer;
+
+  BuiltList<int> get list;
+  BuiltSet<String> get set;
+  BuiltMap<String, int> get map;
+  BuiltListMultimap<int, bool> get listMultimap;
+  BuiltSetMultimap<String, bool> get setMultimap;
+
+  BuiltList<int?> get nullsInList;
+  BuiltSet<String?> get nullsInSet;
+  BuiltMap<String?, int?> get nullsInMap;
+  BuiltListMultimap<int?, bool> get nullsInListMultimap;
+  BuiltSetMultimap<String, bool?> get nullsInSetMultimap;
+
+  BuiltList<int>? get nullableList;
+  BuiltSet<String>? get nullableSet;
+  BuiltMap<String, int>? get nullableMap;
+  BuiltListMultimap<int, bool>? get nullableListMultimap;
+  BuiltSetMultimap<String, bool>? get nullableSetMultimap;
+
+  BuiltList<Foo<int?>> get nullableInGenericsList;
+
+  BuiltList<BuiltList<int?>?> get nestedNullablesList;
+
+  factory Collections([void Function(CollectionsBuilder) updates]) =
+      _$Collections;
+  Collections._();
+}
+
+class Foo<T> {}

--- a/built_types/end_to_end_test/lib/collections.g.dart
+++ b/built_types/end_to_end_test/lib/collections.g.dart
@@ -1,0 +1,588 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
+
+part of 'collections.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<Collections> _$collectionsSerializer = _$CollectionsSerializer();
+
+class _$CollectionsSerializer implements StructuredSerializer<Collections> {
+  @override
+  final Iterable<Type> types = const [Collections, _$Collections];
+  @override
+  final String wireName = 'Collections';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Collections object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'list',
+      serializers.serialize(object.list,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(int)])),
+      'set',
+      serializers.serialize(object.set,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(String)])),
+      'map',
+      serializers.serialize(object.map,
+          specifiedType: const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)])),
+      'listMultimap',
+      serializers.serialize(object.listMultimap,
+          specifiedType: const FullType(BuiltListMultimap,
+              const [const FullType(int), const FullType(bool)])),
+      'setMultimap',
+      serializers.serialize(object.setMultimap,
+          specifiedType: const FullType(BuiltSetMultimap,
+              const [const FullType(String), const FullType(bool)])),
+      'nullsInList',
+      serializers.serialize(object.nullsInList,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType.nullable(int)])),
+      'nullsInSet',
+      serializers.serialize(object.nullsInSet,
+          specifiedType: const FullType(
+              BuiltSet, const [const FullType.nullable(String)])),
+      'nullsInMap',
+      serializers.serialize(object.nullsInMap,
+          specifiedType: const FullType(BuiltMap, const [
+            const FullType.nullable(String),
+            const FullType.nullable(int)
+          ])),
+      'nullsInListMultimap',
+      serializers.serialize(object.nullsInListMultimap,
+          specifiedType: const FullType(BuiltListMultimap,
+              const [const FullType.nullable(int), const FullType(bool)])),
+      'nullsInSetMultimap',
+      serializers.serialize(object.nullsInSetMultimap,
+          specifiedType: const FullType(BuiltSetMultimap,
+              const [const FullType(String), const FullType.nullable(bool)])),
+      'nullableInGenericsList',
+      serializers.serialize(object.nullableInGenericsList,
+          specifiedType: const FullType(BuiltList, const [
+            const FullType(Foo, const [const FullType.nullable(int)])
+          ])),
+      'nestedNullablesList',
+      serializers.serialize(object.nestedNullablesList,
+          specifiedType: const FullType(BuiltList, const [
+            const FullType.nullable(
+                BuiltList, const [const FullType.nullable(int)])
+          ])),
+    ];
+    Object? value;
+    value = object.nullableList;
+    if (value != null) {
+      result
+        ..add('nullableList')
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(int)])));
+    }
+    value = object.nullableSet;
+    if (value != null) {
+      result
+        ..add('nullableSet')
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltSet, const [const FullType(String)])));
+    }
+    value = object.nullableMap;
+    if (value != null) {
+      result
+        ..add('nullableMap')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltMap,
+                const [const FullType(String), const FullType(int)])));
+    }
+    value = object.nullableListMultimap;
+    if (value != null) {
+      result
+        ..add('nullableListMultimap')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltListMultimap,
+                const [const FullType(int), const FullType(bool)])));
+    }
+    value = object.nullableSetMultimap;
+    if (value != null) {
+      result
+        ..add('nullableSetMultimap')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltSetMultimap,
+                const [const FullType(String), const FullType(bool)])));
+    }
+    return result;
+  }
+
+  @override
+  Collections deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CollectionsBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'list':
+          result.list.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(int)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'set':
+          result.set.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltSet, const [const FullType(String)]))!
+              as BuiltSet<Object?>);
+          break;
+        case 'map':
+          result.map.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap,
+                  const [const FullType(String), const FullType(int)]))!);
+          break;
+        case 'listMultimap':
+          result.listMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltListMultimap,
+                  const [const FullType(int), const FullType(bool)]))!);
+          break;
+        case 'setMultimap':
+          result.setMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltSetMultimap,
+                  const [const FullType(String), const FullType(bool)]))!);
+          break;
+        case 'nullsInList':
+          result.nullsInList.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType.nullable(int)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'nullsInSet':
+          result.nullsInSet.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltSet, const [const FullType.nullable(String)]))!
+              as BuiltSet<Object?>);
+          break;
+        case 'nullsInMap':
+          result.nullsInMap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, const [
+                const FullType.nullable(String),
+                const FullType.nullable(int)
+              ]))!);
+          break;
+        case 'nullsInListMultimap':
+          result.nullsInListMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltListMultimap, const [
+                const FullType.nullable(int),
+                const FullType(bool)
+              ]))!);
+          break;
+        case 'nullsInSetMultimap':
+          result.nullsInSetMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltSetMultimap, const [
+                const FullType(String),
+                const FullType.nullable(bool)
+              ]))!);
+          break;
+        case 'nullableList':
+          result.nullableList.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(int)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'nullableSet':
+          result.nullableSet.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltSet, const [const FullType(String)]))!
+              as BuiltSet<Object?>);
+          break;
+        case 'nullableMap':
+          result.nullableMap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap,
+                  const [const FullType(String), const FullType(int)]))!);
+          break;
+        case 'nullableListMultimap':
+          result.nullableListMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltListMultimap,
+                  const [const FullType(int), const FullType(bool)]))!);
+          break;
+        case 'nullableSetMultimap':
+          result.nullableSetMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltSetMultimap,
+                  const [const FullType(String), const FullType(bool)]))!);
+          break;
+        case 'nullableInGenericsList':
+          result.nullableInGenericsList.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(Foo, const [const FullType.nullable(int)])
+              ]))! as BuiltList<Object?>);
+          break;
+        case 'nestedNullablesList':
+          result.nestedNullablesList.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType.nullable(
+                    BuiltList, const [const FullType.nullable(int)])
+              ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$Collections extends Collections {
+  @override
+  final BuiltList<int> list;
+  @override
+  final BuiltSet<String> set;
+  @override
+  final BuiltMap<String, int> map;
+  @override
+  final BuiltListMultimap<int, bool> listMultimap;
+  @override
+  final BuiltSetMultimap<String, bool> setMultimap;
+  @override
+  final BuiltList<int?> nullsInList;
+  @override
+  final BuiltSet<String?> nullsInSet;
+  @override
+  final BuiltMap<String?, int?> nullsInMap;
+  @override
+  final BuiltListMultimap<int?, bool> nullsInListMultimap;
+  @override
+  final BuiltSetMultimap<String, bool?> nullsInSetMultimap;
+  @override
+  final BuiltList<int>? nullableList;
+  @override
+  final BuiltSet<String>? nullableSet;
+  @override
+  final BuiltMap<String, int>? nullableMap;
+  @override
+  final BuiltListMultimap<int, bool>? nullableListMultimap;
+  @override
+  final BuiltSetMultimap<String, bool>? nullableSetMultimap;
+  @override
+  final BuiltList<Foo<int?>> nullableInGenericsList;
+  @override
+  final BuiltList<BuiltList<int?>?> nestedNullablesList;
+
+  factory _$Collections([void Function(CollectionsBuilder)? updates]) =>
+      (CollectionsBuilder()..update(updates))._build();
+
+  _$Collections._(
+      {required this.list,
+      required this.set,
+      required this.map,
+      required this.listMultimap,
+      required this.setMultimap,
+      required this.nullsInList,
+      required this.nullsInSet,
+      required this.nullsInMap,
+      required this.nullsInListMultimap,
+      required this.nullsInSetMultimap,
+      this.nullableList,
+      this.nullableSet,
+      this.nullableMap,
+      this.nullableListMultimap,
+      this.nullableSetMultimap,
+      required this.nullableInGenericsList,
+      required this.nestedNullablesList})
+      : super._();
+  @override
+  Collections rebuild(void Function(CollectionsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CollectionsBuilder toBuilder() => CollectionsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Collections &&
+        list == other.list &&
+        set == other.set &&
+        map == other.map &&
+        listMultimap == other.listMultimap &&
+        setMultimap == other.setMultimap &&
+        nullsInList == other.nullsInList &&
+        nullsInSet == other.nullsInSet &&
+        nullsInMap == other.nullsInMap &&
+        nullsInListMultimap == other.nullsInListMultimap &&
+        nullsInSetMultimap == other.nullsInSetMultimap &&
+        nullableList == other.nullableList &&
+        nullableSet == other.nullableSet &&
+        nullableMap == other.nullableMap &&
+        nullableListMultimap == other.nullableListMultimap &&
+        nullableSetMultimap == other.nullableSetMultimap &&
+        nullableInGenericsList == other.nullableInGenericsList &&
+        nestedNullablesList == other.nestedNullablesList;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, list.hashCode);
+    _$hash = $jc(_$hash, set.hashCode);
+    _$hash = $jc(_$hash, map.hashCode);
+    _$hash = $jc(_$hash, listMultimap.hashCode);
+    _$hash = $jc(_$hash, setMultimap.hashCode);
+    _$hash = $jc(_$hash, nullsInList.hashCode);
+    _$hash = $jc(_$hash, nullsInSet.hashCode);
+    _$hash = $jc(_$hash, nullsInMap.hashCode);
+    _$hash = $jc(_$hash, nullsInListMultimap.hashCode);
+    _$hash = $jc(_$hash, nullsInSetMultimap.hashCode);
+    _$hash = $jc(_$hash, nullableList.hashCode);
+    _$hash = $jc(_$hash, nullableSet.hashCode);
+    _$hash = $jc(_$hash, nullableMap.hashCode);
+    _$hash = $jc(_$hash, nullableListMultimap.hashCode);
+    _$hash = $jc(_$hash, nullableSetMultimap.hashCode);
+    _$hash = $jc(_$hash, nullableInGenericsList.hashCode);
+    _$hash = $jc(_$hash, nestedNullablesList.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Collections')
+          ..add('list', list)
+          ..add('set', set)
+          ..add('map', map)
+          ..add('listMultimap', listMultimap)
+          ..add('setMultimap', setMultimap)
+          ..add('nullsInList', nullsInList)
+          ..add('nullsInSet', nullsInSet)
+          ..add('nullsInMap', nullsInMap)
+          ..add('nullsInListMultimap', nullsInListMultimap)
+          ..add('nullsInSetMultimap', nullsInSetMultimap)
+          ..add('nullableList', nullableList)
+          ..add('nullableSet', nullableSet)
+          ..add('nullableMap', nullableMap)
+          ..add('nullableListMultimap', nullableListMultimap)
+          ..add('nullableSetMultimap', nullableSetMultimap)
+          ..add('nullableInGenericsList', nullableInGenericsList)
+          ..add('nestedNullablesList', nestedNullablesList))
+        .toString();
+  }
+}
+
+class CollectionsBuilder implements Builder<Collections, CollectionsBuilder> {
+  _$Collections? _$v;
+
+  ListBuilder<int>? _list;
+  ListBuilder<int> get list => _$this._list ??= ListBuilder<int>();
+  set list(ListBuilder<int>? list) => _$this._list = list;
+
+  SetBuilder<String>? _set;
+  SetBuilder<String> get set => _$this._set ??= SetBuilder<String>();
+  set set(SetBuilder<String>? set) => _$this._set = set;
+
+  MapBuilder<String, int>? _map;
+  MapBuilder<String, int> get map => _$this._map ??= MapBuilder<String, int>();
+  set map(MapBuilder<String, int>? map) => _$this._map = map;
+
+  ListMultimapBuilder<int, bool>? _listMultimap;
+  ListMultimapBuilder<int, bool> get listMultimap =>
+      _$this._listMultimap ??= ListMultimapBuilder<int, bool>();
+  set listMultimap(ListMultimapBuilder<int, bool>? listMultimap) =>
+      _$this._listMultimap = listMultimap;
+
+  SetMultimapBuilder<String, bool>? _setMultimap;
+  SetMultimapBuilder<String, bool> get setMultimap =>
+      _$this._setMultimap ??= SetMultimapBuilder<String, bool>();
+  set setMultimap(SetMultimapBuilder<String, bool>? setMultimap) =>
+      _$this._setMultimap = setMultimap;
+
+  ListBuilder<int?>? _nullsInList;
+  ListBuilder<int?> get nullsInList =>
+      _$this._nullsInList ??= ListBuilder<int?>();
+  set nullsInList(ListBuilder<int?>? nullsInList) =>
+      _$this._nullsInList = nullsInList;
+
+  SetBuilder<String?>? _nullsInSet;
+  SetBuilder<String?> get nullsInSet =>
+      _$this._nullsInSet ??= SetBuilder<String?>();
+  set nullsInSet(SetBuilder<String?>? nullsInSet) =>
+      _$this._nullsInSet = nullsInSet;
+
+  MapBuilder<String?, int?>? _nullsInMap;
+  MapBuilder<String?, int?> get nullsInMap =>
+      _$this._nullsInMap ??= MapBuilder<String?, int?>();
+  set nullsInMap(MapBuilder<String?, int?>? nullsInMap) =>
+      _$this._nullsInMap = nullsInMap;
+
+  ListMultimapBuilder<int?, bool>? _nullsInListMultimap;
+  ListMultimapBuilder<int?, bool> get nullsInListMultimap =>
+      _$this._nullsInListMultimap ??= ListMultimapBuilder<int?, bool>();
+  set nullsInListMultimap(
+          ListMultimapBuilder<int?, bool>? nullsInListMultimap) =>
+      _$this._nullsInListMultimap = nullsInListMultimap;
+
+  SetMultimapBuilder<String, bool?>? _nullsInSetMultimap;
+  SetMultimapBuilder<String, bool?> get nullsInSetMultimap =>
+      _$this._nullsInSetMultimap ??= SetMultimapBuilder<String, bool?>();
+  set nullsInSetMultimap(
+          SetMultimapBuilder<String, bool?>? nullsInSetMultimap) =>
+      _$this._nullsInSetMultimap = nullsInSetMultimap;
+
+  ListBuilder<int>? _nullableList;
+  ListBuilder<int> get nullableList =>
+      _$this._nullableList ??= ListBuilder<int>();
+  set nullableList(ListBuilder<int>? nullableList) =>
+      _$this._nullableList = nullableList;
+
+  SetBuilder<String>? _nullableSet;
+  SetBuilder<String> get nullableSet =>
+      _$this._nullableSet ??= SetBuilder<String>();
+  set nullableSet(SetBuilder<String>? nullableSet) =>
+      _$this._nullableSet = nullableSet;
+
+  MapBuilder<String, int>? _nullableMap;
+  MapBuilder<String, int> get nullableMap =>
+      _$this._nullableMap ??= MapBuilder<String, int>();
+  set nullableMap(MapBuilder<String, int>? nullableMap) =>
+      _$this._nullableMap = nullableMap;
+
+  ListMultimapBuilder<int, bool>? _nullableListMultimap;
+  ListMultimapBuilder<int, bool> get nullableListMultimap =>
+      _$this._nullableListMultimap ??= ListMultimapBuilder<int, bool>();
+  set nullableListMultimap(
+          ListMultimapBuilder<int, bool>? nullableListMultimap) =>
+      _$this._nullableListMultimap = nullableListMultimap;
+
+  SetMultimapBuilder<String, bool>? _nullableSetMultimap;
+  SetMultimapBuilder<String, bool> get nullableSetMultimap =>
+      _$this._nullableSetMultimap ??= SetMultimapBuilder<String, bool>();
+  set nullableSetMultimap(
+          SetMultimapBuilder<String, bool>? nullableSetMultimap) =>
+      _$this._nullableSetMultimap = nullableSetMultimap;
+
+  ListBuilder<Foo<int?>>? _nullableInGenericsList;
+  ListBuilder<Foo<int?>> get nullableInGenericsList =>
+      _$this._nullableInGenericsList ??= ListBuilder<Foo<int?>>();
+  set nullableInGenericsList(ListBuilder<Foo<int?>>? nullableInGenericsList) =>
+      _$this._nullableInGenericsList = nullableInGenericsList;
+
+  ListBuilder<BuiltList<int?>?>? _nestedNullablesList;
+  ListBuilder<BuiltList<int?>?> get nestedNullablesList =>
+      _$this._nestedNullablesList ??= ListBuilder<BuiltList<int?>?>();
+  set nestedNullablesList(ListBuilder<BuiltList<int?>?>? nestedNullablesList) =>
+      _$this._nestedNullablesList = nestedNullablesList;
+
+  CollectionsBuilder();
+
+  CollectionsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _list = $v.list.toBuilder();
+      _set = $v.set.toBuilder();
+      _map = $v.map.toBuilder();
+      _listMultimap = $v.listMultimap.toBuilder();
+      _setMultimap = $v.setMultimap.toBuilder();
+      _nullsInList = $v.nullsInList.toBuilder();
+      _nullsInSet = $v.nullsInSet.toBuilder();
+      _nullsInMap = $v.nullsInMap.toBuilder();
+      _nullsInListMultimap = $v.nullsInListMultimap.toBuilder();
+      _nullsInSetMultimap = $v.nullsInSetMultimap.toBuilder();
+      _nullableList = $v.nullableList?.toBuilder();
+      _nullableSet = $v.nullableSet?.toBuilder();
+      _nullableMap = $v.nullableMap?.toBuilder();
+      _nullableListMultimap = $v.nullableListMultimap?.toBuilder();
+      _nullableSetMultimap = $v.nullableSetMultimap?.toBuilder();
+      _nullableInGenericsList = $v.nullableInGenericsList.toBuilder();
+      _nestedNullablesList = $v.nestedNullablesList.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Collections other) {
+    _$v = other as _$Collections;
+  }
+
+  @override
+  void update(void Function(CollectionsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Collections build() => _build();
+
+  _$Collections _build() {
+    _$Collections _$result;
+    try {
+      _$result = _$v ??
+          _$Collections._(
+            list: list.build(),
+            set: set.build(),
+            map: map.build(),
+            listMultimap: listMultimap.build(),
+            setMultimap: setMultimap.build(),
+            nullsInList: nullsInList.build(),
+            nullsInSet: nullsInSet.build(),
+            nullsInMap: nullsInMap.build(),
+            nullsInListMultimap: nullsInListMultimap.build(),
+            nullsInSetMultimap: nullsInSetMultimap.build(),
+            nullableList: _nullableList?.build(),
+            nullableSet: _nullableSet?.build(),
+            nullableMap: _nullableMap?.build(),
+            nullableListMultimap: _nullableListMultimap?.build(),
+            nullableSetMultimap: _nullableSetMultimap?.build(),
+            nullableInGenericsList: nullableInGenericsList.build(),
+            nestedNullablesList: nestedNullablesList.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'list';
+        list.build();
+        _$failedField = 'set';
+        set.build();
+        _$failedField = 'map';
+        map.build();
+        _$failedField = 'listMultimap';
+        listMultimap.build();
+        _$failedField = 'setMultimap';
+        setMultimap.build();
+        _$failedField = 'nullsInList';
+        nullsInList.build();
+        _$failedField = 'nullsInSet';
+        nullsInSet.build();
+        _$failedField = 'nullsInMap';
+        nullsInMap.build();
+        _$failedField = 'nullsInListMultimap';
+        nullsInListMultimap.build();
+        _$failedField = 'nullsInSetMultimap';
+        nullsInSetMultimap.build();
+        _$failedField = 'nullableList';
+        _nullableList?.build();
+        _$failedField = 'nullableSet';
+        _nullableSet?.build();
+        _$failedField = 'nullableMap';
+        _nullableMap?.build();
+        _$failedField = 'nullableListMultimap';
+        _nullableListMultimap?.build();
+        _$failedField = 'nullableSetMultimap';
+        _nullableSetMultimap?.build();
+        _$failedField = 'nullableInGenericsList';
+        nullableInGenericsList.build();
+        _$failedField = 'nestedNullablesList';
+        nestedNullablesList.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'Collections', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/lib/enums.dart
+++ b/built_types/end_to_end_test/lib/enums.dart
@@ -1,0 +1,154 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+library enums_nnbd;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'enums.g.dart';
+
+class TestEnum extends EnumClass {
+  static Serializer<TestEnum> get serializer => _$testEnumSerializer;
+
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(super.name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+
+typedef TestEnumMixin = _$TestEnumMixin;
+
+class SecondTestEnum extends EnumClass {
+  static const SecondTestEnum yes = _$ys;
+  static const SecondTestEnum no = _$n;
+  static const SecondTestEnum definitely = _$definitely;
+
+  const SecondTestEnum._(String name) : super(name);
+
+  static BuiltSet<SecondTestEnum> get values => _$vls;
+  static SecondTestEnum valueOf(String name) => _$vlOf(name);
+}
+
+@BuiltValueEnum(wireName: 'E')
+class WireNameEnum extends EnumClass {
+  static Serializer<WireNameEnum> get serializer => _$wireNameEnumSerializer;
+
+  @BuiltValueEnumConst(wireName: 'y')
+  static const WireNameEnum yes = _$wireYes;
+
+  @BuiltValueEnumConst(wireName: 'n')
+  static const WireNameEnum no = _$wireNo;
+
+  @BuiltValueEnumConst(wireName: 'd')
+  static const WireNameEnum definitely = _$wireDefinitely;
+
+  const WireNameEnum._(String name) : super(name);
+
+  static BuiltSet<WireNameEnum> get values => _$wireValues;
+  static WireNameEnum valueOf(String name) => _$wireValueOf(name);
+}
+
+class WireNumberEnum extends EnumClass {
+  static Serializer<WireNumberEnum> get serializer =>
+      _$wireNumberEnumSerializer;
+
+  @BuiltValueEnumConst(wireNumber: 1)
+  static const WireNumberEnum yes = _$wireNumberYes;
+
+  @BuiltValueEnumConst(wireNumber: 2)
+  static const WireNumberEnum no = _$wireNumberNo;
+
+  // `wireName` on fields can be mixed in the same class.
+  @BuiltValueEnumConst(wireName: '3')
+  static const WireNumberEnum definitely = _$wireNumberDefinitely;
+
+  const WireNumberEnum._(String name) : super(name);
+
+  static BuiltSet<WireNumberEnum> get values => _$wireNumberValues;
+  static WireNumberEnum valueOf(String name) => _$wireNumberValueOf(name);
+}
+
+// Check escaping for dollar sign in enum values.
+class DollarValueEnum extends EnumClass {
+  static Serializer<DollarValueEnum> get serializer =>
+      _$dollarValueEnumSerializer;
+
+  static const DollarValueEnum value$ = _$value$;
+
+  @BuiltValueEnumConst(wireName: 'value')
+  static const DollarValueEnum $value = _$value;
+
+  const DollarValueEnum._(String name) : super(name);
+
+  static BuiltSet<DollarValueEnum> get values => _$dollarValues;
+  static DollarValueEnum valueOf(String name) => _$dollarValueOf(name);
+}
+
+class FallbackEnum extends EnumClass {
+  static Serializer<FallbackEnum> get serializer => _$fallbackEnumSerializer;
+
+  static const FallbackEnum yes = _$fbYes;
+
+  @BuiltValueEnumConst(fallback: true)
+  static const FallbackEnum no = _$fbNo;
+
+  const FallbackEnum._(String name) : super(name);
+
+  static BuiltSet<FallbackEnum> get values => _$fbValues;
+  static FallbackEnum valueOf(String name) => _$fbValueOf(name);
+}
+
+class FallbackNumberEnum extends EnumClass {
+  static Serializer<FallbackNumberEnum> get serializer =>
+      _$fallbackNumberEnumSerializer;
+
+  @BuiltValueEnumConst(wireNumber: 0)
+  static const FallbackNumberEnum yes = _$fbNumberYes;
+
+  @BuiltValueEnumConst(wireNumber: -1, fallback: true)
+  static const FallbackNumberEnum no = _$fbNumberNo;
+
+  const FallbackNumberEnum._(String name) : super(name);
+
+  static BuiltSet<FallbackNumberEnum> get values => _$fbNumberValues;
+  static FallbackNumberEnum valueOf(String name) => _$fbNumberValueOf(name);
+}
+
+class EnumWith$Dollar_UnderScore extends EnumClass {
+  static Serializer<EnumWith$Dollar_UnderScore> get serializer =>
+      _$enumWith$DollarUnderScoreSerializer;
+
+  @BuiltValueEnumConst(wireNumber: 0)
+  static const EnumWith$Dollar_UnderScore $value =
+      _$dollar_UnderScoreEnum$Value;
+
+  @BuiltValueEnumConst(wireNumber: -1, fallback: true)
+  static const EnumWith$Dollar_UnderScore value$ =
+      _$dollar_UnderScoreEnumValue$;
+
+  const EnumWith$Dollar_UnderScore._(String name) : super(name);
+
+  static BuiltSet<EnumWith$Dollar_UnderScore> get values =>
+      _$enum$Dollar_UnderScoreValues;
+  static EnumWith$Dollar_UnderScore valueOf(String name) =>
+      _$enum$Dollar_UnderScoreValueOf(name);
+}
+
+class NewConstructorEnum extends EnumClass {
+  static Serializer<NewConstructorEnum> get serializer =>
+      _$newConstructorEnumSerializer;
+
+  static const NewConstructorEnum yes = _$newYes;
+  static const NewConstructorEnum no = _$newNo;
+
+  const new _(super.name);
+
+  static BuiltSet<NewConstructorEnum> get values => _$newValues;
+  static NewConstructorEnum valueOf(String name) => _$newValueOf(name);
+}

--- a/built_types/end_to_end_test/lib/enums.g.dart
+++ b/built_types/end_to_end_test/lib/enums.g.dart
@@ -1,0 +1,455 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'enums.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+const TestEnum _$yes = const TestEnum._('yes');
+const TestEnum _$no = const TestEnum._('no');
+const TestEnum _$maybe = const TestEnum._('maybe');
+
+TestEnum _$valueOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$yes;
+    case 'no':
+      return _$no;
+    case 'maybe':
+      return _$maybe;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<TestEnum> _$values = BuiltSet<TestEnum>(const <TestEnum>[
+  _$yes,
+  _$no,
+  _$maybe,
+]);
+
+class _$TestEnumMeta {
+  const _$TestEnumMeta();
+  TestEnum get yes => _$yes;
+  TestEnum get no => _$no;
+  TestEnum get maybe => _$maybe;
+  TestEnum valueOf(String name) => _$valueOf(name);
+  BuiltSet<TestEnum> get values => _$values;
+}
+
+mixin _$TestEnumMixin {
+  // ignore: non_constant_identifier_names
+  _$TestEnumMeta get TestEnum => const _$TestEnumMeta();
+}
+
+const SecondTestEnum _$ys = const SecondTestEnum._('yes');
+const SecondTestEnum _$n = const SecondTestEnum._('no');
+const SecondTestEnum _$definitely = const SecondTestEnum._('definitely');
+
+SecondTestEnum _$vlOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$ys;
+    case 'no':
+      return _$n;
+    case 'definitely':
+      return _$definitely;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<SecondTestEnum> _$vls = BuiltSet<SecondTestEnum>(
+  const <SecondTestEnum>[_$ys, _$n, _$definitely],
+);
+
+const WireNameEnum _$wireYes = const WireNameEnum._('yes');
+const WireNameEnum _$wireNo = const WireNameEnum._('no');
+const WireNameEnum _$wireDefinitely = const WireNameEnum._('definitely');
+
+WireNameEnum _$wireValueOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$wireYes;
+    case 'no':
+      return _$wireNo;
+    case 'definitely':
+      return _$wireDefinitely;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<WireNameEnum> _$wireValues = BuiltSet<WireNameEnum>(
+  const <WireNameEnum>[_$wireYes, _$wireNo, _$wireDefinitely],
+);
+
+const WireNumberEnum _$wireNumberYes = const WireNumberEnum._('yes');
+const WireNumberEnum _$wireNumberNo = const WireNumberEnum._('no');
+const WireNumberEnum _$wireNumberDefinitely = const WireNumberEnum._(
+  'definitely',
+);
+
+WireNumberEnum _$wireNumberValueOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$wireNumberYes;
+    case 'no':
+      return _$wireNumberNo;
+    case 'definitely':
+      return _$wireNumberDefinitely;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<WireNumberEnum> _$wireNumberValues = BuiltSet<WireNumberEnum>(
+  const <WireNumberEnum>[
+    _$wireNumberYes,
+    _$wireNumberNo,
+    _$wireNumberDefinitely,
+  ],
+);
+
+const DollarValueEnum _$value$ = const DollarValueEnum._('value\$');
+const DollarValueEnum _$value = const DollarValueEnum._('\$value');
+
+DollarValueEnum _$dollarValueOf(String name) {
+  switch (name) {
+    case 'value\$':
+      return _$value$;
+    case '\$value':
+      return _$value;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<DollarValueEnum> _$dollarValues = BuiltSet<DollarValueEnum>(
+  const <DollarValueEnum>[_$value$, _$value],
+);
+
+const FallbackEnum _$fbYes = const FallbackEnum._('yes');
+const FallbackEnum _$fbNo = const FallbackEnum._('no');
+
+FallbackEnum _$fbValueOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$fbYes;
+    case 'no':
+      return _$fbNo;
+    default:
+      return _$fbNo;
+  }
+}
+
+final BuiltSet<FallbackEnum> _$fbValues = BuiltSet<FallbackEnum>(
+  const <FallbackEnum>[_$fbYes, _$fbNo],
+);
+
+const FallbackNumberEnum _$fbNumberYes = const FallbackNumberEnum._('yes');
+const FallbackNumberEnum _$fbNumberNo = const FallbackNumberEnum._('no');
+
+FallbackNumberEnum _$fbNumberValueOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$fbNumberYes;
+    case 'no':
+      return _$fbNumberNo;
+    default:
+      return _$fbNumberNo;
+  }
+}
+
+final BuiltSet<FallbackNumberEnum> _$fbNumberValues =
+    BuiltSet<FallbackNumberEnum>(const <FallbackNumberEnum>[
+      _$fbNumberYes,
+      _$fbNumberNo,
+    ]);
+
+const EnumWith$Dollar_UnderScore _$dollar_UnderScoreEnum$Value =
+    const EnumWith$Dollar_UnderScore._('\$value');
+const EnumWith$Dollar_UnderScore _$dollar_UnderScoreEnumValue$ =
+    const EnumWith$Dollar_UnderScore._('value\$');
+
+EnumWith$Dollar_UnderScore _$enum$Dollar_UnderScoreValueOf(String name) {
+  switch (name) {
+    case '\$value':
+      return _$dollar_UnderScoreEnum$Value;
+    case 'value\$':
+      return _$dollar_UnderScoreEnumValue$;
+    default:
+      return _$dollar_UnderScoreEnumValue$;
+  }
+}
+
+final BuiltSet<EnumWith$Dollar_UnderScore> _$enum$Dollar_UnderScoreValues =
+    BuiltSet<EnumWith$Dollar_UnderScore>(const <EnumWith$Dollar_UnderScore>[
+      _$dollar_UnderScoreEnum$Value,
+      _$dollar_UnderScoreEnumValue$,
+    ]);
+
+const NewConstructorEnum _$newYes = const NewConstructorEnum._('yes');
+const NewConstructorEnum _$newNo = const NewConstructorEnum._('no');
+
+NewConstructorEnum _$newValueOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$newYes;
+    case 'no':
+      return _$newNo;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<NewConstructorEnum> _$newValues = BuiltSet<NewConstructorEnum>(
+  const <NewConstructorEnum>[_$newYes, _$newNo],
+);
+
+Serializer<TestEnum> _$testEnumSerializer = _$TestEnumSerializer();
+Serializer<WireNameEnum> _$wireNameEnumSerializer = _$WireNameEnumSerializer();
+Serializer<WireNumberEnum> _$wireNumberEnumSerializer =
+    _$WireNumberEnumSerializer();
+Serializer<DollarValueEnum> _$dollarValueEnumSerializer =
+    _$DollarValueEnumSerializer();
+Serializer<FallbackEnum> _$fallbackEnumSerializer = _$FallbackEnumSerializer();
+Serializer<FallbackNumberEnum> _$fallbackNumberEnumSerializer =
+    _$FallbackNumberEnumSerializer();
+Serializer<EnumWith$Dollar_UnderScore> _$enumWith$DollarUnderScoreSerializer =
+    _$EnumWith$Dollar_UnderScoreSerializer();
+Serializer<NewConstructorEnum> _$newConstructorEnumSerializer =
+    _$NewConstructorEnumSerializer();
+
+class _$TestEnumSerializer implements PrimitiveSerializer<TestEnum> {
+  @override
+  final Iterable<Type> types = const <Type>[TestEnum];
+  @override
+  final String wireName = 'TestEnum';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    TestEnum object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => object.name;
+
+  @override
+  TestEnum deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => TestEnum.valueOf(serialized as String);
+}
+
+class _$WireNameEnumSerializer implements PrimitiveSerializer<WireNameEnum> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    'yes': 'y',
+    'no': 'n',
+    'definitely': 'd',
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    'y': 'yes',
+    'n': 'no',
+    'd': 'definitely',
+  };
+
+  @override
+  final Iterable<Type> types = const <Type>[WireNameEnum];
+  @override
+  final String wireName = 'E';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    WireNameEnum object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => _toWire[object.name] ?? object.name;
+
+  @override
+  WireNameEnum deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => WireNameEnum.valueOf(
+    _fromWire[serialized] ?? (serialized is String ? serialized : ''),
+  );
+}
+
+class _$WireNumberEnumSerializer
+    implements PrimitiveSerializer<WireNumberEnum> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    'yes': 1,
+    'no': 2,
+    'definitely': '3',
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    1: 'yes',
+    2: 'no',
+    '3': 'definitely',
+  };
+
+  @override
+  final Iterable<Type> types = const <Type>[WireNumberEnum];
+  @override
+  final String wireName = 'WireNumberEnum';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    WireNumberEnum object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => _toWire[object.name] ?? object.name;
+
+  @override
+  WireNumberEnum deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => WireNumberEnum.valueOf(
+    _fromWire[serialized] ?? (serialized is String ? serialized : ''),
+  );
+}
+
+class _$DollarValueEnumSerializer
+    implements PrimitiveSerializer<DollarValueEnum> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    '\$value': 'value',
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    'value': '\$value',
+  };
+
+  @override
+  final Iterable<Type> types = const <Type>[DollarValueEnum];
+  @override
+  final String wireName = 'DollarValueEnum';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    DollarValueEnum object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => _toWire[object.name] ?? object.name;
+
+  @override
+  DollarValueEnum deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => DollarValueEnum.valueOf(
+    _fromWire[serialized] ?? (serialized is String ? serialized : ''),
+  );
+}
+
+class _$FallbackEnumSerializer implements PrimitiveSerializer<FallbackEnum> {
+  @override
+  final Iterable<Type> types = const <Type>[FallbackEnum];
+  @override
+  final String wireName = 'FallbackEnum';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    FallbackEnum object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => object.name;
+
+  @override
+  FallbackEnum deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => FallbackEnum.valueOf(serialized as String);
+}
+
+class _$FallbackNumberEnumSerializer
+    implements PrimitiveSerializer<FallbackNumberEnum> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    'yes': 0,
+    'no': -1,
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    0: 'yes',
+    -1: 'no',
+  };
+
+  @override
+  final Iterable<Type> types = const <Type>[FallbackNumberEnum];
+  @override
+  final String wireName = 'FallbackNumberEnum';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    FallbackNumberEnum object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => _toWire[object.name] ?? object.name;
+
+  @override
+  FallbackNumberEnum deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => FallbackNumberEnum.valueOf(
+    _fromWire[serialized] ?? (serialized is String ? serialized : ''),
+  );
+}
+
+class _$EnumWith$Dollar_UnderScoreSerializer
+    implements PrimitiveSerializer<EnumWith$Dollar_UnderScore> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    '\$value': 0,
+    'value\$': -1,
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    0: '\$value',
+    -1: 'value\$',
+  };
+
+  @override
+  final Iterable<Type> types = const <Type>[EnumWith$Dollar_UnderScore];
+  @override
+  final String wireName = 'EnumWith\$Dollar_UnderScore';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    EnumWith$Dollar_UnderScore object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => _toWire[object.name] ?? object.name;
+
+  @override
+  EnumWith$Dollar_UnderScore deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => EnumWith$Dollar_UnderScore.valueOf(
+    _fromWire[serialized] ?? (serialized is String ? serialized : ''),
+  );
+}
+
+class _$NewConstructorEnumSerializer
+    implements PrimitiveSerializer<NewConstructorEnum> {
+  @override
+  final Iterable<Type> types = const <Type>[NewConstructorEnum];
+  @override
+  final String wireName = 'NewConstructorEnum';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    NewConstructorEnum object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => object.name;
+
+  @override
+  NewConstructorEnum deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => NewConstructorEnum.valueOf(serialized as String);
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/lib/errors_matchers.dart
+++ b/built_types/end_to_end_test/lib/errors_matchers.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2018, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:test/test.dart';
+
+Matcher isErrorContaining(String string) => _ErrorContaining(string);
+
+class _ErrorContaining extends TypeMatcher<Error> {
+  String string;
+
+  _ErrorContaining(this.string);
+
+  @override
+  Description describe(Description description) {
+    super.describe(description);
+    description.add(' containing "$string"');
+    return description;
+  }
+
+  @override
+  bool matches(dynamic item, Map<Object?, Object?> matchState) =>
+      item is Error && item.toString().contains(string);
+}

--- a/built_types/end_to_end_test/lib/exports_built_value.dart
+++ b/built_types/end_to_end_test/lib/exports_built_value.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2025, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+export 'package:built_value/built_value.dart';

--- a/built_types/end_to_end_test/lib/generics.dart
+++ b/built_types/end_to_end_test/lib/generics.dart
@@ -1,0 +1,225 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'generics.g.dart';
+
+abstract class GenericValue<T>
+    implements Built<GenericValue<T>, GenericValueBuilder<T>> {
+  static Serializer<GenericValue<Object?>> get serializer =>
+      _$genericValueSerializer;
+
+  T get value;
+
+  factory GenericValue([Function(GenericValueBuilder<T>) updates]) =
+      _$GenericValue<T>;
+  factory GenericValue.of(T value) => _$GenericValue._(value: value);
+  GenericValue._();
+}
+
+abstract class InitializeGenericValue<T>
+    implements
+        Built<InitializeGenericValue<T>, InitializeGenericValueBuilder<T>> {
+  static void _initializeBuilder<T>(InitializeGenericValueBuilder<T> b) {
+    if (T == int) {
+      b.value = 3 as T;
+    }
+  }
+
+  T get value;
+
+  factory InitializeGenericValue(
+          [Function(InitializeGenericValueBuilder<T>) updates]) =
+      _$InitializeGenericValue<T>;
+  factory InitializeGenericValue.of(T value) =>
+      _$InitializeGenericValue._(value: value);
+  InitializeGenericValue._();
+}
+
+abstract class BoundGenericValue<T extends num>
+    implements Built<BoundGenericValue<T>, BoundGenericValueBuilder<T>> {
+  static Serializer<BoundGenericValue> get serializer =>
+      _$boundGenericValueSerializer;
+
+  T get value;
+  T? get nullableValue;
+
+  factory BoundGenericValue([Function(BoundGenericValueBuilder<T>) updates]) =
+      _$BoundGenericValue<T>;
+  BoundGenericValue._();
+}
+
+abstract class BoundNullableGenericValue<T extends num?>
+    implements
+        Built<BoundNullableGenericValue<T>,
+            BoundNullableGenericValueBuilder<T>> {
+  static Serializer<BoundNullableGenericValue> get serializer =>
+      _$boundNullableGenericValueSerializer;
+
+  T get value;
+  T? get nullableValue;
+
+  factory BoundNullableGenericValue(
+          [Function(BoundNullableGenericValueBuilder<T>) updates]) =
+      _$BoundNullableGenericValue<T>;
+  BoundNullableGenericValue._();
+}
+
+abstract class CollectionGenericValue<T>
+    implements
+        Built<CollectionGenericValue<T>, CollectionGenericValueBuilder<T>> {
+  static Serializer<CollectionGenericValue<Object?>> get serializer =>
+      _$collectionGenericValueSerializer;
+
+  BuiltList<T> get values;
+
+  factory CollectionGenericValue(
+          [Function(CollectionGenericValueBuilder<T>) updates]) =
+      _$CollectionGenericValue<T>;
+  CollectionGenericValue._();
+}
+
+abstract class GenericContainer
+    implements Built<GenericContainer, GenericContainerBuilder> {
+  static Serializer<GenericContainer> get serializer =>
+      _$genericContainerSerializer;
+
+  GenericValue<String> get genericValue;
+  BoundGenericValue<double> get boundGenericValue;
+  CollectionGenericValue<String> get collectionGenericValue;
+
+  factory GenericContainer([void Function(GenericContainerBuilder) updates]) =
+      _$GenericContainer;
+  GenericContainer._();
+}
+
+// Check generation for `strict_raw_types`.
+abstract class DynamicGenericContainer
+    implements Built<DynamicGenericContainer, DynamicGenericContainerBuilder> {
+  Generic<dynamic> get foo;
+
+  factory DynamicGenericContainer(
+          [void Function(DynamicGenericContainerBuilder) updates]) =
+      _$DynamicGenericContainer;
+  DynamicGenericContainer._();
+}
+
+abstract class PassthroughGenericContainer<T>
+    implements
+        Built<PassthroughGenericContainer<T>,
+            PassthroughGenericContainerBuilder<T>> {
+  static Serializer<PassthroughGenericContainer<Object?>> get serializer =>
+      _$passthroughGenericContainerSerializer;
+
+  GenericValue<T> get genericValue;
+  CollectionGenericValue<T> get collectionGenericValue;
+
+  factory PassthroughGenericContainer(
+          [void Function(PassthroughGenericContainerBuilder<T>) updates]) =
+      _$PassthroughGenericContainer<T>;
+  PassthroughGenericContainer._();
+}
+
+abstract class NestedGenericContainer
+    implements Built<NestedGenericContainer, NestedGenericContainerBuilder> {
+  static Serializer<NestedGenericContainer> get serializer =>
+      _$nestedGenericContainerSerializer;
+
+  GenericValue<BuiltMap<int, String>> get map;
+
+  factory NestedGenericContainer(
+          [void Function(NestedGenericContainerBuilder) updates]) =
+      _$NestedGenericContainer;
+  NestedGenericContainer._();
+}
+
+abstract class CustomBuilderGenericValue<T>
+    implements
+        Built<CustomBuilderGenericValue<T>,
+            CustomBuilderGenericValueBuilder<T>> {
+  T get value;
+
+  factory CustomBuilderGenericValue(
+          [Function(CustomBuilderGenericValueBuilder<T>) updates]) =
+      _$CustomBuilderGenericValue<T>;
+  CustomBuilderGenericValue._();
+}
+
+abstract class CustomBuilderGenericValueBuilder<T>
+    implements
+        Builder<CustomBuilderGenericValue<T>,
+            CustomBuilderGenericValueBuilder<T>> {
+  T? value;
+
+  factory CustomBuilderGenericValueBuilder() =
+      _$CustomBuilderGenericValueBuilder<T>;
+  CustomBuilderGenericValueBuilder._();
+}
+
+abstract class Generic<T> {
+  T get value;
+}
+
+abstract class ConcreteGeneric
+    implements Built<ConcreteGeneric, ConcreteGenericBuilder>, Generic<int> {
+  static Serializer<ConcreteGeneric> get serializer =>
+      _$concreteGenericSerializer;
+
+  factory ConcreteGeneric([void Function(ConcreteGenericBuilder) updates]) =
+      _$ConcreteGeneric;
+  ConcreteGeneric._();
+}
+
+abstract class GenericFunction<T>
+    implements Built<GenericFunction<T>, GenericFunctionBuilder<T>> {
+  Function(T) get function;
+
+  factory GenericFunction([Function(GenericFunctionBuilder<T>) updates]) =
+      _$GenericFunction<T>;
+  GenericFunction._();
+}
+
+// Check that we do not generate builder factories for generic fields that are
+// not `Built` types.
+abstract class NonBuiltGeneric
+    implements Built<NonBuiltGeneric, NonBuiltGenericBuilder> {
+  static Serializer<NonBuiltGeneric> get serializer =>
+      _$nonBuiltGenericSerializer;
+
+  NonBuilt<int> get value;
+
+  factory NonBuiltGeneric([Function(NonBuiltGenericBuilder) updates]) =
+      _$NonBuiltGeneric;
+  NonBuiltGeneric._();
+}
+
+class NonBuilt<T> {}
+
+// To check generation does not omit the generics.
+abstract class EmptyGeneric<K, V>
+    implements Built<EmptyGeneric<K, V>, EmptyGenericBuilder<K, V>> {
+  factory EmptyGeneric([void Function(EmptyGenericBuilder<K, V>) updates]) =
+      _$EmptyGeneric<K, V>;
+  EmptyGeneric._();
+  static Serializer<EmptyGeneric<Object?, Object?>> get serializer =>
+      _$emptyGenericSerializer;
+}
+
+// To check generation of `FullType` in serializer when first param can be
+// const but second can't.
+abstract class ConstAndGeneric<T>
+    implements Built<ConstAndGeneric<T>, ConstAndGenericBuilder<T>> {
+  static Serializer<ConstAndGeneric<Object?>> get serializer =>
+      _$constAndGenericSerializer;
+
+  factory ConstAndGeneric([void Function(ConstAndGenericBuilder<T>) updates]) =
+      _$ConstAndGeneric<T>;
+  ConstAndGeneric._();
+
+  BuiltMap<String, T> get map;
+}

--- a/built_types/end_to_end_test/lib/generics.g.dart
+++ b/built_types/end_to_end_test/lib/generics.g.dart
@@ -1,0 +1,2020 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
+
+part of 'generics.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GenericValue<Object?>> _$genericValueSerializer =
+    _$GenericValueSerializer();
+Serializer<BoundGenericValue<num>> _$boundGenericValueSerializer =
+    _$BoundGenericValueSerializer();
+Serializer<BoundNullableGenericValue<num>>
+    _$boundNullableGenericValueSerializer =
+    _$BoundNullableGenericValueSerializer();
+Serializer<CollectionGenericValue<Object?>> _$collectionGenericValueSerializer =
+    _$CollectionGenericValueSerializer();
+Serializer<GenericContainer> _$genericContainerSerializer =
+    _$GenericContainerSerializer();
+Serializer<PassthroughGenericContainer<Object?>>
+    _$passthroughGenericContainerSerializer =
+    _$PassthroughGenericContainerSerializer();
+Serializer<NestedGenericContainer> _$nestedGenericContainerSerializer =
+    _$NestedGenericContainerSerializer();
+Serializer<ConcreteGeneric> _$concreteGenericSerializer =
+    _$ConcreteGenericSerializer();
+Serializer<NonBuiltGeneric> _$nonBuiltGenericSerializer =
+    _$NonBuiltGenericSerializer();
+Serializer<EmptyGeneric<Object?, Object?>> _$emptyGenericSerializer =
+    _$EmptyGenericSerializer();
+Serializer<ConstAndGeneric<Object?>> _$constAndGenericSerializer =
+    _$ConstAndGenericSerializer();
+
+class _$GenericValueSerializer
+    implements StructuredSerializer<GenericValue<Object?>> {
+  @override
+  final Iterable<Type> types = const [GenericValue, _$GenericValue];
+  @override
+  final String wireName = 'GenericValue';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GenericValue<Object?> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: parameterT),
+    ];
+
+    return result;
+  }
+
+  @override
+  GenericValue<Object?> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = isUnderspecified
+        ? GenericValueBuilder<Object?>()
+        : serializers.newBuilder(specifiedType) as GenericValueBuilder<Object?>;
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(value, specifiedType: parameterT);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BoundGenericValueSerializer
+    implements StructuredSerializer<BoundGenericValue<num>> {
+  @override
+  final Iterable<Type> types = const [BoundGenericValue, _$BoundGenericValue];
+  @override
+  final String wireName = 'BoundGenericValue';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, BoundGenericValue<num> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: parameterT),
+    ];
+    Object? value;
+    value = object.nullableValue;
+    if (value != null) {
+      result
+        ..add('nullableValue')
+        ..add(serializers.serialize(value, specifiedType: parameterT));
+    }
+    return result;
+  }
+
+  @override
+  BoundGenericValue<num> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = isUnderspecified
+        ? BoundGenericValueBuilder<num>()
+        : serializers.newBuilder(specifiedType)
+            as BoundGenericValueBuilder<num>;
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(value, specifiedType: parameterT)! as num;
+          break;
+        case 'nullableValue':
+          result.nullableValue =
+              serializers.deserialize(value, specifiedType: parameterT) as num?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BoundNullableGenericValueSerializer
+    implements StructuredSerializer<BoundNullableGenericValue<num>> {
+  @override
+  final Iterable<Type> types = const [
+    BoundNullableGenericValue,
+    _$BoundNullableGenericValue
+  ];
+  @override
+  final String wireName = 'BoundNullableGenericValue';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, BoundNullableGenericValue<num> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: parameterT),
+    ];
+    Object? value;
+    value = object.nullableValue;
+    if (value != null) {
+      result
+        ..add('nullableValue')
+        ..add(serializers.serialize(value, specifiedType: parameterT));
+    }
+    return result;
+  }
+
+  @override
+  BoundNullableGenericValue<num> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = isUnderspecified
+        ? BoundNullableGenericValueBuilder<num>()
+        : serializers.newBuilder(specifiedType)
+            as BoundNullableGenericValueBuilder<num>;
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(value, specifiedType: parameterT)! as num;
+          break;
+        case 'nullableValue':
+          result.nullableValue =
+              serializers.deserialize(value, specifiedType: parameterT) as num?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CollectionGenericValueSerializer
+    implements StructuredSerializer<CollectionGenericValue<Object?>> {
+  @override
+  final Iterable<Type> types = const [
+    CollectionGenericValue,
+    _$CollectionGenericValue
+  ];
+  @override
+  final String wireName = 'CollectionGenericValue';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, CollectionGenericValue<Object?> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = <Object?>[
+      'values',
+      serializers.serialize(object.values,
+          specifiedType: FullType(BuiltList, [parameterT])),
+    ];
+
+    return result;
+  }
+
+  @override
+  CollectionGenericValue<Object?> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = isUnderspecified
+        ? CollectionGenericValueBuilder<Object?>()
+        : serializers.newBuilder(specifiedType)
+            as CollectionGenericValueBuilder<Object?>;
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'values':
+          result.values.replace(serializers.deserialize(value,
+                  specifiedType: FullType(BuiltList, [parameterT]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GenericContainerSerializer
+    implements StructuredSerializer<GenericContainer> {
+  @override
+  final Iterable<Type> types = const [GenericContainer, _$GenericContainer];
+  @override
+  final String wireName = 'GenericContainer';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GenericContainer object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'genericValue',
+      serializers.serialize(object.genericValue,
+          specifiedType:
+              const FullType(GenericValue, const [const FullType(String)])),
+      'boundGenericValue',
+      serializers.serialize(object.boundGenericValue,
+          specifiedType: const FullType(
+              BoundGenericValue, const [const FullType(double)])),
+      'collectionGenericValue',
+      serializers.serialize(object.collectionGenericValue,
+          specifiedType: const FullType(
+              CollectionGenericValue, const [const FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GenericContainer deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GenericContainerBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'genericValue':
+          result.genericValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      GenericValue, const [const FullType(String)]))!
+              as GenericValue<String>);
+          break;
+        case 'boundGenericValue':
+          result.boundGenericValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BoundGenericValue, const [const FullType(double)]))!
+              as BoundGenericValue<double>);
+          break;
+        case 'collectionGenericValue':
+          result.collectionGenericValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      CollectionGenericValue, const [const FullType(String)]))!
+              as CollectionGenericValue<String>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PassthroughGenericContainerSerializer
+    implements StructuredSerializer<PassthroughGenericContainer<Object?>> {
+  @override
+  final Iterable<Type> types = const [
+    PassthroughGenericContainer,
+    _$PassthroughGenericContainer
+  ];
+  @override
+  final String wireName = 'PassthroughGenericContainer';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, PassthroughGenericContainer<Object?> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = <Object?>[
+      'genericValue',
+      serializers.serialize(object.genericValue,
+          specifiedType: FullType(GenericValue, [parameterT])),
+      'collectionGenericValue',
+      serializers.serialize(object.collectionGenericValue,
+          specifiedType: FullType(CollectionGenericValue, [parameterT])),
+    ];
+
+    return result;
+  }
+
+  @override
+  PassthroughGenericContainer<Object?> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = isUnderspecified
+        ? PassthroughGenericContainerBuilder<Object?>()
+        : serializers.newBuilder(specifiedType)
+            as PassthroughGenericContainerBuilder<Object?>;
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'genericValue':
+          result.genericValue.replace(serializers.deserialize(value,
+                  specifiedType: FullType(GenericValue, [parameterT]))!
+              as GenericValue<Object>);
+          break;
+        case 'collectionGenericValue':
+          result.collectionGenericValue.replace(serializers.deserialize(value,
+                  specifiedType:
+                      FullType(CollectionGenericValue, [parameterT]))!
+              as CollectionGenericValue<Object>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$NestedGenericContainerSerializer
+    implements StructuredSerializer<NestedGenericContainer> {
+  @override
+  final Iterable<Type> types = const [
+    NestedGenericContainer,
+    _$NestedGenericContainer
+  ];
+  @override
+  final String wireName = 'NestedGenericContainer';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, NestedGenericContainer object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'map',
+      serializers.serialize(object.map,
+          specifiedType: const FullType(GenericValue, const [
+            const FullType(
+                BuiltMap, const [const FullType(int), const FullType(String)])
+          ])),
+    ];
+
+    return result;
+  }
+
+  @override
+  NestedGenericContainer deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = NestedGenericContainerBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'map':
+          result.map.replace(serializers.deserialize(value,
+              specifiedType: const FullType(GenericValue, const [
+                const FullType(BuiltMap,
+                    const [const FullType(int), const FullType(String)])
+              ]))! as GenericValue<BuiltMap<int, String>>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ConcreteGenericSerializer
+    implements StructuredSerializer<ConcreteGeneric> {
+  @override
+  final Iterable<Type> types = const [ConcreteGeneric, _$ConcreteGeneric];
+  @override
+  final String wireName = 'ConcreteGeneric';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ConcreteGeneric object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ConcreteGeneric deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ConcreteGenericBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$NonBuiltGenericSerializer
+    implements StructuredSerializer<NonBuiltGeneric> {
+  @override
+  final Iterable<Type> types = const [NonBuiltGeneric, _$NonBuiltGeneric];
+  @override
+  final String wireName = 'NonBuiltGeneric';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, NonBuiltGeneric object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value,
+          specifiedType: const FullType(NonBuilt, const [const FullType(int)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  NonBuiltGeneric deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = NonBuiltGenericBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value = serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(NonBuilt, const [const FullType(int)]))!
+              as NonBuilt<int>;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$EmptyGenericSerializer
+    implements StructuredSerializer<EmptyGeneric<Object?, Object?>> {
+  @override
+  final Iterable<Type> types = const [EmptyGeneric, _$EmptyGeneric];
+  @override
+  final String wireName = 'EmptyGeneric';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, EmptyGeneric<Object?, Object?> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return <Object?>[];
+  }
+
+  @override
+  EmptyGeneric<Object?, Object?> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return EmptyGenericBuilder<Object?, Object?>().build();
+  }
+}
+
+class _$ConstAndGenericSerializer
+    implements StructuredSerializer<ConstAndGeneric<Object?>> {
+  @override
+  final Iterable<Type> types = const [ConstAndGeneric, _$ConstAndGeneric];
+  @override
+  final String wireName = 'ConstAndGeneric';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, ConstAndGeneric<Object?> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = <Object?>[
+      'map',
+      serializers.serialize(object.map,
+          specifiedType:
+              FullType(BuiltMap, [const FullType(String), parameterT])),
+    ];
+
+    return result;
+  }
+
+  @override
+  ConstAndGeneric<Object?> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = isUnderspecified
+        ? ConstAndGenericBuilder<Object?>()
+        : serializers.newBuilder(specifiedType)
+            as ConstAndGenericBuilder<Object?>;
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'map':
+          result.map.replace(serializers.deserialize(value,
+              specifiedType:
+                  FullType(BuiltMap, [const FullType(String), parameterT]))!);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GenericValue<T> extends GenericValue<T> {
+  @override
+  final T value;
+
+  factory _$GenericValue([void Function(GenericValueBuilder<T>)? updates]) =>
+      (GenericValueBuilder<T>()..update(updates))._build();
+
+  _$GenericValue._({required this.value}) : super._();
+  @override
+  GenericValue<T> rebuild(void Function(GenericValueBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GenericValueBuilder<T> toBuilder() => GenericValueBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GenericValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GenericValue')..add('value', value))
+        .toString();
+  }
+}
+
+class GenericValueBuilder<T>
+    implements Builder<GenericValue<T>, GenericValueBuilder<T>> {
+  _$GenericValue<T>? _$v;
+
+  T? _value;
+  T? get value => _$this._value;
+  set value(T? value) => _$this._value = value;
+
+  GenericValueBuilder();
+
+  GenericValueBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GenericValue<T> other) {
+    _$v = other as _$GenericValue<T>;
+  }
+
+  @override
+  void update(void Function(GenericValueBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GenericValue<T> build() => _build();
+
+  _$GenericValue<T> _build() {
+    final _$result = _$v ??
+        _$GenericValue<T>._(
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'GenericValue', 'value'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$InitializeGenericValue<T> extends InitializeGenericValue<T> {
+  @override
+  final T value;
+
+  factory _$InitializeGenericValue(
+          [void Function(InitializeGenericValueBuilder<T>)? updates]) =>
+      (InitializeGenericValueBuilder<T>()..update(updates))._build();
+
+  _$InitializeGenericValue._({required this.value}) : super._();
+  @override
+  InitializeGenericValue<T> rebuild(
+          void Function(InitializeGenericValueBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  InitializeGenericValueBuilder<T> toBuilder() =>
+      InitializeGenericValueBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is InitializeGenericValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'InitializeGenericValue')
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class InitializeGenericValueBuilder<T>
+    implements
+        Builder<InitializeGenericValue<T>, InitializeGenericValueBuilder<T>> {
+  _$InitializeGenericValue<T>? _$v;
+
+  T? _value;
+  T? get value => _$this._value;
+  set value(T? value) => _$this._value = value;
+
+  InitializeGenericValueBuilder() {
+    InitializeGenericValue._initializeBuilder(this);
+  }
+
+  InitializeGenericValueBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(InitializeGenericValue<T> other) {
+    _$v = other as _$InitializeGenericValue<T>;
+  }
+
+  @override
+  void update(void Function(InitializeGenericValueBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  InitializeGenericValue<T> build() => _build();
+
+  _$InitializeGenericValue<T> _build() {
+    final _$result = _$v ??
+        _$InitializeGenericValue<T>._(
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'InitializeGenericValue', 'value'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$BoundGenericValue<T extends num> extends BoundGenericValue<T> {
+  @override
+  final T value;
+  @override
+  final T? nullableValue;
+
+  factory _$BoundGenericValue(
+          [void Function(BoundGenericValueBuilder<T>)? updates]) =>
+      (BoundGenericValueBuilder<T>()..update(updates))._build();
+
+  _$BoundGenericValue._({required this.value, this.nullableValue}) : super._();
+  @override
+  BoundGenericValue<T> rebuild(
+          void Function(BoundGenericValueBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BoundGenericValueBuilder<T> toBuilder() =>
+      BoundGenericValueBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BoundGenericValue &&
+        value == other.value &&
+        nullableValue == other.nullableValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, nullableValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BoundGenericValue')
+          ..add('value', value)
+          ..add('nullableValue', nullableValue))
+        .toString();
+  }
+}
+
+class BoundGenericValueBuilder<T extends num>
+    implements Builder<BoundGenericValue<T>, BoundGenericValueBuilder<T>> {
+  _$BoundGenericValue<T>? _$v;
+
+  T? _value;
+  T? get value => _$this._value;
+  set value(T? value) => _$this._value = value;
+
+  T? _nullableValue;
+  T? get nullableValue => _$this._nullableValue;
+  set nullableValue(T? nullableValue) => _$this._nullableValue = nullableValue;
+
+  BoundGenericValueBuilder();
+
+  BoundGenericValueBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _nullableValue = $v.nullableValue;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BoundGenericValue<T> other) {
+    _$v = other as _$BoundGenericValue<T>;
+  }
+
+  @override
+  void update(void Function(BoundGenericValueBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BoundGenericValue<T> build() => _build();
+
+  _$BoundGenericValue<T> _build() {
+    final _$result = _$v ??
+        _$BoundGenericValue<T>._(
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'BoundGenericValue', 'value'),
+          nullableValue: nullableValue,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$BoundNullableGenericValue<T extends num?>
+    extends BoundNullableGenericValue<T> {
+  @override
+  final T value;
+  @override
+  final T? nullableValue;
+
+  factory _$BoundNullableGenericValue(
+          [void Function(BoundNullableGenericValueBuilder<T>)? updates]) =>
+      (BoundNullableGenericValueBuilder<T>()..update(updates))._build();
+
+  _$BoundNullableGenericValue._({required this.value, this.nullableValue})
+      : super._();
+  @override
+  BoundNullableGenericValue<T> rebuild(
+          void Function(BoundNullableGenericValueBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BoundNullableGenericValueBuilder<T> toBuilder() =>
+      BoundNullableGenericValueBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BoundNullableGenericValue &&
+        value == other.value &&
+        nullableValue == other.nullableValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, nullableValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BoundNullableGenericValue')
+          ..add('value', value)
+          ..add('nullableValue', nullableValue))
+        .toString();
+  }
+}
+
+class BoundNullableGenericValueBuilder<T extends num?>
+    implements
+        Builder<BoundNullableGenericValue<T>,
+            BoundNullableGenericValueBuilder<T>> {
+  _$BoundNullableGenericValue<T>? _$v;
+
+  T? _value;
+  T? get value => _$this._value;
+  set value(T? value) => _$this._value = value;
+
+  T? _nullableValue;
+  T? get nullableValue => _$this._nullableValue;
+  set nullableValue(T? nullableValue) => _$this._nullableValue = nullableValue;
+
+  BoundNullableGenericValueBuilder();
+
+  BoundNullableGenericValueBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _nullableValue = $v.nullableValue;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BoundNullableGenericValue<T> other) {
+    _$v = other as _$BoundNullableGenericValue<T>;
+  }
+
+  @override
+  void update(void Function(BoundNullableGenericValueBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BoundNullableGenericValue<T> build() => _build();
+
+  _$BoundNullableGenericValue<T> _build() {
+    final _$result = _$v ??
+        _$BoundNullableGenericValue<T>._(
+          value: null is T
+              ? value as T
+              : BuiltValueNullFieldError.checkNotNull(
+                  value, r'BoundNullableGenericValue', 'value'),
+          nullableValue: nullableValue,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CollectionGenericValue<T> extends CollectionGenericValue<T> {
+  @override
+  final BuiltList<T> values;
+
+  factory _$CollectionGenericValue(
+          [void Function(CollectionGenericValueBuilder<T>)? updates]) =>
+      (CollectionGenericValueBuilder<T>()..update(updates))._build();
+
+  _$CollectionGenericValue._({required this.values}) : super._();
+  @override
+  CollectionGenericValue<T> rebuild(
+          void Function(CollectionGenericValueBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CollectionGenericValueBuilder<T> toBuilder() =>
+      CollectionGenericValueBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CollectionGenericValue && values == other.values;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, values.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CollectionGenericValue')
+          ..add('values', values))
+        .toString();
+  }
+}
+
+class CollectionGenericValueBuilder<T>
+    implements
+        Builder<CollectionGenericValue<T>, CollectionGenericValueBuilder<T>> {
+  _$CollectionGenericValue<T>? _$v;
+
+  ListBuilder<T>? _values;
+  ListBuilder<T> get values => _$this._values ??= ListBuilder<T>();
+  set values(ListBuilder<T>? values) => _$this._values = values;
+
+  CollectionGenericValueBuilder();
+
+  CollectionGenericValueBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _values = $v.values.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CollectionGenericValue<T> other) {
+    _$v = other as _$CollectionGenericValue<T>;
+  }
+
+  @override
+  void update(void Function(CollectionGenericValueBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CollectionGenericValue<T> build() => _build();
+
+  _$CollectionGenericValue<T> _build() {
+    _$CollectionGenericValue<T> _$result;
+    try {
+      _$result = _$v ??
+          _$CollectionGenericValue<T>._(
+            values: values.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'values';
+        values.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'CollectionGenericValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GenericContainer extends GenericContainer {
+  @override
+  final GenericValue<String> genericValue;
+  @override
+  final BoundGenericValue<double> boundGenericValue;
+  @override
+  final CollectionGenericValue<String> collectionGenericValue;
+
+  factory _$GenericContainer(
+          [void Function(GenericContainerBuilder)? updates]) =>
+      (GenericContainerBuilder()..update(updates))._build();
+
+  _$GenericContainer._(
+      {required this.genericValue,
+      required this.boundGenericValue,
+      required this.collectionGenericValue})
+      : super._();
+  @override
+  GenericContainer rebuild(void Function(GenericContainerBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GenericContainerBuilder toBuilder() =>
+      GenericContainerBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GenericContainer &&
+        genericValue == other.genericValue &&
+        boundGenericValue == other.boundGenericValue &&
+        collectionGenericValue == other.collectionGenericValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, genericValue.hashCode);
+    _$hash = $jc(_$hash, boundGenericValue.hashCode);
+    _$hash = $jc(_$hash, collectionGenericValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GenericContainer')
+          ..add('genericValue', genericValue)
+          ..add('boundGenericValue', boundGenericValue)
+          ..add('collectionGenericValue', collectionGenericValue))
+        .toString();
+  }
+}
+
+class GenericContainerBuilder
+    implements Builder<GenericContainer, GenericContainerBuilder> {
+  _$GenericContainer? _$v;
+
+  GenericValueBuilder<String>? _genericValue;
+  GenericValueBuilder<String> get genericValue =>
+      _$this._genericValue ??= GenericValueBuilder<String>();
+  set genericValue(GenericValueBuilder<String>? genericValue) =>
+      _$this._genericValue = genericValue;
+
+  BoundGenericValueBuilder<double>? _boundGenericValue;
+  BoundGenericValueBuilder<double> get boundGenericValue =>
+      _$this._boundGenericValue ??= BoundGenericValueBuilder<double>();
+  set boundGenericValue(BoundGenericValueBuilder<double>? boundGenericValue) =>
+      _$this._boundGenericValue = boundGenericValue;
+
+  CollectionGenericValueBuilder<String>? _collectionGenericValue;
+  CollectionGenericValueBuilder<String> get collectionGenericValue =>
+      _$this._collectionGenericValue ??=
+          CollectionGenericValueBuilder<String>();
+  set collectionGenericValue(
+          CollectionGenericValueBuilder<String>? collectionGenericValue) =>
+      _$this._collectionGenericValue = collectionGenericValue;
+
+  GenericContainerBuilder();
+
+  GenericContainerBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _genericValue = $v.genericValue.toBuilder();
+      _boundGenericValue = $v.boundGenericValue.toBuilder();
+      _collectionGenericValue = $v.collectionGenericValue.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GenericContainer other) {
+    _$v = other as _$GenericContainer;
+  }
+
+  @override
+  void update(void Function(GenericContainerBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GenericContainer build() => _build();
+
+  _$GenericContainer _build() {
+    _$GenericContainer _$result;
+    try {
+      _$result = _$v ??
+          _$GenericContainer._(
+            genericValue: genericValue.build(),
+            boundGenericValue: boundGenericValue.build(),
+            collectionGenericValue: collectionGenericValue.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'genericValue';
+        genericValue.build();
+        _$failedField = 'boundGenericValue';
+        boundGenericValue.build();
+        _$failedField = 'collectionGenericValue';
+        collectionGenericValue.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GenericContainer', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$DynamicGenericContainer extends DynamicGenericContainer {
+  @override
+  final Generic<dynamic> foo;
+
+  factory _$DynamicGenericContainer(
+          [void Function(DynamicGenericContainerBuilder)? updates]) =>
+      (DynamicGenericContainerBuilder()..update(updates))._build();
+
+  _$DynamicGenericContainer._({required this.foo}) : super._();
+  @override
+  DynamicGenericContainer rebuild(
+          void Function(DynamicGenericContainerBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DynamicGenericContainerBuilder toBuilder() =>
+      DynamicGenericContainerBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DynamicGenericContainer && foo == other.foo;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, foo.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DynamicGenericContainer')
+          ..add('foo', foo))
+        .toString();
+  }
+}
+
+class DynamicGenericContainerBuilder
+    implements
+        Builder<DynamicGenericContainer, DynamicGenericContainerBuilder> {
+  _$DynamicGenericContainer? _$v;
+
+  Generic<dynamic>? _foo;
+  Generic<dynamic>? get foo => _$this._foo;
+  set foo(Generic<dynamic>? foo) => _$this._foo = foo;
+
+  DynamicGenericContainerBuilder();
+
+  DynamicGenericContainerBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _foo = $v.foo;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(DynamicGenericContainer other) {
+    _$v = other as _$DynamicGenericContainer;
+  }
+
+  @override
+  void update(void Function(DynamicGenericContainerBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DynamicGenericContainer build() => _build();
+
+  _$DynamicGenericContainer _build() {
+    final _$result = _$v ??
+        _$DynamicGenericContainer._(
+          foo: BuiltValueNullFieldError.checkNotNull(
+              foo, r'DynamicGenericContainer', 'foo'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$PassthroughGenericContainer<T> extends PassthroughGenericContainer<T> {
+  @override
+  final GenericValue<T> genericValue;
+  @override
+  final CollectionGenericValue<T> collectionGenericValue;
+
+  factory _$PassthroughGenericContainer(
+          [void Function(PassthroughGenericContainerBuilder<T>)? updates]) =>
+      (PassthroughGenericContainerBuilder<T>()..update(updates))._build();
+
+  _$PassthroughGenericContainer._(
+      {required this.genericValue, required this.collectionGenericValue})
+      : super._();
+  @override
+  PassthroughGenericContainer<T> rebuild(
+          void Function(PassthroughGenericContainerBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PassthroughGenericContainerBuilder<T> toBuilder() =>
+      PassthroughGenericContainerBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PassthroughGenericContainer &&
+        genericValue == other.genericValue &&
+        collectionGenericValue == other.collectionGenericValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, genericValue.hashCode);
+    _$hash = $jc(_$hash, collectionGenericValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PassthroughGenericContainer')
+          ..add('genericValue', genericValue)
+          ..add('collectionGenericValue', collectionGenericValue))
+        .toString();
+  }
+}
+
+class PassthroughGenericContainerBuilder<T>
+    implements
+        Builder<PassthroughGenericContainer<T>,
+            PassthroughGenericContainerBuilder<T>> {
+  _$PassthroughGenericContainer<T>? _$v;
+
+  GenericValueBuilder<T>? _genericValue;
+  GenericValueBuilder<T> get genericValue =>
+      _$this._genericValue ??= GenericValueBuilder<T>();
+  set genericValue(GenericValueBuilder<T>? genericValue) =>
+      _$this._genericValue = genericValue;
+
+  CollectionGenericValueBuilder<T>? _collectionGenericValue;
+  CollectionGenericValueBuilder<T> get collectionGenericValue =>
+      _$this._collectionGenericValue ??= CollectionGenericValueBuilder<T>();
+  set collectionGenericValue(
+          CollectionGenericValueBuilder<T>? collectionGenericValue) =>
+      _$this._collectionGenericValue = collectionGenericValue;
+
+  PassthroughGenericContainerBuilder();
+
+  PassthroughGenericContainerBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _genericValue = $v.genericValue.toBuilder();
+      _collectionGenericValue = $v.collectionGenericValue.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PassthroughGenericContainer<T> other) {
+    _$v = other as _$PassthroughGenericContainer<T>;
+  }
+
+  @override
+  void update(void Function(PassthroughGenericContainerBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PassthroughGenericContainer<T> build() => _build();
+
+  _$PassthroughGenericContainer<T> _build() {
+    _$PassthroughGenericContainer<T> _$result;
+    try {
+      _$result = _$v ??
+          _$PassthroughGenericContainer<T>._(
+            genericValue: genericValue.build(),
+            collectionGenericValue: collectionGenericValue.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'genericValue';
+        genericValue.build();
+        _$failedField = 'collectionGenericValue';
+        collectionGenericValue.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'PassthroughGenericContainer', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$NestedGenericContainer extends NestedGenericContainer {
+  @override
+  final GenericValue<BuiltMap<int, String>> map;
+
+  factory _$NestedGenericContainer(
+          [void Function(NestedGenericContainerBuilder)? updates]) =>
+      (NestedGenericContainerBuilder()..update(updates))._build();
+
+  _$NestedGenericContainer._({required this.map}) : super._();
+  @override
+  NestedGenericContainer rebuild(
+          void Function(NestedGenericContainerBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  NestedGenericContainerBuilder toBuilder() =>
+      NestedGenericContainerBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is NestedGenericContainer && map == other.map;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, map.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'NestedGenericContainer')
+          ..add('map', map))
+        .toString();
+  }
+}
+
+class NestedGenericContainerBuilder
+    implements Builder<NestedGenericContainer, NestedGenericContainerBuilder> {
+  _$NestedGenericContainer? _$v;
+
+  GenericValueBuilder<BuiltMap<int, String>>? _map;
+  GenericValueBuilder<BuiltMap<int, String>> get map =>
+      _$this._map ??= GenericValueBuilder<BuiltMap<int, String>>();
+  set map(GenericValueBuilder<BuiltMap<int, String>>? map) => _$this._map = map;
+
+  NestedGenericContainerBuilder();
+
+  NestedGenericContainerBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _map = $v.map.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(NestedGenericContainer other) {
+    _$v = other as _$NestedGenericContainer;
+  }
+
+  @override
+  void update(void Function(NestedGenericContainerBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  NestedGenericContainer build() => _build();
+
+  _$NestedGenericContainer _build() {
+    _$NestedGenericContainer _$result;
+    try {
+      _$result = _$v ??
+          _$NestedGenericContainer._(
+            map: map.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'map';
+        map.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'NestedGenericContainer', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CustomBuilderGenericValue<T> extends CustomBuilderGenericValue<T> {
+  @override
+  final T value;
+
+  factory _$CustomBuilderGenericValue(
+          [void Function(CustomBuilderGenericValueBuilder<T>)? updates]) =>
+      (CustomBuilderGenericValueBuilder<T>()..update(updates)).build()
+          as _$CustomBuilderGenericValue<T>;
+
+  _$CustomBuilderGenericValue._({required this.value}) : super._();
+  @override
+  CustomBuilderGenericValue<T> rebuild(
+          void Function(CustomBuilderGenericValueBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _$CustomBuilderGenericValueBuilder<T> toBuilder() =>
+      _$CustomBuilderGenericValueBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CustomBuilderGenericValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CustomBuilderGenericValue')
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class _$CustomBuilderGenericValueBuilder<T>
+    extends CustomBuilderGenericValueBuilder<T> {
+  _$CustomBuilderGenericValue<T>? _$v;
+
+  @override
+  T? get value {
+    _$this;
+    return super.value;
+  }
+
+  @override
+  set value(T? value) {
+    _$this;
+    super.value = value;
+  }
+
+  _$CustomBuilderGenericValueBuilder() : super._();
+
+  CustomBuilderGenericValueBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CustomBuilderGenericValue<T> other) {
+    _$v = other as _$CustomBuilderGenericValue<T>;
+  }
+
+  @override
+  void update(void Function(CustomBuilderGenericValueBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CustomBuilderGenericValue<T> build() => _build();
+
+  _$CustomBuilderGenericValue<T> _build() {
+    final _$result = _$v ??
+        _$CustomBuilderGenericValue<T>._(
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'CustomBuilderGenericValue', 'value'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ConcreteGeneric extends ConcreteGeneric {
+  @override
+  final int value;
+
+  factory _$ConcreteGeneric([void Function(ConcreteGenericBuilder)? updates]) =>
+      (ConcreteGenericBuilder()..update(updates))._build();
+
+  _$ConcreteGeneric._({required this.value}) : super._();
+  @override
+  ConcreteGeneric rebuild(void Function(ConcreteGenericBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ConcreteGenericBuilder toBuilder() => ConcreteGenericBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ConcreteGeneric && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ConcreteGeneric')
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class ConcreteGenericBuilder
+    implements Builder<ConcreteGeneric, ConcreteGenericBuilder> {
+  _$ConcreteGeneric? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  ConcreteGenericBuilder();
+
+  ConcreteGenericBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ConcreteGeneric other) {
+    _$v = other as _$ConcreteGeneric;
+  }
+
+  @override
+  void update(void Function(ConcreteGenericBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ConcreteGeneric build() => _build();
+
+  _$ConcreteGeneric _build() {
+    final _$result = _$v ??
+        _$ConcreteGeneric._(
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'ConcreteGeneric', 'value'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GenericFunction<T> extends GenericFunction<T> {
+  @override
+  final Function(T) function;
+
+  factory _$GenericFunction(
+          [void Function(GenericFunctionBuilder<T>)? updates]) =>
+      (GenericFunctionBuilder<T>()..update(updates))._build();
+
+  _$GenericFunction._({required this.function}) : super._();
+  @override
+  GenericFunction<T> rebuild(
+          void Function(GenericFunctionBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GenericFunctionBuilder<T> toBuilder() =>
+      GenericFunctionBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    final dynamic _$dynamicOther = other;
+    return other is GenericFunction && function == _$dynamicOther.function;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, function.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GenericFunction')
+          ..add('function', function))
+        .toString();
+  }
+}
+
+class GenericFunctionBuilder<T>
+    implements Builder<GenericFunction<T>, GenericFunctionBuilder<T>> {
+  _$GenericFunction<T>? _$v;
+
+  Function(T)? _function;
+  Function(T)? get function => _$this._function;
+  set function(Function(T)? function) => _$this._function = function;
+
+  GenericFunctionBuilder();
+
+  GenericFunctionBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _function = $v.function;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GenericFunction<T> other) {
+    _$v = other as _$GenericFunction<T>;
+  }
+
+  @override
+  void update(void Function(GenericFunctionBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GenericFunction<T> build() => _build();
+
+  _$GenericFunction<T> _build() {
+    final _$result = _$v ??
+        _$GenericFunction<T>._(
+          function: BuiltValueNullFieldError.checkNotNull(
+              function, r'GenericFunction', 'function'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$NonBuiltGeneric extends NonBuiltGeneric {
+  @override
+  final NonBuilt<int> value;
+
+  factory _$NonBuiltGeneric([void Function(NonBuiltGenericBuilder)? updates]) =>
+      (NonBuiltGenericBuilder()..update(updates))._build();
+
+  _$NonBuiltGeneric._({required this.value}) : super._();
+  @override
+  NonBuiltGeneric rebuild(void Function(NonBuiltGenericBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  NonBuiltGenericBuilder toBuilder() => NonBuiltGenericBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is NonBuiltGeneric && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'NonBuiltGeneric')
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class NonBuiltGenericBuilder
+    implements Builder<NonBuiltGeneric, NonBuiltGenericBuilder> {
+  _$NonBuiltGeneric? _$v;
+
+  NonBuilt<int>? _value;
+  NonBuilt<int>? get value => _$this._value;
+  set value(NonBuilt<int>? value) => _$this._value = value;
+
+  NonBuiltGenericBuilder();
+
+  NonBuiltGenericBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(NonBuiltGeneric other) {
+    _$v = other as _$NonBuiltGeneric;
+  }
+
+  @override
+  void update(void Function(NonBuiltGenericBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  NonBuiltGeneric build() => _build();
+
+  _$NonBuiltGeneric _build() {
+    final _$result = _$v ??
+        _$NonBuiltGeneric._(
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'NonBuiltGeneric', 'value'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$EmptyGeneric<K, V> extends EmptyGeneric<K, V> {
+  factory _$EmptyGeneric([void Function(EmptyGenericBuilder<K, V>)? updates]) =>
+      (EmptyGenericBuilder<K, V>()..update(updates))._build();
+
+  _$EmptyGeneric._() : super._();
+  @override
+  EmptyGeneric<K, V> rebuild(
+          void Function(EmptyGenericBuilder<K, V>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  EmptyGenericBuilder<K, V> toBuilder() =>
+      EmptyGenericBuilder<K, V>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is EmptyGeneric;
+  }
+
+  @override
+  int get hashCode {
+    return 592793250;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper(r'EmptyGeneric').toString();
+  }
+}
+
+class EmptyGenericBuilder<K, V>
+    implements Builder<EmptyGeneric<K, V>, EmptyGenericBuilder<K, V>> {
+  _$EmptyGeneric<K, V>? _$v;
+
+  EmptyGenericBuilder();
+
+  @override
+  void replace(EmptyGeneric<K, V> other) {
+    _$v = other as _$EmptyGeneric<K, V>;
+  }
+
+  @override
+  void update(void Function(EmptyGenericBuilder<K, V>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  EmptyGeneric<K, V> build() => _build();
+
+  _$EmptyGeneric<K, V> _build() {
+    final _$result = _$v ?? _$EmptyGeneric<K, V>._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ConstAndGeneric<T> extends ConstAndGeneric<T> {
+  @override
+  final BuiltMap<String, T> map;
+
+  factory _$ConstAndGeneric(
+          [void Function(ConstAndGenericBuilder<T>)? updates]) =>
+      (ConstAndGenericBuilder<T>()..update(updates))._build();
+
+  _$ConstAndGeneric._({required this.map}) : super._();
+  @override
+  ConstAndGeneric<T> rebuild(
+          void Function(ConstAndGenericBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ConstAndGenericBuilder<T> toBuilder() =>
+      ConstAndGenericBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ConstAndGeneric && map == other.map;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, map.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ConstAndGeneric')..add('map', map))
+        .toString();
+  }
+}
+
+class ConstAndGenericBuilder<T>
+    implements Builder<ConstAndGeneric<T>, ConstAndGenericBuilder<T>> {
+  _$ConstAndGeneric<T>? _$v;
+
+  MapBuilder<String, T>? _map;
+  MapBuilder<String, T> get map => _$this._map ??= MapBuilder<String, T>();
+  set map(MapBuilder<String, T>? map) => _$this._map = map;
+
+  ConstAndGenericBuilder();
+
+  ConstAndGenericBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _map = $v.map.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ConstAndGeneric<T> other) {
+    _$v = other as _$ConstAndGeneric<T>;
+  }
+
+  @override
+  void update(void Function(ConstAndGenericBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ConstAndGeneric<T> build() => _build();
+
+  _$ConstAndGeneric<T> _build() {
+    _$ConstAndGeneric<T> _$result;
+    try {
+      _$result = _$v ??
+          _$ConstAndGeneric<T>._(
+            map: map.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'map';
+        map.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'ConstAndGeneric', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/lib/imported_values.dart
+++ b/built_types/end_to_end_test/lib/imported_values.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/values.dart' as prefix;
+
+part 'imported_values.g.dart';
+
+abstract class ImportedValue
+    implements Built<ImportedValue, ImportedValueBuilder> {
+  static Serializer<ImportedValue> get serializer => _$importedValueSerializer;
+
+  prefix.SimpleValue get simpleValue;
+  BuiltList<prefix.SimpleValue> get simpleValues;
+
+  factory ImportedValue([void Function(ImportedValueBuilder) updates]) =
+      _$ImportedValue;
+  ImportedValue._();
+}
+
+// With a custom builder.
+abstract class ImportedCustomValue
+    implements Built<ImportedCustomValue, ImportedCustomValueBuilder> {
+  static Serializer<ImportedCustomValue> get serializer =>
+      _$importedCustomValueSerializer;
+
+  prefix.SimpleValue get simpleValue;
+  BuiltList<prefix.SimpleValue> get simpleValues;
+
+  factory ImportedCustomValue(
+          [void Function(ImportedCustomValueBuilder) updates]) =
+      _$ImportedCustomValue;
+  ImportedCustomValue._();
+}
+
+abstract class ImportedCustomValueBuilder
+    implements Builder<ImportedCustomValue, ImportedCustomValueBuilder> {
+  prefix.SimpleValue? simpleValue;
+  BuiltList<prefix.SimpleValue>? simpleValues;
+
+  ImportedCustomValueBuilder._();
+  factory ImportedCustomValueBuilder() = _$ImportedCustomValueBuilder;
+}
+
+// With a custom builder using nested buliders.
+abstract class ImportedCustomNestedValue
+    implements
+        Built<ImportedCustomNestedValue, ImportedCustomNestedValueBuilder> {
+  static Serializer<ImportedCustomNestedValue> get serializer =>
+      _$importedCustomNestedValueSerializer;
+
+  prefix.SimpleValue get simpleValue;
+  BuiltList<prefix.SimpleValue> get simpleValues;
+
+  factory ImportedCustomNestedValue(
+          [void Function(ImportedCustomNestedValueBuilder) updates]) =
+      _$ImportedCustomNestedValue;
+  ImportedCustomNestedValue._();
+}
+
+abstract class ImportedCustomNestedValueBuilder
+    implements
+        Builder<ImportedCustomNestedValue, ImportedCustomNestedValueBuilder> {
+  prefix.SimpleValueBuilder simpleValue = prefix.SimpleValueBuilder();
+  ListBuilder<prefix.SimpleValue> simpleValues = ListBuilder();
+
+  ImportedCustomNestedValueBuilder._();
+  factory ImportedCustomNestedValueBuilder() =
+      _$ImportedCustomNestedValueBuilder;
+}

--- a/built_types/end_to_end_test/lib/imported_values.g.dart
+++ b/built_types/end_to_end_test/lib/imported_values.g.dart
@@ -1,0 +1,536 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
+
+part of 'imported_values.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<ImportedValue> _$importedValueSerializer =
+    _$ImportedValueSerializer();
+Serializer<ImportedCustomValue> _$importedCustomValueSerializer =
+    _$ImportedCustomValueSerializer();
+Serializer<ImportedCustomNestedValue> _$importedCustomNestedValueSerializer =
+    _$ImportedCustomNestedValueSerializer();
+
+class _$ImportedValueSerializer implements StructuredSerializer<ImportedValue> {
+  @override
+  final Iterable<Type> types = const [ImportedValue, _$ImportedValue];
+  @override
+  final String wireName = 'ImportedValue';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ImportedValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'simpleValue',
+      serializers.serialize(object.simpleValue,
+          specifiedType: const FullType(prefix.SimpleValue)),
+      'simpleValues',
+      serializers.serialize(object.simpleValues,
+          specifiedType: const FullType(
+              BuiltList, const [const FullType(prefix.SimpleValue)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  ImportedValue deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ImportedValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'simpleValue':
+          result.simpleValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(prefix.SimpleValue))!
+              as prefix.SimpleValue);
+          break;
+        case 'simpleValues':
+          result.simpleValues.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(prefix.SimpleValue)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ImportedCustomValueSerializer
+    implements StructuredSerializer<ImportedCustomValue> {
+  @override
+  final Iterable<Type> types = const [
+    ImportedCustomValue,
+    _$ImportedCustomValue
+  ];
+  @override
+  final String wireName = 'ImportedCustomValue';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, ImportedCustomValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'simpleValue',
+      serializers.serialize(object.simpleValue,
+          specifiedType: const FullType(prefix.SimpleValue)),
+      'simpleValues',
+      serializers.serialize(object.simpleValues,
+          specifiedType: const FullType(
+              BuiltList, const [const FullType(prefix.SimpleValue)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  ImportedCustomValue deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ImportedCustomValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'simpleValue':
+          result.simpleValue = serializers.deserialize(value,
+                  specifiedType: const FullType(prefix.SimpleValue))!
+              as prefix.SimpleValue;
+          break;
+        case 'simpleValues':
+          result.simpleValues = serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(prefix.SimpleValue)]))!
+              as BuiltList<prefix.SimpleValue>;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ImportedCustomNestedValueSerializer
+    implements StructuredSerializer<ImportedCustomNestedValue> {
+  @override
+  final Iterable<Type> types = const [
+    ImportedCustomNestedValue,
+    _$ImportedCustomNestedValue
+  ];
+  @override
+  final String wireName = 'ImportedCustomNestedValue';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, ImportedCustomNestedValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'simpleValue',
+      serializers.serialize(object.simpleValue,
+          specifiedType: const FullType(prefix.SimpleValue)),
+      'simpleValues',
+      serializers.serialize(object.simpleValues,
+          specifiedType: const FullType(
+              BuiltList, const [const FullType(prefix.SimpleValue)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  ImportedCustomNestedValue deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ImportedCustomNestedValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'simpleValue':
+          result.simpleValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(prefix.SimpleValue))!
+              as prefix.SimpleValue);
+          break;
+        case 'simpleValues':
+          result.simpleValues.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(prefix.SimpleValue)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ImportedValue extends ImportedValue {
+  @override
+  final prefix.SimpleValue simpleValue;
+  @override
+  final BuiltList<prefix.SimpleValue> simpleValues;
+
+  factory _$ImportedValue([void Function(ImportedValueBuilder)? updates]) =>
+      (ImportedValueBuilder()..update(updates))._build();
+
+  _$ImportedValue._({required this.simpleValue, required this.simpleValues})
+      : super._();
+  @override
+  ImportedValue rebuild(void Function(ImportedValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ImportedValueBuilder toBuilder() => ImportedValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ImportedValue &&
+        simpleValue == other.simpleValue &&
+        simpleValues == other.simpleValues;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, simpleValues.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ImportedValue')
+          ..add('simpleValue', simpleValue)
+          ..add('simpleValues', simpleValues))
+        .toString();
+  }
+}
+
+class ImportedValueBuilder
+    implements Builder<ImportedValue, ImportedValueBuilder> {
+  _$ImportedValue? _$v;
+
+  prefix.SimpleValueBuilder? _simpleValue;
+  prefix.SimpleValueBuilder get simpleValue =>
+      _$this._simpleValue ??= prefix.SimpleValueBuilder();
+  set simpleValue(prefix.SimpleValueBuilder? simpleValue) =>
+      _$this._simpleValue = simpleValue;
+
+  ListBuilder<prefix.SimpleValue>? _simpleValues;
+  ListBuilder<prefix.SimpleValue> get simpleValues =>
+      _$this._simpleValues ??= ListBuilder<prefix.SimpleValue>();
+  set simpleValues(ListBuilder<prefix.SimpleValue>? simpleValues) =>
+      _$this._simpleValues = simpleValues;
+
+  ImportedValueBuilder();
+
+  ImportedValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _simpleValue = $v.simpleValue.toBuilder();
+      _simpleValues = $v.simpleValues.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ImportedValue other) {
+    _$v = other as _$ImportedValue;
+  }
+
+  @override
+  void update(void Function(ImportedValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ImportedValue build() => _build();
+
+  _$ImportedValue _build() {
+    _$ImportedValue _$result;
+    try {
+      _$result = _$v ??
+          _$ImportedValue._(
+            simpleValue: simpleValue.build(),
+            simpleValues: simpleValues.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        simpleValue.build();
+        _$failedField = 'simpleValues';
+        simpleValues.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'ImportedValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ImportedCustomValue extends ImportedCustomValue {
+  @override
+  final prefix.SimpleValue simpleValue;
+  @override
+  final BuiltList<prefix.SimpleValue> simpleValues;
+
+  factory _$ImportedCustomValue(
+          [void Function(ImportedCustomValueBuilder)? updates]) =>
+      (ImportedCustomValueBuilder()..update(updates)).build()
+          as _$ImportedCustomValue;
+
+  _$ImportedCustomValue._(
+      {required this.simpleValue, required this.simpleValues})
+      : super._();
+  @override
+  ImportedCustomValue rebuild(
+          void Function(ImportedCustomValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _$ImportedCustomValueBuilder toBuilder() =>
+      _$ImportedCustomValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ImportedCustomValue &&
+        simpleValue == other.simpleValue &&
+        simpleValues == other.simpleValues;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, simpleValues.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ImportedCustomValue')
+          ..add('simpleValue', simpleValue)
+          ..add('simpleValues', simpleValues))
+        .toString();
+  }
+}
+
+class _$ImportedCustomValueBuilder extends ImportedCustomValueBuilder {
+  _$ImportedCustomValue? _$v;
+
+  @override
+  prefix.SimpleValue? get simpleValue {
+    _$this;
+    return super.simpleValue;
+  }
+
+  @override
+  set simpleValue(prefix.SimpleValue? simpleValue) {
+    _$this;
+    super.simpleValue = simpleValue;
+  }
+
+  @override
+  BuiltList<prefix.SimpleValue>? get simpleValues {
+    _$this;
+    return super.simpleValues;
+  }
+
+  @override
+  set simpleValues(BuiltList<prefix.SimpleValue>? simpleValues) {
+    _$this;
+    super.simpleValues = simpleValues;
+  }
+
+  _$ImportedCustomValueBuilder() : super._();
+
+  ImportedCustomValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.simpleValue = $v.simpleValue;
+      super.simpleValues = $v.simpleValues;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ImportedCustomValue other) {
+    _$v = other as _$ImportedCustomValue;
+  }
+
+  @override
+  void update(void Function(ImportedCustomValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ImportedCustomValue build() => _build();
+
+  _$ImportedCustomValue _build() {
+    final _$result = _$v ??
+        _$ImportedCustomValue._(
+          simpleValue: BuiltValueNullFieldError.checkNotNull(
+              simpleValue, r'ImportedCustomValue', 'simpleValue'),
+          simpleValues: BuiltValueNullFieldError.checkNotNull(
+              simpleValues, r'ImportedCustomValue', 'simpleValues'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ImportedCustomNestedValue extends ImportedCustomNestedValue {
+  @override
+  final prefix.SimpleValue simpleValue;
+  @override
+  final BuiltList<prefix.SimpleValue> simpleValues;
+
+  factory _$ImportedCustomNestedValue(
+          [void Function(ImportedCustomNestedValueBuilder)? updates]) =>
+      (ImportedCustomNestedValueBuilder()..update(updates)).build()
+          as _$ImportedCustomNestedValue;
+
+  _$ImportedCustomNestedValue._(
+      {required this.simpleValue, required this.simpleValues})
+      : super._();
+  @override
+  ImportedCustomNestedValue rebuild(
+          void Function(ImportedCustomNestedValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _$ImportedCustomNestedValueBuilder toBuilder() =>
+      _$ImportedCustomNestedValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ImportedCustomNestedValue &&
+        simpleValue == other.simpleValue &&
+        simpleValues == other.simpleValues;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, simpleValues.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ImportedCustomNestedValue')
+          ..add('simpleValue', simpleValue)
+          ..add('simpleValues', simpleValues))
+        .toString();
+  }
+}
+
+class _$ImportedCustomNestedValueBuilder
+    extends ImportedCustomNestedValueBuilder {
+  _$ImportedCustomNestedValue? _$v;
+
+  @override
+  prefix.SimpleValueBuilder get simpleValue {
+    _$this;
+    return super.simpleValue;
+  }
+
+  @override
+  set simpleValue(prefix.SimpleValueBuilder simpleValue) {
+    _$this;
+    super.simpleValue = simpleValue;
+  }
+
+  @override
+  ListBuilder<prefix.SimpleValue> get simpleValues {
+    _$this;
+    return super.simpleValues;
+  }
+
+  @override
+  set simpleValues(ListBuilder<prefix.SimpleValue> simpleValues) {
+    _$this;
+    super.simpleValues = simpleValues;
+  }
+
+  _$ImportedCustomNestedValueBuilder() : super._();
+
+  ImportedCustomNestedValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.simpleValue = $v.simpleValue.toBuilder();
+      super.simpleValues = $v.simpleValues.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ImportedCustomNestedValue other) {
+    _$v = other as _$ImportedCustomNestedValue;
+  }
+
+  @override
+  void update(void Function(ImportedCustomNestedValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ImportedCustomNestedValue build() => _build();
+
+  _$ImportedCustomNestedValue _build() {
+    _$ImportedCustomNestedValue _$result;
+    try {
+      _$result = _$v ??
+          _$ImportedCustomNestedValue._(
+            simpleValue: simpleValue.build(),
+            simpleValues: simpleValues.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        simpleValue.build();
+        _$failedField = 'simpleValues';
+        simpleValues.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'ImportedCustomNestedValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/lib/interfaces.dart
+++ b/built_types/end_to_end_test/lib/interfaces.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+library interfaces;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'interfaces.g.dart';
+
+abstract class HasInt {
+  int get anInt;
+}
+
+abstract class ValueWithInt
+    implements Built<ValueWithInt, ValueWithIntBuilder>, HasInt {
+  static Serializer<ValueWithInt> get serializer => _$valueWithIntSerializer;
+  static final int youCanHaveStaticFields = 3;
+
+  @override
+  int get anInt;
+
+  String get note;
+
+  factory ValueWithInt([void Function(ValueWithIntBuilder) updates]) =
+      _$ValueWithInt;
+  ValueWithInt._();
+}
+
+class EnumWithInt extends EnumClass implements HasInt {
+  /// Serializer field makes the enum_class serializable.
+  static Serializer<EnumWithInt> get serializer => _$enumWithIntSerializer;
+
+  static const EnumWithInt one = _$one;
+  static const EnumWithInt two = _$two;
+  static const EnumWithInt three = _$three;
+
+  const EnumWithInt._(String name) : super(name);
+
+  static BuiltSet<EnumWithInt> get values => _$values;
+
+  static EnumWithInt valueOf(String name) => _$valueOf(name);
+
+  @override
+  int get anInt {
+    switch (this) {
+      case one:
+        return 1;
+      case two:
+        return 2;
+      case three:
+        return 3;
+      default:
+        throw StateError(toString());
+    }
+  }
+}
+
+abstract class ValueWithHasInt
+    implements Built<ValueWithHasInt, ValueWithHasIntBuilder> {
+  static Serializer<ValueWithHasInt> get serializer =>
+      _$valueWithHasIntSerializer;
+
+  factory ValueWithHasInt([void Function(ValueWithHasIntBuilder) updates]) =
+      _$ValueWithHasInt;
+  ValueWithHasInt._();
+
+  HasInt get hasInt;
+}

--- a/built_types/end_to_end_test/lib/interfaces.g.dart
+++ b/built_types/end_to_end_test/lib/interfaces.g.dart
@@ -1,0 +1,315 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
+
+part of 'interfaces.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+const EnumWithInt _$one = const EnumWithInt._('one');
+const EnumWithInt _$two = const EnumWithInt._('two');
+const EnumWithInt _$three = const EnumWithInt._('three');
+
+EnumWithInt _$valueOf(String name) {
+  switch (name) {
+    case 'one':
+      return _$one;
+    case 'two':
+      return _$two;
+    case 'three':
+      return _$three;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<EnumWithInt> _$values =
+    BuiltSet<EnumWithInt>(const <EnumWithInt>[
+  _$one,
+  _$two,
+  _$three,
+]);
+
+Serializer<ValueWithInt> _$valueWithIntSerializer = _$ValueWithIntSerializer();
+Serializer<EnumWithInt> _$enumWithIntSerializer = _$EnumWithIntSerializer();
+Serializer<ValueWithHasInt> _$valueWithHasIntSerializer =
+    _$ValueWithHasIntSerializer();
+
+class _$ValueWithIntSerializer implements StructuredSerializer<ValueWithInt> {
+  @override
+  final Iterable<Type> types = const [ValueWithInt, _$ValueWithInt];
+  @override
+  final String wireName = 'ValueWithInt';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ValueWithInt object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+      'note',
+      serializers.serialize(object.note, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ValueWithInt deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ValueWithIntBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'anInt':
+          result.anInt = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+        case 'note':
+          result.note = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$EnumWithIntSerializer implements PrimitiveSerializer<EnumWithInt> {
+  @override
+  final Iterable<Type> types = const <Type>[EnumWithInt];
+  @override
+  final String wireName = 'EnumWithInt';
+
+  @override
+  Object serialize(Serializers serializers, EnumWithInt object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
+
+  @override
+  EnumWithInt deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      EnumWithInt.valueOf(serialized as String);
+}
+
+class _$ValueWithHasIntSerializer
+    implements StructuredSerializer<ValueWithHasInt> {
+  @override
+  final Iterable<Type> types = const [ValueWithHasInt, _$ValueWithHasInt];
+  @override
+  final String wireName = 'ValueWithHasInt';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ValueWithHasInt object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'hasInt',
+      serializers.serialize(object.hasInt,
+          specifiedType: const FullType(HasInt)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ValueWithHasInt deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ValueWithHasIntBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'hasInt':
+          result.hasInt = serializers.deserialize(value,
+              specifiedType: const FullType(HasInt))! as HasInt;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ValueWithInt extends ValueWithInt {
+  @override
+  final int anInt;
+  @override
+  final String note;
+
+  factory _$ValueWithInt([void Function(ValueWithIntBuilder)? updates]) =>
+      (ValueWithIntBuilder()..update(updates))._build();
+
+  _$ValueWithInt._({required this.anInt, required this.note}) : super._();
+  @override
+  ValueWithInt rebuild(void Function(ValueWithIntBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ValueWithIntBuilder toBuilder() => ValueWithIntBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithInt && anInt == other.anInt && note == other.note;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, note.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueWithInt')
+          ..add('anInt', anInt)
+          ..add('note', note))
+        .toString();
+  }
+}
+
+class ValueWithIntBuilder
+    implements Builder<ValueWithInt, ValueWithIntBuilder> {
+  _$ValueWithInt? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  String? _note;
+  String? get note => _$this._note;
+  set note(String? note) => _$this._note = note;
+
+  ValueWithIntBuilder();
+
+  ValueWithIntBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _note = $v.note;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithInt other) {
+    _$v = other as _$ValueWithInt;
+  }
+
+  @override
+  void update(void Function(ValueWithIntBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithInt build() => _build();
+
+  _$ValueWithInt _build() {
+    final _$result = _$v ??
+        _$ValueWithInt._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValueWithInt', 'anInt'),
+          note: BuiltValueNullFieldError.checkNotNull(
+              note, r'ValueWithInt', 'note'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithHasInt extends ValueWithHasInt {
+  @override
+  final HasInt hasInt;
+
+  factory _$ValueWithHasInt([void Function(ValueWithHasIntBuilder)? updates]) =>
+      (ValueWithHasIntBuilder()..update(updates))._build();
+
+  _$ValueWithHasInt._({required this.hasInt}) : super._();
+  @override
+  ValueWithHasInt rebuild(void Function(ValueWithHasIntBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ValueWithHasIntBuilder toBuilder() => ValueWithHasIntBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithHasInt && hasInt == other.hasInt;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, hasInt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueWithHasInt')
+          ..add('hasInt', hasInt))
+        .toString();
+  }
+}
+
+class ValueWithHasIntBuilder
+    implements Builder<ValueWithHasInt, ValueWithHasIntBuilder> {
+  _$ValueWithHasInt? _$v;
+
+  HasInt? _hasInt;
+  HasInt? get hasInt => _$this._hasInt;
+  set hasInt(HasInt? hasInt) => _$this._hasInt = hasInt;
+
+  ValueWithHasIntBuilder();
+
+  ValueWithHasIntBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _hasInt = $v.hasInt;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithHasInt other) {
+    _$v = other as _$ValueWithHasInt;
+  }
+
+  @override
+  void update(void Function(ValueWithHasIntBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithHasInt build() => _build();
+
+  _$ValueWithHasInt _build() {
+    final _$result = _$v ??
+        _$ValueWithHasInt._(
+          hasInt: BuiltValueNullFieldError.checkNotNull(
+              hasInt, r'ValueWithHasInt', 'hasInt'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/lib/mixins.dart
+++ b/built_types/end_to_end_test/lib/mixins.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/mixins_src.dart';
+
+part 'mixins.g.dart';
+
+abstract class UsesMixin extends Object
+    with Mixin
+    implements Built<UsesMixin, UsesMixinBuilder> {
+  static Serializer<UsesMixin> get serializer => _$usesMixinSerializer;
+
+  factory UsesMixin([void Function(UsesMixinBuilder) updates]) = _$UsesMixin;
+  UsesMixin._();
+}
+
+// This catches a regression in determining whether a getter should cause a
+// field to be created. We only want that if there is no concrete
+// implementation. This precise combination of mixins and interfaces caused
+// the concrete implementation to be missed and an unwanted field to be
+// created.
+abstract class GetsCorrectFieldsViaMixins extends Object
+    with ConcreteMixin, AbstractMixin
+    implements
+        Built<GetsCorrectFieldsViaMixins, GetsCorrectFieldsViaMixinsBuilder>,
+        MixinBase {
+  factory GetsCorrectFieldsViaMixins(
+          [void Function(GetsCorrectFieldsViaMixinsBuilder) updates]) =
+      _$GetsCorrectFieldsViaMixins;
+  GetsCorrectFieldsViaMixins._();
+}
+
+abstract class MixinBase {
+  int get shouldBeAField;
+  int get shouldNotBeAField;
+}
+
+mixin ConcreteMixin implements MixinBase {
+  @override
+  int get shouldNotBeAField => 1;
+}
+
+mixin AbstractMixin implements MixinBase {}

--- a/built_types/end_to_end_test/lib/mixins.g.dart
+++ b/built_types/end_to_end_test/lib/mixins.g.dart
@@ -1,0 +1,195 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
+
+part of 'mixins.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<UsesMixin> _$usesMixinSerializer = _$UsesMixinSerializer();
+
+class _$UsesMixinSerializer implements StructuredSerializer<UsesMixin> {
+  @override
+  final Iterable<Type> types = const [UsesMixin, _$UsesMixin];
+  @override
+  final String wireName = 'UsesMixin';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsesMixin object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return <Object?>[];
+  }
+
+  @override
+  UsesMixin deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return UsesMixinBuilder().build();
+  }
+}
+
+class _$UsesMixin extends UsesMixin {
+  @override
+  final String Function(String) typeDef;
+
+  factory _$UsesMixin([void Function(UsesMixinBuilder)? updates]) =>
+      (UsesMixinBuilder()..update(updates))._build();
+
+  _$UsesMixin._({required this.typeDef}) : super._();
+  @override
+  UsesMixin rebuild(void Function(UsesMixinBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsesMixinBuilder toBuilder() => UsesMixinBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsesMixin && typeDef == other.typeDef;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, typeDef.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsesMixin')..add('typeDef', typeDef))
+        .toString();
+  }
+}
+
+class UsesMixinBuilder implements Builder<UsesMixin, UsesMixinBuilder> {
+  _$UsesMixin? _$v;
+
+  String Function(String)? _typeDef;
+  String Function(String)? get typeDef => _$this._typeDef;
+  set typeDef(String Function(String)? typeDef) => _$this._typeDef = typeDef;
+
+  UsesMixinBuilder();
+
+  UsesMixinBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _typeDef = $v.typeDef;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(UsesMixin other) {
+    _$v = other as _$UsesMixin;
+  }
+
+  @override
+  void update(void Function(UsesMixinBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsesMixin build() => _build();
+
+  _$UsesMixin _build() {
+    final _$result = _$v ??
+        _$UsesMixin._(
+          typeDef: BuiltValueNullFieldError.checkNotNull(
+              typeDef, r'UsesMixin', 'typeDef'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GetsCorrectFieldsViaMixins extends GetsCorrectFieldsViaMixins {
+  @override
+  final int shouldBeAField;
+
+  factory _$GetsCorrectFieldsViaMixins(
+          [void Function(GetsCorrectFieldsViaMixinsBuilder)? updates]) =>
+      (GetsCorrectFieldsViaMixinsBuilder()..update(updates))._build();
+
+  _$GetsCorrectFieldsViaMixins._({required this.shouldBeAField}) : super._();
+  @override
+  GetsCorrectFieldsViaMixins rebuild(
+          void Function(GetsCorrectFieldsViaMixinsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GetsCorrectFieldsViaMixinsBuilder toBuilder() =>
+      GetsCorrectFieldsViaMixinsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GetsCorrectFieldsViaMixins &&
+        shouldBeAField == other.shouldBeAField;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, shouldBeAField.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GetsCorrectFieldsViaMixins')
+          ..add('shouldBeAField', shouldBeAField))
+        .toString();
+  }
+}
+
+class GetsCorrectFieldsViaMixinsBuilder
+    implements
+        Builder<GetsCorrectFieldsViaMixins, GetsCorrectFieldsViaMixinsBuilder> {
+  _$GetsCorrectFieldsViaMixins? _$v;
+
+  int? _shouldBeAField;
+  int? get shouldBeAField => _$this._shouldBeAField;
+  set shouldBeAField(int? shouldBeAField) =>
+      _$this._shouldBeAField = shouldBeAField;
+
+  GetsCorrectFieldsViaMixinsBuilder();
+
+  GetsCorrectFieldsViaMixinsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _shouldBeAField = $v.shouldBeAField;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GetsCorrectFieldsViaMixins other) {
+    _$v = other as _$GetsCorrectFieldsViaMixins;
+  }
+
+  @override
+  void update(void Function(GetsCorrectFieldsViaMixinsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GetsCorrectFieldsViaMixins build() => _build();
+
+  _$GetsCorrectFieldsViaMixins _build() {
+    final _$result = _$v ??
+        _$GetsCorrectFieldsViaMixins._(
+          shouldBeAField: BuiltValueNullFieldError.checkNotNull(
+              shouldBeAField, r'GetsCorrectFieldsViaMixins', 'shouldBeAField'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/lib/mixins_src.dart
+++ b/built_types/end_to_end_test/lib/mixins_src.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+// Test coverage for handling of file types read from a separate file.
+
+import 'package:built_value/built_value.dart';
+
+typedef TypeDef = String Function(String a);
+
+abstract class Mixin {
+  @BuiltValueField(serialize: false)
+  TypeDef get typeDef;
+}
+
+// Don't fail on encountering new mixin syntax.
+mixin Foo {}
+
+mixin FunctionMixin {
+  Function get mixinBareFunction;
+  Future<void> Function(int, double) get mixinPositionalFunction;
+  Future<void> Function(int, [double]) get mixinOptionalFunction;
+  Future<void> Function(int x, double y) get mixinPositionalNamedFunction;
+  Future<void> Function(int x, {int y, double z}) get mixinNamedFunction;
+  Future<void> Function(int x, {required int y, required double z})
+      get mixinRequiredNamedFunction;
+}

--- a/built_types/end_to_end_test/lib/not_triggered.dart
+++ b/built_types/end_to_end_test/lib/not_triggered.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2025, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'exports_built_value.dart';
+
+// This file is ignored because it does not match a defined trigger in
+// `built_value_generator` `build.yaml`.
+//
+// If there is a bug causing it to not be ignored, the build of this package
+// will break because these are not valid `built_value` classes.
+
+abstract class Value implements Built<Value, ValueBuilder> {}
+
+abstract class ValueBuilder implements Builder<Value, ValueBuilder> {}

--- a/built_types/end_to_end_test/lib/polymorphism.dart
+++ b/built_types/end_to_end_test/lib/polymorphism.dart
@@ -1,0 +1,260 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'polymorphism.g.dart';
+
+@BuiltValue(instantiable: false)
+abstract class Animal extends Object with Walker implements OtherInterface {
+  @override
+  int get legs;
+
+  Animal rebuild(void Function(AnimalBuilder) updates);
+  AnimalBuilder toBuilder();
+}
+
+// Polymorphic base classes are allowed to omit implementing `Built` while
+// still being allowed to implement any other interface.
+abstract class OtherInterface {}
+
+// Check a second layer of `instantiable: false` inheritance.
+@BuiltValue(instantiable: false)
+abstract class Mammal implements Animal {
+  @override
+  Mammal rebuild(void Function(MammalBuilder) updates);
+  @override
+  MammalBuilder toBuilder();
+}
+
+abstract class Cat with Walker implements Mammal, Built<Cat, CatBuilder> {
+  static Serializer<Cat> get serializer => _$catSerializer;
+
+  bool get tail;
+
+  factory Cat([void Function(CatBuilder) updates]) = _$Cat;
+  Cat._();
+}
+
+abstract class Fish extends Object
+    with Swimmer, Walker
+    implements Animal, Built<Fish, FishBuilder> {
+  static Serializer<Fish> get serializer => _$fishSerializer;
+
+  @override
+  int get fins;
+
+  factory Fish([void Function(FishBuilder) updates]) = _$Fish;
+  Fish._();
+}
+
+// Fields should come via mixins with no need for interfaces.
+abstract class Robot extends Object
+    with Swimmer, Walker
+    implements Built<Robot, RobotBuilder> {
+  static Serializer<Robot> get serializer => _$robotSerializer;
+
+  factory Robot([void Function(RobotBuilder) updates]) = _$Robot;
+  Robot._();
+}
+
+abstract class Walker {
+  int get legs;
+
+  bool get canWalk => legs > 1;
+}
+
+abstract class Swimmer {
+  int get fins;
+
+  bool get canSwim => fins > 1;
+}
+
+abstract class Cage implements Built<Cage, CageBuilder> {
+  static Serializer<Cage> get serializer => _$cageSerializer;
+
+  Animal get inhabitant;
+  BuiltList<Animal> get otherInhabitants;
+
+  factory Cage([void Function(CageBuilder) updates]) = _$Cage;
+  Cage._();
+}
+
+// It's possible to implement getters via mixins. Such getters are treated
+// exactly as concrete getters in the immediate class -- they are ignored.
+abstract class FourLeggedWalker {
+  int get legs => 4;
+}
+
+abstract class HasLegs {
+  int get legs;
+}
+
+// "Legs" field comes from "FourLeggedWalker" mixin and does not lead to a
+// generated field.
+abstract class StandardCat extends Object
+    with Walker, FourLeggedWalker
+    implements HasLegs, Built<StandardCat, StandardCatBuilder> {
+  static Serializer<StandardCat> get serializer => _$standardCatSerializer;
+
+  bool get tail;
+
+  factory StandardCat([void Function(StandardCatBuilder) updates]) =
+      _$StandardCat;
+  StandardCat._();
+}
+
+@BuiltValue(instantiable: false)
+abstract class HasField<T> {
+  T get field;
+
+  HasField<T> rebuild(void Function(HasFieldBuilder<T>) updates);
+  HasFieldBuilder<T> toBuilder();
+}
+
+abstract class HasString
+    implements Built<HasString, HasStringBuilder>, HasField<String> {
+  static Serializer<HasString> get serializer => _$hasStringSerializer;
+
+  @override
+  String get field;
+
+  factory HasString([void Function(HasStringBuilder) updates]) = _$HasString;
+  HasString._();
+}
+
+abstract class HasDouble
+    implements Built<HasDouble, HasDoubleBuilder>, HasField<double> {
+  static Serializer<HasDouble> get serializer => _$hasDoubleSerializer;
+
+  @override
+  double get field;
+
+  factory HasDouble([void Function(HasDoubleBuilder) updates]) = _$HasDouble;
+  HasDouble._();
+}
+
+// Check generation for fields that are pulled in via a chain of `implements`.
+// Check both the "abstract" case and the "implemented by mixin" case.
+abstract class ChainedInterface {
+  int get foo;
+  int get moreFoo;
+}
+
+abstract class ChainedInterface2 implements ChainedInterface {
+  int get bar;
+  int get moreBar;
+}
+
+abstract class MoreMixin {
+  int get moreFoo => 0;
+  int get moreBar => 1;
+}
+
+abstract class UsesChainedInterface extends Object
+    with MoreMixin
+    implements
+        Built<UsesChainedInterface, UsesChainedInterfaceBuilder>,
+        ChainedInterface2 {
+  factory UsesChainedInterface(
+          [void Function(UsesChainedInterfaceBuilder) updates]) =
+      _$UsesChainedInterface;
+  UsesChainedInterface._();
+}
+
+// Check that a non-instantiable `built` class is allow to omit `Built`, and
+// the corresponding hand-coded builder is allowed to omit `Builder`, to
+// choose which fields to specify, and to omit factory and constructor.
+@BuiltValue(instantiable: false)
+abstract class HandCoded {
+  int get fieldInBaseBuilder;
+  int get fieldNotInBaseBuilder;
+
+  HandCoded rebuild(void Function(HandCodedBuilder) updates);
+}
+
+abstract class HandCodedBuilder {
+  int? fieldInBaseBuilder;
+}
+
+abstract class UsesHandCoded
+    implements Built<UsesHandCoded, UsesHandCodedBuilder>, HandCoded {
+  static Serializer<UsesHandCoded> get serializer => _$usesHandCodedSerializer;
+
+  // If a field is not present in the base builder, we're free to supply an
+  // implementation rather than using the generated one.
+  @override
+  int get fieldNotInBaseBuilder => 37;
+
+  factory UsesHandCoded([void Function(UsesHandCodedBuilder) updates]) =
+      _$UsesHandCoded;
+  UsesHandCoded._();
+}
+
+// Check generation when two @BuiltValue(instantiable: false) classes are
+// implemented. Currently needs a workaround due to analyzer issue:
+// https://github.com/dart-lang/sdk/issues/32025
+@BuiltValue(instantiable: false)
+abstract class One {}
+
+@BuiltValue(instantiable: false)
+abstract class Two {}
+
+abstract class ImplementsTwo
+    implements Built<ImplementsTwo, ImplementsTwoBuilder>, One, Two {
+  factory ImplementsTwo([void Function(ImplementsTwoBuilder) updates]) =
+      _$ImplementsTwo;
+  ImplementsTwo._();
+}
+
+// Nullability of nested builders.
+@BuiltValue(instantiable: false)
+abstract class Vehicle {
+  // some property
+  VehicleColor get color;
+
+  // common BuiltValue interface
+  Vehicle rebuild(void Function(VehicleBuilder b) updates);
+  VehicleBuilder toBuilder();
+}
+
+abstract class Car implements Vehicle, Built<Car, CarBuilder> {
+  Car._();
+
+  factory Car([void Function(CarBuilder)? updates]) = _$Car;
+
+  int get seatsCount;
+}
+
+// Check that generated builders mix in parent buildes when the class mixes
+// in the other class; otherwise, they won't build.
+abstract class MixinCar
+    with Vehicle
+    implements Built<MixinCar, MixinCarBuilder> {
+  MixinCar._();
+
+  factory MixinCar([void Function(MixinCarBuilder)? updates]) = _$MixinCar;
+
+  int get seatsCount;
+}
+
+abstract class VehicleColor
+    implements Built<VehicleColor, VehicleColorBuilder> {
+  VehicleColor._();
+
+  factory VehicleColor([void Function(VehicleColorBuilder)? updates]) =
+      _$VehicleColor;
+
+  String get label;
+}
+
+@BuiltValue(instantiable: false, nestedBuilders: false)
+abstract class NotInstantiableNotNested
+    implements
+        Built<NotInstantiableNotNested, NotInstantiableNotNestedBuilder> {
+  BuiltList<String> get list;
+}

--- a/built_types/end_to_end_test/lib/polymorphism.g.dart
+++ b/built_types/end_to_end_test/lib/polymorphism.g.dart
@@ -1,0 +1,1541 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
+
+part of 'polymorphism.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<Cat> _$catSerializer = _$CatSerializer();
+Serializer<Fish> _$fishSerializer = _$FishSerializer();
+Serializer<Robot> _$robotSerializer = _$RobotSerializer();
+Serializer<Cage> _$cageSerializer = _$CageSerializer();
+Serializer<StandardCat> _$standardCatSerializer = _$StandardCatSerializer();
+Serializer<HasString> _$hasStringSerializer = _$HasStringSerializer();
+Serializer<HasDouble> _$hasDoubleSerializer = _$HasDoubleSerializer();
+Serializer<UsesHandCoded> _$usesHandCodedSerializer =
+    _$UsesHandCodedSerializer();
+
+class _$CatSerializer implements StructuredSerializer<Cat> {
+  @override
+  final Iterable<Type> types = const [Cat, _$Cat];
+  @override
+  final String wireName = 'Cat';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Cat object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'tail',
+      serializers.serialize(object.tail, specifiedType: const FullType(bool)),
+      'legs',
+      serializers.serialize(object.legs, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Cat deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CatBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'tail':
+          result.tail = serializers.deserialize(value,
+              specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'legs':
+          result.legs = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$FishSerializer implements StructuredSerializer<Fish> {
+  @override
+  final Iterable<Type> types = const [Fish, _$Fish];
+  @override
+  final String wireName = 'Fish';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Fish object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'fins',
+      serializers.serialize(object.fins, specifiedType: const FullType(int)),
+      'legs',
+      serializers.serialize(object.legs, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Fish deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = FishBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'fins':
+          result.fins = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+        case 'legs':
+          result.legs = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RobotSerializer implements StructuredSerializer<Robot> {
+  @override
+  final Iterable<Type> types = const [Robot, _$Robot];
+  @override
+  final String wireName = 'Robot';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Robot object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'fins',
+      serializers.serialize(object.fins, specifiedType: const FullType(int)),
+      'legs',
+      serializers.serialize(object.legs, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Robot deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RobotBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'fins':
+          result.fins = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+        case 'legs':
+          result.legs = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CageSerializer implements StructuredSerializer<Cage> {
+  @override
+  final Iterable<Type> types = const [Cage, _$Cage];
+  @override
+  final String wireName = 'Cage';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Cage object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'inhabitant',
+      serializers.serialize(object.inhabitant,
+          specifiedType: const FullType(Animal)),
+      'otherInhabitants',
+      serializers.serialize(object.otherInhabitants,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(Animal)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  Cage deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CageBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'inhabitant':
+          result.inhabitant = serializers.deserialize(value,
+              specifiedType: const FullType(Animal))! as Animal;
+          break;
+        case 'otherInhabitants':
+          result.otherInhabitants.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(Animal)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$StandardCatSerializer implements StructuredSerializer<StandardCat> {
+  @override
+  final Iterable<Type> types = const [StandardCat, _$StandardCat];
+  @override
+  final String wireName = 'StandardCat';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, StandardCat object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'tail',
+      serializers.serialize(object.tail, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  StandardCat deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = StandardCatBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'tail':
+          result.tail = serializers.deserialize(value,
+              specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$HasStringSerializer implements StructuredSerializer<HasString> {
+  @override
+  final Iterable<Type> types = const [HasString, _$HasString];
+  @override
+  final String wireName = 'HasString';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, HasString object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'field',
+      serializers.serialize(object.field,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  HasString deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = HasStringBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'field':
+          result.field = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$HasDoubleSerializer implements StructuredSerializer<HasDouble> {
+  @override
+  final Iterable<Type> types = const [HasDouble, _$HasDouble];
+  @override
+  final String wireName = 'HasDouble';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, HasDouble object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'field',
+      serializers.serialize(object.field,
+          specifiedType: const FullType(double)),
+    ];
+
+    return result;
+  }
+
+  @override
+  HasDouble deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = HasDoubleBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'field':
+          result.field = serializers.deserialize(value,
+              specifiedType: const FullType(double))! as double;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UsesHandCodedSerializer implements StructuredSerializer<UsesHandCoded> {
+  @override
+  final Iterable<Type> types = const [UsesHandCoded, _$UsesHandCoded];
+  @override
+  final String wireName = 'UsesHandCoded';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsesHandCoded object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'fieldInBaseBuilder',
+      serializers.serialize(object.fieldInBaseBuilder,
+          specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  UsesHandCoded deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsesHandCodedBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'fieldInBaseBuilder':
+          result.fieldInBaseBuilder = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+abstract class AnimalBuilder {
+  void replace(Animal other);
+  void update(void Function(AnimalBuilder) updates);
+  int? get legs;
+  set legs(int? legs);
+}
+
+abstract class MammalBuilder implements AnimalBuilder {
+  void replace(covariant Mammal other);
+  void update(void Function(MammalBuilder) updates);
+  int? get legs;
+  set legs(covariant int? legs);
+}
+
+class _$Cat extends Cat {
+  @override
+  final bool tail;
+  @override
+  final int legs;
+
+  factory _$Cat([void Function(CatBuilder)? updates]) =>
+      (CatBuilder()..update(updates))._build();
+
+  _$Cat._({required this.tail, required this.legs}) : super._();
+  @override
+  Cat rebuild(void Function(CatBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CatBuilder toBuilder() => CatBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Cat && tail == other.tail && legs == other.legs;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, tail.hashCode);
+    _$hash = $jc(_$hash, legs.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Cat')
+          ..add('tail', tail)
+          ..add('legs', legs))
+        .toString();
+  }
+}
+
+class CatBuilder implements Builder<Cat, CatBuilder>, MammalBuilder {
+  _$Cat? _$v;
+
+  bool? _tail;
+  bool? get tail => _$this._tail;
+  set tail(covariant bool? tail) => _$this._tail = tail;
+
+  int? _legs;
+  int? get legs => _$this._legs;
+  set legs(covariant int? legs) => _$this._legs = legs;
+
+  CatBuilder();
+
+  CatBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _tail = $v.tail;
+      _legs = $v.legs;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant Cat other) {
+    _$v = other as _$Cat;
+  }
+
+  @override
+  void update(void Function(CatBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Cat build() => _build();
+
+  _$Cat _build() {
+    final _$result = _$v ??
+        _$Cat._(
+          tail: BuiltValueNullFieldError.checkNotNull(tail, r'Cat', 'tail'),
+          legs: BuiltValueNullFieldError.checkNotNull(legs, r'Cat', 'legs'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$Fish extends Fish {
+  @override
+  final int fins;
+  @override
+  final int legs;
+
+  factory _$Fish([void Function(FishBuilder)? updates]) =>
+      (FishBuilder()..update(updates))._build();
+
+  _$Fish._({required this.fins, required this.legs}) : super._();
+  @override
+  Fish rebuild(void Function(FishBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  FishBuilder toBuilder() => FishBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Fish && fins == other.fins && legs == other.legs;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, fins.hashCode);
+    _$hash = $jc(_$hash, legs.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Fish')
+          ..add('fins', fins)
+          ..add('legs', legs))
+        .toString();
+  }
+}
+
+class FishBuilder implements Builder<Fish, FishBuilder>, AnimalBuilder {
+  _$Fish? _$v;
+
+  int? _fins;
+  int? get fins => _$this._fins;
+  set fins(covariant int? fins) => _$this._fins = fins;
+
+  int? _legs;
+  int? get legs => _$this._legs;
+  set legs(covariant int? legs) => _$this._legs = legs;
+
+  FishBuilder();
+
+  FishBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _fins = $v.fins;
+      _legs = $v.legs;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant Fish other) {
+    _$v = other as _$Fish;
+  }
+
+  @override
+  void update(void Function(FishBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Fish build() => _build();
+
+  _$Fish _build() {
+    final _$result = _$v ??
+        _$Fish._(
+          fins: BuiltValueNullFieldError.checkNotNull(fins, r'Fish', 'fins'),
+          legs: BuiltValueNullFieldError.checkNotNull(legs, r'Fish', 'legs'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$Robot extends Robot {
+  @override
+  final int fins;
+  @override
+  final int legs;
+
+  factory _$Robot([void Function(RobotBuilder)? updates]) =>
+      (RobotBuilder()..update(updates))._build();
+
+  _$Robot._({required this.fins, required this.legs}) : super._();
+  @override
+  Robot rebuild(void Function(RobotBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RobotBuilder toBuilder() => RobotBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Robot && fins == other.fins && legs == other.legs;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, fins.hashCode);
+    _$hash = $jc(_$hash, legs.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Robot')
+          ..add('fins', fins)
+          ..add('legs', legs))
+        .toString();
+  }
+}
+
+class RobotBuilder implements Builder<Robot, RobotBuilder> {
+  _$Robot? _$v;
+
+  int? _fins;
+  int? get fins => _$this._fins;
+  set fins(int? fins) => _$this._fins = fins;
+
+  int? _legs;
+  int? get legs => _$this._legs;
+  set legs(int? legs) => _$this._legs = legs;
+
+  RobotBuilder();
+
+  RobotBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _fins = $v.fins;
+      _legs = $v.legs;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Robot other) {
+    _$v = other as _$Robot;
+  }
+
+  @override
+  void update(void Function(RobotBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Robot build() => _build();
+
+  _$Robot _build() {
+    final _$result = _$v ??
+        _$Robot._(
+          fins: BuiltValueNullFieldError.checkNotNull(fins, r'Robot', 'fins'),
+          legs: BuiltValueNullFieldError.checkNotNull(legs, r'Robot', 'legs'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$Cage extends Cage {
+  @override
+  final Animal inhabitant;
+  @override
+  final BuiltList<Animal> otherInhabitants;
+
+  factory _$Cage([void Function(CageBuilder)? updates]) =>
+      (CageBuilder()..update(updates))._build();
+
+  _$Cage._({required this.inhabitant, required this.otherInhabitants})
+      : super._();
+  @override
+  Cage rebuild(void Function(CageBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CageBuilder toBuilder() => CageBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Cage &&
+        inhabitant == other.inhabitant &&
+        otherInhabitants == other.otherInhabitants;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, inhabitant.hashCode);
+    _$hash = $jc(_$hash, otherInhabitants.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Cage')
+          ..add('inhabitant', inhabitant)
+          ..add('otherInhabitants', otherInhabitants))
+        .toString();
+  }
+}
+
+class CageBuilder implements Builder<Cage, CageBuilder> {
+  _$Cage? _$v;
+
+  Animal? _inhabitant;
+  Animal? get inhabitant => _$this._inhabitant;
+  set inhabitant(Animal? inhabitant) => _$this._inhabitant = inhabitant;
+
+  ListBuilder<Animal>? _otherInhabitants;
+  ListBuilder<Animal> get otherInhabitants =>
+      _$this._otherInhabitants ??= ListBuilder<Animal>();
+  set otherInhabitants(ListBuilder<Animal>? otherInhabitants) =>
+      _$this._otherInhabitants = otherInhabitants;
+
+  CageBuilder();
+
+  CageBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _inhabitant = $v.inhabitant;
+      _otherInhabitants = $v.otherInhabitants.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Cage other) {
+    _$v = other as _$Cage;
+  }
+
+  @override
+  void update(void Function(CageBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Cage build() => _build();
+
+  _$Cage _build() {
+    _$Cage _$result;
+    try {
+      _$result = _$v ??
+          _$Cage._(
+            inhabitant: BuiltValueNullFieldError.checkNotNull(
+                inhabitant, r'Cage', 'inhabitant'),
+            otherInhabitants: otherInhabitants.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'otherInhabitants';
+        otherInhabitants.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'Cage', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$StandardCat extends StandardCat {
+  @override
+  final bool tail;
+
+  factory _$StandardCat([void Function(StandardCatBuilder)? updates]) =>
+      (StandardCatBuilder()..update(updates))._build();
+
+  _$StandardCat._({required this.tail}) : super._();
+  @override
+  StandardCat rebuild(void Function(StandardCatBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  StandardCatBuilder toBuilder() => StandardCatBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is StandardCat && tail == other.tail;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, tail.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'StandardCat')..add('tail', tail))
+        .toString();
+  }
+}
+
+class StandardCatBuilder implements Builder<StandardCat, StandardCatBuilder> {
+  _$StandardCat? _$v;
+
+  bool? _tail;
+  bool? get tail => _$this._tail;
+  set tail(bool? tail) => _$this._tail = tail;
+
+  StandardCatBuilder();
+
+  StandardCatBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _tail = $v.tail;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(StandardCat other) {
+    _$v = other as _$StandardCat;
+  }
+
+  @override
+  void update(void Function(StandardCatBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  StandardCat build() => _build();
+
+  _$StandardCat _build() {
+    final _$result = _$v ??
+        _$StandardCat._(
+          tail: BuiltValueNullFieldError.checkNotNull(
+              tail, r'StandardCat', 'tail'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract class HasFieldBuilder<T> {
+  void replace(HasField<T> other);
+  void update(void Function(HasFieldBuilder<T>) updates);
+  T? get field;
+  set field(T? field);
+}
+
+class _$HasString extends HasString {
+  @override
+  final String field;
+
+  factory _$HasString([void Function(HasStringBuilder)? updates]) =>
+      (HasStringBuilder()..update(updates))._build();
+
+  _$HasString._({required this.field}) : super._();
+  @override
+  HasString rebuild(void Function(HasStringBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  HasStringBuilder toBuilder() => HasStringBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is HasString && field == other.field;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, field.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'HasString')..add('field', field))
+        .toString();
+  }
+}
+
+class HasStringBuilder
+    implements Builder<HasString, HasStringBuilder>, HasFieldBuilder<String> {
+  _$HasString? _$v;
+
+  String? _field;
+  String? get field => _$this._field;
+  set field(covariant String? field) => _$this._field = field;
+
+  HasStringBuilder();
+
+  HasStringBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _field = $v.field;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant HasString other) {
+    _$v = other as _$HasString;
+  }
+
+  @override
+  void update(void Function(HasStringBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  HasString build() => _build();
+
+  _$HasString _build() {
+    final _$result = _$v ??
+        _$HasString._(
+          field: BuiltValueNullFieldError.checkNotNull(
+              field, r'HasString', 'field'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$HasDouble extends HasDouble {
+  @override
+  final double field;
+
+  factory _$HasDouble([void Function(HasDoubleBuilder)? updates]) =>
+      (HasDoubleBuilder()..update(updates))._build();
+
+  _$HasDouble._({required this.field}) : super._();
+  @override
+  HasDouble rebuild(void Function(HasDoubleBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  HasDoubleBuilder toBuilder() => HasDoubleBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is HasDouble && field == other.field;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, field.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'HasDouble')..add('field', field))
+        .toString();
+  }
+}
+
+class HasDoubleBuilder
+    implements Builder<HasDouble, HasDoubleBuilder>, HasFieldBuilder<double> {
+  _$HasDouble? _$v;
+
+  double? _field;
+  double? get field => _$this._field;
+  set field(covariant double? field) => _$this._field = field;
+
+  HasDoubleBuilder();
+
+  HasDoubleBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _field = $v.field;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant HasDouble other) {
+    _$v = other as _$HasDouble;
+  }
+
+  @override
+  void update(void Function(HasDoubleBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  HasDouble build() => _build();
+
+  _$HasDouble _build() {
+    final _$result = _$v ??
+        _$HasDouble._(
+          field: BuiltValueNullFieldError.checkNotNull(
+              field, r'HasDouble', 'field'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$UsesChainedInterface extends UsesChainedInterface {
+  @override
+  final int bar;
+  @override
+  final int foo;
+
+  factory _$UsesChainedInterface(
+          [void Function(UsesChainedInterfaceBuilder)? updates]) =>
+      (UsesChainedInterfaceBuilder()..update(updates))._build();
+
+  _$UsesChainedInterface._({required this.bar, required this.foo}) : super._();
+  @override
+  UsesChainedInterface rebuild(
+          void Function(UsesChainedInterfaceBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsesChainedInterfaceBuilder toBuilder() =>
+      UsesChainedInterfaceBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsesChainedInterface &&
+        bar == other.bar &&
+        foo == other.foo;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, bar.hashCode);
+    _$hash = $jc(_$hash, foo.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsesChainedInterface')
+          ..add('bar', bar)
+          ..add('foo', foo))
+        .toString();
+  }
+}
+
+class UsesChainedInterfaceBuilder
+    implements Builder<UsesChainedInterface, UsesChainedInterfaceBuilder> {
+  _$UsesChainedInterface? _$v;
+
+  int? _bar;
+  int? get bar => _$this._bar;
+  set bar(int? bar) => _$this._bar = bar;
+
+  int? _foo;
+  int? get foo => _$this._foo;
+  set foo(int? foo) => _$this._foo = foo;
+
+  UsesChainedInterfaceBuilder();
+
+  UsesChainedInterfaceBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _bar = $v.bar;
+      _foo = $v.foo;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(UsesChainedInterface other) {
+    _$v = other as _$UsesChainedInterface;
+  }
+
+  @override
+  void update(void Function(UsesChainedInterfaceBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsesChainedInterface build() => _build();
+
+  _$UsesChainedInterface _build() {
+    final _$result = _$v ??
+        _$UsesChainedInterface._(
+          bar: BuiltValueNullFieldError.checkNotNull(
+              bar, r'UsesChainedInterface', 'bar'),
+          foo: BuiltValueNullFieldError.checkNotNull(
+              foo, r'UsesChainedInterface', 'foo'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$UsesHandCoded extends UsesHandCoded {
+  @override
+  final int fieldInBaseBuilder;
+
+  factory _$UsesHandCoded([void Function(UsesHandCodedBuilder)? updates]) =>
+      (UsesHandCodedBuilder()..update(updates))._build();
+
+  _$UsesHandCoded._({required this.fieldInBaseBuilder}) : super._();
+  @override
+  UsesHandCoded rebuild(void Function(UsesHandCodedBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsesHandCodedBuilder toBuilder() => UsesHandCodedBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsesHandCoded &&
+        fieldInBaseBuilder == other.fieldInBaseBuilder;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, fieldInBaseBuilder.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsesHandCoded')
+          ..add('fieldInBaseBuilder', fieldInBaseBuilder))
+        .toString();
+  }
+}
+
+class UsesHandCodedBuilder
+    implements Builder<UsesHandCoded, UsesHandCodedBuilder>, HandCodedBuilder {
+  _$UsesHandCoded? _$v;
+
+  int? _fieldInBaseBuilder;
+  int? get fieldInBaseBuilder => _$this._fieldInBaseBuilder;
+  set fieldInBaseBuilder(covariant int? fieldInBaseBuilder) =>
+      _$this._fieldInBaseBuilder = fieldInBaseBuilder;
+
+  UsesHandCodedBuilder();
+
+  UsesHandCodedBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _fieldInBaseBuilder = $v.fieldInBaseBuilder;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsesHandCoded other) {
+    _$v = other as _$UsesHandCoded;
+  }
+
+  @override
+  void update(void Function(UsesHandCodedBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsesHandCoded build() => _build();
+
+  _$UsesHandCoded _build() {
+    final _$result = _$v ??
+        _$UsesHandCoded._(
+          fieldInBaseBuilder: BuiltValueNullFieldError.checkNotNull(
+              fieldInBaseBuilder, r'UsesHandCoded', 'fieldInBaseBuilder'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract class OneBuilder {
+  void replace(One other);
+  void update(void Function(OneBuilder) updates);
+}
+
+abstract class TwoBuilder {
+  void replace(Two other);
+  void update(void Function(TwoBuilder) updates);
+}
+
+class _$ImplementsTwo extends ImplementsTwo {
+  factory _$ImplementsTwo([void Function(ImplementsTwoBuilder)? updates]) =>
+      (ImplementsTwoBuilder()..update(updates))._build();
+
+  _$ImplementsTwo._() : super._();
+  @override
+  ImplementsTwo rebuild(void Function(ImplementsTwoBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ImplementsTwoBuilder toBuilder() => ImplementsTwoBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ImplementsTwo;
+  }
+
+  @override
+  int get hashCode {
+    return 185492149;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper(r'ImplementsTwo').toString();
+  }
+}
+
+class ImplementsTwoBuilder
+    implements
+        Builder<ImplementsTwo, ImplementsTwoBuilder>,
+        OneBuilder,
+        TwoBuilder {
+  _$ImplementsTwo? _$v;
+
+  ImplementsTwoBuilder();
+
+  @override
+// ignore: override_on_non_overriding_method
+  void replace(covariant ImplementsTwo other) {
+    _$v = other as _$ImplementsTwo;
+  }
+
+  @override
+  void update(void Function(ImplementsTwoBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ImplementsTwo build() => _build();
+
+  _$ImplementsTwo _build() {
+    final _$result = _$v ?? _$ImplementsTwo._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract class VehicleBuilder {
+  void replace(Vehicle other);
+  void update(void Function(VehicleBuilder) updates);
+  VehicleColorBuilder get color;
+  set color(VehicleColorBuilder? color);
+}
+
+class _$Car extends Car {
+  @override
+  final int seatsCount;
+  @override
+  final VehicleColor color;
+
+  factory _$Car([void Function(CarBuilder)? updates]) =>
+      (CarBuilder()..update(updates))._build();
+
+  _$Car._({required this.seatsCount, required this.color}) : super._();
+  @override
+  Car rebuild(void Function(CarBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CarBuilder toBuilder() => CarBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Car &&
+        seatsCount == other.seatsCount &&
+        color == other.color;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, seatsCount.hashCode);
+    _$hash = $jc(_$hash, color.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Car')
+          ..add('seatsCount', seatsCount)
+          ..add('color', color))
+        .toString();
+  }
+}
+
+class CarBuilder implements Builder<Car, CarBuilder>, VehicleBuilder {
+  _$Car? _$v;
+
+  int? _seatsCount;
+  int? get seatsCount => _$this._seatsCount;
+  set seatsCount(covariant int? seatsCount) => _$this._seatsCount = seatsCount;
+
+  VehicleColorBuilder? _color;
+  VehicleColorBuilder get color => _$this._color ??= VehicleColorBuilder();
+  set color(covariant VehicleColorBuilder? color) => _$this._color = color;
+
+  CarBuilder();
+
+  CarBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _seatsCount = $v.seatsCount;
+      _color = $v.color.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant Car other) {
+    _$v = other as _$Car;
+  }
+
+  @override
+  void update(void Function(CarBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Car build() => _build();
+
+  _$Car _build() {
+    _$Car _$result;
+    try {
+      _$result = _$v ??
+          _$Car._(
+            seatsCount: BuiltValueNullFieldError.checkNotNull(
+                seatsCount, r'Car', 'seatsCount'),
+            color: color.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'color';
+        color.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'Car', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$MixinCar extends MixinCar {
+  @override
+  final int seatsCount;
+  @override
+  final VehicleColor color;
+
+  factory _$MixinCar([void Function(MixinCarBuilder)? updates]) =>
+      (MixinCarBuilder()..update(updates))._build();
+
+  _$MixinCar._({required this.seatsCount, required this.color}) : super._();
+  @override
+  MixinCar rebuild(void Function(MixinCarBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  MixinCarBuilder toBuilder() => MixinCarBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is MixinCar &&
+        seatsCount == other.seatsCount &&
+        color == other.color;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, seatsCount.hashCode);
+    _$hash = $jc(_$hash, color.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'MixinCar')
+          ..add('seatsCount', seatsCount)
+          ..add('color', color))
+        .toString();
+  }
+}
+
+class MixinCarBuilder
+    with VehicleBuilder
+    implements Builder<MixinCar, MixinCarBuilder> {
+  _$MixinCar? _$v;
+
+  int? _seatsCount;
+  int? get seatsCount => _$this._seatsCount;
+  set seatsCount(covariant int? seatsCount) => _$this._seatsCount = seatsCount;
+
+  VehicleColorBuilder? _color;
+  VehicleColorBuilder get color => _$this._color ??= VehicleColorBuilder();
+  set color(covariant VehicleColorBuilder? color) => _$this._color = color;
+
+  MixinCarBuilder();
+
+  MixinCarBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _seatsCount = $v.seatsCount;
+      _color = $v.color.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant MixinCar other) {
+    _$v = other as _$MixinCar;
+  }
+
+  @override
+  void update(void Function(MixinCarBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  MixinCar build() => _build();
+
+  _$MixinCar _build() {
+    _$MixinCar _$result;
+    try {
+      _$result = _$v ??
+          _$MixinCar._(
+            seatsCount: BuiltValueNullFieldError.checkNotNull(
+                seatsCount, r'MixinCar', 'seatsCount'),
+            color: color.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'color';
+        color.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'MixinCar', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$VehicleColor extends VehicleColor {
+  @override
+  final String label;
+
+  factory _$VehicleColor([void Function(VehicleColorBuilder)? updates]) =>
+      (VehicleColorBuilder()..update(updates))._build();
+
+  _$VehicleColor._({required this.label}) : super._();
+  @override
+  VehicleColor rebuild(void Function(VehicleColorBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  VehicleColorBuilder toBuilder() => VehicleColorBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is VehicleColor && label == other.label;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, label.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'VehicleColor')..add('label', label))
+        .toString();
+  }
+}
+
+class VehicleColorBuilder
+    implements Builder<VehicleColor, VehicleColorBuilder> {
+  _$VehicleColor? _$v;
+
+  String? _label;
+  String? get label => _$this._label;
+  set label(String? label) => _$this._label = label;
+
+  VehicleColorBuilder();
+
+  VehicleColorBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _label = $v.label;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(VehicleColor other) {
+    _$v = other as _$VehicleColor;
+  }
+
+  @override
+  void update(void Function(VehicleColorBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  VehicleColor build() => _build();
+
+  _$VehicleColor _build() {
+    final _$result = _$v ??
+        _$VehicleColor._(
+          label: BuiltValueNullFieldError.checkNotNull(
+              label, r'VehicleColor', 'label'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract class NotInstantiableNotNestedBuilder
+    implements
+        Builder<NotInstantiableNotNested, NotInstantiableNotNestedBuilder> {
+  BuiltList<String>? get list;
+  set list(BuiltList<String>? list);
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/lib/records.dart
+++ b/built_types/end_to_end_test/lib/records.dart
@@ -1,0 +1,161 @@
+// Copyright (c) 2023, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'records.g.dart';
+
+abstract class SimpleRecordValue
+    implements Built<SimpleRecordValue, SimpleRecordValueBuilder> {
+  (int, int) get record;
+
+  factory SimpleRecordValue([void Function(SimpleRecordValueBuilder) updates]) =
+      _$SimpleRecordValue;
+  SimpleRecordValue._();
+}
+
+abstract class ComplexRecordValue
+    implements Built<ComplexRecordValue, ComplexRecordValueBuilder> {
+  // These don't work yet: https://github.com/dart-lang/dart_style/issues/1224
+  //
+  // () get record0;
+  // ()? get record0;
+  //
+  // These need extra work to generate the "," as needed.
+  //
+  // (int,) get record1;
+  // (int,)? get record1n;
+
+  (int, int) get record2;
+  (int?, int) get record2p;
+  (int, int)? get record2n;
+  (int x, int y) get record3;
+  (int? x, int y) get record3p;
+  (int x, int y)? get record3n;
+  ({int x, int y}) get record4;
+  ({int? x, int y}) get record4p;
+  ({int x, int y})? get record4n;
+  (BuiltList<int> a, {BuiltList<ComplexRecordValue> b}) get record5;
+  (BuiltList<int>? a, {BuiltList<ComplexRecordValue> b}) get record5p;
+  (BuiltList<int> a, {BuiltList<ComplexRecordValue> b})? get record5n;
+
+  @BuiltValueField(compare: false)
+  (void Function() a, {void Function() b}) get record6;
+  @BuiltValueField(compare: false)
+  (void Function()? a, {void Function() b}) get record6p;
+  @BuiltValueField(compare: false)
+  (void Function() a, {void Function() b})? get record6n;
+
+  factory ComplexRecordValue([
+    void Function(ComplexRecordValueBuilder) updates,
+  ]) = _$ComplexRecordValue;
+  ComplexRecordValue._();
+}
+
+typedef RecordOfIntInt = (int, int);
+
+// Record serialization is not supported, so a class with records is only
+// serializable if record fields are not serialized.
+abstract class SerializableRecordValue
+    implements Built<SerializableRecordValue, SerializableRecordValueBuilder> {
+  static Serializer<SerializableRecordValue> get serializer =>
+      _$serializableRecordValueSerializer;
+
+  int get value;
+  RecordOfIntInt? get record;
+  RecordOfIntOrList? get intOrList;
+
+  factory SerializableRecordValue([
+    void Function(SerializableRecordValueBuilder) updates,
+  ]) = _$SerializableRecordValue;
+  SerializableRecordValue._();
+}
+
+class RecordOfIntIntSerializer implements StructuredSerializer<RecordOfIntInt> {
+  @override
+  RecordOfIntInt deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return (serialized.elementAt(0)! as int, serialized.elementAt(1)! as int);
+  }
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    RecordOfIntInt object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return [object.$1, object.$2];
+  }
+
+  @override
+  Iterable<Type> get types => [RecordOfIntInt];
+
+  @override
+  String get wireName => 'RecordOfIntInt';
+}
+
+typedef RecordOfIntOrList = (int?, BuiltList<String>?);
+
+class RecordOfIntOrListSerializer
+    implements PrimitiveSerializer<RecordOfIntOrList> {
+  const RecordOfIntOrListSerializer();
+
+  @override
+  Iterable<Type> get types => const [RecordOfIntOrList];
+
+  @override
+  String get wireName => 'RecordOfIntOrList';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RecordOfIntOrList object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    dynamic value;
+    value = object.$1;
+    if (value != null) {
+      return serializers.serialize(value, specifiedType: const FullType(int))!;
+    }
+    value = object.$2;
+    if (value != null) {
+      return serializers.serialize(
+        value,
+        specifiedType: const FullType(BuiltList, [FullType(String)]),
+      )!;
+    }
+
+    throw StateError('Tried to serialize without any value.');
+  }
+
+  @override
+  RecordOfIntOrList deserialize(
+    Serializers serializers,
+    Object data, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    BuiltList<String>? list;
+    try {
+      list =
+          serializers.deserialize(
+                data,
+                specifiedType: const FullType(BuiltList, [FullType(String)]),
+              )!
+              as BuiltList<String>;
+    } catch (_) {}
+    int? number;
+    try {
+      number =
+          serializers.deserialize(data, specifiedType: const FullType(int))!
+              as int;
+    } catch (_) {}
+
+    return (number, list);
+  }
+}

--- a/built_types/end_to_end_test/lib/records.g.dart
+++ b/built_types/end_to_end_test/lib/records.g.dart
@@ -1,0 +1,599 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'records.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<SerializableRecordValue> _$serializableRecordValueSerializer =
+    _$SerializableRecordValueSerializer();
+
+class _$SerializableRecordValueSerializer
+    implements StructuredSerializer<SerializableRecordValue> {
+  @override
+  final Iterable<Type> types = const [
+    SerializableRecordValue,
+    _$SerializableRecordValue,
+  ];
+  @override
+  final String wireName = 'SerializableRecordValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    SerializableRecordValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.record;
+    if (value != null) {
+      result
+        ..add('record')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(RecordOfIntInt),
+          ),
+        );
+    }
+    value = object.intOrList;
+    if (value != null) {
+      result
+        ..add('intOrList')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(RecordOfIntOrList),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  SerializableRecordValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = SerializableRecordValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+        case 'record':
+          result.record = serializers.deserialize(
+            value,
+            specifiedType: const FullType(RecordOfIntInt),
+          ) as RecordOfIntInt?;
+          break;
+        case 'intOrList':
+          result.intOrList = serializers.deserialize(
+            value,
+            specifiedType: const FullType(RecordOfIntOrList),
+          ) as RecordOfIntOrList?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SimpleRecordValue extends SimpleRecordValue {
+  @override
+  final (int, int) record;
+
+  factory _$SimpleRecordValue([
+    void Function(SimpleRecordValueBuilder)? updates,
+  ]) => (SimpleRecordValueBuilder()..update(updates))._build();
+
+  _$SimpleRecordValue._({required this.record}) : super._();
+  @override
+  SimpleRecordValue rebuild(void Function(SimpleRecordValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SimpleRecordValueBuilder toBuilder() =>
+      SimpleRecordValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SimpleRecordValue && record == other.record;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, record.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'SimpleRecordValue',
+    )..add('record', record)).toString();
+  }
+}
+
+class SimpleRecordValueBuilder
+    implements Builder<SimpleRecordValue, SimpleRecordValueBuilder> {
+  _$SimpleRecordValue? _$v;
+
+  (int, int)? _record;
+  (int, int)? get record => _$this._record;
+  set record((int, int)? record) => _$this._record = record;
+
+  SimpleRecordValueBuilder();
+
+  SimpleRecordValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _record = $v.record;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SimpleRecordValue other) {
+    _$v = other as _$SimpleRecordValue;
+  }
+
+  @override
+  void update(void Function(SimpleRecordValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SimpleRecordValue build() => _build();
+
+  _$SimpleRecordValue _build() {
+    final _$result =
+        _$v ??
+        _$SimpleRecordValue._(
+          record: BuiltValueNullFieldError.checkNotNull(
+            record,
+            r'SimpleRecordValue',
+            'record',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ComplexRecordValue extends ComplexRecordValue {
+  @override
+  final (int, int) record2;
+  @override
+  final (int?, int) record2p;
+  @override
+  final (int, int)? record2n;
+  @override
+  final (int x, int y) record3;
+  @override
+  final (int? x, int y) record3p;
+  @override
+  final (int x, int y)? record3n;
+  @override
+  final ({int x, int y}) record4;
+  @override
+  final ({int? x, int y}) record4p;
+  @override
+  final ({int x, int y})? record4n;
+  @override
+  final (BuiltList<int> a, {BuiltList<ComplexRecordValue> b}) record5;
+  @override
+  final (BuiltList<int>? a, {BuiltList<ComplexRecordValue> b}) record5p;
+  @override
+  final (BuiltList<int> a, {BuiltList<ComplexRecordValue> b})? record5n;
+  @override
+  final (void Function() a, {void Function() b}) record6;
+  @override
+  final (void Function()? a, {void Function() b}) record6p;
+  @override
+  final (void Function() a, {void Function() b})? record6n;
+
+  factory _$ComplexRecordValue([
+    void Function(ComplexRecordValueBuilder)? updates,
+  ]) => (ComplexRecordValueBuilder()..update(updates))._build();
+
+  _$ComplexRecordValue._({
+    required this.record2,
+    required this.record2p,
+    this.record2n,
+    required this.record3,
+    required this.record3p,
+    this.record3n,
+    required this.record4,
+    required this.record4p,
+    this.record4n,
+    required this.record5,
+    required this.record5p,
+    this.record5n,
+    required this.record6,
+    required this.record6p,
+    this.record6n,
+  }) : super._();
+  @override
+  ComplexRecordValue rebuild(
+    void Function(ComplexRecordValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  ComplexRecordValueBuilder toBuilder() =>
+      ComplexRecordValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ComplexRecordValue &&
+        record2 == other.record2 &&
+        record2p == other.record2p &&
+        record2n == other.record2n &&
+        record3 == other.record3 &&
+        record3p == other.record3p &&
+        record3n == other.record3n &&
+        record4 == other.record4 &&
+        record4p == other.record4p &&
+        record4n == other.record4n &&
+        record5 == other.record5 &&
+        record5p == other.record5p &&
+        record5n == other.record5n;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, record2.hashCode);
+    _$hash = $jc(_$hash, record2p.hashCode);
+    _$hash = $jc(_$hash, record2n.hashCode);
+    _$hash = $jc(_$hash, record3.hashCode);
+    _$hash = $jc(_$hash, record3p.hashCode);
+    _$hash = $jc(_$hash, record3n.hashCode);
+    _$hash = $jc(_$hash, record4.hashCode);
+    _$hash = $jc(_$hash, record4p.hashCode);
+    _$hash = $jc(_$hash, record4n.hashCode);
+    _$hash = $jc(_$hash, record5.hashCode);
+    _$hash = $jc(_$hash, record5p.hashCode);
+    _$hash = $jc(_$hash, record5n.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ComplexRecordValue')
+          ..add('record2', record2)
+          ..add('record2p', record2p)
+          ..add('record2n', record2n)
+          ..add('record3', record3)
+          ..add('record3p', record3p)
+          ..add('record3n', record3n)
+          ..add('record4', record4)
+          ..add('record4p', record4p)
+          ..add('record4n', record4n)
+          ..add('record5', record5)
+          ..add('record5p', record5p)
+          ..add('record5n', record5n)
+          ..add('record6', record6)
+          ..add('record6p', record6p)
+          ..add('record6n', record6n))
+        .toString();
+  }
+}
+
+class ComplexRecordValueBuilder
+    implements Builder<ComplexRecordValue, ComplexRecordValueBuilder> {
+  _$ComplexRecordValue? _$v;
+
+  (int, int)? _record2;
+  (int, int)? get record2 => _$this._record2;
+  set record2((int, int)? record2) => _$this._record2 = record2;
+
+  (int?, int)? _record2p;
+  (int?, int)? get record2p => _$this._record2p;
+  set record2p((int?, int)? record2p) => _$this._record2p = record2p;
+
+  (int, int)? _record2n;
+  (int, int)? get record2n => _$this._record2n;
+  set record2n((int, int)? record2n) => _$this._record2n = record2n;
+
+  (int x, int y)? _record3;
+  (int x, int y)? get record3 => _$this._record3;
+  set record3((int x, int y)? record3) => _$this._record3 = record3;
+
+  (int? x, int y)? _record3p;
+  (int? x, int y)? get record3p => _$this._record3p;
+  set record3p((int? x, int y)? record3p) => _$this._record3p = record3p;
+
+  (int x, int y)? _record3n;
+  (int x, int y)? get record3n => _$this._record3n;
+  set record3n((int x, int y)? record3n) => _$this._record3n = record3n;
+
+  ({int x, int y})? _record4;
+  ({int x, int y})? get record4 => _$this._record4;
+  set record4(({int x, int y})? record4) => _$this._record4 = record4;
+
+  ({int? x, int y})? _record4p;
+  ({int? x, int y})? get record4p => _$this._record4p;
+  set record4p(({int? x, int y})? record4p) => _$this._record4p = record4p;
+
+  ({int x, int y})? _record4n;
+  ({int x, int y})? get record4n => _$this._record4n;
+  set record4n(({int x, int y})? record4n) => _$this._record4n = record4n;
+
+  (BuiltList<int> a, {BuiltList<ComplexRecordValue> b})? _record5;
+  (BuiltList<int> a, {BuiltList<ComplexRecordValue> b})? get record5 =>
+      _$this._record5;
+  set record5((BuiltList<int> a, {BuiltList<ComplexRecordValue> b})? record5) =>
+      _$this._record5 = record5;
+
+  (BuiltList<int>? a, {BuiltList<ComplexRecordValue> b})? _record5p;
+  (BuiltList<int>? a, {BuiltList<ComplexRecordValue> b})? get record5p =>
+      _$this._record5p;
+  set record5p(
+    (BuiltList<int>? a, {BuiltList<ComplexRecordValue> b})? record5p,
+  ) => _$this._record5p = record5p;
+
+  (BuiltList<int> a, {BuiltList<ComplexRecordValue> b})? _record5n;
+  (BuiltList<int> a, {BuiltList<ComplexRecordValue> b})? get record5n =>
+      _$this._record5n;
+  set record5n(
+    (BuiltList<int> a, {BuiltList<ComplexRecordValue> b})? record5n,
+  ) => _$this._record5n = record5n;
+
+  (void Function() a, {void Function() b})? _record6;
+  (void Function() a, {void Function() b})? get record6 => _$this._record6;
+  set record6((void Function() a, {void Function() b})? record6) =>
+      _$this._record6 = record6;
+
+  (void Function()? a, {void Function() b})? _record6p;
+  (void Function()? a, {void Function() b})? get record6p => _$this._record6p;
+  set record6p((void Function()? a, {void Function() b})? record6p) =>
+      _$this._record6p = record6p;
+
+  (void Function() a, {void Function() b})? _record6n;
+  (void Function() a, {void Function() b})? get record6n => _$this._record6n;
+  set record6n((void Function() a, {void Function() b})? record6n) =>
+      _$this._record6n = record6n;
+
+  ComplexRecordValueBuilder();
+
+  ComplexRecordValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _record2 = $v.record2;
+      _record2p = $v.record2p;
+      _record2n = $v.record2n;
+      _record3 = $v.record3;
+      _record3p = $v.record3p;
+      _record3n = $v.record3n;
+      _record4 = $v.record4;
+      _record4p = $v.record4p;
+      _record4n = $v.record4n;
+      _record5 = $v.record5;
+      _record5p = $v.record5p;
+      _record5n = $v.record5n;
+      _record6 = $v.record6;
+      _record6p = $v.record6p;
+      _record6n = $v.record6n;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ComplexRecordValue other) {
+    _$v = other as _$ComplexRecordValue;
+  }
+
+  @override
+  void update(void Function(ComplexRecordValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ComplexRecordValue build() => _build();
+
+  _$ComplexRecordValue _build() {
+    final _$result =
+        _$v ??
+        _$ComplexRecordValue._(
+          record2: BuiltValueNullFieldError.checkNotNull(
+            record2,
+            r'ComplexRecordValue',
+            'record2',
+          ),
+          record2p: BuiltValueNullFieldError.checkNotNull(
+            record2p,
+            r'ComplexRecordValue',
+            'record2p',
+          ),
+          record2n: record2n,
+          record3: BuiltValueNullFieldError.checkNotNull(
+            record3,
+            r'ComplexRecordValue',
+            'record3',
+          ),
+          record3p: BuiltValueNullFieldError.checkNotNull(
+            record3p,
+            r'ComplexRecordValue',
+            'record3p',
+          ),
+          record3n: record3n,
+          record4: BuiltValueNullFieldError.checkNotNull(
+            record4,
+            r'ComplexRecordValue',
+            'record4',
+          ),
+          record4p: BuiltValueNullFieldError.checkNotNull(
+            record4p,
+            r'ComplexRecordValue',
+            'record4p',
+          ),
+          record4n: record4n,
+          record5: BuiltValueNullFieldError.checkNotNull(
+            record5,
+            r'ComplexRecordValue',
+            'record5',
+          ),
+          record5p: BuiltValueNullFieldError.checkNotNull(
+            record5p,
+            r'ComplexRecordValue',
+            'record5p',
+          ),
+          record5n: record5n,
+          record6: BuiltValueNullFieldError.checkNotNull(
+            record6,
+            r'ComplexRecordValue',
+            'record6',
+          ),
+          record6p: BuiltValueNullFieldError.checkNotNull(
+            record6p,
+            r'ComplexRecordValue',
+            'record6p',
+          ),
+          record6n: record6n,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$SerializableRecordValue extends SerializableRecordValue {
+  @override
+  final int value;
+  @override
+  final RecordOfIntInt? record;
+  @override
+  final RecordOfIntOrList? intOrList;
+
+  factory _$SerializableRecordValue([
+    void Function(SerializableRecordValueBuilder)? updates,
+  ]) => (SerializableRecordValueBuilder()..update(updates))._build();
+
+  _$SerializableRecordValue._({
+    required this.value,
+    this.record,
+    this.intOrList,
+  }) : super._();
+  @override
+  SerializableRecordValue rebuild(
+    void Function(SerializableRecordValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  SerializableRecordValueBuilder toBuilder() =>
+      SerializableRecordValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SerializableRecordValue &&
+        value == other.value &&
+        record == other.record &&
+        intOrList == other.intOrList;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, record.hashCode);
+    _$hash = $jc(_$hash, intOrList.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SerializableRecordValue')
+          ..add('value', value)
+          ..add('record', record)
+          ..add('intOrList', intOrList))
+        .toString();
+  }
+}
+
+class SerializableRecordValueBuilder
+    implements
+        Builder<SerializableRecordValue, SerializableRecordValueBuilder> {
+  _$SerializableRecordValue? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  RecordOfIntInt? _record;
+  RecordOfIntInt? get record => _$this._record;
+  set record(RecordOfIntInt? record) => _$this._record = record;
+
+  RecordOfIntOrList? _intOrList;
+  RecordOfIntOrList? get intOrList => _$this._intOrList;
+  set intOrList(RecordOfIntOrList? intOrList) => _$this._intOrList = intOrList;
+
+  SerializableRecordValueBuilder();
+
+  SerializableRecordValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _record = $v.record;
+      _intOrList = $v.intOrList;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SerializableRecordValue other) {
+    _$v = other as _$SerializableRecordValue;
+  }
+
+  @override
+  void update(void Function(SerializableRecordValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SerializableRecordValue build() => _build();
+
+  _$SerializableRecordValue _build() {
+    final _$result =
+        _$v ??
+        _$SerializableRecordValue._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'SerializableRecordValue',
+            'value',
+          ),
+          record: record,
+          intOrList: intOrList,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/lib/serializers.dart
+++ b/built_types/end_to_end_test/lib/serializers.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library serializers_nnbd;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/collections.dart';
+import 'package:end_to_end_test/enums.dart';
+import 'package:end_to_end_test/generics.dart';
+import 'package:end_to_end_test/imported_values.dart';
+import 'package:end_to_end_test/interfaces.dart';
+import 'package:end_to_end_test/polymorphism.dart';
+import 'package:end_to_end_test/records.dart';
+import 'package:end_to_end_test/standard_json.dart';
+import 'package:end_to_end_test/values.dart';
+
+part 'serializers.g.dart';
+
+@SerializersFor([
+  BoundGenericValue,
+  Cage,
+  Cat,
+  CollectionGenericValue,
+  Collections,
+  CompoundValue,
+  CompoundValueNoNestingField,
+  CompoundValueNestingField,
+  CompoundValueExplicitNoNesting,
+  CompoundValueNoAutoNesting,
+  CompoundValueNoAutoNestingField,
+  CompoundValueAutoNestingField,
+  CompoundValueNoNesting,
+  ConcreteGeneric,
+  EnumWithInt,
+  FallbackEnum,
+  FallbackNumberEnum,
+  FieldDiscoveryValue,
+  Fish,
+  GenericContainer,
+  GenericValue,
+  HasDouble,
+  HasString,
+  ImportedValue,
+  ImportedCustomValue,
+  ImportedCustomNestedValue,
+  NamedFactoryValue,
+  NestedGenericContainer,
+  NewConstructorEnum,
+  NewConstructorValue,
+  NonBuiltGeneric,
+  OtherValue,
+  PartiallySerializableValue,
+  PassthroughGenericContainer,
+  PrimitivesValue,
+  Robot,
+  SecondTestEnum,
+  SerializesNullsValue,
+  SerializableRecordValue,
+  SimpleValue,
+  StandardCat,
+  StandardJsonValue,
+  TestEnum,
+  UsesHandCoded,
+  $ValueSpecial,
+  ValueUsingImportAs,
+  ValueWithAwkwardNestedBuilder,
+  ValueWithBuilderFinalizer,
+  ValueWithBuilderInitializer,
+  ValueWithCustomSerializer,
+  ValueWithHasInt,
+  ValueWithInt,
+  WireNameEnum,
+  WireNameValue,
+  WireNumberEnum,
+])
+final Serializers serializers = _$serializers;
+
+// Check that multiple `Serializers` can be declared in one file.
+@SerializersFor([Cat])
+final Serializers moreSerializers = _$moreSerializers;
+
+// Check that generation does not fail due to new type `Never`.
+Never get never => throw 'Never!';
+
+// Check that generation does not fail due to new type `Record`.
+(int, int) get record => (0, 0);

--- a/built_types/end_to_end_test/lib/serializers.g.dart
+++ b/built_types/end_to_end_test/lib/serializers.g.dart
@@ -1,0 +1,270 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'serializers.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializers _$serializers =
+    (Serializers().toBuilder()
+          ..add($ValueSpecial.serializer)
+          ..add(BoundGenericValue.serializer)
+          ..add(Cage.serializer)
+          ..add(Cat.serializer)
+          ..add(CollectionGenericValue.serializer)
+          ..add(Collections.serializer)
+          ..add(ComplexValue.serializer)
+          ..add(CompoundValue.serializer)
+          ..add(CompoundValueAutoNestingField.serializer)
+          ..add(CompoundValueExplicitNoNesting.serializer)
+          ..add(CompoundValueNestingField.serializer)
+          ..add(CompoundValueNoAutoNesting.serializer)
+          ..add(CompoundValueNoAutoNestingField.serializer)
+          ..add(CompoundValueNoNesting.serializer)
+          ..add(CompoundValueNoNestingField.serializer)
+          ..add(ConcreteGeneric.serializer)
+          ..add(DiscoverableValue.serializer)
+          ..add(EnumWithInt.serializer)
+          ..add(FallbackEnum.serializer)
+          ..add(FallbackNumberEnum.serializer)
+          ..add(FieldDiscoveryValue.serializer)
+          ..add(Fish.serializer)
+          ..add(GenericContainer.serializer)
+          ..add(GenericValue.serializer)
+          ..add(HasDouble.serializer)
+          ..add(HasString.serializer)
+          ..add(ImportedCustomNestedValue.serializer)
+          ..add(ImportedCustomValue.serializer)
+          ..add(ImportedValue.serializer)
+          ..add(NamedFactoryValue.serializer)
+          ..add(NestedGenericContainer.serializer)
+          ..add(NewConstructorEnum.serializer)
+          ..add(NewConstructorValue.serializer)
+          ..add(NoFieldsValue.serializer)
+          ..add(NonBuiltGeneric.serializer)
+          ..add(OtherValue.serializer)
+          ..add(PartiallySerializableValue.serializer)
+          ..add(PassthroughGenericContainer.serializer)
+          ..add(PrimitivesValue.serializer)
+          ..add(Robot.serializer)
+          ..add(SecondDiscoverableValue.serializer)
+          ..add(SerializableRecordValue.serializer)
+          ..add(SerializesNullsValue.serializer)
+          ..add(SimpleValue.serializer)
+          ..add(StandardCat.serializer)
+          ..add(StandardJsonValue.serializer)
+          ..add(TestEnum.serializer)
+          ..add(ThirdDiscoverableValue.serializer)
+          ..add(UsesHandCoded.serializer)
+          ..add(ValidatedValue.serializer)
+          ..add(ValueUsingImportAs.serializer)
+          ..add(ValueWithAwkwardNestedBuilder.serializer)
+          ..add(ValueWithBuilderFinalizer.serializer)
+          ..add(ValueWithBuilderInitializer.serializer)
+          ..add(ValueWithCustomSerializer.serializer)
+          ..add(ValueWithHasInt.serializer)
+          ..add(ValueWithInt.serializer)
+          ..add(WireNameEnum.serializer)
+          ..add(WireNameValue.serializer)
+          ..add(WireNumberEnum.serializer)
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(Animal)]),
+            () => ListBuilder<Animal>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(SimpleValue)]),
+            () => ListBuilder<SimpleValue>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(SimpleValue)]),
+            () => ListBuilder<SimpleValue>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(SimpleValue)]),
+            () => ListBuilder<SimpleValue>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [
+              const FullType(ThirdDiscoverableValue),
+            ]),
+            () => ListBuilder<ThirdDiscoverableValue>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(int)]),
+            () => ListBuilder<int>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltMap, const [
+              const FullType(int),
+              const FullType(String),
+            ]),
+            () => MapBuilder<int, String>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(int)]),
+            () => ListBuilder<int>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSet, const [const FullType(String)]),
+            () => SetBuilder<String>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltMap, const [
+              const FullType(String),
+              const FullType(int),
+            ]),
+            () => MapBuilder<String, int>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltListMultimap, const [
+              const FullType(int),
+              const FullType(bool),
+            ]),
+            () => ListMultimapBuilder<int, bool>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSetMultimap, const [
+              const FullType(String),
+              const FullType(bool),
+            ]),
+            () => SetMultimapBuilder<String, bool>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType.nullable(int)]),
+            () => ListBuilder<int?>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSet, const [const FullType.nullable(String)]),
+            () => SetBuilder<String?>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltMap, const [
+              const FullType.nullable(String),
+              const FullType.nullable(int),
+            ]),
+            () => MapBuilder<String?, int?>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltListMultimap, const [
+              const FullType.nullable(int),
+              const FullType(bool),
+            ]),
+            () => ListMultimapBuilder<int?, bool>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSetMultimap, const [
+              const FullType(String),
+              const FullType.nullable(bool),
+            ]),
+            () => SetMultimapBuilder<String, bool?>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(int)]),
+            () => ListBuilder<int>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSet, const [const FullType(String)]),
+            () => SetBuilder<String>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltMap, const [
+              const FullType(String),
+              const FullType(int),
+            ]),
+            () => MapBuilder<String, int>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltListMultimap, const [
+              const FullType(int),
+              const FullType(bool),
+            ]),
+            () => ListMultimapBuilder<int, bool>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSetMultimap, const [
+              const FullType(String),
+              const FullType(bool),
+            ]),
+            () => SetMultimapBuilder<String, bool>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [
+              const FullType(Foo, const [const FullType.nullable(int)]),
+            ]),
+            () => ListBuilder<Foo<int?>>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [
+              const FullType.nullable(BuiltList, const [
+                const FullType.nullable(int),
+              ]),
+            ]),
+            () => ListBuilder<BuiltList<int?>?>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltMap, const [
+              const FullType(String),
+              const FullType(JsonObject),
+            ]),
+            () => MapBuilder<String, JsonObject>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(Animal)]),
+            () => ListBuilder<Animal>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltSet, const [const FullType(Animal)]),
+            () => SetBuilder<Animal>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(String)]),
+            () => ListBuilder<String>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType.nullable(int)]),
+            () => ListBuilder<int?>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType.nullable(String)]),
+            () => ListBuilder<String?>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltMap, const [
+              const FullType(String),
+              const FullType.nullable(int),
+            ]),
+            () => MapBuilder<String, int?>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BuiltList, const [const FullType(Object)]),
+            () => ListBuilder<Object>(),
+          )
+          ..addBuilderFactory(
+            const FullType(GenericValue, const [
+              const FullType(BuiltMap, const [
+                const FullType(int),
+                const FullType(String),
+              ]),
+            ]),
+            () => GenericValueBuilder<BuiltMap<int, String>>(),
+          )
+          ..addBuilderFactory(
+            const FullType(GenericValue, const [const FullType(String)]),
+            () => GenericValueBuilder<String>(),
+          )
+          ..addBuilderFactory(
+            const FullType(BoundGenericValue, const [const FullType(double)]),
+            () => BoundGenericValueBuilder<double>(),
+          )
+          ..addBuilderFactory(
+            const FullType(CollectionGenericValue, const [
+              const FullType(String),
+            ]),
+            () => CollectionGenericValueBuilder<String>(),
+          ))
+        .build();
+Serializers _$moreSerializers = (Serializers().toBuilder()..add(Cat.serializer))
+    .build();
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/lib/standard_json.dart
+++ b/built_types/end_to_end_test/lib/standard_json.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/polymorphism.dart';
+import 'package:end_to_end_test/values.dart';
+
+part 'standard_json.g.dart';
+
+abstract class StandardJsonValue
+    implements Built<StandardJsonValue, StandardJsonValueBuilder> {
+  static Serializer<StandardJsonValue> get serializer =>
+      _$standardJsonValueSerializer;
+
+  num get number;
+  String get text;
+  ComplexValue get value;
+  BuiltMap<String, JsonObject> get keyValues;
+  BuiltList<Animal> get zoo;
+  BuiltSet<Animal> get uniqueZoo;
+
+  BuiltList<String>? get strings;
+
+  BuiltList<int?> get nullsInList;
+  BuiltList<String?> get nullsInSet;
+  BuiltMap<String, int?> get nullsInMap;
+
+  // Always serialized with type.
+  ComplexValueInterface? get object;
+  BuiltList<Object> get objects;
+
+  factory StandardJsonValue([void Function(StandardJsonValueBuilder) updates]) =
+      _$StandardJsonValue;
+  StandardJsonValue._();
+}
+
+abstract class ComplexValueInterface {}
+
+abstract class ComplexValue
+    implements Built<ComplexValue, ComplexValueBuilder>, ComplexValueInterface {
+  static Serializer<ComplexValue> get serializer => _$complexValueSerializer;
+
+  int get primitive;
+  int? get nullablePrimitive;
+  int? get nullablePrimitiveDoNotUse;
+  SimpleValue get value;
+  SimpleValue? get nullableValue;
+  SimpleValue? get nullableValueDoNotUse;
+
+  factory ComplexValue([void Function(ComplexValueBuilder) updates]) =
+      _$ComplexValue;
+  ComplexValue._();
+}

--- a/built_types/end_to_end_test/lib/standard_json.g.dart
+++ b/built_types/end_to_end_test/lib/standard_json.g.dart
@@ -1,0 +1,679 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
+
+part of 'standard_json.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<StandardJsonValue> _$standardJsonValueSerializer =
+    _$StandardJsonValueSerializer();
+Serializer<ComplexValue> _$complexValueSerializer = _$ComplexValueSerializer();
+
+class _$StandardJsonValueSerializer
+    implements StructuredSerializer<StandardJsonValue> {
+  @override
+  final Iterable<Type> types = const [StandardJsonValue, _$StandardJsonValue];
+  @override
+  final String wireName = 'StandardJsonValue';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, StandardJsonValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'number',
+      serializers.serialize(object.number, specifiedType: const FullType(num)),
+      'text',
+      serializers.serialize(object.text, specifiedType: const FullType(String)),
+      'value',
+      serializers.serialize(object.value,
+          specifiedType: const FullType(ComplexValue)),
+      'keyValues',
+      serializers.serialize(object.keyValues,
+          specifiedType: const FullType(BuiltMap,
+              const [const FullType(String), const FullType(JsonObject)])),
+      'zoo',
+      serializers.serialize(object.zoo,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(Animal)])),
+      'uniqueZoo',
+      serializers.serialize(object.uniqueZoo,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(Animal)])),
+      'nullsInList',
+      serializers.serialize(object.nullsInList,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType.nullable(int)])),
+      'nullsInSet',
+      serializers.serialize(object.nullsInSet,
+          specifiedType: const FullType(
+              BuiltList, const [const FullType.nullable(String)])),
+      'nullsInMap',
+      serializers.serialize(object.nullsInMap,
+          specifiedType: const FullType(BuiltMap,
+              const [const FullType(String), const FullType.nullable(int)])),
+      'objects',
+      serializers.serialize(object.objects,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(Object)])),
+    ];
+    Object? value;
+    value = object.strings;
+    if (value != null) {
+      result
+        ..add('strings')
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(String)])));
+    }
+    value = object.object;
+    if (value != null) {
+      result
+        ..add('object')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(ComplexValueInterface)));
+    }
+    return result;
+  }
+
+  @override
+  StandardJsonValue deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = StandardJsonValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'number':
+          result.number = serializers.deserialize(value,
+              specifiedType: const FullType(num))! as num;
+          break;
+        case 'text':
+          result.text = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'value':
+          result.value.replace(serializers.deserialize(value,
+              specifiedType: const FullType(ComplexValue))! as ComplexValue);
+          break;
+        case 'keyValues':
+          result.keyValues.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, const [
+                const FullType(String),
+                const FullType(JsonObject)
+              ]))!);
+          break;
+        case 'zoo':
+          result.zoo.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(Animal)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'uniqueZoo':
+          result.uniqueZoo.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltSet, const [const FullType(Animal)]))!
+              as BuiltSet<Object?>);
+          break;
+        case 'strings':
+          result.strings.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'nullsInList':
+          result.nullsInList.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType.nullable(int)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'nullsInSet':
+          result.nullsInSet.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType.nullable(String)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'nullsInMap':
+          result.nullsInMap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, const [
+                const FullType(String),
+                const FullType.nullable(int)
+              ]))!);
+          break;
+        case 'object':
+          result.object = serializers.deserialize(value,
+                  specifiedType: const FullType(ComplexValueInterface))
+              as ComplexValueInterface?;
+          break;
+        case 'objects':
+          result.objects.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(Object)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ComplexValueSerializer implements StructuredSerializer<ComplexValue> {
+  @override
+  final Iterable<Type> types = const [ComplexValue, _$ComplexValue];
+  @override
+  final String wireName = 'ComplexValue';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ComplexValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'primitive',
+      serializers.serialize(object.primitive,
+          specifiedType: const FullType(int)),
+      'value',
+      serializers.serialize(object.value,
+          specifiedType: const FullType(SimpleValue)),
+    ];
+    Object? value;
+    value = object.nullablePrimitive;
+    if (value != null) {
+      result
+        ..add('nullablePrimitive')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.nullablePrimitiveDoNotUse;
+    if (value != null) {
+      result
+        ..add('nullablePrimitiveDoNotUse')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.nullableValue;
+    if (value != null) {
+      result
+        ..add('nullableValue')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(SimpleValue)));
+    }
+    value = object.nullableValueDoNotUse;
+    if (value != null) {
+      result
+        ..add('nullableValueDoNotUse')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(SimpleValue)));
+    }
+    return result;
+  }
+
+  @override
+  ComplexValue deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ComplexValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'primitive':
+          result.primitive = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+        case 'nullablePrimitive':
+          result.nullablePrimitive = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
+          break;
+        case 'nullablePrimitiveDoNotUse':
+          result.nullablePrimitiveDoNotUse = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
+          break;
+        case 'value':
+          result.value.replace(serializers.deserialize(value,
+              specifiedType: const FullType(SimpleValue))! as SimpleValue);
+          break;
+        case 'nullableValue':
+          result.nullableValue.replace(serializers.deserialize(value,
+              specifiedType: const FullType(SimpleValue))! as SimpleValue);
+          break;
+        case 'nullableValueDoNotUse':
+          result.nullableValueDoNotUse.replace(serializers.deserialize(value,
+              specifiedType: const FullType(SimpleValue))! as SimpleValue);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$StandardJsonValue extends StandardJsonValue {
+  @override
+  final num number;
+  @override
+  final String text;
+  @override
+  final ComplexValue value;
+  @override
+  final BuiltMap<String, JsonObject> keyValues;
+  @override
+  final BuiltList<Animal> zoo;
+  @override
+  final BuiltSet<Animal> uniqueZoo;
+  @override
+  final BuiltList<String>? strings;
+  @override
+  final BuiltList<int?> nullsInList;
+  @override
+  final BuiltList<String?> nullsInSet;
+  @override
+  final BuiltMap<String, int?> nullsInMap;
+  @override
+  final ComplexValueInterface? object;
+  @override
+  final BuiltList<Object> objects;
+
+  factory _$StandardJsonValue(
+          [void Function(StandardJsonValueBuilder)? updates]) =>
+      (StandardJsonValueBuilder()..update(updates))._build();
+
+  _$StandardJsonValue._(
+      {required this.number,
+      required this.text,
+      required this.value,
+      required this.keyValues,
+      required this.zoo,
+      required this.uniqueZoo,
+      this.strings,
+      required this.nullsInList,
+      required this.nullsInSet,
+      required this.nullsInMap,
+      this.object,
+      required this.objects})
+      : super._();
+  @override
+  StandardJsonValue rebuild(void Function(StandardJsonValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  StandardJsonValueBuilder toBuilder() =>
+      StandardJsonValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is StandardJsonValue &&
+        number == other.number &&
+        text == other.text &&
+        value == other.value &&
+        keyValues == other.keyValues &&
+        zoo == other.zoo &&
+        uniqueZoo == other.uniqueZoo &&
+        strings == other.strings &&
+        nullsInList == other.nullsInList &&
+        nullsInSet == other.nullsInSet &&
+        nullsInMap == other.nullsInMap &&
+        object == other.object &&
+        objects == other.objects;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, number.hashCode);
+    _$hash = $jc(_$hash, text.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, keyValues.hashCode);
+    _$hash = $jc(_$hash, zoo.hashCode);
+    _$hash = $jc(_$hash, uniqueZoo.hashCode);
+    _$hash = $jc(_$hash, strings.hashCode);
+    _$hash = $jc(_$hash, nullsInList.hashCode);
+    _$hash = $jc(_$hash, nullsInSet.hashCode);
+    _$hash = $jc(_$hash, nullsInMap.hashCode);
+    _$hash = $jc(_$hash, object.hashCode);
+    _$hash = $jc(_$hash, objects.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'StandardJsonValue')
+          ..add('number', number)
+          ..add('text', text)
+          ..add('value', value)
+          ..add('keyValues', keyValues)
+          ..add('zoo', zoo)
+          ..add('uniqueZoo', uniqueZoo)
+          ..add('strings', strings)
+          ..add('nullsInList', nullsInList)
+          ..add('nullsInSet', nullsInSet)
+          ..add('nullsInMap', nullsInMap)
+          ..add('object', object)
+          ..add('objects', objects))
+        .toString();
+  }
+}
+
+class StandardJsonValueBuilder
+    implements Builder<StandardJsonValue, StandardJsonValueBuilder> {
+  _$StandardJsonValue? _$v;
+
+  num? _number;
+  num? get number => _$this._number;
+  set number(num? number) => _$this._number = number;
+
+  String? _text;
+  String? get text => _$this._text;
+  set text(String? text) => _$this._text = text;
+
+  ComplexValueBuilder? _value;
+  ComplexValueBuilder get value => _$this._value ??= ComplexValueBuilder();
+  set value(ComplexValueBuilder? value) => _$this._value = value;
+
+  MapBuilder<String, JsonObject>? _keyValues;
+  MapBuilder<String, JsonObject> get keyValues =>
+      _$this._keyValues ??= MapBuilder<String, JsonObject>();
+  set keyValues(MapBuilder<String, JsonObject>? keyValues) =>
+      _$this._keyValues = keyValues;
+
+  ListBuilder<Animal>? _zoo;
+  ListBuilder<Animal> get zoo => _$this._zoo ??= ListBuilder<Animal>();
+  set zoo(ListBuilder<Animal>? zoo) => _$this._zoo = zoo;
+
+  SetBuilder<Animal>? _uniqueZoo;
+  SetBuilder<Animal> get uniqueZoo =>
+      _$this._uniqueZoo ??= SetBuilder<Animal>();
+  set uniqueZoo(SetBuilder<Animal>? uniqueZoo) => _$this._uniqueZoo = uniqueZoo;
+
+  ListBuilder<String>? _strings;
+  ListBuilder<String> get strings => _$this._strings ??= ListBuilder<String>();
+  set strings(ListBuilder<String>? strings) => _$this._strings = strings;
+
+  ListBuilder<int?>? _nullsInList;
+  ListBuilder<int?> get nullsInList =>
+      _$this._nullsInList ??= ListBuilder<int?>();
+  set nullsInList(ListBuilder<int?>? nullsInList) =>
+      _$this._nullsInList = nullsInList;
+
+  ListBuilder<String?>? _nullsInSet;
+  ListBuilder<String?> get nullsInSet =>
+      _$this._nullsInSet ??= ListBuilder<String?>();
+  set nullsInSet(ListBuilder<String?>? nullsInSet) =>
+      _$this._nullsInSet = nullsInSet;
+
+  MapBuilder<String, int?>? _nullsInMap;
+  MapBuilder<String, int?> get nullsInMap =>
+      _$this._nullsInMap ??= MapBuilder<String, int?>();
+  set nullsInMap(MapBuilder<String, int?>? nullsInMap) =>
+      _$this._nullsInMap = nullsInMap;
+
+  ComplexValueInterface? _object;
+  ComplexValueInterface? get object => _$this._object;
+  set object(ComplexValueInterface? object) => _$this._object = object;
+
+  ListBuilder<Object>? _objects;
+  ListBuilder<Object> get objects => _$this._objects ??= ListBuilder<Object>();
+  set objects(ListBuilder<Object>? objects) => _$this._objects = objects;
+
+  StandardJsonValueBuilder();
+
+  StandardJsonValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _number = $v.number;
+      _text = $v.text;
+      _value = $v.value.toBuilder();
+      _keyValues = $v.keyValues.toBuilder();
+      _zoo = $v.zoo.toBuilder();
+      _uniqueZoo = $v.uniqueZoo.toBuilder();
+      _strings = $v.strings?.toBuilder();
+      _nullsInList = $v.nullsInList.toBuilder();
+      _nullsInSet = $v.nullsInSet.toBuilder();
+      _nullsInMap = $v.nullsInMap.toBuilder();
+      _object = $v.object;
+      _objects = $v.objects.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(StandardJsonValue other) {
+    _$v = other as _$StandardJsonValue;
+  }
+
+  @override
+  void update(void Function(StandardJsonValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  StandardJsonValue build() => _build();
+
+  _$StandardJsonValue _build() {
+    _$StandardJsonValue _$result;
+    try {
+      _$result = _$v ??
+          _$StandardJsonValue._(
+            number: BuiltValueNullFieldError.checkNotNull(
+                number, r'StandardJsonValue', 'number'),
+            text: BuiltValueNullFieldError.checkNotNull(
+                text, r'StandardJsonValue', 'text'),
+            value: value.build(),
+            keyValues: keyValues.build(),
+            zoo: zoo.build(),
+            uniqueZoo: uniqueZoo.build(),
+            strings: _strings?.build(),
+            nullsInList: nullsInList.build(),
+            nullsInSet: nullsInSet.build(),
+            nullsInMap: nullsInMap.build(),
+            object: object,
+            objects: objects.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+        _$failedField = 'keyValues';
+        keyValues.build();
+        _$failedField = 'zoo';
+        zoo.build();
+        _$failedField = 'uniqueZoo';
+        uniqueZoo.build();
+        _$failedField = 'strings';
+        _strings?.build();
+        _$failedField = 'nullsInList';
+        nullsInList.build();
+        _$failedField = 'nullsInSet';
+        nullsInSet.build();
+        _$failedField = 'nullsInMap';
+        nullsInMap.build();
+
+        _$failedField = 'objects';
+        objects.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'StandardJsonValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ComplexValue extends ComplexValue {
+  @override
+  final int primitive;
+  @override
+  final int? nullablePrimitive;
+  @override
+  final int? nullablePrimitiveDoNotUse;
+  @override
+  final SimpleValue value;
+  @override
+  final SimpleValue? nullableValue;
+  @override
+  final SimpleValue? nullableValueDoNotUse;
+
+  factory _$ComplexValue([void Function(ComplexValueBuilder)? updates]) =>
+      (ComplexValueBuilder()..update(updates))._build();
+
+  _$ComplexValue._(
+      {required this.primitive,
+      this.nullablePrimitive,
+      this.nullablePrimitiveDoNotUse,
+      required this.value,
+      this.nullableValue,
+      this.nullableValueDoNotUse})
+      : super._();
+  @override
+  ComplexValue rebuild(void Function(ComplexValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ComplexValueBuilder toBuilder() => ComplexValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ComplexValue &&
+        primitive == other.primitive &&
+        nullablePrimitive == other.nullablePrimitive &&
+        nullablePrimitiveDoNotUse == other.nullablePrimitiveDoNotUse &&
+        value == other.value &&
+        nullableValue == other.nullableValue &&
+        nullableValueDoNotUse == other.nullableValueDoNotUse;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, primitive.hashCode);
+    _$hash = $jc(_$hash, nullablePrimitive.hashCode);
+    _$hash = $jc(_$hash, nullablePrimitiveDoNotUse.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, nullableValue.hashCode);
+    _$hash = $jc(_$hash, nullableValueDoNotUse.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ComplexValue')
+          ..add('primitive', primitive)
+          ..add('nullablePrimitive', nullablePrimitive)
+          ..add('nullablePrimitiveDoNotUse', nullablePrimitiveDoNotUse)
+          ..add('value', value)
+          ..add('nullableValue', nullableValue)
+          ..add('nullableValueDoNotUse', nullableValueDoNotUse))
+        .toString();
+  }
+}
+
+class ComplexValueBuilder
+    implements Builder<ComplexValue, ComplexValueBuilder> {
+  _$ComplexValue? _$v;
+
+  int? _primitive;
+  int? get primitive => _$this._primitive;
+  set primitive(int? primitive) => _$this._primitive = primitive;
+
+  int? _nullablePrimitive;
+  int? get nullablePrimitive => _$this._nullablePrimitive;
+  set nullablePrimitive(int? nullablePrimitive) =>
+      _$this._nullablePrimitive = nullablePrimitive;
+
+  int? _nullablePrimitiveDoNotUse;
+  int? get nullablePrimitiveDoNotUse => _$this._nullablePrimitiveDoNotUse;
+  set nullablePrimitiveDoNotUse(int? nullablePrimitiveDoNotUse) =>
+      _$this._nullablePrimitiveDoNotUse = nullablePrimitiveDoNotUse;
+
+  SimpleValueBuilder? _value;
+  SimpleValueBuilder get value => _$this._value ??= SimpleValueBuilder();
+  set value(SimpleValueBuilder? value) => _$this._value = value;
+
+  SimpleValueBuilder? _nullableValue;
+  SimpleValueBuilder get nullableValue =>
+      _$this._nullableValue ??= SimpleValueBuilder();
+  set nullableValue(SimpleValueBuilder? nullableValue) =>
+      _$this._nullableValue = nullableValue;
+
+  SimpleValueBuilder? _nullableValueDoNotUse;
+  SimpleValueBuilder get nullableValueDoNotUse =>
+      _$this._nullableValueDoNotUse ??= SimpleValueBuilder();
+  set nullableValueDoNotUse(SimpleValueBuilder? nullableValueDoNotUse) =>
+      _$this._nullableValueDoNotUse = nullableValueDoNotUse;
+
+  ComplexValueBuilder();
+
+  ComplexValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _primitive = $v.primitive;
+      _nullablePrimitive = $v.nullablePrimitive;
+      _nullablePrimitiveDoNotUse = $v.nullablePrimitiveDoNotUse;
+      _value = $v.value.toBuilder();
+      _nullableValue = $v.nullableValue?.toBuilder();
+      _nullableValueDoNotUse = $v.nullableValueDoNotUse?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ComplexValue other) {
+    _$v = other as _$ComplexValue;
+  }
+
+  @override
+  void update(void Function(ComplexValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ComplexValue build() => _build();
+
+  _$ComplexValue _build() {
+    _$ComplexValue _$result;
+    try {
+      _$result = _$v ??
+          _$ComplexValue._(
+            primitive: BuiltValueNullFieldError.checkNotNull(
+                primitive, r'ComplexValue', 'primitive'),
+            nullablePrimitive: nullablePrimitive,
+            nullablePrimitiveDoNotUse: nullablePrimitiveDoNotUse,
+            value: value.build(),
+            nullableValue: _nullableValue?.build(),
+            nullableValueDoNotUse: _nullableValueDoNotUse?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+        _$failedField = 'nullableValue';
+        _nullableValue?.build();
+        _$failedField = 'nullableValueDoNotUse';
+        _nullableValueDoNotUse?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'ComplexValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/lib/values.dart
+++ b/built_types/end_to_end_test/lib/values.dart
@@ -1,0 +1,1012 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/enums.dart' as using_import_as;
+import 'package:end_to_end_test/mixins_src.dart';
+import 'package:fixnum/fixnum.dart';
+
+part 'values.g.dart';
+
+abstract class SimpleValue implements Built<SimpleValue, SimpleValueBuilder> {
+  static Serializer<SimpleValue> get serializer => _$simpleValueSerializer;
+
+  int get anInt;
+
+  String? get aString;
+  bool? get $mustBeEscaped;
+
+  factory SimpleValue([void Function(SimpleValueBuilder) updates]) =
+      _$SimpleValue;
+  SimpleValue._();
+}
+
+abstract class CompoundValue
+    implements Built<CompoundValue, CompoundValueBuilder> {
+  static Serializer<CompoundValue> get serializer => _$compoundValueSerializer;
+
+  SimpleValue get simpleValue;
+  ValidatedValue? get validatedValue;
+
+  factory CompoundValue([void Function(CompoundValueBuilder) updates]) =
+      _$CompoundValue;
+  CompoundValue._();
+}
+
+@BuiltValue(nestedBuilders: false)
+abstract class CompoundValueNoNesting
+    implements Built<CompoundValueNoNesting, CompoundValueNoNestingBuilder> {
+  static Serializer<CompoundValueNoNesting> get serializer =>
+      _$compoundValueNoNestingSerializer;
+
+  SimpleValue get simpleValue;
+  ValidatedValue? get validatedValue;
+
+  factory CompoundValueNoNesting([
+    void Function(CompoundValueNoNestingBuilder) updates,
+  ]) = _$CompoundValueNoNesting;
+  CompoundValueNoNesting._();
+}
+
+@BuiltValue(autoCreateNestedBuilders: false)
+abstract class CompoundValueNoAutoNesting
+    implements
+        Built<CompoundValueNoAutoNesting, CompoundValueNoAutoNestingBuilder> {
+  static Serializer<CompoundValueNoAutoNesting> get serializer =>
+      _$compoundValueNoAutoNestingSerializer;
+
+  NoFieldsValue get value;
+
+  factory CompoundValueNoAutoNesting([
+    void Function(CompoundValueNoAutoNestingBuilder) updates,
+  ]) = _$CompoundValueNoAutoNesting;
+  CompoundValueNoAutoNesting._();
+}
+
+@BuiltValue(nestedBuilders: false, comparableBuilders: true)
+abstract class CompoundValueComparableBuilders
+    implements
+        Built<
+          CompoundValueComparableBuilders,
+          CompoundValueComparableBuildersBuilder
+        > {
+  static Serializer<CompoundValueComparableBuilders> get serializer =>
+      _$compoundValueComparableBuildersSerializer;
+
+  SimpleValue get simpleValue;
+  ValidatedValue? get validatedValue;
+
+  factory CompoundValueComparableBuilders([
+    void Function(CompoundValueComparableBuildersBuilder) updates,
+  ]) = _$CompoundValueComparableBuilders;
+  CompoundValueComparableBuilders._();
+}
+
+// Class using nesting by default.
+abstract class CompoundValueNoNestingField
+    implements
+        Built<CompoundValueNoNestingField, CompoundValueNoNestingFieldBuilder> {
+  static Serializer<CompoundValueNoNestingField> get serializer =>
+      _$compoundValueNoNestingFieldSerializer;
+
+  // One field not using nesting.
+  @BuiltValueField(nestedBuilder: false)
+  SimpleValue get simpleValue;
+
+  // One nullable field not using nesting.
+  @BuiltValueField(nestedBuilder: false)
+  ValidatedValue? get validatedValue;
+
+  // One field using nesting.
+  SimpleValue get simpleValueWithNested;
+
+  // One nullable field using nesting.
+  ValidatedValue? get validatedValueWithNested;
+
+  factory CompoundValueNoNestingField([
+    void Function(CompoundValueNoNestingFieldBuilder) updates,
+  ]) = _$CompoundValueNoNestingField;
+
+  CompoundValueNoNestingField._();
+}
+
+// Class not using nesting by default.
+@BuiltValue(nestedBuilders: false)
+abstract class CompoundValueNestingField
+    implements
+        Built<CompoundValueNestingField, CompoundValueNestingFieldBuilder> {
+  static Serializer<CompoundValueNestingField> get serializer =>
+      _$compoundValueNestingFieldSerializer;
+
+  // One field not using nesting.
+  SimpleValue get simpleValue;
+
+  // One nullable field not using nesting.
+  ValidatedValue? get validatedValue;
+
+  // One field using nesting.
+  @BuiltValueField(nestedBuilder: true)
+  SimpleValue get simpleValueWithNested;
+
+  // One nullable field using nesting.
+  @BuiltValueField(nestedBuilder: true)
+  ValidatedValue? get validatedValueWithNested;
+
+  factory CompoundValueNestingField([
+    void Function(CompoundValueNestingFieldBuilder) updates,
+  ]) = _$CompoundValueNestingField;
+
+  CompoundValueNestingField._();
+}
+
+// Class using auto create builder nesting by default.
+abstract class CompoundValueNoAutoNestingField
+    implements
+        Built<
+          CompoundValueNoAutoNestingField,
+          CompoundValueNoAutoNestingFieldBuilder
+        > {
+  static Serializer<CompoundValueNoAutoNestingField> get serializer =>
+      _$compoundValueNoAutoNestingFieldSerializer;
+
+  // One field not using auto create builder nesting.
+  @BuiltValueField(autoCreateNestedBuilder: false)
+  NoFieldsValue get value;
+
+  // One field using auto create builder nesting.
+  NoFieldsValue get valueWithAutoCreate;
+
+  factory CompoundValueNoAutoNestingField([
+    void Function(CompoundValueNoAutoNestingFieldBuilder) updates,
+  ]) = _$CompoundValueNoAutoNestingField;
+
+  CompoundValueNoAutoNestingField._();
+}
+
+// Class not using auto create builder nesting by default.
+abstract class CompoundValueAutoNestingField
+    implements
+        Built<
+          CompoundValueAutoNestingField,
+          CompoundValueAutoNestingFieldBuilder
+        > {
+  static Serializer<CompoundValueAutoNestingField> get serializer =>
+      _$compoundValueAutoNestingFieldSerializer;
+
+  // One field not using auto create builder nesting.
+  NoFieldsValue get value;
+
+  // One field using auto create builder nesting.
+  @BuiltValueField(autoCreateNestedBuilder: true)
+  NoFieldsValue get valueWithAutoCreate;
+
+  factory CompoundValueAutoNestingField([
+    void Function(CompoundValueAutoNestingFieldBuilder) updates,
+  ]) = _$CompoundValueAutoNestingField;
+
+  CompoundValueAutoNestingField._();
+}
+
+abstract class CompoundValueExplicitNoNesting
+    implements
+        Built<
+          CompoundValueExplicitNoNesting,
+          CompoundValueExplicitNoNestingBuilder
+        > {
+  static Serializer<CompoundValueExplicitNoNesting> get serializer =>
+      _$compoundValueExplicitNoNestingSerializer;
+
+  SimpleValue get simpleValue;
+  ValidatedValue? get validatedValue;
+
+  factory CompoundValueExplicitNoNesting([
+    void Function(CompoundValueExplicitNoNestingBuilder) updates,
+  ]) = _$CompoundValueExplicitNoNesting;
+  CompoundValueExplicitNoNesting._();
+}
+
+abstract class CompoundValueExplicitNoNestingBuilder
+    implements
+        Builder<
+          CompoundValueExplicitNoNesting,
+          CompoundValueExplicitNoNestingBuilder
+        > {
+  // One field using nesting.
+  SimpleValueBuilder simpleValue = SimpleValueBuilder();
+  // One field not using nesting.
+  ValidatedValue? validatedValue;
+
+  factory CompoundValueExplicitNoNestingBuilder() =
+      _$CompoundValueExplicitNoNestingBuilder;
+  CompoundValueExplicitNoNestingBuilder._();
+}
+
+// Check that nested collections work with a manually declared builder.
+abstract class ExplicitNestedList
+    implements Built<ExplicitNestedList, ExplicitNestedListBuilder> {
+  BuiltList<BuiltList<int>> get nestedList;
+
+  factory ExplicitNestedList([
+    void Function(ExplicitNestedListBuilder) updates,
+  ]) = _$ExplicitNestedList;
+  ExplicitNestedList._();
+}
+
+abstract class ExplicitNestedListBuilder
+    implements Builder<ExplicitNestedList, ExplicitNestedListBuilder> {
+  ListBuilder<BuiltList<int>> nestedList = ListBuilder();
+
+  factory ExplicitNestedListBuilder() = _$ExplicitNestedListBuilder;
+  ExplicitNestedListBuilder._();
+}
+
+abstract class ExplicitNonNullBuilderNullableSetter
+    implements
+        Built<
+          ExplicitNonNullBuilderNullableSetter,
+          ExplicitNonNullBuilderNullableSetterBuilder
+        > {
+  SimpleValue? get simpleValue;
+
+  factory ExplicitNonNullBuilderNullableSetter([
+    void Function(ExplicitNonNullBuilderNullableSetterBuilder) updates,
+  ]) = _$ExplicitNonNullBuilderNullableSetter;
+  ExplicitNonNullBuilderNullableSetter._();
+}
+
+abstract class ExplicitNonNullBuilderNullableSetterBuilder
+    implements
+        Builder<
+          ExplicitNonNullBuilderNullableSetter,
+          ExplicitNonNullBuilderNullableSetterBuilder
+        > {
+  SimpleValueBuilder get simpleValue;
+  set simpleValue(SimpleValueBuilder? value);
+
+  factory ExplicitNonNullBuilderNullableSetterBuilder() =
+      _$ExplicitNonNullBuilderNullableSetterBuilder;
+  ExplicitNonNullBuilderNullableSetterBuilder._();
+}
+
+abstract class ExplicitNonNullBuilderNullableField
+    implements
+        Built<
+          ExplicitNonNullBuilderNullableField,
+          ExplicitNonNullBuilderNullableFieldBuilder
+        > {
+  SimpleValue? get simpleValue;
+
+  factory ExplicitNonNullBuilderNullableField([
+    void Function(ExplicitNonNullBuilderNullableFieldBuilder) updates,
+  ]) = _$ExplicitNonNullBuilderNullableField;
+  ExplicitNonNullBuilderNullableField._();
+}
+
+abstract class ExplicitNonNullBuilderNullableFieldBuilder
+    implements
+        Builder<
+          ExplicitNonNullBuilderNullableField,
+          ExplicitNonNullBuilderNullableFieldBuilder
+        > {
+  SimpleValueBuilder? simpleValue;
+
+  factory ExplicitNonNullBuilderNullableFieldBuilder() =
+      _$ExplicitNonNullBuilderNullableFieldBuilder;
+  ExplicitNonNullBuilderNullableFieldBuilder._();
+}
+
+abstract class DerivedValue
+    implements Built<DerivedValue, DerivedValueBuilder> {
+  int get anInt;
+
+  @memoized
+  int get derivedValue {
+    ++derivedValueGetterCount;
+
+    return anInt + 10;
+  }
+
+  @memoized
+  Iterable<String> get derivedString {
+    ++derivedStringGetterCount;
+
+    return [toString()];
+  }
+
+  @memoized
+  int? get nullableDerivedValue {
+    ++nullableDerivedGetterCount;
+
+    return null;
+  }
+
+  factory DerivedValue([void Function(DerivedValueBuilder) updates]) =
+      _$DerivedValue;
+  DerivedValue._();
+}
+
+int derivedValueGetterCount = 0;
+
+int derivedStringGetterCount = 0;
+
+int nullableDerivedGetterCount = 0;
+
+abstract class ValueWithCode
+    implements Built<ValueWithCode, ValueWithCodeBuilder> {
+  static final int youCanHaveStaticFields = 3;
+
+  int get anInt;
+  String? get aString;
+
+  String get youCanWriteDerivedGetters => anInt.toString() + aString!;
+
+  factory ValueWithCode([void Function(ValueWithCodeBuilder) updates]) =
+      _$ValueWithCode;
+  ValueWithCode._();
+
+  factory ValueWithCode.fromCustomFactory(int anInt) => ValueWithCode(
+    (b) => b
+      ..anInt = anInt
+      ..aString = 'two',
+  );
+}
+
+abstract class ValueWithDefaults
+    implements Built<ValueWithDefaults, ValueWithDefaultsBuilder> {
+  int get anInt;
+  String? get aString;
+  SimpleValue get value;
+
+  factory ValueWithDefaults([void Function(ValueWithDefaultsBuilder) updates]) =
+      _$ValueWithDefaults;
+  ValueWithDefaults._();
+}
+
+abstract class ValueWithDefaultsBuilder
+    implements Builder<ValueWithDefaults, ValueWithDefaultsBuilder> {
+  int anInt = 7;
+
+  String? aString;
+  SimpleValueBuilder value = SimpleValue((b) => b..anInt = 3).toBuilder();
+
+  factory ValueWithDefaultsBuilder() = _$ValueWithDefaultsBuilder;
+  ValueWithDefaultsBuilder._();
+}
+
+abstract class ValueWithBuilderSmarts
+    implements Built<ValueWithBuilderSmarts, ValueWithBuilderSmartsBuilder> {
+  String get value;
+
+  factory ValueWithBuilderSmarts([
+    void Function(ValueWithBuilderSmartsBuilder) updates,
+  ]) = _$ValueWithBuilderSmarts;
+  ValueWithBuilderSmarts._();
+}
+
+abstract class ValueWithBuilderSmartsBuilder
+    implements Builder<ValueWithBuilderSmarts, ValueWithBuilderSmartsBuilder> {
+  String? _value;
+  String get value => _value!;
+  set value(String v) {
+    if (v == 'not allowed') throw ArgumentError('not allowed');
+    _value = v;
+  }
+
+  factory ValueWithBuilderSmartsBuilder() = _$ValueWithBuilderSmartsBuilder;
+  ValueWithBuilderSmartsBuilder._();
+}
+
+abstract class ValidatedValue
+    implements Built<ValidatedValue, ValidatedValueBuilder> {
+  static Serializer<ValidatedValue> get serializer =>
+      _$validatedValueSerializer;
+
+  int get anInt;
+
+  String? get aString;
+
+  factory ValidatedValue([void Function(ValidatedValueBuilder) updates]) =
+      _$ValidatedValue;
+
+  ValidatedValue._() {
+    if (anInt == 7) throw StateError('anInt may not be 7');
+  }
+}
+
+abstract class ValueUsingImportAs
+    implements Built<ValueUsingImportAs, ValueUsingImportAsBuilder> {
+  static Serializer<ValueUsingImportAs> get serializer =>
+      _$valueUsingImportAsSerializer;
+
+  using_import_as.TestEnum get value;
+  using_import_as.TestEnum? get nullableValue;
+
+  factory ValueUsingImportAs([
+    void Function(ValueUsingImportAsBuilder) updates,
+  ]) = _$ValueUsingImportAs;
+
+  ValueUsingImportAs._();
+}
+
+abstract class NoFieldsValue
+    implements Built<NoFieldsValue, NoFieldsValueBuilder> {
+  static Serializer<NoFieldsValue> get serializer => _$noFieldsValueSerializer;
+
+  factory NoFieldsValue([void Function(NoFieldsValueBuilder) updates]) =
+      _$NoFieldsValue;
+
+  NoFieldsValue._();
+}
+
+abstract class PrimitivesValue
+    implements Built<PrimitivesValue, PrimitivesValueBuilder> {
+  static Serializer<PrimitivesValue> get serializer =>
+      _$primitivesValueSerializer;
+
+  bool get boolean;
+  int get integer;
+  Int64 get int64;
+  double get dbl;
+  num get number;
+  String get string;
+  DateTime get dateTime;
+  Duration get duration;
+  RegExp get regExp;
+  Uri get uri;
+  BigInt get bigInt;
+
+  factory PrimitivesValue([void Function(PrimitivesValueBuilder) updates]) =
+      _$PrimitivesValue;
+
+  PrimitivesValue._();
+}
+
+typedef MyFunctionType = int Function(String);
+
+abstract class FunctionValue
+    implements Built<FunctionValue, FunctionValueBuilder> {
+  MyFunctionType get function;
+
+  factory FunctionValue([void Function(FunctionValueBuilder) updates]) =
+      _$FunctionValue;
+
+  FunctionValue._();
+}
+
+abstract class ListOfFunctionValue
+    implements Built<ListOfFunctionValue, ListOfFunctionValueBuilder> {
+  BuiltList<MyFunctionType> get functions;
+
+  factory ListOfFunctionValue([
+    void Function(ListOfFunctionValueBuilder) updates,
+  ]) = _$ListOfFunctionValue;
+
+  ListOfFunctionValue._();
+}
+
+abstract class PartiallySerializableValue
+    implements
+        Built<PartiallySerializableValue, PartiallySerializableValueBuilder> {
+  static Serializer<PartiallySerializableValue> get serializer =>
+      _$partiallySerializableValueSerializer;
+
+  int get value;
+
+  @BuiltValueField(serialize: false)
+  int? get transientValue;
+
+  factory PartiallySerializableValue([
+    void Function(PartiallySerializableValueBuilder) updates,
+  ]) = _$PartiallySerializableValue;
+
+  PartiallySerializableValue._();
+}
+
+abstract class NamedFactoryValue
+    implements Built<NamedFactoryValue, NamedFactoryValueBuilder> {
+  static Serializer<NamedFactoryValue> get serializer =>
+      _$namedFactoryValueSerializer;
+
+  int get value;
+
+  factory NamedFactoryValue(int value) => _$NamedFactoryValue._(value: value);
+
+  NamedFactoryValue._();
+}
+
+@BuiltValue(wireName: r'$V')
+abstract class WireNameValue
+    implements Built<WireNameValue, WireNameValueBuilder> {
+  static Serializer<WireNameValue> get serializer => _$wireNameValueSerializer;
+
+  @BuiltValueField(wireName: r'$v')
+  int get value;
+
+  factory WireNameValue([void Function(WireNameValueBuilder) updates]) =
+      _$WireNameValue;
+
+  WireNameValue._();
+}
+
+// Check discovery of serializable types via fields.
+abstract class FieldDiscoveryValue
+    implements Built<FieldDiscoveryValue, FieldDiscoveryValueBuilder> {
+  static Serializer<FieldDiscoveryValue> get serializer =>
+      _$fieldDiscoveryValueSerializer;
+
+  DiscoverableValue get value;
+  BuiltList<ThirdDiscoverableValue> get values;
+
+  // Check that discovery doesn't recurse forever on reference to self.
+  FieldDiscoveryValue? get recursiveValue;
+
+  factory FieldDiscoveryValue([
+    void Function(FieldDiscoveryValueBuilder) updates,
+  ]) = _$FieldDiscoveryValue;
+  FieldDiscoveryValue._();
+}
+
+// Discovered indirectly via FieldDiscoveryValue.
+abstract class DiscoverableValue
+    implements Built<DiscoverableValue, DiscoverableValueBuilder> {
+  static Serializer<DiscoverableValue> get serializer =>
+      _$discoverableValueSerializer;
+
+  SecondDiscoverableValue get value;
+
+  factory DiscoverableValue([void Function(DiscoverableValueBuilder) updates]) =
+      _$DiscoverableValue;
+  DiscoverableValue._();
+}
+
+// Discovered indirectly via DiscoverableValue.
+abstract class SecondDiscoverableValue
+    implements Built<SecondDiscoverableValue, SecondDiscoverableValueBuilder> {
+  static Serializer<SecondDiscoverableValue> get serializer =>
+      _$secondDiscoverableValueSerializer;
+
+  int get value;
+
+  factory SecondDiscoverableValue([
+    void Function(SecondDiscoverableValueBuilder) updates,
+  ]) = _$SecondDiscoverableValue;
+  SecondDiscoverableValue._();
+}
+
+// Discovered indirectly via FieldDiscoveryValue.
+abstract class ThirdDiscoverableValue
+    implements Built<ThirdDiscoverableValue, ThirdDiscoverableValueBuilder> {
+  static Serializer<ThirdDiscoverableValue> get serializer =>
+      _$thirdDiscoverableValueSerializer;
+
+  int get value;
+
+  factory ThirdDiscoverableValue([
+    void Function(ThirdDiscoverableValueBuilder) updates,
+  ]) = _$ThirdDiscoverableValue;
+  ThirdDiscoverableValue._();
+}
+
+// Check that discovery doesn't recurse forever when there is a loop in field
+// types.
+abstract class RecursiveValueA
+    implements Built<RecursiveValueA, RecursiveValueABuilder> {
+  static Serializer<RecursiveValueA> get serializer =>
+      _$recursiveValueASerializer;
+
+  RecursiveValueB get value;
+
+  factory RecursiveValueA([void Function(RecursiveValueABuilder) updates]) =
+      _$RecursiveValueA;
+  RecursiveValueA._();
+}
+
+abstract class RecursiveValueB
+    implements Built<RecursiveValueB, RecursiveValueBBuilder> {
+  static Serializer<RecursiveValueB> get serializer =>
+      _$recursiveValueBSerializer;
+
+  RecursiveValueA get value;
+
+  factory RecursiveValueB([void Function(RecursiveValueBBuilder) updates]) =
+      _$RecursiveValueB;
+  RecursiveValueB._();
+}
+
+abstract class ValueWithCustomSerializer
+    implements
+        Built<ValueWithCustomSerializer, ValueWithCustomSerializerBuilder> {
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ValueWithCustomSerializer> get serializer =>
+      const ValueWithCustomSerializerSerializer();
+
+  int get value;
+
+  factory ValueWithCustomSerializer([
+    void Function(ValueWithCustomSerializerBuilder) updates,
+  ]) = _$ValueWithCustomSerializer;
+  ValueWithCustomSerializer._();
+}
+
+class ValueWithCustomSerializerSerializer
+    implements PrimitiveSerializer<ValueWithCustomSerializer> {
+  @override
+  Iterable<Type> get types => [
+    ValueWithCustomSerializer,
+    _$ValueWithCustomSerializer,
+  ];
+
+  const ValueWithCustomSerializerSerializer();
+
+  @override
+  String get wireName => 'ValueWithCustomSerializer';
+
+  @override
+  ValueWithCustomSerializer deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return ValueWithCustomSerializer((b) => b.value = serialized as int);
+  }
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ValueWithCustomSerializer object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return object.value;
+  }
+}
+
+@BuiltValue(generateBuilderOnSetField: true)
+abstract class ValueWithOnSet
+    implements Built<ValueWithOnSet, ValueWithOnSetBuilder> {
+  int get value;
+
+  factory ValueWithOnSet([void Function(ValueWithOnSetBuilder) updates]) =
+      _$ValueWithOnSet;
+  ValueWithOnSet._();
+}
+
+// Check that `toString` from a mixin is not redefined.
+abstract class CustomToStringValue extends Object
+    with CustomToString
+    implements Built<CustomToStringValue, CustomToStringValueBuilder> {
+  factory CustomToStringValue([
+    void Function(CustomToStringValueBuilder) updates,
+  ]) = _$CustomToStringValue;
+  CustomToStringValue._();
+}
+
+mixin CustomToString {
+  @override
+  String toString() => 'custom';
+}
+
+// Check that a field can be called `other`.
+abstract class OtherValue implements Built<OtherValue, OtherValueBuilder> {
+  static Serializer<OtherValue> get serializer => _$otherValueSerializer;
+
+  int get other;
+
+  factory OtherValue([void Function(OtherValueBuilder) updates]) = _$OtherValue;
+  OtherValue._();
+}
+
+@BuiltValue(defaultCompare: false, defaultSerialize: false)
+abstract class DefaultsForFieldSettingsValue
+    implements
+        Built<
+          DefaultsForFieldSettingsValue,
+          DefaultsForFieldSettingsValueBuilder
+        > {
+  static Serializer<DefaultsForFieldSettingsValue> get serializer =>
+      _$defaultsForFieldSettingsValueSerializer;
+
+  int get ignored;
+
+  @BuiltValueField(compare: true)
+  int get compared;
+
+  @BuiltValueField(serialize: true)
+  int get serialized;
+
+  factory DefaultsForFieldSettingsValue([
+    void Function(DefaultsForFieldSettingsValueBuilder) updates,
+  ]) = _$DefaultsForFieldSettingsValue;
+
+  DefaultsForFieldSettingsValue._();
+}
+
+abstract class ValueWithBuilderInitializer
+    implements
+        Built<ValueWithBuilderInitializer, ValueWithBuilderInitializerBuilder> {
+  static Serializer<ValueWithBuilderInitializer> get serializer =>
+      _$valueWithBuilderInitializerSerializer;
+
+  static void _initializeBuilder(ValueWithBuilderInitializerBuilder b) => b
+    ..anIntWithDefault = 7
+    ..nullableIntWithDefault = 8
+    ..nestedValueWithDefault.anInt = 9
+    ..nullableNestedValueWithDefault.anInt = 10;
+
+  int get anInt;
+  int get anIntWithDefault;
+  int? get nullableInt;
+  int? get nullableIntWithDefault;
+
+  SimpleValue get nestedValue;
+  SimpleValue get nestedValueWithDefault;
+  SimpleValue? get nullableNestedValue;
+  SimpleValue? get nullableNestedValueWithDefault;
+
+  factory ValueWithBuilderInitializer([
+    void Function(ValueWithBuilderInitializerBuilder) updates,
+  ]) = _$ValueWithBuilderInitializer;
+  ValueWithBuilderInitializer._();
+}
+
+abstract class ValueWithBuilderFinalizer
+    implements
+        Built<ValueWithBuilderFinalizer, ValueWithBuilderFinalizerBuilder> {
+  static Serializer<ValueWithBuilderFinalizer> get serializer =>
+      _$valueWithBuilderFinalizerSerializer;
+
+  /// Build hook forcing [anInt] to be odd.
+  static void _finalizeBuilder(ValueWithBuilderFinalizerBuilder b) {
+    if (b.anInt!.isEven) b.anInt = b.anInt! + 1;
+  }
+
+  int get anInt;
+
+  factory ValueWithBuilderFinalizer([
+    void Function(ValueWithBuilderFinalizerBuilder) updates,
+  ]) = _$ValueWithBuilderFinalizer;
+  ValueWithBuilderFinalizer._();
+}
+
+abstract class ValueWithGenericBuilderInitializer<T>
+    implements
+        Built<
+          ValueWithGenericBuilderInitializer<T>,
+          ValueWithGenericBuilderInitializerBuilder<T>
+        > {
+  static void _initializeBuilder<TT>(
+    ValueWithGenericBuilderInitializerBuilder<TT> b,
+  ) {
+    if (TT == int) {
+      b.value = 42 as TT;
+    }
+  }
+
+  T? get value;
+
+  factory ValueWithGenericBuilderInitializer([
+    void Function(ValueWithGenericBuilderInitializerBuilder<T>) updates,
+  ]) = _$ValueWithGenericBuilderInitializer<T>;
+  ValueWithGenericBuilderInitializer._();
+}
+
+abstract class HashcodeValue
+    implements Built<HashcodeValue, HashcodeValueBuilder> {
+  int get x;
+  int get y;
+
+  HashcodeValue._();
+  factory HashcodeValue([void Function(HashcodeValueBuilder) updates]) =
+      _$HashcodeValue;
+}
+
+abstract class MemoizedHashcodeValue
+    implements Built<MemoizedHashcodeValue, MemoizedHashcodeValueBuilder> {
+  int get x;
+  int get y;
+
+  @override
+  @memoized
+  int get hashCode;
+
+  MemoizedHashcodeValue._();
+  factory MemoizedHashcodeValue([
+    void Function(MemoizedHashcodeValueBuilder) updates,
+  ]) = _$MemoizedHashcodeValue;
+}
+
+abstract class _PrivateValue
+    implements Built<_PrivateValue, _PrivateValueBuilder> {
+  _PrivateValue._();
+  factory _PrivateValue(void Function(_PrivateValueBuilder) updates) =
+      _$PrivateValue;
+}
+
+abstract class SerializesNullsValue
+    implements Built<SerializesNullsValue, SerializesNullsValueBuilder> {
+  @BuiltValueSerializer(serializeNulls: true)
+  static Serializer<SerializesNullsValue> get serializer =>
+      _$serializesNullsValueSerializer;
+
+  String? get value;
+
+  factory SerializesNullsValue([
+    void Function(SerializesNullsValueBuilder) updates,
+  ]) = _$SerializesNullsValue;
+  SerializesNullsValue._();
+}
+
+abstract class NullableObjectValue
+    implements Built<NullableObjectValue, NullableObjectValueBuilder> {
+  static Serializer<NullableObjectValue> get serializer =>
+      _$nullableObjectValueSerializer;
+
+  Object? get value;
+
+  factory NullableObjectValue([
+    void Function(NullableObjectValueBuilder) updates,
+  ]) = _$NullableObjectValue;
+  NullableObjectValue._();
+}
+
+abstract class ValueWithHooks
+    implements Built<ValueWithHooks, ValueWithHooksBuilder> {
+  static Serializer<ValueWithHooks> get serializer =>
+      _$valueWithHooksSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void hook1(ValueWithHooksBuilder b) {
+    b.hook1Count = (b.hook1Count ?? 0) + 1;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void hook2(ValueWithHooksBuilder b) {
+    b.hook2Count = (b.hook2Count ?? 0) + 1;
+  }
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void justInitialize(ValueWithHooksBuilder b) {
+    b.hookOrdering.add('justInitialize');
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void justFinalize(ValueWithHooksBuilder b) {
+    b.hookOrdering.add('justFinalize');
+  }
+
+  @BuiltValueHook(finalizeBuilder: true, initializeBuilder: true)
+  static void both(ValueWithHooksBuilder b) {
+    b.hookOrdering.add('both');
+  }
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void moreJustInitialize(ValueWithHooksBuilder b) {
+    b.hookOrdering.add('moreJustInitialize');
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void moreJustFinalize(ValueWithHooksBuilder b) {
+    b.hookOrdering.add('moreJustFinalize');
+  }
+
+  @BuiltValueHook(finalizeBuilder: true, initializeBuilder: true)
+  static void moreBoth(ValueWithHooksBuilder b) {
+    b.hookOrdering.add('moreBoth');
+  }
+
+  int get hook1Count;
+  int get hook2Count;
+  BuiltList<String> get hookOrdering;
+
+  factory ValueWithHooks([void Function(ValueWithHooksBuilder) updates]) =
+      _$ValueWithHooks;
+  ValueWithHooks._();
+}
+
+abstract class $ValueSpecial
+    implements Built<$ValueSpecial, $ValueSpecialBuilder> {
+  static Serializer<$ValueSpecial> get serializer => _$$valueSpecialSerializer;
+
+  int get anInt;
+
+  String? get aString;
+  bool? get $mustBeEscaped;
+
+  SimpleValue? get $mustAlsoEscaped;
+  SimpleValue? get $assert;
+  SimpleValue? get $10;
+
+  factory $ValueSpecial([void Function($ValueSpecialBuilder) updates]) =
+      _$$ValueSpecial;
+  $ValueSpecial._();
+}
+
+/// Value with manually written builder.
+///
+/// The manually written builder has nullable nested builders; it always
+/// auto-instantiates one and never instantiates the other.
+@BuiltValue()
+abstract class ValueWithAwkwardNestedBuilder
+    implements
+        Built<
+          ValueWithAwkwardNestedBuilder,
+          ValueWithAwkwardNestedBuilderBuilder
+        > {
+  @BuiltValueSerializer(serializeNulls: true)
+  static Serializer<ValueWithAwkwardNestedBuilder> get serializer =>
+      _$valueWithAwkwardNestedBuilderSerializer;
+
+  SimpleValue? get value1;
+  SimpleValue? get value2;
+  // Check built_collection types as casts are handled differently.
+  BuiltList<int> get values;
+  BuiltMap<int, String> get map;
+
+  factory ValueWithAwkwardNestedBuilder([
+    void Function(ValueWithAwkwardNestedBuilderBuilder) updates,
+  ]) = _$ValueWithAwkwardNestedBuilder;
+  ValueWithAwkwardNestedBuilder._();
+}
+
+abstract class ValueWithAwkwardNestedBuilderBuilder
+    implements
+        Builder<
+          ValueWithAwkwardNestedBuilder,
+          ValueWithAwkwardNestedBuilderBuilder
+        > {
+  SimpleValueBuilder? value1;
+  SimpleValueBuilder? _value2;
+  SimpleValueBuilder? get value2 => (_value2 ??= SimpleValueBuilder());
+  set value2(SimpleValueBuilder? b) => _value2 = b;
+  ListBuilder<int>? values = ListBuilder<int>();
+  MapBuilder<int, String>? map = MapBuilder<int, String>();
+
+  factory ValueWithAwkwardNestedBuilderBuilder() =
+      _$ValueWithAwkwardNestedBuilderBuilder;
+  ValueWithAwkwardNestedBuilderBuilder._();
+}
+
+abstract class VariousFunctionsValue
+        // Functions declared in a different file are rendered via DartType instead
+        // of using the AST, so check those too.
+        with
+        FunctionMixin
+    implements Built<VariousFunctionsValue, VariousFunctionsValueBuilder> {
+  Function get bareFunction;
+  Future<void> Function(int, double) get positionalFunction;
+  Future<void> Function(int, [double]) get optionalFunction;
+  Future<void> Function(int x, double y) get positionalNamedFunction;
+  Future<void> Function(int x, {int y, double z}) get namedFunction;
+  Future<void> Function(int x, {required int y, required double z})
+  get requiredNamedFunction;
+
+  factory VariousFunctionsValue([
+    void Function(VariousFunctionsValueBuilder) updates,
+  ]) = _$VariousFunctionsValue;
+  VariousFunctionsValue._();
+}
+
+abstract class NewConstructorValue
+    implements Built<NewConstructorValue, NewConstructorValueBuilder> {
+  static Serializer<NewConstructorValue> get serializer =>
+      _$newConstructorValueSerializer;
+
+  int get anInt;
+
+  new _();
+
+  factory NewConstructorValue.new([
+    void Function(NewConstructorValueBuilder) updates,
+  ]) = _$NewConstructorValue;
+}
+
+abstract class NewConstructorValueBuilder
+    implements Builder<NewConstructorValue, NewConstructorValueBuilder> {
+  int? anInt;
+
+  new _();
+
+  factory NewConstructorValueBuilder.new() = _$NewConstructorValueBuilder;
+}

--- a/built_types/end_to_end_test/lib/values.g.dart
+++ b/built_types/end_to_end_test/lib/values.g.dart
@@ -1,0 +1,8247 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'values.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<SimpleValue> _$simpleValueSerializer = _$SimpleValueSerializer();
+Serializer<CompoundValue> _$compoundValueSerializer =
+    _$CompoundValueSerializer();
+Serializer<CompoundValueNoNesting> _$compoundValueNoNestingSerializer =
+    _$CompoundValueNoNestingSerializer();
+Serializer<CompoundValueNoAutoNesting> _$compoundValueNoAutoNestingSerializer =
+    _$CompoundValueNoAutoNestingSerializer();
+Serializer<CompoundValueComparableBuilders>
+_$compoundValueComparableBuildersSerializer =
+    _$CompoundValueComparableBuildersSerializer();
+Serializer<CompoundValueNoNestingField>
+_$compoundValueNoNestingFieldSerializer =
+    _$CompoundValueNoNestingFieldSerializer();
+Serializer<CompoundValueNestingField> _$compoundValueNestingFieldSerializer =
+    _$CompoundValueNestingFieldSerializer();
+Serializer<CompoundValueNoAutoNestingField>
+_$compoundValueNoAutoNestingFieldSerializer =
+    _$CompoundValueNoAutoNestingFieldSerializer();
+Serializer<CompoundValueAutoNestingField>
+_$compoundValueAutoNestingFieldSerializer =
+    _$CompoundValueAutoNestingFieldSerializer();
+Serializer<CompoundValueExplicitNoNesting>
+_$compoundValueExplicitNoNestingSerializer =
+    _$CompoundValueExplicitNoNestingSerializer();
+Serializer<ValidatedValue> _$validatedValueSerializer =
+    _$ValidatedValueSerializer();
+Serializer<ValueUsingImportAs> _$valueUsingImportAsSerializer =
+    _$ValueUsingImportAsSerializer();
+Serializer<NoFieldsValue> _$noFieldsValueSerializer =
+    _$NoFieldsValueSerializer();
+Serializer<PrimitivesValue> _$primitivesValueSerializer =
+    _$PrimitivesValueSerializer();
+Serializer<PartiallySerializableValue> _$partiallySerializableValueSerializer =
+    _$PartiallySerializableValueSerializer();
+Serializer<NamedFactoryValue> _$namedFactoryValueSerializer =
+    _$NamedFactoryValueSerializer();
+Serializer<WireNameValue> _$wireNameValueSerializer =
+    _$WireNameValueSerializer();
+Serializer<FieldDiscoveryValue> _$fieldDiscoveryValueSerializer =
+    _$FieldDiscoveryValueSerializer();
+Serializer<DiscoverableValue> _$discoverableValueSerializer =
+    _$DiscoverableValueSerializer();
+Serializer<SecondDiscoverableValue> _$secondDiscoverableValueSerializer =
+    _$SecondDiscoverableValueSerializer();
+Serializer<ThirdDiscoverableValue> _$thirdDiscoverableValueSerializer =
+    _$ThirdDiscoverableValueSerializer();
+Serializer<RecursiveValueA> _$recursiveValueASerializer =
+    _$RecursiveValueASerializer();
+Serializer<RecursiveValueB> _$recursiveValueBSerializer =
+    _$RecursiveValueBSerializer();
+Serializer<OtherValue> _$otherValueSerializer = _$OtherValueSerializer();
+Serializer<DefaultsForFieldSettingsValue>
+_$defaultsForFieldSettingsValueSerializer =
+    _$DefaultsForFieldSettingsValueSerializer();
+Serializer<ValueWithBuilderInitializer>
+_$valueWithBuilderInitializerSerializer =
+    _$ValueWithBuilderInitializerSerializer();
+Serializer<ValueWithBuilderFinalizer> _$valueWithBuilderFinalizerSerializer =
+    _$ValueWithBuilderFinalizerSerializer();
+Serializer<SerializesNullsValue> _$serializesNullsValueSerializer =
+    _$SerializesNullsValueSerializer();
+Serializer<NullableObjectValue> _$nullableObjectValueSerializer =
+    _$NullableObjectValueSerializer();
+Serializer<ValueWithHooks> _$valueWithHooksSerializer =
+    _$ValueWithHooksSerializer();
+Serializer<$ValueSpecial> _$$valueSpecialSerializer =
+    _$$ValueSpecialSerializer();
+Serializer<ValueWithAwkwardNestedBuilder>
+_$valueWithAwkwardNestedBuilderSerializer =
+    _$ValueWithAwkwardNestedBuilderSerializer();
+Serializer<NewConstructorValue> _$newConstructorValueSerializer =
+    _$NewConstructorValueSerializer();
+
+class _$SimpleValueSerializer implements StructuredSerializer<SimpleValue> {
+  @override
+  final Iterable<Type> types = const [SimpleValue, _$SimpleValue];
+  @override
+  final String wireName = 'SimpleValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    SimpleValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.aString;
+    if (value != null) {
+      result
+        ..add('aString')
+        ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)),
+        );
+    }
+    value = object.$mustBeEscaped;
+    if (value != null) {
+      result
+        ..add('\$mustBeEscaped')
+        ..add(
+          serializers.serialize(value, specifiedType: const FullType(bool)),
+        );
+    }
+    return result;
+  }
+
+  @override
+  SimpleValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = SimpleValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'anInt':
+          result.anInt =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+        case 'aString':
+          result.aString = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String?;
+          break;
+        case '\$mustBeEscaped':
+          result.$mustBeEscaped = serializers.deserialize(
+            value,
+            specifiedType: const FullType(bool),
+          ) as bool?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CompoundValueSerializer implements StructuredSerializer<CompoundValue> {
+  @override
+  final Iterable<Type> types = const [CompoundValue, _$CompoundValue];
+  @override
+  final String wireName = 'CompoundValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    CompoundValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'simpleValue',
+      serializers.serialize(
+        object.simpleValue,
+        specifiedType: const FullType(SimpleValue),
+      ),
+    ];
+    Object? value;
+    value = object.validatedValue;
+    if (value != null) {
+      result
+        ..add('validatedValue')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  CompoundValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CompoundValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'simpleValue':
+          result.simpleValue.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+        case 'validatedValue':
+          result.validatedValue.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(ValidatedValue),
+                )!
+                as ValidatedValue,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CompoundValueNoNestingSerializer
+    implements StructuredSerializer<CompoundValueNoNesting> {
+  @override
+  final Iterable<Type> types = const [
+    CompoundValueNoNesting,
+    _$CompoundValueNoNesting,
+  ];
+  @override
+  final String wireName = 'CompoundValueNoNesting';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    CompoundValueNoNesting object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'simpleValue',
+      serializers.serialize(
+        object.simpleValue,
+        specifiedType: const FullType(SimpleValue),
+      ),
+    ];
+    Object? value;
+    value = object.validatedValue;
+    if (value != null) {
+      result
+        ..add('validatedValue')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  CompoundValueNoNesting deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CompoundValueNoNestingBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'simpleValue':
+          result.simpleValue =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(SimpleValue),
+                  )!
+                  as SimpleValue;
+          break;
+        case 'validatedValue':
+          result.validatedValue = serializers.deserialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ) as ValidatedValue?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CompoundValueNoAutoNestingSerializer
+    implements StructuredSerializer<CompoundValueNoAutoNesting> {
+  @override
+  final Iterable<Type> types = const [
+    CompoundValueNoAutoNesting,
+    _$CompoundValueNoAutoNesting,
+  ];
+  @override
+  final String wireName = 'CompoundValueNoAutoNesting';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    CompoundValueNoAutoNesting object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(
+        object.value,
+        specifiedType: const FullType(NoFieldsValue),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  CompoundValueNoAutoNesting deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CompoundValueNoAutoNestingBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              (serializers.deserialize(
+                        value,
+                        specifiedType: const FullType(NoFieldsValue),
+                      )!
+                      as NoFieldsValue)
+                  .toBuilder();
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CompoundValueComparableBuildersSerializer
+    implements StructuredSerializer<CompoundValueComparableBuilders> {
+  @override
+  final Iterable<Type> types = const [
+    CompoundValueComparableBuilders,
+    _$CompoundValueComparableBuilders,
+  ];
+  @override
+  final String wireName = 'CompoundValueComparableBuilders';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    CompoundValueComparableBuilders object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'simpleValue',
+      serializers.serialize(
+        object.simpleValue,
+        specifiedType: const FullType(SimpleValue),
+      ),
+    ];
+    Object? value;
+    value = object.validatedValue;
+    if (value != null) {
+      result
+        ..add('validatedValue')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  CompoundValueComparableBuilders deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CompoundValueComparableBuildersBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'simpleValue':
+          result.simpleValue =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(SimpleValue),
+                  )!
+                  as SimpleValue;
+          break;
+        case 'validatedValue':
+          result.validatedValue = serializers.deserialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ) as ValidatedValue?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CompoundValueNoNestingFieldSerializer
+    implements StructuredSerializer<CompoundValueNoNestingField> {
+  @override
+  final Iterable<Type> types = const [
+    CompoundValueNoNestingField,
+    _$CompoundValueNoNestingField,
+  ];
+  @override
+  final String wireName = 'CompoundValueNoNestingField';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    CompoundValueNoNestingField object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'simpleValue',
+      serializers.serialize(
+        object.simpleValue,
+        specifiedType: const FullType(SimpleValue),
+      ),
+      'simpleValueWithNested',
+      serializers.serialize(
+        object.simpleValueWithNested,
+        specifiedType: const FullType(SimpleValue),
+      ),
+    ];
+    Object? value;
+    value = object.validatedValue;
+    if (value != null) {
+      result
+        ..add('validatedValue')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ),
+        );
+    }
+    value = object.validatedValueWithNested;
+    if (value != null) {
+      result
+        ..add('validatedValueWithNested')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  CompoundValueNoNestingField deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CompoundValueNoNestingFieldBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'simpleValue':
+          result.simpleValue =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(SimpleValue),
+                  )!
+                  as SimpleValue;
+          break;
+        case 'validatedValue':
+          result.validatedValue = serializers.deserialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ) as ValidatedValue?;
+          break;
+        case 'simpleValueWithNested':
+          result.simpleValueWithNested.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+        case 'validatedValueWithNested':
+          result.validatedValueWithNested.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(ValidatedValue),
+                )!
+                as ValidatedValue,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CompoundValueNestingFieldSerializer
+    implements StructuredSerializer<CompoundValueNestingField> {
+  @override
+  final Iterable<Type> types = const [
+    CompoundValueNestingField,
+    _$CompoundValueNestingField,
+  ];
+  @override
+  final String wireName = 'CompoundValueNestingField';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    CompoundValueNestingField object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'simpleValue',
+      serializers.serialize(
+        object.simpleValue,
+        specifiedType: const FullType(SimpleValue),
+      ),
+      'simpleValueWithNested',
+      serializers.serialize(
+        object.simpleValueWithNested,
+        specifiedType: const FullType(SimpleValue),
+      ),
+    ];
+    Object? value;
+    value = object.validatedValue;
+    if (value != null) {
+      result
+        ..add('validatedValue')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ),
+        );
+    }
+    value = object.validatedValueWithNested;
+    if (value != null) {
+      result
+        ..add('validatedValueWithNested')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  CompoundValueNestingField deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CompoundValueNestingFieldBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'simpleValue':
+          result.simpleValue =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(SimpleValue),
+                  )!
+                  as SimpleValue;
+          break;
+        case 'validatedValue':
+          result.validatedValue = serializers.deserialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ) as ValidatedValue?;
+          break;
+        case 'simpleValueWithNested':
+          result.simpleValueWithNested.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+        case 'validatedValueWithNested':
+          result.validatedValueWithNested.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(ValidatedValue),
+                )!
+                as ValidatedValue,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CompoundValueNoAutoNestingFieldSerializer
+    implements StructuredSerializer<CompoundValueNoAutoNestingField> {
+  @override
+  final Iterable<Type> types = const [
+    CompoundValueNoAutoNestingField,
+    _$CompoundValueNoAutoNestingField,
+  ];
+  @override
+  final String wireName = 'CompoundValueNoAutoNestingField';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    CompoundValueNoAutoNestingField object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(
+        object.value,
+        specifiedType: const FullType(NoFieldsValue),
+      ),
+      'valueWithAutoCreate',
+      serializers.serialize(
+        object.valueWithAutoCreate,
+        specifiedType: const FullType(NoFieldsValue),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  CompoundValueNoAutoNestingField deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CompoundValueNoAutoNestingFieldBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              (serializers.deserialize(
+                        value,
+                        specifiedType: const FullType(NoFieldsValue),
+                      )!
+                      as NoFieldsValue)
+                  .toBuilder();
+          break;
+        case 'valueWithAutoCreate':
+          result.valueWithAutoCreate.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(NoFieldsValue),
+                )!
+                as NoFieldsValue,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CompoundValueAutoNestingFieldSerializer
+    implements StructuredSerializer<CompoundValueAutoNestingField> {
+  @override
+  final Iterable<Type> types = const [
+    CompoundValueAutoNestingField,
+    _$CompoundValueAutoNestingField,
+  ];
+  @override
+  final String wireName = 'CompoundValueAutoNestingField';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    CompoundValueAutoNestingField object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(
+        object.value,
+        specifiedType: const FullType(NoFieldsValue),
+      ),
+      'valueWithAutoCreate',
+      serializers.serialize(
+        object.valueWithAutoCreate,
+        specifiedType: const FullType(NoFieldsValue),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  CompoundValueAutoNestingField deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CompoundValueAutoNestingFieldBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(NoFieldsValue),
+                )!
+                as NoFieldsValue,
+          );
+          break;
+        case 'valueWithAutoCreate':
+          result.valueWithAutoCreate.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(NoFieldsValue),
+                )!
+                as NoFieldsValue,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CompoundValueExplicitNoNestingSerializer
+    implements StructuredSerializer<CompoundValueExplicitNoNesting> {
+  @override
+  final Iterable<Type> types = const [
+    CompoundValueExplicitNoNesting,
+    _$CompoundValueExplicitNoNesting,
+  ];
+  @override
+  final String wireName = 'CompoundValueExplicitNoNesting';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    CompoundValueExplicitNoNesting object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'simpleValue',
+      serializers.serialize(
+        object.simpleValue,
+        specifiedType: const FullType(SimpleValue),
+      ),
+    ];
+    Object? value;
+    value = object.validatedValue;
+    if (value != null) {
+      result
+        ..add('validatedValue')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  CompoundValueExplicitNoNesting deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = CompoundValueExplicitNoNestingBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'simpleValue':
+          result.simpleValue.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+        case 'validatedValue':
+          result.validatedValue = serializers.deserialize(
+            value,
+            specifiedType: const FullType(ValidatedValue),
+          ) as ValidatedValue?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ValidatedValueSerializer
+    implements StructuredSerializer<ValidatedValue> {
+  @override
+  final Iterable<Type> types = const [ValidatedValue, _$ValidatedValue];
+  @override
+  final String wireName = 'ValidatedValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    ValidatedValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.aString;
+    if (value != null) {
+      result
+        ..add('aString')
+        ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)),
+        );
+    }
+    return result;
+  }
+
+  @override
+  ValidatedValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = ValidatedValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'anInt':
+          result.anInt =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+        case 'aString':
+          result.aString = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ValueUsingImportAsSerializer
+    implements StructuredSerializer<ValueUsingImportAs> {
+  @override
+  final Iterable<Type> types = const [ValueUsingImportAs, _$ValueUsingImportAs];
+  @override
+  final String wireName = 'ValueUsingImportAs';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    ValueUsingImportAs object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(
+        object.value,
+        specifiedType: const FullType(using_import_as.TestEnum),
+      ),
+    ];
+    Object? value;
+    value = object.nullableValue;
+    if (value != null) {
+      result
+        ..add('nullableValue')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(using_import_as.TestEnum),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  ValueUsingImportAs deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = ValueUsingImportAsBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(using_import_as.TestEnum),
+                  )!
+                  as using_import_as.TestEnum;
+          break;
+        case 'nullableValue':
+          result.nullableValue = serializers.deserialize(
+            value,
+            specifiedType: const FullType(using_import_as.TestEnum),
+          ) as using_import_as.TestEnum?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$NoFieldsValueSerializer implements StructuredSerializer<NoFieldsValue> {
+  @override
+  final Iterable<Type> types = const [NoFieldsValue, _$NoFieldsValue];
+  @override
+  final String wireName = 'NoFieldsValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    NoFieldsValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return <Object?>[];
+  }
+
+  @override
+  NoFieldsValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    return NoFieldsValueBuilder().build();
+  }
+}
+
+class _$PrimitivesValueSerializer
+    implements StructuredSerializer<PrimitivesValue> {
+  @override
+  final Iterable<Type> types = const [PrimitivesValue, _$PrimitivesValue];
+  @override
+  final String wireName = 'PrimitivesValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    PrimitivesValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'boolean',
+      serializers.serialize(
+        object.boolean,
+        specifiedType: const FullType(bool),
+      ),
+      'integer',
+      serializers.serialize(object.integer, specifiedType: const FullType(int)),
+      'int64',
+      serializers.serialize(object.int64, specifiedType: const FullType(Int64)),
+      'dbl',
+      serializers.serialize(object.dbl, specifiedType: const FullType(double)),
+      'number',
+      serializers.serialize(object.number, specifiedType: const FullType(num)),
+      'string',
+      serializers.serialize(
+        object.string,
+        specifiedType: const FullType(String),
+      ),
+      'dateTime',
+      serializers.serialize(
+        object.dateTime,
+        specifiedType: const FullType(DateTime),
+      ),
+      'duration',
+      serializers.serialize(
+        object.duration,
+        specifiedType: const FullType(Duration),
+      ),
+      'regExp',
+      serializers.serialize(
+        object.regExp,
+        specifiedType: const FullType(RegExp),
+      ),
+      'uri',
+      serializers.serialize(object.uri, specifiedType: const FullType(Uri)),
+      'bigInt',
+      serializers.serialize(
+        object.bigInt,
+        specifiedType: const FullType(BigInt),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  PrimitivesValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = PrimitivesValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'boolean':
+          result.boolean =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(bool),
+                  )!
+                  as bool;
+          break;
+        case 'integer':
+          result.integer =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+        case 'int64':
+          result.int64 =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(Int64),
+                  )!
+                  as Int64;
+          break;
+        case 'dbl':
+          result.dbl =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(double),
+                  )!
+                  as double;
+          break;
+        case 'number':
+          result.number =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(num),
+                  )!
+                  as num;
+          break;
+        case 'string':
+          result.string =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(String),
+                  )!
+                  as String;
+          break;
+        case 'dateTime':
+          result.dateTime =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(DateTime),
+                  )!
+                  as DateTime;
+          break;
+        case 'duration':
+          result.duration =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(Duration),
+                  )!
+                  as Duration;
+          break;
+        case 'regExp':
+          result.regExp =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(RegExp),
+                  )!
+                  as RegExp;
+          break;
+        case 'uri':
+          result.uri =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(Uri),
+                  )!
+                  as Uri;
+          break;
+        case 'bigInt':
+          result.bigInt =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(BigInt),
+                  )!
+                  as BigInt;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PartiallySerializableValueSerializer
+    implements StructuredSerializer<PartiallySerializableValue> {
+  @override
+  final Iterable<Type> types = const [
+    PartiallySerializableValue,
+    _$PartiallySerializableValue,
+  ];
+  @override
+  final String wireName = 'PartiallySerializableValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    PartiallySerializableValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PartiallySerializableValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = PartiallySerializableValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$NamedFactoryValueSerializer
+    implements StructuredSerializer<NamedFactoryValue> {
+  @override
+  final Iterable<Type> types = const [NamedFactoryValue, _$NamedFactoryValue];
+  @override
+  final String wireName = 'NamedFactoryValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    NamedFactoryValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  NamedFactoryValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = NamedFactoryValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$WireNameValueSerializer implements StructuredSerializer<WireNameValue> {
+  @override
+  final Iterable<Type> types = const [WireNameValue, _$WireNameValue];
+  @override
+  final String wireName = '\$V';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    WireNameValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      '\$v',
+      serializers.serialize(object.value, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  WireNameValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = WireNameValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '\$v':
+          result.value =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$FieldDiscoveryValueSerializer
+    implements StructuredSerializer<FieldDiscoveryValue> {
+  @override
+  final Iterable<Type> types = const [
+    FieldDiscoveryValue,
+    _$FieldDiscoveryValue,
+  ];
+  @override
+  final String wireName = 'FieldDiscoveryValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    FieldDiscoveryValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(
+        object.value,
+        specifiedType: const FullType(DiscoverableValue),
+      ),
+      'values',
+      serializers.serialize(
+        object.values,
+        specifiedType: const FullType(BuiltList, const [
+          const FullType(ThirdDiscoverableValue),
+        ]),
+      ),
+    ];
+    Object? value;
+    value = object.recursiveValue;
+    if (value != null) {
+      result
+        ..add('recursiveValue')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(FieldDiscoveryValue),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  FieldDiscoveryValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = FieldDiscoveryValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(DiscoverableValue),
+                )!
+                as DiscoverableValue,
+          );
+          break;
+        case 'values':
+          result.values.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(BuiltList, const [
+                    const FullType(ThirdDiscoverableValue),
+                  ]),
+                )!
+                as BuiltList<Object?>,
+          );
+          break;
+        case 'recursiveValue':
+          result.recursiveValue.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(FieldDiscoveryValue),
+                )!
+                as FieldDiscoveryValue,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$DiscoverableValueSerializer
+    implements StructuredSerializer<DiscoverableValue> {
+  @override
+  final Iterable<Type> types = const [DiscoverableValue, _$DiscoverableValue];
+  @override
+  final String wireName = 'DiscoverableValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    DiscoverableValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(
+        object.value,
+        specifiedType: const FullType(SecondDiscoverableValue),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  DiscoverableValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = DiscoverableValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SecondDiscoverableValue),
+                )!
+                as SecondDiscoverableValue,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SecondDiscoverableValueSerializer
+    implements StructuredSerializer<SecondDiscoverableValue> {
+  @override
+  final Iterable<Type> types = const [
+    SecondDiscoverableValue,
+    _$SecondDiscoverableValue,
+  ];
+  @override
+  final String wireName = 'SecondDiscoverableValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    SecondDiscoverableValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  SecondDiscoverableValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = SecondDiscoverableValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ThirdDiscoverableValueSerializer
+    implements StructuredSerializer<ThirdDiscoverableValue> {
+  @override
+  final Iterable<Type> types = const [
+    ThirdDiscoverableValue,
+    _$ThirdDiscoverableValue,
+  ];
+  @override
+  final String wireName = 'ThirdDiscoverableValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    ThirdDiscoverableValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ThirdDiscoverableValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = ThirdDiscoverableValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RecursiveValueASerializer
+    implements StructuredSerializer<RecursiveValueA> {
+  @override
+  final Iterable<Type> types = const [RecursiveValueA, _$RecursiveValueA];
+  @override
+  final String wireName = 'RecursiveValueA';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    RecursiveValueA object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(
+        object.value,
+        specifiedType: const FullType(RecursiveValueB),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  RecursiveValueA deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = RecursiveValueABuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(RecursiveValueB),
+                )!
+                as RecursiveValueB,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RecursiveValueBSerializer
+    implements StructuredSerializer<RecursiveValueB> {
+  @override
+  final Iterable<Type> types = const [RecursiveValueB, _$RecursiveValueB];
+  @override
+  final String wireName = 'RecursiveValueB';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    RecursiveValueB object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(
+        object.value,
+        specifiedType: const FullType(RecursiveValueA),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  RecursiveValueB deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = RecursiveValueBBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(RecursiveValueA),
+                )!
+                as RecursiveValueA,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$OtherValueSerializer implements StructuredSerializer<OtherValue> {
+  @override
+  final Iterable<Type> types = const [OtherValue, _$OtherValue];
+  @override
+  final String wireName = 'OtherValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    OtherValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'other',
+      serializers.serialize(object.other, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  OtherValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = OtherValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'other':
+          result.other =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$DefaultsForFieldSettingsValueSerializer
+    implements StructuredSerializer<DefaultsForFieldSettingsValue> {
+  @override
+  final Iterable<Type> types = const [
+    DefaultsForFieldSettingsValue,
+    _$DefaultsForFieldSettingsValue,
+  ];
+  @override
+  final String wireName = 'DefaultsForFieldSettingsValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    DefaultsForFieldSettingsValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'serialized',
+      serializers.serialize(
+        object.serialized,
+        specifiedType: const FullType(int),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  DefaultsForFieldSettingsValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = DefaultsForFieldSettingsValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'serialized':
+          result.serialized =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ValueWithBuilderInitializerSerializer
+    implements StructuredSerializer<ValueWithBuilderInitializer> {
+  @override
+  final Iterable<Type> types = const [
+    ValueWithBuilderInitializer,
+    _$ValueWithBuilderInitializer,
+  ];
+  @override
+  final String wireName = 'ValueWithBuilderInitializer';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    ValueWithBuilderInitializer object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+      'anIntWithDefault',
+      serializers.serialize(
+        object.anIntWithDefault,
+        specifiedType: const FullType(int),
+      ),
+      'nestedValue',
+      serializers.serialize(
+        object.nestedValue,
+        specifiedType: const FullType(SimpleValue),
+      ),
+      'nestedValueWithDefault',
+      serializers.serialize(
+        object.nestedValueWithDefault,
+        specifiedType: const FullType(SimpleValue),
+      ),
+    ];
+    Object? value;
+    value = object.nullableInt;
+    if (value != null) {
+      result
+        ..add('nullableInt')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.nullableIntWithDefault;
+    if (value != null) {
+      result
+        ..add('nullableIntWithDefault')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.nullableNestedValue;
+    if (value != null) {
+      result
+        ..add('nullableNestedValue')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(SimpleValue),
+          ),
+        );
+    }
+    value = object.nullableNestedValueWithDefault;
+    if (value != null) {
+      result
+        ..add('nullableNestedValueWithDefault')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(SimpleValue),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  ValueWithBuilderInitializer deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = ValueWithBuilderInitializerBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'anInt':
+          result.anInt =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+        case 'anIntWithDefault':
+          result.anIntWithDefault =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+        case 'nullableInt':
+          result.nullableInt = serializers.deserialize(
+            value,
+            specifiedType: const FullType(int),
+          ) as int?;
+          break;
+        case 'nullableIntWithDefault':
+          result.nullableIntWithDefault = serializers.deserialize(
+            value,
+            specifiedType: const FullType(int),
+          ) as int?;
+          break;
+        case 'nestedValue':
+          result.nestedValue.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+        case 'nestedValueWithDefault':
+          result.nestedValueWithDefault.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+        case 'nullableNestedValue':
+          result.nullableNestedValue.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+        case 'nullableNestedValueWithDefault':
+          result.nullableNestedValueWithDefault.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ValueWithBuilderFinalizerSerializer
+    implements StructuredSerializer<ValueWithBuilderFinalizer> {
+  @override
+  final Iterable<Type> types = const [
+    ValueWithBuilderFinalizer,
+    _$ValueWithBuilderFinalizer,
+  ];
+  @override
+  final String wireName = 'ValueWithBuilderFinalizer';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    ValueWithBuilderFinalizer object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ValueWithBuilderFinalizer deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = ValueWithBuilderFinalizerBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'anInt':
+          result.anInt =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SerializesNullsValueSerializer
+    implements StructuredSerializer<SerializesNullsValue> {
+  @override
+  final Iterable<Type> types = const [
+    SerializesNullsValue,
+    _$SerializesNullsValue,
+  ];
+  @override
+  final String wireName = 'SerializesNullsValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    SerializesNullsValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.value;
+
+    result
+      ..add('value')
+      ..add(
+        serializers.serialize(value, specifiedType: const FullType(String)),
+      );
+
+    return result;
+  }
+
+  @override
+  SerializesNullsValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = SerializesNullsValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$NullableObjectValueSerializer
+    implements StructuredSerializer<NullableObjectValue> {
+  @override
+  final Iterable<Type> types = const [
+    NullableObjectValue,
+    _$NullableObjectValue,
+  ];
+  @override
+  final String wireName = 'NullableObjectValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    NullableObjectValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.value;
+    if (value != null) {
+      result
+        ..add('value')
+        ..add(
+          serializers.serialize(value, specifiedType: const FullType(Object)),
+        );
+    }
+    return result;
+  }
+
+  @override
+  NullableObjectValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = NullableObjectValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value = serializers.deserialize(
+            value,
+            specifiedType: const FullType(Object),
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ValueWithHooksSerializer
+    implements StructuredSerializer<ValueWithHooks> {
+  @override
+  final Iterable<Type> types = const [ValueWithHooks, _$ValueWithHooks];
+  @override
+  final String wireName = 'ValueWithHooks';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    ValueWithHooks object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'hook1Count',
+      serializers.serialize(
+        object.hook1Count,
+        specifiedType: const FullType(int),
+      ),
+      'hook2Count',
+      serializers.serialize(
+        object.hook2Count,
+        specifiedType: const FullType(int),
+      ),
+      'hookOrdering',
+      serializers.serialize(
+        object.hookOrdering,
+        specifiedType: const FullType(BuiltList, const [
+          const FullType(String),
+        ]),
+      ),
+    ];
+
+    return result;
+  }
+
+  @override
+  ValueWithHooks deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = ValueWithHooksBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'hook1Count':
+          result.hook1Count =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+        case 'hook2Count':
+          result.hook2Count =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+        case 'hookOrdering':
+          result.hookOrdering.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(BuiltList, const [
+                    const FullType(String),
+                  ]),
+                )!
+                as BuiltList<Object?>,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$$ValueSpecialSerializer implements StructuredSerializer<$ValueSpecial> {
+  @override
+  final Iterable<Type> types = const [$ValueSpecial, _$$ValueSpecial];
+  @override
+  final String wireName = '\$ValueSpecial';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    $ValueSpecial object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.aString;
+    if (value != null) {
+      result
+        ..add('aString')
+        ..add(
+          serializers.serialize(value, specifiedType: const FullType(String)),
+        );
+    }
+    value = object.$mustBeEscaped;
+    if (value != null) {
+      result
+        ..add('\$mustBeEscaped')
+        ..add(
+          serializers.serialize(value, specifiedType: const FullType(bool)),
+        );
+    }
+    value = object.$mustAlsoEscaped;
+    if (value != null) {
+      result
+        ..add('\$mustAlsoEscaped')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(SimpleValue),
+          ),
+        );
+    }
+    value = object.$assert;
+    if (value != null) {
+      result
+        ..add('\$assert')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(SimpleValue),
+          ),
+        );
+    }
+    value = object.$10;
+    if (value != null) {
+      result
+        ..add('\$10')
+        ..add(
+          serializers.serialize(
+            value,
+            specifiedType: const FullType(SimpleValue),
+          ),
+        );
+    }
+    return result;
+  }
+
+  @override
+  $ValueSpecial deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = $ValueSpecialBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'anInt':
+          result.anInt =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+        case 'aString':
+          result.aString = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String?;
+          break;
+        case '\$mustBeEscaped':
+          result.$mustBeEscaped = serializers.deserialize(
+            value,
+            specifiedType: const FullType(bool),
+          ) as bool?;
+          break;
+        case '\$mustAlsoEscaped':
+          result.$mustAlsoEscaped.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+        case '\$assert':
+          result.$assert.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+        case '\$10':
+          result.$10.replace(
+            serializers.deserialize(
+                  value,
+                  specifiedType: const FullType(SimpleValue),
+                )!
+                as SimpleValue,
+          );
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ValueWithAwkwardNestedBuilderSerializer
+    implements StructuredSerializer<ValueWithAwkwardNestedBuilder> {
+  @override
+  final Iterable<Type> types = const [
+    ValueWithAwkwardNestedBuilder,
+    _$ValueWithAwkwardNestedBuilder,
+  ];
+  @override
+  final String wireName = 'ValueWithAwkwardNestedBuilder';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    ValueWithAwkwardNestedBuilder object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'values',
+      serializers.serialize(
+        object.values,
+        specifiedType: const FullType(BuiltList, const [const FullType(int)]),
+      ),
+      'map',
+      serializers.serialize(
+        object.map,
+        specifiedType: const FullType(BuiltMap, const [
+          const FullType(int),
+          const FullType(String),
+        ]),
+      ),
+    ];
+    Object? value;
+    value = object.value1;
+
+    result
+      ..add('value1')
+      ..add(
+        serializers.serialize(
+          value,
+          specifiedType: const FullType(SimpleValue),
+        ),
+      );
+    value = object.value2;
+
+    result
+      ..add('value2')
+      ..add(
+        serializers.serialize(
+          value,
+          specifiedType: const FullType(SimpleValue),
+        ),
+      );
+
+    return result;
+  }
+
+  @override
+  ValueWithAwkwardNestedBuilder deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    T $cast<T>(dynamic any) => any as T;
+
+    final result = ValueWithAwkwardNestedBuilderBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value1':
+          var maybeBuilder = result.value1;
+          var fieldValue =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(SimpleValue),
+                  )!
+                  as SimpleValue;
+          if (maybeBuilder == null) {
+            result.value1 = $cast(fieldValue.toBuilder());
+          } else {
+            maybeBuilder.replace(fieldValue);
+          }
+          break;
+        case 'value2':
+          var maybeBuilder = result.value2;
+          var fieldValue =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(SimpleValue),
+                  )!
+                  as SimpleValue;
+          if (maybeBuilder == null) {
+            result.value2 = $cast(fieldValue.toBuilder());
+          } else {
+            maybeBuilder.replace(fieldValue);
+          }
+          break;
+        case 'values':
+          var maybeBuilder = result.values;
+          var fieldValue =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(BuiltList, const [
+                      const FullType(int),
+                    ]),
+                  )!
+                  as BuiltList<int>;
+          if (maybeBuilder == null) {
+            result.values = $cast(fieldValue.toBuilder());
+          } else {
+            maybeBuilder.replace(fieldValue);
+          }
+          break;
+        case 'map':
+          var maybeBuilder = result.map;
+          var fieldValue =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(BuiltMap, const [
+                      const FullType(int),
+                      const FullType(String),
+                    ]),
+                  )!
+                  as BuiltMap<int, String>;
+          if (maybeBuilder == null) {
+            result.map = $cast(fieldValue.toBuilder());
+          } else {
+            maybeBuilder.replace(fieldValue);
+          }
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$NewConstructorValueSerializer
+    implements StructuredSerializer<NewConstructorValue> {
+  @override
+  final Iterable<Type> types = const [
+    NewConstructorValue,
+    _$NewConstructorValue,
+  ];
+  @override
+  final String wireName = 'NewConstructorValue';
+
+  @override
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    NewConstructorValue object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  NewConstructorValue deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = NewConstructorValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'anInt':
+          result.anInt =
+              serializers.deserialize(
+                    value,
+                    specifiedType: const FullType(int),
+                  )!
+                  as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SimpleValue extends SimpleValue {
+  @override
+  final int anInt;
+  @override
+  final String? aString;
+  @override
+  final bool? $mustBeEscaped;
+
+  factory _$SimpleValue([void Function(SimpleValueBuilder)? updates]) =>
+      (SimpleValueBuilder()..update(updates))._build();
+
+  _$SimpleValue._({required this.anInt, this.aString, this.$mustBeEscaped})
+    : super._();
+  @override
+  SimpleValue rebuild(void Function(SimpleValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SimpleValueBuilder toBuilder() => SimpleValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SimpleValue &&
+        anInt == other.anInt &&
+        aString == other.aString &&
+        $mustBeEscaped == other.$mustBeEscaped;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, aString.hashCode);
+    _$hash = $jc(_$hash, $mustBeEscaped.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SimpleValue')
+          ..add('anInt', anInt)
+          ..add('aString', aString)
+          ..add('\$mustBeEscaped', $mustBeEscaped))
+        .toString();
+  }
+}
+
+class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
+  _$SimpleValue? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  String? _aString;
+  String? get aString => _$this._aString;
+  set aString(String? aString) => _$this._aString = aString;
+
+  bool? _$mustBeEscaped;
+  bool? get $mustBeEscaped => _$this._$mustBeEscaped;
+  set $mustBeEscaped(bool? $mustBeEscaped) =>
+      _$this._$mustBeEscaped = $mustBeEscaped;
+
+  SimpleValueBuilder();
+
+  SimpleValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _aString = $v.aString;
+      _$mustBeEscaped = $v.$mustBeEscaped;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SimpleValue other) {
+    _$v = other as _$SimpleValue;
+  }
+
+  @override
+  void update(void Function(SimpleValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SimpleValue build() => _build();
+
+  _$SimpleValue _build() {
+    final _$result =
+        _$v ??
+        _$SimpleValue._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+            anInt,
+            r'SimpleValue',
+            'anInt',
+          ),
+          aString: aString,
+          $mustBeEscaped: $mustBeEscaped,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CompoundValue extends CompoundValue {
+  @override
+  final SimpleValue simpleValue;
+  @override
+  final ValidatedValue? validatedValue;
+
+  factory _$CompoundValue([void Function(CompoundValueBuilder)? updates]) =>
+      (CompoundValueBuilder()..update(updates))._build();
+
+  _$CompoundValue._({required this.simpleValue, this.validatedValue})
+    : super._();
+  @override
+  CompoundValue rebuild(void Function(CompoundValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CompoundValueBuilder toBuilder() => CompoundValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValue &&
+        simpleValue == other.simpleValue &&
+        validatedValue == other.validatedValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, validatedValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CompoundValue')
+          ..add('simpleValue', simpleValue)
+          ..add('validatedValue', validatedValue))
+        .toString();
+  }
+}
+
+class CompoundValueBuilder
+    implements Builder<CompoundValue, CompoundValueBuilder> {
+  _$CompoundValue? _$v;
+
+  SimpleValueBuilder? _simpleValue;
+  SimpleValueBuilder get simpleValue =>
+      _$this._simpleValue ??= SimpleValueBuilder();
+  set simpleValue(SimpleValueBuilder? simpleValue) =>
+      _$this._simpleValue = simpleValue;
+
+  ValidatedValueBuilder? _validatedValue;
+  ValidatedValueBuilder get validatedValue =>
+      _$this._validatedValue ??= ValidatedValueBuilder();
+  set validatedValue(ValidatedValueBuilder? validatedValue) =>
+      _$this._validatedValue = validatedValue;
+
+  CompoundValueBuilder();
+
+  CompoundValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _simpleValue = $v.simpleValue.toBuilder();
+      _validatedValue = $v.validatedValue?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValue other) {
+    _$v = other as _$CompoundValue;
+  }
+
+  @override
+  void update(void Function(CompoundValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValue build() => _build();
+
+  _$CompoundValue _build() {
+    _$CompoundValue _$result;
+    try {
+      _$result =
+          _$v ??
+          _$CompoundValue._(
+            simpleValue: simpleValue.build(),
+            validatedValue: _validatedValue?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        simpleValue.build();
+        _$failedField = 'validatedValue';
+        _validatedValue?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'CompoundValue',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CompoundValueNoNesting extends CompoundValueNoNesting {
+  @override
+  final SimpleValue simpleValue;
+  @override
+  final ValidatedValue? validatedValue;
+
+  factory _$CompoundValueNoNesting([
+    void Function(CompoundValueNoNestingBuilder)? updates,
+  ]) => (CompoundValueNoNestingBuilder()..update(updates))._build();
+
+  _$CompoundValueNoNesting._({required this.simpleValue, this.validatedValue})
+    : super._();
+  @override
+  CompoundValueNoNesting rebuild(
+    void Function(CompoundValueNoNestingBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  CompoundValueNoNestingBuilder toBuilder() =>
+      CompoundValueNoNestingBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValueNoNesting &&
+        simpleValue == other.simpleValue &&
+        validatedValue == other.validatedValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, validatedValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CompoundValueNoNesting')
+          ..add('simpleValue', simpleValue)
+          ..add('validatedValue', validatedValue))
+        .toString();
+  }
+}
+
+class CompoundValueNoNestingBuilder
+    implements Builder<CompoundValueNoNesting, CompoundValueNoNestingBuilder> {
+  _$CompoundValueNoNesting? _$v;
+
+  SimpleValue? _simpleValue;
+  SimpleValue? get simpleValue => _$this._simpleValue;
+  set simpleValue(SimpleValue? simpleValue) =>
+      _$this._simpleValue = simpleValue;
+
+  ValidatedValue? _validatedValue;
+  ValidatedValue? get validatedValue => _$this._validatedValue;
+  set validatedValue(ValidatedValue? validatedValue) =>
+      _$this._validatedValue = validatedValue;
+
+  CompoundValueNoNestingBuilder();
+
+  CompoundValueNoNestingBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _simpleValue = $v.simpleValue;
+      _validatedValue = $v.validatedValue;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValueNoNesting other) {
+    _$v = other as _$CompoundValueNoNesting;
+  }
+
+  @override
+  void update(void Function(CompoundValueNoNestingBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValueNoNesting build() => _build();
+
+  _$CompoundValueNoNesting _build() {
+    final _$result =
+        _$v ??
+        _$CompoundValueNoNesting._(
+          simpleValue: BuiltValueNullFieldError.checkNotNull(
+            simpleValue,
+            r'CompoundValueNoNesting',
+            'simpleValue',
+          ),
+          validatedValue: validatedValue,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CompoundValueNoAutoNesting extends CompoundValueNoAutoNesting {
+  @override
+  final NoFieldsValue value;
+
+  factory _$CompoundValueNoAutoNesting([
+    void Function(CompoundValueNoAutoNestingBuilder)? updates,
+  ]) => (CompoundValueNoAutoNestingBuilder()..update(updates))._build();
+
+  _$CompoundValueNoAutoNesting._({required this.value}) : super._();
+  @override
+  CompoundValueNoAutoNesting rebuild(
+    void Function(CompoundValueNoAutoNestingBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  CompoundValueNoAutoNestingBuilder toBuilder() =>
+      CompoundValueNoAutoNestingBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValueNoAutoNesting && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'CompoundValueNoAutoNesting',
+    )..add('value', value)).toString();
+  }
+}
+
+class CompoundValueNoAutoNestingBuilder
+    implements
+        Builder<CompoundValueNoAutoNesting, CompoundValueNoAutoNestingBuilder> {
+  _$CompoundValueNoAutoNesting? _$v;
+
+  NoFieldsValueBuilder? _value;
+  NoFieldsValueBuilder? get value => _$this._value;
+  set value(NoFieldsValueBuilder? value) => _$this._value = value;
+
+  CompoundValueNoAutoNestingBuilder();
+
+  CompoundValueNoAutoNestingBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValueNoAutoNesting other) {
+    _$v = other as _$CompoundValueNoAutoNesting;
+  }
+
+  @override
+  void update(void Function(CompoundValueNoAutoNestingBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValueNoAutoNesting build() => _build();
+
+  _$CompoundValueNoAutoNesting _build() {
+    _$CompoundValueNoAutoNesting _$result;
+    try {
+      _$result =
+          _$v ??
+          _$CompoundValueNoAutoNesting._(
+            value: BuiltValueNullFieldError.checkNotNull(
+              _value?.build(),
+              r'CompoundValueNoAutoNesting',
+              'value',
+            ),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value';
+        _value?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'CompoundValueNoAutoNesting',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CompoundValueComparableBuilders
+    extends CompoundValueComparableBuilders {
+  @override
+  final SimpleValue simpleValue;
+  @override
+  final ValidatedValue? validatedValue;
+
+  factory _$CompoundValueComparableBuilders([
+    void Function(CompoundValueComparableBuildersBuilder)? updates,
+  ]) => (CompoundValueComparableBuildersBuilder()..update(updates))._build();
+
+  _$CompoundValueComparableBuilders._({
+    required this.simpleValue,
+    this.validatedValue,
+  }) : super._();
+  @override
+  CompoundValueComparableBuilders rebuild(
+    void Function(CompoundValueComparableBuildersBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  CompoundValueComparableBuildersBuilder toBuilder() =>
+      CompoundValueComparableBuildersBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValueComparableBuilders &&
+        simpleValue == other.simpleValue &&
+        validatedValue == other.validatedValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, validatedValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CompoundValueComparableBuilders')
+          ..add('simpleValue', simpleValue)
+          ..add('validatedValue', validatedValue))
+        .toString();
+  }
+}
+
+class CompoundValueComparableBuildersBuilder
+    implements
+        Builder<
+          CompoundValueComparableBuilders,
+          CompoundValueComparableBuildersBuilder
+        > {
+  _$CompoundValueComparableBuilders? _$v;
+
+  SimpleValue? _simpleValue;
+  SimpleValue? get simpleValue => _$this._simpleValue;
+  set simpleValue(SimpleValue? simpleValue) =>
+      _$this._simpleValue = simpleValue;
+
+  ValidatedValue? _validatedValue;
+  ValidatedValue? get validatedValue => _$this._validatedValue;
+  set validatedValue(ValidatedValue? validatedValue) =>
+      _$this._validatedValue = validatedValue;
+
+  CompoundValueComparableBuildersBuilder();
+
+  CompoundValueComparableBuildersBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _simpleValue = $v.simpleValue;
+      _validatedValue = $v.validatedValue;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValueComparableBuilders other) {
+    _$v = other as _$CompoundValueComparableBuilders;
+  }
+
+  @override
+  void update(void Function(CompoundValueComparableBuildersBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValueComparableBuilders build() => _build();
+
+  _$CompoundValueComparableBuilders _build() {
+    final _$result =
+        _$v ??
+        _$CompoundValueComparableBuilders._(
+          simpleValue: BuiltValueNullFieldError.checkNotNull(
+            simpleValue,
+            r'CompoundValueComparableBuilders',
+            'simpleValue',
+          ),
+          validatedValue: validatedValue,
+        );
+    replace(_$result);
+    return _$result;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValueComparableBuildersBuilder &&
+        simpleValue == other.simpleValue &&
+        validatedValue == other.validatedValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 1;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, validatedValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+}
+
+class _$CompoundValueNoNestingField extends CompoundValueNoNestingField {
+  @override
+  final SimpleValue simpleValue;
+  @override
+  final ValidatedValue? validatedValue;
+  @override
+  final SimpleValue simpleValueWithNested;
+  @override
+  final ValidatedValue? validatedValueWithNested;
+
+  factory _$CompoundValueNoNestingField([
+    void Function(CompoundValueNoNestingFieldBuilder)? updates,
+  ]) => (CompoundValueNoNestingFieldBuilder()..update(updates))._build();
+
+  _$CompoundValueNoNestingField._({
+    required this.simpleValue,
+    this.validatedValue,
+    required this.simpleValueWithNested,
+    this.validatedValueWithNested,
+  }) : super._();
+  @override
+  CompoundValueNoNestingField rebuild(
+    void Function(CompoundValueNoNestingFieldBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  CompoundValueNoNestingFieldBuilder toBuilder() =>
+      CompoundValueNoNestingFieldBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValueNoNestingField &&
+        simpleValue == other.simpleValue &&
+        validatedValue == other.validatedValue &&
+        simpleValueWithNested == other.simpleValueWithNested &&
+        validatedValueWithNested == other.validatedValueWithNested;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, validatedValue.hashCode);
+    _$hash = $jc(_$hash, simpleValueWithNested.hashCode);
+    _$hash = $jc(_$hash, validatedValueWithNested.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CompoundValueNoNestingField')
+          ..add('simpleValue', simpleValue)
+          ..add('validatedValue', validatedValue)
+          ..add('simpleValueWithNested', simpleValueWithNested)
+          ..add('validatedValueWithNested', validatedValueWithNested))
+        .toString();
+  }
+}
+
+class CompoundValueNoNestingFieldBuilder
+    implements
+        Builder<
+          CompoundValueNoNestingField,
+          CompoundValueNoNestingFieldBuilder
+        > {
+  _$CompoundValueNoNestingField? _$v;
+
+  SimpleValue? _simpleValue;
+  SimpleValue? get simpleValue => _$this._simpleValue;
+  set simpleValue(SimpleValue? simpleValue) =>
+      _$this._simpleValue = simpleValue;
+
+  ValidatedValue? _validatedValue;
+  ValidatedValue? get validatedValue => _$this._validatedValue;
+  set validatedValue(ValidatedValue? validatedValue) =>
+      _$this._validatedValue = validatedValue;
+
+  SimpleValueBuilder? _simpleValueWithNested;
+  SimpleValueBuilder get simpleValueWithNested =>
+      _$this._simpleValueWithNested ??= SimpleValueBuilder();
+  set simpleValueWithNested(SimpleValueBuilder? simpleValueWithNested) =>
+      _$this._simpleValueWithNested = simpleValueWithNested;
+
+  ValidatedValueBuilder? _validatedValueWithNested;
+  ValidatedValueBuilder get validatedValueWithNested =>
+      _$this._validatedValueWithNested ??= ValidatedValueBuilder();
+  set validatedValueWithNested(
+    ValidatedValueBuilder? validatedValueWithNested,
+  ) => _$this._validatedValueWithNested = validatedValueWithNested;
+
+  CompoundValueNoNestingFieldBuilder();
+
+  CompoundValueNoNestingFieldBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _simpleValue = $v.simpleValue;
+      _validatedValue = $v.validatedValue;
+      _simpleValueWithNested = $v.simpleValueWithNested.toBuilder();
+      _validatedValueWithNested = $v.validatedValueWithNested?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValueNoNestingField other) {
+    _$v = other as _$CompoundValueNoNestingField;
+  }
+
+  @override
+  void update(void Function(CompoundValueNoNestingFieldBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValueNoNestingField build() => _build();
+
+  _$CompoundValueNoNestingField _build() {
+    _$CompoundValueNoNestingField _$result;
+    try {
+      _$result =
+          _$v ??
+          _$CompoundValueNoNestingField._(
+            simpleValue: BuiltValueNullFieldError.checkNotNull(
+              simpleValue,
+              r'CompoundValueNoNestingField',
+              'simpleValue',
+            ),
+            validatedValue: validatedValue,
+            simpleValueWithNested: simpleValueWithNested.build(),
+            validatedValueWithNested: _validatedValueWithNested?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValueWithNested';
+        simpleValueWithNested.build();
+        _$failedField = 'validatedValueWithNested';
+        _validatedValueWithNested?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'CompoundValueNoNestingField',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CompoundValueNestingField extends CompoundValueNestingField {
+  @override
+  final SimpleValue simpleValue;
+  @override
+  final ValidatedValue? validatedValue;
+  @override
+  final SimpleValue simpleValueWithNested;
+  @override
+  final ValidatedValue? validatedValueWithNested;
+
+  factory _$CompoundValueNestingField([
+    void Function(CompoundValueNestingFieldBuilder)? updates,
+  ]) => (CompoundValueNestingFieldBuilder()..update(updates))._build();
+
+  _$CompoundValueNestingField._({
+    required this.simpleValue,
+    this.validatedValue,
+    required this.simpleValueWithNested,
+    this.validatedValueWithNested,
+  }) : super._();
+  @override
+  CompoundValueNestingField rebuild(
+    void Function(CompoundValueNestingFieldBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  CompoundValueNestingFieldBuilder toBuilder() =>
+      CompoundValueNestingFieldBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValueNestingField &&
+        simpleValue == other.simpleValue &&
+        validatedValue == other.validatedValue &&
+        simpleValueWithNested == other.simpleValueWithNested &&
+        validatedValueWithNested == other.validatedValueWithNested;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, validatedValue.hashCode);
+    _$hash = $jc(_$hash, simpleValueWithNested.hashCode);
+    _$hash = $jc(_$hash, validatedValueWithNested.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CompoundValueNestingField')
+          ..add('simpleValue', simpleValue)
+          ..add('validatedValue', validatedValue)
+          ..add('simpleValueWithNested', simpleValueWithNested)
+          ..add('validatedValueWithNested', validatedValueWithNested))
+        .toString();
+  }
+}
+
+class CompoundValueNestingFieldBuilder
+    implements
+        Builder<CompoundValueNestingField, CompoundValueNestingFieldBuilder> {
+  _$CompoundValueNestingField? _$v;
+
+  SimpleValue? _simpleValue;
+  SimpleValue? get simpleValue => _$this._simpleValue;
+  set simpleValue(SimpleValue? simpleValue) =>
+      _$this._simpleValue = simpleValue;
+
+  ValidatedValue? _validatedValue;
+  ValidatedValue? get validatedValue => _$this._validatedValue;
+  set validatedValue(ValidatedValue? validatedValue) =>
+      _$this._validatedValue = validatedValue;
+
+  SimpleValueBuilder? _simpleValueWithNested;
+  SimpleValueBuilder get simpleValueWithNested =>
+      _$this._simpleValueWithNested ??= SimpleValueBuilder();
+  set simpleValueWithNested(SimpleValueBuilder? simpleValueWithNested) =>
+      _$this._simpleValueWithNested = simpleValueWithNested;
+
+  ValidatedValueBuilder? _validatedValueWithNested;
+  ValidatedValueBuilder get validatedValueWithNested =>
+      _$this._validatedValueWithNested ??= ValidatedValueBuilder();
+  set validatedValueWithNested(
+    ValidatedValueBuilder? validatedValueWithNested,
+  ) => _$this._validatedValueWithNested = validatedValueWithNested;
+
+  CompoundValueNestingFieldBuilder();
+
+  CompoundValueNestingFieldBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _simpleValue = $v.simpleValue;
+      _validatedValue = $v.validatedValue;
+      _simpleValueWithNested = $v.simpleValueWithNested.toBuilder();
+      _validatedValueWithNested = $v.validatedValueWithNested?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValueNestingField other) {
+    _$v = other as _$CompoundValueNestingField;
+  }
+
+  @override
+  void update(void Function(CompoundValueNestingFieldBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValueNestingField build() => _build();
+
+  _$CompoundValueNestingField _build() {
+    _$CompoundValueNestingField _$result;
+    try {
+      _$result =
+          _$v ??
+          _$CompoundValueNestingField._(
+            simpleValue: BuiltValueNullFieldError.checkNotNull(
+              simpleValue,
+              r'CompoundValueNestingField',
+              'simpleValue',
+            ),
+            validatedValue: validatedValue,
+            simpleValueWithNested: simpleValueWithNested.build(),
+            validatedValueWithNested: _validatedValueWithNested?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValueWithNested';
+        simpleValueWithNested.build();
+        _$failedField = 'validatedValueWithNested';
+        _validatedValueWithNested?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'CompoundValueNestingField',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CompoundValueNoAutoNestingField
+    extends CompoundValueNoAutoNestingField {
+  @override
+  final NoFieldsValue value;
+  @override
+  final NoFieldsValue valueWithAutoCreate;
+
+  factory _$CompoundValueNoAutoNestingField([
+    void Function(CompoundValueNoAutoNestingFieldBuilder)? updates,
+  ]) => (CompoundValueNoAutoNestingFieldBuilder()..update(updates))._build();
+
+  _$CompoundValueNoAutoNestingField._({
+    required this.value,
+    required this.valueWithAutoCreate,
+  }) : super._();
+  @override
+  CompoundValueNoAutoNestingField rebuild(
+    void Function(CompoundValueNoAutoNestingFieldBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  CompoundValueNoAutoNestingFieldBuilder toBuilder() =>
+      CompoundValueNoAutoNestingFieldBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValueNoAutoNestingField &&
+        value == other.value &&
+        valueWithAutoCreate == other.valueWithAutoCreate;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, valueWithAutoCreate.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CompoundValueNoAutoNestingField')
+          ..add('value', value)
+          ..add('valueWithAutoCreate', valueWithAutoCreate))
+        .toString();
+  }
+}
+
+class CompoundValueNoAutoNestingFieldBuilder
+    implements
+        Builder<
+          CompoundValueNoAutoNestingField,
+          CompoundValueNoAutoNestingFieldBuilder
+        > {
+  _$CompoundValueNoAutoNestingField? _$v;
+
+  NoFieldsValueBuilder? _value;
+  NoFieldsValueBuilder? get value => _$this._value;
+  set value(NoFieldsValueBuilder? value) => _$this._value = value;
+
+  NoFieldsValueBuilder? _valueWithAutoCreate;
+  NoFieldsValueBuilder get valueWithAutoCreate =>
+      _$this._valueWithAutoCreate ??= NoFieldsValueBuilder();
+  set valueWithAutoCreate(NoFieldsValueBuilder? valueWithAutoCreate) =>
+      _$this._valueWithAutoCreate = valueWithAutoCreate;
+
+  CompoundValueNoAutoNestingFieldBuilder();
+
+  CompoundValueNoAutoNestingFieldBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value.toBuilder();
+      _valueWithAutoCreate = $v.valueWithAutoCreate.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValueNoAutoNestingField other) {
+    _$v = other as _$CompoundValueNoAutoNestingField;
+  }
+
+  @override
+  void update(void Function(CompoundValueNoAutoNestingFieldBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValueNoAutoNestingField build() => _build();
+
+  _$CompoundValueNoAutoNestingField _build() {
+    _$CompoundValueNoAutoNestingField _$result;
+    try {
+      _$result =
+          _$v ??
+          _$CompoundValueNoAutoNestingField._(
+            value: BuiltValueNullFieldError.checkNotNull(
+              _value?.build(),
+              r'CompoundValueNoAutoNestingField',
+              'value',
+            ),
+            valueWithAutoCreate: valueWithAutoCreate.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value';
+        _value?.build();
+        _$failedField = 'valueWithAutoCreate';
+        valueWithAutoCreate.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'CompoundValueNoAutoNestingField',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CompoundValueAutoNestingField extends CompoundValueAutoNestingField {
+  @override
+  final NoFieldsValue value;
+  @override
+  final NoFieldsValue valueWithAutoCreate;
+
+  factory _$CompoundValueAutoNestingField([
+    void Function(CompoundValueAutoNestingFieldBuilder)? updates,
+  ]) => (CompoundValueAutoNestingFieldBuilder()..update(updates))._build();
+
+  _$CompoundValueAutoNestingField._({
+    required this.value,
+    required this.valueWithAutoCreate,
+  }) : super._();
+  @override
+  CompoundValueAutoNestingField rebuild(
+    void Function(CompoundValueAutoNestingFieldBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  CompoundValueAutoNestingFieldBuilder toBuilder() =>
+      CompoundValueAutoNestingFieldBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValueAutoNestingField &&
+        value == other.value &&
+        valueWithAutoCreate == other.valueWithAutoCreate;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, valueWithAutoCreate.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CompoundValueAutoNestingField')
+          ..add('value', value)
+          ..add('valueWithAutoCreate', valueWithAutoCreate))
+        .toString();
+  }
+}
+
+class CompoundValueAutoNestingFieldBuilder
+    implements
+        Builder<
+          CompoundValueAutoNestingField,
+          CompoundValueAutoNestingFieldBuilder
+        > {
+  _$CompoundValueAutoNestingField? _$v;
+
+  NoFieldsValueBuilder? _value;
+  NoFieldsValueBuilder get value => _$this._value ??= NoFieldsValueBuilder();
+  set value(NoFieldsValueBuilder? value) => _$this._value = value;
+
+  NoFieldsValueBuilder? _valueWithAutoCreate;
+  NoFieldsValueBuilder get valueWithAutoCreate =>
+      _$this._valueWithAutoCreate ??= NoFieldsValueBuilder();
+  set valueWithAutoCreate(NoFieldsValueBuilder? valueWithAutoCreate) =>
+      _$this._valueWithAutoCreate = valueWithAutoCreate;
+
+  CompoundValueAutoNestingFieldBuilder();
+
+  CompoundValueAutoNestingFieldBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value.toBuilder();
+      _valueWithAutoCreate = $v.valueWithAutoCreate.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValueAutoNestingField other) {
+    _$v = other as _$CompoundValueAutoNestingField;
+  }
+
+  @override
+  void update(void Function(CompoundValueAutoNestingFieldBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValueAutoNestingField build() => _build();
+
+  _$CompoundValueAutoNestingField _build() {
+    _$CompoundValueAutoNestingField _$result;
+    try {
+      _$result =
+          _$v ??
+          _$CompoundValueAutoNestingField._(
+            value: value.build(),
+            valueWithAutoCreate: valueWithAutoCreate.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+        _$failedField = 'valueWithAutoCreate';
+        valueWithAutoCreate.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'CompoundValueAutoNestingField',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CompoundValueExplicitNoNesting extends CompoundValueExplicitNoNesting {
+  @override
+  final SimpleValue simpleValue;
+  @override
+  final ValidatedValue? validatedValue;
+
+  factory _$CompoundValueExplicitNoNesting([
+    void Function(CompoundValueExplicitNoNestingBuilder)? updates,
+  ]) =>
+      (CompoundValueExplicitNoNestingBuilder()..update(updates)).build()
+          as _$CompoundValueExplicitNoNesting;
+
+  _$CompoundValueExplicitNoNesting._({
+    required this.simpleValue,
+    this.validatedValue,
+  }) : super._();
+  @override
+  CompoundValueExplicitNoNesting rebuild(
+    void Function(CompoundValueExplicitNoNestingBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  _$CompoundValueExplicitNoNestingBuilder toBuilder() =>
+      _$CompoundValueExplicitNoNestingBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValueExplicitNoNesting &&
+        simpleValue == other.simpleValue &&
+        validatedValue == other.validatedValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, validatedValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CompoundValueExplicitNoNesting')
+          ..add('simpleValue', simpleValue)
+          ..add('validatedValue', validatedValue))
+        .toString();
+  }
+}
+
+class _$CompoundValueExplicitNoNestingBuilder
+    extends CompoundValueExplicitNoNestingBuilder {
+  _$CompoundValueExplicitNoNesting? _$v;
+
+  @override
+  SimpleValueBuilder get simpleValue {
+    _$this;
+    return super.simpleValue;
+  }
+
+  @override
+  set simpleValue(SimpleValueBuilder simpleValue) {
+    _$this;
+    super.simpleValue = simpleValue;
+  }
+
+  @override
+  ValidatedValue? get validatedValue {
+    _$this;
+    return super.validatedValue;
+  }
+
+  @override
+  set validatedValue(ValidatedValue? validatedValue) {
+    _$this;
+    super.validatedValue = validatedValue;
+  }
+
+  _$CompoundValueExplicitNoNestingBuilder() : super._();
+
+  CompoundValueExplicitNoNestingBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.simpleValue = $v.simpleValue.toBuilder();
+      super.validatedValue = $v.validatedValue;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValueExplicitNoNesting other) {
+    _$v = other as _$CompoundValueExplicitNoNesting;
+  }
+
+  @override
+  void update(void Function(CompoundValueExplicitNoNestingBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValueExplicitNoNesting build() => _build();
+
+  _$CompoundValueExplicitNoNesting _build() {
+    _$CompoundValueExplicitNoNesting _$result;
+    try {
+      _$result =
+          _$v ??
+          _$CompoundValueExplicitNoNesting._(
+            simpleValue: simpleValue.build(),
+            validatedValue: validatedValue,
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        simpleValue.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'CompoundValueExplicitNoNesting',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ExplicitNestedList extends ExplicitNestedList {
+  @override
+  final BuiltList<BuiltList<int>> nestedList;
+
+  factory _$ExplicitNestedList([
+    void Function(ExplicitNestedListBuilder)? updates,
+  ]) =>
+      (ExplicitNestedListBuilder()..update(updates)).build()
+          as _$ExplicitNestedList;
+
+  _$ExplicitNestedList._({required this.nestedList}) : super._();
+  @override
+  ExplicitNestedList rebuild(
+    void Function(ExplicitNestedListBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  _$ExplicitNestedListBuilder toBuilder() =>
+      _$ExplicitNestedListBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ExplicitNestedList && nestedList == other.nestedList;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, nestedList.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'ExplicitNestedList',
+    )..add('nestedList', nestedList)).toString();
+  }
+}
+
+class _$ExplicitNestedListBuilder extends ExplicitNestedListBuilder {
+  _$ExplicitNestedList? _$v;
+
+  @override
+  ListBuilder<BuiltList<int>> get nestedList {
+    _$this;
+    return super.nestedList;
+  }
+
+  @override
+  set nestedList(ListBuilder<BuiltList<int>> nestedList) {
+    _$this;
+    super.nestedList = nestedList;
+  }
+
+  _$ExplicitNestedListBuilder() : super._();
+
+  ExplicitNestedListBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.nestedList = $v.nestedList.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ExplicitNestedList other) {
+    _$v = other as _$ExplicitNestedList;
+  }
+
+  @override
+  void update(void Function(ExplicitNestedListBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ExplicitNestedList build() => _build();
+
+  _$ExplicitNestedList _build() {
+    _$ExplicitNestedList _$result;
+    try {
+      _$result = _$v ?? _$ExplicitNestedList._(nestedList: nestedList.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'nestedList';
+        nestedList.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'ExplicitNestedList',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ExplicitNonNullBuilderNullableSetter
+    extends ExplicitNonNullBuilderNullableSetter {
+  @override
+  final SimpleValue? simpleValue;
+
+  factory _$ExplicitNonNullBuilderNullableSetter([
+    void Function(ExplicitNonNullBuilderNullableSetterBuilder)? updates,
+  ]) =>
+      (ExplicitNonNullBuilderNullableSetterBuilder()..update(updates)).build()
+          as _$ExplicitNonNullBuilderNullableSetter;
+
+  _$ExplicitNonNullBuilderNullableSetter._({this.simpleValue}) : super._();
+  @override
+  ExplicitNonNullBuilderNullableSetter rebuild(
+    void Function(ExplicitNonNullBuilderNullableSetterBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  _$ExplicitNonNullBuilderNullableSetterBuilder toBuilder() =>
+      _$ExplicitNonNullBuilderNullableSetterBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ExplicitNonNullBuilderNullableSetter &&
+        simpleValue == other.simpleValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'ExplicitNonNullBuilderNullableSetter',
+    )..add('simpleValue', simpleValue)).toString();
+  }
+}
+
+class _$ExplicitNonNullBuilderNullableSetterBuilder
+    extends ExplicitNonNullBuilderNullableSetterBuilder {
+  _$ExplicitNonNullBuilderNullableSetter? _$v;
+
+  SimpleValueBuilder? _simpleValue;
+  @override
+  SimpleValueBuilder get simpleValue {
+    _$this;
+    return _simpleValue ??= SimpleValueBuilder();
+  }
+
+  @override
+  set simpleValue(SimpleValueBuilder? simpleValue) {
+    _$this;
+    _simpleValue = simpleValue;
+  }
+
+  _$ExplicitNonNullBuilderNullableSetterBuilder() : super._();
+
+  ExplicitNonNullBuilderNullableSetterBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _simpleValue = $v.simpleValue?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ExplicitNonNullBuilderNullableSetter other) {
+    _$v = other as _$ExplicitNonNullBuilderNullableSetter;
+  }
+
+  @override
+  void update(
+    void Function(ExplicitNonNullBuilderNullableSetterBuilder)? updates,
+  ) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ExplicitNonNullBuilderNullableSetter build() => _build();
+
+  _$ExplicitNonNullBuilderNullableSetter _build() {
+    _$ExplicitNonNullBuilderNullableSetter _$result;
+    try {
+      _$result =
+          _$v ??
+          _$ExplicitNonNullBuilderNullableSetter._(
+            simpleValue: _simpleValue?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        _simpleValue?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'ExplicitNonNullBuilderNullableSetter',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ExplicitNonNullBuilderNullableField
+    extends ExplicitNonNullBuilderNullableField {
+  @override
+  final SimpleValue? simpleValue;
+
+  factory _$ExplicitNonNullBuilderNullableField([
+    void Function(ExplicitNonNullBuilderNullableFieldBuilder)? updates,
+  ]) =>
+      (ExplicitNonNullBuilderNullableFieldBuilder()..update(updates)).build()
+          as _$ExplicitNonNullBuilderNullableField;
+
+  _$ExplicitNonNullBuilderNullableField._({this.simpleValue}) : super._();
+  @override
+  ExplicitNonNullBuilderNullableField rebuild(
+    void Function(ExplicitNonNullBuilderNullableFieldBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  _$ExplicitNonNullBuilderNullableFieldBuilder toBuilder() =>
+      _$ExplicitNonNullBuilderNullableFieldBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ExplicitNonNullBuilderNullableField &&
+        simpleValue == other.simpleValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'ExplicitNonNullBuilderNullableField',
+    )..add('simpleValue', simpleValue)).toString();
+  }
+}
+
+class _$ExplicitNonNullBuilderNullableFieldBuilder
+    extends ExplicitNonNullBuilderNullableFieldBuilder {
+  _$ExplicitNonNullBuilderNullableField? _$v;
+
+  @override
+  SimpleValueBuilder get simpleValue {
+    _$this;
+    return super.simpleValue ??= SimpleValueBuilder();
+  }
+
+  @override
+  set simpleValue(SimpleValueBuilder? simpleValue) {
+    _$this;
+    super.simpleValue = simpleValue;
+  }
+
+  _$ExplicitNonNullBuilderNullableFieldBuilder() : super._();
+
+  ExplicitNonNullBuilderNullableFieldBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.simpleValue = $v.simpleValue?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ExplicitNonNullBuilderNullableField other) {
+    _$v = other as _$ExplicitNonNullBuilderNullableField;
+  }
+
+  @override
+  void update(
+    void Function(ExplicitNonNullBuilderNullableFieldBuilder)? updates,
+  ) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ExplicitNonNullBuilderNullableField build() => _build();
+
+  _$ExplicitNonNullBuilderNullableField _build() {
+    _$ExplicitNonNullBuilderNullableField _$result;
+    try {
+      _$result =
+          _$v ??
+          _$ExplicitNonNullBuilderNullableField._(
+            simpleValue: super.simpleValue?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        super.simpleValue?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'ExplicitNonNullBuilderNullableField',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$DerivedValue extends DerivedValue {
+  @override
+  final int anInt;
+  int? __derivedValue;
+  Iterable<String>? __derivedString;
+  int? __nullableDerivedValue;
+  bool ___nullableDerivedValue = false;
+
+  factory _$DerivedValue([void Function(DerivedValueBuilder)? updates]) =>
+      (DerivedValueBuilder()..update(updates))._build();
+
+  _$DerivedValue._({required this.anInt}) : super._();
+  @override
+  int get derivedValue => __derivedValue ??= super.derivedValue;
+
+  @override
+  Iterable<String> get derivedString => __derivedString ??= super.derivedString;
+
+  @override
+  int? get nullableDerivedValue {
+    if (!___nullableDerivedValue) {
+      __nullableDerivedValue = super.nullableDerivedValue;
+      ___nullableDerivedValue = true;
+    }
+    return __nullableDerivedValue;
+  }
+
+  @override
+  DerivedValue rebuild(void Function(DerivedValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DerivedValueBuilder toBuilder() => DerivedValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DerivedValue && anInt == other.anInt;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'DerivedValue',
+    )..add('anInt', anInt)).toString();
+  }
+}
+
+class DerivedValueBuilder
+    implements Builder<DerivedValue, DerivedValueBuilder> {
+  _$DerivedValue? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  DerivedValueBuilder();
+
+  DerivedValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(DerivedValue other) {
+    _$v = other as _$DerivedValue;
+  }
+
+  @override
+  void update(void Function(DerivedValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DerivedValue build() => _build();
+
+  _$DerivedValue _build() {
+    final _$result =
+        _$v ??
+        _$DerivedValue._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+            anInt,
+            r'DerivedValue',
+            'anInt',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithCode extends ValueWithCode {
+  @override
+  final int anInt;
+  @override
+  final String? aString;
+
+  factory _$ValueWithCode([void Function(ValueWithCodeBuilder)? updates]) =>
+      (ValueWithCodeBuilder()..update(updates))._build();
+
+  _$ValueWithCode._({required this.anInt, this.aString}) : super._();
+  @override
+  ValueWithCode rebuild(void Function(ValueWithCodeBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ValueWithCodeBuilder toBuilder() => ValueWithCodeBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithCode &&
+        anInt == other.anInt &&
+        aString == other.aString;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, aString.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueWithCode')
+          ..add('anInt', anInt)
+          ..add('aString', aString))
+        .toString();
+  }
+}
+
+class ValueWithCodeBuilder
+    implements Builder<ValueWithCode, ValueWithCodeBuilder> {
+  _$ValueWithCode? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  String? _aString;
+  String? get aString => _$this._aString;
+  set aString(String? aString) => _$this._aString = aString;
+
+  ValueWithCodeBuilder();
+
+  ValueWithCodeBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _aString = $v.aString;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithCode other) {
+    _$v = other as _$ValueWithCode;
+  }
+
+  @override
+  void update(void Function(ValueWithCodeBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithCode build() => _build();
+
+  _$ValueWithCode _build() {
+    final _$result =
+        _$v ??
+        _$ValueWithCode._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+            anInt,
+            r'ValueWithCode',
+            'anInt',
+          ),
+          aString: aString,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithDefaults extends ValueWithDefaults {
+  @override
+  final int anInt;
+  @override
+  final String? aString;
+  @override
+  final SimpleValue value;
+
+  factory _$ValueWithDefaults([
+    void Function(ValueWithDefaultsBuilder)? updates,
+  ]) =>
+      (ValueWithDefaultsBuilder()..update(updates)).build()
+          as _$ValueWithDefaults;
+
+  _$ValueWithDefaults._({
+    required this.anInt,
+    this.aString,
+    required this.value,
+  }) : super._();
+  @override
+  ValueWithDefaults rebuild(void Function(ValueWithDefaultsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _$ValueWithDefaultsBuilder toBuilder() =>
+      _$ValueWithDefaultsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithDefaults &&
+        anInt == other.anInt &&
+        aString == other.aString &&
+        value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, aString.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueWithDefaults')
+          ..add('anInt', anInt)
+          ..add('aString', aString)
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class _$ValueWithDefaultsBuilder extends ValueWithDefaultsBuilder {
+  _$ValueWithDefaults? _$v;
+
+  @override
+  int get anInt {
+    _$this;
+    return super.anInt;
+  }
+
+  @override
+  set anInt(int anInt) {
+    _$this;
+    super.anInt = anInt;
+  }
+
+  @override
+  String? get aString {
+    _$this;
+    return super.aString;
+  }
+
+  @override
+  set aString(String? aString) {
+    _$this;
+    super.aString = aString;
+  }
+
+  @override
+  SimpleValueBuilder get value {
+    _$this;
+    return super.value;
+  }
+
+  @override
+  set value(SimpleValueBuilder value) {
+    _$this;
+    super.value = value;
+  }
+
+  _$ValueWithDefaultsBuilder() : super._();
+
+  ValueWithDefaultsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.anInt = $v.anInt;
+      super.aString = $v.aString;
+      super.value = $v.value.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithDefaults other) {
+    _$v = other as _$ValueWithDefaults;
+  }
+
+  @override
+  void update(void Function(ValueWithDefaultsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithDefaults build() => _build();
+
+  _$ValueWithDefaults _build() {
+    _$ValueWithDefaults _$result;
+    try {
+      _$result =
+          _$v ??
+          _$ValueWithDefaults._(
+            anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt,
+              r'ValueWithDefaults',
+              'anInt',
+            ),
+            aString: aString,
+            value: value.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'ValueWithDefaults',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithBuilderSmarts extends ValueWithBuilderSmarts {
+  @override
+  final String value;
+
+  factory _$ValueWithBuilderSmarts([
+    void Function(ValueWithBuilderSmartsBuilder)? updates,
+  ]) =>
+      (ValueWithBuilderSmartsBuilder()..update(updates)).build()
+          as _$ValueWithBuilderSmarts;
+
+  _$ValueWithBuilderSmarts._({required this.value}) : super._();
+  @override
+  ValueWithBuilderSmarts rebuild(
+    void Function(ValueWithBuilderSmartsBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  _$ValueWithBuilderSmartsBuilder toBuilder() =>
+      _$ValueWithBuilderSmartsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithBuilderSmarts && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'ValueWithBuilderSmarts',
+    )..add('value', value)).toString();
+  }
+}
+
+class _$ValueWithBuilderSmartsBuilder extends ValueWithBuilderSmartsBuilder {
+  _$ValueWithBuilderSmarts? _$v;
+
+  @override
+  String get value {
+    _$this;
+    return super.value;
+  }
+
+  @override
+  set value(String value) {
+    _$this;
+    super.value = value;
+  }
+
+  _$ValueWithBuilderSmartsBuilder() : super._();
+
+  ValueWithBuilderSmartsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithBuilderSmarts other) {
+    _$v = other as _$ValueWithBuilderSmarts;
+  }
+
+  @override
+  void update(void Function(ValueWithBuilderSmartsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithBuilderSmarts build() => _build();
+
+  _$ValueWithBuilderSmarts _build() {
+    final _$result =
+        _$v ??
+        _$ValueWithBuilderSmarts._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'ValueWithBuilderSmarts',
+            'value',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValidatedValue extends ValidatedValue {
+  @override
+  final int anInt;
+  @override
+  final String? aString;
+
+  factory _$ValidatedValue([void Function(ValidatedValueBuilder)? updates]) =>
+      (ValidatedValueBuilder()..update(updates))._build();
+
+  _$ValidatedValue._({required this.anInt, this.aString}) : super._();
+  @override
+  ValidatedValue rebuild(void Function(ValidatedValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ValidatedValueBuilder toBuilder() => ValidatedValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValidatedValue &&
+        anInt == other.anInt &&
+        aString == other.aString;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, aString.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValidatedValue')
+          ..add('anInt', anInt)
+          ..add('aString', aString))
+        .toString();
+  }
+}
+
+class ValidatedValueBuilder
+    implements Builder<ValidatedValue, ValidatedValueBuilder> {
+  _$ValidatedValue? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  String? _aString;
+  String? get aString => _$this._aString;
+  set aString(String? aString) => _$this._aString = aString;
+
+  ValidatedValueBuilder();
+
+  ValidatedValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _aString = $v.aString;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValidatedValue other) {
+    _$v = other as _$ValidatedValue;
+  }
+
+  @override
+  void update(void Function(ValidatedValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValidatedValue build() => _build();
+
+  _$ValidatedValue _build() {
+    final _$result =
+        _$v ??
+        _$ValidatedValue._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+            anInt,
+            r'ValidatedValue',
+            'anInt',
+          ),
+          aString: aString,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueUsingImportAs extends ValueUsingImportAs {
+  @override
+  final using_import_as.TestEnum value;
+  @override
+  final using_import_as.TestEnum? nullableValue;
+
+  factory _$ValueUsingImportAs([
+    void Function(ValueUsingImportAsBuilder)? updates,
+  ]) => (ValueUsingImportAsBuilder()..update(updates))._build();
+
+  _$ValueUsingImportAs._({required this.value, this.nullableValue}) : super._();
+  @override
+  ValueUsingImportAs rebuild(
+    void Function(ValueUsingImportAsBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  ValueUsingImportAsBuilder toBuilder() =>
+      ValueUsingImportAsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueUsingImportAs &&
+        value == other.value &&
+        nullableValue == other.nullableValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, nullableValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueUsingImportAs')
+          ..add('value', value)
+          ..add('nullableValue', nullableValue))
+        .toString();
+  }
+}
+
+class ValueUsingImportAsBuilder
+    implements Builder<ValueUsingImportAs, ValueUsingImportAsBuilder> {
+  _$ValueUsingImportAs? _$v;
+
+  using_import_as.TestEnum? _value;
+  using_import_as.TestEnum? get value => _$this._value;
+  set value(using_import_as.TestEnum? value) => _$this._value = value;
+
+  using_import_as.TestEnum? _nullableValue;
+  using_import_as.TestEnum? get nullableValue => _$this._nullableValue;
+  set nullableValue(using_import_as.TestEnum? nullableValue) =>
+      _$this._nullableValue = nullableValue;
+
+  ValueUsingImportAsBuilder();
+
+  ValueUsingImportAsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _nullableValue = $v.nullableValue;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueUsingImportAs other) {
+    _$v = other as _$ValueUsingImportAs;
+  }
+
+  @override
+  void update(void Function(ValueUsingImportAsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueUsingImportAs build() => _build();
+
+  _$ValueUsingImportAs _build() {
+    final _$result =
+        _$v ??
+        _$ValueUsingImportAs._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'ValueUsingImportAs',
+            'value',
+          ),
+          nullableValue: nullableValue,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$NoFieldsValue extends NoFieldsValue {
+  factory _$NoFieldsValue([void Function(NoFieldsValueBuilder)? updates]) =>
+      (NoFieldsValueBuilder()..update(updates))._build();
+
+  _$NoFieldsValue._() : super._();
+  @override
+  NoFieldsValue rebuild(void Function(NoFieldsValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  NoFieldsValueBuilder toBuilder() => NoFieldsValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is NoFieldsValue;
+  }
+
+  @override
+  int get hashCode {
+    return 601485316;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper(r'NoFieldsValue').toString();
+  }
+}
+
+class NoFieldsValueBuilder
+    implements Builder<NoFieldsValue, NoFieldsValueBuilder> {
+  _$NoFieldsValue? _$v;
+
+  NoFieldsValueBuilder();
+
+  @override
+  void replace(NoFieldsValue other) {
+    _$v = other as _$NoFieldsValue;
+  }
+
+  @override
+  void update(void Function(NoFieldsValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  NoFieldsValue build() => _build();
+
+  _$NoFieldsValue _build() {
+    final _$result = _$v ?? _$NoFieldsValue._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$PrimitivesValue extends PrimitivesValue {
+  @override
+  final bool boolean;
+  @override
+  final int integer;
+  @override
+  final Int64 int64;
+  @override
+  final double dbl;
+  @override
+  final num number;
+  @override
+  final String string;
+  @override
+  final DateTime dateTime;
+  @override
+  final Duration duration;
+  @override
+  final RegExp regExp;
+  @override
+  final Uri uri;
+  @override
+  final BigInt bigInt;
+
+  factory _$PrimitivesValue([void Function(PrimitivesValueBuilder)? updates]) =>
+      (PrimitivesValueBuilder()..update(updates))._build();
+
+  _$PrimitivesValue._({
+    required this.boolean,
+    required this.integer,
+    required this.int64,
+    required this.dbl,
+    required this.number,
+    required this.string,
+    required this.dateTime,
+    required this.duration,
+    required this.regExp,
+    required this.uri,
+    required this.bigInt,
+  }) : super._();
+  @override
+  PrimitivesValue rebuild(void Function(PrimitivesValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PrimitivesValueBuilder toBuilder() => PrimitivesValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PrimitivesValue &&
+        boolean == other.boolean &&
+        integer == other.integer &&
+        int64 == other.int64 &&
+        dbl == other.dbl &&
+        number == other.number &&
+        string == other.string &&
+        dateTime == other.dateTime &&
+        duration == other.duration &&
+        regExp == other.regExp &&
+        uri == other.uri &&
+        bigInt == other.bigInt;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, boolean.hashCode);
+    _$hash = $jc(_$hash, integer.hashCode);
+    _$hash = $jc(_$hash, int64.hashCode);
+    _$hash = $jc(_$hash, dbl.hashCode);
+    _$hash = $jc(_$hash, number.hashCode);
+    _$hash = $jc(_$hash, string.hashCode);
+    _$hash = $jc(_$hash, dateTime.hashCode);
+    _$hash = $jc(_$hash, duration.hashCode);
+    _$hash = $jc(_$hash, regExp.hashCode);
+    _$hash = $jc(_$hash, uri.hashCode);
+    _$hash = $jc(_$hash, bigInt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PrimitivesValue')
+          ..add('boolean', boolean)
+          ..add('integer', integer)
+          ..add('int64', int64)
+          ..add('dbl', dbl)
+          ..add('number', number)
+          ..add('string', string)
+          ..add('dateTime', dateTime)
+          ..add('duration', duration)
+          ..add('regExp', regExp)
+          ..add('uri', uri)
+          ..add('bigInt', bigInt))
+        .toString();
+  }
+}
+
+class PrimitivesValueBuilder
+    implements Builder<PrimitivesValue, PrimitivesValueBuilder> {
+  _$PrimitivesValue? _$v;
+
+  bool? _boolean;
+  bool? get boolean => _$this._boolean;
+  set boolean(bool? boolean) => _$this._boolean = boolean;
+
+  int? _integer;
+  int? get integer => _$this._integer;
+  set integer(int? integer) => _$this._integer = integer;
+
+  Int64? _int64;
+  Int64? get int64 => _$this._int64;
+  set int64(Int64? int64) => _$this._int64 = int64;
+
+  double? _dbl;
+  double? get dbl => _$this._dbl;
+  set dbl(double? dbl) => _$this._dbl = dbl;
+
+  num? _number;
+  num? get number => _$this._number;
+  set number(num? number) => _$this._number = number;
+
+  String? _string;
+  String? get string => _$this._string;
+  set string(String? string) => _$this._string = string;
+
+  DateTime? _dateTime;
+  DateTime? get dateTime => _$this._dateTime;
+  set dateTime(DateTime? dateTime) => _$this._dateTime = dateTime;
+
+  Duration? _duration;
+  Duration? get duration => _$this._duration;
+  set duration(Duration? duration) => _$this._duration = duration;
+
+  RegExp? _regExp;
+  RegExp? get regExp => _$this._regExp;
+  set regExp(RegExp? regExp) => _$this._regExp = regExp;
+
+  Uri? _uri;
+  Uri? get uri => _$this._uri;
+  set uri(Uri? uri) => _$this._uri = uri;
+
+  BigInt? _bigInt;
+  BigInt? get bigInt => _$this._bigInt;
+  set bigInt(BigInt? bigInt) => _$this._bigInt = bigInt;
+
+  PrimitivesValueBuilder();
+
+  PrimitivesValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _boolean = $v.boolean;
+      _integer = $v.integer;
+      _int64 = $v.int64;
+      _dbl = $v.dbl;
+      _number = $v.number;
+      _string = $v.string;
+      _dateTime = $v.dateTime;
+      _duration = $v.duration;
+      _regExp = $v.regExp;
+      _uri = $v.uri;
+      _bigInt = $v.bigInt;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PrimitivesValue other) {
+    _$v = other as _$PrimitivesValue;
+  }
+
+  @override
+  void update(void Function(PrimitivesValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PrimitivesValue build() => _build();
+
+  _$PrimitivesValue _build() {
+    final _$result =
+        _$v ??
+        _$PrimitivesValue._(
+          boolean: BuiltValueNullFieldError.checkNotNull(
+            boolean,
+            r'PrimitivesValue',
+            'boolean',
+          ),
+          integer: BuiltValueNullFieldError.checkNotNull(
+            integer,
+            r'PrimitivesValue',
+            'integer',
+          ),
+          int64: BuiltValueNullFieldError.checkNotNull(
+            int64,
+            r'PrimitivesValue',
+            'int64',
+          ),
+          dbl: BuiltValueNullFieldError.checkNotNull(
+            dbl,
+            r'PrimitivesValue',
+            'dbl',
+          ),
+          number: BuiltValueNullFieldError.checkNotNull(
+            number,
+            r'PrimitivesValue',
+            'number',
+          ),
+          string: BuiltValueNullFieldError.checkNotNull(
+            string,
+            r'PrimitivesValue',
+            'string',
+          ),
+          dateTime: BuiltValueNullFieldError.checkNotNull(
+            dateTime,
+            r'PrimitivesValue',
+            'dateTime',
+          ),
+          duration: BuiltValueNullFieldError.checkNotNull(
+            duration,
+            r'PrimitivesValue',
+            'duration',
+          ),
+          regExp: BuiltValueNullFieldError.checkNotNull(
+            regExp,
+            r'PrimitivesValue',
+            'regExp',
+          ),
+          uri: BuiltValueNullFieldError.checkNotNull(
+            uri,
+            r'PrimitivesValue',
+            'uri',
+          ),
+          bigInt: BuiltValueNullFieldError.checkNotNull(
+            bigInt,
+            r'PrimitivesValue',
+            'bigInt',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$FunctionValue extends FunctionValue {
+  @override
+  final MyFunctionType function;
+
+  factory _$FunctionValue([void Function(FunctionValueBuilder)? updates]) =>
+      (FunctionValueBuilder()..update(updates))._build();
+
+  _$FunctionValue._({required this.function}) : super._();
+  @override
+  FunctionValue rebuild(void Function(FunctionValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  FunctionValueBuilder toBuilder() => FunctionValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is FunctionValue && function == other.function;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, function.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'FunctionValue',
+    )..add('function', function)).toString();
+  }
+}
+
+class FunctionValueBuilder
+    implements Builder<FunctionValue, FunctionValueBuilder> {
+  _$FunctionValue? _$v;
+
+  MyFunctionType? _function;
+  MyFunctionType? get function => _$this._function;
+  set function(MyFunctionType? function) => _$this._function = function;
+
+  FunctionValueBuilder();
+
+  FunctionValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _function = $v.function;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(FunctionValue other) {
+    _$v = other as _$FunctionValue;
+  }
+
+  @override
+  void update(void Function(FunctionValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  FunctionValue build() => _build();
+
+  _$FunctionValue _build() {
+    final _$result =
+        _$v ??
+        _$FunctionValue._(
+          function: BuiltValueNullFieldError.checkNotNull(
+            function,
+            r'FunctionValue',
+            'function',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ListOfFunctionValue extends ListOfFunctionValue {
+  @override
+  final BuiltList<MyFunctionType> functions;
+
+  factory _$ListOfFunctionValue([
+    void Function(ListOfFunctionValueBuilder)? updates,
+  ]) => (ListOfFunctionValueBuilder()..update(updates))._build();
+
+  _$ListOfFunctionValue._({required this.functions}) : super._();
+  @override
+  ListOfFunctionValue rebuild(
+    void Function(ListOfFunctionValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  ListOfFunctionValueBuilder toBuilder() =>
+      ListOfFunctionValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ListOfFunctionValue && functions == other.functions;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, functions.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'ListOfFunctionValue',
+    )..add('functions', functions)).toString();
+  }
+}
+
+class ListOfFunctionValueBuilder
+    implements Builder<ListOfFunctionValue, ListOfFunctionValueBuilder> {
+  _$ListOfFunctionValue? _$v;
+
+  ListBuilder<MyFunctionType>? _functions;
+  ListBuilder<MyFunctionType> get functions =>
+      _$this._functions ??= ListBuilder<MyFunctionType>();
+  set functions(ListBuilder<MyFunctionType>? functions) =>
+      _$this._functions = functions;
+
+  ListOfFunctionValueBuilder();
+
+  ListOfFunctionValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _functions = $v.functions.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ListOfFunctionValue other) {
+    _$v = other as _$ListOfFunctionValue;
+  }
+
+  @override
+  void update(void Function(ListOfFunctionValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ListOfFunctionValue build() => _build();
+
+  _$ListOfFunctionValue _build() {
+    _$ListOfFunctionValue _$result;
+    try {
+      _$result = _$v ?? _$ListOfFunctionValue._(functions: functions.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'functions';
+        functions.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'ListOfFunctionValue',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$PartiallySerializableValue extends PartiallySerializableValue {
+  @override
+  final int value;
+  @override
+  final int? transientValue;
+
+  factory _$PartiallySerializableValue([
+    void Function(PartiallySerializableValueBuilder)? updates,
+  ]) => (PartiallySerializableValueBuilder()..update(updates))._build();
+
+  _$PartiallySerializableValue._({required this.value, this.transientValue})
+    : super._();
+  @override
+  PartiallySerializableValue rebuild(
+    void Function(PartiallySerializableValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  PartiallySerializableValueBuilder toBuilder() =>
+      PartiallySerializableValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PartiallySerializableValue &&
+        value == other.value &&
+        transientValue == other.transientValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, transientValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PartiallySerializableValue')
+          ..add('value', value)
+          ..add('transientValue', transientValue))
+        .toString();
+  }
+}
+
+class PartiallySerializableValueBuilder
+    implements
+        Builder<PartiallySerializableValue, PartiallySerializableValueBuilder> {
+  _$PartiallySerializableValue? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  int? _transientValue;
+  int? get transientValue => _$this._transientValue;
+  set transientValue(int? transientValue) =>
+      _$this._transientValue = transientValue;
+
+  PartiallySerializableValueBuilder();
+
+  PartiallySerializableValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _transientValue = $v.transientValue;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(PartiallySerializableValue other) {
+    _$v = other as _$PartiallySerializableValue;
+  }
+
+  @override
+  void update(void Function(PartiallySerializableValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PartiallySerializableValue build() => _build();
+
+  _$PartiallySerializableValue _build() {
+    final _$result =
+        _$v ??
+        _$PartiallySerializableValue._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'PartiallySerializableValue',
+            'value',
+          ),
+          transientValue: transientValue,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$NamedFactoryValue extends NamedFactoryValue {
+  @override
+  final int value;
+
+  factory _$NamedFactoryValue([
+    void Function(NamedFactoryValueBuilder)? updates,
+  ]) => (NamedFactoryValueBuilder()..update(updates))._build();
+
+  _$NamedFactoryValue._({required this.value}) : super._();
+  @override
+  NamedFactoryValue rebuild(void Function(NamedFactoryValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  NamedFactoryValueBuilder toBuilder() =>
+      NamedFactoryValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is NamedFactoryValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'NamedFactoryValue',
+    )..add('value', value)).toString();
+  }
+}
+
+class NamedFactoryValueBuilder
+    implements Builder<NamedFactoryValue, NamedFactoryValueBuilder> {
+  _$NamedFactoryValue? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  NamedFactoryValueBuilder();
+
+  NamedFactoryValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(NamedFactoryValue other) {
+    _$v = other as _$NamedFactoryValue;
+  }
+
+  @override
+  void update(void Function(NamedFactoryValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  NamedFactoryValue build() => _build();
+
+  _$NamedFactoryValue _build() {
+    final _$result =
+        _$v ??
+        _$NamedFactoryValue._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'NamedFactoryValue',
+            'value',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$WireNameValue extends WireNameValue {
+  @override
+  final int value;
+
+  factory _$WireNameValue([void Function(WireNameValueBuilder)? updates]) =>
+      (WireNameValueBuilder()..update(updates))._build();
+
+  _$WireNameValue._({required this.value}) : super._();
+  @override
+  WireNameValue rebuild(void Function(WireNameValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WireNameValueBuilder toBuilder() => WireNameValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is WireNameValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'WireNameValue',
+    )..add('value', value)).toString();
+  }
+}
+
+class WireNameValueBuilder
+    implements Builder<WireNameValue, WireNameValueBuilder> {
+  _$WireNameValue? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  WireNameValueBuilder();
+
+  WireNameValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(WireNameValue other) {
+    _$v = other as _$WireNameValue;
+  }
+
+  @override
+  void update(void Function(WireNameValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  WireNameValue build() => _build();
+
+  _$WireNameValue _build() {
+    final _$result =
+        _$v ??
+        _$WireNameValue._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'WireNameValue',
+            'value',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$FieldDiscoveryValue extends FieldDiscoveryValue {
+  @override
+  final DiscoverableValue value;
+  @override
+  final BuiltList<ThirdDiscoverableValue> values;
+  @override
+  final FieldDiscoveryValue? recursiveValue;
+
+  factory _$FieldDiscoveryValue([
+    void Function(FieldDiscoveryValueBuilder)? updates,
+  ]) => (FieldDiscoveryValueBuilder()..update(updates))._build();
+
+  _$FieldDiscoveryValue._({
+    required this.value,
+    required this.values,
+    this.recursiveValue,
+  }) : super._();
+  @override
+  FieldDiscoveryValue rebuild(
+    void Function(FieldDiscoveryValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  FieldDiscoveryValueBuilder toBuilder() =>
+      FieldDiscoveryValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is FieldDiscoveryValue &&
+        value == other.value &&
+        values == other.values &&
+        recursiveValue == other.recursiveValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jc(_$hash, values.hashCode);
+    _$hash = $jc(_$hash, recursiveValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'FieldDiscoveryValue')
+          ..add('value', value)
+          ..add('values', values)
+          ..add('recursiveValue', recursiveValue))
+        .toString();
+  }
+}
+
+class FieldDiscoveryValueBuilder
+    implements Builder<FieldDiscoveryValue, FieldDiscoveryValueBuilder> {
+  _$FieldDiscoveryValue? _$v;
+
+  DiscoverableValueBuilder? _value;
+  DiscoverableValueBuilder get value =>
+      _$this._value ??= DiscoverableValueBuilder();
+  set value(DiscoverableValueBuilder? value) => _$this._value = value;
+
+  ListBuilder<ThirdDiscoverableValue>? _values;
+  ListBuilder<ThirdDiscoverableValue> get values =>
+      _$this._values ??= ListBuilder<ThirdDiscoverableValue>();
+  set values(ListBuilder<ThirdDiscoverableValue>? values) =>
+      _$this._values = values;
+
+  FieldDiscoveryValueBuilder? _recursiveValue;
+  FieldDiscoveryValueBuilder get recursiveValue =>
+      _$this._recursiveValue ??= FieldDiscoveryValueBuilder();
+  set recursiveValue(FieldDiscoveryValueBuilder? recursiveValue) =>
+      _$this._recursiveValue = recursiveValue;
+
+  FieldDiscoveryValueBuilder();
+
+  FieldDiscoveryValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value.toBuilder();
+      _values = $v.values.toBuilder();
+      _recursiveValue = $v.recursiveValue?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(FieldDiscoveryValue other) {
+    _$v = other as _$FieldDiscoveryValue;
+  }
+
+  @override
+  void update(void Function(FieldDiscoveryValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  FieldDiscoveryValue build() => _build();
+
+  _$FieldDiscoveryValue _build() {
+    _$FieldDiscoveryValue _$result;
+    try {
+      _$result =
+          _$v ??
+          _$FieldDiscoveryValue._(
+            value: value.build(),
+            values: values.build(),
+            recursiveValue: _recursiveValue?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+        _$failedField = 'values';
+        values.build();
+        _$failedField = 'recursiveValue';
+        _recursiveValue?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'FieldDiscoveryValue',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$DiscoverableValue extends DiscoverableValue {
+  @override
+  final SecondDiscoverableValue value;
+
+  factory _$DiscoverableValue([
+    void Function(DiscoverableValueBuilder)? updates,
+  ]) => (DiscoverableValueBuilder()..update(updates))._build();
+
+  _$DiscoverableValue._({required this.value}) : super._();
+  @override
+  DiscoverableValue rebuild(void Function(DiscoverableValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DiscoverableValueBuilder toBuilder() =>
+      DiscoverableValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DiscoverableValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'DiscoverableValue',
+    )..add('value', value)).toString();
+  }
+}
+
+class DiscoverableValueBuilder
+    implements Builder<DiscoverableValue, DiscoverableValueBuilder> {
+  _$DiscoverableValue? _$v;
+
+  SecondDiscoverableValueBuilder? _value;
+  SecondDiscoverableValueBuilder get value =>
+      _$this._value ??= SecondDiscoverableValueBuilder();
+  set value(SecondDiscoverableValueBuilder? value) => _$this._value = value;
+
+  DiscoverableValueBuilder();
+
+  DiscoverableValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(DiscoverableValue other) {
+    _$v = other as _$DiscoverableValue;
+  }
+
+  @override
+  void update(void Function(DiscoverableValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DiscoverableValue build() => _build();
+
+  _$DiscoverableValue _build() {
+    _$DiscoverableValue _$result;
+    try {
+      _$result = _$v ?? _$DiscoverableValue._(value: value.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'DiscoverableValue',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$SecondDiscoverableValue extends SecondDiscoverableValue {
+  @override
+  final int value;
+
+  factory _$SecondDiscoverableValue([
+    void Function(SecondDiscoverableValueBuilder)? updates,
+  ]) => (SecondDiscoverableValueBuilder()..update(updates))._build();
+
+  _$SecondDiscoverableValue._({required this.value}) : super._();
+  @override
+  SecondDiscoverableValue rebuild(
+    void Function(SecondDiscoverableValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  SecondDiscoverableValueBuilder toBuilder() =>
+      SecondDiscoverableValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SecondDiscoverableValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'SecondDiscoverableValue',
+    )..add('value', value)).toString();
+  }
+}
+
+class SecondDiscoverableValueBuilder
+    implements
+        Builder<SecondDiscoverableValue, SecondDiscoverableValueBuilder> {
+  _$SecondDiscoverableValue? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  SecondDiscoverableValueBuilder();
+
+  SecondDiscoverableValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SecondDiscoverableValue other) {
+    _$v = other as _$SecondDiscoverableValue;
+  }
+
+  @override
+  void update(void Function(SecondDiscoverableValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SecondDiscoverableValue build() => _build();
+
+  _$SecondDiscoverableValue _build() {
+    final _$result =
+        _$v ??
+        _$SecondDiscoverableValue._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'SecondDiscoverableValue',
+            'value',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ThirdDiscoverableValue extends ThirdDiscoverableValue {
+  @override
+  final int value;
+
+  factory _$ThirdDiscoverableValue([
+    void Function(ThirdDiscoverableValueBuilder)? updates,
+  ]) => (ThirdDiscoverableValueBuilder()..update(updates))._build();
+
+  _$ThirdDiscoverableValue._({required this.value}) : super._();
+  @override
+  ThirdDiscoverableValue rebuild(
+    void Function(ThirdDiscoverableValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  ThirdDiscoverableValueBuilder toBuilder() =>
+      ThirdDiscoverableValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ThirdDiscoverableValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'ThirdDiscoverableValue',
+    )..add('value', value)).toString();
+  }
+}
+
+class ThirdDiscoverableValueBuilder
+    implements Builder<ThirdDiscoverableValue, ThirdDiscoverableValueBuilder> {
+  _$ThirdDiscoverableValue? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  ThirdDiscoverableValueBuilder();
+
+  ThirdDiscoverableValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ThirdDiscoverableValue other) {
+    _$v = other as _$ThirdDiscoverableValue;
+  }
+
+  @override
+  void update(void Function(ThirdDiscoverableValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ThirdDiscoverableValue build() => _build();
+
+  _$ThirdDiscoverableValue _build() {
+    final _$result =
+        _$v ??
+        _$ThirdDiscoverableValue._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'ThirdDiscoverableValue',
+            'value',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$RecursiveValueA extends RecursiveValueA {
+  @override
+  final RecursiveValueB value;
+
+  factory _$RecursiveValueA([void Function(RecursiveValueABuilder)? updates]) =>
+      (RecursiveValueABuilder()..update(updates))._build();
+
+  _$RecursiveValueA._({required this.value}) : super._();
+  @override
+  RecursiveValueA rebuild(void Function(RecursiveValueABuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RecursiveValueABuilder toBuilder() => RecursiveValueABuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RecursiveValueA && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'RecursiveValueA',
+    )..add('value', value)).toString();
+  }
+}
+
+class RecursiveValueABuilder
+    implements Builder<RecursiveValueA, RecursiveValueABuilder> {
+  _$RecursiveValueA? _$v;
+
+  RecursiveValueBBuilder? _value;
+  RecursiveValueBBuilder get value =>
+      _$this._value ??= RecursiveValueBBuilder();
+  set value(RecursiveValueBBuilder? value) => _$this._value = value;
+
+  RecursiveValueABuilder();
+
+  RecursiveValueABuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(RecursiveValueA other) {
+    _$v = other as _$RecursiveValueA;
+  }
+
+  @override
+  void update(void Function(RecursiveValueABuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RecursiveValueA build() => _build();
+
+  _$RecursiveValueA _build() {
+    _$RecursiveValueA _$result;
+    try {
+      _$result = _$v ?? _$RecursiveValueA._(value: value.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'RecursiveValueA',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$RecursiveValueB extends RecursiveValueB {
+  @override
+  final RecursiveValueA value;
+
+  factory _$RecursiveValueB([void Function(RecursiveValueBBuilder)? updates]) =>
+      (RecursiveValueBBuilder()..update(updates))._build();
+
+  _$RecursiveValueB._({required this.value}) : super._();
+  @override
+  RecursiveValueB rebuild(void Function(RecursiveValueBBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RecursiveValueBBuilder toBuilder() => RecursiveValueBBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RecursiveValueB && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'RecursiveValueB',
+    )..add('value', value)).toString();
+  }
+}
+
+class RecursiveValueBBuilder
+    implements Builder<RecursiveValueB, RecursiveValueBBuilder> {
+  _$RecursiveValueB? _$v;
+
+  RecursiveValueABuilder? _value;
+  RecursiveValueABuilder get value =>
+      _$this._value ??= RecursiveValueABuilder();
+  set value(RecursiveValueABuilder? value) => _$this._value = value;
+
+  RecursiveValueBBuilder();
+
+  RecursiveValueBBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(RecursiveValueB other) {
+    _$v = other as _$RecursiveValueB;
+  }
+
+  @override
+  void update(void Function(RecursiveValueBBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RecursiveValueB build() => _build();
+
+  _$RecursiveValueB _build() {
+    _$RecursiveValueB _$result;
+    try {
+      _$result = _$v ?? _$RecursiveValueB._(value: value.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value';
+        value.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'RecursiveValueB',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithCustomSerializer extends ValueWithCustomSerializer {
+  @override
+  final int value;
+
+  factory _$ValueWithCustomSerializer([
+    void Function(ValueWithCustomSerializerBuilder)? updates,
+  ]) => (ValueWithCustomSerializerBuilder()..update(updates))._build();
+
+  _$ValueWithCustomSerializer._({required this.value}) : super._();
+  @override
+  ValueWithCustomSerializer rebuild(
+    void Function(ValueWithCustomSerializerBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  ValueWithCustomSerializerBuilder toBuilder() =>
+      ValueWithCustomSerializerBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithCustomSerializer && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'ValueWithCustomSerializer',
+    )..add('value', value)).toString();
+  }
+}
+
+class ValueWithCustomSerializerBuilder
+    implements
+        Builder<ValueWithCustomSerializer, ValueWithCustomSerializerBuilder> {
+  _$ValueWithCustomSerializer? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  ValueWithCustomSerializerBuilder();
+
+  ValueWithCustomSerializerBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithCustomSerializer other) {
+    _$v = other as _$ValueWithCustomSerializer;
+  }
+
+  @override
+  void update(void Function(ValueWithCustomSerializerBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithCustomSerializer build() => _build();
+
+  _$ValueWithCustomSerializer _build() {
+    final _$result =
+        _$v ??
+        _$ValueWithCustomSerializer._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'ValueWithCustomSerializer',
+            'value',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithOnSet extends ValueWithOnSet {
+  @override
+  final int value;
+
+  factory _$ValueWithOnSet([void Function(ValueWithOnSetBuilder)? updates]) =>
+      (ValueWithOnSetBuilder()..update(updates))._build();
+
+  _$ValueWithOnSet._({required this.value}) : super._();
+  @override
+  ValueWithOnSet rebuild(void Function(ValueWithOnSetBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ValueWithOnSetBuilder toBuilder() => ValueWithOnSetBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithOnSet && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'ValueWithOnSet',
+    )..add('value', value)).toString();
+  }
+}
+
+class ValueWithOnSetBuilder
+    implements Builder<ValueWithOnSet, ValueWithOnSetBuilder> {
+  _$ValueWithOnSet? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  void Function() onSet = () {};
+
+  set value(int? value) {
+    _$this._value = value;
+    onSet();
+  }
+
+  ValueWithOnSetBuilder();
+
+  ValueWithOnSetBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithOnSet other) {
+    _$v = other as _$ValueWithOnSet;
+  }
+
+  @override
+  void update(void Function(ValueWithOnSetBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithOnSet build() => _build();
+
+  _$ValueWithOnSet _build() {
+    final _$result =
+        _$v ??
+        _$ValueWithOnSet._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'ValueWithOnSet',
+            'value',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CustomToStringValue extends CustomToStringValue {
+  factory _$CustomToStringValue([
+    void Function(CustomToStringValueBuilder)? updates,
+  ]) => (CustomToStringValueBuilder()..update(updates))._build();
+
+  _$CustomToStringValue._() : super._();
+  @override
+  CustomToStringValue rebuild(
+    void Function(CustomToStringValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  CustomToStringValueBuilder toBuilder() =>
+      CustomToStringValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CustomToStringValue;
+  }
+
+  @override
+  int get hashCode {
+    return 617836932;
+  }
+}
+
+class CustomToStringValueBuilder
+    implements Builder<CustomToStringValue, CustomToStringValueBuilder> {
+  _$CustomToStringValue? _$v;
+
+  CustomToStringValueBuilder();
+
+  @override
+  void replace(CustomToStringValue other) {
+    _$v = other as _$CustomToStringValue;
+  }
+
+  @override
+  void update(void Function(CustomToStringValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CustomToStringValue build() => _build();
+
+  _$CustomToStringValue _build() {
+    final _$result = _$v ?? _$CustomToStringValue._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$OtherValue extends OtherValue {
+  @override
+  final int other;
+
+  factory _$OtherValue([void Function(OtherValueBuilder)? updates]) =>
+      (OtherValueBuilder()..update(updates))._build();
+
+  _$OtherValue._({required this.other}) : super._();
+  @override
+  OtherValue rebuild(void Function(OtherValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OtherValueBuilder toBuilder() => OtherValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OtherValue && this.other == other.other;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, other.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'OtherValue',
+    )..add('other', other)).toString();
+  }
+}
+
+class OtherValueBuilder implements Builder<OtherValue, OtherValueBuilder> {
+  _$OtherValue? _$v;
+
+  int? _other;
+  int? get other => _$this._other;
+  set other(int? other) => _$this._other = other;
+
+  OtherValueBuilder();
+
+  OtherValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _other = $v.other;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(OtherValue other) {
+    _$v = other as _$OtherValue;
+  }
+
+  @override
+  void update(void Function(OtherValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OtherValue build() => _build();
+
+  _$OtherValue _build() {
+    final _$result =
+        _$v ??
+        _$OtherValue._(
+          other: BuiltValueNullFieldError.checkNotNull(
+            other,
+            r'OtherValue',
+            'other',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$DefaultsForFieldSettingsValue extends DefaultsForFieldSettingsValue {
+  @override
+  final int ignored;
+  @override
+  final int compared;
+  @override
+  final int serialized;
+
+  factory _$DefaultsForFieldSettingsValue([
+    void Function(DefaultsForFieldSettingsValueBuilder)? updates,
+  ]) => (DefaultsForFieldSettingsValueBuilder()..update(updates))._build();
+
+  _$DefaultsForFieldSettingsValue._({
+    required this.ignored,
+    required this.compared,
+    required this.serialized,
+  }) : super._();
+  @override
+  DefaultsForFieldSettingsValue rebuild(
+    void Function(DefaultsForFieldSettingsValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  DefaultsForFieldSettingsValueBuilder toBuilder() =>
+      DefaultsForFieldSettingsValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DefaultsForFieldSettingsValue && compared == other.compared;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, compared.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DefaultsForFieldSettingsValue')
+          ..add('ignored', ignored)
+          ..add('compared', compared)
+          ..add('serialized', serialized))
+        .toString();
+  }
+}
+
+class DefaultsForFieldSettingsValueBuilder
+    implements
+        Builder<
+          DefaultsForFieldSettingsValue,
+          DefaultsForFieldSettingsValueBuilder
+        > {
+  _$DefaultsForFieldSettingsValue? _$v;
+
+  int? _ignored;
+  int? get ignored => _$this._ignored;
+  set ignored(int? ignored) => _$this._ignored = ignored;
+
+  int? _compared;
+  int? get compared => _$this._compared;
+  set compared(int? compared) => _$this._compared = compared;
+
+  int? _serialized;
+  int? get serialized => _$this._serialized;
+  set serialized(int? serialized) => _$this._serialized = serialized;
+
+  DefaultsForFieldSettingsValueBuilder();
+
+  DefaultsForFieldSettingsValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _ignored = $v.ignored;
+      _compared = $v.compared;
+      _serialized = $v.serialized;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(DefaultsForFieldSettingsValue other) {
+    _$v = other as _$DefaultsForFieldSettingsValue;
+  }
+
+  @override
+  void update(void Function(DefaultsForFieldSettingsValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DefaultsForFieldSettingsValue build() => _build();
+
+  _$DefaultsForFieldSettingsValue _build() {
+    final _$result =
+        _$v ??
+        _$DefaultsForFieldSettingsValue._(
+          ignored: BuiltValueNullFieldError.checkNotNull(
+            ignored,
+            r'DefaultsForFieldSettingsValue',
+            'ignored',
+          ),
+          compared: BuiltValueNullFieldError.checkNotNull(
+            compared,
+            r'DefaultsForFieldSettingsValue',
+            'compared',
+          ),
+          serialized: BuiltValueNullFieldError.checkNotNull(
+            serialized,
+            r'DefaultsForFieldSettingsValue',
+            'serialized',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithBuilderInitializer extends ValueWithBuilderInitializer {
+  @override
+  final int anInt;
+  @override
+  final int anIntWithDefault;
+  @override
+  final int? nullableInt;
+  @override
+  final int? nullableIntWithDefault;
+  @override
+  final SimpleValue nestedValue;
+  @override
+  final SimpleValue nestedValueWithDefault;
+  @override
+  final SimpleValue? nullableNestedValue;
+  @override
+  final SimpleValue? nullableNestedValueWithDefault;
+
+  factory _$ValueWithBuilderInitializer([
+    void Function(ValueWithBuilderInitializerBuilder)? updates,
+  ]) => (ValueWithBuilderInitializerBuilder()..update(updates))._build();
+
+  _$ValueWithBuilderInitializer._({
+    required this.anInt,
+    required this.anIntWithDefault,
+    this.nullableInt,
+    this.nullableIntWithDefault,
+    required this.nestedValue,
+    required this.nestedValueWithDefault,
+    this.nullableNestedValue,
+    this.nullableNestedValueWithDefault,
+  }) : super._();
+  @override
+  ValueWithBuilderInitializer rebuild(
+    void Function(ValueWithBuilderInitializerBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  ValueWithBuilderInitializerBuilder toBuilder() =>
+      ValueWithBuilderInitializerBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithBuilderInitializer &&
+        anInt == other.anInt &&
+        anIntWithDefault == other.anIntWithDefault &&
+        nullableInt == other.nullableInt &&
+        nullableIntWithDefault == other.nullableIntWithDefault &&
+        nestedValue == other.nestedValue &&
+        nestedValueWithDefault == other.nestedValueWithDefault &&
+        nullableNestedValue == other.nullableNestedValue &&
+        nullableNestedValueWithDefault == other.nullableNestedValueWithDefault;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, anIntWithDefault.hashCode);
+    _$hash = $jc(_$hash, nullableInt.hashCode);
+    _$hash = $jc(_$hash, nullableIntWithDefault.hashCode);
+    _$hash = $jc(_$hash, nestedValue.hashCode);
+    _$hash = $jc(_$hash, nestedValueWithDefault.hashCode);
+    _$hash = $jc(_$hash, nullableNestedValue.hashCode);
+    _$hash = $jc(_$hash, nullableNestedValueWithDefault.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueWithBuilderInitializer')
+          ..add('anInt', anInt)
+          ..add('anIntWithDefault', anIntWithDefault)
+          ..add('nullableInt', nullableInt)
+          ..add('nullableIntWithDefault', nullableIntWithDefault)
+          ..add('nestedValue', nestedValue)
+          ..add('nestedValueWithDefault', nestedValueWithDefault)
+          ..add('nullableNestedValue', nullableNestedValue)
+          ..add(
+            'nullableNestedValueWithDefault',
+            nullableNestedValueWithDefault,
+          ))
+        .toString();
+  }
+}
+
+class ValueWithBuilderInitializerBuilder
+    implements
+        Builder<
+          ValueWithBuilderInitializer,
+          ValueWithBuilderInitializerBuilder
+        > {
+  _$ValueWithBuilderInitializer? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  int? _anIntWithDefault;
+  int? get anIntWithDefault => _$this._anIntWithDefault;
+  set anIntWithDefault(int? anIntWithDefault) =>
+      _$this._anIntWithDefault = anIntWithDefault;
+
+  int? _nullableInt;
+  int? get nullableInt => _$this._nullableInt;
+  set nullableInt(int? nullableInt) => _$this._nullableInt = nullableInt;
+
+  int? _nullableIntWithDefault;
+  int? get nullableIntWithDefault => _$this._nullableIntWithDefault;
+  set nullableIntWithDefault(int? nullableIntWithDefault) =>
+      _$this._nullableIntWithDefault = nullableIntWithDefault;
+
+  SimpleValueBuilder? _nestedValue;
+  SimpleValueBuilder get nestedValue =>
+      _$this._nestedValue ??= SimpleValueBuilder();
+  set nestedValue(SimpleValueBuilder? nestedValue) =>
+      _$this._nestedValue = nestedValue;
+
+  SimpleValueBuilder? _nestedValueWithDefault;
+  SimpleValueBuilder get nestedValueWithDefault =>
+      _$this._nestedValueWithDefault ??= SimpleValueBuilder();
+  set nestedValueWithDefault(SimpleValueBuilder? nestedValueWithDefault) =>
+      _$this._nestedValueWithDefault = nestedValueWithDefault;
+
+  SimpleValueBuilder? _nullableNestedValue;
+  SimpleValueBuilder get nullableNestedValue =>
+      _$this._nullableNestedValue ??= SimpleValueBuilder();
+  set nullableNestedValue(SimpleValueBuilder? nullableNestedValue) =>
+      _$this._nullableNestedValue = nullableNestedValue;
+
+  SimpleValueBuilder? _nullableNestedValueWithDefault;
+  SimpleValueBuilder get nullableNestedValueWithDefault =>
+      _$this._nullableNestedValueWithDefault ??= SimpleValueBuilder();
+  set nullableNestedValueWithDefault(
+    SimpleValueBuilder? nullableNestedValueWithDefault,
+  ) => _$this._nullableNestedValueWithDefault = nullableNestedValueWithDefault;
+
+  ValueWithBuilderInitializerBuilder() {
+    ValueWithBuilderInitializer._initializeBuilder(this);
+  }
+
+  ValueWithBuilderInitializerBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _anIntWithDefault = $v.anIntWithDefault;
+      _nullableInt = $v.nullableInt;
+      _nullableIntWithDefault = $v.nullableIntWithDefault;
+      _nestedValue = $v.nestedValue.toBuilder();
+      _nestedValueWithDefault = $v.nestedValueWithDefault.toBuilder();
+      _nullableNestedValue = $v.nullableNestedValue?.toBuilder();
+      _nullableNestedValueWithDefault = $v.nullableNestedValueWithDefault
+          ?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithBuilderInitializer other) {
+    _$v = other as _$ValueWithBuilderInitializer;
+  }
+
+  @override
+  void update(void Function(ValueWithBuilderInitializerBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithBuilderInitializer build() => _build();
+
+  _$ValueWithBuilderInitializer _build() {
+    _$ValueWithBuilderInitializer _$result;
+    try {
+      _$result =
+          _$v ??
+          _$ValueWithBuilderInitializer._(
+            anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt,
+              r'ValueWithBuilderInitializer',
+              'anInt',
+            ),
+            anIntWithDefault: BuiltValueNullFieldError.checkNotNull(
+              anIntWithDefault,
+              r'ValueWithBuilderInitializer',
+              'anIntWithDefault',
+            ),
+            nullableInt: nullableInt,
+            nullableIntWithDefault: nullableIntWithDefault,
+            nestedValue: nestedValue.build(),
+            nestedValueWithDefault: nestedValueWithDefault.build(),
+            nullableNestedValue: _nullableNestedValue?.build(),
+            nullableNestedValueWithDefault: _nullableNestedValueWithDefault
+                ?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'nestedValue';
+        nestedValue.build();
+        _$failedField = 'nestedValueWithDefault';
+        nestedValueWithDefault.build();
+        _$failedField = 'nullableNestedValue';
+        _nullableNestedValue?.build();
+        _$failedField = 'nullableNestedValueWithDefault';
+        _nullableNestedValueWithDefault?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'ValueWithBuilderInitializer',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithBuilderFinalizer extends ValueWithBuilderFinalizer {
+  @override
+  final int anInt;
+
+  factory _$ValueWithBuilderFinalizer([
+    void Function(ValueWithBuilderFinalizerBuilder)? updates,
+  ]) => (ValueWithBuilderFinalizerBuilder()..update(updates))._build();
+
+  _$ValueWithBuilderFinalizer._({required this.anInt}) : super._();
+  @override
+  ValueWithBuilderFinalizer rebuild(
+    void Function(ValueWithBuilderFinalizerBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  ValueWithBuilderFinalizerBuilder toBuilder() =>
+      ValueWithBuilderFinalizerBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithBuilderFinalizer && anInt == other.anInt;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'ValueWithBuilderFinalizer',
+    )..add('anInt', anInt)).toString();
+  }
+}
+
+class ValueWithBuilderFinalizerBuilder
+    implements
+        Builder<ValueWithBuilderFinalizer, ValueWithBuilderFinalizerBuilder> {
+  _$ValueWithBuilderFinalizer? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  ValueWithBuilderFinalizerBuilder();
+
+  ValueWithBuilderFinalizerBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithBuilderFinalizer other) {
+    _$v = other as _$ValueWithBuilderFinalizer;
+  }
+
+  @override
+  void update(void Function(ValueWithBuilderFinalizerBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithBuilderFinalizer build() => _build();
+
+  _$ValueWithBuilderFinalizer _build() {
+    ValueWithBuilderFinalizer._finalizeBuilder(this);
+    final _$result =
+        _$v ??
+        _$ValueWithBuilderFinalizer._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+            anInt,
+            r'ValueWithBuilderFinalizer',
+            'anInt',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithGenericBuilderInitializer<T>
+    extends ValueWithGenericBuilderInitializer<T> {
+  @override
+  final T? value;
+
+  factory _$ValueWithGenericBuilderInitializer([
+    void Function(ValueWithGenericBuilderInitializerBuilder<T>)? updates,
+  ]) => (ValueWithGenericBuilderInitializerBuilder<T>()..update(updates))
+      ._build();
+
+  _$ValueWithGenericBuilderInitializer._({this.value}) : super._();
+  @override
+  ValueWithGenericBuilderInitializer<T> rebuild(
+    void Function(ValueWithGenericBuilderInitializerBuilder<T>) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  ValueWithGenericBuilderInitializerBuilder<T> toBuilder() =>
+      ValueWithGenericBuilderInitializerBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithGenericBuilderInitializer && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'ValueWithGenericBuilderInitializer',
+    )..add('value', value)).toString();
+  }
+}
+
+class ValueWithGenericBuilderInitializerBuilder<T>
+    implements
+        Builder<
+          ValueWithGenericBuilderInitializer<T>,
+          ValueWithGenericBuilderInitializerBuilder<T>
+        > {
+  _$ValueWithGenericBuilderInitializer<T>? _$v;
+
+  T? _value;
+  T? get value => _$this._value;
+  set value(T? value) => _$this._value = value;
+
+  ValueWithGenericBuilderInitializerBuilder() {
+    ValueWithGenericBuilderInitializer._initializeBuilder(this);
+  }
+
+  ValueWithGenericBuilderInitializerBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithGenericBuilderInitializer<T> other) {
+    _$v = other as _$ValueWithGenericBuilderInitializer<T>;
+  }
+
+  @override
+  void update(
+    void Function(ValueWithGenericBuilderInitializerBuilder<T>)? updates,
+  ) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithGenericBuilderInitializer<T> build() => _build();
+
+  _$ValueWithGenericBuilderInitializer<T> _build() {
+    final _$result =
+        _$v ?? _$ValueWithGenericBuilderInitializer<T>._(value: value);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$HashcodeValue extends HashcodeValue {
+  @override
+  final int x;
+  @override
+  final int y;
+
+  factory _$HashcodeValue([void Function(HashcodeValueBuilder)? updates]) =>
+      (HashcodeValueBuilder()..update(updates))._build();
+
+  _$HashcodeValue._({required this.x, required this.y}) : super._();
+  @override
+  HashcodeValue rebuild(void Function(HashcodeValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  HashcodeValueBuilder toBuilder() => HashcodeValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is HashcodeValue && x == other.x && y == other.y;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, x.hashCode);
+    _$hash = $jc(_$hash, y.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'HashcodeValue')
+          ..add('x', x)
+          ..add('y', y))
+        .toString();
+  }
+}
+
+class HashcodeValueBuilder
+    implements Builder<HashcodeValue, HashcodeValueBuilder> {
+  _$HashcodeValue? _$v;
+
+  int? _x;
+  int? get x => _$this._x;
+  set x(int? x) => _$this._x = x;
+
+  int? _y;
+  int? get y => _$this._y;
+  set y(int? y) => _$this._y = y;
+
+  HashcodeValueBuilder();
+
+  HashcodeValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _x = $v.x;
+      _y = $v.y;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(HashcodeValue other) {
+    _$v = other as _$HashcodeValue;
+  }
+
+  @override
+  void update(void Function(HashcodeValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  HashcodeValue build() => _build();
+
+  _$HashcodeValue _build() {
+    final _$result =
+        _$v ??
+        _$HashcodeValue._(
+          x: BuiltValueNullFieldError.checkNotNull(x, r'HashcodeValue', 'x'),
+          y: BuiltValueNullFieldError.checkNotNull(y, r'HashcodeValue', 'y'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$MemoizedHashcodeValue extends MemoizedHashcodeValue {
+  @override
+  final int x;
+  @override
+  final int y;
+
+  factory _$MemoizedHashcodeValue([
+    void Function(MemoizedHashcodeValueBuilder)? updates,
+  ]) => (MemoizedHashcodeValueBuilder()..update(updates))._build();
+
+  _$MemoizedHashcodeValue._({required this.x, required this.y}) : super._();
+  @override
+  MemoizedHashcodeValue rebuild(
+    void Function(MemoizedHashcodeValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  MemoizedHashcodeValueBuilder toBuilder() =>
+      MemoizedHashcodeValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is MemoizedHashcodeValue && x == other.x && y == other.y;
+  }
+
+  int? __hashCode;
+  @override
+  int get hashCode {
+    if (__hashCode != null) return __hashCode!;
+    var _$hash = 0;
+    _$hash = $jc(_$hash, x.hashCode);
+    _$hash = $jc(_$hash, y.hashCode);
+    _$hash = $jf(_$hash);
+    return __hashCode ??= _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'MemoizedHashcodeValue')
+          ..add('x', x)
+          ..add('y', y))
+        .toString();
+  }
+}
+
+class MemoizedHashcodeValueBuilder
+    implements Builder<MemoizedHashcodeValue, MemoizedHashcodeValueBuilder> {
+  _$MemoizedHashcodeValue? _$v;
+
+  int? _x;
+  int? get x => _$this._x;
+  set x(int? x) => _$this._x = x;
+
+  int? _y;
+  int? get y => _$this._y;
+  set y(int? y) => _$this._y = y;
+
+  MemoizedHashcodeValueBuilder();
+
+  MemoizedHashcodeValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _x = $v.x;
+      _y = $v.y;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(MemoizedHashcodeValue other) {
+    _$v = other as _$MemoizedHashcodeValue;
+  }
+
+  @override
+  void update(void Function(MemoizedHashcodeValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  MemoizedHashcodeValue build() => _build();
+
+  _$MemoizedHashcodeValue _build() {
+    final _$result =
+        _$v ??
+        _$MemoizedHashcodeValue._(
+          x: BuiltValueNullFieldError.checkNotNull(
+            x,
+            r'MemoizedHashcodeValue',
+            'x',
+          ),
+          y: BuiltValueNullFieldError.checkNotNull(
+            y,
+            r'MemoizedHashcodeValue',
+            'y',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$PrivateValue extends _PrivateValue {
+  factory _$PrivateValue([void Function(_PrivateValueBuilder)? updates]) =>
+      (_PrivateValueBuilder()..update(updates))._build();
+
+  _$PrivateValue._() : super._();
+  @override
+  _PrivateValue rebuild(void Function(_PrivateValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _PrivateValueBuilder toBuilder() => _PrivateValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is _PrivateValue;
+  }
+
+  @override
+  int get hashCode {
+    return 75608033;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper(r'_PrivateValue').toString();
+  }
+}
+
+class _PrivateValueBuilder
+    implements Builder<_PrivateValue, _PrivateValueBuilder> {
+  _$PrivateValue? _$v;
+
+  _PrivateValueBuilder();
+
+  @override
+  void replace(_PrivateValue other) {
+    _$v = other as _$PrivateValue;
+  }
+
+  @override
+  void update(void Function(_PrivateValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _PrivateValue build() => _build();
+
+  _$PrivateValue _build() {
+    final _$result = _$v ?? _$PrivateValue._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$SerializesNullsValue extends SerializesNullsValue {
+  @override
+  final String? value;
+
+  factory _$SerializesNullsValue([
+    void Function(SerializesNullsValueBuilder)? updates,
+  ]) => (SerializesNullsValueBuilder()..update(updates))._build();
+
+  _$SerializesNullsValue._({this.value}) : super._();
+  @override
+  SerializesNullsValue rebuild(
+    void Function(SerializesNullsValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  SerializesNullsValueBuilder toBuilder() =>
+      SerializesNullsValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SerializesNullsValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'SerializesNullsValue',
+    )..add('value', value)).toString();
+  }
+}
+
+class SerializesNullsValueBuilder
+    implements Builder<SerializesNullsValue, SerializesNullsValueBuilder> {
+  _$SerializesNullsValue? _$v;
+
+  String? _value;
+  String? get value => _$this._value;
+  set value(String? value) => _$this._value = value;
+
+  SerializesNullsValueBuilder();
+
+  SerializesNullsValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SerializesNullsValue other) {
+    _$v = other as _$SerializesNullsValue;
+  }
+
+  @override
+  void update(void Function(SerializesNullsValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SerializesNullsValue build() => _build();
+
+  _$SerializesNullsValue _build() {
+    final _$result = _$v ?? _$SerializesNullsValue._(value: value);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$NullableObjectValue extends NullableObjectValue {
+  @override
+  final Object? value;
+
+  factory _$NullableObjectValue([
+    void Function(NullableObjectValueBuilder)? updates,
+  ]) => (NullableObjectValueBuilder()..update(updates))._build();
+
+  _$NullableObjectValue._({this.value}) : super._();
+  @override
+  NullableObjectValue rebuild(
+    void Function(NullableObjectValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  NullableObjectValueBuilder toBuilder() =>
+      NullableObjectValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is NullableObjectValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'NullableObjectValue',
+    )..add('value', value)).toString();
+  }
+}
+
+class NullableObjectValueBuilder
+    implements Builder<NullableObjectValue, NullableObjectValueBuilder> {
+  _$NullableObjectValue? _$v;
+
+  Object? _value;
+  Object? get value => _$this._value;
+  set value(Object? value) => _$this._value = value;
+
+  NullableObjectValueBuilder();
+
+  NullableObjectValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(NullableObjectValue other) {
+    _$v = other as _$NullableObjectValue;
+  }
+
+  @override
+  void update(void Function(NullableObjectValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  NullableObjectValue build() => _build();
+
+  _$NullableObjectValue _build() {
+    final _$result = _$v ?? _$NullableObjectValue._(value: value);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithHooks extends ValueWithHooks {
+  @override
+  final int hook1Count;
+  @override
+  final int hook2Count;
+  @override
+  final BuiltList<String> hookOrdering;
+
+  factory _$ValueWithHooks([void Function(ValueWithHooksBuilder)? updates]) =>
+      (ValueWithHooksBuilder()..update(updates))._build();
+
+  _$ValueWithHooks._({
+    required this.hook1Count,
+    required this.hook2Count,
+    required this.hookOrdering,
+  }) : super._();
+  @override
+  ValueWithHooks rebuild(void Function(ValueWithHooksBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ValueWithHooksBuilder toBuilder() => ValueWithHooksBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithHooks &&
+        hook1Count == other.hook1Count &&
+        hook2Count == other.hook2Count &&
+        hookOrdering == other.hookOrdering;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, hook1Count.hashCode);
+    _$hash = $jc(_$hash, hook2Count.hashCode);
+    _$hash = $jc(_$hash, hookOrdering.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueWithHooks')
+          ..add('hook1Count', hook1Count)
+          ..add('hook2Count', hook2Count)
+          ..add('hookOrdering', hookOrdering))
+        .toString();
+  }
+}
+
+class ValueWithHooksBuilder
+    implements Builder<ValueWithHooks, ValueWithHooksBuilder> {
+  _$ValueWithHooks? _$v;
+
+  int? _hook1Count;
+  int? get hook1Count => _$this._hook1Count;
+  set hook1Count(int? hook1Count) => _$this._hook1Count = hook1Count;
+
+  int? _hook2Count;
+  int? get hook2Count => _$this._hook2Count;
+  set hook2Count(int? hook2Count) => _$this._hook2Count = hook2Count;
+
+  ListBuilder<String>? _hookOrdering;
+  ListBuilder<String> get hookOrdering =>
+      _$this._hookOrdering ??= ListBuilder<String>();
+  set hookOrdering(ListBuilder<String>? hookOrdering) =>
+      _$this._hookOrdering = hookOrdering;
+
+  ValueWithHooksBuilder() {
+    ValueWithHooks.hook1(this);
+    ValueWithHooks.justInitialize(this);
+    ValueWithHooks.both(this);
+    ValueWithHooks.moreJustInitialize(this);
+    ValueWithHooks.moreBoth(this);
+  }
+
+  ValueWithHooksBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _hook1Count = $v.hook1Count;
+      _hook2Count = $v.hook2Count;
+      _hookOrdering = $v.hookOrdering.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithHooks other) {
+    _$v = other as _$ValueWithHooks;
+  }
+
+  @override
+  void update(void Function(ValueWithHooksBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithHooks build() => _build();
+
+  _$ValueWithHooks _build() {
+    ValueWithHooks.hook2(this);
+    ValueWithHooks.justFinalize(this);
+    ValueWithHooks.both(this);
+    ValueWithHooks.moreJustFinalize(this);
+    ValueWithHooks.moreBoth(this);
+    _$ValueWithHooks _$result;
+    try {
+      _$result =
+          _$v ??
+          _$ValueWithHooks._(
+            hook1Count: BuiltValueNullFieldError.checkNotNull(
+              hook1Count,
+              r'ValueWithHooks',
+              'hook1Count',
+            ),
+            hook2Count: BuiltValueNullFieldError.checkNotNull(
+              hook2Count,
+              r'ValueWithHooks',
+              'hook2Count',
+            ),
+            hookOrdering: hookOrdering.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'hookOrdering';
+        hookOrdering.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'ValueWithHooks',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$$ValueSpecial extends $ValueSpecial {
+  @override
+  final int anInt;
+  @override
+  final String? aString;
+  @override
+  final bool? $mustBeEscaped;
+  @override
+  final SimpleValue? $mustAlsoEscaped;
+  @override
+  final SimpleValue? $assert;
+  @override
+  final SimpleValue? $10;
+
+  factory _$$ValueSpecial([void Function($ValueSpecialBuilder)? updates]) =>
+      ($ValueSpecialBuilder()..update(updates))._build();
+
+  _$$ValueSpecial._({
+    required this.anInt,
+    this.aString,
+    this.$mustBeEscaped,
+    this.$mustAlsoEscaped,
+    this.$assert,
+    this.$10,
+  }) : super._();
+  @override
+  $ValueSpecial rebuild(void Function($ValueSpecialBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  $ValueSpecialBuilder toBuilder() => $ValueSpecialBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is $ValueSpecial &&
+        anInt == other.anInt &&
+        aString == other.aString &&
+        $mustBeEscaped == other.$mustBeEscaped &&
+        $mustAlsoEscaped == other.$mustAlsoEscaped &&
+        $assert == other.$assert &&
+        $10 == other.$10;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, aString.hashCode);
+    _$hash = $jc(_$hash, $mustBeEscaped.hashCode);
+    _$hash = $jc(_$hash, $mustAlsoEscaped.hashCode);
+    _$hash = $jc(_$hash, $assert.hashCode);
+    _$hash = $jc(_$hash, $10.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'$ValueSpecial')
+          ..add('anInt', anInt)
+          ..add('aString', aString)
+          ..add('\$mustBeEscaped', $mustBeEscaped)
+          ..add('\$mustAlsoEscaped', $mustAlsoEscaped)
+          ..add('\$assert', $assert)
+          ..add('\$10', $10))
+        .toString();
+  }
+}
+
+class $ValueSpecialBuilder
+    implements Builder<$ValueSpecial, $ValueSpecialBuilder> {
+  _$$ValueSpecial? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  String? _aString;
+  String? get aString => _$this._aString;
+  set aString(String? aString) => _$this._aString = aString;
+
+  bool? _$mustBeEscaped;
+  bool? get $mustBeEscaped => _$this._$mustBeEscaped;
+  set $mustBeEscaped(bool? $mustBeEscaped) =>
+      _$this._$mustBeEscaped = $mustBeEscaped;
+
+  SimpleValueBuilder? _$mustAlsoEscaped;
+  SimpleValueBuilder get $mustAlsoEscaped =>
+      _$this._$mustAlsoEscaped ??= SimpleValueBuilder();
+  set $mustAlsoEscaped(SimpleValueBuilder? $mustAlsoEscaped) =>
+      _$this._$mustAlsoEscaped = $mustAlsoEscaped;
+
+  SimpleValueBuilder? _$assert;
+  SimpleValueBuilder get $assert => _$this._$assert ??= SimpleValueBuilder();
+  set $assert(SimpleValueBuilder? $assert) => _$this._$assert = $assert;
+
+  SimpleValueBuilder? _$10;
+  SimpleValueBuilder get $10 => _$this._$10 ??= SimpleValueBuilder();
+  set $10(SimpleValueBuilder? $10) => _$this._$10 = $10;
+
+  $ValueSpecialBuilder();
+
+  $ValueSpecialBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _aString = $v.aString;
+      _$mustBeEscaped = $v.$mustBeEscaped;
+      _$mustAlsoEscaped = $v.$mustAlsoEscaped?.toBuilder();
+      _$assert = $v.$assert?.toBuilder();
+      _$10 = $v.$10?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace($ValueSpecial other) {
+    _$v = other as _$$ValueSpecial;
+  }
+
+  @override
+  void update(void Function($ValueSpecialBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  $ValueSpecial build() => _build();
+
+  _$$ValueSpecial _build() {
+    _$$ValueSpecial _$result;
+    try {
+      _$result =
+          _$v ??
+          _$$ValueSpecial._(
+            anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt,
+              r'$ValueSpecial',
+              'anInt',
+            ),
+            aString: aString,
+            $mustBeEscaped: $mustBeEscaped,
+            $mustAlsoEscaped: _$mustAlsoEscaped?.build(),
+            $assert: _$assert?.build(),
+            $10: _$10?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = '\$mustAlsoEscaped';
+        _$mustAlsoEscaped?.build();
+        _$failedField = '\$assert';
+        _$assert?.build();
+        _$failedField = '\$10';
+        _$10?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'$ValueSpecial',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithAwkwardNestedBuilder extends ValueWithAwkwardNestedBuilder {
+  @override
+  final SimpleValue? value1;
+  @override
+  final SimpleValue? value2;
+  @override
+  final BuiltList<int> values;
+  @override
+  final BuiltMap<int, String> map;
+
+  factory _$ValueWithAwkwardNestedBuilder([
+    void Function(ValueWithAwkwardNestedBuilderBuilder)? updates,
+  ]) =>
+      (ValueWithAwkwardNestedBuilderBuilder()..update(updates)).build()
+          as _$ValueWithAwkwardNestedBuilder;
+
+  _$ValueWithAwkwardNestedBuilder._({
+    this.value1,
+    this.value2,
+    required this.values,
+    required this.map,
+  }) : super._();
+  @override
+  ValueWithAwkwardNestedBuilder rebuild(
+    void Function(ValueWithAwkwardNestedBuilderBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  _$ValueWithAwkwardNestedBuilderBuilder toBuilder() =>
+      _$ValueWithAwkwardNestedBuilderBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithAwkwardNestedBuilder &&
+        value1 == other.value1 &&
+        value2 == other.value2 &&
+        values == other.values &&
+        map == other.map;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value1.hashCode);
+    _$hash = $jc(_$hash, value2.hashCode);
+    _$hash = $jc(_$hash, values.hashCode);
+    _$hash = $jc(_$hash, map.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueWithAwkwardNestedBuilder')
+          ..add('value1', value1)
+          ..add('value2', value2)
+          ..add('values', values)
+          ..add('map', map))
+        .toString();
+  }
+}
+
+class _$ValueWithAwkwardNestedBuilderBuilder
+    extends ValueWithAwkwardNestedBuilderBuilder {
+  _$ValueWithAwkwardNestedBuilder? _$v;
+
+  @override
+  SimpleValueBuilder get value1 {
+    _$this;
+    return super.value1 ??= SimpleValueBuilder();
+  }
+
+  @override
+  set value1(SimpleValueBuilder? value1) {
+    _$this;
+    super.value1 = value1;
+  }
+
+  @override
+  SimpleValueBuilder get value2 {
+    _$this;
+    return super.value2 ??= SimpleValueBuilder();
+  }
+
+  @override
+  set value2(SimpleValueBuilder? value2) {
+    _$this;
+    super.value2 = value2;
+  }
+
+  @override
+  ListBuilder<int> get values {
+    _$this;
+    return super.values ??= ListBuilder<int>();
+  }
+
+  @override
+  set values(ListBuilder<int>? values) {
+    _$this;
+    super.values = values;
+  }
+
+  @override
+  MapBuilder<int, String> get map {
+    _$this;
+    return super.map ??= MapBuilder<int, String>();
+  }
+
+  @override
+  set map(MapBuilder<int, String>? map) {
+    _$this;
+    super.map = map;
+  }
+
+  _$ValueWithAwkwardNestedBuilderBuilder() : super._();
+
+  ValueWithAwkwardNestedBuilderBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.value1 = $v.value1?.toBuilder();
+      super.value2 = $v.value2?.toBuilder();
+      super.values = $v.values.toBuilder();
+      super.map = $v.map.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithAwkwardNestedBuilder other) {
+    _$v = other as _$ValueWithAwkwardNestedBuilder;
+  }
+
+  @override
+  void update(void Function(ValueWithAwkwardNestedBuilderBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithAwkwardNestedBuilder build() => _build();
+
+  _$ValueWithAwkwardNestedBuilder _build() {
+    _$ValueWithAwkwardNestedBuilder _$result;
+    try {
+      _$result =
+          _$v ??
+          _$ValueWithAwkwardNestedBuilder._(
+            value1: super.value1?.build(),
+            value2: super.value2?.build(),
+            values: values.build(),
+            map: map.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'value1';
+        super.value1?.build();
+        _$failedField = 'value2';
+        super.value2?.build();
+        _$failedField = 'values';
+        values.build();
+        _$failedField = 'map';
+        map.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+          r'ValueWithAwkwardNestedBuilder',
+          _$failedField,
+          e.toString(),
+        );
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$VariousFunctionsValue extends VariousFunctionsValue {
+  @override
+  final Function bareFunction;
+  @override
+  final Future<void> Function(int, double) positionalFunction;
+  @override
+  final Future<void> Function(int, [double]) optionalFunction;
+  @override
+  final Future<void> Function(int x, double y) positionalNamedFunction;
+  @override
+  final Future<void> Function(int x, {int y, double z}) namedFunction;
+  @override
+  final Future<void> Function(int x, {required int y, required double z})
+  requiredNamedFunction;
+  @override
+  final Function mixinBareFunction;
+  @override
+  final Future<void> Function(int, double) mixinPositionalFunction;
+  @override
+  final Future<void> Function(int, [double]) mixinOptionalFunction;
+  @override
+  final Future<void> Function(int, double) mixinPositionalNamedFunction;
+  @override
+  final Future<void> Function(int, {int y, double z}) mixinNamedFunction;
+  @override
+  final Future<void> Function(int, {required int y, required double z})
+  mixinRequiredNamedFunction;
+
+  factory _$VariousFunctionsValue([
+    void Function(VariousFunctionsValueBuilder)? updates,
+  ]) => (VariousFunctionsValueBuilder()..update(updates))._build();
+
+  _$VariousFunctionsValue._({
+    required this.bareFunction,
+    required this.positionalFunction,
+    required this.optionalFunction,
+    required this.positionalNamedFunction,
+    required this.namedFunction,
+    required this.requiredNamedFunction,
+    required this.mixinBareFunction,
+    required this.mixinPositionalFunction,
+    required this.mixinOptionalFunction,
+    required this.mixinPositionalNamedFunction,
+    required this.mixinNamedFunction,
+    required this.mixinRequiredNamedFunction,
+  }) : super._();
+  @override
+  VariousFunctionsValue rebuild(
+    void Function(VariousFunctionsValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  VariousFunctionsValueBuilder toBuilder() =>
+      VariousFunctionsValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is VariousFunctionsValue &&
+        bareFunction == other.bareFunction &&
+        positionalFunction == other.positionalFunction &&
+        optionalFunction == other.optionalFunction &&
+        positionalNamedFunction == other.positionalNamedFunction &&
+        namedFunction == other.namedFunction &&
+        requiredNamedFunction == other.requiredNamedFunction &&
+        mixinBareFunction == other.mixinBareFunction &&
+        mixinPositionalFunction == other.mixinPositionalFunction &&
+        mixinOptionalFunction == other.mixinOptionalFunction &&
+        mixinPositionalNamedFunction == other.mixinPositionalNamedFunction &&
+        mixinNamedFunction == other.mixinNamedFunction &&
+        mixinRequiredNamedFunction == other.mixinRequiredNamedFunction;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, bareFunction.hashCode);
+    _$hash = $jc(_$hash, positionalFunction.hashCode);
+    _$hash = $jc(_$hash, optionalFunction.hashCode);
+    _$hash = $jc(_$hash, positionalNamedFunction.hashCode);
+    _$hash = $jc(_$hash, namedFunction.hashCode);
+    _$hash = $jc(_$hash, requiredNamedFunction.hashCode);
+    _$hash = $jc(_$hash, mixinBareFunction.hashCode);
+    _$hash = $jc(_$hash, mixinPositionalFunction.hashCode);
+    _$hash = $jc(_$hash, mixinOptionalFunction.hashCode);
+    _$hash = $jc(_$hash, mixinPositionalNamedFunction.hashCode);
+    _$hash = $jc(_$hash, mixinNamedFunction.hashCode);
+    _$hash = $jc(_$hash, mixinRequiredNamedFunction.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'VariousFunctionsValue')
+          ..add('bareFunction', bareFunction)
+          ..add('positionalFunction', positionalFunction)
+          ..add('optionalFunction', optionalFunction)
+          ..add('positionalNamedFunction', positionalNamedFunction)
+          ..add('namedFunction', namedFunction)
+          ..add('requiredNamedFunction', requiredNamedFunction)
+          ..add('mixinBareFunction', mixinBareFunction)
+          ..add('mixinPositionalFunction', mixinPositionalFunction)
+          ..add('mixinOptionalFunction', mixinOptionalFunction)
+          ..add('mixinPositionalNamedFunction', mixinPositionalNamedFunction)
+          ..add('mixinNamedFunction', mixinNamedFunction)
+          ..add('mixinRequiredNamedFunction', mixinRequiredNamedFunction))
+        .toString();
+  }
+}
+
+class VariousFunctionsValueBuilder
+    implements Builder<VariousFunctionsValue, VariousFunctionsValueBuilder> {
+  _$VariousFunctionsValue? _$v;
+
+  Function? _bareFunction;
+  Function? get bareFunction => _$this._bareFunction;
+  set bareFunction(Function? bareFunction) =>
+      _$this._bareFunction = bareFunction;
+
+  Future<void> Function(int, double)? _positionalFunction;
+  Future<void> Function(int, double)? get positionalFunction =>
+      _$this._positionalFunction;
+  set positionalFunction(
+    Future<void> Function(int, double)? positionalFunction,
+  ) => _$this._positionalFunction = positionalFunction;
+
+  Future<void> Function(int, [double])? _optionalFunction;
+  Future<void> Function(int, [double])? get optionalFunction =>
+      _$this._optionalFunction;
+  set optionalFunction(
+    Future<void> Function(int, [double])? optionalFunction,
+  ) => _$this._optionalFunction = optionalFunction;
+
+  Future<void> Function(int x, double y)? _positionalNamedFunction;
+  Future<void> Function(int x, double y)? get positionalNamedFunction =>
+      _$this._positionalNamedFunction;
+  set positionalNamedFunction(
+    Future<void> Function(int x, double y)? positionalNamedFunction,
+  ) => _$this._positionalNamedFunction = positionalNamedFunction;
+
+  Future<void> Function(int x, {int y, double z})? _namedFunction;
+  Future<void> Function(int x, {int y, double z})? get namedFunction =>
+      _$this._namedFunction;
+  set namedFunction(
+    Future<void> Function(int x, {int y, double z})? namedFunction,
+  ) => _$this._namedFunction = namedFunction;
+
+  Future<void> Function(int x, {required int y, required double z})?
+  _requiredNamedFunction;
+  Future<void> Function(int x, {required int y, required double z})?
+  get requiredNamedFunction => _$this._requiredNamedFunction;
+  set requiredNamedFunction(
+    Future<void> Function(int x, {required int y, required double z})?
+    requiredNamedFunction,
+  ) => _$this._requiredNamedFunction = requiredNamedFunction;
+
+  Function? _mixinBareFunction;
+  Function? get mixinBareFunction => _$this._mixinBareFunction;
+  set mixinBareFunction(Function? mixinBareFunction) =>
+      _$this._mixinBareFunction = mixinBareFunction;
+
+  Future<void> Function(int, double)? _mixinPositionalFunction;
+  Future<void> Function(int, double)? get mixinPositionalFunction =>
+      _$this._mixinPositionalFunction;
+  set mixinPositionalFunction(
+    Future<void> Function(int, double)? mixinPositionalFunction,
+  ) => _$this._mixinPositionalFunction = mixinPositionalFunction;
+
+  Future<void> Function(int, [double])? _mixinOptionalFunction;
+  Future<void> Function(int, [double])? get mixinOptionalFunction =>
+      _$this._mixinOptionalFunction;
+  set mixinOptionalFunction(
+    Future<void> Function(int, [double])? mixinOptionalFunction,
+  ) => _$this._mixinOptionalFunction = mixinOptionalFunction;
+
+  Future<void> Function(int, double)? _mixinPositionalNamedFunction;
+  Future<void> Function(int, double)? get mixinPositionalNamedFunction =>
+      _$this._mixinPositionalNamedFunction;
+  set mixinPositionalNamedFunction(
+    Future<void> Function(int, double)? mixinPositionalNamedFunction,
+  ) => _$this._mixinPositionalNamedFunction = mixinPositionalNamedFunction;
+
+  Future<void> Function(int, {int y, double z})? _mixinNamedFunction;
+  Future<void> Function(int, {int y, double z})? get mixinNamedFunction =>
+      _$this._mixinNamedFunction;
+  set mixinNamedFunction(
+    Future<void> Function(int, {int y, double z})? mixinNamedFunction,
+  ) => _$this._mixinNamedFunction = mixinNamedFunction;
+
+  Future<void> Function(int, {required int y, required double z})?
+  _mixinRequiredNamedFunction;
+  Future<void> Function(int, {required int y, required double z})?
+  get mixinRequiredNamedFunction => _$this._mixinRequiredNamedFunction;
+  set mixinRequiredNamedFunction(
+    Future<void> Function(int, {required int y, required double z})?
+    mixinRequiredNamedFunction,
+  ) => _$this._mixinRequiredNamedFunction = mixinRequiredNamedFunction;
+
+  VariousFunctionsValueBuilder();
+
+  VariousFunctionsValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _bareFunction = $v.bareFunction;
+      _positionalFunction = $v.positionalFunction;
+      _optionalFunction = $v.optionalFunction;
+      _positionalNamedFunction = $v.positionalNamedFunction;
+      _namedFunction = $v.namedFunction;
+      _requiredNamedFunction = $v.requiredNamedFunction;
+      _mixinBareFunction = $v.mixinBareFunction;
+      _mixinPositionalFunction = $v.mixinPositionalFunction;
+      _mixinOptionalFunction = $v.mixinOptionalFunction;
+      _mixinPositionalNamedFunction = $v.mixinPositionalNamedFunction;
+      _mixinNamedFunction = $v.mixinNamedFunction;
+      _mixinRequiredNamedFunction = $v.mixinRequiredNamedFunction;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(VariousFunctionsValue other) {
+    _$v = other as _$VariousFunctionsValue;
+  }
+
+  @override
+  void update(void Function(VariousFunctionsValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  VariousFunctionsValue build() => _build();
+
+  _$VariousFunctionsValue _build() {
+    final _$result =
+        _$v ??
+        _$VariousFunctionsValue._(
+          bareFunction: BuiltValueNullFieldError.checkNotNull(
+            bareFunction,
+            r'VariousFunctionsValue',
+            'bareFunction',
+          ),
+          positionalFunction: BuiltValueNullFieldError.checkNotNull(
+            positionalFunction,
+            r'VariousFunctionsValue',
+            'positionalFunction',
+          ),
+          optionalFunction: BuiltValueNullFieldError.checkNotNull(
+            optionalFunction,
+            r'VariousFunctionsValue',
+            'optionalFunction',
+          ),
+          positionalNamedFunction: BuiltValueNullFieldError.checkNotNull(
+            positionalNamedFunction,
+            r'VariousFunctionsValue',
+            'positionalNamedFunction',
+          ),
+          namedFunction: BuiltValueNullFieldError.checkNotNull(
+            namedFunction,
+            r'VariousFunctionsValue',
+            'namedFunction',
+          ),
+          requiredNamedFunction: BuiltValueNullFieldError.checkNotNull(
+            requiredNamedFunction,
+            r'VariousFunctionsValue',
+            'requiredNamedFunction',
+          ),
+          mixinBareFunction: BuiltValueNullFieldError.checkNotNull(
+            mixinBareFunction,
+            r'VariousFunctionsValue',
+            'mixinBareFunction',
+          ),
+          mixinPositionalFunction: BuiltValueNullFieldError.checkNotNull(
+            mixinPositionalFunction,
+            r'VariousFunctionsValue',
+            'mixinPositionalFunction',
+          ),
+          mixinOptionalFunction: BuiltValueNullFieldError.checkNotNull(
+            mixinOptionalFunction,
+            r'VariousFunctionsValue',
+            'mixinOptionalFunction',
+          ),
+          mixinPositionalNamedFunction: BuiltValueNullFieldError.checkNotNull(
+            mixinPositionalNamedFunction,
+            r'VariousFunctionsValue',
+            'mixinPositionalNamedFunction',
+          ),
+          mixinNamedFunction: BuiltValueNullFieldError.checkNotNull(
+            mixinNamedFunction,
+            r'VariousFunctionsValue',
+            'mixinNamedFunction',
+          ),
+          mixinRequiredNamedFunction: BuiltValueNullFieldError.checkNotNull(
+            mixinRequiredNamedFunction,
+            r'VariousFunctionsValue',
+            'mixinRequiredNamedFunction',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$NewConstructorValue extends NewConstructorValue {
+  @override
+  final int anInt;
+
+  factory _$NewConstructorValue([
+    void Function(NewConstructorValueBuilder)? updates,
+  ]) =>
+      (NewConstructorValueBuilder()..update(updates)).build()
+          as _$NewConstructorValue;
+
+  _$NewConstructorValue._({required this.anInt}) : super._();
+  @override
+  NewConstructorValue rebuild(
+    void Function(NewConstructorValueBuilder) updates,
+  ) => (toBuilder()..update(updates)).build();
+
+  @override
+  _$NewConstructorValueBuilder toBuilder() =>
+      _$NewConstructorValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is NewConstructorValue && anInt == other.anInt;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'NewConstructorValue',
+    )..add('anInt', anInt)).toString();
+  }
+}
+
+class _$NewConstructorValueBuilder extends NewConstructorValueBuilder {
+  _$NewConstructorValue? _$v;
+
+  @override
+  int? get anInt {
+    _$this;
+    return super.anInt;
+  }
+
+  @override
+  set anInt(int? anInt) {
+    _$this;
+    super.anInt = anInt;
+  }
+
+  _$NewConstructorValueBuilder() : super._();
+
+  NewConstructorValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.anInt = $v.anInt;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(NewConstructorValue other) {
+    _$v = other as _$NewConstructorValue;
+  }
+
+  @override
+  void update(void Function(NewConstructorValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  NewConstructorValue build() => _build();
+
+  _$NewConstructorValue _build() {
+    final _$result =
+        _$v ??
+        _$NewConstructorValue._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+            anInt,
+            r'NewConstructorValue',
+            'anInt',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/pubspec.yaml
+++ b/built_types/end_to_end_test/pubspec.yaml
@@ -1,0 +1,22 @@
+name: end_to_end_test
+version: 8.13.0
+publish_to: none
+description: >
+  Tests, not for publishing.
+homepage: https://github.com/google/built_value.dart
+
+environment:
+  sdk: '>=3.13.0 <4.0.0'
+
+dependencies:
+  built_collection: ^5.0.0
+  built_value: ^8.7.0
+
+dev_dependencies:
+  build: '>=3.1.0 <5.0.0'
+  build_runner: '>=2.5.0 <3.0.0'
+  built_value_generator: ^8.13.0
+  fixnum: ^1.0.0
+  pedantic: ^1.4.0
+  quiver: '>=0.21.0 <4.0.0'
+  test: ^1.16.0

--- a/built_types/end_to_end_test/test/collections_serializer_test.dart
+++ b/built_types/end_to_end_test/test/collections_serializer_test.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/collections.dart';
+import 'package:end_to_end_test/serializers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Collections', () {
+    var data = Collections((b) => b
+      ..list.add(1)
+      ..set.add('two')
+      ..map['three'] = 4
+      ..nullsInList.replace(<int?>[1, null])
+      ..nullsInSet.replace(<String?>['one', null])
+      ..nullsInMap.addAll({null: 1, 'two': 2})
+      ..nullsInListMultimap.add(null, false)
+      ..nullsInListMultimap.add(1, true)
+      ..nullsInSetMultimap.add('one', null)
+      ..nullsInSetMultimap.add('two', true)
+      ..listMultimap.addValues(4, [true, false])
+      ..setMultimap.addValues('five', [true, false])
+      ..nestedNullablesList.replace(<BuiltList<int?>?>[
+        null,
+        BuiltList<int?>(<int?>[1, null]),
+      ]));
+    var serialized = json.decode(json.encode([
+      'Collections',
+      'list',
+      [1],
+      'set',
+      ['two'],
+      'map',
+      ['three', 4],
+      'listMultimap',
+      [
+        4,
+        [true, false]
+      ],
+      'setMultimap',
+      [
+        'five',
+        [true, false]
+      ],
+      'nullsInList',
+      <int?>[1, null],
+      'nullsInSet',
+      <String?>['one', null],
+      'nullsInMap',
+      <Object?>[null, 1, 'two', 2],
+      'nullsInListMultimap',
+      [
+        null,
+        [false],
+        1,
+        [true],
+      ],
+      'nullsInSetMultimap',
+      [
+        'one',
+        [null],
+        'two',
+        [true],
+      ],
+      'nullableInGenericsList',
+      <Object>[],
+      'nestedNullablesList',
+      [
+        null,
+        [1, null],
+      ],
+    ])) as Object;
+    var serializersWithBuilder = (serializers.toBuilder()
+          ..addBuilderFactory(FullType(BuiltList, [FullType.nullable(int)]),
+              () => ListBuilder<int?>()))
+        .build();
+
+    test('can be serialized', () {
+      expect(serializersWithBuilder.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializersWithBuilder.deserialize(serialized), data);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/collections_test.dart
+++ b/built_types/end_to_end_test/test/collections_test.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_collection/src/internal/hash.dart';
+import 'package:end_to_end_test/collections.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Collections', () {
+    test('can be instantiated', () {
+      Collections();
+    });
+
+    test('default to empty if not nullable', () {
+      expect(Collections().list.isEmpty, true);
+      expect(Collections().set.isEmpty, true);
+      expect(Collections().map.isEmpty, true);
+      expect(Collections().listMultimap.isEmpty, true);
+      expect(Collections().setMultimap.isEmpty, true);
+    });
+
+    test('default to null if nullable', () {
+      expect(Collections().nullableList, null);
+      expect(Collections().nullableSet, null);
+      expect(Collections().nullableMap, null);
+      expect(Collections().nullableListMultimap, null);
+      expect(Collections().nullableSetMultimap, null);
+    });
+
+    test('can be updated via builder', () {
+      final collections = Collections((b) => b
+        ..list.add(1)
+        ..set.add('two')
+        ..map['three'] = 4
+        ..listMultimap.add(5, true)
+        ..setMultimap.add('six', false));
+
+      expect(collections.list, [1]);
+      expect(collections.set, ['two']);
+      expect(collections.map.toMap(), {'three': 4});
+      expect(collections.listMultimap.toMap(), {
+        5: [true]
+      });
+      expect(collections.setMultimap.toMap(), {
+        'six': [false]
+      });
+    });
+
+    test('can be set from null via builder', () {
+      final collections = Collections((b) => b
+        ..nullableList.add(1)
+        ..nullableSet.add('two')
+        ..nullableMap['three'] = 4
+        ..nullableListMultimap.add(5, true)
+        ..nullableSetMultimap.add('six', false));
+
+      expect(collections.nullableList, [1]);
+      expect(collections.nullableSet, ['two']);
+      expect(collections.nullableMap!.toMap(), {'three': 4});
+      expect(collections.nullableListMultimap!.toMap(), {
+        5: [true]
+      });
+      expect(collections.nullableSetMultimap!.toMap(), {
+        'six': [false]
+      });
+    });
+
+    test('hash matches quiver hash', () {
+      final collections = Collections((b) => b
+        ..list.add(1)
+        ..set.add('two')
+        ..map['three'] = 4
+        ..listMultimap.add(5, true)
+        ..setMultimap.add('six', false));
+
+      expect(
+          collections.hashCode,
+          hashObjects(<Object?>[
+            collections.list,
+            collections.set,
+            collections.map,
+            collections.listMultimap,
+            collections.setMultimap,
+            collections.nullsInList,
+            collections.nullsInSet,
+            collections.nullsInMap,
+            collections.nullsInListMultimap,
+            collections.nullsInSetMultimap,
+            collections.nullableList,
+            collections.nullableSet,
+            collections.nullableMap,
+            collections.nullableListMultimap,
+            collections.nullableSetMultimap,
+            collections.nullableInGenericsList,
+            collections.nestedNullablesList,
+          ]));
+    });
+
+    test('nullable in generics works', () {
+      Collections((b) => b
+        ..list.add(1)
+        ..set.add('two')
+        ..map['three'] = 4
+        ..listMultimap.add(5, true)
+        ..setMultimap.add('six', false)
+        ..nullableInGenericsList.add(Foo<int?>()));
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/enums_serializer_test.dart
+++ b/built_types/end_to_end_test/test/enums_serializer_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'dart:convert';
+
+import 'package:end_to_end_test/enums.dart';
+import 'package:end_to_end_test/serializers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TestEnum', () {
+    var data = TestEnum.yes;
+    var serialized = json.decode(json.encode(['TestEnum', 'yes'])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('NewConstructorEnum', () {
+    var data = NewConstructorEnum.yes;
+    var serialized =
+        json.decode(json.encode(['NewConstructorEnum', 'yes'])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('WireNameEnum', () {
+    var data = WireNameEnum.yes;
+    var serialized = json.decode(json.encode(['E', 'y'])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('WireNumberEnum', () {
+    var data = WireNumberEnum.yes;
+    var serialized = json.decode(json.encode(['WireNumberEnum', 1])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('FallbackEnum', () {
+    var data = FallbackEnum.no;
+    var serialized =
+        json.decode(json.encode(['FallbackEnum', 'some_unrecognized_value']))
+            as Object;
+
+    test('deserializes using fallback', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('FallbackNumberEnum', () {
+    var data = FallbackNumberEnum.no;
+    var serialized =
+        json.decode(json.encode(['FallbackNumberEnum', 75])) as Object;
+
+    test('deserializes using fallback', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/enums_test.dart
+++ b/built_types/end_to_end_test/test/enums_test.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:end_to_end_test/enums.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(TestEnumMixin, () {
+    test('mixin works as expected', () {
+      expect(UsesTestEnumMixin().toString(), 'yes no maybe');
+    });
+  });
+  group(FallbackEnum, () {
+    test('valueOf works for non-fallback values', () {
+      expect(FallbackEnum.valueOf('yes'), FallbackEnum.yes);
+    });
+
+    test('valueOf uses fallback', () {
+      expect(FallbackEnum.valueOf('arbitrary_unrecognized_string'),
+          FallbackEnum.no);
+    });
+  });
+  group(NewConstructorEnum, () {
+    test('values and valueOf work as expected', () {
+      expect(NewConstructorEnum.values,
+          [NewConstructorEnum.yes, NewConstructorEnum.no]);
+      expect(NewConstructorEnum.valueOf('yes'), NewConstructorEnum.yes);
+      expect(NewConstructorEnum.valueOf('no'), NewConstructorEnum.no);
+    });
+  });
+}
+
+class UsesTestEnumMixin with TestEnumMixin {
+  // Refer to the constants to check they are available via the mixin from
+  // another class.
+  @override
+  String toString() =>
+      '${this.TestEnum.yes} ${this.TestEnum.no} ${this.TestEnum.maybe}';
+}

--- a/built_types/end_to_end_test/test/generics_serializer_test.dart
+++ b/built_types/end_to_end_test/test/generics_serializer_test.dart
@@ -1,0 +1,462 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/generics.dart';
+import 'package:end_to_end_test/serializers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GenericValue with known specifiedType but missing builder', () {
+    var data = GenericValue<int>((b) => b..value = 1);
+    var specifiedType = const FullType(GenericValue, [FullType(int)]);
+    var serialized = json.decode(json.encode([
+      'value',
+      1,
+    ])) as Object;
+
+    test('cannot be serialized', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<StateError>()));
+    });
+
+    test('cannot be deserialized', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<DeserializationError>()));
+    });
+  });
+
+  group('GenericValue with known specifiedType and correct builder', () {
+    var data = GenericValue<int>((b) => b..value = 1);
+    var specifiedType = const FullType(GenericValue, [FullType(int)]);
+    var serializersWithBuilder = (serializers.toBuilder()
+          ..addBuilderFactory(specifiedType, () => GenericValueBuilder<int>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      'value',
+      1,
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(
+          serializersWithBuilder.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(
+          serializersWithBuilder.deserialize(serialized,
+              specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type on deserialization', () {
+      expect(
+          serializersWithBuilder
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType
+              .toString(),
+          r'_$GenericValue<int>');
+    });
+  });
+
+  group('GenericValue with unknown specifiedType', () {
+    var data = GenericValue<int>((b) => b..value = 1);
+    var serialized = json.decode(json.encode([
+      'GenericValue',
+      'value',
+      ['int', 1],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+
+    test('loses generic type on deserialization', () {
+      expect(serializers.deserialize(serialized).runtimeType.toString(),
+          r'_$GenericValue<Object?>');
+    });
+  });
+
+  group('BoundGenericValue with known specifiedType but missing builder', () {
+    var data = BoundGenericValue<int>((b) => b..value = 1);
+    var specifiedType = const FullType(BoundGenericValue, [FullType(int)]);
+    var serialized = json.decode(json.encode([
+      'value',
+      1,
+    ])) as Object;
+
+    test('cannot be serialized', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<StateError>()));
+    });
+
+    test('cannot be deserialized', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<DeserializationError>()));
+    });
+  });
+
+  group('BoundGenericValue with known specifiedType and correct builder', () {
+    var data = BoundGenericValue<int>((b) => b..value = 1);
+    var specifiedType = const FullType(BoundGenericValue, [FullType(int)]);
+    var serializersWithBuilder = (serializers.toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => BoundGenericValueBuilder<int>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      'value',
+      1,
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(
+          serializersWithBuilder.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(
+          serializersWithBuilder.deserialize(serialized,
+              specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type on deserialization', () {
+      expect(
+          serializersWithBuilder
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType
+              .toString(),
+          r'_$BoundGenericValue<int>');
+    });
+  });
+
+  group('BoundGenericValue with unknown specifiedType', () {
+    var data = BoundGenericValue<int>((b) => b..value = 1);
+    var serialized = json.decode(json.encode([
+      'BoundGenericValue',
+      'value',
+      ['int', 1],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+
+    test('loses generic type on deserialization', () {
+      expect(serializers.deserialize(serialized).runtimeType.toString(),
+          r'_$BoundGenericValue<num>');
+    });
+  });
+
+  group('CollectionGenericValue with known specifiedType but missing builder',
+      () {
+    var data = CollectionGenericValue<int>((b) => b..values.add(1));
+    var specifiedType = const FullType(CollectionGenericValue, [FullType(int)]);
+    var serialized = json.decode(json.encode([
+      'values',
+      [
+        1,
+      ],
+    ])) as Object;
+
+    test('cannot be serialized', () {
+      expect(() => serializers.serialize(data, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<StateError>()));
+    });
+
+    test('cannot be deserialized', () {
+      expect(
+          () =>
+              serializers.deserialize(serialized, specifiedType: specifiedType),
+          throwsA(const TypeMatcher<DeserializationError>()));
+    });
+  });
+
+  group('CollectionGenericValue with known specifiedType and correct builder',
+      () {
+    var data = CollectionGenericValue<int>((b) => b..values.add(1));
+    var specifiedType = const FullType(CollectionGenericValue, [FullType(int)]);
+    var serializersWithBuilder = (serializers.toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => CollectionGenericValueBuilder<int>())
+          ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]),
+              () => ListBuilder<int>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      'values',
+      [
+        1,
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      serializersWithBuilder
+          .expectBuilder(const FullType(BuiltList, [FullType(int)]));
+      expect(
+          serializersWithBuilder.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(
+          serializersWithBuilder.deserialize(serialized,
+              specifiedType: specifiedType),
+          data);
+    });
+
+    test('keeps generic type on deserialization', () {
+      expect(
+          serializersWithBuilder
+              .deserialize(serialized, specifiedType: specifiedType)
+              .runtimeType
+              .toString(),
+          r'_$CollectionGenericValue<int>');
+    });
+  });
+
+  group('CollectionGenericValue with unknown specifiedType', () {
+    var data = CollectionGenericValue<int>((b) => b..values.add(1));
+    var serialized = json.decode(json.encode([
+      'CollectionGenericValue',
+      'values',
+      [
+        ['int', 1]
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+
+    test('loses generic type on deserialization', () {
+      expect(serializers.deserialize(serialized).runtimeType.toString(),
+          r'_$CollectionGenericValue<Object?>');
+    });
+  });
+
+  group('GenericContainer with known specifiedType', () {
+    var data = GenericContainer((b) => b
+      ..genericValue.value = '1'
+      ..boundGenericValue.value = 2.2
+      ..collectionGenericValue.values.add('3'));
+    var specifiedType = const FullType(GenericContainer, [FullType(int)]);
+    // TODO(davidmorgan): adding this builder manually shouldn't be necessary.
+    // Auto-add builders for nested generic types.
+    var serializersWithBuilder = (serializers.toBuilder()
+          ..addBuilderFactory(const FullType(BuiltList, [FullType(String)]),
+              () => ListBuilder<String>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      'genericValue',
+      ['value', '1'],
+      'boundGenericValue',
+      ['value', 2.2],
+      'collectionGenericValue',
+      [
+        'values',
+        ['3']
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      serializersWithBuilder
+          .expectBuilder(const FullType(BuiltList, [FullType(int)]));
+      expect(
+          serializersWithBuilder.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(
+          serializersWithBuilder.deserialize(serialized,
+              specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('GenericContainer with unknown specifiedType', () {
+    var data = GenericContainer((b) => b
+      ..genericValue.value = '1'
+      ..boundGenericValue.value = 2.2
+      ..collectionGenericValue.values.add('3'));
+    // TODO(davidmorgan): adding this builder manually shouldn't be necessary.
+    // Auto-add builders for nested generic types.
+    var serializersWithBuilder = (serializers.toBuilder()
+          ..addBuilderFactory(const FullType(BuiltList, [FullType(String)]),
+              () => ListBuilder<String>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      'GenericContainer',
+      'genericValue',
+      ['value', '1'],
+      'boundGenericValue',
+      ['value', 2.2],
+      'collectionGenericValue',
+      [
+        'values',
+        ['3']
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializersWithBuilder.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializersWithBuilder.deserialize(serialized), data);
+    });
+  });
+
+  group('PassthroughGenericContainer with known specifiedType', () {
+    var data = PassthroughGenericContainer<int>((b) => b
+      ..genericValue.value = 1
+      ..collectionGenericValue.values.add(3));
+    var specifiedType =
+        const FullType(PassthroughGenericContainer, [FullType(int)]);
+    // TODO(davidmorgan): adding this builder manually shouldn't be necessary.
+    // Auto-add builders for nested generic types.
+    var serializersWithBuilder = (serializers.toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => PassthroughGenericContainerBuilder<int>())
+          ..addBuilderFactory(const FullType(GenericValue, [FullType(int)]),
+              () => GenericValueBuilder<int>())
+          ..addBuilderFactory(
+              const FullType(CollectionGenericValue, [FullType(int)]),
+              () => CollectionGenericValueBuilder<int>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      'genericValue',
+      ['value', 1],
+      'collectionGenericValue',
+      [
+        'values',
+        [3]
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(
+          serializersWithBuilder.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(
+          serializersWithBuilder.deserialize(serialized,
+              specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('PassthroughGenericContainer with unknown specifiedType', () {
+    var data = PassthroughGenericContainer<int>((b) => b
+      ..genericValue.value = 1
+      ..collectionGenericValue.values.add(3));
+    var specifiedType =
+        const FullType(PassthroughGenericContainer, [FullType(int)]);
+    // TODO(davidmorgan): adding this builder manually shouldn't be necessary.
+    // Auto-add builders for nested generic types.
+    var serializersWithBuilder = (serializers.toBuilder()
+          ..addBuilderFactory(
+              specifiedType, () => PassthroughGenericContainerBuilder<int>())
+          ..addBuilderFactory(const FullType(GenericValue, [FullType(Object)]),
+              () => GenericValueBuilder<Object>())
+          ..addBuilderFactory(
+              const FullType(CollectionGenericValue, [FullType(Object)]),
+              () => CollectionGenericValueBuilder<Object>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      'PassthroughGenericContainer',
+      'genericValue',
+      [
+        'value',
+        ['int', 1]
+      ],
+      'collectionGenericValue',
+      [
+        'values',
+        [
+          ['int', 3]
+        ]
+      ]
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializersWithBuilder.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializersWithBuilder.deserialize(serialized), data);
+    });
+  });
+
+  group('NestedGenericContainer with known specifiedType', () {
+    var data = NestedGenericContainer(
+        (b) => b..map.value = BuiltMap<int, String>({1: 'one'}));
+    var specifiedType = const FullType(NestedGenericContainer);
+    // TODO(davidmorgan): adding this builder manually shouldn't be necessary.
+    // Auto-add builders for nested generic types.
+    var serializersWithBuilder = (serializers.toBuilder()
+          ..addBuilderFactory(
+              const FullType(BuiltMap, [FullType(int), FullType(String)]),
+              () => MapBuilder<int, String>()))
+        .build();
+    var serialized = json.decode(json.encode([
+      'map',
+      [
+        'value',
+        [1, 'one'],
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(
+          serializersWithBuilder.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(
+          serializersWithBuilder.deserialize(serialized,
+              specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('ConcreteGeneric with unknown specifiedType', () {
+    var data = ConcreteGeneric((b) => b..value = 1);
+    var serialized =
+        json.decode(json.encode(['ConcreteGeneric', 'value', 1])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/generics_test.dart
+++ b/built_types/end_to_end_test/test/generics_test.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_value/built_value.dart';
+import 'package:end_to_end_test/generics.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GenericValue', () {
+    test('can be instantiated', () {
+      GenericValue<int>((b) => b..value = 0);
+    });
+
+    test('throws on null for non-nullable fields on build', () {
+      expect(() => GenericValue<int>(),
+          throwsA(const TypeMatcher<BuiltValueNullFieldError>()));
+    });
+
+    test('fields can be set via build constructor', () {
+      final value = GenericValue<int>((b) => b..value = 1);
+      expect(value.value, 1);
+    });
+
+    test('fields can be updated via rebuild method', () {
+      final value =
+          GenericValue<int>((b) => b..value = 0).rebuild((b) => b..value = 1);
+      expect(value.value, 1);
+    });
+
+    test('builder can be instantiated', () {
+      GenericValueBuilder<int>();
+    });
+  });
+
+  group('InitializeGenericValue', () {
+    test('can initialize itself for int', () {
+      InitializeGenericValue<int>();
+    });
+  });
+
+  group('BoundGenericValue', () {
+    test('can be instantiated', () {
+      BoundGenericValue<int>((b) => b.value = 0);
+      BoundGenericValue<int>((b) => b
+        ..value = 0
+        ..nullableValue = 1);
+    });
+  });
+
+  group('BoundNullableGenericValue', () {
+    test('can be instantiated', () {
+      BoundNullableGenericValue<int>((b) => b.value = 1);
+      BoundNullableGenericValue<int>((b) => b
+        ..value = 1
+        ..nullableValue = 2);
+      BoundNullableGenericValue<int?>();
+      BoundNullableGenericValue<int?>((b) => b.value = 1);
+      BoundNullableGenericValue<int?>((b) => b
+        ..value = 1
+        ..nullableValue = 2);
+    });
+
+    test('throws on null for non-nullable fields on build', () {
+      expect(() => BoundNullableGenericValue<int>(),
+          throwsA(const TypeMatcher<BuiltValueNullFieldError>()));
+    });
+  });
+
+  group('GenericFunction', () {
+    test('can be compared', () {
+      // Generic functions have troublesome behaviour when casting. Check that
+      // operator== does not throw due to a disallowed cast.
+      final function = (int x) {};
+      expect(
+          GenericFunction<int>((b) => b..function = function) ==
+              GenericFunction<int>((b) => b..function = function),
+          true);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/imported_values_serializer_test.dart
+++ b/built_types/end_to_end_test/test/imported_values_serializer_test.dart
@@ -1,0 +1,94 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:end_to_end_test/imported_values.dart';
+import 'package:end_to_end_test/serializers.dart';
+import 'package:end_to_end_test/values.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ImportedValue', () {
+    var data = ImportedValue((b) => b.simpleValue
+      ..anInt = 1
+      ..aString = 'two');
+    var serialized = json.decode(json.encode([
+      'ImportedValue',
+      'simpleValue',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'simpleValues',
+      <Object>[],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('ImportedCustomValue', () {
+    var data = ImportedCustomValue((b) => b
+      ..simpleValue = SimpleValue((b) => b
+        ..anInt = 1
+        ..aString = 'two')
+      ..simpleValues = BuiltList.of([]));
+    var serialized = json.decode(json.encode([
+      'ImportedCustomValue',
+      'simpleValue',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'simpleValues',
+      <Object>[],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('ImportedCustomNestedValue', () {
+    var data = ImportedCustomNestedValue((b) => b.simpleValue
+      ..anInt = 1
+      ..aString = 'two');
+    var serialized = json.decode(json.encode([
+      'ImportedCustomNestedValue',
+      'simpleValue',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'simpleValues',
+      <Object>[],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/imported_values_test.dart
+++ b/built_types/end_to_end_test/test/imported_values_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_collection/built_collection.dart';
+import 'package:end_to_end_test/imported_values.dart';
+import 'package:end_to_end_test/values.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ImportedValue', () {
+    test('can be instantiated', () {
+      ImportedValue((b) => b..simpleValue.anInt = 3);
+    });
+  });
+
+  group('ImportedCustomValue', () {
+    test('can be instantiated', () {
+      ImportedCustomValue((b) => b
+        ..simpleValue = SimpleValue((b) => b..anInt = 3)
+        ..simpleValues = BuiltList.of([]));
+    });
+  });
+
+  group('ImportedCustomNestedValue', () {
+    test('can be instantiated', () {
+      ImportedCustomNestedValue((b) => b
+        ..simpleValue.anInt = 3
+        ..simpleValues.add(SimpleValue((b) => b..anInt = 4)));
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/interfaces_serializer_test.dart
+++ b/built_types/end_to_end_test/test/interfaces_serializer_test.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:end_to_end_test/interfaces.dart';
+import 'package:end_to_end_test/serializers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HasInt', () {
+    var data = BuiltList.of([
+      ValueWithHasInt((b) => b.hasInt = ValueWithInt((b) => b
+        ..anInt = 2
+        ..note = 'two')),
+      ValueWithHasInt((b) => b.hasInt = EnumWithInt.one),
+    ]);
+    var serialized = json.decode(json.encode([
+      'list',
+      [
+        'ValueWithHasInt',
+        'hasInt',
+        ['ValueWithInt', 'anInt', 2, 'note', 'two']
+      ],
+      [
+        'ValueWithHasInt',
+        'hasInt',
+        ['EnumWithInt', 'one']
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/mixins_test.dart
+++ b/built_types/end_to_end_test/test/mixins_test.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:end_to_end_test/mixins.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(GetsCorrectFieldsViaMixins, () {
+    test('has correct fields', () {
+      // If it has any unwanted fields they will not be nullable so this will
+      // throw.
+      var value = GetsCorrectFieldsViaMixins((b) => b..shouldBeAField = 1);
+      expect(value.shouldBeAField, 1);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/polymorphism_serializer_test.dart
+++ b/built_types/end_to_end_test/test/polymorphism_serializer_test.dart
@@ -1,0 +1,144 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:end_to_end_test/polymorphism.dart';
+import 'package:end_to_end_test/serializers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Cat', () {
+    var data = Cat((b) => b
+      ..legs = 4
+      ..tail = true);
+    var serialized = json.decode(json.encode([
+      'Cat',
+      'tail',
+      true,
+      'legs',
+      4,
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+
+    test('can be serialized by moreSerializers', () {
+      expect(moreSerializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized by moreSerializers', () {
+      expect(moreSerializers.deserialize(serialized), data);
+    });
+  });
+
+  group('Robot', () {
+    var data = Robot((b) => b
+      ..legs = 4
+      ..fins = 3);
+    var serialized = json.decode(json.encode([
+      'Robot',
+      'fins',
+      3,
+      'legs',
+      4,
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('StandardCat', () {
+    var data = StandardCat((b) => b..tail = true);
+    var serialized = json.decode(json.encode([
+      'StandardCat',
+      'tail',
+      true,
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('HasField', () {
+    var data = BuiltList<HasField<dynamic>>(<Object>[
+      HasString((b) => b..field = 'hello'),
+      HasDouble((b) => b..field = 3.14)
+    ]);
+    var serialized = json.decode(json.encode([
+      'list',
+      ['HasString', 'field', 'hello'],
+      ['HasDouble', 'field', 3.14]
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('Cage', () {
+    var data = Cage((b) => b
+      ..inhabitant = Cat((b) => b
+        ..tail = true
+        ..legs = 4)
+      ..otherInhabitants.add(Fish((b) => b
+        ..legs = 0
+        ..fins = 4)));
+    var serialized = json.decode(json.encode([
+      'Cage',
+      'inhabitant',
+      ['Cat', 'tail', true, 'legs', 4],
+      'otherInhabitants',
+      [
+        ['Fish', 'fins', 4, 'legs', 0]
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('UsesHandCoded', () {
+    var data = UsesHandCoded((b) => b..fieldInBaseBuilder = 4);
+    var serialized = json.decode(json.encode([
+      'UsesHandCoded',
+      'fieldInBaseBuilder',
+      4,
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/polymorphism_test.dart
+++ b/built_types/end_to_end_test/test/polymorphism_test.dart
@@ -1,0 +1,168 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_collection/built_collection.dart';
+import 'package:end_to_end_test/polymorphism.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Cat', () {
+    test('can be instantiated', () {
+      Cat((b) => b
+        ..legs = 4
+        ..tail = true);
+    });
+
+    test('has method from mixin', () {
+      expect(
+          Cat((b) => b
+            ..legs = 4
+            ..tail = true).canWalk,
+          true);
+    });
+  });
+
+  group('Fish', () {
+    test('can be instantiated', () {
+      Fish((b) => b
+        ..legs = 0
+        ..fins = 2);
+    });
+
+    test('has method from mixin', () {
+      expect(
+          Fish((b) => b
+            ..legs = 0
+            ..fins = 2).canWalk,
+          false);
+    });
+
+    test('has method from second mixin', () {
+      expect(
+          Fish((b) => b
+            ..legs = 0
+            ..fins = 2).canSwim,
+          true);
+    });
+  });
+
+  group('Robot', () {
+    test('can be instantiated', () {
+      Robot((b) => b
+        ..legs = 0
+        ..fins = 2);
+    });
+
+    test('has method from mixin', () {
+      expect(
+          Robot((b) => b
+            ..legs = 0
+            ..fins = 2).canWalk,
+          false);
+    });
+
+    test('has method from second mixin', () {
+      expect(
+          Robot((b) => b
+            ..legs = 0
+            ..fins = 2).canSwim,
+          true);
+    });
+  });
+
+  group('Animal', () {
+    test('can be used as an interface, including builder', () {
+      final animals = [
+        Cat((b) => b
+          ..legs = 4
+          ..tail = true),
+        Fish((b) => b
+          ..legs = 0
+          ..fins = 2),
+      ];
+
+      final modifiedAnimals = animals
+          .map((animal) => animal.rebuild((b) => b.legs = b.legs! + 1))
+          .toList();
+
+      final expectedAnimals = [
+        Cat((b) => b
+          ..legs = 5
+          ..tail = true),
+        Fish((b) => b
+          ..legs = 1
+          ..fins = 2),
+      ];
+
+      expect(modifiedAnimals, expectedAnimals);
+    });
+  });
+
+  group('Cage', () {
+    test('holds any animal; does not try to use the abstract builder', () {
+      Cage((b) => b.inhabitant = Cat((b) => b
+        ..legs = 4
+        ..tail = true));
+    });
+  });
+
+  group('StandardCat', () {
+    test('uses legs field from mixin', () {
+      expect(StandardCat((b) => b..tail = true).legs, 4);
+    });
+  });
+
+  group('HasField', () {
+    test('can be used as an interface, including builder', () {
+      final hasFields = <HasField<dynamic>>[
+        HasString((b) => b..field = 'hello'),
+        HasDouble((b) => b..field = 3.14)
+      ];
+
+      final modifiedHasFields = hasFields
+          .map((hasField) => hasField.rebuild((b) => b..field += b.field));
+
+      final expectedHasFields = [
+        HasString((b) => b..field = 'hellohello'),
+        HasDouble((b) => b..field = 6.28)
+      ];
+
+      expect(modifiedHasFields, expectedHasFields);
+    });
+  });
+
+  group('UsesHandCoded', () {
+    test('can be instantiated', () {
+      UsesHandCoded((b) => b..fieldInBaseBuilder = 3);
+    });
+
+    test('can be updated via base interface', () {
+      final HandCoded handCoded =
+          UsesHandCoded((b) => b..fieldInBaseBuilder = 3);
+      final updatedHandCoded =
+          handCoded.rebuild((b) => b..fieldInBaseBuilder = 4);
+      expect(updatedHandCoded.fieldInBaseBuilder, 4);
+    });
+  });
+
+  group(Vehicle, () {
+    test('nested builder getter is not nullable', () {
+      // This is purely a static check, the function isn't actually called.
+      // Access `b.color` without `!` to ensure the getter is not nullable.
+      (Vehicle vehicle) {
+        return vehicle.rebuild((b) => b.color.replace(VehicleColor()));
+      };
+    });
+  });
+
+  group(NotInstantiableNotNested, () {
+    test('does not nest builders', () {
+      // This is purely a static check, the function isn't actually called.
+      // Check that the builder field is not a nested builder.
+      (NotInstantiableNotNested value) =>
+          value.rebuild((b) => b..list = BuiltList());
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/private_value_test.dart
+++ b/built_types/end_to_end_test/test/private_value_test.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library value_test;
+
+import 'package:test/test.dart';
+import 'package:built_value/built_value.dart';
+
+part 'private_value_test.g.dart';
+
+// This has to go here so we can access it in the test.
+abstract class _PrivateValue
+    implements Built<_PrivateValue, _PrivateValueBuilder> {
+  int get value;
+
+  factory _PrivateValue(Function(_PrivateValueBuilder) updates) =
+      _$PrivateValue;
+
+  _PrivateValue._();
+}
+
+void main() {
+  group('PrivateValue', () {
+    test('can be instantiated', () {
+      _PrivateValue((b) => b..value = 0);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/private_value_test.g.dart
+++ b/built_types/end_to_end_test/test/private_value_test.g.dart
@@ -1,0 +1,93 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'private_value_test.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+class _$PrivateValue extends _PrivateValue {
+  @override
+  final int value;
+
+  factory _$PrivateValue([void Function(_PrivateValueBuilder)? updates]) =>
+      (_PrivateValueBuilder()..update(updates))._build();
+
+  _$PrivateValue._({required this.value}) : super._();
+  @override
+  _PrivateValue rebuild(void Function(_PrivateValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _PrivateValueBuilder toBuilder() => _PrivateValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is _PrivateValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+      r'_PrivateValue',
+    )..add('value', value)).toString();
+  }
+}
+
+class _PrivateValueBuilder
+    implements Builder<_PrivateValue, _PrivateValueBuilder> {
+  _$PrivateValue? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  _PrivateValueBuilder();
+
+  _PrivateValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(_PrivateValue other) {
+    _$v = other as _$PrivateValue;
+  }
+
+  @override
+  void update(void Function(_PrivateValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  _PrivateValue build() => _build();
+
+  _$PrivateValue _build() {
+    final _$result =
+        _$v ??
+        _$PrivateValue._(
+          value: BuiltValueNullFieldError.checkNotNull(
+            value,
+            r'_PrivateValue',
+            'value',
+          ),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/end_to_end_test/test/records_serializer_test.dart
+++ b/built_types/end_to_end_test/test/records_serializer_test.dart
@@ -1,0 +1,116 @@
+// Copyright (c) 2023, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
+import 'package:end_to_end_test/errors_matchers.dart';
+import 'package:end_to_end_test/records.dart';
+import 'package:end_to_end_test/serializers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('$SerializableRecordValue with no record value', () {
+    var data = SerializableRecordValue((b) => b..value = 1);
+    var serialized = json.decode(
+      json.encode(['SerializableRecordValue', 'value', 1]),
+    ) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('$SerializableRecordValue with a record value', () {
+    var data = SerializableRecordValue(
+      (b) => b
+        ..value = 1
+        ..record = (1, 2),
+    );
+    var serialized = json.decode(
+      json.encode([
+        'SerializableRecordValue',
+        'value',
+        1,
+        'record',
+        [1, 2],
+      ]),
+    ) as Object;
+    var serializersWithCustomSerializer =
+        (serializers.toBuilder()..add(RecordOfIntIntSerializer())).build();
+
+    test('gives advice about custom serializer on failure to serialize', () {
+      expect(
+        () => serializers.serialize(data),
+        throwsA(
+          isErrorContaining('record types are not automatically serializable'),
+        ),
+      );
+    });
+
+    test('gives advice about custom serializer on failure to deserialize', () {
+      expect(
+        () => serializers.deserialize(serialized),
+        throwsA(
+          isErrorContaining('record types are not automatically serializable'),
+        ),
+      );
+    });
+
+    test('can be serialized with custom serializer', () {
+      expect(serializersWithCustomSerializer.serialize(data), serialized);
+    });
+
+    test('can be deserialized with custom deserializer', () {
+      expect(serializersWithCustomSerializer.deserialize(serialized), data);
+    });
+  });
+
+  group('$SerializableRecordValue with a record list value', () {
+    var data = SerializableRecordValue(
+      (b) => b
+        ..value = 1
+        ..intOrList = (null, BuiltList(['value0', 'value1', 'value2'])),
+    );
+    var serialized = json.decode(
+      json.encode({
+        'value': 1,
+        'intOrList': ['value0', 'value1', 'value2'],
+      }),
+    ) as Object;
+    var serializersWithCustomSerializer =
+        (serializers.toBuilder()
+              ..addPlugin(
+                StandardJsonPlugin(typesToLeaveAsList: {RecordOfIntOrList}),
+              )
+              ..add(RecordOfIntOrListSerializer()))
+            .build();
+
+    test('can be serialized with custom serializer', () {
+      expect(
+        serializersWithCustomSerializer.serialize(
+          data,
+          specifiedType: FullType(SerializableRecordValue),
+        ),
+        serialized,
+      );
+    });
+
+    test('can be deserialized with custom deserializer', () {
+      expect(
+        serializersWithCustomSerializer.deserialize(
+          serialized,
+          specifiedType: FullType(SerializableRecordValue),
+        ),
+        data,
+      );
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/records_test.dart
+++ b/built_types/end_to_end_test/test/records_test.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2023, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/built_collection.dart';
+import 'package:end_to_end_test/records.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(SimpleRecordValue, () {
+    test('can be instantiated', () {
+      SimpleRecordValue((b) => b..record = (0, 0));
+    });
+
+    test('compares equal when equal', () {
+      final value1 = SimpleRecordValue((b) => b..record = (0, 0));
+      final value2 = SimpleRecordValue((b) => b..record = (0, 0));
+      expect(value1, value2);
+    });
+
+    test('compares not equal when not equal', () {
+      final value1 = SimpleRecordValue((b) => b..record = (0, 0));
+      final value2 = SimpleRecordValue((b) => b..record = (0, 1));
+      expect(value1, isNot(equals(value2)));
+    });
+
+    test('hashes equal when equal', () {
+      final value1 = SimpleRecordValue((b) => b..record = (0, 0));
+      final value2 = SimpleRecordValue((b) => b..record = (0, 0));
+      expect(value1.hashCode, value2.hashCode);
+    });
+
+    test('hashes not equal when not equal', () {
+      final value1 = SimpleRecordValue((b) => b..record = (0, 0));
+      final value2 = SimpleRecordValue((b) => b..record = (0, 1));
+      expect(value1.hashCode, isNot(equals(value2.hashCode)));
+    });
+
+    test('has toString', () {
+      final value = SimpleRecordValue((b) => b..record = (0, 0));
+      expect(value.toString(), '''SimpleRecordValue {
+  record=(0, 0),
+}''');
+    });
+  });
+
+  group(ComplexRecordValue, () {
+    final value1 = ComplexRecordValue(
+      (b) => b
+        ..record2 = (0, 0)
+        ..record2p = (null, 0)
+        ..record3 = (10, 10)
+        ..record3p = (null, 10)
+        ..record4 = (x: 20, y: 20)
+        ..record4p = (x: null, y: 20)
+        ..record5 = ([1].build(), b: BuiltList<ComplexRecordValue>())
+        ..record5p = (null, b: BuiltList<ComplexRecordValue>())
+        ..record6 = (() {}, b: () {})
+        ..record6p = (null, b: () {}),
+    );
+    final value1a = ComplexRecordValue(
+      (b) => b
+        ..record2 = (0, 0)
+        ..record2p = (null, 0)
+        ..record3 = (10, 10)
+        ..record3p = (null, 10)
+        ..record4 = (x: 20, y: 20)
+        ..record4p = (x: null, y: 20)
+        ..record5 = ([1].build(), b: BuiltList<ComplexRecordValue>())
+        ..record5p = (null, b: BuiltList<ComplexRecordValue>())
+        ..record6 = (() {}, b: () {})
+        ..record6p = (null, b: () {}),
+    );
+    final value2 = ComplexRecordValue(
+      (b) => b
+        ..record2 = (0, 1)
+        ..record2p = (null, 1)
+        ..record3 = (10, 11)
+        ..record3p = (null, 11)
+        ..record4 = (x: 20, y: 21)
+        ..record4p = (x: null, y: 21)
+        ..record5 = ([1, 2].build(), b: BuiltList<ComplexRecordValue>())
+        ..record5p = (null, b: BuiltList<ComplexRecordValue>())
+        ..record6 = (() {}, b: () {})
+        ..record6p = (null, b: () {}),
+    );
+
+    test('compares equal when equal', () {
+      expect(value1, value1a);
+    });
+
+    test('compares not equal when not equal', () {
+      expect(value1, isNot(equals(value2)));
+    });
+
+    test('hashes equal when equal', () {
+      expect(value1.hashCode, value1a.hashCode);
+    });
+
+    test('hashes not equal when not equal', () {
+      expect(value1.hashCode, isNot(equals(value2.hashCode)));
+    });
+
+    test('has toString', () {
+      expect(value1.toString(), '''ComplexRecordValue {
+  record2=(0, 0),
+  record2p=(null, 0),
+  record3=(10, 10),
+  record3p=(null, 10),
+  record4=(x: 20, y: 20),
+  record4p=(x: null, y: 20),
+  record5=([1], b: []),
+  record5p=(null, b: []),
+  record6=(Closure: () => void, b: Closure: () => void),
+  record6p=(null, b: Closure: () => void),
+}''');
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/standard_json_serializer_test.dart
+++ b/built_types/end_to_end_test/test/standard_json_serializer_test.dart
@@ -1,0 +1,228 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'dart:convert';
+
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
+import 'package:end_to_end_test/polymorphism.dart';
+import 'package:end_to_end_test/serializers.dart';
+import 'package:end_to_end_test/standard_json.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('StandardJsonValue', () {
+    var data = StandardJsonValue((b) => b
+      ..number = 3
+      ..text = 'some text'
+      ..value.primitive = 4
+      ..value.nullablePrimitive = 5
+      ..value.value.anInt = 6
+      ..value.nullableValue.anInt = 7
+      ..keyValues['one'] = JsonObject(1)
+      ..keyValues['two'] = JsonObject('two')
+      ..keyValues['three'] = JsonObject(true)
+      ..keyValues['four'] = JsonObject([1, 2, 3])
+      ..keyValues['five'] = JsonObject({'one': 1, 'two': 2})
+      ..zoo.add(Cat((b) => b
+        ..tail = true
+        ..legs = 4))
+      ..uniqueZoo.add(Cat((b) => b
+        ..tail = false
+        ..legs = 3))
+      ..nullsInList.replace(<Object?>[null, 3])
+      ..nullsInSet.replace(<Object?>['three', null])
+      ..nullsInMap['four'] = null
+      ..nullsInMap['five'] = 5
+      ..object = ComplexValue((b) => b
+        ..primitive = 6
+        ..value.anInt = 7)
+      ..objects.add(ComplexValue((b) => b
+        ..primitive = 8
+        ..value.anInt = 9)));
+    var specifiedType = FullType(StandardJsonValue);
+    var serializersWithPlugin =
+        (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
+    var serialized = json.decode(json.encode({
+      'number': 3,
+      'text': 'some text',
+      'value': {
+        'primitive': 4,
+        'nullablePrimitive': 5,
+        'value': {'anInt': 6},
+        'nullableValue': {'anInt': 7}
+      },
+      'keyValues': {
+        'one': 1,
+        'two': 'two',
+        'three': true,
+        'four': [1, 2, 3],
+        'five': {'one': 1, 'two': 2},
+      },
+      'zoo': [
+        {r'$': 'Cat', 'tail': true, 'legs': 4}
+      ],
+      'uniqueZoo': [
+        {r'$': 'Cat', 'tail': false, 'legs': 3}
+      ],
+      'nullsInList': <Object?>[null, 3],
+      'nullsInSet': <Object?>['three', null],
+      'nullsInMap': {'four': null, 'five': 5},
+      'object': {
+        r'$': 'ComplexValue',
+        'primitive': 6,
+        'value': {'anInt': 7}
+      },
+      'objects': <Object>[
+        {
+          r'$': 'ComplexValue',
+          'primitive': 8,
+          'value': {'anInt': 9}
+        }
+      ],
+    })) as Object;
+
+    test('can be serialized', () {
+      expect(
+          serializersWithPlugin.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('serializes to Map<String, Object>>', () {
+      expect(
+          serializersWithPlugin
+              .serialize(data, specifiedType: specifiedType)
+              .runtimeType,
+          <String, Object?>{}.runtimeType);
+    });
+
+    test('can be deserialized', () {
+      expect(
+          serializersWithPlugin.deserialize(serialized,
+              specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('StandardJsonValue with extraneous nulls', () {
+    var data = StandardJsonValue((b) => b
+      ..number = 3
+      ..text = 'some text'
+      ..value.primitive = 4
+      ..value.value.anInt = 5
+      ..keyValues['one'] = JsonObject(1)
+      ..keyValues['two'] = JsonObject('two')
+      ..keyValues['three'] = JsonObject(true)
+      ..keyValues['four'] = JsonObject([1, 2, 3])
+      ..keyValues['five'] = JsonObject({'one': 1, 'two': 2}));
+    var specifiedType = FullType(StandardJsonValue);
+    var serializersWithPlugin =
+        (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
+    var serialized = json.decode(json.encode({
+      'number': 3,
+      'text': 'some text',
+      'value': {
+        'primitive': 4,
+        'value': {'anInt': 5}
+      },
+      'keyValues': {
+        'one': 1,
+        'two': 'two',
+        'three': true,
+        'four': [1, 2, 3],
+        'five': {'one': 1, 'two': 2},
+      },
+      'strings': null,
+    })) as Object;
+
+    test('can be deserialized', () {
+      expect(
+          serializersWithPlugin.deserialize(serialized,
+              specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('StandardJsonValue with unknown specifiedType', () {
+    var data = StandardJsonValue((b) => b
+      ..number = 3
+      ..text = 'some text'
+      ..value.primitive = 4
+      ..value.nullablePrimitive = 5
+      ..value.value.anInt = 6
+      ..value.nullableValue.anInt = 7
+      ..keyValues['one'] = JsonObject(1)
+      ..keyValues['two'] = JsonObject('two')
+      ..keyValues['three'] = JsonObject(true)
+      ..keyValues['four'] = JsonObject([1, 2, 3])
+      ..keyValues['five'] = JsonObject({'one': 1, 'two': 2})
+      ..zoo.add(Cat((b) => b
+        ..tail = true
+        ..legs = 4))
+      ..nullsInList.replace(<Object?>[null, 3])
+      ..nullsInSet.replace(<Object?>['three', null])
+      ..nullsInMap['four'] = null
+      ..nullsInMap['five'] = 5
+      ..object = ComplexValue((b) => b
+        ..primitive = 6
+        ..value.anInt = 7)
+      ..objects.add(ComplexValue((b) => b
+        ..primitive = 8
+        ..value.anInt = 9)));
+    var serializersWithPlugin =
+        (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
+    var serialized = {
+      r'$': 'StandardJsonValue',
+      'number': 3,
+      'text': 'some text',
+      'value': {
+        'primitive': 4,
+        'nullablePrimitive': 5,
+        'value': {'anInt': 6},
+        'nullableValue': {'anInt': 7}
+      },
+      'keyValues': {
+        'one': 1,
+        'two': 'two',
+        'three': true,
+        'four': [1, 2, 3],
+        'five': {'one': 1, 'two': 2},
+      },
+      'zoo': [
+        {r'$': 'Cat', 'tail': true, 'legs': 4}
+      ],
+      'uniqueZoo': <Object>[],
+      'nullsInList': <Object?>[null, 3],
+      'nullsInSet': <Object?>['three', null],
+      'nullsInMap': {'four': null, 'five': 5},
+      'object': {
+        r'$': 'ComplexValue',
+        'primitive': 6,
+        'value': {'anInt': 7}
+      },
+      'objects': <Object>[
+        {
+          r'$': 'ComplexValue',
+          'primitive': 8,
+          'value': {'anInt': 9}
+        }
+      ],
+    };
+
+    test('can be serialized', () {
+      expect(serializersWithPlugin.serialize(data), serialized);
+    });
+
+    test('serializes to Map<String, Object>', () {
+      expect(serializersWithPlugin.serialize(data).runtimeType,
+          <String, Object>{}.runtimeType);
+    });
+
+    test('can be deserialized', () {
+      expect(serializersWithPlugin.deserialize(serialized), data);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/to_string_test.dart
+++ b/built_types/end_to_end_test/test/to_string_test.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_value/built_value.dart';
+import 'package:end_to_end_test/values.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('toString', () {
+    test('omits nulls', () {
+      final value = CompoundValue((b) => b..simpleValue.anInt = 1);
+
+      expect(value.toString(), '''CompoundValue {
+  simpleValue=SimpleValue {
+    anInt=1,
+  },
+}''');
+    });
+
+    test('can be customized', () {
+      newBuiltValueToStringHelper = (className) =>
+          FlatBuiltValueToStringHelper(className);
+      final value = CompoundValue((b) => b..simpleValue.anInt = 1);
+
+      expect(
+        value.toString(),
+        '''CompoundValue {simpleValue=SimpleValue {anInt=1}}''',
+      );
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/values_serializer_test.dart
+++ b/built_types/end_to_end_test/test/values_serializer_test.dart
@@ -1,0 +1,720 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'dart:convert';
+
+import 'package:built_value/serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
+import 'package:end_to_end_test/enums.dart';
+import 'package:end_to_end_test/errors_matchers.dart';
+import 'package:end_to_end_test/serializers.dart';
+import 'package:end_to_end_test/values.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SimpleValue', () {
+    var data = SimpleValue((b) => b
+      ..anInt = 1
+      ..aString = 'two'
+      ..$mustBeEscaped = true);
+    var serialized = json.decode(json.encode([
+      'SimpleValue',
+      'anInt',
+      1,
+      'aString',
+      'two',
+      '\$mustBeEscaped',
+      true,
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+
+    test('can be deserialized from json with explicit null', () {
+      var data = SimpleValue((b) => b
+        ..anInt = 1
+        ..$mustBeEscaped = true);
+      var serialized = json.decode(json.encode([
+        'SimpleValue',
+        'anInt',
+        1,
+        'aString',
+        null,
+        '\$mustBeEscaped',
+        true,
+      ])) as Object;
+
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('SimpleValue with null nullable field', () {
+    var data = SimpleValue((b) => b
+      ..anInt = 1
+      ..$mustBeEscaped = true);
+    var serialized = json.decode(json.encode([
+      'SimpleValue',
+      'anInt',
+      1,
+      '\$mustBeEscaped',
+      true,
+    ])) as List<Object?>;
+    serialized.addAll(['aString', null]);
+
+    test('can be deserialized with explicit null', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('CompoundValue', () {
+    var data = CompoundValue((b) => b
+      ..simpleValue.anInt = 1
+      ..simpleValue.aString = 'two'
+      ..validatedValue = ValidatedValue((b) => b.anInt = 3).toBuilder());
+    var serialized = json.decode(json.encode([
+      'CompoundValue',
+      'simpleValue',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'validatedValue',
+      [
+        'anInt',
+        3,
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+
+    test('has good error message on deserialize with wrong primitive type', () {
+      final incorrectSerialized = [
+        'CompoundValue',
+        'simpleValue',
+        [
+          'anInt',
+          1,
+          'aString',
+          'two',
+        ],
+        'validatedValue',
+        [
+          'anInt',
+          'foo',
+        ],
+      ];
+      expect(
+          () => serializers.deserialize(incorrectSerialized),
+          throwsA(isErrorContaining('Deserializing to '
+              "'unspecified' failed due to: Deserializing to "
+              "'ValidatedValue' failed due to: Deserializing to 'int' "
+              "failed due to: type 'String' is not a subtype of type "
+              "'int' in type cast")));
+    });
+  });
+
+  group('CompoundValueNoNesting', () {
+    var data = CompoundValueNoNesting((b) => b
+      ..simpleValue = SimpleValue((b) => b
+        ..anInt = 1
+        ..aString = 'two')
+      ..validatedValue = ValidatedValue((b) => b.anInt = 3));
+    var serialized = json.decode(json.encode([
+      'CompoundValueNoNesting',
+      'simpleValue',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'validatedValue',
+      [
+        'anInt',
+        3,
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('CompoundValueNoAutoNesting', () {
+    var data =
+        CompoundValueNoAutoNesting((b) => b..value = NoFieldsValueBuilder());
+    var serialized = json.decode(json.encode([
+      'CompoundValueNoAutoNesting',
+      'value',
+      <String>[],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('CompoundValueNoNestingField', () {
+    var data = CompoundValueNoNestingField((b) => b
+      ..simpleValue = SimpleValue((b) => b
+        ..anInt = 1
+        ..aString = 'two')
+      ..validatedValue = ValidatedValue((b) => b.anInt = 3)
+      ..simpleValueWithNested.anInt = 1
+      ..simpleValueWithNested.aString = 'two'
+      ..validatedValueWithNested.anInt = 3);
+    var serialized = json.decode(json.encode([
+      'CompoundValueNoNestingField',
+      'simpleValue',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'simpleValueWithNested',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'validatedValue',
+      [
+        'anInt',
+        3,
+      ],
+      'validatedValueWithNested',
+      [
+        'anInt',
+        3,
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('CompoundValueNestingField', () {
+    var data = CompoundValueNestingField((b) => b
+      ..simpleValue = SimpleValue((b) => b
+        ..anInt = 1
+        ..aString = 'two')
+      ..validatedValue = ValidatedValue((b) => b.anInt = 3)
+      ..simpleValueWithNested.anInt = 1
+      ..simpleValueWithNested.aString = 'two'
+      ..validatedValueWithNested.anInt = 3);
+    var serialized = json.decode(json.encode([
+      'CompoundValueNestingField',
+      'simpleValue',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'simpleValueWithNested',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'validatedValue',
+      [
+        'anInt',
+        3,
+      ],
+      'validatedValueWithNested',
+      [
+        'anInt',
+        3,
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('CompoundValueNoAutoNestingField', () {
+    var data = CompoundValueNoAutoNestingField(
+        (b) => b..value = NoFieldsValueBuilder());
+    var serialized = json.decode(json.encode([
+      'CompoundValueNoAutoNestingField',
+      'value',
+      <String>[],
+      'valueWithAutoCreate',
+      <String>[],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('CompoundValueAutoNestingField', () {
+    var data =
+        CompoundValueAutoNestingField((b) => b..value = NoFieldsValueBuilder());
+    var serialized = json.decode(json.encode([
+      'CompoundValueAutoNestingField',
+      'value',
+      <String>[],
+      'valueWithAutoCreate',
+      <String>[],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('CompoundValueExplicitNoNesting', () {
+    var data = CompoundValueExplicitNoNesting((b) => b
+      ..simpleValue.replace(SimpleValue((b) => b
+        ..anInt = 1
+        ..aString = 'two'))
+      ..validatedValue = ValidatedValue((b) => b.anInt = 3));
+    var serialized = json.decode(json.encode([
+      'CompoundValueExplicitNoNesting',
+      'simpleValue',
+      [
+        'anInt',
+        1,
+        'aString',
+        'two',
+      ],
+      'validatedValue',
+      [
+        'anInt',
+        3,
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('CompoundValue using StandardJsonPlugin', () {
+    var data = CompoundValue((b) => b
+      ..simpleValue.anInt = 1
+      ..simpleValue.aString = 'two'
+      ..validatedValue = ValidatedValue((b) => b.anInt = 3).toBuilder());
+    var specifiedType = const FullType(CompoundValue);
+    var serializersWithPlugin =
+        (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
+    var serialized = {
+      'simpleValue': {
+        'anInt': 1,
+        'aString': 'two',
+      },
+      'validatedValue': {
+        'anInt': 3,
+      },
+    };
+
+    test('can be serialized', () {
+      expect(
+          serializersWithPlugin.serialize(data, specifiedType: specifiedType),
+          serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(
+          serializersWithPlugin.deserialize(serialized,
+              specifiedType: specifiedType),
+          data);
+    });
+  });
+
+  group('ValueUsingImportAs', () {
+    var data = ValueUsingImportAs((b) => b.value = TestEnum.yes);
+    var serialized = json.decode(json.encode([
+      'ValueUsingImportAs',
+      'value',
+      'yes',
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('PrimitivesValue', () {
+    var data = PrimitivesValue((b) => b
+      ..boolean = true
+      ..integer = 42
+      ..int64 = Int64.MAX_VALUE
+      ..dbl = 2.5
+      ..number = 17.5
+      ..string = 'test'
+      ..dateTime = DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true)
+      ..duration = Duration(microseconds: 12345)
+      ..regExp = RegExp(r'\w+@\d+')
+      ..uri = Uri.parse('https://github.com/google/built_value.dart')
+      ..bigInt = BigInt.parse('123456789012345678901234567890'));
+    var serialized = json.decode(json.encode([
+      'PrimitivesValue',
+      'boolean',
+      true,
+      'integer',
+      42,
+      'int64',
+      '9223372036854775807',
+      'dbl',
+      2.5,
+      'number',
+      17.5,
+      'string',
+      'test',
+      'dateTime',
+      1000000,
+      'duration',
+      12345,
+      'regExp',
+      r'\w+@\d+',
+      'uri',
+      'https://github.com/google/built_value.dart',
+      'bigInt',
+      '123456789012345678901234567890',
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('NamedFactoryValue', () {
+    var data = NamedFactoryValue(3);
+    var serialized =
+        json.decode(json.encode(['NamedFactoryValue', 'value', 3])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('FieldDiscoveryValue', () {
+    var data = FieldDiscoveryValue((b) => b
+      ..value.value.value = 1
+      ..values.add(ThirdDiscoverableValue((b) => b..value = 4)));
+    var serialized = json.decode(json.encode([
+      'FieldDiscoveryValue',
+      'value',
+      [
+        'value',
+        ['value', 1],
+      ],
+      'values',
+      [
+        [
+          'value',
+          4,
+        ]
+      ],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('PartiallySerializableValue', () {
+    var data = PartiallySerializableValue((b) => b
+      ..value = 1
+      ..transientValue = 2);
+    var serialized = json.decode(json.encode([
+      'PartiallySerializableValue',
+      'value',
+      1,
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized),
+          data.rebuild((b) => b..transientValue = null));
+    });
+  });
+
+  group('WireNameValue', () {
+    var data = WireNameValue((b) => b..value = 1);
+    var serialized = json.decode(json.encode([
+      r'$V',
+      r'$v',
+      1,
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('ValueWithCustomSerializer', () {
+    var data = ValueWithCustomSerializer((b) => b..value = 1);
+    var serialized =
+        json.decode(json.encode(['ValueWithCustomSerializer', 1])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('OtherValue', () {
+    var data = OtherValue((b) => b..other = 1);
+    var serialized =
+        json.decode(json.encode(['OtherValue', 'other', 1])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('ValuesWithBuilderInitializer', () {
+    var data = ValueWithBuilderInitializer((b) => b
+      ..anInt = 1
+      ..nestedValue.anInt = 2);
+    var serialized = json.decode(json.encode([
+      'ValueWithBuilderInitializer',
+      'anInt',
+      1,
+      'anIntWithDefault',
+      7,
+      'nestedValue',
+      ['anInt', 2],
+      'nestedValueWithDefault',
+      ['anInt', 9],
+      'nullableIntWithDefault',
+      8,
+      'nullableNestedValueWithDefault',
+      ['anInt', 10],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+
+    test('adds defaults for missing fields on deserialization', () {
+      var serializedWithoutDefaults = [
+        'ValueWithBuilderInitializer',
+        'anInt',
+        1,
+        'nestedValue',
+        ['anInt', 2],
+      ];
+      expect(serializers.deserialize(serializedWithoutDefaults), data);
+    });
+  });
+
+  group('ValueWithBuilderFinalizer', () {
+    var data = ValueWithBuilderFinalizer((b) => b..anInt = 1);
+    var serialized =
+        json.decode(json.encode(['ValueWithBuilderFinalizer', 'anInt', 1]))
+            as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+
+    test('runs hook on deserialize', () {
+      var serializedWhichTriggersHook = [
+        'ValueWithBuilderFinalizer', 'anInt',
+        // Hook will change 0 to 1.
+        0,
+      ];
+      expect(serializers.deserialize(serializedWhichTriggersHook), data);
+    });
+  });
+
+  group(SerializesNullsValue, () {
+    final data = SerializesNullsValue();
+    final serialized = json
+        .decode(json.encode(['SerializesNullsValue', 'value', null])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group(ValueWithAwkwardNestedBuilder, () {
+    final data = ValueWithAwkwardNestedBuilder((b) => b
+      ..value1 = SimpleValue((b) => b
+        ..anInt = 1
+        ..aString = '1').toBuilder()
+      ..value2!.anInt = 2
+      ..value2!.aString = '2'
+      ..values!.add(3)
+      ..map![4] = '4');
+    final serialized = json.decode(json.encode([
+      'ValueWithAwkwardNestedBuilder',
+      'values',
+      [3],
+      'map',
+      [4, '4'],
+      'value1',
+      ['anInt', 1, 'aString', '1'],
+      'value2',
+      ['anInt', 2, 'aString', '2'],
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group(r'$ValueSpecial', () {
+    var data = $ValueSpecial(
+      (b) => b
+        ..aString = 'String'
+        ..anInt = 42
+        ..$mustBeEscaped = true
+        ..$mustAlsoEscaped = SimpleValue(
+          (b) => b
+            ..anInt = 1
+            ..aString = '1',
+        ).toBuilder()
+        ..$assert = SimpleValue(
+          (b) => b
+            ..anInt = 1
+            ..aString = '1',
+        ).toBuilder()
+        ..$10 = SimpleValue(
+          (b) => b
+            ..anInt = 1
+            ..aString = '1',
+        ).toBuilder(),
+    );
+    var serialized = json.decode(json.encode([
+      r'$ValueSpecial',
+      'anInt',
+      42,
+      'aString',
+      'String',
+      r'$mustBeEscaped',
+      true,
+      r'$mustAlsoEscaped',
+      ['anInt', 1, 'aString', '1'],
+      r'$assert',
+      ['anInt', 1, 'aString', '1'],
+      r'$10',
+      ['anInt', 1, 'aString', '1']
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+
+  group('NewConstructorValue', () {
+    var data = NewConstructorValue((b) => b..anInt = 1);
+    var serialized = json.decode(json.encode([
+      'NewConstructorValue',
+      'anInt',
+      1,
+    ])) as Object;
+
+    test('can be serialized', () {
+      expect(serializers.serialize(data), serialized);
+    });
+
+    test('can be deserialized', () {
+      expect(serializers.deserialize(serialized), data);
+    });
+  });
+}

--- a/built_types/end_to_end_test/test/values_test.dart
+++ b/built_types/end_to_end_test/test/values_test.dart
@@ -1,0 +1,517 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// @dart=2.12
+
+import 'package:built_collection/src/internal/hash.dart';
+import 'package:built_value/built_value.dart';
+import 'package:end_to_end_test/enums.dart';
+import 'package:end_to_end_test/errors_matchers.dart';
+import 'package:end_to_end_test/values.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SimpleValue', () {
+    test('can be instantiated', () {
+      SimpleValue((b) => b..anInt = 0);
+    });
+
+    test('throws on null for non-nullable fields on build', () {
+      expect(() => SimpleValue(),
+          throwsA(const TypeMatcher<BuiltValueNullFieldError>()));
+    });
+
+    test('includes field name in null error message', () {
+      expect(() => SimpleValue(), throwsA(isErrorContaining('anInt')));
+    });
+
+    test('includes class name in null error message', () {
+      expect(() => SimpleValue(), throwsA(isErrorContaining('SimpleValue')));
+    });
+
+    test('fields can be set via build constructor', () {
+      final value = SimpleValue((b) => b
+        ..anInt = 1
+        ..aString = 'two'
+        ..$mustBeEscaped = true);
+      expect(value.anInt, 1);
+      expect(value.aString, 'two');
+      expect(value.$mustBeEscaped, true);
+    });
+
+    test('fields can be updated via rebuild method', () {
+      final value = SimpleValue((b) => b
+        ..anInt = 0
+        ..aString = ''
+        ..$mustBeEscaped = true).rebuild((b) => b
+        ..anInt = 1
+        ..aString = 'two'
+        ..$mustBeEscaped = false);
+      expect(value.anInt, 1);
+      expect(value.aString, 'two');
+      expect(value.$mustBeEscaped, false);
+    });
+
+    test('builder can be instantiated', () {
+      SimpleValueBuilder();
+    });
+
+    test('builder exposes values via getters', () {
+      final builder = SimpleValue((b) => b
+        ..anInt = 0
+        ..aString = '').toBuilder();
+      expect(builder.anInt, 0);
+    });
+
+    test('compares equal when equal', () {
+      final value1 = SimpleValue((b) => b
+        ..anInt = 0
+        ..aString = '');
+      final value2 = SimpleValue((b) => b
+        ..anInt = 0
+        ..aString = '');
+      expect(value1, value2);
+    });
+
+    test('compares not equal when not equal', () {
+      final value1 = SimpleValue((b) => b
+        ..anInt = 0
+        ..aString = '');
+      final value2 = SimpleValue((b) => b
+        ..anInt = 1
+        ..aString = '');
+      expect(value1, isNot(equals(value2)));
+    });
+
+    test('hash matches quiver hash', () {
+      final value = SimpleValue((b) => b
+        ..anInt = 73
+        ..aString = 'seventythree'
+        ..$mustBeEscaped = true);
+      expect(
+          value.hashCode,
+          hashObjects(<Object?>[
+            value.anInt,
+            value.aString,
+            value.$mustBeEscaped,
+          ]));
+    });
+
+    test('hashes equal when equal', () {
+      final value1 = SimpleValue((b) => b
+        ..anInt = 0
+        ..aString = '');
+      final value2 = SimpleValue((b) => b
+        ..anInt = 0
+        ..aString = '');
+      expect(value1.hashCode, value2.hashCode);
+    });
+
+    test('hashes not equal when not equal', () {
+      final value1 = SimpleValue((b) => b
+        ..anInt = 0
+        ..aString = '');
+      final value2 = SimpleValue((b) => b
+        ..anInt = 1
+        ..aString = '');
+      expect(value1.hashCode, isNot(equals(value2.hashCode)));
+    });
+
+    test('has toString', () {
+      final value1 = SimpleValue((b) => b
+        ..anInt = 0
+        ..aString = ''
+        ..$mustBeEscaped = true);
+      expect(value1.toString(), '''SimpleValue {
+  anInt=0,
+  aString=,
+  \$mustBeEscaped=true,
+}''');
+    });
+  });
+
+  group('CompoundValue', () {
+    test('can be instantiated', () {
+      CompoundValue((b) => b..simpleValue.anInt = 1);
+    });
+
+    test('throws on null for non-nullable nested fields on build', () {
+      expect(() => CompoundValue(),
+          throwsA(const TypeMatcher<BuiltValueNestedFieldError>()));
+    });
+
+    test('includes helpful information in null error message', () {
+      expect(
+          () => CompoundValue(),
+          throwsA(allOf(
+              // Mentions outer type.
+              isErrorContaining('"CompoundValue"'),
+              // Mentions field in outer type.
+              isErrorContaining('"simpleValue"'),
+              // Mentions inner type.
+              isErrorContaining('"SimpleValue"'),
+              // Mentions field in inner type.
+              isErrorContaining('"anInt"'))));
+    });
+
+    test('allows nested updates', () {
+      expect(
+          CompoundValue((b) => b
+            ..simpleValue.anInt = 1
+            ..simpleValue.aString = 'two').simpleValue.anInt,
+          1);
+    });
+
+    test('nullable nested builders can be assigned', () {
+      expect(
+          CompoundValue((b) => b
+            ..simpleValue.anInt = 1
+            ..validatedValue.anInt = 2).validatedValue!.anInt,
+          2);
+    });
+
+    test('hash matches quiver hash', () {
+      final value = CompoundValue((b) => b
+        ..simpleValue.anInt = 1
+        ..simpleValue.aString = 'two');
+
+      expect(value.hashCode,
+          hashObjects(<Object?>[value.simpleValue, value.validatedValue]));
+    });
+  });
+
+  group('CompoundValueNoNesting', () {
+    test('does not use nested builders', () {
+      CompoundValueNoNesting(
+          (b) => b..simpleValue = SimpleValue((b) => b..anInt = 1));
+    });
+  });
+
+  group('CompoundValueNoNestingField', () {
+    test('does not use nested builders', () {
+      CompoundValueNoNestingField((b) => b
+        ..simpleValue = SimpleValue((b) => b..anInt = 1)
+        ..simpleValueWithNested.anInt = 1);
+    });
+  });
+
+  group('CompoundValueNestingField', () {
+    test('does not use nested builders', () {
+      CompoundValueNestingField((b) => b
+        ..simpleValue = SimpleValue((b) => b..anInt = 1)
+        ..simpleValueWithNested.anInt = 1);
+    });
+  });
+
+  group(CompoundValueNoAutoNesting, () {
+    test('does not auto create nested builders', () {
+      expect(() => CompoundValueNoAutoNesting((b) => b..value),
+          throwsA(const TypeMatcher<BuiltValueNullFieldError>()));
+    });
+  });
+
+  group('CompoundValueComparableBuilders', () {
+    test('builder implements operator==', () {
+      final left = CompoundValueComparableBuilders(
+          (b) => b..simpleValue = SimpleValue((b) => b..anInt = 1));
+      final right = CompoundValueComparableBuilders(
+          (b) => b..simpleValue = SimpleValue((b) => b..anInt = 1));
+      expect(left.toBuilder() == right.toBuilder(), true);
+    });
+
+    test('built does not equal builder', () {
+      final value = CompoundValueComparableBuilders(
+          (b) => b..simpleValue = SimpleValue((b) => b..anInt = 1));
+
+      /// ignore: unrelated_type_equality_checks
+      expect(value == value.toBuilder(), false);
+    });
+
+    test('builder implements hashCode', () {
+      final left = CompoundValueComparableBuilders(
+          (b) => b..simpleValue = SimpleValue((b) => b..anInt = 1));
+      final right = CompoundValueComparableBuilders(
+          (b) => b..simpleValue = SimpleValue((b) => b..anInt = 1));
+      expect(left.toBuilder().hashCode == right.toBuilder().hashCode, true);
+    });
+
+    test('built hashCode does not equal builder hashCode', () {
+      final value = CompoundValueComparableBuilders(
+          (b) => b..simpleValue = SimpleValue((b) => b..anInt = 1));
+
+      // It's not actually required that the hash codes differ; but since
+      // they are not equal, it's better if the hash codes _do_ differ. This
+      // helps performance if you put both built and builder in a hash set or
+      // map.
+      expect(value.hashCode, isNot(value.toBuilder().hashCode));
+    });
+  });
+
+  group('ExplicitNonNullBuilderNullableSetter', () {
+    final simpleValue = SimpleValue((b) => b.anInt = 1);
+
+    test('defaults the value to null', () {
+      expect(ExplicitNonNullBuilderNullableSetter().simpleValue, isNull);
+    });
+
+    test('allows setting the value', () {
+      final value = ExplicitNonNullBuilderNullableSetter(
+          (b) => b.simpleValue.replace(simpleValue));
+
+      expect(value.simpleValue, equals(simpleValue));
+    });
+
+    test('allows setting the value to null', () {
+      var value = ExplicitNonNullBuilderNullableSetter(
+          (b) => b.simpleValue.replace(simpleValue));
+
+      value = value.rebuild((b) => b.simpleValue = null);
+
+      expect(value.simpleValue, isNull);
+    });
+  });
+
+  group('ExplicitNonNullBuilderNullableField', () {
+    final simpleValue = SimpleValue((b) => b.anInt = 1);
+
+    test('defaults the value to null', () {
+      expect(ExplicitNonNullBuilderNullableField().simpleValue, isNull);
+    });
+
+    test('allows setting the value', () {
+      final value = ExplicitNonNullBuilderNullableField(
+          (b) => b.simpleValue!.replace(simpleValue));
+
+      expect(value.simpleValue, equals(simpleValue));
+    });
+
+    test('allows setting the value to null', () {
+      var value = ExplicitNonNullBuilderNullableField(
+          (b) => b.simpleValue!.replace(simpleValue));
+
+      value = value.rebuild((b) => b.simpleValue = null);
+
+      expect(value.simpleValue, isNull);
+    });
+  });
+
+  group('DerivedValue', () {
+    test('caches derivedValue', () {
+      final value = DerivedValue((b) => b..anInt = 7);
+      expect(derivedValueGetterCount, 0);
+      expect(value.derivedValue, 17);
+      expect(derivedValueGetterCount, 1);
+      expect(value.derivedValue, 17);
+      expect(derivedValueGetterCount, 1);
+    });
+
+    test('caches derivedString', () {
+      final value = DerivedValue((b) => b..anInt = 0);
+      expect(derivedStringGetterCount, 0);
+      expect(value.derivedString, [value.toString()]);
+      expect(derivedStringGetterCount, 1);
+      expect(value.derivedString, [value.toString()]);
+      expect(derivedStringGetterCount, 1);
+    });
+
+    test('caches nullableDerivedValue', () {
+      final value = DerivedValue((b) => b..anInt = 7);
+      expect(nullableDerivedGetterCount, 0);
+      expect(value.nullableDerivedValue, null);
+      expect(nullableDerivedGetterCount, 1);
+      expect(value.nullableDerivedValue, null);
+      expect(nullableDerivedGetterCount, 1);
+    });
+  });
+
+  group('ValidatedValue', () {
+    test('can be instantiated', () {
+      ValidatedValue((b) => b..anInt = 1);
+    });
+
+    test('does custom validation', () {
+      expect(() => ValidatedValue((b) => b..anInt = 7),
+          throwsA(const TypeMatcher<StateError>()));
+    });
+  });
+
+  group('ValueWithCode', () {
+    test('can be instantiated via custom factory', () {
+      expect(
+          ValueWithCode.fromCustomFactory(12),
+          ValueWithCode((b) => b
+            ..anInt = 12
+            ..aString = 'two'));
+    });
+
+    test('has derived getter', () {
+      expect(
+          ValueWithCode((b) => b
+            ..anInt = 12
+            ..aString = 'two').youCanWriteDerivedGetters,
+          '12two');
+    });
+  });
+
+  group('ValueWithDefaults', () {
+    test('has defaults', () {
+      expect(ValueWithDefaults().anInt, 7);
+    });
+
+    test('builder exposes values via getters', () {
+      final builder = ValueWithDefaults((b) => b..anInt = 12).toBuilder();
+      expect(builder.anInt, 12);
+    });
+  });
+
+  group(ValueWithBuilderSmarts, () {
+    test('can be instantiated', () {
+      ValueWithBuilderSmarts((b) => b..value = 'hi');
+    });
+
+    test('validates on set', () {
+      expect(() => ValueWithBuilderSmarts((b) => b..value = 'not allowed'),
+          throwsA(const TypeMatcher<ArgumentError>()));
+    });
+  });
+
+  group('ValueWithOnSet', () {
+    test('notifies on sets', () {
+      var notified = false;
+      var builder = ValueWithOnSet((b) => b..value = 2).toBuilder();
+      builder.onSet = () => notified = true;
+      builder.value = 3;
+      expect(notified, true);
+    });
+  });
+
+  group(CustomToStringValue, () {
+    test('has custom toString()', () {
+      expect(CustomToStringValue().toString(), 'custom');
+    });
+  });
+
+  group('ValueUsingImportAs', () {
+    test('can be instantiated', () {
+      ValueUsingImportAs((b) => b..value = TestEnum.yes);
+    });
+  });
+
+  group('OtherValue', () {
+    test('compares correctly', () {
+      var value = OtherValue((b) => b..other = 1);
+      var equalValue = OtherValue((b) => b..other = 1);
+      var notEqualValue = OtherValue((b) => b..other = 2);
+      expect(value, equalValue);
+      expect(value, isNot(equals(notEqualValue)));
+    });
+  });
+
+  group('ValueWithBuilderInitializer', () {
+    test('has defaults', () {
+      var value = ValueWithBuilderInitializer((b) => b
+        ..anInt = 1
+        ..nestedValue.anInt = 2);
+      expect(
+          value,
+          ValueWithBuilderInitializer((b) => b
+            ..anInt = 1
+            ..nestedValue.anInt = 2));
+    });
+  });
+
+  group('ValueWithBuilderFinalizer', () {
+    test('applies hook', () {
+      expect(ValueWithBuilderFinalizer((b) => b..anInt = 0).anInt, 1);
+    });
+  });
+
+  group('DefaultsForFieldSettingsValue', () {
+    test('compares correctly', () {
+      var value = DefaultsForFieldSettingsValue((b) => b
+        ..ignored = 0
+        ..compared = 0
+        ..serialized = 0);
+      var equalValue = DefaultsForFieldSettingsValue((b) => b
+        ..ignored = 1
+        ..compared = 0
+        ..serialized = 0);
+      var differentValue = DefaultsForFieldSettingsValue((b) => b
+        ..ignored = 0
+        ..compared = 1
+        ..serialized = 0);
+      expect(value, equalValue);
+      expect(value, isNot(differentValue));
+    });
+  });
+
+  group('ValueWithGenericBuilderInitializer', () {
+    test('works with generics', () {
+      // Initializer only fires for ints, it sets the value to 42.
+      var valueThatTriggersInitializer =
+          ValueWithGenericBuilderInitializer<int>();
+      expect(valueThatTriggersInitializer.value, 42);
+
+      var valueThatDoesNotTriggerInitializer =
+          ValueWithGenericBuilderInitializer<String>();
+      expect(valueThatDoesNotTriggerInitializer.value, null);
+    });
+  });
+
+  group('MemoizedHashcodeValue', () {
+    test('computes same hashCode as HashcodeValue', () {
+      var value = HashcodeValue((b) => b
+        ..x = 42
+        ..y = 43);
+      var valueWithMemoization = MemoizedHashcodeValue((b) => b
+        ..x = 42
+        ..y = 43);
+
+      expect(valueWithMemoization.hashCode, value.hashCode);
+    });
+  });
+
+  group(ValueWithHooks, () {
+    test('initialize hooks run', () {
+      var value = ValueWithHooks();
+      expect(value.hook1Count, 1);
+    });
+
+    test('initialize hooks run initially', () {
+      var value = ValueWithHooks((b) => b..hook1Count = 100);
+      expect(value.hook1Count, 100);
+    });
+
+    test('finalize hooks run', () {
+      var value = ValueWithHooks();
+      expect(value.hook2Count, 1);
+    });
+
+    test('finalize hooks run finally', () {
+      var value = ValueWithHooks((b) => b..hook1Count = 100);
+      expect(value.hook2Count, 1);
+    });
+
+    test('multiple hooks ordering', () {
+      var value = ValueWithHooks();
+      expect(value.hookOrdering, [
+        'justInitialize',
+        'both',
+        'moreJustInitialize',
+        'moreBoth',
+        'justFinalize',
+        'both',
+        'moreJustFinalize',
+        'moreBoth',
+      ]);
+    });
+  });
+
+  group('NewConstructorValue', () {
+    test('has correct field name and type with new _()', () {
+      final value = NewConstructorValue((b) => b..anInt = 42);
+      expect(value.anInt, 42);
+      expect(value.anInt, isA<int>());
+    });
+  });
+}

--- a/built_types/example/analysis_options.yaml
+++ b/built_types/example/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/built_types/example/bin/example.dart
+++ b/built_types/example/bin/example.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+import 'package:example/example.dart';
+
+/// Simple usage examples for built_value.
+void main() {
+  example();
+  standardJsonExample();
+}

--- a/built_types/example/lib/collections.dart
+++ b/built_types/example/lib/collections.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library collections;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'collections.g.dart';
+
+/// Example of how to use built_value.
+///
+/// Classes can contain collections; these must be from built_collection. In
+/// the builder, the builder corresponding to the collection is provided.
+abstract class Collections implements Built<Collections, CollectionsBuilder> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializers] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static Serializer<Collections> get serializer => _$collectionsSerializer;
+
+  BuiltList<int> get list;
+  BuiltSet<String> get set;
+  BuiltMap<String, int> get map;
+  BuiltListMultimap<int, bool> get listMultimap;
+  BuiltSetMultimap<String, bool> get setMultimap;
+
+  BuiltList<int>? get nullableList;
+  BuiltSet<String>? get nullableSet;
+  BuiltMap<String, int>? get nullableMap;
+  BuiltListMultimap<int, bool>? get nullableListMultimap;
+  BuiltSetMultimap<String, bool>? get nullableSetMultimap;
+
+  factory Collections([void Function(CollectionsBuilder) updates]) =
+      _$Collections;
+  Collections._();
+}

--- a/built_types/example/lib/collections.g.dart
+++ b/built_types/example/lib/collections.g.dart
@@ -1,0 +1,394 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'collections.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<Collections> _$collectionsSerializer = _$CollectionsSerializer();
+
+class _$CollectionsSerializer implements StructuredSerializer<Collections> {
+  @override
+  final Iterable<Type> types = const [Collections, _$Collections];
+  @override
+  final String wireName = 'Collections';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Collections object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'list',
+      serializers.serialize(object.list,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(int)])),
+      'set',
+      serializers.serialize(object.set,
+          specifiedType:
+              const FullType(BuiltSet, const [const FullType(String)])),
+      'map',
+      serializers.serialize(object.map,
+          specifiedType: const FullType(
+              BuiltMap, const [const FullType(String), const FullType(int)])),
+      'listMultimap',
+      serializers.serialize(object.listMultimap,
+          specifiedType: const FullType(BuiltListMultimap,
+              const [const FullType(int), const FullType(bool)])),
+      'setMultimap',
+      serializers.serialize(object.setMultimap,
+          specifiedType: const FullType(BuiltSetMultimap,
+              const [const FullType(String), const FullType(bool)])),
+    ];
+    Object? value;
+    value = object.nullableList;
+    if (value != null) {
+      result
+        ..add('nullableList')
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(int)])));
+    }
+    value = object.nullableSet;
+    if (value != null) {
+      result
+        ..add('nullableSet')
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltSet, const [const FullType(String)])));
+    }
+    value = object.nullableMap;
+    if (value != null) {
+      result
+        ..add('nullableMap')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltMap,
+                const [const FullType(String), const FullType(int)])));
+    }
+    value = object.nullableListMultimap;
+    if (value != null) {
+      result
+        ..add('nullableListMultimap')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltListMultimap,
+                const [const FullType(int), const FullType(bool)])));
+    }
+    value = object.nullableSetMultimap;
+    if (value != null) {
+      result
+        ..add('nullableSetMultimap')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltSetMultimap,
+                const [const FullType(String), const FullType(bool)])));
+    }
+    return result;
+  }
+
+  @override
+  Collections deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CollectionsBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'list':
+          result.list.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(int)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'set':
+          result.set.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltSet, const [const FullType(String)]))!
+              as BuiltSet<Object?>);
+          break;
+        case 'map':
+          result.map.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap,
+                  const [const FullType(String), const FullType(int)]))!);
+          break;
+        case 'listMultimap':
+          result.listMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltListMultimap,
+                  const [const FullType(int), const FullType(bool)]))!);
+          break;
+        case 'setMultimap':
+          result.setMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltSetMultimap,
+                  const [const FullType(String), const FullType(bool)]))!);
+          break;
+        case 'nullableList':
+          result.nullableList.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(int)]))!
+              as BuiltList<Object?>);
+          break;
+        case 'nullableSet':
+          result.nullableSet.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltSet, const [const FullType(String)]))!
+              as BuiltSet<Object?>);
+          break;
+        case 'nullableMap':
+          result.nullableMap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap,
+                  const [const FullType(String), const FullType(int)]))!);
+          break;
+        case 'nullableListMultimap':
+          result.nullableListMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltListMultimap,
+                  const [const FullType(int), const FullType(bool)]))!);
+          break;
+        case 'nullableSetMultimap':
+          result.nullableSetMultimap.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltSetMultimap,
+                  const [const FullType(String), const FullType(bool)]))!);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$Collections extends Collections {
+  @override
+  final BuiltList<int> list;
+  @override
+  final BuiltSet<String> set;
+  @override
+  final BuiltMap<String, int> map;
+  @override
+  final BuiltListMultimap<int, bool> listMultimap;
+  @override
+  final BuiltSetMultimap<String, bool> setMultimap;
+  @override
+  final BuiltList<int>? nullableList;
+  @override
+  final BuiltSet<String>? nullableSet;
+  @override
+  final BuiltMap<String, int>? nullableMap;
+  @override
+  final BuiltListMultimap<int, bool>? nullableListMultimap;
+  @override
+  final BuiltSetMultimap<String, bool>? nullableSetMultimap;
+
+  factory _$Collections([void Function(CollectionsBuilder)? updates]) =>
+      (CollectionsBuilder()..update(updates))._build();
+
+  _$Collections._(
+      {required this.list,
+      required this.set,
+      required this.map,
+      required this.listMultimap,
+      required this.setMultimap,
+      this.nullableList,
+      this.nullableSet,
+      this.nullableMap,
+      this.nullableListMultimap,
+      this.nullableSetMultimap})
+      : super._();
+  @override
+  Collections rebuild(void Function(CollectionsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CollectionsBuilder toBuilder() => CollectionsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Collections &&
+        list == other.list &&
+        set == other.set &&
+        map == other.map &&
+        listMultimap == other.listMultimap &&
+        setMultimap == other.setMultimap &&
+        nullableList == other.nullableList &&
+        nullableSet == other.nullableSet &&
+        nullableMap == other.nullableMap &&
+        nullableListMultimap == other.nullableListMultimap &&
+        nullableSetMultimap == other.nullableSetMultimap;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, list.hashCode);
+    _$hash = $jc(_$hash, set.hashCode);
+    _$hash = $jc(_$hash, map.hashCode);
+    _$hash = $jc(_$hash, listMultimap.hashCode);
+    _$hash = $jc(_$hash, setMultimap.hashCode);
+    _$hash = $jc(_$hash, nullableList.hashCode);
+    _$hash = $jc(_$hash, nullableSet.hashCode);
+    _$hash = $jc(_$hash, nullableMap.hashCode);
+    _$hash = $jc(_$hash, nullableListMultimap.hashCode);
+    _$hash = $jc(_$hash, nullableSetMultimap.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Collections')
+          ..add('list', list)
+          ..add('set', set)
+          ..add('map', map)
+          ..add('listMultimap', listMultimap)
+          ..add('setMultimap', setMultimap)
+          ..add('nullableList', nullableList)
+          ..add('nullableSet', nullableSet)
+          ..add('nullableMap', nullableMap)
+          ..add('nullableListMultimap', nullableListMultimap)
+          ..add('nullableSetMultimap', nullableSetMultimap))
+        .toString();
+  }
+}
+
+class CollectionsBuilder implements Builder<Collections, CollectionsBuilder> {
+  _$Collections? _$v;
+
+  ListBuilder<int>? _list;
+  ListBuilder<int> get list => _$this._list ??= ListBuilder<int>();
+  set list(ListBuilder<int>? list) => _$this._list = list;
+
+  SetBuilder<String>? _set;
+  SetBuilder<String> get set => _$this._set ??= SetBuilder<String>();
+  set set(SetBuilder<String>? set) => _$this._set = set;
+
+  MapBuilder<String, int>? _map;
+  MapBuilder<String, int> get map => _$this._map ??= MapBuilder<String, int>();
+  set map(MapBuilder<String, int>? map) => _$this._map = map;
+
+  ListMultimapBuilder<int, bool>? _listMultimap;
+  ListMultimapBuilder<int, bool> get listMultimap =>
+      _$this._listMultimap ??= ListMultimapBuilder<int, bool>();
+  set listMultimap(ListMultimapBuilder<int, bool>? listMultimap) =>
+      _$this._listMultimap = listMultimap;
+
+  SetMultimapBuilder<String, bool>? _setMultimap;
+  SetMultimapBuilder<String, bool> get setMultimap =>
+      _$this._setMultimap ??= SetMultimapBuilder<String, bool>();
+  set setMultimap(SetMultimapBuilder<String, bool>? setMultimap) =>
+      _$this._setMultimap = setMultimap;
+
+  ListBuilder<int>? _nullableList;
+  ListBuilder<int> get nullableList =>
+      _$this._nullableList ??= ListBuilder<int>();
+  set nullableList(ListBuilder<int>? nullableList) =>
+      _$this._nullableList = nullableList;
+
+  SetBuilder<String>? _nullableSet;
+  SetBuilder<String> get nullableSet =>
+      _$this._nullableSet ??= SetBuilder<String>();
+  set nullableSet(SetBuilder<String>? nullableSet) =>
+      _$this._nullableSet = nullableSet;
+
+  MapBuilder<String, int>? _nullableMap;
+  MapBuilder<String, int> get nullableMap =>
+      _$this._nullableMap ??= MapBuilder<String, int>();
+  set nullableMap(MapBuilder<String, int>? nullableMap) =>
+      _$this._nullableMap = nullableMap;
+
+  ListMultimapBuilder<int, bool>? _nullableListMultimap;
+  ListMultimapBuilder<int, bool> get nullableListMultimap =>
+      _$this._nullableListMultimap ??= ListMultimapBuilder<int, bool>();
+  set nullableListMultimap(
+          ListMultimapBuilder<int, bool>? nullableListMultimap) =>
+      _$this._nullableListMultimap = nullableListMultimap;
+
+  SetMultimapBuilder<String, bool>? _nullableSetMultimap;
+  SetMultimapBuilder<String, bool> get nullableSetMultimap =>
+      _$this._nullableSetMultimap ??= SetMultimapBuilder<String, bool>();
+  set nullableSetMultimap(
+          SetMultimapBuilder<String, bool>? nullableSetMultimap) =>
+      _$this._nullableSetMultimap = nullableSetMultimap;
+
+  CollectionsBuilder();
+
+  CollectionsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _list = $v.list.toBuilder();
+      _set = $v.set.toBuilder();
+      _map = $v.map.toBuilder();
+      _listMultimap = $v.listMultimap.toBuilder();
+      _setMultimap = $v.setMultimap.toBuilder();
+      _nullableList = $v.nullableList?.toBuilder();
+      _nullableSet = $v.nullableSet?.toBuilder();
+      _nullableMap = $v.nullableMap?.toBuilder();
+      _nullableListMultimap = $v.nullableListMultimap?.toBuilder();
+      _nullableSetMultimap = $v.nullableSetMultimap?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Collections other) {
+    _$v = other as _$Collections;
+  }
+
+  @override
+  void update(void Function(CollectionsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Collections build() => _build();
+
+  _$Collections _build() {
+    _$Collections _$result;
+    try {
+      _$result = _$v ??
+          _$Collections._(
+            list: list.build(),
+            set: set.build(),
+            map: map.build(),
+            listMultimap: listMultimap.build(),
+            setMultimap: setMultimap.build(),
+            nullableList: _nullableList?.build(),
+            nullableSet: _nullableSet?.build(),
+            nullableMap: _nullableMap?.build(),
+            nullableListMultimap: _nullableListMultimap?.build(),
+            nullableSetMultimap: _nullableSetMultimap?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'list';
+        list.build();
+        _$failedField = 'set';
+        set.build();
+        _$failedField = 'map';
+        map.build();
+        _$failedField = 'listMultimap';
+        listMultimap.build();
+        _$failedField = 'setMultimap';
+        setMultimap.build();
+        _$failedField = 'nullableList';
+        _nullableList?.build();
+        _$failedField = 'nullableSet';
+        _nullableSet?.build();
+        _$failedField = 'nullableMap';
+        _nullableMap?.build();
+        _$failedField = 'nullableListMultimap';
+        _nullableListMultimap?.build();
+        _$failedField = 'nullableSetMultimap';
+        _nullableSetMultimap?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'Collections', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/example/lib/enums.dart
+++ b/built_types/example/lib/enums.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library enums;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'enums.g.dart';
+
+/// Example of how to use [EnumClass].
+///
+/// Enum constants must be declared as `static const`. Initialize them from
+/// the generated code. You can use any initializer starting _$ and the
+/// generated code will match it. For example, you could initialize "yes" to
+/// "_$yes", "_$y" or even "_$abc".
+///
+/// You need to write three pieces of boilerplate to hook up the generated
+/// code: a constructor called `_`, a `values` method, and a `valueOf` method.
+class TestEnum extends EnumClass {
+  /// Example of how to make an [EnumClass] serializable.
+  ///
+  /// Declare a static final [Serializers] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static Serializer<TestEnum> get serializer => _$testEnumSerializer;
+
+  static const TestEnum yes = _$yes;
+  static const TestEnum no = _$no;
+  static const TestEnum maybe = _$maybe;
+
+  const TestEnum._(String name) : super(name);
+
+  static BuiltSet<TestEnum> get values => _$values;
+  static TestEnum valueOf(String name) => _$valueOf(name);
+}
+
+/// It's possible to have multiple enums in the same file.
+///
+/// For this to work, you need to change any generated names that clash. For
+/// example, _$values and _$valueOf will always clash. You can change them
+/// to anything you like, the code generation will match what you write.
+class SecondTestEnum extends EnumClass {
+  static const SecondTestEnum yes = _$ys;
+  static const SecondTestEnum no = _$n;
+  static const SecondTestEnum definitely = _$definitely;
+
+  const SecondTestEnum._(String name) : super(name);
+
+  static BuiltSet<SecondTestEnum> get values => _$vls;
+  static SecondTestEnum valueOf(String name) => _$vlOf(name);
+}
+
+/// If you need to change the values sent over the wire when serializing you
+/// can do so using the [BuiltValueEnum] and [BuiltValueEnumConst] annotations.
+@BuiltValueEnum(wireName: 'E')
+class WireNameEnum extends EnumClass {
+  static Serializer<WireNameEnum> get serializer => _$wireNameEnumSerializer;
+
+  @BuiltValueEnumConst(wireName: 'y')
+  static const WireNameEnum yes = _$wireYes;
+
+  @BuiltValueEnumConst(wireName: 'n')
+  static const WireNameEnum no = _$wireNo;
+
+  @BuiltValueEnumConst(wireName: 'd')
+  static const WireNameEnum definitely = _$wireDefinitely;
+
+  const WireNameEnum._(String name) : super(name);
+
+  static BuiltSet<WireNameEnum> get values => _$wireValues;
+  static WireNameEnum valueOf(String name) => _$wireValueOf(name);
+}

--- a/built_types/example/lib/enums.g.dart
+++ b/built_types/example/lib/enums.g.dart
@@ -1,0 +1,129 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'enums.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+const TestEnum _$yes = const TestEnum._('yes');
+const TestEnum _$no = const TestEnum._('no');
+const TestEnum _$maybe = const TestEnum._('maybe');
+
+TestEnum _$valueOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$yes;
+    case 'no':
+      return _$no;
+    case 'maybe':
+      return _$maybe;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<TestEnum> _$values = BuiltSet<TestEnum>(const <TestEnum>[
+  _$yes,
+  _$no,
+  _$maybe,
+]);
+
+const SecondTestEnum _$ys = const SecondTestEnum._('yes');
+const SecondTestEnum _$n = const SecondTestEnum._('no');
+const SecondTestEnum _$definitely = const SecondTestEnum._('definitely');
+
+SecondTestEnum _$vlOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$ys;
+    case 'no':
+      return _$n;
+    case 'definitely':
+      return _$definitely;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<SecondTestEnum> _$vls =
+    BuiltSet<SecondTestEnum>(const <SecondTestEnum>[
+  _$ys,
+  _$n,
+  _$definitely,
+]);
+
+const WireNameEnum _$wireYes = const WireNameEnum._('yes');
+const WireNameEnum _$wireNo = const WireNameEnum._('no');
+const WireNameEnum _$wireDefinitely = const WireNameEnum._('definitely');
+
+WireNameEnum _$wireValueOf(String name) {
+  switch (name) {
+    case 'yes':
+      return _$wireYes;
+    case 'no':
+      return _$wireNo;
+    case 'definitely':
+      return _$wireDefinitely;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<WireNameEnum> _$wireValues =
+    BuiltSet<WireNameEnum>(const <WireNameEnum>[
+  _$wireYes,
+  _$wireNo,
+  _$wireDefinitely,
+]);
+
+Serializer<TestEnum> _$testEnumSerializer = _$TestEnumSerializer();
+Serializer<WireNameEnum> _$wireNameEnumSerializer = _$WireNameEnumSerializer();
+
+class _$TestEnumSerializer implements PrimitiveSerializer<TestEnum> {
+  @override
+  final Iterable<Type> types = const <Type>[TestEnum];
+  @override
+  final String wireName = 'TestEnum';
+
+  @override
+  Object serialize(Serializers serializers, TestEnum object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
+
+  @override
+  TestEnum deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      TestEnum.valueOf(serialized as String);
+}
+
+class _$WireNameEnumSerializer implements PrimitiveSerializer<WireNameEnum> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    'yes': 'y',
+    'no': 'n',
+    'definitely': 'd',
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    'y': 'yes',
+    'n': 'no',
+    'd': 'definitely',
+  };
+
+  @override
+  final Iterable<Type> types = const <Type>[WireNameEnum];
+  @override
+  final String wireName = 'E';
+
+  @override
+  Object serialize(Serializers serializers, WireNameEnum object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      _toWire[object.name] ?? object.name;
+
+  @override
+  WireNameEnum deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      WireNameEnum.valueOf(
+          _fromWire[serialized] ?? (serialized is String ? serialized : ''));
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/example/lib/example.dart
+++ b/built_types/example/lib/example.dart
@@ -1,0 +1,152 @@
+import 'package:built_value/standard_json_plugin.dart';
+import 'package:example/generics.dart';
+import 'package:example/polymorphism.dart';
+import 'package:example/serializers.dart';
+import 'package:example/values.dart';
+
+/// Simple usage examples for built_value.
+void example() {
+  // Values must be created with all required fields.
+  final value = SimpleValue((b) => b..anInt = 3);
+
+  // Nullable fields will default to null if not set.
+  final value2 = SimpleValue((b) => b
+    ..anInt = 3
+    ..aString = 'three');
+
+  // All values implement operator==, hashCode and toString.
+  assert(value != value2);
+
+  // Values based on existing values are created via "rebuild".
+  final value3 = value.rebuild((b) => b..aString = 'three');
+  assert(value2 == value3);
+
+  // Or, you can convert to a builder and hold the builder for a while.
+  final builder = value3.toBuilder();
+  builder.anInt = 4;
+  final value4 = builder.build();
+  assert(value3 != value4);
+
+  // Nested built_value fields are built with nested builders.
+  final value5 = CompoundValue((b) => b
+    ..simpleValue.anInt = 1
+    ..validatedValue.anInt = 2);
+
+  // Values can use generics.
+  final value6 = GenericValue<String>((b) => b..value = 'string');
+
+  // Values with a simplified factory still have a builder.
+  final value7 = VerySimpleValue(3);
+  final value8 = value7.rebuild((b) => b..value = 4);
+
+  // Values can use polymorphism.
+  final animals = <Animal>[
+    Cat((b) => b
+      ..legs = 3
+      ..tail = true),
+    Fish((b) => b
+      ..legs = 0
+      ..fins = 4),
+  ];
+  final modifiedAnimals = animals
+      .map((animal) => animal.rebuild((b) => b.legs = b.legs! + 1))
+      .toList();
+
+  // Everything is serializable.
+  for (var object in [
+    value,
+    value2,
+    value3,
+    value4,
+    value5,
+    value6,
+    value7,
+    value8,
+    modifiedAnimals[0],
+    modifiedAnimals[1],
+  ]) {
+    var serialized = serializers.serialize(object);
+    print(serialized);
+    assert(serializers.deserialize(serialized) == object);
+  }
+
+  // See chat_example and end_to_end_test for more complex usage!
+}
+
+/// Examples of using StandardJsonPlugin.
+///
+/// The plugin changes the built_value serialization format to the Map-based
+/// format used by most JSON APIs.
+///
+/// Where needed the plugin specifies which type to serialize/deserialize using
+/// a `discriminator` field. By default this field is called `$`; you can pass
+/// a different name to the `StandardJsonPlugin` constructor. If the wire
+/// format should not contain the type name, you must instead explicitly
+/// specify which type to serialize/deserialize. Both cases are shown below.
+void standardJsonExample() {
+  final standardSerializers =
+      (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
+
+  // In this first example we know the type we want to serialize/deserialize,
+  // so the type is not mentioned on the wire.
+  final serializedAccount = {
+    'id': 3,
+    'name': 'John Smith',
+    'keyValues': {
+      'visited': 1732,
+      'active': true,
+      'email': 'john.smith@example.com',
+      'tags': [74, 123, 4001],
+      'preferences': {
+        'showMenu': true,
+        'skipIntro': true,
+        'colorScheme': 'light',
+      }
+    }
+  };
+
+  // Use the deserializeWith method to specify what type you're deserializing.
+  final value = standardSerializers.deserializeWith(
+      Account.serializer, serializedAccount)!;
+  print(value);
+
+  assert(value.id == 3);
+  assert(value.name == 'John Smith');
+  assert(value.keyValues['tags']!.asList[2] == 4001);
+  assert(value.keyValues['preferences']!.asMap['colorScheme'] == 'light');
+
+  // Use the serializeWith method to specify what type you're serializing.
+  final serializedAgain =
+      standardSerializers.serializeWith(Account.serializer, value);
+  assert(serializedAccount.toString() == serializedAgain.toString());
+
+  // In this second example we don't know the type we want to
+  // serialize/deserialize, so it has to be specified on the wire.
+  final serializedAccountWithDiscriminator = {
+    r'$': 'Account',
+    'id': 3,
+    'name': 'John Smith',
+    'keyValues': {
+      'visited': 1732,
+      'active': true,
+      'email': 'john.smith@example.com',
+      'tags': [74, 123, 4001],
+      'preferences': {
+        'showMenu': true,
+        'skipIntro': true,
+        'colorScheme': 'light',
+      }
+    }
+  };
+
+  // We don't have to specify the type when deserializing.
+  final value2 =
+      standardSerializers.deserialize(serializedAccountWithDiscriminator);
+  print(value2);
+  assert(value == value2);
+
+  // We don't have to specify the type when serializing.
+  final serializedAgain2 = standardSerializers.serialize(value2);
+  assert(serializedAccountWithDiscriminator.toString() ==
+      serializedAgain2.toString());
+}

--- a/built_types/example/lib/generics.dart
+++ b/built_types/example/lib/generics.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library generics;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'generics.g.dart';
+
+/// Example of how to use built_value.
+///
+/// The value class must implement [Built]. It must be abstract, and have
+/// fields declared as abstract getters. Finally, it must have a particular
+/// constructor and factory, as shown here.
+abstract class GenericValue<T>
+    implements Built<GenericValue<T>, GenericValueBuilder<T>> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializer] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static Serializer<GenericValue> get serializer => _$genericValueSerializer;
+
+  T get value;
+
+  factory GenericValue([Function(GenericValueBuilder<T>) updates]) =
+      _$GenericValue<T>;
+  GenericValue._();
+}
+
+abstract class BoundGenericValue<T extends num>
+    implements Built<BoundGenericValue<T>, BoundGenericValueBuilder<T>> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializer] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static Serializer<BoundGenericValue> get serializer =>
+      _$boundGenericValueSerializer;
+
+  T get value;
+
+  factory BoundGenericValue([Function(BoundGenericValueBuilder<T>) updates]) =
+      _$BoundGenericValue<T>;
+  BoundGenericValue._();
+}
+
+abstract class CollectionGenericValue<T>
+    implements
+        Built<CollectionGenericValue<T>, CollectionGenericValueBuilder<T>> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializer] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static Serializer<CollectionGenericValue> get serializer =>
+      _$collectionGenericValueSerializer;
+
+  BuiltList<T> get values;
+
+  factory CollectionGenericValue(
+          [Function(CollectionGenericValueBuilder<T>) updates]) =
+      _$CollectionGenericValue<T>;
+  CollectionGenericValue._();
+}
+
+abstract class GenericContainer
+    implements Built<GenericContainer, GenericContainerBuilder> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializer] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static Serializer<GenericContainer> get serializer =>
+      _$genericContainerSerializer;
+
+  GenericValue<String> get genericValue;
+  BoundGenericValue<double> get boundGenericValue;
+  CollectionGenericValue<String> get collectionGenericValue;
+
+  factory GenericContainer([void Function(GenericContainerBuilder) updates]) =
+      _$GenericContainer;
+  GenericContainer._();
+}

--- a/built_types/example/lib/generics.g.dart
+++ b/built_types/example/lib/generics.g.dart
@@ -1,0 +1,649 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'generics.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GenericValue<Object?>> _$genericValueSerializer =
+    _$GenericValueSerializer();
+Serializer<BoundGenericValue<num>> _$boundGenericValueSerializer =
+    _$BoundGenericValueSerializer();
+Serializer<CollectionGenericValue<Object?>> _$collectionGenericValueSerializer =
+    _$CollectionGenericValueSerializer();
+Serializer<GenericContainer> _$genericContainerSerializer =
+    _$GenericContainerSerializer();
+
+class _$GenericValueSerializer
+    implements StructuredSerializer<GenericValue<Object?>> {
+  @override
+  final Iterable<Type> types = const [GenericValue, _$GenericValue];
+  @override
+  final String wireName = 'GenericValue';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GenericValue<Object?> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: parameterT),
+    ];
+
+    return result;
+  }
+
+  @override
+  GenericValue<Object?> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = isUnderspecified
+        ? GenericValueBuilder<Object?>()
+        : serializers.newBuilder(specifiedType) as GenericValueBuilder<Object?>;
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(value, specifiedType: parameterT);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BoundGenericValueSerializer
+    implements StructuredSerializer<BoundGenericValue<num>> {
+  @override
+  final Iterable<Type> types = const [BoundGenericValue, _$BoundGenericValue];
+  @override
+  final String wireName = 'BoundGenericValue';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, BoundGenericValue<num> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: parameterT),
+    ];
+
+    return result;
+  }
+
+  @override
+  BoundGenericValue<num> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = isUnderspecified
+        ? BoundGenericValueBuilder<num>()
+        : serializers.newBuilder(specifiedType)
+            as BoundGenericValueBuilder<num>;
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value =
+              serializers.deserialize(value, specifiedType: parameterT)! as num;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CollectionGenericValueSerializer
+    implements StructuredSerializer<CollectionGenericValue<Object?>> {
+  @override
+  final Iterable<Type> types = const [
+    CollectionGenericValue,
+    _$CollectionGenericValue
+  ];
+  @override
+  final String wireName = 'CollectionGenericValue';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, CollectionGenericValue<Object?> object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = <Object?>[
+      'values',
+      serializers.serialize(object.values,
+          specifiedType: FullType(BuiltList, [parameterT])),
+    ];
+
+    return result;
+  }
+
+  @override
+  CollectionGenericValue<Object?> deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final isUnderspecified =
+        specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
+    if (!isUnderspecified) serializers.expectBuilder(specifiedType);
+    final parameterT =
+        isUnderspecified ? FullType.object : specifiedType.parameters[0];
+
+    final result = isUnderspecified
+        ? CollectionGenericValueBuilder<Object?>()
+        : serializers.newBuilder(specifiedType)
+            as CollectionGenericValueBuilder<Object?>;
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'values':
+          result.values.replace(serializers.deserialize(value,
+                  specifiedType: FullType(BuiltList, [parameterT]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GenericContainerSerializer
+    implements StructuredSerializer<GenericContainer> {
+  @override
+  final Iterable<Type> types = const [GenericContainer, _$GenericContainer];
+  @override
+  final String wireName = 'GenericContainer';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GenericContainer object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'genericValue',
+      serializers.serialize(object.genericValue,
+          specifiedType:
+              const FullType(GenericValue, const [const FullType(String)])),
+      'boundGenericValue',
+      serializers.serialize(object.boundGenericValue,
+          specifiedType: const FullType(
+              BoundGenericValue, const [const FullType(double)])),
+      'collectionGenericValue',
+      serializers.serialize(object.collectionGenericValue,
+          specifiedType: const FullType(
+              CollectionGenericValue, const [const FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GenericContainer deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GenericContainerBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'genericValue':
+          result.genericValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      GenericValue, const [const FullType(String)]))!
+              as GenericValue<String>);
+          break;
+        case 'boundGenericValue':
+          result.boundGenericValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BoundGenericValue, const [const FullType(double)]))!
+              as BoundGenericValue<double>);
+          break;
+        case 'collectionGenericValue':
+          result.collectionGenericValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      CollectionGenericValue, const [const FullType(String)]))!
+              as CollectionGenericValue<String>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GenericValue<T> extends GenericValue<T> {
+  @override
+  final T value;
+
+  factory _$GenericValue([void Function(GenericValueBuilder<T>)? updates]) =>
+      (GenericValueBuilder<T>()..update(updates))._build();
+
+  _$GenericValue._({required this.value}) : super._();
+  @override
+  GenericValue<T> rebuild(void Function(GenericValueBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GenericValueBuilder<T> toBuilder() => GenericValueBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GenericValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GenericValue')..add('value', value))
+        .toString();
+  }
+}
+
+class GenericValueBuilder<T>
+    implements Builder<GenericValue<T>, GenericValueBuilder<T>> {
+  _$GenericValue<T>? _$v;
+
+  T? _value;
+  T? get value => _$this._value;
+  set value(T? value) => _$this._value = value;
+
+  GenericValueBuilder();
+
+  GenericValueBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GenericValue<T> other) {
+    _$v = other as _$GenericValue<T>;
+  }
+
+  @override
+  void update(void Function(GenericValueBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GenericValue<T> build() => _build();
+
+  _$GenericValue<T> _build() {
+    final _$result = _$v ??
+        _$GenericValue<T>._(
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'GenericValue', 'value'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$BoundGenericValue<T extends num> extends BoundGenericValue<T> {
+  @override
+  final T value;
+
+  factory _$BoundGenericValue(
+          [void Function(BoundGenericValueBuilder<T>)? updates]) =>
+      (BoundGenericValueBuilder<T>()..update(updates))._build();
+
+  _$BoundGenericValue._({required this.value}) : super._();
+  @override
+  BoundGenericValue<T> rebuild(
+          void Function(BoundGenericValueBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BoundGenericValueBuilder<T> toBuilder() =>
+      BoundGenericValueBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BoundGenericValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BoundGenericValue')
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class BoundGenericValueBuilder<T extends num>
+    implements Builder<BoundGenericValue<T>, BoundGenericValueBuilder<T>> {
+  _$BoundGenericValue<T>? _$v;
+
+  T? _value;
+  T? get value => _$this._value;
+  set value(T? value) => _$this._value = value;
+
+  BoundGenericValueBuilder();
+
+  BoundGenericValueBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(BoundGenericValue<T> other) {
+    _$v = other as _$BoundGenericValue<T>;
+  }
+
+  @override
+  void update(void Function(BoundGenericValueBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BoundGenericValue<T> build() => _build();
+
+  _$BoundGenericValue<T> _build() {
+    final _$result = _$v ??
+        _$BoundGenericValue<T>._(
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'BoundGenericValue', 'value'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CollectionGenericValue<T> extends CollectionGenericValue<T> {
+  @override
+  final BuiltList<T> values;
+
+  factory _$CollectionGenericValue(
+          [void Function(CollectionGenericValueBuilder<T>)? updates]) =>
+      (CollectionGenericValueBuilder<T>()..update(updates))._build();
+
+  _$CollectionGenericValue._({required this.values}) : super._();
+  @override
+  CollectionGenericValue<T> rebuild(
+          void Function(CollectionGenericValueBuilder<T>) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CollectionGenericValueBuilder<T> toBuilder() =>
+      CollectionGenericValueBuilder<T>()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CollectionGenericValue && values == other.values;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, values.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CollectionGenericValue')
+          ..add('values', values))
+        .toString();
+  }
+}
+
+class CollectionGenericValueBuilder<T>
+    implements
+        Builder<CollectionGenericValue<T>, CollectionGenericValueBuilder<T>> {
+  _$CollectionGenericValue<T>? _$v;
+
+  ListBuilder<T>? _values;
+  ListBuilder<T> get values => _$this._values ??= ListBuilder<T>();
+  set values(ListBuilder<T>? values) => _$this._values = values;
+
+  CollectionGenericValueBuilder();
+
+  CollectionGenericValueBuilder<T> get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _values = $v.values.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CollectionGenericValue<T> other) {
+    _$v = other as _$CollectionGenericValue<T>;
+  }
+
+  @override
+  void update(void Function(CollectionGenericValueBuilder<T>)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CollectionGenericValue<T> build() => _build();
+
+  _$CollectionGenericValue<T> _build() {
+    _$CollectionGenericValue<T> _$result;
+    try {
+      _$result = _$v ??
+          _$CollectionGenericValue<T>._(
+            values: values.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'values';
+        values.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'CollectionGenericValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GenericContainer extends GenericContainer {
+  @override
+  final GenericValue<String> genericValue;
+  @override
+  final BoundGenericValue<double> boundGenericValue;
+  @override
+  final CollectionGenericValue<String> collectionGenericValue;
+
+  factory _$GenericContainer(
+          [void Function(GenericContainerBuilder)? updates]) =>
+      (GenericContainerBuilder()..update(updates))._build();
+
+  _$GenericContainer._(
+      {required this.genericValue,
+      required this.boundGenericValue,
+      required this.collectionGenericValue})
+      : super._();
+  @override
+  GenericContainer rebuild(void Function(GenericContainerBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GenericContainerBuilder toBuilder() =>
+      GenericContainerBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GenericContainer &&
+        genericValue == other.genericValue &&
+        boundGenericValue == other.boundGenericValue &&
+        collectionGenericValue == other.collectionGenericValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, genericValue.hashCode);
+    _$hash = $jc(_$hash, boundGenericValue.hashCode);
+    _$hash = $jc(_$hash, collectionGenericValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GenericContainer')
+          ..add('genericValue', genericValue)
+          ..add('boundGenericValue', boundGenericValue)
+          ..add('collectionGenericValue', collectionGenericValue))
+        .toString();
+  }
+}
+
+class GenericContainerBuilder
+    implements Builder<GenericContainer, GenericContainerBuilder> {
+  _$GenericContainer? _$v;
+
+  GenericValueBuilder<String>? _genericValue;
+  GenericValueBuilder<String> get genericValue =>
+      _$this._genericValue ??= GenericValueBuilder<String>();
+  set genericValue(GenericValueBuilder<String>? genericValue) =>
+      _$this._genericValue = genericValue;
+
+  BoundGenericValueBuilder<double>? _boundGenericValue;
+  BoundGenericValueBuilder<double> get boundGenericValue =>
+      _$this._boundGenericValue ??= BoundGenericValueBuilder<double>();
+  set boundGenericValue(BoundGenericValueBuilder<double>? boundGenericValue) =>
+      _$this._boundGenericValue = boundGenericValue;
+
+  CollectionGenericValueBuilder<String>? _collectionGenericValue;
+  CollectionGenericValueBuilder<String> get collectionGenericValue =>
+      _$this._collectionGenericValue ??=
+          CollectionGenericValueBuilder<String>();
+  set collectionGenericValue(
+          CollectionGenericValueBuilder<String>? collectionGenericValue) =>
+      _$this._collectionGenericValue = collectionGenericValue;
+
+  GenericContainerBuilder();
+
+  GenericContainerBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _genericValue = $v.genericValue.toBuilder();
+      _boundGenericValue = $v.boundGenericValue.toBuilder();
+      _collectionGenericValue = $v.collectionGenericValue.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GenericContainer other) {
+    _$v = other as _$GenericContainer;
+  }
+
+  @override
+  void update(void Function(GenericContainerBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GenericContainer build() => _build();
+
+  _$GenericContainer _build() {
+    _$GenericContainer _$result;
+    try {
+      _$result = _$v ??
+          _$GenericContainer._(
+            genericValue: genericValue.build(),
+            boundGenericValue: boundGenericValue.build(),
+            collectionGenericValue: collectionGenericValue.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'genericValue';
+        genericValue.build();
+        _$failedField = 'boundGenericValue';
+        boundGenericValue.build();
+        _$failedField = 'collectionGenericValue';
+        collectionGenericValue.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GenericContainer', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/example/lib/interfaces.dart
+++ b/built_types/example/lib/interfaces.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library interfaces;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'interfaces.g.dart';
+
+/// Example "serializable" interface.
+///
+/// In fact it is the implementations of the interface that must be
+/// serializable. See examples below.
+abstract class HasInt {
+  int get anInt;
+}
+
+/// Example [HasInt] implementation that is not serializable.
+///
+/// To be serializable it must use built_value or enum_class.
+abstract class WrongHasInt implements HasInt {
+  @override
+  int anInt = 4;
+}
+
+/// Example [HasInt] that is serializable because it uses built_value.
+abstract class ValueWithInt
+    implements Built<ValueWithInt, ValueWithIntBuilder>, HasInt {
+  /// Serializer field makes the built_value serializable.
+  static Serializer<ValueWithInt> get serializer => _$valueWithIntSerializer;
+  static final int youCanHaveStaticFields = 3;
+
+  @override
+  int get anInt;
+
+  String get note;
+
+  factory ValueWithInt([void Function(ValueWithIntBuilder) updates]) =
+      _$ValueWithInt;
+  ValueWithInt._();
+}
+
+/// Builder class for [ValueWithInt].
+abstract class ValueWithIntBuilder
+    implements Builder<ValueWithInt, ValueWithIntBuilder> {
+  int? anInt;
+  String? note;
+
+  factory ValueWithIntBuilder() = _$ValueWithIntBuilder;
+  ValueWithIntBuilder._();
+}
+
+/// Example [HasInt] that is serializable because it uses enum_class.
+class EnumWithInt extends EnumClass implements HasInt {
+  /// Serializer field makes the enum_class serializable.
+  static Serializer<EnumWithInt> get serializer => _$enumWithIntSerializer;
+
+  static const EnumWithInt one = _$one;
+  static const EnumWithInt two = _$two;
+  static const EnumWithInt three = _$three;
+
+  const EnumWithInt._(String name) : super(name);
+
+  static BuiltSet<EnumWithInt> get values => _$values;
+
+  static EnumWithInt valueOf(String name) => _$valueOf(name);
+
+  @override
+  int get anInt {
+    switch (this) {
+      case one:
+        return 1;
+      case two:
+        return 2;
+      case three:
+        return 3;
+      default:
+        throw StateError(toString());
+    }
+  }
+}

--- a/built_types/example/lib/interfaces.g.dart
+++ b/built_types/example/lib/interfaces.g.dart
@@ -1,0 +1,205 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'interfaces.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+const EnumWithInt _$one = const EnumWithInt._('one');
+const EnumWithInt _$two = const EnumWithInt._('two');
+const EnumWithInt _$three = const EnumWithInt._('three');
+
+EnumWithInt _$valueOf(String name) {
+  switch (name) {
+    case 'one':
+      return _$one;
+    case 'two':
+      return _$two;
+    case 'three':
+      return _$three;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<EnumWithInt> _$values =
+    BuiltSet<EnumWithInt>(const <EnumWithInt>[
+  _$one,
+  _$two,
+  _$three,
+]);
+
+Serializer<ValueWithInt> _$valueWithIntSerializer = _$ValueWithIntSerializer();
+Serializer<EnumWithInt> _$enumWithIntSerializer = _$EnumWithIntSerializer();
+
+class _$ValueWithIntSerializer implements StructuredSerializer<ValueWithInt> {
+  @override
+  final Iterable<Type> types = const [ValueWithInt, _$ValueWithInt];
+  @override
+  final String wireName = 'ValueWithInt';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ValueWithInt object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+      'note',
+      serializers.serialize(object.note, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ValueWithInt deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ValueWithIntBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'anInt':
+          result.anInt = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+        case 'note':
+          result.note = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$EnumWithIntSerializer implements PrimitiveSerializer<EnumWithInt> {
+  @override
+  final Iterable<Type> types = const <Type>[EnumWithInt];
+  @override
+  final String wireName = 'EnumWithInt';
+
+  @override
+  Object serialize(Serializers serializers, EnumWithInt object,
+          {FullType specifiedType = FullType.unspecified}) =>
+      object.name;
+
+  @override
+  EnumWithInt deserialize(Serializers serializers, Object serialized,
+          {FullType specifiedType = FullType.unspecified}) =>
+      EnumWithInt.valueOf(serialized as String);
+}
+
+class _$ValueWithInt extends ValueWithInt {
+  @override
+  final int anInt;
+  @override
+  final String note;
+
+  factory _$ValueWithInt([void Function(ValueWithIntBuilder)? updates]) =>
+      (ValueWithIntBuilder()..update(updates)).build() as _$ValueWithInt;
+
+  _$ValueWithInt._({required this.anInt, required this.note}) : super._();
+  @override
+  ValueWithInt rebuild(void Function(ValueWithIntBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _$ValueWithIntBuilder toBuilder() => _$ValueWithIntBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithInt && anInt == other.anInt && note == other.note;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, note.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueWithInt')
+          ..add('anInt', anInt)
+          ..add('note', note))
+        .toString();
+  }
+}
+
+class _$ValueWithIntBuilder extends ValueWithIntBuilder {
+  _$ValueWithInt? _$v;
+
+  @override
+  int? get anInt {
+    _$this;
+    return super.anInt;
+  }
+
+  @override
+  set anInt(int? anInt) {
+    _$this;
+    super.anInt = anInt;
+  }
+
+  @override
+  String? get note {
+    _$this;
+    return super.note;
+  }
+
+  @override
+  set note(String? note) {
+    _$this;
+    super.note = note;
+  }
+
+  _$ValueWithIntBuilder() : super._();
+
+  ValueWithIntBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.anInt = $v.anInt;
+      super.note = $v.note;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithInt other) {
+    _$v = other as _$ValueWithInt;
+  }
+
+  @override
+  void update(void Function(ValueWithIntBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithInt build() => _build();
+
+  _$ValueWithInt _build() {
+    final _$result = _$v ??
+        _$ValueWithInt._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValueWithInt', 'anInt'),
+          note: BuiltValueNullFieldError.checkNotNull(
+              note, r'ValueWithInt', 'note'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/example/lib/polymorphism.dart
+++ b/built_types/example/lib/polymorphism.dart
@@ -1,0 +1,79 @@
+library polymorphism;
+
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+part 'polymorphism.g.dart';
+
+/// Example of using polymorphism.
+///
+/// Built Value classes and builders can implement interfaces and use mixins as
+/// any other class.
+///
+/// One special case is if you want to `rebuild` instances via an interface.
+/// Then, the interface needs to implement `Built`, but should not itself be
+/// instantiated. You can do this by marking the class `instantiable: false`,
+/// as here.
+///
+/// Very little code is generated for a non-instantiable Built Value; just the
+/// interface for the builder. You can write this yourself if you prefer, then
+/// nothing will be generated.
+///
+/// Note that dart2js has never supported implementing the same interface
+/// with different generics, and in Dart 2 none of the runtimes supports it.
+/// A correct fix for this is planned, but until then, the only way to make
+/// this work is to omit the `Built` interface from the base type as done
+/// here. See https://github.com/google/built_value.dart/issues/352
+@BuiltValue(instantiable: false)
+abstract class Animal extends Object with Walker {
+  @override
+  int get legs;
+
+  Animal rebuild(void Function(AnimalBuilder) updates);
+  AnimalBuilder toBuilder();
+}
+
+/// `Cat` implements the non-instantiable Built Value `Animal`. The generated
+/// builder `CatBuilder` automatically extends 'AnimalBuilder`. This allows you
+/// to use `Cat` as an `Animal`.
+abstract class Cat extends Object
+    with Walker
+    implements Animal, Built<Cat, CatBuilder> {
+  /// Serializer field makes the built_value serializable.
+  static Serializer<Cat> get serializer => _$catSerializer;
+
+  bool get tail;
+
+  factory Cat([void Function(CatBuilder) updates]) = _$Cat;
+  Cat._();
+}
+
+/// `Fish` implements the non-instantiable Built Value `Animal`. The generated
+/// builder `FishBuilder` automatically extends 'AnimalBuilder`. This allows
+/// you to use `Fish` as an `Animal`.
+abstract class Fish extends Object
+    with Swimmer, Walker
+    implements Animal, Built<Fish, FishBuilder> {
+  /// Serializer field makes the built_value serializable.
+  static Serializer<Fish> get serializer => _$fishSerializer;
+
+  @override
+  int get fins;
+
+  factory Fish([void Function(FishBuilder) updates]) = _$Fish;
+  Fish._();
+}
+
+/// As with any Built Value, behaviour can be added via mixins.
+mixin Walker {
+  int get legs;
+
+  bool get canWalk => legs > 0;
+}
+
+/// As with any Built Value, behaviour can be added via mixins.
+mixin Swimmer {
+  int get fins;
+
+  bool get canSwim => fins > 1;
+}

--- a/built_types/example/lib/polymorphism.g.dart
+++ b/built_types/example/lib/polymorphism.g.dart
@@ -1,0 +1,285 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'polymorphism.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<Cat> _$catSerializer = _$CatSerializer();
+Serializer<Fish> _$fishSerializer = _$FishSerializer();
+
+class _$CatSerializer implements StructuredSerializer<Cat> {
+  @override
+  final Iterable<Type> types = const [Cat, _$Cat];
+  @override
+  final String wireName = 'Cat';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Cat object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'tail',
+      serializers.serialize(object.tail, specifiedType: const FullType(bool)),
+      'legs',
+      serializers.serialize(object.legs, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Cat deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CatBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'tail':
+          result.tail = serializers.deserialize(value,
+              specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'legs':
+          result.legs = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$FishSerializer implements StructuredSerializer<Fish> {
+  @override
+  final Iterable<Type> types = const [Fish, _$Fish];
+  @override
+  final String wireName = 'Fish';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Fish object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'fins',
+      serializers.serialize(object.fins, specifiedType: const FullType(int)),
+      'legs',
+      serializers.serialize(object.legs, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  Fish deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = FishBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'fins':
+          result.fins = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+        case 'legs':
+          result.legs = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+abstract mixin class AnimalBuilder {
+  void replace(Animal other);
+  void update(void Function(AnimalBuilder) updates);
+  int? get legs;
+  set legs(int? legs);
+}
+
+class _$Cat extends Cat {
+  @override
+  final bool tail;
+  @override
+  final int legs;
+
+  factory _$Cat([void Function(CatBuilder)? updates]) =>
+      (CatBuilder()..update(updates))._build();
+
+  _$Cat._({required this.tail, required this.legs}) : super._();
+  @override
+  Cat rebuild(void Function(CatBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CatBuilder toBuilder() => CatBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Cat && tail == other.tail && legs == other.legs;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, tail.hashCode);
+    _$hash = $jc(_$hash, legs.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Cat')
+          ..add('tail', tail)
+          ..add('legs', legs))
+        .toString();
+  }
+}
+
+class CatBuilder implements Builder<Cat, CatBuilder>, AnimalBuilder {
+  _$Cat? _$v;
+
+  bool? _tail;
+  bool? get tail => _$this._tail;
+  set tail(covariant bool? tail) => _$this._tail = tail;
+
+  int? _legs;
+  int? get legs => _$this._legs;
+  set legs(covariant int? legs) => _$this._legs = legs;
+
+  CatBuilder();
+
+  CatBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _tail = $v.tail;
+      _legs = $v.legs;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant Cat other) {
+    _$v = other as _$Cat;
+  }
+
+  @override
+  void update(void Function(CatBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Cat build() => _build();
+
+  _$Cat _build() {
+    final _$result = _$v ??
+        _$Cat._(
+          tail: BuiltValueNullFieldError.checkNotNull(tail, r'Cat', 'tail'),
+          legs: BuiltValueNullFieldError.checkNotNull(legs, r'Cat', 'legs'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$Fish extends Fish {
+  @override
+  final int fins;
+  @override
+  final int legs;
+
+  factory _$Fish([void Function(FishBuilder)? updates]) =>
+      (FishBuilder()..update(updates))._build();
+
+  _$Fish._({required this.fins, required this.legs}) : super._();
+  @override
+  Fish rebuild(void Function(FishBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  FishBuilder toBuilder() => FishBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Fish && fins == other.fins && legs == other.legs;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, fins.hashCode);
+    _$hash = $jc(_$hash, legs.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Fish')
+          ..add('fins', fins)
+          ..add('legs', legs))
+        .toString();
+  }
+}
+
+class FishBuilder implements Builder<Fish, FishBuilder>, AnimalBuilder {
+  _$Fish? _$v;
+
+  int? _fins;
+  int? get fins => _$this._fins;
+  set fins(covariant int? fins) => _$this._fins = fins;
+
+  int? _legs;
+  int? get legs => _$this._legs;
+  set legs(covariant int? legs) => _$this._legs = legs;
+
+  FishBuilder();
+
+  FishBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _fins = $v.fins;
+      _legs = $v.legs;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant Fish other) {
+    _$v = other as _$Fish;
+  }
+
+  @override
+  void update(void Function(FishBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Fish build() => _build();
+
+  _$Fish _build() {
+    final _$result = _$v ??
+        _$Fish._(
+          fins: BuiltValueNullFieldError.checkNotNull(fins, r'Fish', 'fins'),
+          legs: BuiltValueNullFieldError.checkNotNull(legs, r'Fish', 'legs'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/example/lib/serializers.dart
+++ b/built_types/example/lib/serializers.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library serializers;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+import 'package:example/generics.dart';
+import 'package:example/polymorphism.dart';
+import 'package:example/values.dart';
+
+part 'serializers.g.dart';
+
+/// Example of how to use built_value serialization.
+///
+/// Declare a top level [Serializers] field called serializers. Annotate it
+/// with [SerializersFor] and provide a `const` `List` of types you want to
+/// be serializable.
+///
+/// The built_value code generator will provide the implementation. It will
+/// contain serializers for all the types asked for explicitly plus all the
+/// types needed transitively via fields.
+///
+/// You usually only need to do this once per project.
+@SerializersFor([
+  Account,
+  Cat,
+  CompoundValue,
+  Fish,
+  GenericValue,
+  SimpleValue,
+  VerySimpleValue,
+])
+final Serializers serializers = _$serializers;

--- a/built_types/example/lib/serializers.g.dart
+++ b/built_types/example/lib/serializers.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'serializers.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializers _$serializers = (Serializers().toBuilder()
+      ..add(Account.serializer)
+      ..add(Cat.serializer)
+      ..add(CompoundValue.serializer)
+      ..add(Fish.serializer)
+      ..add(GenericValue.serializer)
+      ..add(SimpleValue.serializer)
+      ..add(ValidatedValue.serializer)
+      ..add(VerySimpleValue.serializer)
+      ..addBuilderFactory(
+          const FullType(BuiltMap,
+              const [const FullType(String), const FullType(JsonObject)]),
+          () => MapBuilder<String, JsonObject>()))
+    .build();
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/example/lib/values.dart
+++ b/built_types/example/lib/values.dart
@@ -1,0 +1,186 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library values;
+
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+
+part 'values.g.dart';
+
+/// Example of how to use built_value.
+///
+/// The value class must implement [Built]. It must be abstract, and have
+/// fields declared as abstract getters. Finally, it must have a particular
+/// constructor and factory, as shown here.
+abstract class SimpleValue implements Built<SimpleValue, SimpleValueBuilder> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializer] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static Serializer<SimpleValue> get serializer => _$simpleValueSerializer;
+
+  int get anInt;
+
+  String? get aString;
+
+  /// The recommended factory exposes the generated builder interface. This
+  /// works well for classes with many fields, or for classes that might be
+  /// changed to have more fields later. For very simple classes, you might
+  /// want something simpler. See [VerySimpleValue].
+  factory SimpleValue([void Function(SimpleValueBuilder) updates]) =
+      _$SimpleValue;
+  SimpleValue._();
+}
+
+abstract class VerySimpleValue
+    implements Built<VerySimpleValue, VerySimpleValueBuilder> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializer] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static Serializer<VerySimpleValue> get serializer =>
+      _$verySimpleValueSerializer;
+
+  int get value;
+
+  /// If you won't usually use the generated builder -- for example, for a
+  /// class with one field -- you can write a simpler factory.
+  factory VerySimpleValue(int value) => _$VerySimpleValue._(value: value);
+  VerySimpleValue._();
+}
+
+/// Fields can use built_value classes.
+abstract class CompoundValue
+    implements Built<CompoundValue, CompoundValueBuilder> {
+  /// Example of how to make a built_value type serializable.
+  ///
+  /// Declare a static final [Serializers] field called `serializer`.
+  /// The built_value code generator will provide the implementation. You need
+  /// to do this for every type you want to serialize.
+  static Serializer<CompoundValue> get serializer => _$compoundValueSerializer;
+
+  SimpleValue get simpleValue;
+  ValidatedValue? get validatedValue;
+
+  factory CompoundValue([void Function(CompoundValueBuilder) updates]) =
+      _$CompoundValue;
+  CompoundValue._();
+}
+
+/// Additional custom validation goes in the constructor.
+abstract class ValidatedValue
+    implements Built<ValidatedValue, ValidatedValueBuilder> {
+  static Serializer<ValidatedValue> get serializer =>
+      _$validatedValueSerializer;
+
+  int get anInt;
+  String? get aString;
+
+  factory ValidatedValue([void Function(ValidatedValueBuilder) updates]) =
+      _$ValidatedValue;
+
+  ValidatedValue._() {
+    if (anInt == 7) throw StateError('anInt may not be 7');
+  }
+}
+
+/// Code can be added to value types.
+abstract class ValueWithCode
+    implements Built<ValueWithCode, ValueWithCodeBuilder> {
+  static final int youCanHaveStaticFields = 3;
+
+  int get anInt;
+  String? get aString;
+
+  String get youCanWriteDerivedGetters => anInt.toString() + aString!;
+
+  factory ValueWithCode([void Function(ValueWithCodeBuilder) updates]) =
+      _$ValueWithCode;
+  ValueWithCode._();
+
+  factory ValueWithCode.fromCustomFactory(int anInt) => ValueWithCode((b) => b
+    ..anInt = anInt
+    ..aString = 'two');
+}
+
+/// Defaults for fields go in an explicit builder class.
+///
+/// Normally you don't need to write your own builder class; one is generated
+/// for you. But if you want to assign defaults or add custom builder code,
+/// you'll need to add an explicit builder, as below.
+abstract class ValueWithDefaults
+    implements Built<ValueWithDefaults, ValueWithDefaultsBuilder> {
+  int get anInt;
+  String? get aString;
+
+  factory ValueWithDefaults([void Function(ValueWithDefaultsBuilder) updates]) =
+      _$ValueWithDefaults;
+  ValueWithDefaults._();
+}
+
+/// Custom builder classes must implement [Builder]. It must be abstract, and
+/// have fields declared as normal public fields. Finally, it must have a
+/// particular constructor and factory, as shown here.
+abstract class ValueWithDefaultsBuilder
+    implements Builder<ValueWithDefaults, ValueWithDefaultsBuilder> {
+  int anInt = 7;
+
+  String? aString;
+
+  factory ValueWithDefaultsBuilder() = _$ValueWithDefaultsBuilder;
+  ValueWithDefaultsBuilder._();
+}
+
+/// Example of how to use [memoized].
+abstract class DerivedValue
+    implements Built<DerivedValue, DerivedValueBuilder> {
+  int get anInt;
+
+  /// This getter is marked [memoized], so it will be called at most once. The
+  /// result will be stored in the instance and reused.
+  @memoized
+  int get derivedValue => anInt + 10;
+
+  /// This getter is marked [memoized], so it will be called at most once. The
+  /// result will be stored in the instance and reused.
+  @memoized
+  Iterable<String> get derivedString => [toString()];
+
+  factory DerivedValue([void Function(DerivedValueBuilder) updates]) =
+      _$DerivedValue;
+  DerivedValue._();
+}
+
+/// Example of a value that also contains a [JsonObject]. This allows a class
+/// with some structured fields to pass through raw JSON as a JsonObject.
+abstract class Account implements Built<Account, AccountBuilder> {
+  static Serializer<Account> get serializer => _$accountSerializer;
+  int get id;
+  String get name;
+  BuiltMap<String, JsonObject> get keyValues;
+
+  factory Account([void Function(AccountBuilder) updates]) = _$Account;
+  Account._();
+}
+
+/// If you need to change the values sent over the wire when serializing you
+/// can do so using the [BuiltValue] and [BuiltValueField] annotations.
+@BuiltValue(wireName: 'V')
+abstract class WireNameValue
+    implements Built<WireNameValue, WireNameValueBuilder> {
+  static Serializer<WireNameValue> get serializer => _$wireNameValueSerializer;
+
+  @BuiltValueField(wireName: 'v')
+  int get value;
+
+  factory WireNameValue([void Function(WireNameValueBuilder) updates]) =
+      _$WireNameValue;
+
+  WireNameValue._();
+}

--- a/built_types/example/lib/values.g.dart
+++ b/built_types/example/lib/values.g.dart
@@ -1,0 +1,1172 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'values.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<SimpleValue> _$simpleValueSerializer = _$SimpleValueSerializer();
+Serializer<VerySimpleValue> _$verySimpleValueSerializer =
+    _$VerySimpleValueSerializer();
+Serializer<CompoundValue> _$compoundValueSerializer =
+    _$CompoundValueSerializer();
+Serializer<ValidatedValue> _$validatedValueSerializer =
+    _$ValidatedValueSerializer();
+Serializer<Account> _$accountSerializer = _$AccountSerializer();
+Serializer<WireNameValue> _$wireNameValueSerializer =
+    _$WireNameValueSerializer();
+
+class _$SimpleValueSerializer implements StructuredSerializer<SimpleValue> {
+  @override
+  final Iterable<Type> types = const [SimpleValue, _$SimpleValue];
+  @override
+  final String wireName = 'SimpleValue';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, SimpleValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.aString;
+    if (value != null) {
+      result
+        ..add('aString')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  SimpleValue deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = SimpleValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'anInt':
+          result.anInt = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+        case 'aString':
+          result.aString = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$VerySimpleValueSerializer
+    implements StructuredSerializer<VerySimpleValue> {
+  @override
+  final Iterable<Type> types = const [VerySimpleValue, _$VerySimpleValue];
+  @override
+  final String wireName = 'VerySimpleValue';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, VerySimpleValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  VerySimpleValue deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = VerySimpleValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CompoundValueSerializer implements StructuredSerializer<CompoundValue> {
+  @override
+  final Iterable<Type> types = const [CompoundValue, _$CompoundValue];
+  @override
+  final String wireName = 'CompoundValue';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, CompoundValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'simpleValue',
+      serializers.serialize(object.simpleValue,
+          specifiedType: const FullType(SimpleValue)),
+    ];
+    Object? value;
+    value = object.validatedValue;
+    if (value != null) {
+      result
+        ..add('validatedValue')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(ValidatedValue)));
+    }
+    return result;
+  }
+
+  @override
+  CompoundValue deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CompoundValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'simpleValue':
+          result.simpleValue.replace(serializers.deserialize(value,
+              specifiedType: const FullType(SimpleValue))! as SimpleValue);
+          break;
+        case 'validatedValue':
+          result.validatedValue.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(ValidatedValue))!
+              as ValidatedValue);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ValidatedValueSerializer
+    implements StructuredSerializer<ValidatedValue> {
+  @override
+  final Iterable<Type> types = const [ValidatedValue, _$ValidatedValue];
+  @override
+  final String wireName = 'ValidatedValue';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ValidatedValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'anInt',
+      serializers.serialize(object.anInt, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.aString;
+    if (value != null) {
+      result
+        ..add('aString')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ValidatedValue deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ValidatedValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'anInt':
+          result.anInt = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+        case 'aString':
+          result.aString = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$AccountSerializer implements StructuredSerializer<Account> {
+  @override
+  final Iterable<Type> types = const [Account, _$Account];
+  @override
+  final String wireName = 'Account';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, Account object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(int)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'keyValues',
+      serializers.serialize(object.keyValues,
+          specifiedType: const FullType(BuiltMap,
+              const [const FullType(String), const FullType(JsonObject)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  Account deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AccountBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'keyValues':
+          result.keyValues.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, const [
+                const FullType(String),
+                const FullType(JsonObject)
+              ]))!);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$WireNameValueSerializer implements StructuredSerializer<WireNameValue> {
+  @override
+  final Iterable<Type> types = const [WireNameValue, _$WireNameValue];
+  @override
+  final String wireName = 'V';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, WireNameValue object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'v',
+      serializers.serialize(object.value, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  WireNameValue deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = WireNameValueBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'v':
+          result.value = serializers.deserialize(value,
+              specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SimpleValue extends SimpleValue {
+  @override
+  final int anInt;
+  @override
+  final String? aString;
+
+  factory _$SimpleValue([void Function(SimpleValueBuilder)? updates]) =>
+      (SimpleValueBuilder()..update(updates))._build();
+
+  _$SimpleValue._({required this.anInt, this.aString}) : super._();
+  @override
+  SimpleValue rebuild(void Function(SimpleValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SimpleValueBuilder toBuilder() => SimpleValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SimpleValue &&
+        anInt == other.anInt &&
+        aString == other.aString;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, aString.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SimpleValue')
+          ..add('anInt', anInt)
+          ..add('aString', aString))
+        .toString();
+  }
+}
+
+class SimpleValueBuilder implements Builder<SimpleValue, SimpleValueBuilder> {
+  _$SimpleValue? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  String? _aString;
+  String? get aString => _$this._aString;
+  set aString(String? aString) => _$this._aString = aString;
+
+  SimpleValueBuilder();
+
+  SimpleValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _aString = $v.aString;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(SimpleValue other) {
+    _$v = other as _$SimpleValue;
+  }
+
+  @override
+  void update(void Function(SimpleValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SimpleValue build() => _build();
+
+  _$SimpleValue _build() {
+    final _$result = _$v ??
+        _$SimpleValue._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'SimpleValue', 'anInt'),
+          aString: aString,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$VerySimpleValue extends VerySimpleValue {
+  @override
+  final int value;
+
+  factory _$VerySimpleValue([void Function(VerySimpleValueBuilder)? updates]) =>
+      (VerySimpleValueBuilder()..update(updates))._build();
+
+  _$VerySimpleValue._({required this.value}) : super._();
+  @override
+  VerySimpleValue rebuild(void Function(VerySimpleValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  VerySimpleValueBuilder toBuilder() => VerySimpleValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is VerySimpleValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'VerySimpleValue')
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class VerySimpleValueBuilder
+    implements Builder<VerySimpleValue, VerySimpleValueBuilder> {
+  _$VerySimpleValue? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  VerySimpleValueBuilder();
+
+  VerySimpleValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(VerySimpleValue other) {
+    _$v = other as _$VerySimpleValue;
+  }
+
+  @override
+  void update(void Function(VerySimpleValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  VerySimpleValue build() => _build();
+
+  _$VerySimpleValue _build() {
+    final _$result = _$v ??
+        _$VerySimpleValue._(
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'VerySimpleValue', 'value'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$CompoundValue extends CompoundValue {
+  @override
+  final SimpleValue simpleValue;
+  @override
+  final ValidatedValue? validatedValue;
+
+  factory _$CompoundValue([void Function(CompoundValueBuilder)? updates]) =>
+      (CompoundValueBuilder()..update(updates))._build();
+
+  _$CompoundValue._({required this.simpleValue, this.validatedValue})
+      : super._();
+  @override
+  CompoundValue rebuild(void Function(CompoundValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CompoundValueBuilder toBuilder() => CompoundValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CompoundValue &&
+        simpleValue == other.simpleValue &&
+        validatedValue == other.validatedValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, simpleValue.hashCode);
+    _$hash = $jc(_$hash, validatedValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CompoundValue')
+          ..add('simpleValue', simpleValue)
+          ..add('validatedValue', validatedValue))
+        .toString();
+  }
+}
+
+class CompoundValueBuilder
+    implements Builder<CompoundValue, CompoundValueBuilder> {
+  _$CompoundValue? _$v;
+
+  SimpleValueBuilder? _simpleValue;
+  SimpleValueBuilder get simpleValue =>
+      _$this._simpleValue ??= SimpleValueBuilder();
+  set simpleValue(SimpleValueBuilder? simpleValue) =>
+      _$this._simpleValue = simpleValue;
+
+  ValidatedValueBuilder? _validatedValue;
+  ValidatedValueBuilder get validatedValue =>
+      _$this._validatedValue ??= ValidatedValueBuilder();
+  set validatedValue(ValidatedValueBuilder? validatedValue) =>
+      _$this._validatedValue = validatedValue;
+
+  CompoundValueBuilder();
+
+  CompoundValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _simpleValue = $v.simpleValue.toBuilder();
+      _validatedValue = $v.validatedValue?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(CompoundValue other) {
+    _$v = other as _$CompoundValue;
+  }
+
+  @override
+  void update(void Function(CompoundValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CompoundValue build() => _build();
+
+  _$CompoundValue _build() {
+    _$CompoundValue _$result;
+    try {
+      _$result = _$v ??
+          _$CompoundValue._(
+            simpleValue: simpleValue.build(),
+            validatedValue: _validatedValue?.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'simpleValue';
+        simpleValue.build();
+        _$failedField = 'validatedValue';
+        _validatedValue?.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'CompoundValue', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValidatedValue extends ValidatedValue {
+  @override
+  final int anInt;
+  @override
+  final String? aString;
+
+  factory _$ValidatedValue([void Function(ValidatedValueBuilder)? updates]) =>
+      (ValidatedValueBuilder()..update(updates))._build();
+
+  _$ValidatedValue._({required this.anInt, this.aString}) : super._();
+  @override
+  ValidatedValue rebuild(void Function(ValidatedValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ValidatedValueBuilder toBuilder() => ValidatedValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValidatedValue &&
+        anInt == other.anInt &&
+        aString == other.aString;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, aString.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValidatedValue')
+          ..add('anInt', anInt)
+          ..add('aString', aString))
+        .toString();
+  }
+}
+
+class ValidatedValueBuilder
+    implements Builder<ValidatedValue, ValidatedValueBuilder> {
+  _$ValidatedValue? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  String? _aString;
+  String? get aString => _$this._aString;
+  set aString(String? aString) => _$this._aString = aString;
+
+  ValidatedValueBuilder();
+
+  ValidatedValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _aString = $v.aString;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValidatedValue other) {
+    _$v = other as _$ValidatedValue;
+  }
+
+  @override
+  void update(void Function(ValidatedValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValidatedValue build() => _build();
+
+  _$ValidatedValue _build() {
+    final _$result = _$v ??
+        _$ValidatedValue._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValidatedValue', 'anInt'),
+          aString: aString,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithCode extends ValueWithCode {
+  @override
+  final int anInt;
+  @override
+  final String? aString;
+
+  factory _$ValueWithCode([void Function(ValueWithCodeBuilder)? updates]) =>
+      (ValueWithCodeBuilder()..update(updates))._build();
+
+  _$ValueWithCode._({required this.anInt, this.aString}) : super._();
+  @override
+  ValueWithCode rebuild(void Function(ValueWithCodeBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ValueWithCodeBuilder toBuilder() => ValueWithCodeBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithCode &&
+        anInt == other.anInt &&
+        aString == other.aString;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, aString.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueWithCode')
+          ..add('anInt', anInt)
+          ..add('aString', aString))
+        .toString();
+  }
+}
+
+class ValueWithCodeBuilder
+    implements Builder<ValueWithCode, ValueWithCodeBuilder> {
+  _$ValueWithCode? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  String? _aString;
+  String? get aString => _$this._aString;
+  set aString(String? aString) => _$this._aString = aString;
+
+  ValueWithCodeBuilder();
+
+  ValueWithCodeBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _aString = $v.aString;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithCode other) {
+    _$v = other as _$ValueWithCode;
+  }
+
+  @override
+  void update(void Function(ValueWithCodeBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithCode build() => _build();
+
+  _$ValueWithCode _build() {
+    final _$result = _$v ??
+        _$ValueWithCode._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValueWithCode', 'anInt'),
+          aString: aString,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$ValueWithDefaults extends ValueWithDefaults {
+  @override
+  final int anInt;
+  @override
+  final String? aString;
+
+  factory _$ValueWithDefaults(
+          [void Function(ValueWithDefaultsBuilder)? updates]) =>
+      (ValueWithDefaultsBuilder()..update(updates)).build()
+          as _$ValueWithDefaults;
+
+  _$ValueWithDefaults._({required this.anInt, this.aString}) : super._();
+  @override
+  ValueWithDefaults rebuild(void Function(ValueWithDefaultsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  _$ValueWithDefaultsBuilder toBuilder() =>
+      _$ValueWithDefaultsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ValueWithDefaults &&
+        anInt == other.anInt &&
+        aString == other.aString;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jc(_$hash, aString.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ValueWithDefaults')
+          ..add('anInt', anInt)
+          ..add('aString', aString))
+        .toString();
+  }
+}
+
+class _$ValueWithDefaultsBuilder extends ValueWithDefaultsBuilder {
+  _$ValueWithDefaults? _$v;
+
+  @override
+  int get anInt {
+    _$this;
+    return super.anInt;
+  }
+
+  @override
+  set anInt(int anInt) {
+    _$this;
+    super.anInt = anInt;
+  }
+
+  @override
+  String? get aString {
+    _$this;
+    return super.aString;
+  }
+
+  @override
+  set aString(String? aString) {
+    _$this;
+    super.aString = aString;
+  }
+
+  _$ValueWithDefaultsBuilder() : super._();
+
+  ValueWithDefaultsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      super.anInt = $v.anInt;
+      super.aString = $v.aString;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ValueWithDefaults other) {
+    _$v = other as _$ValueWithDefaults;
+  }
+
+  @override
+  void update(void Function(ValueWithDefaultsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ValueWithDefaults build() => _build();
+
+  _$ValueWithDefaults _build() {
+    final _$result = _$v ??
+        _$ValueWithDefaults._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'ValueWithDefaults', 'anInt'),
+          aString: aString,
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$DerivedValue extends DerivedValue {
+  @override
+  final int anInt;
+  int? __derivedValue;
+  Iterable<String>? __derivedString;
+
+  factory _$DerivedValue([void Function(DerivedValueBuilder)? updates]) =>
+      (DerivedValueBuilder()..update(updates))._build();
+
+  _$DerivedValue._({required this.anInt}) : super._();
+  @override
+  int get derivedValue => __derivedValue ??= super.derivedValue;
+
+  @override
+  Iterable<String> get derivedString => __derivedString ??= super.derivedString;
+
+  @override
+  DerivedValue rebuild(void Function(DerivedValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DerivedValueBuilder toBuilder() => DerivedValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DerivedValue && anInt == other.anInt;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, anInt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DerivedValue')..add('anInt', anInt))
+        .toString();
+  }
+}
+
+class DerivedValueBuilder
+    implements Builder<DerivedValue, DerivedValueBuilder> {
+  _$DerivedValue? _$v;
+
+  int? _anInt;
+  int? get anInt => _$this._anInt;
+  set anInt(int? anInt) => _$this._anInt = anInt;
+
+  DerivedValueBuilder();
+
+  DerivedValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _anInt = $v.anInt;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(DerivedValue other) {
+    _$v = other as _$DerivedValue;
+  }
+
+  @override
+  void update(void Function(DerivedValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DerivedValue build() => _build();
+
+  _$DerivedValue _build() {
+    final _$result = _$v ??
+        _$DerivedValue._(
+          anInt: BuiltValueNullFieldError.checkNotNull(
+              anInt, r'DerivedValue', 'anInt'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$Account extends Account {
+  @override
+  final int id;
+  @override
+  final String name;
+  @override
+  final BuiltMap<String, JsonObject> keyValues;
+
+  factory _$Account([void Function(AccountBuilder)? updates]) =>
+      (AccountBuilder()..update(updates))._build();
+
+  _$Account._({required this.id, required this.name, required this.keyValues})
+      : super._();
+  @override
+  Account rebuild(void Function(AccountBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AccountBuilder toBuilder() => AccountBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Account &&
+        id == other.id &&
+        name == other.name &&
+        keyValues == other.keyValues;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, keyValues.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'Account')
+          ..add('id', id)
+          ..add('name', name)
+          ..add('keyValues', keyValues))
+        .toString();
+  }
+}
+
+class AccountBuilder implements Builder<Account, AccountBuilder> {
+  _$Account? _$v;
+
+  int? _id;
+  int? get id => _$this._id;
+  set id(int? id) => _$this._id = id;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  MapBuilder<String, JsonObject>? _keyValues;
+  MapBuilder<String, JsonObject> get keyValues =>
+      _$this._keyValues ??= MapBuilder<String, JsonObject>();
+  set keyValues(MapBuilder<String, JsonObject>? keyValues) =>
+      _$this._keyValues = keyValues;
+
+  AccountBuilder();
+
+  AccountBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
+      _name = $v.name;
+      _keyValues = $v.keyValues.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(Account other) {
+    _$v = other as _$Account;
+  }
+
+  @override
+  void update(void Function(AccountBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  Account build() => _build();
+
+  _$Account _build() {
+    _$Account _$result;
+    try {
+      _$result = _$v ??
+          _$Account._(
+            id: BuiltValueNullFieldError.checkNotNull(id, r'Account', 'id'),
+            name:
+                BuiltValueNullFieldError.checkNotNull(name, r'Account', 'name'),
+            keyValues: keyValues.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'keyValues';
+        keyValues.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'Account', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$WireNameValue extends WireNameValue {
+  @override
+  final int value;
+
+  factory _$WireNameValue([void Function(WireNameValueBuilder)? updates]) =>
+      (WireNameValueBuilder()..update(updates))._build();
+
+  _$WireNameValue._({required this.value}) : super._();
+  @override
+  WireNameValue rebuild(void Function(WireNameValueBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WireNameValueBuilder toBuilder() => WireNameValueBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is WireNameValue && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'WireNameValue')..add('value', value))
+        .toString();
+  }
+}
+
+class WireNameValueBuilder
+    implements Builder<WireNameValue, WireNameValueBuilder> {
+  _$WireNameValue? _$v;
+
+  int? _value;
+  int? get value => _$this._value;
+  set value(int? value) => _$this._value = value;
+
+  WireNameValueBuilder();
+
+  WireNameValueBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(WireNameValue other) {
+    _$v = other as _$WireNameValue;
+  }
+
+  @override
+  void update(void Function(WireNameValueBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  WireNameValue build() => _build();
+
+  _$WireNameValue _build() {
+    final _$result = _$v ??
+        _$WireNameValue._(
+          value: BuiltValueNullFieldError.checkNotNull(
+              value, r'WireNameValue', 'value'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/built_types/example/pubspec.yaml
+++ b/built_types/example/pubspec.yaml
@@ -1,0 +1,19 @@
+name: example
+publish_to: none
+description: >
+  Just an example, not for publishing.
+homepage: https://github.com/google/built_value.dart
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  built_collection: ^5.0.0
+  built_value: ^8.7.0
+
+dev_dependencies:
+  build_runner: '>=1.0.0 <3.0.0'
+  built_value_generator: ^8.13.0
+  pedantic: ^1.4.0
+  quiver: '>=0.21.0 <4.0.0'
+  test: ^1.0.0

--- a/built_types/example/test/example_test.dart
+++ b/built_types/example/test/example_test.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:example/example.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Example', () {
+    test('runs', () {
+      example();
+      standardJsonExample();
+    });
+  });
+}

--- a/built_types/tool/presubmit
+++ b/built_types/tool/presubmit
@@ -1,0 +1,83 @@
+#!/bin/bash --
+# Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+# All rights reserved. Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -e
+
+directories="built_value built_value_generator built_value_test \
+    end_to_end_test benchmark example chat_example"
+
+parent_directory=$PWD
+
+for directory in $directories; do
+  echo
+  echo "*** Formatting $directory..."
+  echo
+  cd "$parent_directory/$directory"
+
+  dart format $(find bin lib test -name \*.dart 2>/dev/null)
+done
+
+for directory in $directories; do
+  echo
+  echo "*** Building $directory..."
+  echo
+  cd "$parent_directory/$directory"
+
+  dart pub get
+  dart pub upgrade
+
+  # Clear any pre-existing build output so package:build doesn't get confused
+  # when we use built_value to build itself.
+  rm -rf .dart_tool/build/
+
+  grep -q build_runner pubspec.yaml && \
+      dart run build_runner build \
+          --delete-conflicting-outputs \
+          --fail-on-severe
+done
+
+for directory in $directories; do
+  echo
+  echo "*** Analyzing $directory..."
+  echo
+  cd "$parent_directory/$directory"
+
+  dart analyze \
+      --fatal-warnings \
+      --fatal-infos \
+      $(find bin lib test -name \*.dart 2>/dev/null)
+done
+
+for directory in $directories; do
+  echo
+  echo "*** Testing $directory..."
+  echo
+  cd "$parent_directory/$directory"
+
+  dart run test
+done
+
+
+echo "*** Preparing to benchmark build..."
+cd "$parent_directory/end_to_end_test"
+cat << 'EOF' > lib/many_values.dart
+import 'package:built_value/built_value.dart';
+part 'many_values.g.dart';
+EOF
+dart run build_runner build
+
+for n in $(seq 1 2500); do
+  cat << 'EOF' | sed -e "s#1#$n#g" >> lib/many_values.dart
+  abstract class Value1 implements Built<Value1, Value1Builder> {
+      factory Value1([void Function(Value1Builder) updates]) = _$Value1;
+      Value1._();
+  }
+EOF
+done
+echo "*** Benchmarking build, should be ~30s..."
+dart run build_runner build
+
+rm "$parent_directory/end_to_end_test/lib/many_values.dart"
+rm "$parent_directory/end_to_end_test/lib/many_values.g.dart"

--- a/built_types/tool/set_version
+++ b/built_types/tool/set_version
@@ -1,0 +1,29 @@
+#!/bin/bash --
+# Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+# All rights reserved. Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+if [ $# -ne 1 ]; then
+  echo "Usage: tool/set_version <version>"
+  echo
+  echo "Updates pubspecs to specified version."
+fi
+
+version=$1
+
+for pubspec in */pubspec.yaml; do
+  # Remove any dependency overrides, strip trailing empty lines.
+  sed -i -n '/dependency_overrides:/q;p' \
+      "$pubspec"
+  sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' "$pubspec"
+
+  # Update versions.
+  sed -i -e \
+      "s#^version: .*#version: $version#" \
+      "$pubspec"
+
+  # Update dependencies.
+  sed -i -e \
+      "s#.*built_value_generator: .*#  built_value_generator: ^$version#" \
+      "$pubspec"
+done

--- a/built_types/tool/use_local_deps
+++ b/built_types/tool/use_local_deps
@@ -1,0 +1,32 @@
+#!/bin/bash --
+# Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
+# All rights reserved. Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+if [ $# -ne 0 ]; then
+  echo "Usage: tool/use_local_deps"
+  echo
+  echo "Changes dependencies to use local paths."
+fi
+
+for pubspec in */pubspec.yaml; do
+  if grep -qv dependency_overrides "$pubspec"; then
+    cat >> "$pubspec" <<EOM
+
+dependency_overrides:
+EOM
+
+    if [ "$pubspec" != built_value/pubspec.yaml ]; then
+      cat >> "$pubspec" <<EOM
+  built_value:
+    path: ../built_value
+EOM
+    fi
+    if [ "$pubspec" != built_value_generator/pubspec.yaml ]; then
+      cat >> "$pubspec" <<EOM
+  built_value_generator:
+    path: ../built_value_generator
+EOM
+    fi
+  fi
+done

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -5,6 +5,12 @@
         },
         {
             "pattern": "^https://bazel.build"
+        },
+        {
+            "pattern": "^https://medium.com"
+        },
+        {
+            "pattern": "^https://steemit.com"
         }
     ]
 }


### PR DESCRIPTION
Import exact files from google/built_value.dart at release-8-13-0, commit 54b4ec6e4f17. Small commit on top to make CI continue to pass.

I propose to import without full git history and without moving all the existing built_value issues in.

It's been in maintenance mode for a long time: we can add new issues here based on new work we want to do--primarily, keeping it up to date with new build_runner and language features.

Also re: git history, Gemini is really good at tracing git history--I don't think it will be a problem for it to hop over to the archive repo.

But, happy to go for the approach we used for mockito (copy history, move issues) if you prefer; or some hybrid.

Cleanup to follow directly: refactor to workspace, add to CI.