### PR TITLE
Run post process builder on incremental builds when no prior step result exists.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Bug fix: allow calling `BuildStep.canRead` on outputs written by the same
   build step.
+- Bug fix: run post-process builder on incremental builds when no prior step
+  result exists.
 
 ## 2.16.1
 

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -970,8 +970,10 @@ class Build {
     }
 
     final stepResult = previousBuild.postProcessBuildStepResultFor(buildStepId);
-    if (stepResult != null &&
-        stepResult.outputs.any(buildInputs.invalidOutputs.contains)) {
+    if (stepResult == null) {
+      return true;
+    }
+    if (stepResult.outputs.any(buildInputs.invalidOutputs.contains)) {
       return true;
     }
 

--- a/build_runner/test/integration_tests/build_command_errors_test.dart
+++ b/build_runner/test/integration_tests/build_command_errors_test.dart
@@ -141,11 +141,17 @@ class TestPostProcessBuilder implements PostProcessBuilder {
 
   @override
   Future<void> build(PostProcessBuildStep buildStep) async {
-    log.warning('post process builder ran');
-    log.severe('post process builder failed');
+    final content = await buildStep.readInputAsString();
+    if (content == 'crash') {
+      throw StateError('post process builder crashed');
+    }
+    if (content != 'ok') {
+      log.warning('post process builder ran');
+      log.severe('post process builder failed');
+    }
     await buildStep.writeAsString(
       buildStep.inputId.addExtension(outputExtension),
-      'failed output',
+      'output: \$content',
     );
   }
 }
@@ -178,5 +184,26 @@ class TestPostProcessBuilder implements PostProcessBuilder {
     );
     expect(output, isNot(contains('post process builder ran')));
     expect(output, contains('post process builder failed'));
+
+    // An unhandled error crashes the post process phase, omitting later inputs.
+    // On an incremental build after fixing the crash, the omitted input runs.
+    tester.write('root_pkg/web/a.txt', 'crash');
+    tester.write('root_pkg/web/b.txt', 'ok');
+    output = await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+      expectExitCode: 1,
+    );
+    expect(output, contains('post process builder crashed'));
+
+    // Fix a.txt. b.txt was omitted in the previous build and must run now.
+    tester.write('root_pkg/web/a.txt', 'ok');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    expect(
+      tester.read(
+        'root_pkg/.dart_tool/build/generated/root_pkg/web/b.txt.post',
+      ),
+      'output: ok',
+    );
   });
 }


### PR DESCRIPTION
If a previous build failed or was interrupted before a post process build step ran for an input, previousBuild.postProcessBuildStepResultFor(buildStepId) returns null. In incremental builds, _postProcessBuildStepShouldRun should run the step when there is no prior result, ensuring omitted post-process outputs are generated.

Found via contract programming experiment.