### PR TITLE
Run build_runner build --workspace --only-check in CI

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -41,16 +41,16 @@ jobs:
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
-    name: "analyze_and_format; linux; PKGS: _benchmark, build, build_config, build_daemon, build_runner, build_test, builder_pkgs/build_web_compilers, builder_pkgs/scratch_space, built_types/_built_value_benchmark, built_types/_built_value_end_to_end_test, built_types/built_value, built_types/built_value_chat_example, built_types/built_value_example, built_types/built_value_generator, built_types/built_value_test, example; `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; PKGS: _benchmark, build, build_config, build_daemon, build_runner, build_test, builder_pkgs/build_web_compilers, builder_pkgs/mockito, builder_pkgs/scratch_space, built_types/_built_value_benchmark, built_types/_built_value_end_to_end_test, built_types/built_value, built_types/built_value_chat_example, built_types/built_value_example, built_types/built_value_generator, built_types/built_value_test, example; `dart analyze --fatal-infos .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:_benchmark-build-build_config-build_daemon-build_runner-build_test-builder_pkgs/build_web_compilers-builder_pkgs/scratch_space-built_types/_built_value_benchmark-built_types/_built_value_end_to_end_test-built_types/built_value-built_types/built_value_chat_example-built_types/built_value_example-built_types/built_value_generator-built_types/built_value_test-example;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:_benchmark-build-build_config-build_daemon-build_runner-build_test-builder_pkgs/build_web_compilers-builder_pkgs/mockito-builder_pkgs/scratch_space-built_types/_built_value_benchmark-built_types/_built_value_end_to_end_test-built_types/built_value-built_types/built_value_chat_example-built_types/built_value_example-built_types/built_value_generator-built_types/built_value_test-example;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:_benchmark-build-build_config-build_daemon-build_runner-build_test-builder_pkgs/build_web_compilers-builder_pkgs/scratch_space-built_types/_built_value_benchmark-built_types/_built_value_end_to_end_test-built_types/built_value-built_types/built_value_chat_example-built_types/built_value_example-built_types/built_value_generator-built_types/built_value_test-example
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:_benchmark-build-build_config-build_daemon-build_runner-build_test-builder_pkgs/build_web_compilers-builder_pkgs/mockito-builder_pkgs/scratch_space-built_types/_built_value_benchmark-built_types/_built_value_end_to_end_test-built_types/built_value-built_types/built_value_chat_example-built_types/built_value_example-built_types/built_value_generator-built_types/built_value_test-example
             os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -126,6 +126,15 @@ jobs:
         run: dart analyze --fatal-infos .
         if: "always() && steps.builder_pkgs_build_web_compilers_pub_upgrade.conclusion == 'success'"
         working-directory: builder_pkgs/build_web_compilers
+      - id: builder_pkgs_mockito_pub_upgrade
+        name: builder_pkgs/mockito; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: builder_pkgs/mockito
+      - name: "builder_pkgs/mockito; dart analyze --fatal-infos ."
+        run: dart analyze --fatal-infos .
+        if: "always() && steps.builder_pkgs_mockito_pub_upgrade.conclusion == 'success'"
+        working-directory: builder_pkgs/mockito
       - id: builder_pkgs_scratch_space_pub_upgrade
         name: builder_pkgs/scratch_space; dart pub upgrade
         run: dart pub upgrade
@@ -384,16 +393,16 @@ jobs:
         if: "always() && steps.example_pub_upgrade.conclusion == 'success'"
         working-directory: example
   job_004:
-    name: "analyze_and_format; linux; PKG: builder_pkgs/mockito; `dart run build_runner build --force-jit --only-check`, `dart analyze --fatal-infos .`"
+    name: "analyze_and_format; linux; PKG: build_runner; `dart run build_runner build --workspace --force-jit --only-check`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:builder_pkgs/mockito;commands:command_1-analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:build_runner;commands:command_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:builder_pkgs/mockito
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:build_runner
             os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -406,19 +415,15 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
-      - id: builder_pkgs_mockito_pub_upgrade
-        name: builder_pkgs/mockito; dart pub upgrade
+      - id: build_runner_pub_upgrade
+        name: build_runner; dart pub upgrade
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: builder_pkgs/mockito
-      - name: "builder_pkgs/mockito; dart run build_runner build --force-jit --only-check"
-        run: dart run build_runner build --force-jit --only-check
-        if: "always() && steps.builder_pkgs_mockito_pub_upgrade.conclusion == 'success'"
-        working-directory: builder_pkgs/mockito
-      - name: "builder_pkgs/mockito; dart analyze --fatal-infos ."
-        run: dart analyze --fatal-infos .
-        if: "always() && steps.builder_pkgs_mockito_pub_upgrade.conclusion == 'success'"
-        working-directory: builder_pkgs/mockito
+        working-directory: build_runner
+      - name: "build_runner; dart run build_runner build --workspace --force-jit --only-check"
+        run: dart run build_runner build --workspace --force-jit --only-check
+        if: "always() && steps.build_runner_pub_upgrade.conclusion == 'success'"
+        working-directory: build_runner
   job_005:
     name: "test; linux; PKG: build; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
