### PR TITLE
Enable auto-publishing for built_types packages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,6 @@ jobs:
     with:
       write-comments: false
       sdk: dev
-      ignore-packages: 'built_types/**'
     permissions:
       id-token: write
       pull-requests: write


### PR DESCRIPTION
Remove ignore-packages from .github/workflows/publish.yaml so built_value, built_value_generator, and built_value_test are included in package validation and auto-publishing.