### PR TITLE
Allow hyphens in package names.

### DIFF
--- a/build/CHANGELOG.md
+++ b/build/CHANGELOG.md
@@ -4,6 +4,7 @@
   to a library. Additions are collected from all builders and written to a
   single shared part file per library. Experimental, may change following
   feedback and discussion at https://github.com/dart-lang/build/discussions.
+- `AssetId` no longer rejects hyphens in package names.
 
 ## 4.0.12-wip
 

--- a/build/lib/src/asset_id.dart
+++ b/build/lib/src/asset_id.dart
@@ -166,4 +166,4 @@ Uri _constructUri(AssetId id) {
   return Uri(scheme: scheme, pathSegments: [id.package, ...pathSegments]);
 }
 
-final _packageRegExp = RegExp(r'^([a-zA-Z0-9_$]+(\.[a-zA-Z0-9_$]+)*)?$');
+final _packageRegExp = RegExp(r'^([a-zA-Z0-9_$-]+(\.[a-zA-Z0-9_$-]+)*)?$');

--- a/build/test/asset_id_test.dart
+++ b/build/test/asset_id_test.dart
@@ -16,7 +16,9 @@ void main() {
       expect(() => AssetId('a.', 'a'), throwsArgumentError);
       expect(() => AssetId('a/b', 'a'), throwsArgumentError);
       expect(() => AssetId('a\\b', 'a'), throwsArgumentError);
-      expect(() => AssetId('a-b', 'a'), throwsArgumentError);
+      // Hyphens are not valid in published packages but are allowed for
+      // google3.
+      expect(AssetId('a-b', 'a').package, 'a-b');
 
       // Dots are valid in package names, just not in published packages.
       expect(AssetId('a.b', 'a').package, 'a.b');


### PR DESCRIPTION
Unblocks rolling to google3.