### PR TITLE
Add testing/bin/build_runner entrypoint for fast integration tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build_runner/lib/src/server/graph_viz_main.dart.js.deps
 build_runner/lib/src/server/graph_viz_main.dart.js.tar.gz
 build_runner/lib/src/server/build_updates_client/hot_reload_client.dart.js.deps
 build_runner/lib/src/server/build_updates_client/hot_reload_client.dart.js.tar.gz
+
+*.dill*
+*.lock*

--- a/build_runner/.pubignore
+++ b/build_runner/.pubignore
@@ -1,0 +1,1 @@
+testing/

--- a/build_runner/lib/src/bootstrap/build_process_state.dart
+++ b/build_runner/lib/src/bootstrap/build_process_state.dart
@@ -107,9 +107,19 @@ class BuildProcessState {
   /// The package config URI.
   ///
   /// If not already set, sets from the current process
-  /// `Isolate.packageConfigSync`.
+  /// `Isolate.packageConfigSync` or falls back to package or workspace path.
   String get packageConfigUri =>
-      (_state['packageConfigUri'] ??= Isolate.packageConfigSync!.toString())
+      (_state['packageConfigUri'] ??=
+              Isolate.packageConfigSync?.toString() ??
+              Uri.file(
+                p.join(
+                  _buildPaths?.workspacePath ??
+                      _buildPaths?.packagePath ??
+                      Directory.current.path,
+                  '.dart_tool',
+                  'package_config.json',
+                ),
+              ).toString())
           as String;
 
   /// The [BuildPaths] used for the process lock.

--- a/build_runner/lib/src/build_plan/build_phase_creator.dart
+++ b/build_runner/lib/src/build_plan/build_phase_creator.dart
@@ -159,8 +159,7 @@ class BuildPhaseCreator {
     BuilderDefinition builderDefinition,
     BuilderOptions globalOptionOverrides,
   ) {
-    final builderFactories =
-        this.builderFactories.builderFactories[builderDefinition.key]!;
+    final builderFactories = this.builderFactories.get(builderDefinition.key)!;
     final result = <InBuildPhase>[];
     for (final builderFactory in builderFactories) {
       for (final buildTarget in buildTargets) {
@@ -180,6 +179,11 @@ class BuildPhaseCreator {
           buildLog.loggerForOther(builderDefinition.key),
         );
         if (builder == null) throw const CannotBuildException();
+        if (builderDefinition.buildExtensions.isNotEmpty &&
+            builder is ConfigurableBuildExtensions) {
+          (builder as ConfigurableBuildExtensions).buildExtensions =
+              builderDefinition.buildExtensions;
+        }
         _validateBuilder(builder);
 
         result.add(
@@ -204,8 +208,9 @@ class BuildPhaseCreator {
     PostProcessBuilderDefinition builderDefinition,
     BuilderOptions globalOptionOverrides,
   ) {
-    final postProcessBuilderFactory =
-        builderFactories.postProcessBuilderFactories[builderDefinition.key]!;
+    final postProcessBuilderFactory = builderFactories.getPostProcess(
+      builderDefinition.key,
+    )!;
     final result = <PostBuildAction>[];
     for (final buildTarget in buildTargets) {
       if (!_shouldApply(builderDefinition, buildTarget)) continue;
@@ -407,4 +412,10 @@ void _validatePostProcessBuilder(PostProcessBuilder builder) {
       'assets in the `build()` method.',
     );
   }
+}
+
+/// Interface for builders that support configuring build extensions
+/// dynamically.
+abstract interface class ConfigurableBuildExtensions {
+  set buildExtensions(Map<String, List<String>> extensions);
 }

--- a/build_runner/lib/src/build_plan/builder_definition.dart
+++ b/build_runner/lib/src/build_plan/builder_definition.dart
@@ -129,6 +129,9 @@ class BuilderDefinition implements AbstractBuilderDefinition {
   /// Whether the builder is skipped if nothing uses its output.
   final bool isOptional;
 
+  /// The build extensions declared in `build.yaml`.
+  final Map<String, List<String>> buildExtensions;
+
   @visibleForTesting
   BuilderDefinition(
     this.key, {
@@ -138,8 +141,10 @@ class BuilderDefinition implements AbstractBuilderDefinition {
     this.outputsToArtifactTree = true,
     this.isOptional = false,
     this.targetBuilderConfigDefaults = const TargetBuilderConfigDefaults(),
+    Map<String, List<String>> buildExtensions = const {},
   }) : package = package ?? (key.contains(':') ? key.split(':').first : ''),
-       appliesBuilders = appliesBuilders.toBuiltList();
+       appliesBuilders = appliesBuilders.toBuiltList(),
+       buildExtensions = Map.unmodifiable(buildExtensions);
 
   factory BuilderDefinition.fromConfig(
     build_config.BuilderDefinition builderDefinition,
@@ -152,6 +157,7 @@ class BuilderDefinition implements AbstractBuilderDefinition {
         builderDefinition.buildTo == build_config.BuildTo.cache,
     isOptional: builderDefinition.isOptional,
     targetBuilderConfigDefaults: builderDefinition.defaults,
+    buildExtensions: builderDefinition.buildExtensions,
   );
 
   /// Whether this builder application is auto applied to [package].

--- a/build_runner/lib/src/build_plan/builder_factories.dart
+++ b/build_runner/lib/src/build_plan/builder_factories.dart
@@ -26,6 +26,33 @@ class BuilderFactories {
        postProcessBuilderFactories = (postProcessBuilderFactories ?? {})
            .build();
 
+  /// Gets builder factories for [key].
+  ///
+  /// Matches the exact key or suffix after colon.
+  BuiltList<BuilderFactory>? get(String key) {
+    final direct = builderFactories[key];
+    if (direct != null) return direct;
+    if (key.contains(':')) {
+      final name = key.split(':').last;
+      return builderFactories[':$name'] ?? builderFactories[name];
+    }
+    return null;
+  }
+
+  /// Gets post process builder factory for [key].
+  ///
+  /// Matches the exact key or suffix after colon.
+  PostProcessBuilderFactory? getPostProcess(String key) {
+    final direct = postProcessBuilderFactories[key];
+    if (direct != null) return direct;
+    if (key.contains(':')) {
+      final name = key.split(':').last;
+      return postProcessBuilderFactories[':$name'] ??
+          postProcessBuilderFactories[name];
+    }
+    return null;
+  }
+
   /// Whether there are factories for all definitions in [builderDefinitions].
   ///
   /// Factories must be of the correct type: post process builder or normal
@@ -34,11 +61,11 @@ class BuilderFactories {
     for (final builderDefinition in builderDefinitions) {
       switch (builderDefinition) {
         case BuilderDefinition _:
-          if (!builderFactories.containsKey(builderDefinition.key)) {
+          if (get(builderDefinition.key) == null) {
             return false;
           }
         case PostProcessBuilderDefinition _:
-          if (!postProcessBuilderFactories.containsKey(builderDefinition.key)) {
+          if (getPostProcess(builderDefinition.key) == null) {
             return false;
           }
       }

--- a/build_runner/lib/src/build_runner.dart
+++ b/build_runner/lib/src/build_runner.dart
@@ -14,8 +14,11 @@ import 'package:yaml/yaml.dart';
 import 'bootstrap/bootstrapper.dart';
 import 'bootstrap/build_process_state.dart';
 import 'bootstrap/compile_type.dart';
+import 'bootstrap/processes.dart';
 import 'build_plan/build_options.dart';
+import 'build_plan/build_packages.dart';
 import 'build_plan/build_paths.dart';
+import 'build_plan/builder_definition.dart';
 import 'build_plan/builder_factories.dart';
 import 'build_runner_command_line.dart';
 import 'commands/build_command.dart';
@@ -32,6 +35,7 @@ import 'commands/test_command.dart';
 import 'commands/test_options.dart';
 import 'commands/watch_command.dart';
 import 'exceptions.dart';
+import 'io/reader_writer.dart';
 import 'logging/build_log.dart';
 
 /// The `build_runner` tool.
@@ -93,7 +97,7 @@ class BuildRunner {
       p.current,
       buildWorkspace: commandLine.workspace ?? false,
     );
-    if (builderFactories == null && commandLine.type != CommandType.daemon) {
+    if (!ChildProcess.isRunning && commandLine.type != CommandType.daemon) {
       await buildProcessState.takeLock(buildPaths);
     }
 
@@ -105,11 +109,25 @@ class BuildRunner {
       );
     }
 
-    if (commandLine.type.requiresBuilders && builderFactories == null) {
-      return await _runWithBuilders(
-        buildPaths: buildPaths,
-        compileStrategy: commandLine.compileStrategy,
-      );
+    var builderFactories = this.builderFactories;
+    if (commandLine.type.requiresBuilders) {
+      if (builderFactories != null) {
+        final buildPackages = await BuildPackages.forPaths(buildPaths);
+        final readerWriter = ReaderWriter(buildPackages);
+        final builderDefinitions = await AbstractBuilderDefinition.load(
+          buildPackages: buildPackages,
+          readerWriter: readerWriter,
+        );
+        if (!builderFactories.hasFactoriesFor(builderDefinitions)) {
+          builderFactories = null;
+        }
+      }
+      if (builderFactories == null) {
+        return await _runWithBuilders(
+          buildPaths: buildPaths,
+          compileStrategy: commandLine.compileStrategy,
+        );
+      }
     }
 
     final removedOptionsUsed = commandLine.removedOptionsUsed;

--- a/build_runner/test/common/build_runner_tester.dart
+++ b/build_runner/test/common/build_runner_tester.dart
@@ -25,14 +25,26 @@ import 'fixture_packages.dart';
 class BuildRunnerTester {
   final Pubspecs pubspecs;
   final Directory tempDirectory;
+  final bool bootstrap;
+  late final String testingEntrypoint = p.join(
+    pubspecs.packageConfig['build_runner']!.root.toFilePath(),
+    'testing',
+    'bin',
+    'build_runner.dill',
+  );
 
-  BuildRunnerTester(Pubspecs pubspecs)
+  BuildRunnerTester(Pubspecs pubspecs, {bool bootstrap = false})
     : this._(
         pubspecs,
         Directory.systemTemp.createTempSync('BuildRunnerTester-'),
+        bootstrap: bootstrap,
       );
 
-  BuildRunnerTester._(this.pubspecs, this.tempDirectory) {
+  BuildRunnerTester._(
+    this.pubspecs,
+    this.tempDirectory, {
+    this.bootstrap = false,
+  }) {
     addTearDown(() async {
       // Temp cleanup can fail on Windows if some process is slow to close,
       // retry for 5s.
@@ -56,7 +68,7 @@ class BuildRunnerTester {
       'BuildRunnerTester-copy-',
     );
     copyPathSync(tempDirectory.path, newTemp.path);
-    return BuildRunnerTester._(pubspecs, newTemp);
+    return BuildRunnerTester._(pubspecs, newTemp, bootstrap: bootstrap);
   }
 
   /// Writes a Dart package to the workspace.
@@ -213,6 +225,56 @@ class BuildRunnerTester {
     }
   }
 
+  /// Ensures package config exists for [directory], running pub get if needed.
+  Future<void> _ensurePackageConfig(String directory) async {
+    final dirPath = p.join(tempDirectory.path, directory);
+    String? workspaceRoot;
+    var current = dirPath;
+    while (current.startsWith(tempDirectory.path)) {
+      final pubspec = File(p.join(current, 'pubspec.yaml'));
+      if (pubspec.existsSync()) {
+        final content = pubspec.readAsStringSync();
+        if (content.contains('workspace:') &&
+            !content.contains('resolution: workspace')) {
+          workspaceRoot = current;
+          break;
+        }
+      }
+      final parent = p.dirname(current);
+      if (parent == current) break;
+      current = parent;
+    }
+
+    final targetDir = workspaceRoot ?? dirPath;
+    final packageConfig = File(
+      p.join(targetDir, '.dart_tool', 'package_config.json'),
+    );
+    var needsPubGet = !packageConfig.existsSync();
+    if (!needsPubGet) {
+      final configMtime = packageConfig.lastModifiedSync();
+      for (final entity in Directory(targetDir).listSync(recursive: true)) {
+        if (entity is File && p.basename(entity.path) == 'pubspec.yaml') {
+          if (entity.lastModifiedSync().isAfter(configMtime)) {
+            needsPubGet = true;
+            break;
+          }
+        }
+      }
+    }
+    if (needsPubGet) {
+      final result = await Process.run('dart', [
+        'pub',
+        'get',
+        '--offline',
+      ], workingDirectory: targetDir);
+      if (result.exitCode != 0) {
+        throw StateError(
+          'pub get failed in $targetDir:\n${result.stderr}\n${result.stdout}',
+        );
+      }
+    }
+  }
+
   /// Runs [commandLine] in [directory].
   ///
   /// By default, expects exit code 0 and fails the test if any other exit code
@@ -224,8 +286,20 @@ class BuildRunnerTester {
     String commandLine, {
     int expectExitCode = 0,
     Map<String, String>? environment,
+    bool? bootstrap,
   }) async {
-    final args = commandLine.split(' ');
+    await _ensurePackageConfig(directory);
+    final useBootstrap = bootstrap ?? this.bootstrap;
+    final effectiveCommandLine =
+        !useBootstrap &&
+            (commandLine == 'dart run build_runner' ||
+                commandLine.startsWith('dart run build_runner '))
+        ? commandLine.replaceFirst(
+            'dart run build_runner',
+            'dart $testingEntrypoint',
+          )
+        : commandLine;
+    final args = effectiveCommandLine.split(' ');
     final command = args.removeAt(0);
     final result = await Process.run(
       command,
@@ -246,8 +320,23 @@ ${result.stdout}${result.stderr}===
   /// Starts [commandLine] in [directory].
   ///
   /// Returns a [BuildRunnerProcess] which can be used to interact with it.
-  Future<BuildRunnerProcess> start(String directory, String commandLine) async {
-    final args = commandLine.split(' ');
+  Future<BuildRunnerProcess> start(
+    String directory,
+    String commandLine, {
+    bool? bootstrap,
+  }) async {
+    await _ensurePackageConfig(directory);
+    final useBootstrap = bootstrap ?? this.bootstrap;
+    final effectiveCommandLine =
+        !useBootstrap &&
+            (commandLine == 'dart run build_runner' ||
+                commandLine.startsWith('dart run build_runner '))
+        ? commandLine.replaceFirst(
+            'dart run build_runner',
+            'dart $testingEntrypoint',
+          )
+        : commandLine;
+    final args = effectiveCommandLine.split(' ');
     final command = args.removeAt(0);
     final process = await Process.start(
       command,
@@ -493,6 +582,85 @@ class Pubspecs {
 
   static Future<Pubspecs> _load() async {
     final config = await loadPackageConfigUri((await Isolate.packageConfig)!);
+    final buildRunnerDir = config['build_runner']!.root.toFilePath();
+    final dillFile = File(
+      p.join(buildRunnerDir, 'testing', 'bin', 'build_runner.dill'),
+    );
+    final scriptFile = File(
+      p.join(buildRunnerDir, 'testing', 'bin', 'build_runner.dart'),
+    );
+    var newestSourceTime = DateTime.fromMillisecondsSinceEpoch(0);
+    for (final dirName in ['lib', 'testing']) {
+      final dir = Directory(p.join(buildRunnerDir, dirName));
+      if (dir.existsSync()) {
+        for (final entity in dir.listSync(recursive: true)) {
+          if (entity is File && entity.path.endsWith('.dart')) {
+            final modified = entity.lastModifiedSync();
+            if (modified.isAfter(newestSourceTime)) {
+              newestSourceTime = modified;
+            }
+          }
+        }
+      }
+    }
+    final lockDir = Directory(
+      p.join(buildRunnerDir, 'testing', 'bin', '.compile.lock'),
+    );
+    var acquired = false;
+    while (!acquired) {
+      try {
+        lockDir.createSync();
+        acquired = true;
+      } on FileSystemException {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        if (dillFile.existsSync() &&
+            !dillFile.lastModifiedSync().isBefore(newestSourceTime)) {
+          break;
+        }
+      }
+    }
+    if (acquired) {
+      try {
+        final needsCompile =
+            !dillFile.existsSync() ||
+            dillFile.lastModifiedSync().isBefore(newestSourceTime);
+        if (needsCompile) {
+          final tempDill = p.join(
+            Directory.systemTemp.path,
+            'build_runner_${pid}_'
+            '${DateTime.now().microsecondsSinceEpoch}.dill',
+          );
+          final result = await Process.run('dart', [
+            'compile',
+            'kernel',
+            scriptFile.path,
+            '-o',
+            tempDill,
+          ], workingDirectory: buildRunnerDir);
+          if (result.exitCode == 0) {
+            final tempFile = File(tempDill);
+            try {
+              tempFile.renameSync(dillFile.path);
+            } on FileSystemException {
+              tempFile.copySync(dillFile.path);
+              tempFile.deleteSync();
+            }
+          } else {
+            throw StateError(
+              'Failed to compile testing entrypoint:\n'
+              '${result.stderr}\n${result.stdout}',
+            );
+          }
+        }
+      } finally {
+        try {
+          lockDir.deleteSync();
+        } on FileSystemException {
+          // Ignore if already cleaned up.
+        }
+      }
+    }
+
     final copiedPackagesDir = Directory.systemTemp.createTempSync(
       'BuildRunnerTester-packages-',
     );
@@ -525,7 +693,7 @@ class Pubspecs {
   }
 
   static void _copyPackage(String source, String dest) {
-    for (final name in ['lib', 'bin']) {
+    for (final name in ['lib', 'bin', 'testing']) {
       final entityPath = p.join(source, name);
       if (FileSystemEntity.isDirectorySync(entityPath)) {
         copyPathSync(entityPath, p.join(dest, name));
@@ -534,7 +702,14 @@ class Pubspecs {
     for (final name in ['pubspec.yaml', 'build.yaml']) {
       final entityPath = p.join(source, name);
       if (FileSystemEntity.isFileSync(entityPath)) {
-        File(entityPath).copySync(p.join(dest, name));
+        var content = File(entityPath).readAsStringSync();
+        if (name == 'pubspec.yaml') {
+          content = content.replaceAll(
+            RegExp(r'resolution:\s*workspace\n?'),
+            '',
+          );
+        }
+        File(p.join(dest, name)).writeAsStringSync(content);
       }
     }
   }

--- a/build_runner/test/integration_tests/build_command_aot_test.dart
+++ b/build_runner/test/integration_tests/build_command_aot_test.dart
@@ -12,7 +12,7 @@ import '../common/common.dart';
 void main() async {
   test('build command AOT', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     // Basic AOT build and rebuild on change.
     tester.writeFixturePackage(FixturePackages.copyBuilder());

--- a/build_runner/test/integration_tests/build_command_config_validation_test.dart
+++ b/build_runner/test/integration_tests/build_command_config_validation_test.dart
@@ -14,7 +14,7 @@ import '../common/common.dart';
 void main() async {
   test('build command config validation', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writePackage(
       name: 'root_pkg',

--- a/build_runner/test/integration_tests/build_command_errors_test.dart
+++ b/build_runner/test/integration_tests/build_command_errors_test.dart
@@ -12,7 +12,7 @@ import '../common/common.dart';
 void main() async {
   test('build command errors', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writePackage(
       name: 'builder_pkg',

--- a/build_runner/test/integration_tests/build_command_invalidation_test.dart
+++ b/build_runner/test/integration_tests/build_command_invalidation_test.dart
@@ -13,7 +13,7 @@ import '../common/common.dart';
 void main() async {
   test('build command invalidation', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writeFixturePackage(FixturePackages.copyBuilder());
     tester.writePackage(

--- a/build_runner/test/integration_tests/build_command_other_args_test.dart
+++ b/build_runner/test/integration_tests/build_command_other_args_test.dart
@@ -12,7 +12,7 @@ import '../common/common.dart';
 void main() {
   test('build command other args', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writePackage(
       name: 'root_pkg',

--- a/build_runner/test/integration_tests/build_command_write_batching_test.dart
+++ b/build_runner/test/integration_tests/build_command_write_batching_test.dart
@@ -13,7 +13,7 @@ import '../common/common.dart';
 void main() async {
   test('build command write batching', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writeFixturePackage(
       FixturePackages.copyBuilder(delayAtBuildStart: true),

--- a/build_runner/test/integration_tests/build_process_lock_test.dart
+++ b/build_runner/test/integration_tests/build_process_lock_test.dart
@@ -14,7 +14,7 @@ import '../common/common.dart';
 void main() async {
   test('build process lock', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writePackage(
       name: 'root_pkg',

--- a/build_runner/test/integration_tests/builder_changes_test.dart
+++ b/build_runner/test/integration_tests/builder_changes_test.dart
@@ -13,7 +13,7 @@ import '../common/common.dart';
 void main() async {
   test('builder changes', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writeFixturePackage(FixturePackages.copyBuilder());
     tester.writePackage(

--- a/build_runner/test/integration_tests/clean_command_test.dart
+++ b/build_runner/test/integration_tests/clean_command_test.dart
@@ -13,7 +13,7 @@ import '../common/common.dart';
 void main() async {
   test('clean command', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writePackage(
       name: 'root_pkg',

--- a/build_runner/test/integration_tests/run_command_test.dart
+++ b/build_runner/test/integration_tests/run_command_test.dart
@@ -13,7 +13,7 @@ import '../common/common.dart';
 void main() async {
   test('run command', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writePackage(
       name: 'builder_pkg',

--- a/build_runner/test/integration_tests/watch_command_concurrent_changes_test.dart
+++ b/build_runner/test/integration_tests/watch_command_concurrent_changes_test.dart
@@ -13,7 +13,7 @@ import '../common/common.dart';
 void main() async {
   test('watch command concurrent changes', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writeFixturePackage(FixturePackages.copyBuilder());
     // Builder with a one second delay before read.

--- a/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
+++ b/build_runner/test/integration_tests/watch_command_generated_builder_test.dart
@@ -20,7 +20,7 @@ void main() async {
   //  - Generated outputs. These are deleted and written during the build.
   test('watch command generated builder', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     // The `builder.g.dart` content that the builder writes.
     final partContent = '''

--- a/build_runner/test/integration_tests/watch_command_test.dart
+++ b/build_runner/test/integration_tests/watch_command_test.dart
@@ -13,7 +13,7 @@ import '../common/common.dart';
 void main() async {
   test('watch command', () async {
     final pubspecs = await Pubspecs.load();
-    final tester = BuildRunnerTester(pubspecs);
+    final tester = BuildRunnerTester(pubspecs, bootstrap: true);
 
     tester.writeFixturePackage(FixturePackages.copyBuilder());
     tester.writePackage(

--- a/build_runner/testing/bin/build_runner.dart
+++ b/build_runner/testing/bin/build_runner.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:build_runner/src/build_runner.dart';
+
+import '../test_builders.dart';
+
+Future<void> main(List<String> arguments) async {
+  final code = await BuildRunner(
+    arguments: arguments,
+    builderFactories: allTestBuilderFactories,
+  ).run();
+  await stdout.flush();
+  await stderr.flush();
+  exit(code);
+}

--- a/build_runner/testing/test_builders.dart
+++ b/build_runner/testing/test_builders.dart
@@ -1,0 +1,255 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:build/build.dart';
+import 'package:build_runner/src/build_plan/build_phase_creator.dart';
+import 'package:build_runner/src/build_plan/builder_factories.dart';
+import 'package:glob/glob.dart';
+
+Builder testBuilderFactory(BuilderOptions options) {
+  final copyFrom = options.config['copy_from'] as String?;
+  final extraContent = options.config['extra_content'] as Object? ?? '';
+  final outputExtension =
+      options.config['output_extension'] as String? ?? '.copy';
+  final delayAtBuildStart =
+      options.config['delay_at_build_start'] as bool? ?? false;
+
+  return _TestBuilder(
+    otherInput: copyFrom == null ? null : AssetId.parse(copyFrom),
+    extraContent: extraContent,
+    outputExtension: outputExtension,
+    delayAtBuildStart: delayAtBuildStart,
+  );
+}
+
+class _TestBuilder implements Builder, ConfigurableBuildExtensions {
+  final AssetId? otherInput;
+  final Object extraContent;
+  final String outputExtension;
+  final bool delayAtBuildStart;
+  @override
+  Map<String, List<String>> buildExtensions;
+
+  _TestBuilder({
+    this.otherInput,
+    this.extraContent = '',
+    this.outputExtension = '.copy',
+    this.delayAtBuildStart = false,
+  }) : buildExtensions = {
+         '.txt': ['.txt$outputExtension'],
+       };
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    if (delayAtBuildStart) {
+      await Future<void>.delayed(const Duration(seconds: 1));
+    }
+
+    final extensions = buildExtensions;
+    for (final entry in extensions.entries) {
+      if (buildStep.inputId.path.endsWith(entry.key)) {
+        for (final outputExt in entry.value) {
+          if (outputExt == '.unused') {
+            return;
+          }
+          if (outputExt == '.g.dart') {
+            await buildStep.inputLibrary;
+            return;
+          }
+          final outputId = outputExt.startsWith(entry.key)
+              ? buildStep.inputId.addExtension(
+                  outputExt.substring(entry.key.length),
+                )
+              : buildStep.inputId.changeExtension(outputExt);
+          final input = await buildStep.readAsString(
+            otherInput ?? buildStep.inputId,
+          );
+          await buildStep.writeAsString(outputId, '$input$extraContent');
+        }
+      }
+    }
+  }
+}
+
+Builder optionalCopyBuilder(BuilderOptions options) => _OptionalCopyBuilder();
+
+class _OptionalCopyBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {
+    '.txt': ['.txt.copy'],
+  };
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    await buildStep.writeAsString(
+      buildStep.inputId.addExtension('.copy'),
+      await buildStep.readAsString(buildStep.inputId),
+    );
+  }
+}
+
+Builder readBuilder(BuilderOptions options) => _ReadBuilder();
+
+class _ReadBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {
+    '.read': ['.read.out'],
+  };
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    final target = await buildStep.readAsString(buildStep.inputId);
+    await buildStep.readAsString(AssetId.parse(target));
+  }
+}
+
+Builder earlyBuilderFactory(BuilderOptions options) =>
+    _WriteIfTriggeredBuilder('.early.txt');
+
+Builder lateBuilderFactory(BuilderOptions options) =>
+    _WriteIfTriggeredBuilder('.late.txt');
+
+class _WriteIfTriggeredBuilder implements Builder {
+  final String extension;
+  _WriteIfTriggeredBuilder(this.extension);
+
+  @override
+  Map<String, List<String>> get buildExtensions => {
+    '.dart': [extension],
+  };
+
+  @override
+  Future<void> build(BuildStep b) async {
+    await b.writeAsString(b.inputId.changeExtension(extension), 'triggered');
+  }
+}
+
+Builder writeTriggeringPartBuilderFactory(BuilderOptions options) =>
+    _WriteTriggeringPartBuilder();
+
+class _WriteTriggeringPartBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {
+    '.dart': ['.g.dart'],
+  };
+
+  @override
+  Future<void> build(BuildStep b) async {
+    await b.writeAsString(
+      b.inputId.changeExtension('.g.dart'),
+      "part of 'a.dart';\n@someAnnotation\nclass B {}",
+    );
+  }
+}
+
+Builder zeroOutputBuilderFactory(BuilderOptions options) =>
+    _ZeroOutputBuilder();
+
+class _ZeroOutputBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {'.txt': []};
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    final otherId = AssetId(buildStep.inputId.package, 'lib/dep.other');
+    await buildStep.canRead(otherId);
+    log.warning('ZeroOutputBuilder ran on ${buildStep.inputId.path}');
+  }
+}
+
+Builder mixedBuilderFactory(BuilderOptions options) => _MixedBuilder();
+
+class _MixedBuilder implements Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {
+    '.txt': [],
+    '.dart': ['.g.dart'],
+  };
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    log.warning('MixedBuilder ran on ${buildStep.inputId.path}');
+    if (buildStep.inputId.path.endsWith('.dart')) {
+      final outputId = buildStep.inputId.changeExtension('.g.dart');
+      await buildStep.writeAsString(outputId, '');
+      if (!await buildStep.canRead(outputId)) {
+        throw StateError('Cannot read self-written output.');
+      }
+    }
+  }
+}
+
+Builder globbingBuilderFactory(BuilderOptions options) => _GlobbingBuilder();
+
+class _GlobbingBuilder extends Builder {
+  @override
+  Map<String, List<String>> get buildExtensions => {
+    '.globPlaceholder': ['.matchingFiles'],
+  };
+
+  @override
+  Future<void> build(BuildStep buildStep) async {
+    final glob = Glob('**.txt');
+    final allAssets = await buildStep.findAssets(glob).toList();
+    allAssets.sort((a, b) => a.path.compareTo(b.path));
+    await buildStep.writeAsString(
+      buildStep.inputId.changeExtension('.matchingFiles'),
+      allAssets.map((id) => id.toString()).join('\n'),
+    );
+  }
+}
+
+PostProcessBuilder testPostProcessBuilder(BuilderOptions options) {
+  final outputExtension =
+      options.config['output_extension'] as String? ?? '.post';
+  final extraContent = options.config['extra_content'] as String? ?? '';
+  return _TestPostProcessBuilder(outputExtension, extraContent);
+}
+
+class _TestPostProcessBuilder implements PostProcessBuilder {
+  final String outputExtension;
+  final String extraContent;
+
+  _TestPostProcessBuilder(this.outputExtension, this.extraContent);
+
+  @override
+  List<String> get inputExtensions => ['.txt'];
+
+  @override
+  Future<void> build(PostProcessBuildStep buildStep) async {
+    await buildStep.writeAsString(
+      buildStep.inputId.addExtension(outputExtension),
+      await buildStep.readInputAsString() + extraContent,
+    );
+  }
+}
+
+final allTestBuilderFactories = BuilderFactories(
+  {
+    ':test_builder': [testBuilderFactory],
+    'test_builder': [testBuilderFactory],
+    ':optional_copy_builder': [optionalCopyBuilder],
+    'optional_copy_builder': [optionalCopyBuilder],
+    ':read_builder': [readBuilder],
+    'read_builder': [readBuilder],
+    ':early_triggered_builder': [earlyBuilderFactory],
+    'early_triggered_builder': [earlyBuilderFactory],
+    ':part_builder': [writeTriggeringPartBuilderFactory],
+    'part_builder': [writeTriggeringPartBuilderFactory],
+    ':late_triggered_builder': [lateBuilderFactory],
+    'late_triggered_builder': [lateBuilderFactory],
+    ':zero_output_builder': [zeroOutputBuilderFactory],
+    'zero_output_builder': [zeroOutputBuilderFactory],
+    ':mixed_builder': [mixedBuilderFactory],
+    'mixed_builder': [mixedBuilderFactory],
+    ':globbing_builder': [globbingBuilderFactory],
+    'globbing_builder': [globbingBuilderFactory],
+  },
+  postProcessBuilderFactories: {
+    ':test_post_process_builder': testPostProcessBuilder,
+    'test_post_process_builder': testPostProcessBuilder,
+  },
+);

--- a/build_test/lib/src/test_builder.dart
+++ b/build_test/lib/src/test_builder.dart
@@ -629,6 +629,9 @@ class _ApplyBuilderDefinitionToPackages implements BuilderDefinition {
   @override
   build_config.TargetBuilderConfigDefaults get targetBuilderConfigDefaults =>
       delegate.targetBuilderConfigDefaults;
+
+  @override
+  Map<String, List<String>> get buildExtensions => delegate.buildExtensions;
 }
 
 /// Returns [name] if it is not in [existingNames], or return a modified version


### PR DESCRIPTION
This doesn't yet speed up the full test suite because there are a small pile of tests doing compiles that are now the slowest thing running.

Those can be refactored next :)

But, this already significantly reduces load running the suite.