@@ -605,6 +610,43 @@ jobs:
       - job_003
       - job_004
   job_010:
+    name: "test; linux; PKG: builder_pkgs/mockito; `dart test --test-randomize-ordering-seed=random`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:builder_pkgs/mockito;commands:test_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:builder_pkgs/mockito
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: "3.14.0-93.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+      - id: builder_pkgs_mockito_pub_upgrade
+        name: builder_pkgs/mockito; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: builder_pkgs/mockito
+      - name: "builder_pkgs/mockito; dart test --test-randomize-ordering-seed=random"
+        run: "dart test --test-randomize-ordering-seed=random"
+        if: "always() && steps.builder_pkgs_mockito_pub_upgrade.conclusion == 'success'"
+        working-directory: builder_pkgs/mockito
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_011:
     name: "test; linux; PKG: builder_pkgs/scratch_space; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -641,7 +683,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_011:
+  job_012:
     name: "test; linux; PKG: built_types/_built_value_benchmark; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -678,7 +720,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_012:
+  job_013:
     name: "test; linux; PKG: built_types/_built_value_end_to_end_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -715,7 +757,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_013:
+  job_014:
     name: "test; linux; PKG: built_types/built_value; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -752,7 +794,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_014:
+  job_015:
     name: "test; linux; PKG: built_types/built_value_chat_example; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -789,7 +831,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_015:
+  job_016:
     name: "test; linux; PKG: built_types/built_value_example; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -826,7 +868,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_016:
+  job_017:
     name: "test; linux; PKG: built_types/built_value_generator; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -863,7 +905,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_017:
+  job_018:
     name: "test; linux; PKG: built_types/built_value_test; `dart test --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -900,7 +942,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_018:
+  job_019:
     name: "test; linux; PKG: build_runner; `../tool/leak_check.sh`"
     runs-on: ubuntu-latest
     steps:
@@ -908,7 +950,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:build_runner;commands:command_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:build_runner;commands:command_1"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:build_runner
             os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev
@@ -937,7 +979,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_019:
+  job_020:
     name: "test; linux; PKG: build_runner; `dart test -t integration1 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -974,7 +1016,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_020:
+  job_021:
     name: "test; linux; PKG: build_runner; `dart test -t integration2 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1011,7 +1053,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_021:
+  job_022:
     name: "test; linux; PKG: build_runner; `dart test -t integration3 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1048,7 +1090,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_022:
+  job_023:
     name: "test; linux; PKG: build_runner; `dart test -t integration4 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1085,7 +1127,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_023:
+  job_024:
     name: "test; linux; PKG: build_runner; `dart test -x integration1 -x integration2 -x integration3 -x integration4 --test-randomize-ordering-seed=random`"
     runs-on: ubuntu-latest
     steps:
@@ -1122,15 +1164,15 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_024:
-    name: "test; linux; PKG: builder_pkgs/mockito; `dart run build_runner build --force-jit --only-check`, `dart test --test-randomize-ordering-seed=random`, `dart test --test-randomize-ordering-seed=random -p chrome`, `dart test --test-randomize-ordering-seed=random -p chrome -c dart2wasm`"
+  job_025:
+    name: "test; linux; PKG: builder_pkgs/mockito; `dart test --test-randomize-ordering-seed=random -p chrome -c dart2wasm`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:builder_pkgs/mockito;commands:command_1-test_0-test_6-test_7"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:builder_pkgs/mockito;commands:test_7"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:builder_pkgs/mockito
             os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev
@@ -1150,18 +1192,6 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: builder_pkgs/mockito
-      - name: "builder_pkgs/mockito; dart run build_runner build --force-jit --only-check"
-        run: dart run build_runner build --force-jit --only-check
-        if: "always() && steps.builder_pkgs_mockito_pub_upgrade.conclusion == 'success'"
-        working-directory: builder_pkgs/mockito
-      - name: "builder_pkgs/mockito; dart test --test-randomize-ordering-seed=random"
-        run: "dart test --test-randomize-ordering-seed=random"
-        if: "always() && steps.builder_pkgs_mockito_pub_upgrade.conclusion == 'success'"
-        working-directory: builder_pkgs/mockito
-      - name: "builder_pkgs/mockito; dart test --test-randomize-ordering-seed=random -p chrome"
-        run: "dart test --test-randomize-ordering-seed=random -p chrome"
-        if: "always() && steps.builder_pkgs_mockito_pub_upgrade.conclusion == 'success'"
-        working-directory: builder_pkgs/mockito
       - name: "builder_pkgs/mockito; dart test --test-randomize-ordering-seed=random -p chrome -c dart2wasm"
         run: "dart test --test-randomize-ordering-seed=random -p chrome -c dart2wasm"
         if: "always() && steps.builder_pkgs_mockito_pub_upgrade.conclusion == 'success'"
