### PR TITLE
Release build_runner 2.16.1.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.11-wip
+## 4.0.11
 
 - Clarify terminology: refer to `.dart_tool/build/generated` as the "artifact
   tree", and the normal output location as the "package path".

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 4.0.11-wip
+version: 4.0.11
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace

--- a/build_config/CHANGELOG.md
+++ b/build_config/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.3-wip
+## 1.3.3
 
 - Clarify terminology: refer to `.dart_tool/build/generated` as the "artifact
   tree", and the normal output location as the "package path".

--- a/build_config/pubspec.yaml
+++ b/build_config/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_config
-version: 1.3.3-wip
+version: 1.3.3
 description: >-
   Format definition and support for parsing `build.yaml` configuration.
 repository: https://github.com/dart-lang/build/tree/master/build_config

--- a/build_daemon/CHANGELOG.md
+++ b/build_daemon/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.1.6-wip
+## 4.1.6
 
 - Add doc comment to `DaemonBuilder.build`.
 

--- a/build_daemon/pubspec.yaml
+++ b/build_daemon/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_daemon
-version: 4.1.6-wip
+version: 4.1.6
 description: A daemon for running Dart builds.
 repository: https://github.com/dart-lang/build/tree/master/build_daemon
 resolution: workspace

--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.16.1-wip
+## 2.16.1
 
 - Clarify terminology: refer to `.dart_tool/build/generated` as the "artifact
   tree", and the normal output location as the "package path".

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.16.1-wip
+version: 2.16.1
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.5.20-wip
+## 3.5.20
 
 - Clarify terminology: refer to `.dart_tool/build/generated` as the "artifact
   tree", and the normal output location as the "package path".

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.20-wip
+version: 3.5.20
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.16.1-wip'
+  build_runner: '2.16.1'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Release for bug fixes for issues introduced in 2.16.0.

Released other packages for documentation updates.