### PR TITLE
Assign currentBuildResult on early exit in BuildSeries.run

### DIFF
--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -237,6 +237,7 @@ class BuildSeries {
           .checkCompileFreshness(digestsAreFresh: false);
       if (!kernelFreshness.outputIsFresh) {
         final result = BuildResult.buildScriptChanged();
+        _currentBuildResult = Future.value(result);
         _buildResultsController.add(result);
         await close();
         return result;
@@ -249,6 +250,7 @@ class BuildSeries {
       // needs a restart to change the build script.
       if (_buildPlan.buildSpec.restartIsNeeded) {
         final result = BuildResult.buildScriptChanged();
+        _currentBuildResult = Future.value(result);
         _buildResultsController.add(result);
         await close();
         return result;

--- a/build_runner/test/build/build_series_test.dart
+++ b/build_runner/test/build/build_series_test.dart
@@ -346,5 +346,29 @@ void main() {
         expect(secondResult.outputs, contains(outputId));
       });
     });
+
+    group('currentBuildResult', () {
+      test('completes with early exit result when build configuration requires '
+          'restart', () async {
+        final planWithBuilderDefinitions = await loadPlan(
+          TestingOverrides(
+            builderDefinitions: [
+              BuilderDefinition('extra:builder', outputsToArtifactTree: false),
+            ].build(),
+            readerWriter: readerWriter,
+            buildPackages: buildPackages,
+            checkBuilderFreshness: false,
+          ),
+        );
+        final series = BuildSeries(planWithBuilderDefinitions);
+        final configId = AssetId('a', 'build.yaml');
+        final result = await series.run({
+          configId,
+        }, recentlyBootstrapped: false);
+
+        expect(result.failureType, FailureType.buildScriptChanged);
+        expect(await series.currentBuildResult, result);
+      });
+    });
   });
 }


### PR DESCRIPTION
Not visible in practice, but code health: don't leave a hanging future.

Found via contract programming experiment.