### PR TITLE
Fully handle deletions of unread inputs.

### DIFF
--- a/build_runner/CHANGELOG.md
+++ b/build_runner/CHANGELOG.md
@@ -13,6 +13,8 @@
   imported files.
 - Bug fix: complete the active building future in daemon mode when the build
   script is updated, preventing asset server requests from hanging.
+- Bug fix: handle deletions of unread sources during watch, serve, and
+  daemon modes.
 
 ## 2.16.1
 

--- a/build_runner/lib/src/build/build_series.dart
+++ b/build_runner/lib/src/build/build_series.dart
@@ -154,12 +154,17 @@ class BuildSeries {
 
       // Changes to files that are part of the build.
 
-      // If not copying to a merged output directory, ignore changes to sources
-      // with no outputs.
+      // If not copying to a merged output directory, ignore modifications to
+      // sources with no outputs.
       if (!_buildPlan.buildSpec.buildOptions.anyMergedOutputDirectory &&
           previousBuild.isSource(id) &&
           previousBuild.digestOf(id) == null) {
-        rejected.add(change);
+        // If its existence was tracked, removal invalidates the build.
+        if (change.type == .REMOVE && previousBuild.wasTrackedInput(id)) {
+          accepted.add(change);
+        } else {
+          rejected.add(change);
+        }
         continue;
       }
 
@@ -170,7 +175,7 @@ class BuildSeries {
         continue;
       }
 
-      // It's an add of a "missing source" or a deletion of an input.
+      // It's a deletion of an input or an update.
       accepted.add(change);
     }
 

--- a/build_runner/lib/src/build/build_state/asset_graph_json.dart
+++ b/build_runner/lib/src/build/build_state/asset_graph_json.dart
@@ -100,5 +100,5 @@ class AssetGraphJson {
 }
 
 /// Increment whenever older `asset_graph.json` files should be rejected.
-const _version = 47;
+const _version = 48;
 final jsonUtf8 = json.fuse(utf8);

--- a/build_runner/lib/src/build/build_state/build_state.dart
+++ b/build_runner/lib/src/build/build_state/build_state.dart
@@ -26,7 +26,7 @@ import 'post_process_build_step_result.dart';
 /// [IncrementalBuildState] and [FinishedBuildState] for serialization and
 /// follow-on incremental builds.
 ///
-/// - Sources and their digests; missing sources.
+/// - Sources and their digests.
 /// - Glob results.
 /// - Build step results.
 /// - Post process build step results.
@@ -36,9 +36,6 @@ class BuildState {
 
   /// Sources.
   final Set<AssetId> _sources;
-
-  /// Sources that were missing when a builder tried to access them.
-  final Set<AssetId> _missingSources;
 
   /// Contents of sources and outputs populated during the build.
   final Map<AssetId, AssetContent> _contents;
@@ -60,7 +57,6 @@ class BuildState {
     required this.buildStepPlan,
     required Map<AssetId, AssetContent?> sources,
   }) : _sources = sources.keys.toSet(),
-       _missingSources = {},
        _contents = {
          for (final entry in sources.entries)
            if (entry.value != null) entry.key: entry.value!,
@@ -95,9 +91,6 @@ class BuildState {
 
   /// Whether [id] is a source file.
   bool isSource(AssetId id) => _sources.contains(id);
-
-  /// Whether [id] is a source file that was accessed but did not exist.
-  bool isMissingSource(AssetId id) => _missingSources.contains(id);
 
   /// Whether [id] is one of: source, declared output or actual post process
   /// output.
@@ -172,9 +165,7 @@ class BuildState {
 
   @visibleForTesting
   IncrementalBuildState toIncrementalBuildState() {
-    final builder = IncrementalBuildStateBuilder()
-      ..sources.addAll(_sources)
-      ..missingSources.addAll(_missingSources);
+    final builder = IncrementalBuildStateBuilder()..sources.addAll(_sources);
 
     for (final entry in _contents.entries) {
       builder.digests[entry.key] = entry.value.digest;
@@ -211,14 +202,6 @@ class BuildState {
       contents: _contents.build(),
     );
   }
-
-  // -- Missing sources.
-
-  /// Adds a source that a builder tried to access but was missing.
-  ///
-  /// The builder must check and find there is no declared output or
-  /// source before calling this.
-  void addMissingSource(AssetId id) => _missingSources.add(id);
 
   // -- Build steps.
 

--- a/build_runner/lib/src/build/build_state/incremental_build_state.dart
+++ b/build_runner/lib/src/build/build_state/incremental_build_state.dart
@@ -25,7 +25,6 @@ abstract class IncrementalBuildState
 
   BuiltSet<AssetId> get sources;
   BuiltMap<AssetId, Digest> get digests;
-  BuiltSet<AssetId> get missingSources;
   BuiltMap<BuildStepId, BuildStepResult> get buildStepResults;
   BuiltMap<PostProcessBuildStepId, PostProcessBuildStepResult>
   get postProcessResults;

--- a/build_runner/lib/src/build/build_state/incremental_build_state.g.dart
+++ b/build_runner/lib/src/build/build_state/incremental_build_state.g.dart
@@ -41,13 +41,6 @@ class _$IncrementalBuildStateSerializer
           const FullType(Digest),
         ]),
       ),
-      'missingSources',
-      serializers.serialize(
-        object.missingSources,
-        specifiedType: const FullType(BuiltSet, const [
-          const FullType(AssetId),
-        ]),
-      ),
       'buildStepResults',
       serializers.serialize(
         object.buildStepResults,
@@ -113,17 +106,6 @@ class _$IncrementalBuildStateSerializer
             )!,
           );
           break;
