### PR TITLE
Fix StateError on BuildStep.canRead for self-written outputs.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.16.2-wip
+
+- Bug fix: allow calling `BuildStep.canRead` on outputs written by the same
+  build step.
+
 ## 2.16.1
 
 - Clarify terminology: refer to `.dart_tool/build/generated` as the "artifact

--- a/build_runner/lib/src/build/build_step_impl.dart
+++ b/build_runner/lib/src/build/build_step_impl.dart
@@ -118,6 +118,7 @@ class BuildStepImpl implements BuildStep {
       track: track,
     );
     if (!isReadable) return false;
+    if (outputs.containsKey(id)) return true;
 
     // Read the file so it's in memory; if that fails the file was deleted
     // during the build and the build is aborted.

--- a/build_runner/pubspec.yaml
+++ b/build_runner/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_runner
-version: 2.16.1
+version: 2.16.2-wip
 description: A build system for Dart code generation and modular compilation.
 repository: https://github.com/dart-lang/build/tree/master/build_runner
 resolution: workspace

--- a/build_runner/test/integration_tests/build_command_zero_output_builder_test.dart
+++ b/build_runner/test/integration_tests/build_command_zero_output_builder_test.dart
@@ -113,9 +113,11 @@ class MixedBuilder implements Builder {
   Future<void> build(BuildStep buildStep) async {
     log.warning('MixedBuilder ran on \${buildStep.inputId.path}');
     if (buildStep.inputId.path.endsWith('.dart')) {
-      await buildStep.writeAsString(
-        buildStep.inputId.changeExtension('.g.dart'), '',
-      );
+      final outputId = buildStep.inputId.changeExtension('.g.dart');
+      await buildStep.writeAsString(outputId, '');
+      if (!await buildStep.canRead(outputId)) {
+        throw StateError('Cannot read self-written output.');
+      }
     }
   }
 }

--- a/build_test/CHANGELOG.md
+++ b/build_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.21-wip
+
+- Use `build_runner` 2.16.2-wip.
+
 ## 3.5.20
 
 - Clarify terminology: refer to `.dart_tool/build/generated` as the "artifact

--- a/build_test/pubspec.yaml
+++ b/build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_test
 description: Utilities for writing unit tests of Builders.
-version: 3.5.20
+version: 3.5.21-wip
 repository: https://github.com/dart-lang/build/tree/master/build_test
 resolution: workspace
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   build: ^4.0.0
   build_config: ^1.0.0
-  build_runner: '2.16.1'
+  build_runner: '2.16.2-wip'
   built_collection: ^5.1.1
   crypto: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
`readAsBytes` and `readAsString` allow the read--correctly--but `canRead` currently throws, incorrectly.

Found via the contract programming experiment.