### PR TITLE
Size options changed lists from finished build step plan.

### DIFF
--- a/build_runner/lib/src/build_plan/previous_build.dart
+++ b/build_runner/lib/src/build_plan/previous_build.dart
@@ -227,10 +227,21 @@ abstract class PreviousBuild
     b.buildStepPlan.replace(finishedBuildState.buildStepPlan);
     b.phasedAssetDeps = previousPhasedAssetDeps.toBuilder();
     b.phaseOptionsChangedList.replace(
-      List.filled(phaseOptionsChangedList.length, false),
+      List.filled(
+        finishedBuildState.buildStepPlan.buildPhases.inBuildPhases.length,
+        false,
+      ),
     );
     b.postBuildOptionsChangedList.replace(
-      List.filled(postBuildOptionsChangedList.length, false),
+      List.filled(
+        finishedBuildState
+            .buildStepPlan
+            .buildPhases
+            .postBuildPhase
+            .builderActions
+            .length,
+        false,
+      ),
     );
     b.incompatibleBuildOutputsToDelete.clear();
   });


### PR DESCRIPTION
In PreviousBuild.updateForNextBuild, compute the lengths of phaseOptionsChangedList and postBuildOptionsChangedList directly from finishedBuildState.buildStepPlan rather than the previous lists.

Not a correctness bug because they are guaranteed to be the same.

But we don't need to rely on them being the same :)

Found via the contract programming experiment.