### PR TITLE
Do not throw in ResourceManager.disposeAll when resource disposal fails.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.12-wip
+
+- Bug fix: handle `Resource` disposal failure gracefully: log an error instead
+  of letting the exception escape.
+
 ## 4.0.11
 
 - Clarify terminology: refer to `.dart_tool/build/generated` as the "artifact

--- a/build/lib/src/resource.dart
+++ b/build/lib/src/resource.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'logging.dart';
+
 typedef CreateInstance<T> = FutureOr<T> Function();
 typedef DisposeInstance<T> = FutureOr<void> Function(T instance);
 typedef BeforeExit = FutureOr<void> Function();
@@ -26,6 +28,12 @@ typedef BeforeExit = FutureOr<void> Function();
 /// If a `dispose` callback is available it will be called between builds and it
 /// should clean up any state that may not be valid on a subsequent build. If no
 /// `dispose` callback is passed the value will be discarded between builds.
+///
+/// If `dispose` throws synchronously or returns a [Future] that completes with
+/// an error, the error is logged and the instance is discarded between builds.
+/// If creating the instance threw an error, disposal discards the failed
+/// creation without logging an error.
+///
 /// Only "universal" state should be retained by the instance after `dispose`.
 /// Any state which is particular to a single build should be cleared or marked
 /// dirty during dispose, and validated before subsequent use. For instance,
@@ -111,14 +119,25 @@ class Resource<T> {
   ///
   /// If a [_userDispose] was provided, invoke it and assume the state can be
   /// retained for the next build.
-  Future<void> _dispose(ResourceManager manager) {
+  Future<void> _dispose(ResourceManager manager) async {
     assert(_instanceByManager.containsKey(manager));
     final oldInstance = _instanceByManager[manager]!;
-    if (_userDispose != null) {
-      return oldInstance.then(_userDispose);
-    } else {
-      _instanceByManager.remove(manager);
-      return Future.value(null);
+    if (_userDispose == null) {
+      unawaited(_instanceByManager.remove(manager));
+      return;
+    }
+    final T instance;
+    try {
+      instance = await oldInstance;
+    } catch (_) {
+      unawaited(_instanceByManager.remove(manager));
+      return;
+    }
+    try {
+      await _userDispose(instance);
+    } catch (error, stackTrace) {
+      unawaited(_instanceByManager.remove(manager));
+      log.severe('Error disposing resource: $error', error, stackTrace);
     }
   }
 }

--- a/build/pubspec.yaml
+++ b/build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build
-version: 4.0.11
+version: 4.0.12-wip
 description: A package for authoring build_runner compatible code generators.
 repository: https://github.com/dart-lang/build/tree/master/build
 resolution: workspace

--- a/build/test/resource_test.dart
+++ b/build/test/resource_test.dart
@@ -7,6 +7,7 @@ library;
 import 'dart:async';
 
 import 'package:build/build.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -45,6 +46,44 @@ void main() {
       await resourceManager.disposeAll();
       final second = await resourceManager.fetch(intResource);
       expect(second, 0);
+    });
+
+    group('on failure', () {
+      final logs = <LogRecord>[];
+      setUp(() {
+        logs.clear();
+        final sub = Logger.root.onRecord.listen(logs.add);
+        addTearDown(sub.cancel);
+      });
+
+      for (final (type, dispose) in [
+        ('sync', (_) => throw StateError('fail')),
+        ('async', (_) async => throw StateError('fail')),
+      ]) {
+        test('discards instance and logs if $type dispose throws', () async {
+          final resource = Resource(Object.new, dispose: dispose);
+          final first = await resourceManager.fetch(resource);
+          await resourceManager.disposeAll();
+          expect(logs.single.message, contains('Error disposing resource'));
+          expect(await resourceManager.fetch(resource), isNot(same(first)));
+        });
+      }
+
+      test('discards instance without logging if create throws', () async {
+        var throws = true;
+        final resource = Resource(
+          () => throws ? throw StateError('fail') : Object(),
+          dispose: (_) {},
+        );
+        await expectLater(
+          resourceManager.fetch(resource),
+          throwsA(isA<StateError>()),
+        );
+        await resourceManager.disposeAll();
+        expect(logs, isEmpty);
+        throws = false;
+        expect(await resourceManager.fetch(resource), isA<Object>());
+      });
     });
 
     test('can asynchronously get resources', () async {


### PR DESCRIPTION
If a resource's userDispose callback throws:
- Log the error via log.severe with the error and stack trace.
- Evict the resource instance from the manager so subsequent builds recreate it rather than reusing an invalid instance.
- Complete the disposal future without throwing so build cleanup is not aborted.

Found via contract programming experiment.