### PR TITLE
Preserve analyzer dependency information on unhandled build failures.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -4,6 +4,9 @@
   build step.
 - Bug fix: run post-process builder on incremental builds when no prior step
   result exists.
+- Bug fix: preserve analyzer dependency information on unhandled build failures,
+  preventing subsequent incremental builds from missing changes to transitively
+  imported files.
 
 ## 2.16.1
 

--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -178,6 +178,19 @@ class Build {
     return result;
   }
 
+  PhasedAssetDeps _computeUpdatedPhasedAssetDeps() {
+    // Combine previous phased asset deps, if any, with the newly loaded
+    // deps. Because of skipped builds, the newly loaded deps might just
+    // say "not generated yet", in which case the old value is retained.
+    final currentPhasedAssetDeps =
+        resolversImpl?.phasedAssetDeps() ?? PhasedAssetDeps();
+    return buildPlan.previousBuild.phasedAssetDeps == null
+        ? currentPhasedAssetDeps
+        : buildPlan.previousBuild.phasedAssetDeps!.update(
+            currentPhasedAssetDeps,
+          );
+  }
+
   Future<BuildResult> _safeBuild() {
     final done = Completer<BuildResult>();
     runZonedGuarded(
@@ -188,20 +201,9 @@ class Build {
         );
         final result = await _runPhases();
 
-        // Combine previous phased asset deps, if any, with the newly loaded
-        // deps. Because of skipped builds, the newly loaded deps might just
-        // say "not generated yet", in which case the old value is retained.
-        final currentPhasedAssetDeps =
-            resolversImpl?.phasedAssetDeps() ?? PhasedAssetDeps();
-        final updatedPhasedAssetDeps =
-            buildPlan.previousBuild.phasedAssetDeps == null
-            ? currentPhasedAssetDeps
-            : buildPlan.previousBuild.phasedAssetDeps!.update(
-                currentPhasedAssetDeps,
-              );
         if (!done.isCompleted) {
           done.complete(
-            result.copyWith(phasedAssetDeps: updatedPhasedAssetDeps),
+            result.copyWith(phasedAssetDeps: _computeUpdatedPhasedAssetDeps()),
           );
         }
       },
@@ -215,6 +217,7 @@ class Build {
             BuildResult(
               status: BuildStatus.failure,
               outputs: BuiltList(),
+              phasedAssetDeps: _computeUpdatedPhasedAssetDeps(),
               buildState: finishedBuildState,
               buildOutputReader: BuildOutputReader(
                 buildPackages: buildPackages,

--- a/build_runner/test/integration_tests/build_command_errors_test.dart
+++ b/build_runner/test/integration_tests/build_command_errors_test.dart
@@ -102,9 +102,9 @@ builders:
   test_builder:
     import: "package:builder_pkg/builder.dart"
     builder_factories: ["testBuilder"]
-    build_extensions: {".dart": [".unused"]}
+    build_extensions: {".dart": [".g.dart"]}
     auto_apply: all_packages
-    build_to: cache
+    build_to: source
     applies_builders:
       - builder_pkg:test_post_process_builder
 post_process_builders:
@@ -126,10 +126,18 @@ TestPostProcessBuilder testPostProcessBuilder(BuilderOptions options)
 
 class TestBuilder implements Builder {
   @override
-  Map<String, List<String>> get buildExtensions => {'.dart': ['.unused']};
+  Map<String, List<String>> get buildExtensions => {'.dart': ['.g.dart']};
 
   @override
-  Future<void> build(BuildStep buildStep) async {}
+  Future<void> build(BuildStep buildStep) async {
+    final lib = await buildStep.inputLibrary;
+    final imported = lib.firstFragment.libraryImports.first.importedLibrary!;
+    final names = imported.topLevelVariables.map((v) => v.name).toList();
+    await buildStep.writeAsString(
+      buildStep.inputId.changeExtension('.g.dart'),
+      '// \$names',
+    );
+  }
 }
 
 class TestPostProcessBuilder implements PostProcessBuilder {
@@ -205,5 +213,24 @@ class TestPostProcessBuilder implements PostProcessBuilder {
       ),
       'output: ok',
     );
+
+    // An unhandled build failure preserves resolver dependency information so
+    // subsequent incremental builds rebuild on transitive changes.
+    tester.write('root_pkg/lib/a.dart', "import 'b.dart';");
+    tester.write('root_pkg/lib/b.dart', 'const b1 = 1;');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    expect(tester.read('root_pkg/lib/a.g.dart'), '// [b1]');
+
+    tester.write('root_pkg/web/a.txt', 'crash');
+    await tester.run(
+      'root_pkg',
+      'dart run build_runner build --force-jit',
+      expectExitCode: 1,
+    );
+
+    tester.write('root_pkg/web/a.txt', 'ok');
+    tester.write('root_pkg/lib/b.dart', 'const b2 = 2;');
+    await tester.run('root_pkg', 'dart run build_runner build --force-jit');
+    expect(tester.read('root_pkg/lib/a.g.dart'), '// [b2]');
   });
 }


### PR DESCRIPTION
In Build._safeBuild, the runZonedGuarded error callback handles unhandled build failures by creating a failure BuildResult. Previously, phasedAssetDeps was omitted from this constructor call, defaulting to an empty graph and causing BuildSeries._runBuildAndWrite to overwrite asset_graph.json and in-memory plan dependencies with empty dependency sets.

Now both normal completion and unhandled failure paths compute and propagate updated phased asset dependencies.

This was a correctness issue: the lost dependency information would lead to missing invalidations.

Found via the contract programming experiment.