### PR TITLE
Revert unreleased 6.0 changes to built_collection

### DIFF
--- a/built_types/built_collection/CHANGELOG.md
+++ b/built_types/built_collection/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## 6.0.0-wip
-
-- Remove `from` constructor from `BuiltList`.
-- Add `of` constructors to `ListBuilder` and `SetBuilder`.
-
 ## 5.1.1
 
 - Test fix for new analyzer hint.

--- a/built_types/built_collection/lib/src/internal/null_safety.dart
+++ b/built_types/built_collection/lib/src/internal/null_safety.dart
@@ -1,2 +1,2 @@
 /// Whether runtime sound mode is enabled.
-const bool isSoundMode = <int?>[] is! List<int>;
+final bool isSoundMode = <int?>[] is! List<int>;

--- a/built_types/built_collection/lib/src/list/built_list.dart
+++ b/built_types/built_collection/lib/src/list/built_list.dart
@@ -18,7 +18,11 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   int? _hashCode;
 
   /// Instantiates with elements from an [Iterable].
-  factory BuiltList([Iterable iterable = const []]) {
+  factory BuiltList([Iterable iterable = const []]) =>
+      BuiltList<E>.from(iterable);
+
+  /// Instantiates with elements from an [Iterable].
+  factory BuiltList.from(Iterable iterable) {
     if (iterable is _BuiltList && iterable.hasExactElementType(E)) {
       return iterable as BuiltList<E>;
     } else {
@@ -44,7 +48,7 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   /// Converts to a [ListBuilder] for modification.
   ///
   /// The `BuiltList` remains immutable and can continue to be used.
-  ListBuilder<E> toBuilder() => ListBuilder<E>.of(this);
+  ListBuilder<E> toBuilder() => ListBuilder<E>(this);
 
   /// Converts to a [ListBuilder], applies updates to it, and builds.
   BuiltList<E> rebuild(Function(ListBuilder<E>) updates) =>

--- a/built_types/built_collection/lib/src/list/list_builder.dart
+++ b/built_types/built_collection/lib/src/list/list_builder.dart
@@ -15,11 +15,6 @@ class ListBuilder<E> {
   late List<E> _list;
   _BuiltList<E>? _listOwner;
 
-  /// Instantiates with elements from an [Iterable<E>].
-  factory ListBuilder.of(Iterable<E> iterable) {
-    return ListBuilder<E>._uninitialized().._replaceOf(iterable);
-  }
-
   /// Instantiates with elements from an [Iterable].
   factory ListBuilder([Iterable iterable = const []]) {
     return ListBuilder<E>._uninitialized()..replace(iterable);
@@ -47,15 +42,6 @@ class ListBuilder<E> {
       _setOwner(iterable);
     } else {
       _setSafeList(List<E>.from(iterable));
-    }
-  }
-
-  /// Replaces all elements with elements from an [Iterable<E>].
-  void _replaceOf(Iterable<E> iterable) {
-    if (iterable is _BuiltList<E>) {
-      _setOwner(iterable);
-    } else {
-      _setSafeList(List<E>.of(iterable));
     }
   }
 

--- a/built_types/built_collection/lib/src/set/set_builder.dart
+++ b/built_types/built_collection/lib/src/set/set_builder.dart
@@ -17,11 +17,6 @@ class SetBuilder<E> {
   late Set<E> _set;
   _BuiltSet<E>? _setOwner;
 
-  /// Instantiates with elements from an [Iterable<E>].
-  factory SetBuilder.of(Iterable<E> iterable) {
-    return SetBuilder<E>._uninitialized().._replaceOf(iterable);
-  }
-
   /// Instantiates with elements from an [Iterable].
   factory SetBuilder([Iterable iterable = const []]) {
     return SetBuilder<E>._uninitialized()..replace(iterable);
@@ -56,15 +51,6 @@ class SetBuilder<E> {
         }
       }
       _setSafeSet(set);
-    }
-  }
-
-  /// Replaces all elements with elements from an [Iterable<E>].
-  void _replaceOf(Iterable<E> iterable) {
-    if (iterable is _BuiltSet<E> && iterable._setFactory == _setFactory) {
-      _withOwner(iterable);
-    } else {
-      _setSafeSet(_createSet()..addAll(iterable));
     }
   }
 

--- a/built_types/built_collection/pubspec.yaml
+++ b/built_types/built_collection/pubspec.yaml
@@ -1,13 +1,13 @@
 name: built_collection
-version: 6.0.0-wip
+version: 5.1.1
 description: >
   Immutable collections based on the SDK collections. Each SDK collection class
   is split into a new immutable collection class and a corresponding mutable
   builder class.
-repository: https://github.com/google/built_collection.dart
+homepage: https://github.com/google/built_collection.dart
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.4.0

--- a/built_types/built_collection/test/list/list_builder_test.dart
+++ b/built_types/built_collection/test/list/list_builder_test.dart
@@ -219,10 +219,6 @@ void main() {
       expect((ListBuilder<int>()..replace([0, 1, 2])).build(), [0, 1, 2]);
     });
 
-    test('can be created with .of constructor', () {
-      expect(ListBuilder.of([1, 2, 3]).build(), [1, 2, 3]);
-    });
-
     // Lazy copies.
 
     test('does not mutate BuiltList when modifying ListBuilder assign', () {

--- a/built_types/built_collection/test/set/set_builder_test.dart
+++ b/built_types/built_collection/test/set/set_builder_test.dart
@@ -123,10 +123,6 @@ void main() {
       expect(builder.build(), orderedEquals([2, 0, 1]));
     });
 
-    test('can be created with .of constructor', () {
-      expect(SetBuilder.of([1, 2, 3]).build(), {1, 2, 3});
-    });
-
     // Lazy copies.
 
     test('does not mutate BuiltSet following reuse of underlying Set', () {


### PR DESCRIPTION
Revert unreleased 6.0 changes to built_collection

Restore built_collection to the exact released v5.1.1 source tree:
- Revert removal of BuiltList.from
- Revert addition of ListBuilder.of and SetBuilder.of
- Restore BuiltList.toBuilder implementation
- Reset version to 5.1.1 in pubspec.yaml and remove 6.0 section from CHANGELOG.md

These are unreleased changes that only landed in google3; will need to reconsider what to actually land+release, for now the workspace forces compatible versions, which is probably for the best.