-        case 'missingSources':
-          result.missingSources.replace(
-            serializers.deserialize(
-                  value,
-                  specifiedType: const FullType(BuiltSet, const [
-                    const FullType(AssetId),
-                  ]),
-                )!
-                as BuiltSet<Object?>,
-          );
-          break;
         case 'buildStepResults':
           result.buildStepResults.replace(
             serializers.deserialize(
@@ -170,8 +152,6 @@ class _$IncrementalBuildState extends IncrementalBuildState {
   @override
   final BuiltMap<AssetId, Digest> digests;
   @override
-  final BuiltSet<AssetId> missingSources;
-  @override
   final BuiltMap<BuildStepId, BuildStepResult> buildStepResults;
   @override
   final BuiltMap<PostProcessBuildStepId, PostProcessBuildStepResult>
@@ -186,7 +166,6 @@ class _$IncrementalBuildState extends IncrementalBuildState {
   _$IncrementalBuildState._({
     required this.sources,
     required this.digests,
-    required this.missingSources,
     required this.buildStepResults,
     required this.postProcessResults,
     required this.globResults,
@@ -206,7 +185,6 @@ class _$IncrementalBuildState extends IncrementalBuildState {
     return other is IncrementalBuildState &&
         sources == other.sources &&
         digests == other.digests &&
-        missingSources == other.missingSources &&
         buildStepResults == other.buildStepResults &&
         postProcessResults == other.postProcessResults &&
         globResults == other.globResults;
@@ -217,7 +195,6 @@ class _$IncrementalBuildState extends IncrementalBuildState {
     var _$hash = 0;
     _$hash = $jc(_$hash, sources.hashCode);
     _$hash = $jc(_$hash, digests.hashCode);
-    _$hash = $jc(_$hash, missingSources.hashCode);
     _$hash = $jc(_$hash, buildStepResults.hashCode);
     _$hash = $jc(_$hash, postProcessResults.hashCode);
     _$hash = $jc(_$hash, globResults.hashCode);
@@ -230,7 +207,6 @@ class _$IncrementalBuildState extends IncrementalBuildState {
     return (newBuiltValueToStringHelper(r'IncrementalBuildState')
           ..add('sources', sources)
           ..add('digests', digests)
-          ..add('missingSources', missingSources)
           ..add('buildStepResults', buildStepResults)
           ..add('postProcessResults', postProcessResults)
           ..add('globResults', globResults))
@@ -251,12 +227,6 @@ class IncrementalBuildStateBuilder
       _$this._digests ??= MapBuilder<AssetId, Digest>();
   set digests(MapBuilder<AssetId, Digest>? digests) =>
       _$this._digests = digests;
-
-  SetBuilder<AssetId>? _missingSources;
-  SetBuilder<AssetId> get missingSources =>
-      _$this._missingSources ??= SetBuilder<AssetId>();
-  set missingSources(SetBuilder<AssetId>? missingSources) =>
-      _$this._missingSources = missingSources;
 
   MapBuilder<BuildStepId, BuildStepResult>? _buildStepResults;
   MapBuilder<BuildStepId, BuildStepResult> get buildStepResults =>
@@ -288,7 +258,6 @@ class IncrementalBuildStateBuilder
     if ($v != null) {
       _sources = $v.sources.toBuilder();
       _digests = $v.digests.toBuilder();
-      _missingSources = $v.missingSources.toBuilder();
       _buildStepResults = $v.buildStepResults.toBuilder();
       _postProcessResults = $v.postProcessResults.toBuilder();
       _globResults = $v.globResults.toBuilder();
@@ -318,7 +287,6 @@ class IncrementalBuildStateBuilder
           _$IncrementalBuildState._(
             sources: sources.build(),
             digests: digests.build(),
-            missingSources: missingSources.build(),
             buildStepResults: buildStepResults.build(),
             postProcessResults: postProcessResults.build(),
             globResults: globResults.build(),
@@ -330,8 +298,6 @@ class IncrementalBuildStateBuilder
         sources.build();
         _$failedField = 'digests';
         digests.build();
-        _$failedField = 'missingSources';
-        missingSources.build();
         _$failedField = 'buildStepResults';
         buildStepResults.build();
         _$failedField = 'postProcessResults';

--- a/build_runner/lib/src/build/builder_filesystem.dart
+++ b/build_runner/lib/src/build/builder_filesystem.dart
@@ -161,7 +161,6 @@ class BuilderFilesystem {
 
     if (Placeholders.isPlaceholderPath(id.path)) return false;
     if (!buildState.isKnownAsset(id)) {
-      buildState.addMissingSource(id);
       return false;
     }
 
@@ -233,9 +232,6 @@ class BuilderFilesystem {
   /// empty string is returned for its content.
   Future<PhasedValue<String>> readPhased(int phase, AssetId id) async {
     if (!buildState.isKnownAsset(id)) {
-      buildState.addMissingSource(id);
-      return PhasedValue.fixed('');
-    } else if (buildState.isMissingSource(id)) {
       return PhasedValue.fixed('');
     }
 

--- a/build_runner/lib/src/build_plan/previous_build.dart
+++ b/build_runner/lib/src/build_plan/previous_build.dart
@@ -61,8 +61,6 @@ abstract class PreviousBuild
       incrementalState?.sources ?? BuiltSet<AssetId>();
   BuiltMap<AssetId, Digest> get digests =>
       incrementalState?.digests ?? BuiltMap<AssetId, Digest>();
-  BuiltSet<AssetId> get missingSources =>
-      incrementalState?.missingSources ?? BuiltSet<AssetId>();
   BuiltMap<BuildStepId, BuildStepResult> get buildStepResults =>
       incrementalState?.buildStepResults ??
       BuiltMap<BuildStepId, BuildStepResult>();
@@ -84,8 +82,22 @@ abstract class PreviousBuild
     return builder.build();
   }
 
+  @memoized
+  BuiltSet<AssetId> get trackedInputs {
+    final builder = SetBuilder<AssetId>();
+    for (final result in buildStepResults.values) {
+      builder.addAll(result.inputs);
+    }
+    for (final result in globResults.values) {
+      builder.addAll(result.inputs);
+    }
+    return builder.build();
+  }
+
   bool isSource(AssetId id) => sources.contains(id);
-  bool isMissingSource(AssetId id) => missingSources.contains(id);
+
+  /// Whether [id] was tracked as an input to any build step or glob.
+  bool wasTrackedInput(AssetId id) => trackedInputs.contains(id);
 
   BuildStepResult? stepResultOrNull(BuildStepId step) => buildStepResults[step];
   BuildStepResult stepResult(BuildStepId step) => stepResultOrNull(step)!;

--- a/build_runner/lib/src/build_plan/previous_build.g.dart
+++ b/build_runner/lib/src/build_plan/previous_build.g.dart
@@ -22,6 +22,7 @@ class _$PreviousBuild extends PreviousBuild {
   @override
   final BuiltList<AssetId> incompatibleBuildOutputsToDelete;
   BuiltMap<AssetId, PostProcessBuildStepId>? __postProcessOutputs;
+  BuiltSet<AssetId>? __trackedInputs;
 
   factory _$PreviousBuild([void Function(PreviousBuildBuilder)? updates]) =>
       (PreviousBuildBuilder()..update(updates))._build();
@@ -38,6 +39,9 @@ class _$PreviousBuild extends PreviousBuild {
   @override
   BuiltMap<AssetId, PostProcessBuildStepId> get postProcessOutputs =>
       __postProcessOutputs ??= super.postProcessOutputs;
+  @override
+  BuiltSet<AssetId> get trackedInputs =>
+      __trackedInputs ??= super.trackedInputs;
 
   @override
   PreviousBuild rebuild(void Function(PreviousBuildBuilder) updates) =>

--- a/build_runner/test/build/build_series_test.dart
+++ b/build_runner/test/build/build_series_test.dart
@@ -9,6 +9,8 @@ import 'package:build_runner/src/build/build_series.dart';
 import 'package:build_runner/src/build/build_state/asset_graph_json.dart';
 import 'package:build_runner/src/build/build_state/build_state.dart';
 import 'package:build_runner/src/build/build_state/build_step_result.dart';
+import 'package:build_runner/src/build/build_state/glob_id.dart';
+import 'package:build_runner/src/build/build_state/glob_result.dart';
 import 'package:build_runner/src/build/library_cycle_graph/phased_asset_deps.dart';
 import 'package:build_runner/src/build_plan/build_options.dart';
 import 'package:build_runner/src/build_plan/build_package.dart';
@@ -22,6 +24,7 @@ import 'package:build_runner/src/commands/watch/asset_change.dart';
 import 'package:build_runner/src/constants.dart';
 import 'package:build_runner/src/io/reader_writer.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 
@@ -111,6 +114,60 @@ void main() {
         expect(filtered.accepted, isEmpty);
         expect(filtered.rejected, [change]);
       });
+
+      test(
+        'accepts removal of unread source whose existence was tracked',
+        () async {
+          final unreadSourceId = AssetId('a', 'lib/no_outputs.txt');
+          await readerWriter.writeAsString(unreadSourceId, '// no outputs');
+          final globId = GlobId(
+            package: 'a',
+            glob: 'lib/*.txt',
+            phaseNumber: 0,
+          );
+          final globResult = GlobResult(
+            (b) => b
+              ..inputs.add(unreadSourceId)
+              ..results.add(unreadSourceId)
+              ..digest = Digest([]),
+          );
+          final buildState = BuildState(
+            buildStepPlan: buildPlan.buildStepPlan,
+            sources: {assetId: null, unreadSourceId: null},
+          );
+          buildState.updateGlobResult(globId, globResult);
+          await writeBuildStateAndPlan(buildState, buildPlan);
+          final loadedPlan = await loadPlan();
+          final buildSeries = BuildSeries(loadedPlan);
+
+          final change = AssetChange(unreadSourceId, ChangeType.REMOVE);
+          final filtered = await buildSeries.filterChanges([change]);
+
+          expect(filtered.accepted, [change]);
+          expect(filtered.rejected, isEmpty);
+        },
+      );
+
+      test(
+        'rejects removal of unread source whose existence was not tracked',
+        () async {
+          final unreadSourceId = AssetId('a', 'lib/no_outputs.txt');
+          await readerWriter.writeAsString(unreadSourceId, '// no outputs');
+          final buildState = BuildState(
+            buildStepPlan: buildPlan.buildStepPlan,
+            sources: {assetId: null, unreadSourceId: null},
+          );
+          await writeBuildStateAndPlan(buildState, buildPlan);
+          final loadedPlan = await loadPlan();
+          final buildSeries = BuildSeries(loadedPlan);
+
+          final change = AssetChange(unreadSourceId, ChangeType.REMOVE);
+          final filtered = await buildSeries.filterChanges([change]);
+
+          expect(filtered.accepted, isEmpty);
+          expect(filtered.rejected, [change]);
+        },
+      );
 
       test('accepts change to read source', () async {
         final buildState = BuildState(

--- a/build_runner/test/build/build_test.dart
+++ b/build_runner/test/build/build_test.dart
@@ -1470,7 +1470,7 @@ targets:
         resumeFrom: result,
       );
 
-      /// Should be deleted using the writer, and converted to missingSource.
+      /// Should be deleted using the writer.
       final newBuildState = AssetGraphJson.deserialize(
         result.readerWriter.testing.readBytes(
           makeAssetId('a|$assetGraphJsonPath'),

--- a/build_runner/test/common/fixture_packages.dart
+++ b/build_runner/test/common/fixture_packages.dart
@@ -27,9 +27,10 @@ class FixturePackages {
     String appliesBuilders = '[]',
     List<String> pathDependencies = const [],
     bool delayAtBuildStart = false,
+    String? defaultGlob,
   }) => FixturePackage(
     name: packageName,
-    dependencies: ['build', 'build_runner'],
+    dependencies: ['build', 'build_runner', 'glob'],
     pathDependencies: pathDependencies,
     files: {
       'build.yaml':
@@ -42,23 +43,27 @@ builders:
     auto_apply: ${applyToAllPackages ? 'all_packages' : 'root_package'}
     build_to: ${buildToCache ? 'cache' : 'source'}
     applies_builders: $appliesBuilders
+${defaultGlob != null ? '    defaults:\n      options:\n        glob: "$defaultGlob"' : ''}
 ''',
       'lib/builder.dart':
           '''
 import 'package:build/build.dart';
+import 'package:glob/glob.dart';
 
 Builder testBuilderFactory(BuilderOptions options) => TestBuilder(
       options.config['copy_from'] == null
           ? null
           : AssetId.parse(options.config['copy_from'] as String),
       options.config['extra_content'] as Object? ?? '',
+      options.config['glob'] as String?,
     );
 
 class TestBuilder implements Builder {
   final AssetId? otherInput;
   final Object extraContent;
+  final String? glob;
 
-  TestBuilder(this.otherInput, this.extraContent);
+  TestBuilder(this.otherInput, this.extraContent, [this.glob]);
 
   @override
   Map<String, List<String>> get buildExtensions
@@ -67,10 +72,19 @@ class TestBuilder implements Builder {
   @override
   Future<void> build(BuildStep buildStep) async {
 ${delayAtBuildStart ? 'await Future.delayed(Duration(seconds: 1));' : ''}
+    final globAssets = glob == null
+        ? <String>[]
+        : ([
+            await for (final asset in buildStep.findAssets(Glob(glob!)))
+              asset.path,
+          ]..sort());
+    final globSuffix =
+        globAssets.isEmpty ? '' : '\\n' + globAssets.join('\\n');
     await buildStep.writeAsString(
         buildStep.inputId.addExtension('$outputExtension'),
         await buildStep.readAsString(otherInput ?? buildStep.inputId) +
-            '\$extraContent',
+            '\$extraContent' +
+            globSuffix,
     );
   }
 }

--- a/build_runner/test/integration_tests/watch_command_test.dart
+++ b/build_runner/test/integration_tests/watch_command_test.dart
@@ -15,12 +15,14 @@ void main() async {
     final pubspecs = await Pubspecs.load();
     final tester = BuildRunnerTester(pubspecs);
 
-    tester.writeFixturePackage(FixturePackages.copyBuilder());
+    tester.writeFixturePackage(
+      FixturePackages.copyBuilder(defaultGlob: 'web/*.md'),
+    );
     tester.writePackage(
       name: 'root_pkg',
       dependencies: ['build_runner'],
       pathDependencies: ['builder_pkg', 'other_pkg'],
-      files: {'web/a.txt': 'a'},
+      files: {'web/a.txt': 'a', 'web/unread.md': 'unread'},
     );
     tester.writePackage(
       name: 'other_pkg',
@@ -35,12 +37,12 @@ void main() async {
       'dart run build_runner watch --force-jit',
     );
     await watch.expect(BuildLog.successPattern);
-    expect(tester.read('root_pkg/web/a.txt.copy'), 'a');
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'a\nweb/unread.md');
 
     // File change.
     tester.write('root_pkg/web/a.txt', 'updated');
     await watch.expect(BuildLog.successPattern);
-    expect(tester.read('root_pkg/web/a.txt.copy'), 'updated');
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'updated\nweb/unread.md');
 
     // File rewrite without change.
     tester.write('root_pkg/web/a.txt', 'updated');
@@ -56,7 +58,7 @@ void main() async {
     // New file.
     tester.write('root_pkg/web/b.txt', 'b');
     await watch.expect(BuildLog.successPattern);
-    expect(tester.read('root_pkg/web/b.txt.copy'), 'b');
+    expect(tester.read('root_pkg/web/b.txt.copy'), 'b\nweb/unread.md');
 
     // State on disk is updated so `build` knows to do nothing.
     output = await tester.copyWorkspace().run(
@@ -69,6 +71,11 @@ void main() async {
     tester.delete('root_pkg/web/b.txt');
     await watch.expect(BuildLog.successPattern);
     expect(tester.read('root_pkg/web/b.txt.copy'), null);
+
+    // Deleted unread file.
+    tester.delete('root_pkg/web/unread.md');
+    await watch.expect(BuildLog.successPattern);
+    expect(tester.read('root_pkg/web/a.txt.copy'), 'updated');
 
     // Deleted output.
     tester.delete('root_pkg/web/a.txt.copy');


### PR DESCRIPTION
Handle deletions of unread inputs in watch, serve, and daemon modes.

A file can be an input and unread if it was matched by a glob.

Previously, watch and daemon modes skipped rebuilds on removals of unread inputs without checking whether those sources had been matched by glob evaluations.

Fix by checking whether deleted files were tracked inputs in the previous build.

Remove `missingSources`; it's replaced by the new more correct tracking.

This was found via the contract programming experiment. The fix ended up leading to an unexpected amount of iteration on the design--starting from my idea "expand missingSources concept and use it for both positive and negative results" but finally landing on "you can remove missingSources altogether" :)