@@ -1171,7 +1201,44 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_025:
+  job_026:
+    name: "test; linux; PKG: builder_pkgs/mockito; `dart test --test-randomize-ordering-seed=random -p chrome`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:builder_pkgs/mockito;commands:test_6"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev;packages:builder_pkgs/mockito
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.14.0-93.0.dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: "3.14.0-93.0.dev"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+      - id: builder_pkgs_mockito_pub_upgrade
+        name: builder_pkgs/mockito; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: builder_pkgs/mockito
+      - name: "builder_pkgs/mockito; dart test --test-randomize-ordering-seed=random -p chrome"
+        run: "dart test --test-randomize-ordering-seed=random -p chrome"
+        if: "always() && steps.builder_pkgs_mockito_pub_upgrade.conclusion == 'success'"
+        working-directory: builder_pkgs/mockito
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_027:
     name: "test; macos; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: macos-latest
     steps:
@@ -1208,7 +1275,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_026:
+  job_028:
     name: "test; macos; PKG: build_runner; `dart test -t integration1 --test-randomize-ordering-seed=random`"
     runs-on: macos-latest
     steps:
@@ -1245,7 +1312,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_027:
+  job_029:
     name: "test; macos; PKG: build_runner; `dart test -t integration2 --test-randomize-ordering-seed=random`"
     runs-on: macos-latest
     steps:
@@ -1282,7 +1349,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_028:
+  job_030:
     name: "test; macos; PKG: build_runner; `dart test -t integration3 --test-randomize-ordering-seed=random`"
     runs-on: macos-latest
     steps:
@@ -1319,7 +1386,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_029:
+  job_031:
     name: "test; macos; PKG: build_runner; `dart test -t integration4 --test-randomize-ordering-seed=random`"
     runs-on: macos-latest
     steps:
@@ -1356,7 +1423,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_030:
+  job_032:
     name: "test; windows; PKG: build_daemon; `dart test --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1383,7 +1450,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_031:
+  job_033:
     name: "test; windows; PKG: build_runner; `dart test -t integration1 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1410,7 +1477,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_032:
+  job_034:
     name: "test; windows; PKG: build_runner; `dart test -t integration2 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1437,7 +1504,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_033:
+  job_035:
     name: "test; windows; PKG: build_runner; `dart test -t integration3 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:
@@ -1464,7 +1531,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_034:
+  job_036:
     name: "test; windows; PKG: build_runner; `dart test -t integration4 --test-randomize-ordering-seed=random`"
     runs-on: windows-latest
     steps:

--- a/build_runner/mono_pkg.yaml
+++ b/build_runner/mono_pkg.yaml
@@ -8,6 +8,7 @@ stages:
 - analyze_and_format:
   - format
   - analyze: --fatal-infos .
+  - command: dart run build_runner build --workspace --force-jit --only-check
 - test:
   - test: -x integration1 -x integration2 -x integration3 -x integration4 --test-randomize-ordering-seed=random
   - test: -t integration1 --test-randomize-ordering-seed=random

--- a/builder_pkgs/mockito/mono_pkg.yaml
+++ b/builder_pkgs/mockito/mono_pkg.yaml
@@ -7,12 +7,8 @@ os:
 stages:
 - analyze_and_format:
   - format
-  - group:
-    - command: dart run build_runner build --force-jit --only-check
-    - analyze: --fatal-infos .
+  - analyze: --fatal-infos .
 - test:
-  - group:
-    - command: dart run build_runner build --force-jit --only-check
-    - test: --test-randomize-ordering-seed=random
-    - test: --test-randomize-ordering-seed=random -p chrome
-    - test: --test-randomize-ordering-seed=random -p chrome -c dart2wasm
+  - test: --test-randomize-ordering-seed=random
+  - test: --test-randomize-ordering-seed=random -p chrome
+  - test: --test-randomize-ordering-seed=random -p chrome -c dart2wasm

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -68,12 +68,12 @@ for PKG in ${PKGS}; do
         dart analyze --fatal-infos . || EXIT_CODE=$?
         ;;
       command_0)
-        echo '../tool/leak_check.sh'
-        ../tool/leak_check.sh || EXIT_CODE=$?
+        echo 'dart run build_runner build --workspace --force-jit --only-check'
+        dart run build_runner build --workspace --force-jit --only-check || EXIT_CODE=$?
         ;;
       command_1)
-        echo 'dart run build_runner build --force-jit --only-check'
-        dart run build_runner build --force-jit --only-check || EXIT_CODE=$?
+        echo '../tool/leak_check.sh'
+        ../tool/leak_check.sh || EXIT_CODE=$?
         ;;
       format)
         echo 'dart format --output=none --set-exit-if-changed .'


### PR DESCRIPTION
Remove the run from mockito; we can verify all generated files in the repo in one go.

Needed in particular for built_value's end to end tests.