### PR TITLE
Do not include input IDs in BuildStepPlan.transitiveDeclaredOutputsOf.

### DIFF
--- a/build_runner/lib/src/build/build.dart
+++ b/build_runner/lib/src/build/build.dart
@@ -768,8 +768,7 @@ class Build {
         }
       } else {
         // If a primary input source file is deleted, the build is skipped.
-        if (buildInputs.deletedSources.contains(primaryInput) ||
-            buildInputs.invalidOutputs.contains(primaryInput)) {
+        if (buildInputs.deletedSources.contains(primaryInput)) {
           return StepAction.skipMissingPrimaryInput;
         }
       }
@@ -799,8 +798,7 @@ class Build {
       }
 
       for (final output in outputs) {
-        if (buildInputs.deletedSources.contains(output) ||
-            buildInputs.invalidOutputs.contains(output)) {
+        if (buildInputs.invalidOutputs.contains(output)) {
           return StepAction.run;
         }
       }

--- a/build_runner/lib/src/build_plan/build_step_plan.dart
+++ b/build_runner/lib/src/build_plan/build_step_plan.dart
@@ -154,12 +154,16 @@ abstract class BuildStepPlan
   Iterable<AssetId> declaredOutputsOf(AssetId id) =>
       declaredOutputsByPrimaryInput[id];
 
+  /// Returns all transitive declared outputs produced from [ids].
+  ///
+  /// Does not include [ids] themselves unless an asset is also declared as an
+  /// output of one of the steps.
   Set<AssetId> transitiveDeclaredOutputsOf(Iterable<AssetId> ids) {
     final results = <AssetId>{};
 
     void addTransitive(AssetId id) {
-      if (results.add(id)) {
-        for (final output in declaredOutputsOf(id)) {
+      for (final output in declaredOutputsOf(id)) {
+        if (results.add(output)) {
           addTransitive(output);
         }
       }

--- a/build_runner/test/build/build_state/build_state_test.dart
+++ b/build_runner/test/build/build_state/build_state_test.dart
@@ -413,9 +413,7 @@ void main() {
 
     test('empty plan', () {
       expect(plan.transitiveDeclaredOutputsOf([]), isEmpty);
-      expect(plan.transitiveDeclaredOutputsOf([makeAssetId('foo|a')]), {
-        makeAssetId('foo|a'),
-      });
+      expect(plan.transitiveDeclaredOutputsOf([makeAssetId('foo|a')]), isEmpty);
     });
 
     test('chain: a -> b -> c', () {
@@ -429,9 +427,9 @@ void main() {
           ..declaredOutputsByPrimaryInput.addValues(b, [c]),
       );
 
-      expect(plan.transitiveDeclaredOutputsOf([a]), unorderedEquals({a, b, c}));
-      expect(plan.transitiveDeclaredOutputsOf([b]), unorderedEquals({b, c}));
-      expect(plan.transitiveDeclaredOutputsOf([c]), unorderedEquals({c}));
+      expect(plan.transitiveDeclaredOutputsOf([a]), unorderedEquals({b, c}));
+      expect(plan.transitiveDeclaredOutputsOf([b]), unorderedEquals({c}));
+      expect(plan.transitiveDeclaredOutputsOf([c]), isEmpty);
     });
 
     test('diamond: a -> b, c; b -> d; c -> d', () {
@@ -447,10 +445,7 @@ void main() {
           ..declaredOutputsByPrimaryInput.addValues(c, [d]),
       );
 
-      expect(
-        plan.transitiveDeclaredOutputsOf([a]),
-        unorderedEquals({a, b, c, d}),
-      );
+      expect(plan.transitiveDeclaredOutputsOf([a]), unorderedEquals({b, c, d}));
     });
 
     test('multiple inputs', () {
@@ -465,10 +460,7 @@ void main() {
           ..declaredOutputsByPrimaryInput.addValues(c, [d]),
       );
 
-      expect(
-        plan.transitiveDeclaredOutputsOf([a, c]),
-        unorderedEquals({a, b, c, d}),
-      );
+      expect(plan.transitiveDeclaredOutputsOf([a, c]), unorderedEquals({b, d}));
     });
   });
 }

--- a/build_runner/test/build_plan/build_plan_test.dart
+++ b/build_runner/test/build_plan/build_plan_test.dart
@@ -137,13 +137,11 @@ void main() {
       buildPlan = await loadPlan();
 
       expect(
-        {
-          ...buildPlan.buildInputs.updatedSources,
-          ...buildPlan.buildInputs.deletedSources,
-          ...buildPlan.buildInputs.invalidOutputs,
-        },
-        {assetId, assetId2, assetId3, outputId},
+        buildPlan.buildInputs.updatedSources,
+        unorderedEquals([assetId2, assetId3]),
       );
+      expect(buildPlan.buildInputs.deletedSources, [assetId]);
+      expect(buildPlan.buildInputs.invalidOutputs, [outputId]);
     });
 
     test('keep output strategy preserves manual changes to outputs '


### PR DESCRIPTION
This prevents confusing sources and outputs, which simplifies some later code.

Not a bug fix: a clarification :)

Found via contract programming experiment.