### PR TITLE
Built types lints

### DIFF
--- a/built_types/_built_collection_benchmark/analysis_options.yaml
+++ b/built_types/_built_collection_benchmark/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/built_types/_built_collection_benchmark/lib/benchmark.dart
+++ b/built_types/_built_collection_benchmark/lib/benchmark.dart
@@ -23,14 +23,14 @@ class BuiltCollectionBenchmark {
   }
 
   Future<void> benchmarkListBuilder() async {
-    for (var entry in listBuilderFunctions.entries) {
-      var name = entry.key;
-      var function = entry.value;
+    for (final entry in listBuilderFunctions.entries) {
+      final name = entry.key;
+      final function = entry.value;
 
-      Iterable<int> list = List<int>.generate(1000, (x) => x);
-      var fastLazyIterable = list.map((x) => x + 1);
-      var slowLazyIterable = list.map(_shortDelay);
-      var builderFactory = () => ListBuilder<int>()..addAll(list);
+      final Iterable<int> list = List<int>.generate(1000, (x) => x);
+      final fastLazyIterable = list.map((x) => x + 1);
+      final slowLazyIterable = list.map(_shortDelay);
+      final builderFactory = () => ListBuilder<int>()..addAll(list);
 
       _benchmark('ListBuilder.$name,list', function, builderFactory, list);
       _benchmark(
@@ -49,14 +49,14 @@ class BuiltCollectionBenchmark {
   }
 
   Future<void> benchmarkSetBuilder() async {
-    for (var entry in setBuilderFunctions.entries) {
-      var name = entry.key;
-      var function = entry.value;
+    for (final entry in setBuilderFunctions.entries) {
+      final name = entry.key;
+      final function = entry.value;
 
-      Iterable<int> list = List<int>.generate(1000, (x) => x);
-      var fastLazyIterable = list.map((x) => x + 1);
-      var slowLazyIterable = list.map(_shortDelay);
-      var builderFactory = () => SetBuilder<int>();
+      final Iterable<int> list = List<int>.generate(1000, (x) => x);
+      final fastLazyIterable = list.map((x) => x + 1);
+      final slowLazyIterable = list.map(_shortDelay);
+      final builderFactory = SetBuilder<int>.new;
 
       _benchmark('SetBuilder.$name,list', function, builderFactory, list);
       _benchmark(
@@ -81,15 +81,15 @@ void _benchmark<B, D>(
   B Function() builderFactory,
   D data,
 ) {
-  var counts = <int>[];
+  final counts = <int>[];
 
   /// Run four times; first is to warm up, remaining three are reported.
   for (var runs = 0; runs != 4; ++runs) {
     /// Run for one second and count how many iterations are completed.
-    var stopwatch = Stopwatch()..start();
+    final stopwatch = Stopwatch()..start();
     var count = 0;
     while (stopwatch.elapsedMilliseconds < 1000) {
-      var builder = builderFactory();
+      final builder = builderFactory();
       for (var j = 0; j != 100; ++j) {
         function(builder, data);
       }

--- a/built_types/_built_collection_benchmark/pubspec.yaml
+++ b/built_types/_built_collection_benchmark/pubspec.yaml
@@ -14,4 +14,4 @@ dev_dependencies:
   build_runner: '>=1.0.0 <3.0.0'
   build_test: any
   build_web_compilers: any
-  pedantic: ^1.4.0
+  dart_flutter_team_lints: ^3.1.0

--- a/built_types/_built_value_benchmark/analysis_options.yaml
+++ b/built_types/_built_value_benchmark/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/built_types/_built_value_benchmark/lib/benchmark.dart
+++ b/built_types/_built_value_benchmark/lib/benchmark.dart
@@ -2,8 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'package:_built_value_benchmark/node.dart';
-import 'package:_built_value_benchmark/simple_value.dart';
+import 'node.dart';
+import 'simple_value.dart';
 
 void benchmark() {
   benchmarkHashCode();

--- a/built_types/_built_value_benchmark/lib/node.dart
+++ b/built_types/_built_value_benchmark/lib/node.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library node;
+library;
 
 import 'package:built_value/built_value.dart';
 

--- a/built_types/_built_value_benchmark/lib/simple_value.dart
+++ b/built_types/_built_value_benchmark/lib/simple_value.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library simple_value;
+library;
 
 import 'package:built_value/built_value.dart';
 

--- a/built_types/_built_value_benchmark/pubspec.yaml
+++ b/built_types/_built_value_benchmark/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
 dev_dependencies:
   build_runner: '>=1.0.0 <3.0.0'
   built_value_generator: ^8.13.0
-  pedantic: ^1.4.0
+  dart_flutter_team_lints: ^3.1.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.0.0

--- a/built_types/_built_value_end_to_end_test/analysis_options.yaml
+++ b/built_types/_built_value_end_to_end_test/analysis_options.yaml
@@ -1,10 +1,1 @@
-include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  language:
-    strict-casts: true
-    strict-raw-types: true
-
-linter:
-  rules:
-    - cast_nullable_to_non_nullable
+include: ../analysis_options.yaml

--- a/built_types/_built_value_end_to_end_test/lib/enums.dart
+++ b/built_types/_built_value_end_to_end_test/lib/enums.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-library enums_nnbd;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
@@ -29,7 +29,7 @@ class SecondTestEnum extends EnumClass {
   static const SecondTestEnum no = _$n;
   static const SecondTestEnum definitely = _$definitely;
 
-  const SecondTestEnum._(String name) : super(name);
+  const SecondTestEnum._(super.name);
 
   static BuiltSet<SecondTestEnum> get values => _$vls;
   static SecondTestEnum valueOf(String name) => _$vlOf(name);
@@ -48,7 +48,7 @@ class WireNameEnum extends EnumClass {
   @BuiltValueEnumConst(wireName: 'd')
   static const WireNameEnum definitely = _$wireDefinitely;
 
-  const WireNameEnum._(String name) : super(name);
+  const WireNameEnum._(super.name);
 
   static BuiltSet<WireNameEnum> get values => _$wireValues;
   static WireNameEnum valueOf(String name) => _$wireValueOf(name);
@@ -68,7 +68,7 @@ class WireNumberEnum extends EnumClass {
   @BuiltValueEnumConst(wireName: '3')
   static const WireNumberEnum definitely = _$wireNumberDefinitely;
 
-  const WireNumberEnum._(String name) : super(name);
+  const WireNumberEnum._(super.name);
 
   static BuiltSet<WireNumberEnum> get values => _$wireNumberValues;
   static WireNumberEnum valueOf(String name) => _$wireNumberValueOf(name);
@@ -84,7 +84,7 @@ class DollarValueEnum extends EnumClass {
   @BuiltValueEnumConst(wireName: 'value')
   static const DollarValueEnum $value = _$value;
 
-  const DollarValueEnum._(String name) : super(name);
+  const DollarValueEnum._(super.name);
 
   static BuiltSet<DollarValueEnum> get values => _$dollarValues;
   static DollarValueEnum valueOf(String name) => _$dollarValueOf(name);
@@ -98,7 +98,7 @@ class FallbackEnum extends EnumClass {
   @BuiltValueEnumConst(fallback: true)
   static const FallbackEnum no = _$fbNo;
 
-  const FallbackEnum._(String name) : super(name);
+  const FallbackEnum._(super.name);
 
   static BuiltSet<FallbackEnum> get values => _$fbValues;
   static FallbackEnum valueOf(String name) => _$fbValueOf(name);
@@ -114,7 +114,7 @@ class FallbackNumberEnum extends EnumClass {
   @BuiltValueEnumConst(wireNumber: -1, fallback: true)
   static const FallbackNumberEnum no = _$fbNumberNo;
 
-  const FallbackNumberEnum._(String name) : super(name);
+  const FallbackNumberEnum._(super.name);
 
   static BuiltSet<FallbackNumberEnum> get values => _$fbNumberValues;
   static FallbackNumberEnum valueOf(String name) => _$fbNumberValueOf(name);
@@ -132,7 +132,7 @@ class EnumWith$Dollar_UnderScore extends EnumClass {
   static const EnumWith$Dollar_UnderScore value$ =
       _$dollar_UnderScoreEnumValue$;
 
-  const EnumWith$Dollar_UnderScore._(String name) : super(name);
+  const EnumWith$Dollar_UnderScore._(super.name);
 
   static BuiltSet<EnumWith$Dollar_UnderScore> get values =>
       _$enum$Dollar_UnderScoreValues;

--- a/built_types/_built_value_end_to_end_test/lib/imported_values.dart
+++ b/built_types/_built_value_end_to_end_test/lib/imported_values.dart
@@ -6,7 +6,7 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:_built_value_end_to_end_test/values.dart' as prefix;
+import 'values.dart' as prefix;
 
 part 'imported_values.g.dart';
 

--- a/built_types/_built_value_end_to_end_test/lib/mixins.dart
+++ b/built_types/_built_value_end_to_end_test/lib/mixins.dart
@@ -5,7 +5,7 @@
 
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:_built_value_end_to_end_test/mixins_src.dart';
+import 'mixins_src.dart';
 
 part 'mixins.g.dart';
 

--- a/built_types/_built_value_end_to_end_test/lib/serializers.dart
+++ b/built_types/_built_value_end_to_end_test/lib/serializers.dart
@@ -2,20 +2,21 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library serializers_nnbd;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
-import 'package:_built_value_end_to_end_test/collections.dart';
-import 'package:_built_value_end_to_end_test/enums.dart';
-import 'package:_built_value_end_to_end_test/generics.dart';
-import 'package:_built_value_end_to_end_test/imported_values.dart';
-import 'package:_built_value_end_to_end_test/interfaces.dart';
-import 'package:_built_value_end_to_end_test/polymorphism.dart';
-import 'package:_built_value_end_to_end_test/records.dart';
-import 'package:_built_value_end_to_end_test/standard_json.dart';
-import 'package:_built_value_end_to_end_test/values.dart';
+
+import 'collections.dart';
+import 'enums.dart';
+import 'generics.dart';
+import 'imported_values.dart';
+import 'interfaces.dart';
+import 'polymorphism.dart';
+import 'records.dart';
+import 'standard_json.dart';
+import 'values.dart';
 
 part 'serializers.g.dart';
 

--- a/built_types/_built_value_end_to_end_test/lib/standard_json.dart
+++ b/built_types/_built_value_end_to_end_test/lib/standard_json.dart
@@ -7,8 +7,8 @@ import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
-import 'package:_built_value_end_to_end_test/polymorphism.dart';
-import 'package:_built_value_end_to_end_test/values.dart';
+import 'polymorphism.dart';
+import 'values.dart';
 
 part 'standard_json.g.dart';
 

--- a/built_types/_built_value_end_to_end_test/lib/values.dart
+++ b/built_types/_built_value_end_to_end_test/lib/values.dart
@@ -5,9 +5,10 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:_built_value_end_to_end_test/enums.dart' as using_import_as;
-import 'package:_built_value_end_to_end_test/mixins_src.dart';
 import 'package:fixnum/fixnum.dart';
+
+import 'enums.dart' as using_import_as;
+import 'mixins_src.dart';
 
 part 'values.g.dart';
 
@@ -958,7 +959,7 @@ abstract class ValueWithAwkwardNestedBuilderBuilder
         > {
   SimpleValueBuilder? value1;
   SimpleValueBuilder? _value2;
-  SimpleValueBuilder? get value2 => (_value2 ??= SimpleValueBuilder());
+  SimpleValueBuilder? get value2 => _value2 ??= SimpleValueBuilder();
   set value2(SimpleValueBuilder? b) => _value2 = b;
   ListBuilder<int>? values = ListBuilder<int>();
   MapBuilder<int, String>? map = MapBuilder<int, String>();
@@ -997,7 +998,7 @@ abstract class NewConstructorValue
 
   new _();
 
-  factory NewConstructorValue.new([
+  factory NewConstructorValue([
     void Function(NewConstructorValueBuilder) updates,
   ]) = _$NewConstructorValue;
 }
@@ -1008,5 +1009,5 @@ abstract class NewConstructorValueBuilder
 
   new _();
 
-  factory NewConstructorValueBuilder.new() = _$NewConstructorValueBuilder;
+  factory NewConstructorValueBuilder() = _$NewConstructorValueBuilder;
 }

--- a/built_types/_built_value_end_to_end_test/pubspec.yaml
+++ b/built_types/_built_value_end_to_end_test/pubspec.yaml
@@ -17,6 +17,6 @@ dev_dependencies:
   build_runner: '>=2.5.0 <3.0.0'
   built_value_generator: ^8.13.0
   fixnum: ^1.0.0
-  pedantic: ^1.4.0
+  dart_flutter_team_lints: ^3.1.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.16.0

--- a/built_types/_built_value_end_to_end_test/pubspec.yaml
+++ b/built_types/_built_value_end_to_end_test/pubspec.yaml
@@ -12,11 +12,11 @@ dependencies:
   built_collection: ^5.0.0
   built_value: ^8.7.0
 
+  fixnum: any
+  test: any
 dev_dependencies:
   build: '>=3.1.0 <5.0.0'
   build_runner: '>=2.5.0 <3.0.0'
   built_value_generator: ^8.13.0
-  fixnum: ^1.0.0
   dart_flutter_team_lints: ^3.1.0
   quiver: '>=0.21.0 <4.0.0'
-  test: ^1.16.0

--- a/built_types/_built_value_end_to_end_test/test/collections_serializer_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/collections_serializer_test.dart
@@ -5,15 +5,15 @@
 
 import 'dart:convert';
 
-import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
 import 'package:_built_value_end_to_end_test/collections.dart';
 import 'package:_built_value_end_to_end_test/serializers.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Collections', () {
-    var data = Collections((b) => b
+    final data = Collections((b) => b
       ..list.add(1)
       ..set.add('two')
       ..map['three'] = 4
@@ -30,7 +30,7 @@ void main() {
         null,
         BuiltList<int?>(<int?>[1, null]),
       ]));
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'Collections',
       'list',
       [1],
@@ -76,8 +76,9 @@ void main() {
         [1, null],
       ],
     ])) as Object;
-    var serializersWithBuilder = (serializers.toBuilder()
-          ..addBuilderFactory(FullType(BuiltList, [FullType.nullable(int)]),
+    final serializersWithBuilder = (serializers.toBuilder()
+          ..addBuilderFactory(
+              const FullType(BuiltList, [FullType.nullable(int)]),
               () => ListBuilder<int?>()))
         .build();
 

--- a/built_types/_built_value_end_to_end_test/test/collections_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/collections_test.dart
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 // @dart=2.12
 
-import 'package:built_collection/src/internal/hash.dart';
 import 'package:_built_value_end_to_end_test/collections.dart';
+import 'package:built_collection/src/internal/hash.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/built_types/_built_value_end_to_end_test/test/enums_serializer_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/enums_serializer_test.dart
@@ -11,8 +11,8 @@ import 'package:test/test.dart';
 
 void main() {
   group('TestEnum', () {
-    var data = TestEnum.yes;
-    var serialized = json.decode(json.encode(['TestEnum', 'yes'])) as Object;
+    final data = TestEnum.yes;
+    final serialized = json.decode(json.encode(['TestEnum', 'yes'])) as Object;
 
     test('can be serialized', () {
       expect(serializers.serialize(data), serialized);
@@ -24,8 +24,8 @@ void main() {
   });
 
   group('NewConstructorEnum', () {
-    var data = NewConstructorEnum.yes;
-    var serialized =
+    final data = NewConstructorEnum.yes;
+    final serialized =
         json.decode(json.encode(['NewConstructorEnum', 'yes'])) as Object;
 
     test('can be serialized', () {
@@ -38,8 +38,8 @@ void main() {
   });
 
   group('WireNameEnum', () {
-    var data = WireNameEnum.yes;
-    var serialized = json.decode(json.encode(['E', 'y'])) as Object;
+    final data = WireNameEnum.yes;
+    final serialized = json.decode(json.encode(['E', 'y'])) as Object;
 
     test('can be serialized', () {
       expect(serializers.serialize(data), serialized);
@@ -51,8 +51,9 @@ void main() {
   });
 
   group('WireNumberEnum', () {
-    var data = WireNumberEnum.yes;
-    var serialized = json.decode(json.encode(['WireNumberEnum', 1])) as Object;
+    final data = WireNumberEnum.yes;
+    final serialized =
+        json.decode(json.encode(['WireNumberEnum', 1])) as Object;
 
     test('can be serialized', () {
       expect(serializers.serialize(data), serialized);
@@ -64,8 +65,8 @@ void main() {
   });
 
   group('FallbackEnum', () {
-    var data = FallbackEnum.no;
-    var serialized =
+    final data = FallbackEnum.no;
+    final serialized =
         json.decode(json.encode(['FallbackEnum', 'some_unrecognized_value']))
             as Object;
 
@@ -75,8 +76,8 @@ void main() {
   });
 
   group('FallbackNumberEnum', () {
-    var data = FallbackNumberEnum.no;
-    var serialized =
+    final data = FallbackNumberEnum.no;
+    final serialized =
         json.decode(json.encode(['FallbackNumberEnum', 75])) as Object;
 
     test('deserializes using fallback', () {

--- a/built_types/_built_value_end_to_end_test/test/generics_serializer_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/generics_serializer_test.dart
@@ -5,17 +5,17 @@
 
 import 'dart:convert';
 
-import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
 import 'package:_built_value_end_to_end_test/generics.dart';
 import 'package:_built_value_end_to_end_test/serializers.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('GenericValue with known specifiedType but missing builder', () {
-    var data = GenericValue<int>((b) => b..value = 1);
-    var specifiedType = const FullType(GenericValue, [FullType(int)]);
-    var serialized = json.decode(json.encode([
+    final data = GenericValue<int>((b) => b..value = 1);
+    final specifiedType = const FullType(GenericValue, [FullType(int)]);
+    final serialized = json.decode(json.encode([
       'value',
       1,
     ])) as Object;
@@ -34,12 +34,12 @@ void main() {
   });
 
   group('GenericValue with known specifiedType and correct builder', () {
-    var data = GenericValue<int>((b) => b..value = 1);
-    var specifiedType = const FullType(GenericValue, [FullType(int)]);
-    var serializersWithBuilder = (serializers.toBuilder()
+    final data = GenericValue<int>((b) => b..value = 1);
+    final specifiedType = const FullType(GenericValue, [FullType(int)]);
+    final serializersWithBuilder = (serializers.toBuilder()
           ..addBuilderFactory(specifiedType, () => GenericValueBuilder<int>()))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'value',
       1,
     ])) as Object;
@@ -68,8 +68,8 @@ void main() {
   });
 
   group('GenericValue with unknown specifiedType', () {
-    var data = GenericValue<int>((b) => b..value = 1);
-    var serialized = json.decode(json.encode([
+    final data = GenericValue<int>((b) => b..value = 1);
+    final serialized = json.decode(json.encode([
       'GenericValue',
       'value',
       ['int', 1],
@@ -90,9 +90,9 @@ void main() {
   });
 
   group('BoundGenericValue with known specifiedType but missing builder', () {
-    var data = BoundGenericValue<int>((b) => b..value = 1);
-    var specifiedType = const FullType(BoundGenericValue, [FullType(int)]);
-    var serialized = json.decode(json.encode([
+    final data = BoundGenericValue<int>((b) => b..value = 1);
+    final specifiedType = const FullType(BoundGenericValue, [FullType(int)]);
+    final serialized = json.decode(json.encode([
       'value',
       1,
     ])) as Object;
@@ -111,13 +111,13 @@ void main() {
   });
 
   group('BoundGenericValue with known specifiedType and correct builder', () {
-    var data = BoundGenericValue<int>((b) => b..value = 1);
-    var specifiedType = const FullType(BoundGenericValue, [FullType(int)]);
-    var serializersWithBuilder = (serializers.toBuilder()
+    final data = BoundGenericValue<int>((b) => b..value = 1);
+    final specifiedType = const FullType(BoundGenericValue, [FullType(int)]);
+    final serializersWithBuilder = (serializers.toBuilder()
           ..addBuilderFactory(
               specifiedType, () => BoundGenericValueBuilder<int>()))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'value',
       1,
     ])) as Object;
@@ -146,8 +146,8 @@ void main() {
   });
 
   group('BoundGenericValue with unknown specifiedType', () {
-    var data = BoundGenericValue<int>((b) => b..value = 1);
-    var serialized = json.decode(json.encode([
+    final data = BoundGenericValue<int>((b) => b..value = 1);
+    final serialized = json.decode(json.encode([
       'BoundGenericValue',
       'value',
       ['int', 1],
@@ -169,9 +169,10 @@ void main() {
 
   group('CollectionGenericValue with known specifiedType but missing builder',
       () {
-    var data = CollectionGenericValue<int>((b) => b..values.add(1));
-    var specifiedType = const FullType(CollectionGenericValue, [FullType(int)]);
-    var serialized = json.decode(json.encode([
+    final data = CollectionGenericValue<int>((b) => b..values.add(1));
+    final specifiedType =
+        const FullType(CollectionGenericValue, [FullType(int)]);
+    final serialized = json.decode(json.encode([
       'values',
       [
         1,
@@ -193,15 +194,16 @@ void main() {
 
   group('CollectionGenericValue with known specifiedType and correct builder',
       () {
-    var data = CollectionGenericValue<int>((b) => b..values.add(1));
-    var specifiedType = const FullType(CollectionGenericValue, [FullType(int)]);
-    var serializersWithBuilder = (serializers.toBuilder()
+    final data = CollectionGenericValue<int>((b) => b..values.add(1));
+    final specifiedType =
+        const FullType(CollectionGenericValue, [FullType(int)]);
+    final serializersWithBuilder = (serializers.toBuilder()
           ..addBuilderFactory(
               specifiedType, () => CollectionGenericValueBuilder<int>())
           ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]),
               () => ListBuilder<int>()))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'values',
       [
         1,
@@ -234,8 +236,8 @@ void main() {
   });
 
   group('CollectionGenericValue with unknown specifiedType', () {
-    var data = CollectionGenericValue<int>((b) => b..values.add(1));
-    var serialized = json.decode(json.encode([
+    final data = CollectionGenericValue<int>((b) => b..values.add(1));
+    final serialized = json.decode(json.encode([
       'CollectionGenericValue',
       'values',
       [
@@ -258,18 +260,18 @@ void main() {
   });
 
   group('GenericContainer with known specifiedType', () {
-    var data = GenericContainer((b) => b
+    final data = GenericContainer((b) => b
       ..genericValue.value = '1'
       ..boundGenericValue.value = 2.2
       ..collectionGenericValue.values.add('3'));
-    var specifiedType = const FullType(GenericContainer, [FullType(int)]);
+    final specifiedType = const FullType(GenericContainer, [FullType(int)]);
     // TODO(davidmorgan): adding this builder manually shouldn't be necessary.
     // Auto-add builders for nested generic types.
-    var serializersWithBuilder = (serializers.toBuilder()
+    final serializersWithBuilder = (serializers.toBuilder()
           ..addBuilderFactory(const FullType(BuiltList, [FullType(String)]),
               () => ListBuilder<String>()))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'genericValue',
       ['value', '1'],
       'boundGenericValue',
@@ -298,17 +300,17 @@ void main() {
   });
 
   group('GenericContainer with unknown specifiedType', () {
-    var data = GenericContainer((b) => b
+    final data = GenericContainer((b) => b
       ..genericValue.value = '1'
       ..boundGenericValue.value = 2.2
       ..collectionGenericValue.values.add('3'));
     // TODO(davidmorgan): adding this builder manually shouldn't be necessary.
     // Auto-add builders for nested generic types.
-    var serializersWithBuilder = (serializers.toBuilder()
+    final serializersWithBuilder = (serializers.toBuilder()
           ..addBuilderFactory(const FullType(BuiltList, [FullType(String)]),
               () => ListBuilder<String>()))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'GenericContainer',
       'genericValue',
       ['value', '1'],
@@ -331,14 +333,14 @@ void main() {
   });
 
   group('PassthroughGenericContainer with known specifiedType', () {
-    var data = PassthroughGenericContainer<int>((b) => b
+    final data = PassthroughGenericContainer<int>((b) => b
       ..genericValue.value = 1
       ..collectionGenericValue.values.add(3));
-    var specifiedType =
+    final specifiedType =
         const FullType(PassthroughGenericContainer, [FullType(int)]);
     // TODO(davidmorgan): adding this builder manually shouldn't be necessary.
     // Auto-add builders for nested generic types.
-    var serializersWithBuilder = (serializers.toBuilder()
+    final serializersWithBuilder = (serializers.toBuilder()
           ..addBuilderFactory(
               specifiedType, () => PassthroughGenericContainerBuilder<int>())
           ..addBuilderFactory(const FullType(GenericValue, [FullType(int)]),
@@ -347,7 +349,7 @@ void main() {
               const FullType(CollectionGenericValue, [FullType(int)]),
               () => CollectionGenericValueBuilder<int>()))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'genericValue',
       ['value', 1],
       'collectionGenericValue',
@@ -372,14 +374,14 @@ void main() {
   });
 
   group('PassthroughGenericContainer with unknown specifiedType', () {
-    var data = PassthroughGenericContainer<int>((b) => b
+    final data = PassthroughGenericContainer<int>((b) => b
       ..genericValue.value = 1
       ..collectionGenericValue.values.add(3));
-    var specifiedType =
+    final specifiedType =
         const FullType(PassthroughGenericContainer, [FullType(int)]);
     // TODO(davidmorgan): adding this builder manually shouldn't be necessary.
     // Auto-add builders for nested generic types.
-    var serializersWithBuilder = (serializers.toBuilder()
+    final serializersWithBuilder = (serializers.toBuilder()
           ..addBuilderFactory(
               specifiedType, () => PassthroughGenericContainerBuilder<int>())
           ..addBuilderFactory(const FullType(GenericValue, [FullType(Object)]),
@@ -388,7 +390,7 @@ void main() {
               const FullType(CollectionGenericValue, [FullType(Object)]),
               () => CollectionGenericValueBuilder<Object>()))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'PassthroughGenericContainer',
       'genericValue',
       [
@@ -414,17 +416,17 @@ void main() {
   });
 
   group('NestedGenericContainer with known specifiedType', () {
-    var data = NestedGenericContainer(
+    final data = NestedGenericContainer(
         (b) => b..map.value = BuiltMap<int, String>({1: 'one'}));
-    var specifiedType = const FullType(NestedGenericContainer);
+    final specifiedType = const FullType(NestedGenericContainer);
     // TODO(davidmorgan): adding this builder manually shouldn't be necessary.
     // Auto-add builders for nested generic types.
-    var serializersWithBuilder = (serializers.toBuilder()
+    final serializersWithBuilder = (serializers.toBuilder()
           ..addBuilderFactory(
               const FullType(BuiltMap, [FullType(int), FullType(String)]),
               () => MapBuilder<int, String>()))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'map',
       [
         'value',
@@ -447,8 +449,8 @@ void main() {
   });
 
   group('ConcreteGeneric with unknown specifiedType', () {
-    var data = ConcreteGeneric((b) => b..value = 1);
-    var serialized =
+    final data = ConcreteGeneric((b) => b..value = 1);
+    final serialized =
         json.decode(json.encode(['ConcreteGeneric', 'value', 1])) as Object;
 
     test('can be serialized', () {

--- a/built_types/_built_value_end_to_end_test/test/generics_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/generics_test.dart
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 // @dart=2.12
 
-import 'package:built_value/built_value.dart';
 import 'package:_built_value_end_to_end_test/generics.dart';
+import 'package:built_value/built_value.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/built_types/_built_value_end_to_end_test/test/imported_values_serializer_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/imported_values_serializer_test.dart
@@ -5,18 +5,18 @@
 
 import 'dart:convert';
 
-import 'package:built_collection/built_collection.dart';
 import 'package:_built_value_end_to_end_test/imported_values.dart';
 import 'package:_built_value_end_to_end_test/serializers.dart';
 import 'package:_built_value_end_to_end_test/values.dart';
+import 'package:built_collection/built_collection.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('ImportedValue', () {
-    var data = ImportedValue((b) => b.simpleValue
+    final data = ImportedValue((b) => b.simpleValue
       ..anInt = 1
       ..aString = 'two');
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'ImportedValue',
       'simpleValue',
       [
@@ -39,12 +39,12 @@ void main() {
   });
 
   group('ImportedCustomValue', () {
-    var data = ImportedCustomValue((b) => b
+    final data = ImportedCustomValue((b) => b
       ..simpleValue = SimpleValue((b) => b
         ..anInt = 1
         ..aString = 'two')
       ..simpleValues = BuiltList.of([]));
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'ImportedCustomValue',
       'simpleValue',
       [
@@ -67,10 +67,10 @@ void main() {
   });
 
   group('ImportedCustomNestedValue', () {
-    var data = ImportedCustomNestedValue((b) => b.simpleValue
+    final data = ImportedCustomNestedValue((b) => b.simpleValue
       ..anInt = 1
       ..aString = 'two');
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'ImportedCustomNestedValue',
       'simpleValue',
       [

--- a/built_types/_built_value_end_to_end_test/test/imported_values_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/imported_values_test.dart
@@ -3,9 +3,9 @@
 // license that can be found in the LICENSE file.
 // @dart=2.12
 
-import 'package:built_collection/built_collection.dart';
 import 'package:_built_value_end_to_end_test/imported_values.dart';
 import 'package:_built_value_end_to_end_test/values.dart';
+import 'package:built_collection/built_collection.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/built_types/_built_value_end_to_end_test/test/interfaces_serializer_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/interfaces_serializer_test.dart
@@ -5,20 +5,20 @@
 
 import 'dart:convert';
 
-import 'package:built_collection/built_collection.dart';
 import 'package:_built_value_end_to_end_test/interfaces.dart';
 import 'package:_built_value_end_to_end_test/serializers.dart';
+import 'package:built_collection/built_collection.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('HasInt', () {
-    var data = BuiltList.of([
+    final data = BuiltList.of([
       ValueWithHasInt((b) => b.hasInt = ValueWithInt((b) => b
         ..anInt = 2
         ..note = 'two')),
       ValueWithHasInt((b) => b.hasInt = EnumWithInt.one),
     ]);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'list',
       [
         'ValueWithHasInt',

--- a/built_types/_built_value_end_to_end_test/test/mixins_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/mixins_test.dart
@@ -11,7 +11,7 @@ void main() {
     test('has correct fields', () {
       // If it has any unwanted fields they will not be nullable so this will
       // throw.
-      var value = GetsCorrectFieldsViaMixins((b) => b..shouldBeAField = 1);
+      final value = GetsCorrectFieldsViaMixins((b) => b..shouldBeAField = 1);
       expect(value.shouldBeAField, 1);
     });
   });

--- a/built_types/_built_value_end_to_end_test/test/polymorphism_serializer_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/polymorphism_serializer_test.dart
@@ -5,17 +5,17 @@
 
 import 'dart:convert';
 
-import 'package:built_collection/built_collection.dart';
 import 'package:_built_value_end_to_end_test/polymorphism.dart';
 import 'package:_built_value_end_to_end_test/serializers.dart';
+import 'package:built_collection/built_collection.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Cat', () {
-    var data = Cat((b) => b
+    final data = Cat((b) => b
       ..legs = 4
       ..tail = true);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'Cat',
       'tail',
       true,
@@ -41,10 +41,10 @@ void main() {
   });
 
   group('Robot', () {
-    var data = Robot((b) => b
+    final data = Robot((b) => b
       ..legs = 4
       ..fins = 3);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'Robot',
       'fins',
       3,
@@ -62,8 +62,8 @@ void main() {
   });
 
   group('StandardCat', () {
-    var data = StandardCat((b) => b..tail = true);
-    var serialized = json.decode(json.encode([
+    final data = StandardCat((b) => b..tail = true);
+    final serialized = json.decode(json.encode([
       'StandardCat',
       'tail',
       true,
@@ -79,11 +79,11 @@ void main() {
   });
 
   group('HasField', () {
-    var data = BuiltList<HasField<dynamic>>(<Object>[
+    final data = BuiltList<HasField<dynamic>>(<Object>[
       HasString((b) => b..field = 'hello'),
       HasDouble((b) => b..field = 3.14)
     ]);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'list',
       ['HasString', 'field', 'hello'],
       ['HasDouble', 'field', 3.14]
@@ -99,14 +99,14 @@ void main() {
   });
 
   group('Cage', () {
-    var data = Cage((b) => b
+    final data = Cage((b) => b
       ..inhabitant = Cat((b) => b
         ..tail = true
         ..legs = 4)
       ..otherInhabitants.add(Fish((b) => b
         ..legs = 0
         ..fins = 4)));
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'Cage',
       'inhabitant',
       ['Cat', 'tail', true, 'legs', 4],
@@ -126,8 +126,8 @@ void main() {
   });
 
   group('UsesHandCoded', () {
-    var data = UsesHandCoded((b) => b..fieldInBaseBuilder = 4);
-    var serialized = json.decode(json.encode([
+    final data = UsesHandCoded((b) => b..fieldInBaseBuilder = 4);
+    final serialized = json.decode(json.encode([
       'UsesHandCoded',
       'fieldInBaseBuilder',
       4,

--- a/built_types/_built_value_end_to_end_test/test/polymorphism_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/polymorphism_test.dart
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 // @dart=2.12
 
-import 'package:built_collection/built_collection.dart';
 import 'package:_built_value_end_to_end_test/polymorphism.dart';
+import 'package:built_collection/built_collection.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/built_types/_built_value_end_to_end_test/test/private_value_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/private_value_test.dart
@@ -2,10 +2,10 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library value_test;
+library;
 
-import 'package:test/test.dart';
 import 'package:built_value/built_value.dart';
+import 'package:test/test.dart';
 
 part 'private_value_test.g.dart';
 

--- a/built_types/_built_value_end_to_end_test/test/records_serializer_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/records_serializer_test.dart
@@ -4,18 +4,18 @@
 
 import 'dart:convert';
 
-import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
-import 'package:built_value/standard_json_plugin.dart';
 import 'package:_built_value_end_to_end_test/errors_matchers.dart';
 import 'package:_built_value_end_to_end_test/records.dart';
 import 'package:_built_value_end_to_end_test/serializers.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('$SerializableRecordValue with no record value', () {
-    var data = SerializableRecordValue((b) => b..value = 1);
-    var serialized = json.decode(
+    final data = SerializableRecordValue((b) => b..value = 1);
+    final serialized = json.decode(
       json.encode(['SerializableRecordValue', 'value', 1]),
     ) as Object;
 
@@ -29,12 +29,12 @@ void main() {
   });
 
   group('$SerializableRecordValue with a record value', () {
-    var data = SerializableRecordValue(
+    final data = SerializableRecordValue(
       (b) => b
         ..value = 1
         ..record = (1, 2),
     );
-    var serialized = json.decode(
+    final serialized = json.decode(
       json.encode([
         'SerializableRecordValue',
         'value',
@@ -43,7 +43,7 @@ void main() {
         [1, 2],
       ]),
     ) as Object;
-    var serializersWithCustomSerializer =
+    final serializersWithCustomSerializer =
         (serializers.toBuilder()..add(RecordOfIntIntSerializer())).build();
 
     test('gives advice about custom serializer on failure to serialize', () {
@@ -74,30 +74,30 @@ void main() {
   });
 
   group('$SerializableRecordValue with a record list value', () {
-    var data = SerializableRecordValue(
+    final data = SerializableRecordValue(
       (b) => b
         ..value = 1
         ..intOrList = (null, BuiltList(['value0', 'value1', 'value2'])),
     );
-    var serialized = json.decode(
+    final serialized = json.decode(
       json.encode({
         'value': 1,
         'intOrList': ['value0', 'value1', 'value2'],
       }),
     ) as Object;
-    var serializersWithCustomSerializer =
+    final serializersWithCustomSerializer =
         (serializers.toBuilder()
               ..addPlugin(
                 StandardJsonPlugin(typesToLeaveAsList: {RecordOfIntOrList}),
               )
-              ..add(RecordOfIntOrListSerializer()))
+              ..add(const RecordOfIntOrListSerializer()))
             .build();
 
     test('can be serialized with custom serializer', () {
       expect(
         serializersWithCustomSerializer.serialize(
           data,
-          specifiedType: FullType(SerializableRecordValue),
+          specifiedType: const FullType(SerializableRecordValue),
         ),
         serialized,
       );
@@ -107,7 +107,7 @@ void main() {
       expect(
         serializersWithCustomSerializer.deserialize(
           serialized,
-          specifiedType: FullType(SerializableRecordValue),
+          specifiedType: const FullType(SerializableRecordValue),
         ),
         data,
       );

--- a/built_types/_built_value_end_to_end_test/test/records_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/records_test.dart
@@ -2,8 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'package:built_collection/built_collection.dart';
 import 'package:_built_value_end_to_end_test/records.dart';
+import 'package:built_collection/built_collection.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/built_types/_built_value_end_to_end_test/test/standard_json_serializer_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/standard_json_serializer_test.dart
@@ -5,17 +5,17 @@
 
 import 'dart:convert';
 
-import 'package:built_value/json_object.dart';
-import 'package:built_value/serializer.dart';
-import 'package:built_value/standard_json_plugin.dart';
 import 'package:_built_value_end_to_end_test/polymorphism.dart';
 import 'package:_built_value_end_to_end_test/serializers.dart';
 import 'package:_built_value_end_to_end_test/standard_json.dart';
+import 'package:built_value/json_object.dart';
+import 'package:built_value/serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('StandardJsonValue', () {
-    var data = StandardJsonValue((b) => b
+    final data = StandardJsonValue((b) => b
       ..number = 3
       ..text = 'some text'
       ..value.primitive = 4
@@ -43,10 +43,10 @@ void main() {
       ..objects.add(ComplexValue((b) => b
         ..primitive = 8
         ..value.anInt = 9)));
-    var specifiedType = FullType(StandardJsonValue);
-    var serializersWithPlugin =
+    final specifiedType = const FullType(StandardJsonValue);
+    final serializersWithPlugin =
         (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
-    var serialized = json.decode(json.encode({
+    final serialized = json.decode(json.encode({
       'number': 3,
       'text': 'some text',
       'value': {
@@ -108,7 +108,7 @@ void main() {
   });
 
   group('StandardJsonValue with extraneous nulls', () {
-    var data = StandardJsonValue((b) => b
+    final data = StandardJsonValue((b) => b
       ..number = 3
       ..text = 'some text'
       ..value.primitive = 4
@@ -118,10 +118,10 @@ void main() {
       ..keyValues['three'] = JsonObject(true)
       ..keyValues['four'] = JsonObject([1, 2, 3])
       ..keyValues['five'] = JsonObject({'one': 1, 'two': 2}));
-    var specifiedType = FullType(StandardJsonValue);
-    var serializersWithPlugin =
+    final specifiedType = const FullType(StandardJsonValue);
+    final serializersWithPlugin =
         (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
-    var serialized = json.decode(json.encode({
+    final serialized = json.decode(json.encode({
       'number': 3,
       'text': 'some text',
       'value': {
@@ -147,7 +147,7 @@ void main() {
   });
 
   group('StandardJsonValue with unknown specifiedType', () {
-    var data = StandardJsonValue((b) => b
+    final data = StandardJsonValue((b) => b
       ..number = 3
       ..text = 'some text'
       ..value.primitive = 4
@@ -172,9 +172,9 @@ void main() {
       ..objects.add(ComplexValue((b) => b
         ..primitive = 8
         ..value.anInt = 9)));
-    var serializersWithPlugin =
+    final serializersWithPlugin =
         (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
-    var serialized = {
+    final serialized = {
       r'$': 'StandardJsonValue',
       'number': 3,
       'text': 'some text',

--- a/built_types/_built_value_end_to_end_test/test/to_string_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/to_string_test.dart
@@ -2,14 +2,13 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'package:built_value/built_value.dart';
 import 'package:_built_value_end_to_end_test/values.dart';
+import 'package:built_value/built_value.dart';
 import 'package:test/test.dart';
 
 void main() {
   tearDown(() {
-    newBuiltValueToStringHelper = (className) =>
-        IndentingBuiltValueToStringHelper(className);
+    newBuiltValueToStringHelper = IndentingBuiltValueToStringHelper.new;
   });
 
   group('toString', () {
@@ -24,8 +23,7 @@ void main() {
     });
 
     test('can be customized', () {
-      newBuiltValueToStringHelper = (className) =>
-          FlatBuiltValueToStringHelper(className);
+      newBuiltValueToStringHelper = FlatBuiltValueToStringHelper.new;
       final value = CompoundValue((b) => b..simpleValue.anInt = 1);
 
       expect(

--- a/built_types/_built_value_end_to_end_test/test/values_serializer_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/values_serializer_test.dart
@@ -5,22 +5,22 @@
 
 import 'dart:convert';
 
-import 'package:built_value/serializer.dart';
-import 'package:built_value/standard_json_plugin.dart';
 import 'package:_built_value_end_to_end_test/enums.dart';
 import 'package:_built_value_end_to_end_test/errors_matchers.dart';
 import 'package:_built_value_end_to_end_test/serializers.dart';
 import 'package:_built_value_end_to_end_test/values.dart';
+import 'package:built_value/serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('SimpleValue', () {
-    var data = SimpleValue((b) => b
+    final data = SimpleValue((b) => b
       ..anInt = 1
       ..aString = 'two'
       ..$mustBeEscaped = true);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'SimpleValue',
       'anInt',
       1,
@@ -39,10 +39,10 @@ void main() {
     });
 
     test('can be deserialized from json with explicit null', () {
-      var data = SimpleValue((b) => b
+      final data = SimpleValue((b) => b
         ..anInt = 1
         ..$mustBeEscaped = true);
-      var serialized = json.decode(json.encode([
+      final serialized = json.decode(json.encode([
         'SimpleValue',
         'anInt',
         1,
@@ -57,10 +57,10 @@ void main() {
   });
 
   group('SimpleValue with null nullable field', () {
-    var data = SimpleValue((b) => b
+    final data = SimpleValue((b) => b
       ..anInt = 1
       ..$mustBeEscaped = true);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'SimpleValue',
       'anInt',
       1,
@@ -75,11 +75,11 @@ void main() {
   });
 
   group('CompoundValue', () {
-    var data = CompoundValue((b) => b
+    final data = CompoundValue((b) => b
       ..simpleValue.anInt = 1
       ..simpleValue.aString = 'two'
       ..validatedValue = ValidatedValue((b) => b.anInt = 3).toBuilder());
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'CompoundValue',
       'simpleValue',
       [
@@ -130,12 +130,12 @@ void main() {
   });
 
   group('CompoundValueNoNesting', () {
-    var data = CompoundValueNoNesting((b) => b
+    final data = CompoundValueNoNesting((b) => b
       ..simpleValue = SimpleValue((b) => b
         ..anInt = 1
         ..aString = 'two')
       ..validatedValue = ValidatedValue((b) => b.anInt = 3));
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'CompoundValueNoNesting',
       'simpleValue',
       [
@@ -161,9 +161,9 @@ void main() {
   });
 
   group('CompoundValueNoAutoNesting', () {
-    var data =
+    final data =
         CompoundValueNoAutoNesting((b) => b..value = NoFieldsValueBuilder());
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'CompoundValueNoAutoNesting',
       'value',
       <String>[],
@@ -179,7 +179,7 @@ void main() {
   });
 
   group('CompoundValueNoNestingField', () {
-    var data = CompoundValueNoNestingField((b) => b
+    final data = CompoundValueNoNestingField((b) => b
       ..simpleValue = SimpleValue((b) => b
         ..anInt = 1
         ..aString = 'two')
@@ -187,7 +187,7 @@ void main() {
       ..simpleValueWithNested.anInt = 1
       ..simpleValueWithNested.aString = 'two'
       ..validatedValueWithNested.anInt = 3);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'CompoundValueNoNestingField',
       'simpleValue',
       [
@@ -225,7 +225,7 @@ void main() {
   });
 
   group('CompoundValueNestingField', () {
-    var data = CompoundValueNestingField((b) => b
+    final data = CompoundValueNestingField((b) => b
       ..simpleValue = SimpleValue((b) => b
         ..anInt = 1
         ..aString = 'two')
@@ -233,7 +233,7 @@ void main() {
       ..simpleValueWithNested.anInt = 1
       ..simpleValueWithNested.aString = 'two'
       ..validatedValueWithNested.anInt = 3);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'CompoundValueNestingField',
       'simpleValue',
       [
@@ -271,9 +271,9 @@ void main() {
   });
 
   group('CompoundValueNoAutoNestingField', () {
-    var data = CompoundValueNoAutoNestingField(
+    final data = CompoundValueNoAutoNestingField(
         (b) => b..value = NoFieldsValueBuilder());
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'CompoundValueNoAutoNestingField',
       'value',
       <String>[],
@@ -291,9 +291,9 @@ void main() {
   });
 
   group('CompoundValueAutoNestingField', () {
-    var data =
+    final data =
         CompoundValueAutoNestingField((b) => b..value = NoFieldsValueBuilder());
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'CompoundValueAutoNestingField',
       'value',
       <String>[],
@@ -311,12 +311,12 @@ void main() {
   });
 
   group('CompoundValueExplicitNoNesting', () {
-    var data = CompoundValueExplicitNoNesting((b) => b
+    final data = CompoundValueExplicitNoNesting((b) => b
       ..simpleValue.replace(SimpleValue((b) => b
         ..anInt = 1
         ..aString = 'two'))
       ..validatedValue = ValidatedValue((b) => b.anInt = 3));
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'CompoundValueExplicitNoNesting',
       'simpleValue',
       [
@@ -342,14 +342,14 @@ void main() {
   });
 
   group('CompoundValue using StandardJsonPlugin', () {
-    var data = CompoundValue((b) => b
+    final data = CompoundValue((b) => b
       ..simpleValue.anInt = 1
       ..simpleValue.aString = 'two'
       ..validatedValue = ValidatedValue((b) => b.anInt = 3).toBuilder());
-    var specifiedType = const FullType(CompoundValue);
-    var serializersWithPlugin =
+    final specifiedType = const FullType(CompoundValue);
+    final serializersWithPlugin =
         (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
-    var serialized = {
+    final serialized = {
       'simpleValue': {
         'anInt': 1,
         'aString': 'two',
@@ -374,8 +374,8 @@ void main() {
   });
 
   group('ValueUsingImportAs', () {
-    var data = ValueUsingImportAs((b) => b.value = TestEnum.yes);
-    var serialized = json.decode(json.encode([
+    final data = ValueUsingImportAs((b) => b.value = TestEnum.yes);
+    final serialized = json.decode(json.encode([
       'ValueUsingImportAs',
       'value',
       'yes',
@@ -391,7 +391,7 @@ void main() {
   });
 
   group('PrimitivesValue', () {
-    var data = PrimitivesValue((b) => b
+    final data = PrimitivesValue((b) => b
       ..boolean = true
       ..integer = 42
       ..int64 = Int64.MAX_VALUE
@@ -399,11 +399,11 @@ void main() {
       ..number = 17.5
       ..string = 'test'
       ..dateTime = DateTime.fromMillisecondsSinceEpoch(1000, isUtc: true)
-      ..duration = Duration(microseconds: 12345)
+      ..duration = const Duration(microseconds: 12345)
       ..regExp = RegExp(r'\w+@\d+')
       ..uri = Uri.parse('https://github.com/google/built_value.dart')
       ..bigInt = BigInt.parse('123456789012345678901234567890'));
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'PrimitivesValue',
       'boolean',
       true,
@@ -439,8 +439,8 @@ void main() {
   });
 
   group('NamedFactoryValue', () {
-    var data = NamedFactoryValue(3);
-    var serialized =
+    final data = NamedFactoryValue(3);
+    final serialized =
         json.decode(json.encode(['NamedFactoryValue', 'value', 3])) as Object;
 
     test('can be serialized', () {
@@ -453,10 +453,10 @@ void main() {
   });
 
   group('FieldDiscoveryValue', () {
-    var data = FieldDiscoveryValue((b) => b
+    final data = FieldDiscoveryValue((b) => b
       ..value.value.value = 1
       ..values.add(ThirdDiscoverableValue((b) => b..value = 4)));
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'FieldDiscoveryValue',
       'value',
       [
@@ -482,10 +482,10 @@ void main() {
   });
 
   group('PartiallySerializableValue', () {
-    var data = PartiallySerializableValue((b) => b
+    final data = PartiallySerializableValue((b) => b
       ..value = 1
       ..transientValue = 2);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'PartiallySerializableValue',
       'value',
       1,
@@ -502,8 +502,8 @@ void main() {
   });
 
   group('WireNameValue', () {
-    var data = WireNameValue((b) => b..value = 1);
-    var serialized = json.decode(json.encode([
+    final data = WireNameValue((b) => b..value = 1);
+    final serialized = json.decode(json.encode([
       r'$V',
       r'$v',
       1,
@@ -519,8 +519,8 @@ void main() {
   });
 
   group('ValueWithCustomSerializer', () {
-    var data = ValueWithCustomSerializer((b) => b..value = 1);
-    var serialized =
+    final data = ValueWithCustomSerializer((b) => b..value = 1);
+    final serialized =
         json.decode(json.encode(['ValueWithCustomSerializer', 1])) as Object;
 
     test('can be serialized', () {
@@ -533,8 +533,8 @@ void main() {
   });
 
   group('OtherValue', () {
-    var data = OtherValue((b) => b..other = 1);
-    var serialized =
+    final data = OtherValue((b) => b..other = 1);
+    final serialized =
         json.decode(json.encode(['OtherValue', 'other', 1])) as Object;
 
     test('can be serialized', () {
@@ -547,10 +547,10 @@ void main() {
   });
 
   group('ValuesWithBuilderInitializer', () {
-    var data = ValueWithBuilderInitializer((b) => b
+    final data = ValueWithBuilderInitializer((b) => b
       ..anInt = 1
       ..nestedValue.anInt = 2);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'ValueWithBuilderInitializer',
       'anInt',
       1,
@@ -575,7 +575,7 @@ void main() {
     });
 
     test('adds defaults for missing fields on deserialization', () {
-      var serializedWithoutDefaults = [
+      final serializedWithoutDefaults = [
         'ValueWithBuilderInitializer',
         'anInt',
         1,
@@ -587,8 +587,8 @@ void main() {
   });
 
   group('ValueWithBuilderFinalizer', () {
-    var data = ValueWithBuilderFinalizer((b) => b..anInt = 1);
-    var serialized =
+    final data = ValueWithBuilderFinalizer((b) => b..anInt = 1);
+    final serialized =
         json.decode(json.encode(['ValueWithBuilderFinalizer', 'anInt', 1]))
             as Object;
 
@@ -601,7 +601,7 @@ void main() {
     });
 
     test('runs hook on deserialize', () {
-      var serializedWhichTriggersHook = [
+      final serializedWhichTriggersHook = [
         'ValueWithBuilderFinalizer', 'anInt',
         // Hook will change 0 to 1.
         0,
@@ -655,7 +655,7 @@ void main() {
   });
 
   group(r'$ValueSpecial', () {
-    var data = $ValueSpecial(
+    final data = $ValueSpecial(
       (b) => b
         ..aString = 'String'
         ..anInt = 42
@@ -676,7 +676,7 @@ void main() {
             ..aString = '1',
         ).toBuilder(),
     );
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       r'$ValueSpecial',
       'anInt',
       42,
@@ -702,8 +702,8 @@ void main() {
   });
 
   group('NewConstructorValue', () {
-    var data = NewConstructorValue((b) => b..anInt = 1);
-    var serialized = json.decode(json.encode([
+    final data = NewConstructorValue((b) => b..anInt = 1);
+    final serialized = json.decode(json.encode([
       'NewConstructorValue',
       'anInt',
       1,

--- a/built_types/_built_value_end_to_end_test/test/values_test.dart
+++ b/built_types/_built_value_end_to_end_test/test/values_test.dart
@@ -3,11 +3,11 @@
 // license that can be found in the LICENSE file.
 // @dart=2.12
 
-import 'package:built_collection/src/internal/hash.dart';
-import 'package:built_value/built_value.dart';
 import 'package:_built_value_end_to_end_test/enums.dart';
 import 'package:_built_value_end_to_end_test/errors_matchers.dart';
 import 'package:_built_value_end_to_end_test/values.dart';
+import 'package:built_collection/src/internal/hash.dart';
+import 'package:built_value/built_value.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -378,7 +378,7 @@ void main() {
   group('ValueWithOnSet', () {
     test('notifies on sets', () {
       var notified = false;
-      var builder = ValueWithOnSet((b) => b..value = 2).toBuilder();
+      final builder = ValueWithOnSet((b) => b..value = 2).toBuilder();
       builder.onSet = () => notified = true;
       builder.value = 3;
       expect(notified, true);
@@ -399,9 +399,9 @@ void main() {
 
   group('OtherValue', () {
     test('compares correctly', () {
-      var value = OtherValue((b) => b..other = 1);
-      var equalValue = OtherValue((b) => b..other = 1);
-      var notEqualValue = OtherValue((b) => b..other = 2);
+      final value = OtherValue((b) => b..other = 1);
+      final equalValue = OtherValue((b) => b..other = 1);
+      final notEqualValue = OtherValue((b) => b..other = 2);
       expect(value, equalValue);
       expect(value, isNot(equals(notEqualValue)));
     });
@@ -409,7 +409,7 @@ void main() {
 
   group('ValueWithBuilderInitializer', () {
     test('has defaults', () {
-      var value = ValueWithBuilderInitializer((b) => b
+      final value = ValueWithBuilderInitializer((b) => b
         ..anInt = 1
         ..nestedValue.anInt = 2);
       expect(
@@ -428,15 +428,15 @@ void main() {
 
   group('DefaultsForFieldSettingsValue', () {
     test('compares correctly', () {
-      var value = DefaultsForFieldSettingsValue((b) => b
+      final value = DefaultsForFieldSettingsValue((b) => b
         ..ignored = 0
         ..compared = 0
         ..serialized = 0);
-      var equalValue = DefaultsForFieldSettingsValue((b) => b
+      final equalValue = DefaultsForFieldSettingsValue((b) => b
         ..ignored = 1
         ..compared = 0
         ..serialized = 0);
-      var differentValue = DefaultsForFieldSettingsValue((b) => b
+      final differentValue = DefaultsForFieldSettingsValue((b) => b
         ..ignored = 0
         ..compared = 1
         ..serialized = 0);
@@ -448,11 +448,11 @@ void main() {
   group('ValueWithGenericBuilderInitializer', () {
     test('works with generics', () {
       // Initializer only fires for ints, it sets the value to 42.
-      var valueThatTriggersInitializer =
+      final valueThatTriggersInitializer =
           ValueWithGenericBuilderInitializer<int>();
       expect(valueThatTriggersInitializer.value, 42);
 
-      var valueThatDoesNotTriggerInitializer =
+      final valueThatDoesNotTriggerInitializer =
           ValueWithGenericBuilderInitializer<String>();
       expect(valueThatDoesNotTriggerInitializer.value, null);
     });
@@ -460,10 +460,10 @@ void main() {
 
   group('MemoizedHashcodeValue', () {
     test('computes same hashCode as HashcodeValue', () {
-      var value = HashcodeValue((b) => b
+      final value = HashcodeValue((b) => b
         ..x = 42
         ..y = 43);
-      var valueWithMemoization = MemoizedHashcodeValue((b) => b
+      final valueWithMemoization = MemoizedHashcodeValue((b) => b
         ..x = 42
         ..y = 43);
 
@@ -473,27 +473,27 @@ void main() {
 
   group(ValueWithHooks, () {
     test('initialize hooks run', () {
-      var value = ValueWithHooks();
+      final value = ValueWithHooks();
       expect(value.hook1Count, 1);
     });
 
     test('initialize hooks run initially', () {
-      var value = ValueWithHooks((b) => b..hook1Count = 100);
+      final value = ValueWithHooks((b) => b..hook1Count = 100);
       expect(value.hook1Count, 100);
     });
 
     test('finalize hooks run', () {
-      var value = ValueWithHooks();
+      final value = ValueWithHooks();
       expect(value.hook2Count, 1);
     });
 
     test('finalize hooks run finally', () {
-      var value = ValueWithHooks((b) => b..hook1Count = 100);
+      final value = ValueWithHooks((b) => b..hook1Count = 100);
       expect(value.hook2Count, 1);
     });
 
     test('multiple hooks ordering', () {
-      var value = ValueWithHooks();
+      final value = ValueWithHooks();
       expect(value.hookOrdering, [
         'justInitialize',
         'both',

--- a/built_types/analysis_options.yaml
+++ b/built_types/analysis_options.yaml
@@ -1,0 +1,33 @@
+include: ../analysis_options.yaml
+
+analyzer:
+  language:
+    strict-casts: false
+  errors:
+    # Legacy APIs in built_value and built_collection use Function instead of
+    # typed/void callbacks.
+    inference_failure_on_function_return_type: ignore
+    inference_failure_on_untyped_parameter: ignore
+    inference_failure_on_collection_literal: ignore
+    avoid_dynamic_calls: ignore
+    comment_references: ignore
+    lines_longer_than_80_chars: ignore
+    type_annotate_public_apis: ignore
+    strict_top_level_inference: ignore
+    # dart fix generates corrupted code when applying this rule to closures
+    # assigned to fields in tests.
+    prefer_function_declarations_over_variables: ignore
+    # Pre-existing patterns in built_types that require non-mechanical refactoring
+    avoid_catching_errors: ignore
+    camel_case_types: ignore
+    constant_identifier_names: ignore
+    depend_on_referenced_packages: ignore
+    hash_and_equals: ignore
+    implementation_imports: ignore
+    invalid_runtime_check_with_js_interop_types: ignore
+    library_private_types_in_public_api: ignore
+    non_constant_identifier_names: ignore
+    only_throw_errors: ignore
+    sort_pub_dependencies: ignore
+    unnecessary_statements: ignore
+    use_is_even_rather_than_modulo: ignore

--- a/built_types/built_collection/CHANGELOG.md
+++ b/built_types/built_collection/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Moved repository to `dart-lang/build`.
 - Require Dart SDK `^3.11.0`.
 - Fix unnecessary non-null assertions in internal copy-on-write collections.
+- Migrate to `package:dart_flutter_team_lints`.
 
 ## 5.1.1
 

--- a/built_types/built_collection/analysis_options.yaml
+++ b/built_types/built_collection/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/built_types/built_collection/example/example.dart
+++ b/built_types/built_collection/example/example.dart
@@ -46,7 +46,7 @@ void main() {
   // If you need to keep a mutable version of the collection around for a
   // while, for example to pass it to other methods, you can use `toBuilder`.
   // Then, later, the collection is made immutable again by calling `build`.
-  var listBuilder = builtList.toBuilder();
+  final listBuilder = builtList.toBuilder();
   listBuilder.addAll([10, 9, 8]);
   // More changes could go here, including passing the builder to other
   // methods.

--- a/built_types/built_collection/lib/built_collection.dart
+++ b/built_types/built_collection/lib/built_collection.dart
@@ -104,6 +104,7 @@
 /// a copy, but return a copy-on-write wrapper. So, Built Collections can be
 /// efficiently and easily used with code that needs core SDK collections but
 /// does not mutate them.
+library;
 
 export 'src/list.dart' hide OverriddenHashcodeBuiltList;
 export 'src/list_multimap.dart' hide OverriddenHashcodeBuiltListMultimap;

--- a/built_types/built_collection/lib/src/internal/iterables.dart
+++ b/built_types/built_collection/lib/src/internal/iterables.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'package:built_collection/src/iterable.dart' show BuiltIterable;
+import '../iterable.dart' show BuiltIterable;
 
 /// Evaluates a lazy iterable.
 ///

--- a/built_types/built_collection/lib/src/iterable.dart
+++ b/built_types/built_collection/lib/src/iterable.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'package:built_collection/src/list.dart' show BuiltList;
-import 'package:built_collection/src/set.dart' show BuiltSet;
+import 'list.dart' show BuiltList;
+import 'set.dart' show BuiltSet;
 
 part 'iterable/built_iterable.dart';

--- a/built_types/built_collection/lib/src/list.dart
+++ b/built_types/built_collection/lib/src/list.dart
@@ -4,13 +4,12 @@
 
 import 'dart:math' show Random;
 
-import 'package:built_collection/src/iterable.dart' show BuiltIterable;
-import 'package:built_collection/src/set.dart' show BuiltSet;
-
 import 'internal/copy_on_write_list.dart';
 import 'internal/hash.dart';
 import 'internal/iterables.dart';
 import 'internal/null_safety.dart';
+import 'iterable.dart' show BuiltIterable;
+import 'set.dart' show BuiltSet;
 
 part 'list/built_list.dart';
 part 'list/list_builder.dart';
@@ -19,8 +18,8 @@ part 'list/list_builder.dart';
 class OverriddenHashcodeBuiltList<T> extends _BuiltList<T> {
   final int _overridenHashCode;
 
-  OverriddenHashcodeBuiltList(Iterable iterable, this._overridenHashCode)
-    : super.from(iterable);
+  OverriddenHashcodeBuiltList(super.iterable, this._overridenHashCode)
+    : super.from();
 
   @override
   // ignore: hash_and_equals

--- a/built_types/built_collection/lib/src/list/built_list.dart
+++ b/built_types/built_collection/lib/src/list/built_list.dart
@@ -243,7 +243,7 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
 
 /// Default implementation of the public [BuiltList] interface.
 class _BuiltList<E> extends BuiltList<E> {
-  _BuiltList.withSafeList(List<E> list) : super._(list);
+  _BuiltList.withSafeList(super.list) : super._();
 
   _BuiltList.from([Iterable iterable = const []])
     : super._(List<E>.from(iterable, growable: false)) {
@@ -259,7 +259,7 @@ class _BuiltList<E> extends BuiltList<E> {
 
   void _maybeCheckForNull() {
     if (!_needsNullCheck) return;
-    for (var element in _list) {
+    for (final element in _list) {
       if (identical(element, null)) {
         throw ArgumentError('iterable contained invalid element: null');
       }

--- a/built_types/built_collection/lib/src/list/list_builder.dart
+++ b/built_types/built_collection/lib/src/list/list_builder.dart
@@ -93,8 +93,8 @@ class ListBuilder<E> {
   void addAll(Iterable<E> iterable) {
     // Add directly to the underlying `List` then check elements there, for
     // performance. Roll back the changes if validation fails.
-    var safeList = _safeList;
-    var lengthBefore = safeList.length;
+    final safeList = _safeList;
+    final lengthBefore = safeList.length;
     safeList.addAll(iterable);
     if (!_needsNullCheck) return;
     try {
@@ -138,11 +138,11 @@ class ListBuilder<E> {
   void insertAll(int index, Iterable<E> iterable) {
     // Add directly to the underlying `List` then check elements there, for
     // performance. Roll back the changes if validation fails.
-    var safeList = _safeList;
-    var lengthBefore = safeList.length;
+    final safeList = _safeList;
+    final lengthBefore = safeList.length;
     safeList.insertAll(index, iterable);
     if (!_needsNullCheck) return;
-    var insertedLength = safeList.length - lengthBefore;
+    final insertedLength = safeList.length - lengthBefore;
     try {
       for (var i = index; i != index + insertedLength; ++i) {
         _checkElement(safeList[i]);
@@ -215,7 +215,7 @@ class ListBuilder<E> {
 
   /// As [Iterable.map], but updates the builder in place. Returns nothing.
   void map(E Function(E) f) {
-    var result = _list.map(f).toList(growable: true);
+    final result = _list.map(f).toList(growable: true);
     _maybeCheckElements(result);
     _setSafeList(result);
   }
@@ -227,7 +227,7 @@ class ListBuilder<E> {
 
   /// As [Iterable.expand], but updates the builder in place. Returns nothing.
   void expand(Iterable<E> Function(E) f) {
-    var result = _list.expand(f).toList(growable: true);
+    final result = _list.expand(f).toList(growable: true);
     _maybeCheckElements(result);
     _setSafeList(result);
   }
@@ -289,7 +289,7 @@ class ListBuilder<E> {
 
   void _maybeCheckElements(Iterable<E> elements) {
     if (!_needsNullCheck) return;
-    for (var element in elements) {
+    for (final element in elements) {
       _checkElement(element);
     }
   }

--- a/built_types/built_collection/lib/src/list_multimap/built_list_multimap.dart
+++ b/built_types/built_collection/lib/src/list_multimap/built_list_multimap.dart
@@ -91,7 +91,7 @@ abstract class BuiltListMultimap<K, V> {
     if (other is! BuiltListMultimap) return false;
     if (other.length != length) return false;
     if (other.hashCode != hashCode) return false;
-    for (var key in keys) {
+    for (final key in keys) {
       if (other[key] != this[key]) return false;
     }
     return true;
@@ -110,7 +110,7 @@ abstract class BuiltListMultimap<K, V> {
 
   /// As [ListMultimap], but results are [BuiltList]s and not mutable.
   BuiltList<V> operator [](Object? key) {
-    var result = _map[key];
+    final result = _map[key];
     return result ?? _emptyList;
   }
 
@@ -123,9 +123,9 @@ abstract class BuiltListMultimap<K, V> {
   /// As [ListMultimap.forEach].
   void forEach(void Function(K, V) f) {
     _map.forEach((key, values) {
-      values.forEach((value) {
+      for (final value in values) {
         f(key, value);
-      });
+      }
     });
   }
 
@@ -166,11 +166,11 @@ abstract class BuiltListMultimap<K, V> {
 
 /// Default implementation of the public [BuiltListMultimap] interface.
 class _BuiltListMultimap<K, V> extends BuiltListMultimap<K, V> {
-  _BuiltListMultimap.withSafeMap(Map<K, BuiltList<V>> map) : super._(map);
+  _BuiltListMultimap.withSafeMap(super.map) : super._();
 
   _BuiltListMultimap.copy(Iterable keys, Function lookup)
     : super._(<K, BuiltList<V>>{}) {
-    for (var key in keys) {
+    for (final key in keys) {
       if (key is K) {
         _map[key] = BuiltList<V>(lookup(key));
       } else {

--- a/built_types/built_collection/lib/src/list_multimap/list_multimap_builder.dart
+++ b/built_types/built_collection/lib/src/list_multimap/list_multimap_builder.dart
@@ -33,8 +33,8 @@ class ListMultimapBuilder<K, V> {
   /// number of `BuiltListMultimap`s.
   BuiltListMultimap<K, V> build() {
     if (_builtMapOwner == null) {
-      for (var key in _builderMap.keys) {
-        var builtList = _builderMap[key]!.build();
+      for (final key in _builderMap.keys) {
+        final builtList = _builderMap[key]!.build();
         if (builtList.isEmpty) {
           _builtMap.remove(key);
         } else {
@@ -89,12 +89,12 @@ class ListMultimapBuilder<K, V> {
     key ??= (T x) => x as K;
 
     if (values != null) {
-      for (var element in iterable) {
+      for (final element in iterable) {
         addValues(key(element), values(element));
       }
     } else {
       value ??= (T x) => x as V;
-      for (var element in iterable) {
+      for (final element in iterable) {
         add(key(element), value(element));
       }
     }
@@ -113,9 +113,9 @@ class ListMultimapBuilder<K, V> {
   /// As [ListMultimap.addValues].
   void addValues(K key, Iterable<V> values) {
     // _disown is called in add.
-    values.forEach((value) {
+    for (final value in values) {
       add(key, value);
-    });
+    }
   }
 
   /// As [ListMultimap.remove].
@@ -129,12 +129,12 @@ class ListMultimapBuilder<K, V> {
   BuiltList<V> removeAll(Object? key) {
     if (key is! K) return BuiltList<V>();
     _makeWriteableCopy();
-    var builder = _builderMap[key];
+    final builder = _builderMap[key];
     if (builder == null) {
       _builderMap[key] = ListBuilder<V>();
       return _builtMap[key] ?? BuiltList<V>();
     }
-    var old = builder.build();
+    final old = builder.build();
     builder.clear();
     return old;
   }
@@ -160,7 +160,7 @@ class ListMultimapBuilder<K, V> {
   ListBuilder<V> _getValuesBuilder(K key) {
     var result = _builderMap[key];
     if (result == null) {
-      var builtValues = _builtMap[key];
+      final builtValues = _builtMap[key];
       if (builtValues == null) {
         result = ListBuilder<V>();
       } else {
@@ -191,9 +191,9 @@ class ListMultimapBuilder<K, V> {
     _builtMap = <K, BuiltList<V>>{};
     _builderMap = <K, ListBuilder<V>>{};
 
-    for (var key in keys) {
+    for (final key in keys) {
       if (key is K) {
-        for (var value in lookup(key)) {
+        for (final value in lookup(key)) {
           if (value is V) {
             add(key, value);
           } else {

--- a/built_types/built_collection/lib/src/map/built_map.dart
+++ b/built_types/built_collection/lib/src/map/built_map.dart
@@ -102,7 +102,7 @@ abstract class BuiltMap<K, V> {
     if (other is! BuiltMap) return false;
     if (other.length != length) return false;
     if (other.hashCode != hashCode) return false;
-    for (var key in keys) {
+    for (final key in keys) {
       if (other[key] != this[key]) return false;
     }
     return true;
@@ -163,14 +163,13 @@ abstract class BuiltMap<K, V> {
 
 /// Default implementation of the public [BuiltMap] interface.
 class _BuiltMap<K, V> extends BuiltMap<K, V> {
-  _BuiltMap.withSafeMap(_MapFactory<K, V>? mapFactory, Map<K, V> map)
-    : super._(mapFactory, map);
+  _BuiltMap.withSafeMap(super.mapFactory, super.map) : super._();
 
   _BuiltMap.copyAndCheckTypes(Iterable keys, Function lookup)
     : super._(null, <K, V>{}) {
-    for (var key in keys) {
+    for (final key in keys) {
       if (key is K) {
-        var value = lookup(key);
+        final value = lookup(key);
         if (value is V) {
           _map[key] = value;
         } else {
@@ -184,13 +183,13 @@ class _BuiltMap<K, V> extends BuiltMap<K, V> {
 
   _BuiltMap.copyAndCheckForNull(Iterable<K> keys, V Function(K) lookup)
     : super._(null, <K, V>{}) {
-    var checkKeys = !isSoundMode && null is! K;
-    var checkValues = !isSoundMode && null is! V;
-    for (var key in keys) {
+    final checkKeys = !isSoundMode && null is! K;
+    final checkValues = !isSoundMode && null is! V;
+    for (final key in keys) {
       if (checkKeys && identical(key, null)) {
         throw ArgumentError('map contained invalid key: null');
       }
-      var value = lookup(key);
+      final value = lookup(key);
       if (checkValues && value == null) {
         throw ArgumentError('map contained invalid value: null');
       }

--- a/built_types/built_collection/lib/src/map/map_builder.dart
+++ b/built_types/built_collection/lib/src/map/map_builder.dart
@@ -41,13 +41,13 @@ class MapBuilder<K, V> {
     if (map is _BuiltMap<K, V> && map._mapFactory == _mapFactory) {
       _setOwner(map);
     } else if (map is BuiltMap) {
-      var replacement = _createMap();
+      final replacement = _createMap();
       map.forEach((dynamic key, dynamic value) {
         replacement[key as K] = value as V;
       });
       _setSafeMap(replacement);
     } else if (map is Map) {
-      var replacement = _createMap();
+      final replacement = _createMap();
       map.forEach((dynamic key, dynamic value) {
         replacement[key as K] = value as V;
       });
@@ -96,7 +96,7 @@ class MapBuilder<K, V> {
   }) {
     key ??= (T x) => x as K;
     value ??= (T x) => x as V;
-    for (var element in iterable) {
+    for (final element in iterable) {
       this[key(element)] = value(element);
     }
   }
@@ -126,7 +126,7 @@ class MapBuilder<K, V> {
   V putIfAbsent(K key, V Function() ifAbsent) {
     _checkKey(key);
     return _safeMap.putIfAbsent(key, () {
-      var value = ifAbsent();
+      final value = ifAbsent();
       _checkValue(value);
       return value;
     });
@@ -210,7 +210,7 @@ class MapBuilder<K, V> {
   void _checkKeys(Iterable<K> keys) {
     if (isSoundMode) return;
     if (null is K) return;
-    for (var key in keys) {
+    for (final key in keys) {
       _checkKey(key);
     }
   }
@@ -226,7 +226,7 @@ class MapBuilder<K, V> {
   void _checkValues(Iterable<V> values) {
     if (isSoundMode) return;
     if (null is V) return;
-    for (var value in values) {
+    for (final value in values) {
       _checkValue(value);
     }
   }

--- a/built_types/built_collection/lib/src/set.dart
+++ b/built_types/built_collection/lib/src/set.dart
@@ -2,14 +2,13 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'package:built_collection/src/iterable.dart' show BuiltIterable;
-import 'package:built_collection/src/list.dart' show BuiltList;
-
-import 'internal/hash.dart';
 import 'internal/copy_on_write_set.dart';
+import 'internal/hash.dart';
 import 'internal/iterables.dart';
 import 'internal/null_safety.dart';
 import 'internal/unmodifiable_set.dart';
+import 'iterable.dart' show BuiltIterable;
+import 'list.dart' show BuiltList;
 
 part 'set/built_set.dart';
 part 'set/set_builder.dart';
@@ -18,8 +17,8 @@ part 'set/set_builder.dart';
 class OverriddenHashcodeBuiltSet<T> extends _BuiltSet<T> {
   final int _overridenHashCode;
 
-  OverriddenHashcodeBuiltSet(Iterable iterable, this._overridenHashCode)
-    : super.from(iterable);
+  OverriddenHashcodeBuiltSet(super.iterable, this._overridenHashCode)
+    : super.from();
 
   @override
   // ignore: hash_and_equals

--- a/built_types/built_collection/lib/src/set/built_set.dart
+++ b/built_types/built_collection/lib/src/set/built_set.dart
@@ -229,8 +229,7 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
 
 /// Default implementation of the public [BuiltSet] interface.
 class _BuiltSet<E> extends BuiltSet<E> {
-  _BuiltSet.withSafeSet(_SetFactory<E>? setFactory, Set<E> set)
-    : super._(setFactory, set);
+  _BuiltSet.withSafeSet(super.setFactory, super.set) : super._();
 
   _BuiltSet.from(Iterable iterable) : super._(null, Set<E>.from(iterable)) {
     _maybeCheckForNull();
@@ -244,7 +243,7 @@ class _BuiltSet<E> extends BuiltSet<E> {
 
   void _maybeCheckForNull() {
     if (!_needsNullCheck) return;
-    for (var element in _set) {
+    for (final element in _set) {
       if (identical(element, null)) {
         throw ArgumentError('iterable contained invalid element: null');
       }

--- a/built_types/built_collection/lib/src/set/set_builder.dart
+++ b/built_types/built_collection/lib/src/set/set_builder.dart
@@ -42,8 +42,8 @@ class SetBuilder<E> {
       _withOwner(iterable);
     } else {
       // Can't use addAll because it requires an Iterable<E>.
-      var set = _createSet();
-      for (var element in iterable) {
+      final set = _createSet();
+      for (final element in iterable) {
         if (element is E) {
           set.add(element);
         } else {
@@ -141,7 +141,7 @@ class SetBuilder<E> {
 
   /// As [Iterable.map], but updates the builder in place. Returns nothing.
   void map(E Function(E) f) {
-    var result = _createSet()..addAll(_set.map(f));
+    final result = _createSet()..addAll(_set.map(f));
     _maybeCheckElements(result);
     _setSafeSet(result);
   }
@@ -153,7 +153,7 @@ class SetBuilder<E> {
 
   /// As [Iterable.expand], but updates the builder in place. Returns nothing.
   void expand(Iterable<E> Function(E) f) {
-    var result = _createSet()..addAll(_set.expand(f));
+    final result = _createSet()..addAll(_set.expand(f));
     _maybeCheckElements(result);
     _setSafeSet(result);
   }
@@ -227,7 +227,7 @@ class SetBuilder<E> {
 
   void _maybeCheckElements(Iterable<E> elements) {
     if (!_needsNullCheck) return;
-    for (var element in elements) {
+    for (final element in elements) {
       _checkElement(element);
     }
   }

--- a/built_types/built_collection/lib/src/set_multimap/built_set_multimap.dart
+++ b/built_types/built_collection/lib/src/set_multimap/built_set_multimap.dart
@@ -97,7 +97,7 @@ abstract class BuiltSetMultimap<K, V> {
     if (other is! BuiltSetMultimap) return false;
     if (other.length != length) return false;
     if (other.hashCode != hashCode) return false;
-    for (var key in keys) {
+    for (final key in keys) {
       if (other[key] != this[key]) return false;
     }
     return true;
@@ -116,7 +116,7 @@ abstract class BuiltSetMultimap<K, V> {
 
   /// As [SetMultimap], but results are [BuiltSet]s and not mutable.
   BuiltSet<V>? operator [](Object? key) {
-    var result = _map[key];
+    final result = _map[key];
     return identical(result, null) ? _emptySet : result;
   }
 
@@ -129,9 +129,9 @@ abstract class BuiltSetMultimap<K, V> {
   /// As [SetMultimap.forEach].
   void forEach(void Function(K, V) f) {
     _map.forEach((key, values) {
-      values.forEach((value) {
+      for (final value in values) {
         f(key, value);
-      });
+      }
     });
   }
 
@@ -172,11 +172,11 @@ abstract class BuiltSetMultimap<K, V> {
 
 /// Default implementation of the public [BuiltSetMultimap] interface.
 class _BuiltSetMultimap<K, V> extends BuiltSetMultimap<K, V> {
-  _BuiltSetMultimap.withSafeMap(Map<K, BuiltSet<V>> map) : super._(map);
+  _BuiltSetMultimap.withSafeMap(super.map) : super._();
 
   _BuiltSetMultimap.copyAndCheck(Iterable keys, Function lookup)
     : super._(<K, BuiltSet<V>>{}) {
-    for (var key in keys) {
+    for (final key in keys) {
       if (key is K) {
         _map[key] = BuiltSet<V>(lookup(key));
       } else {

--- a/built_types/built_collection/lib/src/set_multimap/set_multimap_builder.dart
+++ b/built_types/built_collection/lib/src/set_multimap/set_multimap_builder.dart
@@ -30,8 +30,8 @@ class SetMultimapBuilder<K, V> {
   /// Converts to a [BuiltSetMultimap].
   BuiltSetMultimap<K, V> build() {
     if (_builtMapOwner == null) {
-      for (var key in _builderMap.keys) {
-        var builtSet = _builderMap[key]!.build();
+      for (final key in _builderMap.keys) {
+        final builtSet = _builderMap[key]!.build();
         if (builtSet.isEmpty) {
           _builtMap.remove(key);
         } else {
@@ -84,12 +84,12 @@ class SetMultimapBuilder<K, V> {
     key ??= (T x) => x as K;
 
     if (values != null) {
-      for (var element in iterable) {
+      for (final element in iterable) {
         addValues(key(element), values(element));
       }
     } else {
       value ??= (T x) => x as V;
-      for (var element in iterable) {
+      for (final element in iterable) {
         add(key(element), value(element));
       }
     }
@@ -108,9 +108,9 @@ class SetMultimapBuilder<K, V> {
   /// As [SetMultimap.addValues].
   void addValues(K key, Iterable<V> values) {
     // _disown is called in add.
-    values.forEach((value) {
+    for (final value in values) {
       add(key, value);
-    });
+    }
   }
 
   /// As [SetMultimap.remove] but returns nothing.
@@ -144,7 +144,7 @@ class SetMultimapBuilder<K, V> {
   SetBuilder<V> _getValuesBuilder(K key) {
     var result = _builderMap[key];
     if (result == null) {
-      var builtValues = _builtMap[key];
+      final builtValues = _builtMap[key];
       if (builtValues == null) {
         result = SetBuilder<V>();
       } else {
@@ -175,9 +175,9 @@ class SetMultimapBuilder<K, V> {
     _builtMap = <K, BuiltSet<V>>{};
     _builderMap = <K, SetBuilder<V>>{};
 
-    for (var key in keys) {
+    for (final key in keys) {
       if (key is K) {
-        for (var value in lookup(key)) {
+        for (final value in lookup(key)) {
           if (value is V) {
             add(key, value);
           } else {

--- a/built_types/built_collection/pubspec.yaml
+++ b/built_types/built_collection/pubspec.yaml
@@ -14,5 +14,5 @@ environment:
   sdk: ^3.11.0
 
 dev_dependencies:
-  pedantic: ^1.4.0
+  dart_flutter_team_lints: ^3.1.0
   test: ^1.16.0-nullsafety

--- a/built_types/built_collection/test/internal/copy_on_write_list_test.dart
+++ b/built_types/built_collection/test/internal/copy_on_write_list_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   group('CopyOnWriteList', () {
     test('has toString equal to List.toString', () {
-      var list = <int>[1, 2, 3];
+      final list = <int>[1, 2, 3];
       expect(CopyOnWriteList(list, false).toString(), list.toString());
     });
   });

--- a/built_types/built_collection/test/internal/copy_on_write_map_test.dart
+++ b/built_types/built_collection/test/internal/copy_on_write_map_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   group('CopyOnWriteMap', () {
     test('has toString equal to Map.toString', () {
-      var map = <int, String>{1: 'one', 2: 'two', 3: 'three'};
+      final map = <int, String>{1: 'one', 2: 'two', 3: 'three'};
       expect(CopyOnWriteMap(map).toString(), map.toString());
     });
   });

--- a/built_types/built_collection/test/internal/copy_on_write_set_test.dart
+++ b/built_types/built_collection/test/internal/copy_on_write_set_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   group('CopyOnWriteSet', () {
     test('has toString equal to Set.toString', () {
-      var set = <int>{1, 2, 3};
+      final set = <int>{1, 2, 3};
       expect(CopyOnWriteSet(set).toString(), set.toString());
     });
   });

--- a/built_types/built_collection/test/list/built_list_test.dart
+++ b/built_types/built_collection/test/list/built_list_test.dart
@@ -2,8 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.s
 
-import 'package:built_collection/src/list.dart';
 import 'package:built_collection/src/internal/test_helpers.dart';
+import 'package:built_collection/src/list.dart';
 import 'package:test/test.dart';
 
 import '../performance.dart';
@@ -11,7 +11,7 @@ import '../performance.dart';
 void main() {
   group('BuiltList', () {
     test('instantiates empty by default', () {
-      var list = BuiltList<int>();
+      final list = BuiltList<int>();
       expect(list.isEmpty, isTrue);
       expect(list.isNotEmpty, isFalse);
     });
@@ -29,14 +29,14 @@ void main() {
     });
 
     test('reports non-emptiness', () {
-      var list = BuiltList<int>([1]);
+      final list = BuiltList<int>([1]);
       expect(list.isEmpty, isFalse);
       expect(list.isNotEmpty, isTrue);
     });
 
     test('can be instantiated from List then converted back to equal List', () {
-      var mutableList = [1];
-      var list = BuiltList<int>(mutableList);
+      final mutableList = [1];
+      final list = BuiltList<int>(mutableList);
       expect(list.toList(), mutableList);
     });
 
@@ -45,15 +45,15 @@ void main() {
     });
 
     test('does not keep a mutable List', () {
-      var mutableList = [1];
-      var list = BuiltList<int>(mutableList);
+      final mutableList = [1];
+      final list = BuiltList<int>(mutableList);
       mutableList.clear();
       expect(list.toList(), [1]);
     });
 
     test('copies from BuiltList instances of different type', () {
-      var list1 = BuiltList<Object>();
-      var list2 = BuiltList<int>(list1);
+      final list1 = BuiltList<Object>();
+      final list2 = BuiltList<int>(list1);
       expect(list1, isNot(same(list2)));
     });
 
@@ -66,7 +66,7 @@ void main() {
     });
 
     test('can be converted to an UnmodifiableListView', () {
-      var immutableList = BuiltList<int>().asList();
+      final immutableList = BuiltList<int>().asList();
       expect(immutableList, const TypeMatcher<List<int>>());
       expect(() => immutableList.add(1), throwsUnsupportedError);
       expect(immutableList, isEmpty);
@@ -103,22 +103,22 @@ void main() {
     });
 
     test('hashes to same value for same contents', () {
-      var list1 = BuiltList<int>([1, 2, 3]);
-      var list2 = BuiltList<int>([1, 2, 3]);
+      final list1 = BuiltList<int>([1, 2, 3]);
+      final list2 = BuiltList<int>([1, 2, 3]);
 
       expect(list1.hashCode, list2.hashCode);
     });
 
     test('hashes to different value for different contents', () {
-      var list1 = BuiltList<int>([1, 2, 3]);
-      var list2 = BuiltList<int>([1, 2, 4]);
+      final list1 = BuiltList<int>([1, 2, 3]);
+      final list2 = BuiltList<int>([1, 2, 4]);
 
       expect(list1.hashCode, isNot(list2.hashCode));
     });
 
     test('caches hash', () {
-      var hashCodeSpy = HashCodeSpy();
-      var list = BuiltList<Object>([hashCodeSpy]);
+      final hashCodeSpy = HashCodeSpy();
+      final list = BuiltList<Object>([hashCodeSpy]);
 
       hashCodeSpy.hashCodeSeen = 0;
       list.hashCode;
@@ -127,13 +127,13 @@ void main() {
     });
 
     test('compares equal to same instance', () {
-      var list = BuiltList<int>([1, 2, 3]);
+      final list = BuiltList<int>([1, 2, 3]);
       expect(list == list, isTrue);
     });
 
     test('compares equal to same contents', () {
-      var list1 = BuiltList<int>([1, 2, 3]);
-      var list2 = BuiltList<int>([1, 2, 3]);
+      final list1 = BuiltList<int>([1, 2, 3]);
+      final list2 = BuiltList<int>([1, 2, 3]);
       expect(list1 == list2, isTrue);
     });
 
@@ -170,7 +170,7 @@ void main() {
     });
 
     test('returns identical with toBuiltList', () {
-      var list = BuiltList<int>([0, 1, 2]);
+      final list = BuiltList<int>([0, 1, 2]);
       expect(list.toBuiltList(), same(list));
     });
 
@@ -181,51 +181,54 @@ void main() {
     // Lazy copies.
 
     test('reuses BuiltList instances of the same type', () {
-      var list1 = BuiltList<int>();
-      var list2 = BuiltList<int>(list1);
+      final list1 = BuiltList<int>();
+      final list2 = BuiltList<int>(list1);
       expect(list1, same(list2));
     });
 
     test('does not reuse BuiltList instances with subtype element type', () {
-      var list1 = BuiltList<_ExtendsA>();
-      var list2 = BuiltList<_A>(list1);
+      final list1 = BuiltList<_ExtendsA>();
+      final list2 = BuiltList<_A>(list1);
       expect(list1, isNot(same(list2)));
     });
 
     test('can be reused via ListBuilder if there are no changes', () {
-      var list1 = BuiltList<Object>();
-      var list2 = list1.toBuilder().build();
+      final list1 = BuiltList<Object>();
+      final list2 = list1.toBuilder().build();
       expect(list1, same(list2));
     });
 
     test('converts to ListBuilder from correct type without copying', () {
-      var makeLongList = () => BuiltList<int>(List<int>.filled(1000000, 0));
-      var longList = makeLongList();
-      var longListToListBuilder = longList.toBuilder;
+      final makeLongList = () => BuiltList<int>(List<int>.filled(1000000, 0));
+      final longList = makeLongList();
+      final longListToListBuilder = longList.toBuilder;
 
       expectMuchFaster(longListToListBuilder, makeLongList);
     });
 
     test('converts to ListBuilder from wrong type by copying', () {
-      var makeLongList = () => BuiltList<Object>(List<int>.filled(1000000, 0));
-      var longList = makeLongList();
-      var longListToListBuilder = () => ListBuilder<int>(longList);
+      final makeLongList = () =>
+          BuiltList<Object>(List<int>.filled(1000000, 0));
+      final longList = makeLongList();
+      final longListToListBuilder = () => ListBuilder<int>(longList);
 
       expectNotMuchFaster(longListToListBuilder, makeLongList);
     });
 
     test('has fast toList', () {
-      var makeLongList = () => BuiltList<Object>(List<int>.filled(1000000, 0));
-      var longList = makeLongList();
-      var longListToList = () => longList.toList();
+      final makeLongList = () =>
+          BuiltList<Object>(List<int>.filled(1000000, 0));
+      final longList = makeLongList();
+      final longListToList = longList.toList;
 
       expectMuchFaster(longListToList, makeLongList);
     });
 
     test('checks for reference identity', () {
-      var makeLongList = () => BuiltList<Object>(List<int>.filled(1000000, 0));
-      var longList = makeLongList();
-      var otherLongList = makeLongList();
+      final makeLongList = () =>
+          BuiltList<Object>(List<int>.filled(1000000, 0));
+      final longList = makeLongList();
+      final otherLongList = makeLongList();
 
       expectMuchFaster(
         () => longList == longList,
@@ -234,7 +237,7 @@ void main() {
     });
 
     test('is not mutated when List from toList is mutated', () {
-      var list = BuiltList<int>();
+      final list = BuiltList<int>();
       list.toList().add(1);
       expect(list, []);
     });
@@ -255,7 +258,7 @@ void main() {
     });
 
     test('returns identical BuiltList on repeated build', () {
-      var listBuilder = ListBuilder<int>([1, 2, 3]);
+      final listBuilder = ListBuilder<int>([1, 2, 3]);
       expect(listBuilder.build(), same(listBuilder.build()));
     });
 
@@ -351,7 +354,9 @@ void main() {
 
     test('implements Iterable.forEach', () {
       var value = 1;
-      BuiltList<int>([2]).forEach((x) => value = x);
+      for (final x in BuiltList<int>([2])) {
+        value = x;
+      }
       expect(value, 2);
     });
 

--- a/built_types/built_collection/test/list/list_builder_test.dart
+++ b/built_types/built_collection/test/list/list_builder_test.dart
@@ -20,79 +20,79 @@ void main() {
     });
 
     test('throws on null assign', () {
-      var builder = ListBuilder<int>([0]);
+      final builder = ListBuilder<int>([0]);
       expect(() => builder[0] = null as dynamic, throwsA(anything));
       expect(builder.build(), orderedEquals([0]));
     });
 
     test('nullable does not throw on null assign', () {
-      var builder = ListBuilder<int?>([0]);
+      final builder = ListBuilder<int?>([0]);
       builder[0] = null;
       expect(builder.build(), orderedEquals([null]));
     });
 
     test('throws on null first', () {
-      var builder = ListBuilder<int>([0]);
+      final builder = ListBuilder<int>([0]);
       expect(() => builder.first = null as dynamic, throwsA(anything));
       expect(builder.build(), orderedEquals([0]));
     });
 
     test('nullable does not throw on null first', () {
-      var builder = ListBuilder<int?>([0]);
+      final builder = ListBuilder<int?>([0]);
       builder.first = null;
       expect(builder.build(), orderedEquals([null]));
     });
 
     test('throws on null last', () {
-      var builder = ListBuilder<int>([0]);
+      final builder = ListBuilder<int>([0]);
       expect(() => builder.last = null as dynamic, throwsA(anything));
       expect(builder.build(), orderedEquals([0]));
     });
 
     test('nullable does not throw on null last', () {
-      var builder = ListBuilder<int?>([0]);
+      final builder = ListBuilder<int?>([0]);
       builder.last = null;
       expect(builder.build(), orderedEquals([null]));
     });
 
     test('throws on null add', () {
-      var builder = ListBuilder<int>();
+      final builder = ListBuilder<int>();
       expect(() => builder.add(null as dynamic), throwsA(anything));
       expect(builder.build(), isEmpty);
     });
 
     test('nullable does not throw on null add', () {
-      var builder = ListBuilder<int?>();
+      final builder = ListBuilder<int?>();
       builder.add(null);
       expect(builder.build(), [null]);
     });
 
     test('throws on null addAll', () {
-      var builder = ListBuilder<int>();
+      final builder = ListBuilder<int>();
       expect(() => builder.addAll([0, 1, null as dynamic]), throwsA(anything));
       expect(builder.build(), isEmpty);
     });
 
     test('nullable does not throw on null addAll', () {
-      var builder = ListBuilder<int?>();
+      final builder = ListBuilder<int?>();
       builder.addAll([0, 1, null]);
       expect(builder.build(), [0, 1, null]);
     });
 
     test('throws on null insert', () {
-      var builder = ListBuilder<int>();
+      final builder = ListBuilder<int>();
       expect(() => builder.insert(0, null as dynamic), throwsA(anything));
       expect(builder.build(), isEmpty);
     });
 
     test('nullable does not throw on null insert', () {
-      var builder = ListBuilder<int?>();
+      final builder = ListBuilder<int?>();
       builder.insert(0, null);
       expect(builder.build(), [null]);
     });
 
     test('throws on null insertAll', () {
-      var builder = ListBuilder<int>();
+      final builder = ListBuilder<int>();
       expect(
         () => builder.insertAll(0, [0, 1, null as dynamic]),
         throwsA(anything),
@@ -101,13 +101,13 @@ void main() {
     });
 
     test('nullable does not throw on null insertAll', () {
-      var builder = ListBuilder<int?>();
+      final builder = ListBuilder<int?>();
       builder.insertAll(0, [0, 1, null]);
       expect(builder.build(), [0, 1, null]);
     });
 
     test('throws on null setAll', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
+      final builder = ListBuilder<int>([0, 1, 2]);
       expect(
         () => builder.setAll(0, [0, 1, null as dynamic]),
         throwsA(anything),
@@ -116,13 +116,13 @@ void main() {
     });
 
     test('nullable does not throw on null setAll', () {
-      var builder = ListBuilder<int?>([0, 1, 2]);
+      final builder = ListBuilder<int?>([0, 1, 2]);
       builder.setAll(0, [0, 1, null]);
       expect(builder.build(), orderedEquals([0, 1, null]));
     });
 
     test('throws on null setRange', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
+      final builder = ListBuilder<int>([0, 1, 2]);
       expect(
         () => builder.setRange(0, 3, [0, 1, null as dynamic]),
         throwsA(anything),
@@ -131,25 +131,25 @@ void main() {
     });
 
     test('nullable does not throw on null setRange', () {
-      var builder = ListBuilder<int?>([0, 1, 2]);
+      final builder = ListBuilder<int?>([0, 1, 2]);
       builder.setRange(0, 3, [0, 1, null]);
       expect(builder.build(), orderedEquals([0, 1, null]));
     });
 
     test('throws on null fillRange', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
+      final builder = ListBuilder<int>([0, 1, 2]);
       expect(() => builder.fillRange(0, 3, null as dynamic), throwsA(anything));
       expect(builder.build(), orderedEquals([0, 1, 2]));
     });
 
     test('nullable does not throw on null fillRange', () {
-      var builder = ListBuilder<int?>([0, 1, 2]);
+      final builder = ListBuilder<int?>([0, 1, 2]);
       builder.fillRange(0, 3, null);
       expect(builder.build(), orderedEquals([null, null, null]));
     });
 
     test('throws on null replaceRange', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
+      final builder = ListBuilder<int>([0, 1, 2]);
       expect(
         () => builder.replaceRange(0, 3, [0, 1, null as dynamic]),
         throwsA(anything),
@@ -158,25 +158,25 @@ void main() {
     });
 
     test('nullable does not throw on null replaceRange', () {
-      var builder = ListBuilder<int?>([0, 1, 2]);
+      final builder = ListBuilder<int?>([0, 1, 2]);
       builder.replaceRange(0, 3, [0, 1, null]);
       expect(builder.build(), orderedEquals([0, 1, null]));
     });
 
     test('throws on null map', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
+      final builder = ListBuilder<int>([0, 1, 2]);
       expect(() => builder.map((x) => null as dynamic), throwsA(anything));
       expect(builder.build(), orderedEquals([0, 1, 2]));
     });
 
     test('nullable does not throw on null map', () {
-      var builder = ListBuilder<int?>([0, 1, 2]);
+      final builder = ListBuilder<int?>([0, 1, 2]);
       builder.map((x) => null);
       expect(builder.build(), orderedEquals([null, null, null]));
     });
 
     test('throws on null expand', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
+      final builder = ListBuilder<int>([0, 1, 2]);
       expect(
         () => builder.expand((x) => [x, null as dynamic]),
         throwsA(anything),
@@ -185,13 +185,13 @@ void main() {
     });
 
     test('nullable does not throw on null expand', () {
-      var builder = ListBuilder<int?>([0, 1, 2]);
+      final builder = ListBuilder<int?>([0, 1, 2]);
       builder.expand((x) => [x, null]);
       expect(builder.build(), orderedEquals([0, null, 1, null, 2, null]));
     });
 
     test('throws on wrong type addAll', () {
-      var builder = ListBuilder<int>();
+      final builder = ListBuilder<int>();
       expect(
         () => builder.addAll(List<int>.from([0, 1, '0'])),
         throwsA(anything),
@@ -200,7 +200,7 @@ void main() {
     });
 
     test('throws on wrong type insertAll', () {
-      var builder = ListBuilder<int>();
+      final builder = ListBuilder<int>();
       expect(
         () => builder.insertAll(0, List<int>.from([0, 1, '0'])),
         throwsA(anything),
@@ -209,7 +209,7 @@ void main() {
     });
 
     test('throws on wrong type setAll', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
+      final builder = ListBuilder<int>([0, 1, 2]);
       expect(
         () => builder.setAll(0, List<int>.from([0, 1, '0'])),
         throwsA(anything),
@@ -218,7 +218,7 @@ void main() {
     });
 
     test('throws on wrong type setRange', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
+      final builder = ListBuilder<int>([0, 1, 2]);
       expect(
         () => builder.setRange(0, 2, List<int>.from([0, 1, '0'])),
         throwsA(anything),
@@ -227,7 +227,7 @@ void main() {
     });
 
     test('throws on wrong type replaceRange', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
+      final builder = ListBuilder<int>([0, 1, 2]);
       expect(
         () => builder.replaceRange(0, 2, List<int>.from([0, 1, '0'])),
         throwsA(anything),
@@ -242,71 +242,71 @@ void main() {
     // Lazy copies.
 
     test('does not mutate BuiltList when modifying ListBuilder assign', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder[0] = 3;
       expect(list, [1, 2]);
     });
 
     test('does not mutate BuiltList when modifying ListBuilder first', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.first = 3;
       expect(list, [1, 2]);
     });
 
     test('does not mutate BuiltList when modifying ListBuilder last', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.last = 3;
       expect(list, [1, 2]);
     });
 
     test('does not mutate BuiltList when modifying ListBuilder add', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.add(3);
       expect(list, [1, 2]);
     });
 
     test('does not mutate BuiltList when modifying ListBuilder addAll', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.addAll([3, 4]);
       expect(list, [1, 2]);
     });
 
     test('does not mutate BuiltList when modifying ListBuilder insert', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.insert(0, 3);
       expect(list, [1, 2]);
     });
 
     test('does not mutate BuiltList when modifying ListBuilder insertAll', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.insertAll(0, [3, 4]);
       expect(list, [1, 2]);
     });
 
     test('does not mutate BuiltList when modifying ListBuilder setAll', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.setAll(0, [3, 4]);
       expect(list, [1, 2]);
     });
 
     test('does not mutate BuiltList when modifying ListBuilder setRange', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.setRange(0, 2, [3, 4, 5]);
       expect(list, [1, 2]);
     });
 
     test('does not mutate BuiltList when modifying ListBuilder fillRange', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.fillRange(0, 2, 3);
       expect(list, [1, 2]);
     });
@@ -314,40 +314,40 @@ void main() {
     test(
       'does not mutate BuiltList when modifying ListBuilder replaceRange',
       () {
-        var list = BuiltList<int>([1, 2]);
-        var listBuilder = list.toBuilder();
+        final list = BuiltList<int>([1, 2]);
+        final listBuilder = list.toBuilder();
         listBuilder.replaceRange(0, 2, [3, 4]);
         expect(list, [1, 2]);
       },
     );
 
     test('does not mutate BuiltList when modifying ListBuilder map', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.map((x) => 3);
       expect(list, [1, 2]);
     });
 
     test('does not mutate BuiltList when modifying ListBuilder expand', () {
-      var list = BuiltList<int>([1, 2]);
-      var listBuilder = list.toBuilder();
+      final list = BuiltList<int>([1, 2]);
+      final listBuilder = list.toBuilder();
       listBuilder.expand((x) => [3, 4]);
       expect(list, [1, 2]);
     });
 
     test('converts to BuiltList without copying', () {
-      var makeLongListBuilder = () =>
+      final makeLongListBuilder = () =>
           ListBuilder<int>(List<int>.filled(1000000, 0));
-      var longListBuilder = makeLongListBuilder();
-      var buildLongListBuilder = () => longListBuilder.build();
+      final longListBuilder = makeLongListBuilder();
+      final buildLongListBuilder = longListBuilder.build;
 
       expectMuchFaster(buildLongListBuilder, makeLongListBuilder);
     });
 
     test('does not mutate BuiltList following mutates after build', () {
-      var listBuilder = ListBuilder<int>([1, 2]);
+      final listBuilder = ListBuilder<int>([1, 2]);
 
-      var list1 = listBuilder.build();
+      final list1 = listBuilder.build();
       expect(list1, [1, 2]);
 
       listBuilder.add(3);
@@ -357,7 +357,7 @@ void main() {
     // List.
 
     test('has a method like List[]', () {
-      var listBuilder = ListBuilder<int>([1, 2]);
+      final listBuilder = ListBuilder<int>([1, 2]);
       ++listBuilder[0];
       --listBuilder[1];
       expect(listBuilder.build(), [2, 1]);
@@ -369,14 +369,14 @@ void main() {
     });
 
     test('has a property like List.first', () {
-      var builder = BuiltList<int>([1, 2, 3]).toBuilder();
+      final builder = BuiltList<int>([1, 2, 3]).toBuilder();
       expect(builder.first, 1);
       builder.first = 2;
       expect(builder.build().first, 2);
     });
 
     test('has a property like List.last', () {
-      var builder = BuiltList<int>([1, 2, 3]).toBuilder();
+      final builder = BuiltList<int>([1, 2, 3]).toBuilder();
       expect(builder.last, 3);
       builder.last = 2;
       expect(builder.build().last, 2);

--- a/built_types/built_collection/test/list_multimap/built_list_multimap_test.dart
+++ b/built_types/built_collection/test/list_multimap/built_list_multimap_test.dart
@@ -3,9 +3,9 @@
 // license that can be found in the LICENSE file.
 // ignore_for_file: unrelated_type_equality_checks
 
+import 'package:built_collection/src/internal/test_helpers.dart';
 import 'package:built_collection/src/list.dart';
 import 'package:built_collection/src/list_multimap.dart';
-import 'package:built_collection/src/internal/test_helpers.dart';
 import 'package:test/test.dart';
 
 import '../performance.dart';
@@ -13,7 +13,7 @@ import '../performance.dart';
 void main() {
   group('BuiltListMultimap', () {
     test('instantiates empty by default', () {
-      var multimap = BuiltListMultimap<int, String>();
+      final multimap = BuiltListMultimap<int, String>();
       expect(multimap.isEmpty, isTrue);
       expect(multimap.isNotEmpty, isFalse);
     });
@@ -27,7 +27,7 @@ void main() {
     });
 
     test('reports non-emptiness', () {
-      var map = BuiltListMultimap<int, String>({
+      final map = BuiltListMultimap<int, String>({
         1: ['1'],
       });
       expect(map.isEmpty, isFalse);
@@ -36,9 +36,9 @@ void main() {
 
     test('can be instantiated from ListMultimap '
         'then converted back to equal ListMultimap', () {
-      var mutableMultimap = _ListMultimap<int, String>();
+      final mutableMultimap = _ListMultimap<int, String>();
       mutableMultimap.add(1, '1');
-      var multimap = BuiltListMultimap<int, String>(mutableMultimap);
+      final multimap = BuiltListMultimap<int, String>(mutableMultimap);
       expect(multimap.toMap(), mutableMultimap.asMap());
     });
 
@@ -65,9 +65,9 @@ void main() {
     });
 
     test('does not keep a mutable ListMultimap', () {
-      var mutableMultimap = _ListMultimap<int, String>();
+      final mutableMultimap = _ListMultimap<int, String>();
       mutableMultimap.add(1, '1');
-      var multimap = BuiltListMultimap<int, String>(mutableMultimap);
+      final multimap = BuiltListMultimap<int, String>(mutableMultimap);
       mutableMultimap.clear();
       expect(multimap.toMap(), {
         1: ['1'],
@@ -75,8 +75,8 @@ void main() {
     });
 
     test('copies from BuiltListMultimap instances of different type', () {
-      var multimap1 = BuiltListMultimap<Object, Object>();
-      var multimap2 = BuiltListMultimap<int, String>(multimap1);
+      final multimap1 = BuiltListMultimap<Object, Object>();
+      final multimap2 = BuiltListMultimap<int, String>(multimap1);
       expect(multimap1, isNot(same(multimap2)));
     });
 
@@ -96,7 +96,7 @@ void main() {
     });
 
     test('can be converted to an UnmodifiableMapView', () {
-      var immutableMap = BuiltListMultimap<int, String>().asMap();
+      final immutableMap = BuiltListMultimap<int, String>().asMap();
       expect(immutableMap, const TypeMatcher<Map<int, Iterable<String>>>());
       expect(() => immutableMap[1] = ['Hello'], throwsUnsupportedError);
       expect(immutableMap, isEmpty);
@@ -190,12 +190,12 @@ void main() {
     });
 
     test('hashes to same value for same contents', () {
-      var multimap1 = BuiltListMultimap<int, String>({
+      final multimap1 = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
       });
-      var multimap2 = BuiltListMultimap<int, String>({
+      final multimap2 = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
@@ -205,12 +205,12 @@ void main() {
     });
 
     test('hashes to different value for different keys', () {
-      var multimap1 = BuiltListMultimap<int, String>({
+      final multimap1 = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
       });
-      var multimap2 = BuiltListMultimap<int, String>({
+      final multimap2 = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         4: ['3'],
@@ -220,12 +220,12 @@ void main() {
     });
 
     test('hashes to different value for different values', () {
-      var multimap1 = BuiltListMultimap<int, String>({
+      final multimap1 = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
       });
-      var multimap2 = BuiltListMultimap<int, String>({
+      final multimap2 = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2', '3'],
         3: ['3'],
@@ -235,8 +235,8 @@ void main() {
     });
 
     test('caches hash', () {
-      var hashCodeSpy = HashCodeSpy();
-      var multimap = BuiltListMultimap<Object, Object>({
+      final hashCodeSpy = HashCodeSpy();
+      final multimap = BuiltListMultimap<Object, Object>({
         1: [hashCodeSpy],
       });
 
@@ -247,7 +247,7 @@ void main() {
     });
 
     test('compares equal to same instance', () {
-      var multimap = BuiltListMultimap<int, String>({
+      final multimap = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
@@ -257,12 +257,12 @@ void main() {
     });
 
     test('compares equal to same contents', () {
-      var multimap1 = BuiltListMultimap<int, String>({
+      final multimap1 = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
       });
-      var multimap2 = BuiltListMultimap<int, String>({
+      final multimap2 = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
@@ -378,16 +378,16 @@ void main() {
     // Lazy copies.
 
     test('reuses BuiltListMultimap instances of the same type', () {
-      var multimap1 = BuiltListMultimap<int, String>();
-      var multimap2 = BuiltListMultimap<int, String>(multimap1);
+      final multimap1 = BuiltListMultimap<int, String>();
+      final multimap2 = BuiltListMultimap<int, String>(multimap1);
       expect(multimap1, same(multimap2));
     });
 
     test(
       'does not reuse BuiltListMultimap instances with subtype key type',
       () {
-        var multimap1 = BuiltListMultimap<_ExtendsA, String>();
-        var multimap2 = BuiltListMultimap<_A, String>(multimap1);
+        final multimap1 = BuiltListMultimap<_ExtendsA, String>();
+        final multimap2 = BuiltListMultimap<_A, String>(multimap1);
         expect(multimap1, isNot(same(multimap2)));
       },
     );
@@ -395,30 +395,31 @@ void main() {
     test(
       'does not reuse BuiltListMultimultimap instances with subtype value type',
       () {
-        var multimap1 = BuiltListMultimap<String, _ExtendsA>();
-        var multimap2 = BuiltListMultimap<String, _A>(multimap1);
+        final multimap1 = BuiltListMultimap<String, _ExtendsA>();
+        final multimap2 = BuiltListMultimap<String, _A>(multimap1);
         expect(multimap1, isNot(same(multimap2)));
       },
     );
 
     test('can be reused via ListMultimapBuilder if there are no changes', () {
-      var multimap1 = BuiltListMultimap<Object, Object>();
-      var multimap2 = multimap1.toBuilder().build();
+      final multimap1 = BuiltListMultimap<Object, Object>();
+      final multimap2 = multimap1.toBuilder().build();
       expect(multimap1, same(multimap2));
     });
 
     test(
       'converts to ListMultimapBuilder from correct type without copying',
       () {
-        var makeLongListMultimap = () {
-          var result = ListMultimapBuilder<int, int>();
+        final makeLongListMultimap = () {
+          final result = ListMultimapBuilder<int, int>();
           for (var i = 0; i != 100000; ++i) {
             result.add(i, i);
           }
           return result.build();
         };
-        var longListMultimap = makeLongListMultimap();
-        var longListMultimapToListMultimapBuilder = longListMultimap.toBuilder;
+        final longListMultimap = makeLongListMultimap();
+        final longListMultimapToListMultimapBuilder =
+            longListMultimap.toBuilder;
 
         expectMuchFaster(
           longListMultimapToListMultimapBuilder,
@@ -428,15 +429,15 @@ void main() {
     );
 
     test('converts to ListMultimapBuilder from wrong type by copying', () {
-      var makeLongListMultimap = () {
-        var result = ListMultimapBuilder<Object, Object>();
+      final makeLongListMultimap = () {
+        final result = ListMultimapBuilder<Object, Object>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
       };
-      var longListMultimap = makeLongListMultimap();
-      var longListMultimapToListMultimapBuilder = () =>
+      final longListMultimap = makeLongListMultimap();
+      final longListMultimapToListMultimapBuilder = () =>
           ListMultimapBuilder<int, int>(longListMultimap);
 
       expectNotMuchFaster(
@@ -446,29 +447,29 @@ void main() {
     });
 
     test('has fast toMap', () {
-      var makeLongListMultimap = () {
-        var result = ListMultimapBuilder<int, int>();
+      final makeLongListMultimap = () {
+        final result = ListMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
       };
-      var longListMultimap = makeLongListMultimap();
-      var longListMultimapToListMultimap = () => longListMultimap.toMap();
+      final longListMultimap = makeLongListMultimap();
+      final longListMultimapToListMultimap = longListMultimap.toMap;
 
       expectMuchFaster(longListMultimapToListMultimap, makeLongListMultimap);
     });
 
     test('checks for reference identity', () {
-      var makeLongListMultimap = () {
-        var result = ListMultimapBuilder<int, int>();
+      final makeLongListMultimap = () {
+        final result = ListMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
       };
-      var longListMultimap = makeLongListMultimap();
-      var otherLongListMultimap = makeLongListMultimap();
+      final longListMultimap = makeLongListMultimap();
+      final otherLongListMultimap = makeLongListMultimap();
 
       expectMuchFaster(
         () => longListMultimap == longListMultimap,
@@ -477,7 +478,7 @@ void main() {
     });
 
     test('is not mutated when Map from toMap is mutated', () {
-      var multimap = BuiltListMultimap<int, String>();
+      final multimap = BuiltListMultimap<int, String>();
       multimap.toMap()[1] = BuiltList<String>(['1']);
       expect(multimap.isEmpty, isTrue);
     });
@@ -525,7 +526,7 @@ void main() {
     });
 
     test('returns stable empty BuiltLists', () {
-      var multimap = BuiltListMultimap<int, String>();
+      final multimap = BuiltListMultimap<int, String>();
       expect(multimap[1], same(multimap[1]));
       expect(multimap[1], same(multimap[2]));
     });
@@ -634,7 +635,7 @@ void main() {
     });
 
     test('has stable keys', () {
-      var multimap = BuiltListMultimap<int, String>({
+      final multimap = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2'],
         3: ['3'],
@@ -643,7 +644,7 @@ void main() {
     });
 
     test('has stable values', () {
-      var multimap = BuiltListMultimap<int, String>({
+      final multimap = BuiltListMultimap<int, String>({
         1: ['1'],
         2: ['2'],
         3: ['3'],

--- a/built_types/built_collection/test/list_multimap/list_multimap_builder_test.dart
+++ b/built_types/built_collection/test/list_multimap/list_multimap_builder_test.dart
@@ -25,7 +25,7 @@ void main() {
     });
 
     test('nullable does not throw on null key add', () {
-      var builder = ListMultimapBuilder<int?, String>();
+      final builder = ListMultimapBuilder<int?, String>();
       builder.add(null, '0');
       expect(builder[null].build(), ['0']);
     });
@@ -38,7 +38,7 @@ void main() {
     });
 
     test('nullable does not throw on null value add', () {
-      var builder = ListMultimapBuilder<int, String?>();
+      final builder = ListMultimapBuilder<int, String?>();
       builder.add(0, null);
       expect(builder[0].build(), [null]);
     });
@@ -122,29 +122,29 @@ void main() {
     test(
       'does not mutate BuiltListMultimap following reuse of underlying Map',
       () {
-        var multimap = BuiltListMultimap<int, String>({
+        final multimap = BuiltListMultimap<int, String>({
           1: ['1'],
           2: ['2'],
         });
-        var multimapBuilder = multimap.toBuilder();
+        final multimapBuilder = multimap.toBuilder();
         multimapBuilder.add(3, '3');
-        expect(multimap.toMap(), ({
+        expect(multimap.toMap(), {
           1: ['1'],
           2: ['2'],
-        }));
+        });
       },
     );
 
     test('converts to BuiltListMultimap without copying', () {
-      var makeLongListMultimapBuilder = () {
-        var result = ListMultimapBuilder<int, int>();
+      final makeLongListMultimapBuilder = () {
+        final result = ListMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(0, i);
         }
         return result;
       };
-      var longListMultimapBuilder = makeLongListMultimapBuilder();
-      var buildLongListMultimapBuilder = () => longListMultimapBuilder.build();
+      final longListMultimapBuilder = makeLongListMultimapBuilder();
+      final buildLongListMultimapBuilder = longListMultimapBuilder.build;
 
       expectMuchFaster(
         buildLongListMultimapBuilder,
@@ -153,44 +153,44 @@ void main() {
     });
 
     test('does not mutate BuiltListMultimap following mutates after build', () {
-      var multimapBuilder = ListMultimapBuilder<int, String>({
+      final multimapBuilder = ListMultimapBuilder<int, String>({
         1: ['1'],
         2: ['2'],
       });
 
-      var map1 = multimapBuilder.build();
-      expect(map1.toMap(), ({
+      final map1 = multimapBuilder.build();
+      expect(map1.toMap(), {
         1: ['1'],
         2: ['2'],
-      }));
+      });
 
       multimapBuilder.add(3, '3');
-      expect(map1.toMap(), ({
+      expect(map1.toMap(), {
         1: ['1'],
         2: ['2'],
-      }));
+      });
 
       multimapBuilder.build();
-      expect(map1.toMap(), ({
+      expect(map1.toMap(), {
         1: ['1'],
         2: ['2'],
-      }));
+      });
 
       multimapBuilder.add(4, '4');
-      expect(map1.toMap(), ({
+      expect(map1.toMap(), {
         1: ['1'],
         2: ['2'],
-      }));
+      });
 
       multimapBuilder.build();
-      expect(map1.toMap(), ({
+      expect(map1.toMap(), {
         1: ['1'],
         2: ['2'],
-      }));
+      });
     });
 
     test('returns identical BuiltListMultimap on repeated build', () {
-      var multimapBuilder = ListMultimapBuilder<int, String>({
+      final multimapBuilder = ListMultimapBuilder<int, String>({
         1: ['1', '2', '3'],
       });
       expect(multimapBuilder.build(), same(multimapBuilder.build()));
@@ -199,20 +199,20 @@ void main() {
     // Modification of existing data.
 
     test('adds to copied lists', () {
-      var multimap = BuiltListMultimap<int, String>({
+      final multimap = BuiltListMultimap<int, String>({
         1: ['1'],
       });
-      var multimapBuilder = multimap.toBuilder();
+      final multimapBuilder = multimap.toBuilder();
       expect((multimapBuilder..add(1, '2')).build().toMap(), {
         1: ['1', '2'],
       });
     });
 
     test('removes from copied lists', () {
-      var multimap = BuiltListMultimap<int, String>({
+      final multimap = BuiltListMultimap<int, String>({
         1: ['1', '2', '3'],
       });
-      var multimapBuilder = multimap.toBuilder();
+      final multimapBuilder = multimap.toBuilder();
       expect(multimapBuilder.remove(1, '2'), true);
       expect(multimapBuilder.build().toMap(), {
         1: ['1', '3'],
@@ -220,27 +220,27 @@ void main() {
     });
 
     test('removes from copied lists to empty', () {
-      var multimap = BuiltListMultimap<int, String>({
+      final multimap = BuiltListMultimap<int, String>({
         1: ['1'],
       });
-      var multimapBuilder = multimap.toBuilder();
+      final multimapBuilder = multimap.toBuilder();
       expect(multimapBuilder.remove(1, '1'), true);
       expect(multimapBuilder.build().toMap(), {});
     });
 
     test('removes all from copied lists', () {
-      var value = ['1', '2', '3'];
-      var multimap = BuiltListMultimap<int, String>({1: value});
-      var multimapBuilder = multimap.toBuilder();
+      final value = ['1', '2', '3'];
+      final multimap = BuiltListMultimap<int, String>({1: value});
+      final multimapBuilder = multimap.toBuilder();
       expect(multimapBuilder.removeAll(1).toList(), value);
       expect(multimapBuilder.build().toMap(), {});
     });
 
     test('clears copied lists', () {
-      var multimap = BuiltListMultimap<int, String>({
+      final multimap = BuiltListMultimap<int, String>({
         1: ['1', '2', '3'],
       });
-      var multimapBuilder = multimap.toBuilder();
+      final multimapBuilder = multimap.toBuilder();
       expect((multimapBuilder..clear()).build().toMap(), {});
     });
 
@@ -251,19 +251,19 @@ void main() {
         (ListMultimapBuilder<int, String>({
           1: ['1'],
         })..add(2, '2')).build().toMap(),
-        ({
+        {
           1: ['1'],
           2: ['2'],
-        }),
+        },
       );
       expect(
         (BuiltListMultimap<int, String>({
           1: ['1'],
         }).toBuilder()..add(2, '2')).build().toMap(),
-        ({
+        {
           1: ['1'],
           2: ['2'],
-        }),
+        },
       );
     });
 
@@ -272,24 +272,24 @@ void main() {
         (ListMultimapBuilder<int, String>({
           1: ['1'],
         })..addValues(2, ['2', '3'])).build().toMap(),
-        ({
+        {
           1: ['1'],
           2: ['2', '3'],
-        }),
+        },
       );
       expect(
         (BuiltListMultimap<int, String>({
           1: ['1'],
         }).toBuilder()..addValues(2, ['2', '3'])).build().toMap(),
-        ({
+        {
           1: ['1'],
           2: ['2', '3'],
-        }),
+        },
       );
     });
 
     test('has a method like ListMultimap.remove', () {
-      var builder = ListMultimapBuilder<int, String>({
+      final builder = ListMultimapBuilder<int, String>({
         1: ['1'],
         2: ['2', '3'],
       });
@@ -313,8 +313,8 @@ void main() {
     });
 
     test('has a method like ListMultimap.removeAll', () {
-      var value = ['2', '3'];
-      var builder = ListMultimapBuilder<int, String>({
+      final value = ['2', '3'];
+      final builder = ListMultimapBuilder<int, String>({
         1: ['1'],
         2: value,
       });
@@ -336,11 +336,11 @@ void main() {
     });
 
     test('removeAll does not detach ListBuilder', () {
-      var builder = ListMultimapBuilder<int, String>({
+      final builder = ListMultimapBuilder<int, String>({
         1: ['1'],
         2: ['2', '3'],
       });
-      var listBuilder = builder[2];
+      final listBuilder = builder[2];
       builder.removeAll(2);
       expect(listBuilder.build().toList(), []);
 
@@ -390,7 +390,7 @@ void main() {
     test(
       'has a method like ListMultimap[] which can be used to write values',
       () {
-        var builder = BuiltListMultimap<int, String>().toBuilder();
+        final builder = BuiltListMultimap<int, String>().toBuilder();
         builder[1].add('1');
         expect(builder.build()[1], ['1']);
       },

--- a/built_types/built_collection/test/map/built_map_test.dart
+++ b/built_types/built_collection/test/map/built_map_test.dart
@@ -3,8 +3,9 @@
 // license that can be found in the LICENSE file.
 
 import 'dart:collection' show SplayTreeMap;
-import 'package:built_collection/src/map.dart';
+
 import 'package:built_collection/src/internal/test_helpers.dart';
+import 'package:built_collection/src/map.dart';
 import 'package:test/test.dart';
 
 import '../performance.dart';
@@ -12,7 +13,7 @@ import '../performance.dart';
 void main() {
   group('BuiltMap', () {
     test('instantiates empty by default', () {
-      var map = BuiltMap<int, String>();
+      final map = BuiltMap<int, String>();
       expect(map.isEmpty, isTrue);
       expect(map.isNotEmpty, isFalse);
     });
@@ -34,14 +35,14 @@ void main() {
     });
 
     test('reports non-emptiness', () {
-      var map = BuiltMap<int, String>({1: '1'});
+      final map = BuiltMap<int, String>({1: '1'});
       expect(map.isEmpty, isFalse);
       expect(map.isNotEmpty, isTrue);
     });
 
     test('can be instantiated from Map then converted back to equal Map', () {
-      var mutableMap = {1: '1'};
-      var map = BuiltMap<int, String>(mutableMap);
+      final mutableMap = {1: '1'};
+      final map = BuiltMap<int, String>(mutableMap);
       expect(map.toMap(), mutableMap);
     });
 
@@ -54,15 +55,15 @@ void main() {
     });
 
     test('does not keep a mutable Map', () {
-      var mutableMap = {1: '1'};
-      var map = BuiltMap<int, String>(mutableMap);
+      final mutableMap = {1: '1'};
+      final map = BuiltMap<int, String>(mutableMap);
       mutableMap.clear();
       expect(map.toMap(), {1: '1'});
     });
 
     test('copies from BuiltMap instances of different type', () {
-      var map1 = BuiltMap<Object, Object>();
-      var map2 = BuiltMap<int, String>(map1);
+      final map1 = BuiltMap<Object, Object>();
+      final map2 = BuiltMap<int, String>(map1);
       expect(map1, isNot(same(map2)));
     });
 
@@ -82,17 +83,17 @@ void main() {
     });
 
     test('uses same base when converted with toMap', () {
-      var built = BuiltMap<int, String>.build(
+      final built = BuiltMap<int, String>.build(
         (b) => b
-          ..withBase(() => SplayTreeMap<int, String>())
+          ..withBase(SplayTreeMap<int, String>.new)
           ..addAll({1: '1', 3: '3'}),
       );
-      var map = built.toMap()..addAll({2: '2', 4: '4'});
+      final map = built.toMap()..addAll({2: '2', 4: '4'});
       expect(map.keys, [1, 2, 3, 4]);
     });
 
     test('can be converted to an UnmodifiableMapView', () {
-      var immutableMap = BuiltMap<int, String>().asMap();
+      final immutableMap = BuiltMap<int, String>().asMap();
       expect(immutableMap, const TypeMatcher<Map<int, String>>());
       expect(() => immutableMap[1] = 'Hello', throwsUnsupportedError);
       expect(immutableMap, isEmpty);
@@ -129,12 +130,12 @@ void main() {
     });
 
     test('passes along its base when converted to SetBuilder', () {
-      var map = BuiltMap<int, String>.build(
+      final map = BuiltMap<int, String>.build(
         (b) => b
-          ..withBase(() => SplayTreeMap<int, String>())
+          ..withBase(SplayTreeMap<int, String>.new)
           ..addAll({10: '10', 15: '15', 5: '5'}),
       );
-      var builder = map.toBuilder()..addAll({2: '2', 12: '12'});
+      final builder = map.toBuilder()..addAll({2: '2', 12: '12'});
       expect(builder.build().keys, orderedEquals([2, 5, 10, 12, 15]));
     });
 
@@ -177,29 +178,29 @@ void main() {
     });
 
     test('hashes to same value for same contents', () {
-      var map1 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
-      var map2 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
+      final map1 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
+      final map2 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
 
       expect(map1.hashCode, map2.hashCode);
     });
 
     test('hashes to different value for different keys', () {
-      var map1 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
-      var map2 = BuiltMap<int, String>({1: '1', 2: '2', 4: '3'});
+      final map1 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
+      final map2 = BuiltMap<int, String>({1: '1', 2: '2', 4: '3'});
 
       expect(map1.hashCode, isNot(map2.hashCode));
     });
 
     test('hashes to different value for different values', () {
-      var map1 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
-      var map2 = BuiltMap<int, String>({1: '1', 2: '2', 3: '4'});
+      final map1 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
+      final map2 = BuiltMap<int, String>({1: '1', 2: '2', 3: '4'});
 
       expect(map1.hashCode, isNot(map2.hashCode));
     });
 
     test('caches hash', () {
-      var hashCodeSpy = HashCodeSpy();
-      var map = BuiltMap<Object, Object>({1: hashCodeSpy});
+      final hashCodeSpy = HashCodeSpy();
+      final map = BuiltMap<Object, Object>({1: hashCodeSpy});
 
       hashCodeSpy.hashCodeSeen = 0;
       map.hashCode;
@@ -208,13 +209,13 @@ void main() {
     });
 
     test('compares equal to same instance', () {
-      var map = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
+      final map = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
       expect(map == map, isTrue);
     });
 
     test('compares equal to same contents', () {
-      var map1 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
-      var map2 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
+      final map1 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
+      final map2 = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
       expect(map1 == map2, isTrue);
     });
 
@@ -292,71 +293,71 @@ void main() {
     // Lazy copies.
 
     test('reuses BuiltMap instances of the same type', () {
-      var map1 = BuiltMap<int, String>();
-      var map2 = BuiltMap<int, String>(map1);
+      final map1 = BuiltMap<int, String>();
+      final map2 = BuiltMap<int, String>(map1);
       expect(map1, same(map2));
     });
 
     test('does not reuse BuiltMap instances with subtype key type', () {
-      var map1 = BuiltMap<_ExtendsA, String>();
-      var map2 = BuiltMap<_A, String>(map1);
+      final map1 = BuiltMap<_ExtendsA, String>();
+      final map2 = BuiltMap<_A, String>(map1);
       expect(map1, isNot(same(map2)));
     });
 
     test('does not reuse BuiltMap instances with subtype value type', () {
-      var map1 = BuiltMap<String, _ExtendsA>();
-      var map2 = BuiltMap<String, _A>(map1);
+      final map1 = BuiltMap<String, _ExtendsA>();
+      final map2 = BuiltMap<String, _A>(map1);
       expect(map1, isNot(same(map2)));
     });
 
     test('can be reused via MapBuilder if there are no changes', () {
-      var map1 = BuiltMap<Object, Object>();
-      var map2 = map1.toBuilder().build();
+      final map1 = BuiltMap<Object, Object>();
+      final map2 = map1.toBuilder().build();
       expect(map1, same(map2));
     });
 
     test('converts to MapBuilder from correct type without copying', () {
-      var makeLongMap = () => BuiltMap<int, int>(
+      final makeLongMap = () => BuiltMap<int, int>(
         Map<int, int>.fromIterable(List<int>.generate(100000, (x) => x)),
       );
-      var longMap = makeLongMap();
-      var longMapToMapBuilder = longMap.toBuilder;
+      final longMap = makeLongMap();
+      final longMapToMapBuilder = longMap.toBuilder;
 
       expectMuchFaster(longMapToMapBuilder, makeLongMap);
     });
 
     test('converts to MapBuilder from wrong type by copying', () {
-      var makeLongMap = () => BuiltMap<Object, Object>(
+      final makeLongMap = () => BuiltMap<Object, Object>(
         Map<int, int>.fromIterable(List<int>.generate(100000, (x) => x)),
       );
-      var longMap = makeLongMap();
-      var longMapToMapBuilder = () => MapBuilder<int, int>(longMap);
+      final longMap = makeLongMap();
+      final longMapToMapBuilder = () => MapBuilder<int, int>(longMap);
 
       expectNotMuchFaster(longMapToMapBuilder, makeLongMap);
     });
 
     test('has fast toMap', () {
-      var makeLongMap = () => BuiltMap<Object, Object>(
+      final makeLongMap = () => BuiltMap<Object, Object>(
         Map<int, int>.fromIterable(List<int>.generate(100000, (x) => x)),
       );
-      var longMap = makeLongMap();
-      var longMapToMap = () => longMap.toMap();
+      final longMap = makeLongMap();
+      final longMapToMap = longMap.toMap;
 
       expectMuchFaster(longMapToMap, makeLongMap);
     });
 
     test('checks for reference identity', () {
-      var makeLongMap = () => BuiltMap<Object, Object>(
+      final makeLongMap = () => BuiltMap<Object, Object>(
         Map<int, int>.fromIterable(List<int>.generate(100000, (x) => x)),
       );
-      var longMap = makeLongMap();
-      var otherLongMap = makeLongMap();
+      final longMap = makeLongMap();
+      final otherLongMap = makeLongMap();
 
       expectMuchFaster(() => longMap == longMap, () => longMap == otherLongMap);
     });
 
     test('is not mutated when Map from toMap is mutated', () {
-      var map = BuiltMap<int, String>();
+      final map = BuiltMap<int, String>();
       map.toMap()[1] = '1';
       expect(map.isEmpty, isTrue);
     });
@@ -373,7 +374,7 @@ void main() {
     });
 
     test('returns identical BuiltMap on repeated build', () {
-      var mapBuilder = MapBuilder<int, String>({1: '1', 2: '2', 3: '3'});
+      final mapBuilder = MapBuilder<int, String>({1: '1', 2: '2', 3: '3'});
       expect(mapBuilder.build(), same(mapBuilder.build()));
     });
 
@@ -438,7 +439,7 @@ void main() {
     });
 
     test('has a method like Map.entries', () {
-      var map = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
+      final map = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
       expect(BuiltMap<int, String>(Map.fromEntries(map.entries)), map);
     });
 
@@ -454,12 +455,12 @@ void main() {
     });
 
     test('has stable keys', () {
-      var map = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
+      final map = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
       expect(map.keys, same(map.keys));
     });
 
     test('has stable values', () {
-      var map = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
+      final map = BuiltMap<int, String>({1: '1', 2: '2', 3: '3'});
       expect(map.values, same(map.values));
     });
 

--- a/built_types/built_collection/test/map/map_builder_test.dart
+++ b/built_types/built_collection/test/map/map_builder_test.dart
@@ -26,7 +26,7 @@ void main() {
     });
 
     test('nullable does not throw on null key put', () {
-      var builder = MapBuilder<int?, String>();
+      final builder = MapBuilder<int?, String>();
       builder[null] = '0';
       expect(builder[null], '0');
     });
@@ -39,7 +39,7 @@ void main() {
     });
 
     test('nullable does not throw on null value put', () {
-      var builder = MapBuilder<int, String?>();
+      final builder = MapBuilder<int, String?>();
       builder[0] = null;
       expect(builder[0], null);
     });
@@ -52,7 +52,7 @@ void main() {
     });
 
     test('nullable does not throw on null key putIfAbsent', () {
-      var builder = MapBuilder<int?, String>();
+      final builder = MapBuilder<int?, String>();
       builder.putIfAbsent(null, () => '0');
       expect(builder[null], '0');
     });
@@ -65,7 +65,7 @@ void main() {
     });
 
     test('nullable does not throw on null value putIfAbsent', () {
-      var builder = MapBuilder<int, String?>();
+      final builder = MapBuilder<int, String?>();
       builder.putIfAbsent(0, () => null);
       expect(builder[0], null);
     });
@@ -78,7 +78,7 @@ void main() {
     });
 
     test('nullable does not throw on null key addAll', () {
-      var builder = MapBuilder<int?, String>();
+      final builder = MapBuilder<int?, String>();
       builder.addAll({null: '0'});
       expect(builder[null], '0');
     });
@@ -91,13 +91,13 @@ void main() {
     });
 
     test('nullable does not throw on null value addAll', () {
-      var builder = MapBuilder<int, String?>();
+      final builder = MapBuilder<int, String?>();
       builder.addAll({0: null});
       expect(builder[0], null);
     });
 
     test('throws on null withBase', () {
-      var builder = MapBuilder<int, String>({2: '2', 0: '0', 1: '1'});
+      final builder = MapBuilder<int, String>({2: '2', 0: '0', 1: '1'});
       expect(() => builder.withBase(null as dynamic), throwsA(anything));
       expect(builder.build().keys, orderedEquals([2, 0, 1]));
     });
@@ -142,8 +142,11 @@ void main() {
 
     test('has addEntries method like Map.addEntries', () {
       expect(
-        (MapBuilder<int, int>()
-              ..addEntries([MapEntry(1, 1), MapEntry(2, 2), MapEntry(3, 3)]))
+        (MapBuilder<int, int>()..addEntries([
+              const MapEntry(1, 1),
+              const MapEntry(2, 2),
+              const MapEntry(3, 3),
+            ]))
             .build()
             .toMap(),
         {1: 1, 2: 2, 3: 3},
@@ -151,13 +154,13 @@ void main() {
     });
 
     test('reuses BuiltMap passed to replace if it has the same base', () {
-      var treeMapBase = () => SplayTreeMap<int, String>();
-      var map = BuiltMap<int, String>.build(
+      final treeMapBase = SplayTreeMap<int, String>.new;
+      final map = BuiltMap<int, String>.build(
         (b) => b
           ..withBase(treeMapBase)
           ..addAll({1: '1', 2: '2'}),
       );
-      var builder = MapBuilder<int, String>()
+      final builder = MapBuilder<int, String>()
         ..withBase(treeMapBase)
         ..replace(map);
       expect(builder.build(), same(map));
@@ -166,25 +169,25 @@ void main() {
     test(
       "doesn't reuse BuiltMap passed to replace if it has a different base",
       () {
-        var map = BuiltMap<int, String>.build(
+        final map = BuiltMap<int, String>.build(
           (b) => b
-            ..withBase(() => SplayTreeMap<int, String>())
+            ..withBase(SplayTreeMap<int, String>.new)
             ..addAll({1: '1', 2: '2'}),
         );
-        var builder = MapBuilder<int, String>()..replace(map);
+        final builder = MapBuilder<int, String>()..replace(map);
         expect(builder.build(), isNot(same(map)));
       },
     );
 
     test('has withBase method that changes the underlying map type', () {
-      var builder = MapBuilder<int, String>({2: '2', 0: '0', 1: '1'});
-      builder.withBase(() => SplayTreeMap<int, String>());
+      final builder = MapBuilder<int, String>({2: '2', 0: '0', 1: '1'});
+      builder.withBase(SplayTreeMap<int, String>.new);
       expect(builder.build().keys, orderedEquals([0, 1, 2]));
     });
 
     test('has withDefaultBase method that resets the underlying map type', () {
-      var builder = MapBuilder<int, String>()
-        ..withBase(() => SplayTreeMap<int, String>())
+      final builder = MapBuilder<int, String>()
+        ..withBase(SplayTreeMap<int, String>.new)
         ..withDefaultBase()
         ..addAll({2: '2', 0: '0', 1: '1'});
       expect(builder.build().keys, orderedEquals([2, 0, 1]));
@@ -193,26 +196,26 @@ void main() {
     // Lazy copies.
 
     test('does not mutate BuiltMap following reuse of underlying Map', () {
-      var map = BuiltMap<int, String>({1: '1', 2: '2'});
-      var mapBuilder = map.toBuilder();
+      final map = BuiltMap<int, String>({1: '1', 2: '2'});
+      final mapBuilder = map.toBuilder();
       mapBuilder[3] = '3';
       expect(map.toMap(), {1: '1', 2: '2'});
     });
 
     test('converts to BuiltMap without copying', () {
-      var makeLongMapBuilder = () => MapBuilder<int, int>(
+      final makeLongMapBuilder = () => MapBuilder<int, int>(
         Map<int, int>.fromIterable(List<int>.generate(100000, (x) => x)),
       );
-      var longMapBuilder = makeLongMapBuilder();
-      var buildLongMapBuilder = () => longMapBuilder.build();
+      final longMapBuilder = makeLongMapBuilder();
+      final buildLongMapBuilder = longMapBuilder.build;
 
       expectMuchFaster(buildLongMapBuilder, makeLongMapBuilder);
     });
 
     test('does not mutate BuiltMap following mutates after build', () {
-      var mapBuilder = MapBuilder<int, String>({1: '1', 2: '2'});
+      final mapBuilder = MapBuilder<int, String>({1: '1', 2: '2'});
 
-      var map1 = mapBuilder.build();
+      final map1 = mapBuilder.build();
       expect(map1.toMap(), {1: '1', 2: '2'});
 
       mapBuilder[3] = '3';
@@ -222,9 +225,9 @@ void main() {
     // Map.
 
     test('has a method like Map[]', () {
-      var mapBuilder = MapBuilder<int, String>({1: '1', 2: '2'});
-      mapBuilder[1] = mapBuilder[1]! + '*';
-      mapBuilder[2] = mapBuilder[2]! + '**';
+      final mapBuilder = MapBuilder<int, String>({1: '1', 2: '2'});
+      mapBuilder[1] = '${mapBuilder[1]!}*';
+      mapBuilder[2] = '${mapBuilder[2]!}**';
       expect(mapBuilder.build().asMap(), {1: '1*', 2: '2**'});
     });
 
@@ -355,13 +358,13 @@ void main() {
       expect(
         (MapBuilder<int, String>(
           {1: '1', 2: '2'},
-        )..updateValue(1, (v) => v + '1', ifAbsent: () => '7')).build().toMap(),
+        )..updateValue(1, (v) => '${v}1', ifAbsent: () => '7')).build().toMap(),
         {1: '11', 2: '2'},
       );
       expect(
         (MapBuilder<int, String>(
           {1: '1', 2: '2'},
-        )..updateValue(7, (v) => v + '1', ifAbsent: () => '7')).build().toMap(),
+        )..updateValue(7, (v) => '${v}1', ifAbsent: () => '7')).build().toMap(),
         {1: '1', 2: '2', 7: '7'},
       );
     });

--- a/built_types/built_collection/test/set/built_set_test.dart
+++ b/built_types/built_collection/test/set/built_set_test.dart
@@ -3,8 +3,9 @@
 // license that can be found in the LICENSE file.
 
 import 'dart:collection' show SplayTreeSet;
-import 'package:built_collection/src/set.dart';
+
 import 'package:built_collection/src/internal/test_helpers.dart';
+import 'package:built_collection/src/set.dart';
 import 'package:test/test.dart';
 
 import '../performance.dart';
@@ -12,7 +13,7 @@ import '../performance.dart';
 void main() {
   group('BuiltSet', () {
     test('instantiates empty by default', () {
-      var set = BuiltSet<int>();
+      final set = BuiltSet<int>();
       expect(set.isEmpty, isTrue);
       expect(set.isNotEmpty, isFalse);
     });
@@ -30,14 +31,14 @@ void main() {
     });
 
     test('reports non-emptiness', () {
-      var set = BuiltSet<int>([1]);
+      final set = BuiltSet<int>([1]);
       expect(set.isEmpty, isFalse);
       expect(set.isNotEmpty, isTrue);
     });
 
     test('can be instantiated from Set then converted back to equal Set', () {
-      var mutableSet = [1];
-      var set = BuiltSet<int>(mutableSet);
+      final mutableSet = [1];
+      final set = BuiltSet<int>(mutableSet);
       expect(set.toSet(), mutableSet);
     });
 
@@ -46,15 +47,15 @@ void main() {
     });
 
     test('does not keep a mutable Set', () {
-      var mutableSet = [1];
-      var set = BuiltSet<int>(mutableSet);
+      final mutableSet = [1];
+      final set = BuiltSet<int>(mutableSet);
       mutableSet.clear();
       expect(set.toSet(), [1]);
     });
 
     test('copies from BuiltSet instances of different type', () {
-      var set1 = BuiltSet<Object>();
-      var set2 = BuiltSet<int>(set1);
+      final set1 = BuiltSet<Object>();
+      final set2 = BuiltSet<int>(set1);
       expect(set1, isNot(same(set2)));
     });
 
@@ -64,17 +65,17 @@ void main() {
     });
 
     test('uses same base when converted with toSet', () {
-      var built = BuiltSet<int>.build(
+      final built = BuiltSet<int>.build(
         (b) => b
-          ..withBase(() => SplayTreeSet<int>())
+          ..withBase(SplayTreeSet<int>.new)
           ..addAll([1, 3]),
       );
-      var set = built.toSet()..addAll([2, 4]);
+      final set = built.toSet()..addAll([2, 4]);
       expect(set, [1, 2, 3, 4]);
     });
 
     test('can be converted to an UnmodifiableSetView', () {
-      var immutableSet = BuiltSet<int>().asSet();
+      final immutableSet = BuiltSet<int>().asSet();
       expect(immutableSet, const TypeMatcher<Set<int>>());
       expect(() => immutableSet.add(1), throwsUnsupportedError);
       expect(immutableSet, isEmpty);
@@ -100,12 +101,12 @@ void main() {
     });
 
     test('passes along its base when converted to SetBuilder', () {
-      var set = BuiltSet<int>.build(
+      final set = BuiltSet<int>.build(
         (b) => b
-          ..withBase(() => SplayTreeSet<int>())
+          ..withBase(SplayTreeSet<int>.new)
           ..addAll([10, 15, 5]),
       );
-      var builder = set.toBuilder()..addAll([2, 12]);
+      final builder = set.toBuilder()..addAll([2, 12]);
       expect(builder.build(), orderedEquals([2, 5, 10, 12, 15]));
     });
 
@@ -114,29 +115,29 @@ void main() {
     });
 
     test('hashes to same value for same contents', () {
-      var set1 = BuiltSet<int>([1, 2, 3]);
-      var set2 = BuiltSet<int>([1, 2, 3]);
+      final set1 = BuiltSet<int>([1, 2, 3]);
+      final set2 = BuiltSet<int>([1, 2, 3]);
 
       expect(set1.hashCode, set2.hashCode);
     });
 
     test('hashes to same value for same contents in different order', () {
-      var set1 = BuiltSet<int>([1, 2, 3]);
-      var set2 = BuiltSet<int>([3, 2, 1]);
+      final set1 = BuiltSet<int>([1, 2, 3]);
+      final set2 = BuiltSet<int>([3, 2, 1]);
 
       expect(set1.hashCode, set2.hashCode);
     });
 
     test('hashes to different value for different contents', () {
-      var set1 = BuiltSet<int>([1, 2, 3]);
-      var set2 = BuiltSet<int>([1, 2, 4]);
+      final set1 = BuiltSet<int>([1, 2, 3]);
+      final set2 = BuiltSet<int>([1, 2, 4]);
 
       expect(set1.hashCode, isNot(set2.hashCode));
     });
 
     test('caches hash', () {
-      var hashCodeSpy = HashCodeSpy();
-      var set = BuiltSet<Object>([hashCodeSpy]);
+      final hashCodeSpy = HashCodeSpy();
+      final set = BuiltSet<Object>([hashCodeSpy]);
 
       hashCodeSpy.hashCodeSeen = 0;
       set.hashCode;
@@ -145,13 +146,13 @@ void main() {
     });
 
     test('compares equal to same instance', () {
-      var set1 = BuiltSet<int>([1, 2, 3]);
+      final set1 = BuiltSet<int>([1, 2, 3]);
       expect(set1 == set1, isTrue);
     });
 
     test('compares equal to same contents', () {
-      var set1 = BuiltSet<int>([1, 2, 3]);
-      var set2 = BuiltSet<int>([1, 2, 3]);
+      final set1 = BuiltSet<int>([1, 2, 3]);
+      final set2 = BuiltSet<int>([1, 2, 3]);
       expect(set1 == set2, isTrue);
     });
 
@@ -209,68 +210,68 @@ void main() {
     });
 
     test('returns identical with toBuiltSet', () {
-      var set = BuiltSet<int>([0, 1, 2]);
+      final set = BuiltSet<int>([0, 1, 2]);
       expect(set.toBuiltSet(), same(set));
     });
 
     // Lazy copies.
 
     test('reuses BuiltSet instances of the same type', () {
-      var set1 = BuiltSet<int>();
-      var set2 = BuiltSet<int>(set1);
+      final set1 = BuiltSet<int>();
+      final set2 = BuiltSet<int>(set1);
       expect(set1, same(set2));
     });
 
     test('does not reuse BuiltSet instances with subtype element type', () {
-      var set1 = BuiltSet<_ExtendsA>();
-      var set2 = BuiltSet<_A>(set1);
+      final set1 = BuiltSet<_ExtendsA>();
+      final set2 = BuiltSet<_A>(set1);
       expect(set1, isNot(same(set2)));
     });
 
     test('can be reused via SetBuilder if there are no changes', () {
-      var set1 = BuiltSet<Object>();
-      var set2 = set1.toBuilder().build();
+      final set1 = BuiltSet<Object>();
+      final set2 = set1.toBuilder().build();
       expect(set1, same(set2));
     });
 
     test('converts to SetBuilder from correct type without copying', () {
-      var makeLongSet = () =>
+      final makeLongSet = () =>
           BuiltSet<int>(Set<int>.from(List<int>.generate(100000, (x) => x)));
-      var longSet = makeLongSet();
-      var longSetToSetBuilder = longSet.toBuilder;
+      final longSet = makeLongSet();
+      final longSetToSetBuilder = longSet.toBuilder;
 
       expectMuchFaster(longSetToSetBuilder, makeLongSet);
     });
 
     test('converts to SetBuilder from wrong type by copying', () {
-      var makeLongSet = () =>
+      final makeLongSet = () =>
           BuiltSet<Object>(Set<int>.from(List<int>.generate(100000, (x) => x)));
-      var longSet = makeLongSet();
-      var longSetToSetBuilder = () => SetBuilder<int>(longSet);
+      final longSet = makeLongSet();
+      final longSetToSetBuilder = () => SetBuilder<int>(longSet);
 
       expectNotMuchFaster(longSetToSetBuilder, makeLongSet);
     });
 
     test('has fast toSet', () {
-      var makeLongSet = () =>
+      final makeLongSet = () =>
           BuiltSet<Object>(Set<int>.from(List<int>.generate(100000, (x) => x)));
-      var longSet = makeLongSet();
-      var longSetToSet = () => longSet.toSet();
+      final longSet = makeLongSet();
+      final longSetToSet = longSet.toSet;
 
       expectMuchFaster(longSetToSet, makeLongSet);
     });
 
     test('checks for reference identity', () {
-      var makeLongSet = () =>
+      final makeLongSet = () =>
           BuiltSet<Object>(Set<int>.from(List<int>.generate(100000, (x) => x)));
-      var longSet = makeLongSet();
-      var otherLongSet = makeLongSet();
+      final longSet = makeLongSet();
+      final otherLongSet = makeLongSet();
 
       expectMuchFaster(() => longSet == longSet, () => longSet == otherLongSet);
     });
 
     test('is not mutated when Set from toSet is mutated', () {
-      var set = BuiltSet<int>();
+      final set = BuiltSet<int>();
       set.toSet().add(1);
       expect(set, []);
     });
@@ -337,7 +338,9 @@ void main() {
 
     test('implements Iterable.forEach', () {
       var value = 1;
-      BuiltSet<int>([2]).forEach((x) => value = x);
+      for (final x in BuiltSet<int>([2])) {
+        value = x;
+      }
       expect(value, 2);
     });
 

--- a/built_types/built_collection/test/set/set_builder_test.dart
+++ b/built_types/built_collection/test/set/set_builder_test.dart
@@ -20,43 +20,43 @@ void main() {
     });
 
     test('throws on null add', () {
-      var builder = SetBuilder<int>();
+      final builder = SetBuilder<int>();
       expect(() => builder.add(null as dynamic), throwsA(anything));
       expect(builder.build(), isEmpty);
     });
 
     test('nullable does not throw on null add', () {
-      var builder = SetBuilder<int?>();
+      final builder = SetBuilder<int?>();
       builder.add(null);
       expect(builder.build(), {null});
     });
 
     test('throws on null addAll', () {
-      var builder = SetBuilder<int>();
+      final builder = SetBuilder<int>();
       expect(() => builder.addAll([0, 1, null as dynamic]), throwsA(anything));
       expect(builder.build(), isEmpty);
     });
 
     test('nullable does not throw on null addAll', () {
-      var builder = SetBuilder<int?>();
+      final builder = SetBuilder<int?>();
       builder.addAll([0, 1, null]);
       expect(builder.build(), orderedEquals([0, 1, null]));
     });
 
     test('throws on null map', () {
-      var builder = SetBuilder<int>([0, 1, 2]);
+      final builder = SetBuilder<int>([0, 1, 2]);
       expect(() => builder.map((x) => null as dynamic), throwsA(anything));
       expect(builder.build(), orderedEquals([0, 1, 2]));
     });
 
     test('nullable does not throw on null map', () {
-      var builder = SetBuilder<int?>([0, 1, 2]);
+      final builder = SetBuilder<int?>([0, 1, 2]);
       builder.map((x) => null);
       expect(builder.build(), orderedEquals([null]));
     });
 
     test('throws on null expand', () {
-      var builder = SetBuilder<int>([0, 1, 2]);
+      final builder = SetBuilder<int>([0, 1, 2]);
       expect(
         () => builder.expand((x) => [x, null as dynamic]),
         throwsA(anything),
@@ -65,13 +65,13 @@ void main() {
     });
 
     test('nullable does not throw on null expand', () {
-      var builder = SetBuilder<int?>([0, 1, 2]);
+      final builder = SetBuilder<int?>([0, 1, 2]);
       builder.expand((x) => [x, null]);
       expect(builder.build(), orderedEquals([0, null, 1, 2]));
     });
 
     test('throws on null withBase', () {
-      var builder = SetBuilder<int>([2, 0, 1]);
+      final builder = SetBuilder<int>([2, 0, 1]);
       expect(() => builder.withBase(null as dynamic), throwsA(anything));
       expect(builder.build(), orderedEquals([2, 0, 1]));
     });
@@ -81,7 +81,7 @@ void main() {
       // type is allowed; just pass.
       if (!isSoundMode) return;
 
-      var builder = SetBuilder<int>();
+      final builder = SetBuilder<int>();
       expect(
         () => builder.addAll(List<int>.from([0, 1, '0'])),
         throwsA(anything),
@@ -94,13 +94,13 @@ void main() {
     });
 
     test('reuses BuiltSet passed to replace if it has the same base', () {
-      var treeSetBase = () => SplayTreeSet<int>();
-      var set = BuiltSet<int>.build(
+      final treeSetBase = SplayTreeSet<int>.new;
+      final set = BuiltSet<int>.build(
         (b) => b
           ..withBase(treeSetBase)
           ..addAll([1, 2]),
       );
-      var builder = SetBuilder<int>()
+      final builder = SetBuilder<int>()
         ..withBase(treeSetBase)
         ..replace(set);
       expect(builder.build(), same(set));
@@ -109,25 +109,25 @@ void main() {
     test(
       "doesn't reuse BuiltSet passed to replace if it has a different base",
       () {
-        var set = BuiltSet<int>.build(
+        final set = BuiltSet<int>.build(
           (b) => b
-            ..withBase(() => SplayTreeSet<int>())
+            ..withBase(SplayTreeSet<int>.new)
             ..addAll([1, 2]),
         );
-        var builder = SetBuilder<int>()..replace(set);
+        final builder = SetBuilder<int>()..replace(set);
         expect(builder.build(), isNot(same(set)));
       },
     );
 
     test('has withBase method that changes the underlying set type', () {
-      var builder = SetBuilder<int>([2, 0, 1]);
-      builder.withBase(() => SplayTreeSet<int>());
+      final builder = SetBuilder<int>([2, 0, 1]);
+      builder.withBase(SplayTreeSet<int>.new);
       expect(builder.build(), orderedEquals([0, 1, 2]));
     });
 
     test('has withDefaultBase method that resets the underlying set type', () {
-      var builder = SetBuilder<int>()
-        ..withBase(() => SplayTreeSet<int>())
+      final builder = SetBuilder<int>()
+        ..withBase(SplayTreeSet<int>.new)
         ..withDefaultBase()
         ..addAll([2, 0, 1]);
       expect(builder.build(), orderedEquals([2, 0, 1]));
@@ -136,25 +136,25 @@ void main() {
     // Lazy copies.
 
     test('does not mutate BuiltSet following reuse of underlying Set', () {
-      var set = BuiltSet<int>([1, 2]);
-      var setBuilder = set.toBuilder();
+      final set = BuiltSet<int>([1, 2]);
+      final setBuilder = set.toBuilder();
       setBuilder.add(3);
       expect(set, [1, 2]);
     });
 
     test('converts to BuiltSet without copying', () {
-      var makeLongSetBuilder = () =>
+      final makeLongSetBuilder = () =>
           SetBuilder<int>(Set<int>.from(List<int>.generate(100000, (x) => x)));
-      var longSetBuilder = makeLongSetBuilder();
-      var buildLongSetBuilder = () => longSetBuilder.build();
+      final longSetBuilder = makeLongSetBuilder();
+      final buildLongSetBuilder = longSetBuilder.build;
 
       expectMuchFaster(buildLongSetBuilder, makeLongSetBuilder);
     });
 
     test('does not mutate BuiltSet following mutates after build', () {
-      var setBuilder = SetBuilder<int>([1, 2]);
+      final setBuilder = SetBuilder<int>([1, 2]);
 
-      var set1 = setBuilder.build();
+      final set1 = setBuilder.build();
       expect(set1, [1, 2]);
 
       setBuilder.add(3);
@@ -162,7 +162,7 @@ void main() {
     });
 
     test('returns identical BuiltSet on repeated build', () {
-      var setBuilder = SetBuilder<int>([1, 2]);
+      final setBuilder = SetBuilder<int>([1, 2]);
       expect(setBuilder.build(), same(setBuilder.build()));
     });
 

--- a/built_types/built_collection/test/set_multimap/built_set_multimap_test.dart
+++ b/built_types/built_collection/test/set_multimap/built_set_multimap_test.dart
@@ -3,9 +3,9 @@
 // license that can be found in the LICENSE file.
 // ignore_for_file: unrelated_type_equality_checks
 
+import 'package:built_collection/src/internal/test_helpers.dart';
 import 'package:built_collection/src/set.dart';
 import 'package:built_collection/src/set_multimap.dart';
-import 'package:built_collection/src/internal/test_helpers.dart';
 import 'package:test/test.dart';
 
 import '../performance.dart';
@@ -13,7 +13,7 @@ import '../performance.dart';
 void main() {
   group('BuiltSetMultimap', () {
     test('instantiates empty by default', () {
-      var multimap = BuiltSetMultimap<int, String>();
+      final multimap = BuiltSetMultimap<int, String>();
       expect(multimap.isEmpty, isTrue);
       expect(multimap.isNotEmpty, isFalse);
     });
@@ -27,7 +27,7 @@ void main() {
     });
 
     test('reports non-emptiness', () {
-      var map = BuiltSetMultimap<int, String>({
+      final map = BuiltSetMultimap<int, String>({
         1: ['1'],
       });
       expect(map.isEmpty, isFalse);
@@ -36,9 +36,9 @@ void main() {
 
     test('can be instantiated from SetMultimap '
         'then converted back to equal SetMultimap', () {
-      var mutableMultimap = _SetMultimap<int, String>();
+      final mutableMultimap = _SetMultimap<int, String>();
       mutableMultimap.add(1, '1');
-      var multimap = BuiltSetMultimap<int, String>(mutableMultimap);
+      final multimap = BuiltSetMultimap<int, String>(mutableMultimap);
       expect(multimap.toMap(), mutableMultimap.asMap());
     });
 
@@ -65,9 +65,9 @@ void main() {
     });
 
     test('does not keep a mutable SetMultimap', () {
-      var mutableMultimap = _SetMultimap<int, String>();
+      final mutableMultimap = _SetMultimap<int, String>();
       mutableMultimap.add(1, '1');
-      var multimap = BuiltSetMultimap<int, String>(mutableMultimap);
+      final multimap = BuiltSetMultimap<int, String>(mutableMultimap);
       mutableMultimap.clear();
       expect(multimap.toMap(), {
         1: ['1'],
@@ -75,8 +75,8 @@ void main() {
     });
 
     test('copies from BuiltSetMultimap instances of different type', () {
-      var multimap1 = BuiltSetMultimap<Object, Object>();
-      var multimap2 = BuiltSetMultimap<int, String>(multimap1);
+      final multimap1 = BuiltSetMultimap<Object, Object>();
+      final multimap2 = BuiltSetMultimap<int, String>(multimap1);
       expect(multimap1, isNot(same(multimap2)));
     });
 
@@ -96,7 +96,7 @@ void main() {
     });
 
     test('can be converted to an UnmodifiableMapView', () {
-      var immutableMap = BuiltSetMultimap<int, String>().asMap();
+      final immutableMap = BuiltSetMultimap<int, String>().asMap();
       expect(immutableMap, const TypeMatcher<Map<int, Iterable<String>>>());
       expect(() => immutableMap[1] = ['Hello'], throwsUnsupportedError);
       expect(immutableMap, isEmpty);
@@ -187,12 +187,12 @@ void main() {
     });
 
     test('hashes to same value for same contents', () {
-      var multimap1 = BuiltSetMultimap<int, String>({
+      final multimap1 = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
       });
-      var multimap2 = BuiltSetMultimap<int, String>({
+      final multimap2 = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
@@ -202,12 +202,12 @@ void main() {
     });
 
     test('hashes to different value for different keys', () {
-      var multimap1 = BuiltSetMultimap<int, String>({
+      final multimap1 = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
       });
-      var multimap2 = BuiltSetMultimap<int, String>({
+      final multimap2 = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         4: ['3'],
@@ -217,12 +217,12 @@ void main() {
     });
 
     test('hashes to different value for different values', () {
-      var multimap1 = BuiltSetMultimap<int, String>({
+      final multimap1 = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
       });
-      var multimap2 = BuiltSetMultimap<int, String>({
+      final multimap2 = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2', '3'],
         3: ['3'],
@@ -232,8 +232,8 @@ void main() {
     });
 
     test('caches hash', () {
-      var hashCodeSpy = HashCodeSpy();
-      var multimap = BuiltSetMultimap<Object, Object>({
+      final hashCodeSpy = HashCodeSpy();
+      final multimap = BuiltSetMultimap<Object, Object>({
         1: [hashCodeSpy],
       });
 
@@ -244,7 +244,7 @@ void main() {
     });
 
     test('compares equal to same instance', () {
-      var multimap = BuiltSetMultimap<int, String>({
+      final multimap = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
@@ -254,12 +254,12 @@ void main() {
     });
 
     test('compares equal to same contents', () {
-      var multimap1 = BuiltSetMultimap<int, String>({
+      final multimap1 = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
       });
-      var multimap2 = BuiltSetMultimap<int, String>({
+      final multimap2 = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2', '2'],
         3: ['3'],
@@ -375,44 +375,44 @@ void main() {
     // Lazy copies.
 
     test('reuses BuiltSetMultimap instances of the same type', () {
-      var multimap1 = BuiltSetMultimap<int, String>();
-      var multimap2 = BuiltSetMultimap<int, String>(multimap1);
+      final multimap1 = BuiltSetMultimap<int, String>();
+      final multimap2 = BuiltSetMultimap<int, String>(multimap1);
       expect(multimap1, same(multimap2));
     });
 
     test('does not reuse BuiltSetMultimap instances with subtype key type', () {
-      var multimap1 = BuiltSetMultimap<_ExtendsA, String>();
-      var multimap2 = BuiltSetMultimap<_A, String>(multimap1);
+      final multimap1 = BuiltSetMultimap<_ExtendsA, String>();
+      final multimap2 = BuiltSetMultimap<_A, String>(multimap1);
       expect(multimap1, isNot(same(multimap2)));
     });
 
     test(
       'does not reuse BuiltSetMultimultimap instances with subtype value type',
       () {
-        var multimap1 = BuiltSetMultimap<String, _ExtendsA>();
-        var multimap2 = BuiltSetMultimap<String, _A>(multimap1);
+        final multimap1 = BuiltSetMultimap<String, _ExtendsA>();
+        final multimap2 = BuiltSetMultimap<String, _A>(multimap1);
         expect(multimap1, isNot(same(multimap2)));
       },
     );
 
     test('can be reused via SetMultimapBuilder if there are no changes', () {
-      var multimap1 = BuiltSetMultimap<Object, Object>();
-      var multimap2 = multimap1.toBuilder().build();
+      final multimap1 = BuiltSetMultimap<Object, Object>();
+      final multimap2 = multimap1.toBuilder().build();
       expect(multimap1, same(multimap2));
     });
 
     test(
       'converts to SetMultimapBuilder from correct type without copying',
       () {
-        var makeLongSetMultimap = () {
-          var result = SetMultimapBuilder<int, int>();
+        final makeLongSetMultimap = () {
+          final result = SetMultimapBuilder<int, int>();
           for (var i = 0; i != 100000; ++i) {
             result.add(i, i);
           }
           return result.build();
         };
-        var longSetMultimap = makeLongSetMultimap();
-        var longSetMultimapToSetMultimapBuilder = longSetMultimap.toBuilder;
+        final longSetMultimap = makeLongSetMultimap();
+        final longSetMultimapToSetMultimapBuilder = longSetMultimap.toBuilder;
 
         expectMuchFaster(
           longSetMultimapToSetMultimapBuilder,
@@ -422,15 +422,15 @@ void main() {
     );
 
     test('converts to SetMultimapBuilder from wrong type by copying', () {
-      var makeLongSetMultimap = () {
-        var result = SetMultimapBuilder<Object, Object>();
+      final makeLongSetMultimap = () {
+        final result = SetMultimapBuilder<Object, Object>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
       };
-      var longSetMultimap = makeLongSetMultimap();
-      var longSetMultimapToSetMultimapBuilder = () =>
+      final longSetMultimap = makeLongSetMultimap();
+      final longSetMultimapToSetMultimapBuilder = () =>
           SetMultimapBuilder<int, int>(longSetMultimap);
 
       expectNotMuchFaster(
@@ -440,29 +440,29 @@ void main() {
     });
 
     test('has fast toMap', () {
-      var makeLongSetMultimap = () {
-        var result = SetMultimapBuilder<int, int>();
+      final makeLongSetMultimap = () {
+        final result = SetMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
       };
-      var longSetMultimap = makeLongSetMultimap();
-      var longSetMultimapToSetMultimap = () => longSetMultimap.toMap();
+      final longSetMultimap = makeLongSetMultimap();
+      final longSetMultimapToSetMultimap = longSetMultimap.toMap;
 
       expectMuchFaster(longSetMultimapToSetMultimap, makeLongSetMultimap);
     });
 
     test('checks for reference identity', () {
-      var makeLongSetMultimap = () {
-        var result = SetMultimapBuilder<int, int>();
+      final makeLongSetMultimap = () {
+        final result = SetMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
       };
-      var longSetMultimap = makeLongSetMultimap();
-      var otherLongSetMultimap = makeLongSetMultimap();
+      final longSetMultimap = makeLongSetMultimap();
+      final otherLongSetMultimap = makeLongSetMultimap();
 
       expectMuchFaster(
         () => longSetMultimap == longSetMultimap,
@@ -471,7 +471,7 @@ void main() {
     });
 
     test('is not mutated when Map from toMap is mutated', () {
-      var multimap = BuiltSetMultimap<int, String>();
+      final multimap = BuiltSetMultimap<int, String>();
       multimap.toMap()[1] = BuiltSet<String>(['1']);
       expect(multimap.isEmpty, isTrue);
     });
@@ -519,7 +519,7 @@ void main() {
     });
 
     test('returns stable empty BuiltSets', () {
-      var multimap = BuiltSetMultimap<int, String>();
+      final multimap = BuiltSetMultimap<int, String>();
       expect(multimap[1], same(multimap[1]));
       expect(multimap[1], same(multimap[2]));
     });
@@ -628,7 +628,7 @@ void main() {
     });
 
     test('has stable keys', () {
-      var multimap = BuiltSetMultimap<int, String>({
+      final multimap = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2'],
         3: ['3'],
@@ -637,7 +637,7 @@ void main() {
     });
 
     test('has stable values', () {
-      var multimap = BuiltSetMultimap<int, String>({
+      final multimap = BuiltSetMultimap<int, String>({
         1: ['1'],
         2: ['2'],
         3: ['3'],

--- a/built_types/built_collection/test/set_multimap/set_multimap_builder_test.dart
+++ b/built_types/built_collection/test/set_multimap/set_multimap_builder_test.dart
@@ -25,7 +25,7 @@ void main() {
     });
 
     test('nullable does not throw on null key add', () {
-      var builder = SetMultimapBuilder<int?, String>();
+      final builder = SetMultimapBuilder<int?, String>();
       builder.add(null, '0');
       expect(builder.build()[null], {'0'});
     });
@@ -38,7 +38,7 @@ void main() {
     });
 
     test('nullable does not throw on null value add', () {
-      var builder = SetMultimapBuilder<int, String?>();
+      final builder = SetMultimapBuilder<int, String?>();
       builder.add(0, null);
       expect(builder.build()[0], {null});
     });
@@ -119,72 +119,72 @@ void main() {
     test(
       'does not mutate BuiltSetMultimap following reuse of underlying Map',
       () {
-        var multimap = BuiltSetMultimap<int, String>({
+        final multimap = BuiltSetMultimap<int, String>({
           1: ['1'],
           2: ['2'],
         });
-        var multimapBuilder = multimap.toBuilder();
+        final multimapBuilder = multimap.toBuilder();
         multimapBuilder.add(3, '3');
-        expect(multimap.toMap(), ({
+        expect(multimap.toMap(), {
           1: ['1'],
           2: ['2'],
-        }));
+        });
       },
     );
 
     test('converts to BuiltSetMultimap without copying', () {
-      var makeLongSetMultimapBuilder = () {
-        var result = SetMultimapBuilder<int, int>();
+      final makeLongSetMultimapBuilder = () {
+        final result = SetMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(0, i);
         }
         return result;
       };
-      var longSetMultimapBuilder = makeLongSetMultimapBuilder();
-      var buildLongSetMultimapBuilder = () => longSetMultimapBuilder.build();
+      final longSetMultimapBuilder = makeLongSetMultimapBuilder();
+      final buildLongSetMultimapBuilder = longSetMultimapBuilder.build;
 
       expectMuchFaster(buildLongSetMultimapBuilder, makeLongSetMultimapBuilder);
     });
 
     test('does not mutate BuiltSetMultimap following mutates after build', () {
-      var multimapBuilder = SetMultimapBuilder<int, String>({
+      final multimapBuilder = SetMultimapBuilder<int, String>({
         1: ['1'],
         2: ['2'],
       });
 
-      var map1 = multimapBuilder.build();
-      expect(map1.toMap(), ({
+      final map1 = multimapBuilder.build();
+      expect(map1.toMap(), {
         1: ['1'],
         2: ['2'],
-      }));
+      });
 
       multimapBuilder.add(3, '3');
-      expect(map1.toMap(), ({
+      expect(map1.toMap(), {
         1: ['1'],
         2: ['2'],
-      }));
+      });
 
       multimapBuilder.build();
-      expect(map1.toMap(), ({
+      expect(map1.toMap(), {
         1: ['1'],
         2: ['2'],
-      }));
+      });
 
       multimapBuilder.add(4, '4');
-      expect(map1.toMap(), ({
+      expect(map1.toMap(), {
         1: ['1'],
         2: ['2'],
-      }));
+      });
 
       multimapBuilder.build();
-      expect(map1.toMap(), ({
+      expect(map1.toMap(), {
         1: ['1'],
         2: ['2'],
-      }));
+      });
     });
 
     test('returns identical BuiltSetMultimap on repeated build', () {
-      var multimapBuilder = SetMultimapBuilder<int, String>({
+      final multimapBuilder = SetMultimapBuilder<int, String>({
         1: ['1', '2', '3'],
       });
       expect(multimapBuilder.build(), same(multimapBuilder.build()));
@@ -193,46 +193,46 @@ void main() {
     // Modification of existing data.
 
     test('adds to copied sets', () {
-      var multimap = BuiltSetMultimap<int, String>({
+      final multimap = BuiltSetMultimap<int, String>({
         1: ['1'],
       });
-      var multimapBuilder = multimap.toBuilder();
+      final multimapBuilder = multimap.toBuilder();
       expect((multimapBuilder..add(1, '2')).build().toMap(), {
         1: ['1', '2'],
       });
     });
 
     test('removes from copied sets', () {
-      var multimap = BuiltSetMultimap<int, String>({
+      final multimap = BuiltSetMultimap<int, String>({
         1: ['1', '2', '3'],
       });
-      var multimapBuilder = multimap.toBuilder();
+      final multimapBuilder = multimap.toBuilder();
       expect((multimapBuilder..remove(1, '2')).build().toMap(), {
         1: ['1', '3'],
       });
     });
 
     test('removes from copied sets to empty', () {
-      var multimap = BuiltSetMultimap<int, String>({
+      final multimap = BuiltSetMultimap<int, String>({
         1: ['1'],
       });
-      var multimapBuilder = multimap.toBuilder();
+      final multimapBuilder = multimap.toBuilder();
       expect((multimapBuilder..remove(1, '1')).build().toMap(), {});
     });
 
     test('removes all from copied sets', () {
-      var multimap = BuiltSetMultimap<int, String>({
+      final multimap = BuiltSetMultimap<int, String>({
         1: ['1', '2', '3'],
       });
-      var multimapBuilder = multimap.toBuilder();
+      final multimapBuilder = multimap.toBuilder();
       expect((multimapBuilder..removeAll(1)).build().toMap(), {});
     });
 
     test('clears copied sets', () {
-      var multimap = BuiltSetMultimap<int, String>({
+      final multimap = BuiltSetMultimap<int, String>({
         1: ['1', '2', '3'],
       });
-      var multimapBuilder = multimap.toBuilder();
+      final multimapBuilder = multimap.toBuilder();
       expect((multimapBuilder..clear()).build().toMap(), {});
     });
 
@@ -243,19 +243,19 @@ void main() {
         (SetMultimapBuilder<int, String>({
           1: ['1'],
         })..add(2, '2')).build().toMap(),
-        ({
+        {
           1: ['1'],
           2: ['2'],
-        }),
+        },
       );
       expect(
         (BuiltSetMultimap<int, String>({
           1: ['1'],
         }).toBuilder()..add(2, '2')).build().toMap(),
-        ({
+        {
           1: ['1'],
           2: ['2'],
-        }),
+        },
       );
     });
 
@@ -264,19 +264,19 @@ void main() {
         (SetMultimapBuilder<int, String>({
           1: ['1'],
         })..addValues(2, ['2', '3'])).build().toMap(),
-        ({
+        {
           1: ['1'],
           2: ['2', '3'],
-        }),
+        },
       );
       expect(
         (BuiltSetMultimap<int, String>({
           1: ['1'],
         }).toBuilder()..addValues(2, ['2', '3'])).build().toMap(),
-        ({
+        {
           1: ['1'],
           2: ['2', '3'],
-        }),
+        },
       );
     });
 

--- a/built_types/built_value/CHANGELOG.md
+++ b/built_types/built_value/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.13.1-wip
+
+- Migrate to `package:dart_flutter_team_lints`.
+
 ## 8.13.0
 
 - Support generating from classes and enums that use the `new` syntax for

--- a/built_types/built_value/analysis_options.yaml
+++ b/built_types/built_value/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/built_types/built_value/lib/async_serializer.dart
+++ b/built_types/built_value/lib/async_serializer.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'package:built_value/serializer.dart';
+import 'serializer.dart';
 
 /// Deserializer for `BuiltList` that runs asynchronously.
 ///
@@ -12,11 +12,11 @@ import 'package:built_value/serializer.dart';
 class BuiltListAsyncDeserializer {
   Stream<Object?> deserialize(Serializers serializers, Iterable serialized,
       {FullType specifiedType = FullType.unspecified}) async* {
-    var elementType = specifiedType.parameters.isEmpty
+    final elementType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
 
-    for (var item in serialized) {
+    for (final item in serialized) {
       yield serializers.deserialize(item, specifiedType: elementType);
     }
   }

--- a/built_types/built_value/lib/built_value.dart
+++ b/built_types/built_value/lib/built_value.dart
@@ -319,7 +319,7 @@ typedef BuiltValueToStringHelperProvider = BuiltValueToStringHelper Function(
 /// are [IndentingBuiltValueToStringHelper], which is the default, and
 /// [FlatBuiltValueToStringHelper].
 BuiltValueToStringHelperProvider newBuiltValueToStringHelper =
-    (String className) => IndentingBuiltValueToStringHelper(className);
+    IndentingBuiltValueToStringHelper.new;
 
 /// Interface for built_value toString() output helpers.
 ///
@@ -364,7 +364,7 @@ class IndentingBuiltValueToStringHelper implements BuiltValueToStringHelper {
     _result!
       ..write(' ' * _indentingBuiltValueToStringHelperIndent)
       ..write('}');
-    var stringResult = _result.toString();
+    final stringResult = _result.toString();
     _result = null;
     return stringResult;
   }
@@ -398,7 +398,7 @@ class FlatBuiltValueToStringHelper implements BuiltValueToStringHelper {
   @override
   String toString() {
     _result!.write('}');
-    var stringResult = _result.toString();
+    final stringResult = _result.toString();
     _result = null;
     return stringResult;
   }

--- a/built_types/built_value/lib/iso_8601_date_time_serializer.dart
+++ b/built_types/built_value/lib/iso_8601_date_time_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import 'serializer.dart';
 
 /// Alternative serializer for [DateTime].
 ///

--- a/built_types/built_value/lib/iso_8601_duration_serializer.dart
+++ b/built_types/built_value/lib/iso_8601_duration_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import 'serializer.dart';
 
 /// Alternative serializer for [Duration].
 ///

--- a/built_types/built_value/lib/serializer.dart
+++ b/built_types/built_value/lib/serializer.dart
@@ -4,19 +4,8 @@
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_collection/src/internal/hash.dart';
-import 'package:built_value/src/big_int_serializer.dart';
-import 'package:built_value/src/date_time_serializer.dart';
-import 'package:built_value/src/duration_serializer.dart';
-import 'package:built_value/src/int32_serializer.dart';
-import 'package:built_value/src/int64_serializer.dart';
-import 'package:built_value/src/json_object_serializer.dart';
-import 'package:built_value/src/list_serializer.dart';
-import 'package:built_value/src/map_serializer.dart';
-import 'package:built_value/src/num_serializer.dart';
-import 'package:built_value/src/set_serializer.dart';
-import 'package:built_value/src/uint8_list_serializer.dart';
-import 'package:built_value/src/uri_serializer.dart';
 
+import 'src/big_int_serializer.dart';
 import 'src/bool_serializer.dart';
 import 'src/built_json_serializers.dart';
 import 'src/built_list_multimap_serializer.dart';
@@ -24,11 +13,22 @@ import 'src/built_list_serializer.dart';
 import 'src/built_map_serializer.dart';
 import 'src/built_set_multimap_serializer.dart';
 import 'src/built_set_serializer.dart';
+import 'src/date_time_serializer.dart';
 import 'src/double_serializer.dart';
+import 'src/duration_serializer.dart';
+import 'src/int32_serializer.dart';
+import 'src/int64_serializer.dart';
 import 'src/int_serializer.dart';
+import 'src/json_object_serializer.dart';
+import 'src/list_serializer.dart';
+import 'src/map_serializer.dart';
 import 'src/null_serializer.dart';
+import 'src/num_serializer.dart';
 import 'src/regexp_serializer.dart';
+import 'src/set_serializer.dart';
 import 'src/string_serializer.dart';
+import 'src/uint8_list_serializer.dart';
+import 'src/uri_serializer.dart';
 
 /// Annotation to trigger code generation of a [Serializers] instance.
 ///
@@ -84,20 +84,20 @@ abstract class Serializers {
           ..add(Uint8ListSerializer())
           ..add(UriSerializer())
           ..addBuilderFactory(const FullType(BuiltList, [FullType.object]),
-              () => ListBuilder<Object>())
+              ListBuilder<Object>.new)
           ..addBuilderFactory(
               const FullType(
                   BuiltListMultimap, [FullType.object, FullType.object]),
-              () => ListMultimapBuilder<Object, Object>())
+              ListMultimapBuilder<Object, Object>.new)
           ..addBuilderFactory(
               const FullType(BuiltMap, [FullType.object, FullType.object]),
-              () => MapBuilder<Object, Object>())
+              MapBuilder<Object, Object>.new)
           ..addBuilderFactory(const FullType(BuiltSet, [FullType.object]),
-              () => SetBuilder<Object>())
+              SetBuilder<Object>.new)
           ..addBuilderFactory(
               const FullType(
                   BuiltSetMultimap, [FullType.object, FullType.object]),
-              () => SetMultimapBuilder<Object, Object>()))
+              SetMultimapBuilder<Object, Object>.new))
         .build();
   }
 
@@ -303,8 +303,8 @@ class FullType {
   String get _nullabilitySuffix => nullable ? '?' : '';
 
   static String _getRawName(Type? type) {
-    var name = type.toString();
-    var genericsStart = name.indexOf('<');
+    final name = type.toString();
+    final genericsStart = name.indexOf('<');
     return genericsStart == -1 ? name : name.substring(0, genericsStart);
   }
 }

--- a/built_types/built_value/lib/src/big_int_serializer.dart
+++ b/built_types/built_value/lib/src/big_int_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class BigIntSerializer implements PrimitiveSerializer<BigInt> {
   final bool structured = false;

--- a/built_types/built_value/lib/src/bool_serializer.dart
+++ b/built_types/built_value/lib/src/bool_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class BoolSerializer implements PrimitiveSerializer<bool> {
   final bool structured = false;

--- a/built_types/built_value/lib/src/built_json_serializers.dart
+++ b/built_types/built_value/lib/src/built_json_serializers.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 /// Default implementation of [Serializers].
 class BuiltJsonSerializers implements Serializers {
@@ -62,12 +62,12 @@ class BuiltJsonSerializers implements Serializers {
   Object? serialize(Object? object,
       {FullType specifiedType = FullType.unspecified}) {
     var transformedObject = object;
-    for (var plugin in serializerPlugins) {
+    for (final plugin in serializerPlugins) {
       transformedObject =
           plugin.beforeSerialize(transformedObject, specifiedType);
     }
     var result = _serialize(transformedObject, specifiedType);
-    for (var plugin in serializerPlugins) {
+    for (final plugin in serializerPlugins) {
       result = plugin.afterSerialize(result, specifiedType);
     }
     return result;
@@ -118,12 +118,12 @@ class BuiltJsonSerializers implements Serializers {
   Object? deserialize(Object? object,
       {FullType specifiedType = FullType.unspecified}) {
     var transformedObject = object;
-    for (var plugin in serializerPlugins) {
+    for (final plugin in serializerPlugins) {
       transformedObject =
           plugin.beforeDeserialize(transformedObject, specifiedType);
     }
     var result = _deserialize(object, transformedObject, specifiedType);
-    for (var plugin in serializerPlugins) {
+    for (final plugin in serializerPlugins) {
       result = plugin.afterDeserialize(result, specifiedType);
     }
     return result;
@@ -147,7 +147,7 @@ class BuiltJsonSerializers implements Serializers {
         }
       } else if (serializer is PrimitiveSerializer) {
         try {
-          var primitive = object[1];
+          final primitive = object[1];
           return primitive == null
               ? null
               : serializer.deserialize(this, primitive);
@@ -205,7 +205,7 @@ class BuiltJsonSerializers implements Serializers {
 
   @override
   Object newBuilder(FullType fullType) {
-    var builderFactory = builderFactories[fullType];
+    final builderFactory = builderFactories[fullType];
     if (builderFactory == null) _throwMissingBuilderFactory(fullType);
     return builderFactory();
   }
@@ -269,7 +269,7 @@ class BuiltJsonSerializersBuilder implements SerializersBuilder {
     }
 
     _wireNameToSerializer[serializer.wireName] = serializer;
-    for (var type in serializer.types) {
+    for (final type in serializer.types) {
       _typeToSerializer[type] = serializer;
       _typeNameToSerializer[_getRawName(type)] = serializer;
     }
@@ -297,7 +297,7 @@ class BuiltJsonSerializersBuilder implements SerializersBuilder {
 
   @override
   void mergeAll(Iterable<Serializers> serializersIterable) {
-    for (var serializers in serializersIterable) {
+    for (final serializers in serializersIterable) {
       merge(serializers);
     }
   }
@@ -319,8 +319,8 @@ class BuiltJsonSerializersBuilder implements SerializersBuilder {
 }
 
 String _getRawName(Type? type) {
-  var name = type.toString();
-  var genericsStart = name.indexOf('<');
+  final name = type.toString();
+  final genericsStart = name.indexOf('<');
   return genericsStart == -1 ? name : name.substring(0, genericsStart);
 }
 

--- a/built_types/built_value/lib/src/built_list_multimap_serializer.dart
+++ b/built_types/built_value/lib/src/built_list_multimap_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class BuiltListMultimapSerializer
     implements StructuredSerializer<BuiltListMultimap> {
@@ -18,19 +18,19 @@ class BuiltListMultimapSerializer
   Iterable<Object?> serialize(
       Serializers serializers, BuiltListMultimap builtListMultimap,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
 
-    var keyType = specifiedType.parameters.isEmpty
+    final keyType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
-    var valueType = specifiedType.parameters.isEmpty
+    final valueType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[1];
 
-    var result = <Object?>[];
-    for (var key in builtListMultimap.keys) {
+    final result = <Object?>[];
+    for (final key in builtListMultimap.keys) {
       result.add(serializers.serialize(key, specifiedType: keyType));
       result.add(builtListMultimap[key]
           .map(
@@ -44,17 +44,17 @@ class BuiltListMultimapSerializer
   BuiltListMultimap deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
 
-    var keyType = specifiedType.parameters.isEmpty
+    final keyType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
-    var valueType = specifiedType.parameters.isEmpty
+    final valueType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[1];
 
-    var result = isUnderspecified
+    final result = isUnderspecified
         ? ListMultimapBuilder<Object, Object>()
         : serializers.newBuilder(specifiedType) as ListMultimapBuilder;
 
@@ -67,7 +67,7 @@ class BuiltListMultimapSerializer
           specifiedType: keyType);
       final values = (serialized.elementAt(i + 1) as Iterable<Object?>).map(
           (value) => serializers.deserialize(value, specifiedType: valueType));
-      for (var value in values) {
+      for (final value in values) {
         result.add(key, value);
       }
     }

--- a/built_types/built_value/lib/src/built_list_serializer.dart
+++ b/built_types/built_value/lib/src/built_list_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class BuiltListSerializer implements StructuredSerializer<BuiltList> {
   final bool structured = true;
@@ -16,11 +16,11 @@ class BuiltListSerializer implements StructuredSerializer<BuiltList> {
   @override
   Iterable<Object?> serialize(Serializers serializers, BuiltList builtList,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
 
-    var elementType = specifiedType.parameters.isEmpty
+    final elementType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
 
@@ -31,14 +31,14 @@ class BuiltListSerializer implements StructuredSerializer<BuiltList> {
   @override
   BuiltList deserialize(Serializers serializers, Iterable serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
 
-    var elementType = specifiedType.parameters.isEmpty
+    final elementType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
 
-    var result = isUnderspecified
+    final result = isUnderspecified
         ? ListBuilder<Object>()
         : serializers.newBuilder(specifiedType) as ListBuilder;
 

--- a/built_types/built_value/lib/src/built_map_serializer.dart
+++ b/built_types/built_value/lib/src/built_map_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class BuiltMapSerializer implements StructuredSerializer<BuiltMap> {
   final bool structured = true;
@@ -16,19 +16,19 @@ class BuiltMapSerializer implements StructuredSerializer<BuiltMap> {
   @override
   Iterable<Object?> serialize(Serializers serializers, BuiltMap builtMap,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
 
-    var keyType = specifiedType.parameters.isEmpty
+    final keyType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
-    var valueType = specifiedType.parameters.isEmpty
+    final valueType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[1];
 
-    var result = <Object?>[];
-    for (var key in builtMap.keys) {
+    final result = <Object?>[];
+    for (final key in builtMap.keys) {
       result.add(serializers.serialize(key, specifiedType: keyType));
       final value = builtMap[key];
       result.add(serializers.serialize(value, specifiedType: valueType));
@@ -39,17 +39,17 @@ class BuiltMapSerializer implements StructuredSerializer<BuiltMap> {
   @override
   BuiltMap deserialize(Serializers serializers, Iterable serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
 
-    var keyType = specifiedType.parameters.isEmpty
+    final keyType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
-    var valueType = specifiedType.parameters.isEmpty
+    final valueType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[1];
 
-    var result = isUnderspecified
+    final result = isUnderspecified
         ? MapBuilder<Object, Object>()
         : serializers.newBuilder(specifiedType) as MapBuilder;
 

--- a/built_types/built_value/lib/src/built_set_multimap_serializer.dart
+++ b/built_types/built_value/lib/src/built_set_multimap_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class BuiltSetMultimapSerializer
     implements StructuredSerializer<BuiltSetMultimap> {
@@ -17,19 +17,19 @@ class BuiltSetMultimapSerializer
   Iterable<Object?> serialize(
       Serializers serializers, BuiltSetMultimap builtSetMultimap,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
 
-    var keyType = specifiedType.parameters.isEmpty
+    final keyType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
-    var valueType = specifiedType.parameters.isEmpty
+    final valueType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[1];
 
-    var result = <Object?>[];
-    for (var key in builtSetMultimap.keys) {
+    final result = <Object?>[];
+    for (final key in builtSetMultimap.keys) {
       result.add(serializers.serialize(key, specifiedType: keyType));
       result.add(builtSetMultimap[key]!
           .map(
@@ -42,17 +42,17 @@ class BuiltSetMultimapSerializer
   @override
   BuiltSetMultimap deserialize(Serializers serializers, Iterable serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
 
-    var keyType = specifiedType.parameters.isEmpty
+    final keyType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
-    var valueType = specifiedType.parameters.isEmpty
+    final valueType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[1];
 
-    var result = isUnderspecified
+    final result = isUnderspecified
         ? SetMultimapBuilder<Object, Object>()
         : serializers.newBuilder(specifiedType) as SetMultimapBuilder;
 
@@ -65,7 +65,7 @@ class BuiltSetMultimapSerializer
           specifiedType: keyType);
       final values = serialized.elementAt(i + 1).map(
           (value) => serializers.deserialize(value, specifiedType: valueType));
-      for (var value in values) {
+      for (final value in values) {
         result.add(key, value);
       }
     }

--- a/built_types/built_value/lib/src/built_set_serializer.dart
+++ b/built_types/built_value/lib/src/built_set_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class BuiltSetSerializer implements StructuredSerializer<BuiltSet> {
   final bool structured = true;
@@ -16,11 +16,11 @@ class BuiltSetSerializer implements StructuredSerializer<BuiltSet> {
   @override
   Iterable<Object?> serialize(Serializers serializers, BuiltSet builtSet,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
 
-    var elementType = specifiedType.parameters.isEmpty
+    final elementType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
 
@@ -31,13 +31,13 @@ class BuiltSetSerializer implements StructuredSerializer<BuiltSet> {
   @override
   BuiltSet deserialize(Serializers serializers, Iterable serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
 
-    var elementType = specifiedType.parameters.isEmpty
+    final elementType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
-    var result = isUnderspecified
+    final result = isUnderspecified
         ? SetBuilder<Object>()
         : serializers.newBuilder(specifiedType) as SetBuilder;
 

--- a/built_types/built_value/lib/src/date_time_serializer.dart
+++ b/built_types/built_value/lib/src/date_time_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 /// Serializer for [DateTime].
 ///
@@ -30,7 +30,7 @@ class DateTimeSerializer implements PrimitiveSerializer<DateTime> {
   @override
   DateTime deserialize(Serializers serializers, Object? serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var microsecondsSinceEpoch = serialized as int;
+    final microsecondsSinceEpoch = serialized as int;
     return DateTime.fromMicrosecondsSinceEpoch(microsecondsSinceEpoch,
         isUtc: true);
   }

--- a/built_types/built_value/lib/src/double_serializer.dart
+++ b/built_types/built_value/lib/src/double_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class DoubleSerializer implements PrimitiveSerializer<double> {
   // Constant names match those in [double].

--- a/built_types/built_value/lib/src/duration_serializer.dart
+++ b/built_types/built_value/lib/src/duration_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 /// Serializer for [Duration].
 ///

--- a/built_types/built_value/lib/src/int32_serializer.dart
+++ b/built_types/built_value/lib/src/int32_serializer.dart
@@ -3,8 +3,9 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
 import 'package:fixnum/fixnum.dart';
+
+import '../serializer.dart';
 
 class Int32Serializer implements PrimitiveSerializer<Int32> {
   final bool structured = false;

--- a/built_types/built_value/lib/src/int64_serializer.dart
+++ b/built_types/built_value/lib/src/int64_serializer.dart
@@ -3,8 +3,9 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
 import 'package:fixnum/fixnum.dart';
+
+import '../serializer.dart';
 
 class Int64Serializer implements PrimitiveSerializer<Int64> {
   final bool structured = false;

--- a/built_types/built_value/lib/src/int_serializer.dart
+++ b/built_types/built_value/lib/src/int_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class IntSerializer implements PrimitiveSerializer<int> {
   final bool structured = false;

--- a/built_types/built_value/lib/src/json_object_serializer.dart
+++ b/built_types/built_value/lib/src/json_object_serializer.dart
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/json_object.dart';
-import 'package:built_value/serializer.dart';
+import '../json_object.dart';
+import '../serializer.dart';
 
 class JsonObjectSerializer implements PrimitiveSerializer<JsonObject> {
   final bool structured = false;

--- a/built_types/built_value/lib/src/list_serializer.dart
+++ b/built_types/built_value/lib/src/list_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class ListSerializer implements StructuredSerializer<List> {
   final bool structured = true;
@@ -15,11 +15,11 @@ class ListSerializer implements StructuredSerializer<List> {
   @override
   Iterable<Object?> serialize(Serializers serializers, List list,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
 
-    var elementType = specifiedType.parameters.isEmpty
+    final elementType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
 
@@ -30,14 +30,14 @@ class ListSerializer implements StructuredSerializer<List> {
   @override
   List deserialize(Serializers serializers, Iterable serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
 
-    var elementType = specifiedType.parameters.isEmpty
+    final elementType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
 
-    var result = isUnderspecified
+    final result = isUnderspecified
         ? <Object>[]
         : serializers.newBuilder(specifiedType) as List;
 

--- a/built_types/built_value/lib/src/map_serializer.dart
+++ b/built_types/built_value/lib/src/map_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class MapSerializer implements StructuredSerializer<Map> {
   final bool structured = true;
@@ -16,19 +16,19 @@ class MapSerializer implements StructuredSerializer<Map> {
   @override
   Iterable<Object?> serialize(Serializers serializers, Map Map,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
 
-    var keyType = specifiedType.parameters.isEmpty
+    final keyType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
-    var valueType = specifiedType.parameters.isEmpty
+    final valueType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[1];
 
-    var result = <Object?>[];
-    for (var key in Map.keys) {
+    final result = <Object?>[];
+    for (final key in Map.keys) {
       result.add(serializers.serialize(key, specifiedType: keyType));
       final value = Map[key];
       result.add(serializers.serialize(value, specifiedType: valueType));
@@ -39,17 +39,17 @@ class MapSerializer implements StructuredSerializer<Map> {
   @override
   Map deserialize(Serializers serializers, Iterable serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
 
-    var keyType = specifiedType.parameters.isEmpty
+    final keyType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
-    var valueType = specifiedType.parameters.isEmpty
+    final valueType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[1];
 
-    var result = isUnderspecified
+    final result = isUnderspecified
         ? <Object, Object>{}
         : serializers.newBuilder(specifiedType) as Map;
 

--- a/built_types/built_value/lib/src/null_serializer.dart
+++ b/built_types/built_value/lib/src/null_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class NullSerializer implements PrimitiveSerializer<Null> {
   final bool structured = false;

--- a/built_types/built_value/lib/src/num_serializer.dart
+++ b/built_types/built_value/lib/src/num_serializer.dart
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
-import 'package:built_value/src/double_serializer.dart';
+import '../serializer.dart';
+import 'double_serializer.dart';
 
 class NumSerializer implements PrimitiveSerializer<num> {
   final bool structured = false;

--- a/built_types/built_value/lib/src/regexp_serializer.dart
+++ b/built_types/built_value/lib/src/regexp_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 /// Runtime type for [RegExp] private implementation.
 final _runtimeType = RegExp('').runtimeType;

--- a/built_types/built_value/lib/src/set_serializer.dart
+++ b/built_types/built_value/lib/src/set_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class SetSerializer implements StructuredSerializer<Set> {
   final bool structured = true;
@@ -15,11 +15,11 @@ class SetSerializer implements StructuredSerializer<Set> {
   @override
   Iterable<Object?> serialize(Serializers serializers, Set set,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
     if (!isUnderspecified) serializers.expectBuilder(specifiedType);
 
-    var elementType = specifiedType.parameters.isEmpty
+    final elementType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
 
@@ -30,14 +30,14 @@ class SetSerializer implements StructuredSerializer<Set> {
   @override
   Set deserialize(Serializers serializers, Iterable serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var isUnderspecified =
+    final isUnderspecified =
         specifiedType.isUnspecified || specifiedType.parameters.isEmpty;
 
-    var elementType = specifiedType.parameters.isEmpty
+    final elementType = specifiedType.parameters.isEmpty
         ? FullType.unspecified
         : specifiedType.parameters[0];
 
-    var result = isUnderspecified
+    final result = isUnderspecified
         ? <Object>{}
         : serializers.newBuilder(specifiedType) as Set;
 

--- a/built_types/built_value/lib/src/string_serializer.dart
+++ b/built_types/built_value/lib/src/string_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class StringSerializer implements PrimitiveSerializer<String> {
   final bool structured = false;

--- a/built_types/built_value/lib/src/uint8_list_serializer.dart
+++ b/built_types/built_value/lib/src/uint8_list_serializer.dart
@@ -6,7 +6,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class Uint8ListSerializer implements PrimitiveSerializer<Uint8List> {
   @override

--- a/built_types/built_value/lib/src/uri_serializer.dart
+++ b/built_types/built_value/lib/src/uri_serializer.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/serializer.dart';
+import '../serializer.dart';
 
 class UriSerializer implements PrimitiveSerializer<Uri> {
   final bool structured = false;

--- a/built_types/built_value/lib/standard_json_plugin.dart
+++ b/built_types/built_value/lib/standard_json_plugin.dart
@@ -2,10 +2,12 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'package:built_collection/built_collection.dart';
-import 'package:built_value/json_object.dart';
-import 'package:built_value/serializer.dart';
 import 'dart:convert' show json;
+
+import 'package:built_collection/built_collection.dart';
+
+import 'json_object.dart';
+import 'serializer.dart';
 
 /// Switches to "standard" JSON format.
 ///
@@ -88,7 +90,7 @@ class StandardJsonPlugin implements SerializerPlugin {
   /// Converts serialization output, a `List`, to a `Map`, when the serialized
   /// type is known statically.
   Map _toMap(List list, bool needsEncodedKeys) {
-    var result = <String, Object?>{};
+    final result = <String, Object?>{};
     for (var i = 0; i != list.length ~/ 2; ++i) {
       final key = list[i * 2];
       final value = list[i * 2 + 1];
@@ -130,7 +132,7 @@ class StandardJsonPlugin implements SerializerPlugin {
       }
     }
 
-    var result = <String, Object>{discriminator: type};
+    final result = <String, Object>{discriminator: type};
     for (var i = 0; i != (list.length - 1) ~/ 2; ++i) {
       final key = needToEncodeKeys
           ? _encodeKey(list[i * 2 + 1])
@@ -154,9 +156,9 @@ class StandardJsonPlugin implements SerializerPlugin {
   /// the map is an actual map with nullable values, so they should be kept.
   List<Object?> _toList(Map map, bool hasEncodedKeys,
       {bool keepNulls = false}) {
-    var nullValueCount =
+    final nullValueCount =
         keepNulls ? 0 : map.values.where((value) => value == null).length;
-    var result = List<Object?>.filled(
+    final result = List<Object?>.filled(
         (map.length - nullValueCount) * 2, 0 /* Will be overwritten. */);
     var i = 0;
     map.forEach((key, value) {
@@ -196,13 +198,13 @@ class StandardJsonPlugin implements SerializerPlugin {
     // A type name of `encoded_map` indicates that the map has non-String keys
     // that have been serialized and JSON-encoded; decode the keys when
     // converting back to a `List`.
-    var needToDecodeKeys = type == 'encoded_map';
+    final needToDecodeKeys = type == 'encoded_map';
     if (needToDecodeKeys) {
       type = 'map';
     }
 
-    var nullValueCount = map.values.where((value) => value == null).length;
-    var result = List<Object>.filled(
+    final nullValueCount = map.values.where((value) => value == null).length;
+    final result = List<Object>.filled(
         (map.length - nullValueCount) * 2 - 1, 0 /* Will be overwritten. */);
     result[0] = type;
 

--- a/built_types/built_value/pubspec.yaml
+++ b/built_types/built_value/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value
-version: 8.13.0
+version: 8.13.1-wip
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library is the runtime dependency.
@@ -19,5 +19,5 @@ dependencies:
   meta: ^1.3.0
 
 dev_dependencies:
-  pedantic: ^1.4.0
+  dart_flutter_team_lints: ^3.1.0
   test: ^1.16.0

--- a/built_types/built_value/test/big_int_serializer_test.dart
+++ b/built_types/built_value/test/big_int_serializer_test.dart
@@ -8,12 +8,12 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('BigInt with known specifiedType', () {
-    var data = BigInt.parse('123456789012345678901234567890');
-    var serialized = '123456789012345678901234567890';
-    var specifiedType = const FullType(BigInt);
+    final data = BigInt.parse('123456789012345678901234567890');
+    final serialized = '123456789012345678901234567890';
+    final specifiedType = const FullType(BigInt);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -27,11 +27,11 @@ void main() {
   });
 
   group('BigInt with unknown specifiedType', () {
-    var data = BigInt.parse('123456789012345678901234567890');
-    var serialized =
+    final data = BigInt.parse('123456789012345678901234567890');
+    final serialized =
         json.decode(json.encode(['BigInt', '123456789012345678901234567890']))
             as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/bool_serializer_test.dart
+++ b/built_types/built_value/test/bool_serializer_test.dart
@@ -8,12 +8,12 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('bool with known specifiedType', () {
-    var data = true;
-    var serialized = true;
-    var specifiedType = const FullType(bool);
+    final data = true;
+    final serialized = true;
+    final specifiedType = const FullType(bool);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -27,9 +27,9 @@ void main() {
   });
 
   group('bool with unknown specifiedType', () {
-    var data = true;
-    var serialized = json.decode(json.encode(['bool', true])) as Object;
-    var specifiedType = FullType.unspecified;
+    final data = true;
+    final serialized = json.decode(json.encode(['bool', true])) as Object;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/builder_factory_test.dart
+++ b/built_types/built_value/test/builder_factory_test.dart
@@ -10,10 +10,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('Missing builder factory', () {
-    var data = BuiltList<int>([1, 2, 3]);
-    var specifiedType = const FullType(BuiltList, [FullType(int)]);
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    final data = BuiltList<int>([1, 2, 3]);
+    final specifiedType = const FullType(BuiltList, [FullType(int)]);
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([1, 2, 3])) as Object;
 
     test('serialize throws with nice message', () {
       expect(

--- a/built_types/built_value/test/built_list_async_deserializer_test.dart
+++ b/built_types/built_value/test/built_list_async_deserializer_test.dart
@@ -11,12 +11,12 @@ import 'package:test/test.dart';
 
 void main() {
   group('BuiltList', () {
-    var data = BuiltList<int>([1, 2, 3]);
-    var specifiedType = const FullType(BuiltList, [FullType(int)]);
-    var serializers = (Serializers().toBuilder()
-          ..addBuilderFactory(specifiedType, () => ListBuilder<int>()))
+    final data = BuiltList<int>([1, 2, 3]);
+    final specifiedType = const FullType(BuiltList, [FullType(int)]);
+    final serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, ListBuilder<int>.new))
         .build();
-    var serialized = json.decode(json.encode([1, 2, 3])) as Iterable;
+    final serialized = json.decode(json.encode([1, 2, 3])) as Iterable;
 
     test('can be deserialized asynchronously', () async {
       final deserialized = await BuiltListAsyncDeserializer()

--- a/built_types/built_value/test/built_list_multimap_serializer_test.dart
+++ b/built_types/built_value/test/built_list_multimap_serializer_test.dart
@@ -10,18 +10,18 @@ import 'package:test/test.dart';
 
 void main() {
   group('BuiltListMultimap with known specifiedType and correct builder', () {
-    var data = BuiltListMultimap<int, String>({
+    final data = BuiltListMultimap<int, String>({
       1: ['one'],
       2: ['two'],
       3: ['three', '3hree']
     });
-    var specifiedType =
+    final specifiedType =
         const FullType(BuiltListMultimap, [FullType(int), FullType(String)]);
-    var serializers = (Serializers().toBuilder()
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(
-              specifiedType, () => ListMultimapBuilder<int, String>()))
+              specifiedType, ListMultimapBuilder<int, String>.new))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       1,
       ['one'],
       2,

--- a/built_types/built_value/test/built_list_serializer_test.dart
+++ b/built_types/built_value/test/built_list_serializer_test.dart
@@ -10,10 +10,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('BuiltList with known specifiedType but missing builder', () {
-    var data = BuiltList<int>([1, 2, 3]);
-    var specifiedType = const FullType(BuiltList, [FullType(int)]);
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    final data = BuiltList<int>([1, 2, 3]);
+    final specifiedType = const FullType(BuiltList, [FullType(int)]);
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([1, 2, 3])) as Object;
 
     test('serialize throws', () {
       expect(() => serializers.serialize(data, specifiedType: specifiedType),
@@ -29,12 +29,12 @@ void main() {
   });
 
   group('BuiltList with known specifiedType and correct builder', () {
-    var data = BuiltList<int>([1, 2, 3]);
-    var specifiedType = const FullType(BuiltList, [FullType(int)]);
-    var serializers = (Serializers().toBuilder()
-          ..addBuilderFactory(specifiedType, () => ListBuilder<int>()))
+    final data = BuiltList<int>([1, 2, 3]);
+    final specifiedType = const FullType(BuiltList, [FullType(int)]);
+    final serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, ListBuilder<int>.new))
         .build();
-    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    final serialized = json.decode(json.encode([1, 2, 3])) as Object;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -56,21 +56,20 @@ void main() {
   });
 
   group('BuiltList nested with known specifiedType and correct builders', () {
-    var data = BuiltList<BuiltList<int>>([
+    final data = BuiltList<BuiltList<int>>([
       BuiltList<int>([1, 2, 3]),
       BuiltList<int>([4, 5, 6]),
       BuiltList<int>([7, 8, 9])
     ]);
-    var specifiedType = const FullType(BuiltList, [
+    final specifiedType = const FullType(BuiltList, [
       FullType(BuiltList, [FullType(int)])
     ]);
-    var serializers = (Serializers().toBuilder()
+    final serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, ListBuilder<BuiltList<int>>.new)
           ..addBuilderFactory(
-              specifiedType, () => ListBuilder<BuiltList<int>>())
-          ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]),
-              () => ListBuilder<int>()))
+              const FullType(BuiltList, [FullType(int)]), ListBuilder<int>.new))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       [1, 2, 3],
       [4, 5, 6],
       [7, 8, 9]
@@ -88,10 +87,10 @@ void main() {
   });
 
   group('BuiltList with unknown specifiedType and no builders', () {
-    var data = BuiltList<int>([1, 2, 3]);
-    var specifiedType = FullType.unspecified;
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([
+    final data = BuiltList<int>([1, 2, 3]);
+    final specifiedType = FullType.unspecified;
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([
       'list',
       ['int', 1],
       ['int', 2],

--- a/built_types/built_value/test/built_map_serializer_test.dart
+++ b/built_types/built_value/test/built_map_serializer_test.dart
@@ -10,11 +10,11 @@ import 'package:test/test.dart';
 
 void main() {
   group('BuiltMap with known specifiedType but missing builder', () {
-    var data = BuiltMap<int, String>({1: 'one', 2: 'two', 3: 'three'});
-    var specifiedType =
+    final data = BuiltMap<int, String>({1: 'one', 2: 'two', 3: 'three'});
+    final specifiedType =
         const FullType(BuiltMap, [FullType(int), FullType(String)]);
-    var serializers = Serializers();
-    var serialized =
+    final serializers = Serializers();
+    final serialized =
         json.decode(json.encode([1, 'one', 2, 'two', 3, 'three'])) as Object;
 
     test('cannot be serialized', () {
@@ -31,13 +31,13 @@ void main() {
   });
 
   group('BuiltMap with known specifiedType and correct builder', () {
-    var data = BuiltMap<int, String>({1: 'one', 2: 'two', 3: 'three'});
-    var specifiedType =
+    final data = BuiltMap<int, String>({1: 'one', 2: 'two', 3: 'three'});
+    final specifiedType =
         const FullType(BuiltMap, [FullType(int), FullType(String)]);
-    var serializers = (Serializers().toBuilder()
-          ..addBuilderFactory(specifiedType, () => MapBuilder<int, String>()))
+    final serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, MapBuilder<int, String>.new))
         .build();
-    var serialized =
+    final serialized =
         json.decode(json.encode([1, 'one', 2, 'two', 3, 'three'])) as Object;
 
     test('can be serialized', () {
@@ -60,19 +60,19 @@ void main() {
   });
 
   group('BuiltMap nested left with known specifiedType', () {
-    var data = BuiltMap<BuiltMap<int, String>, String>({
+    final data = BuiltMap<BuiltMap<int, String>, String>({
       BuiltMap<int, String>({1: 'one'}): 'one!',
       BuiltMap<int, String>({2: 'two'}): 'two!'
     });
     const innerTypeLeft = FullType(BuiltMap, [FullType(int), FullType(String)]);
-    var specifiedType =
+    final specifiedType =
         const FullType(BuiltMap, [innerTypeLeft, FullType(String)]);
-    var serializers = (Serializers().toBuilder()
-          ..addBuilderFactory(innerTypeLeft, () => MapBuilder<int, String>())
+    final serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(innerTypeLeft, MapBuilder<int, String>.new)
           ..addBuilderFactory(
-              specifiedType, () => MapBuilder<BuiltMap<int, String>, String>()))
+              specifiedType, MapBuilder<BuiltMap<int, String>, String>.new))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       [1, 'one'],
       'one!',
       [2, 'two'],
@@ -91,21 +91,20 @@ void main() {
   });
 
   group('BuiltMap nested right with known specifiedType', () {
-    var data = BuiltMap<int, BuiltMap<String, String>>({
+    final data = BuiltMap<int, BuiltMap<String, String>>({
       1: BuiltMap<String, String>({'one': 'one!'}),
       2: BuiltMap<String, String>({'two': 'two!'})
     });
     const innerTypeRight =
         FullType(BuiltMap, [FullType(String), FullType(String)]);
-    var specifiedType =
+    final specifiedType =
         const FullType(BuiltMap, [FullType(int), innerTypeRight]);
-    var serializers = (Serializers().toBuilder()
+    final serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(innerTypeRight, MapBuilder<String, String>.new)
           ..addBuilderFactory(
-              innerTypeRight, () => MapBuilder<String, String>())
-          ..addBuilderFactory(
-              specifiedType, () => MapBuilder<int, BuiltMap<String, String>>()))
+              specifiedType, MapBuilder<int, BuiltMap<String, String>>.new))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       1,
       ['one', 'one!'],
       2,
@@ -124,7 +123,7 @@ void main() {
   });
 
   group('BuiltMap nested both with known specifiedType', () {
-    var data = BuiltMap<BuiltMap<int, int>, BuiltMap<String, String>>({
+    final data = BuiltMap<BuiltMap<int, int>, BuiltMap<String, String>>({
       BuiltMap<int, int>({1: 1}): BuiltMap<String, String>({'one': 'one!'}),
       BuiltMap<int, int>({2: 2}): BuiltMap<String, String>({'two': 'two!'})
     });
@@ -132,17 +131,17 @@ void main() {
         FullType(BuiltMap, [FullType(int), FullType(int)]);
     const builtMapOfStringStringGenericType =
         FullType(BuiltMap, [FullType(String), FullType(String)]);
-    var specifiedType = const FullType(BuiltMap,
+    final specifiedType = const FullType(BuiltMap,
         [builtMapOfIntIntGenericType, builtMapOfStringStringGenericType]);
-    var serializers = (Serializers().toBuilder()
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(
-              builtMapOfIntIntGenericType, () => MapBuilder<int, int>())
-          ..addBuilderFactory(builtMapOfStringStringGenericType,
-              () => MapBuilder<String, String>())
+              builtMapOfIntIntGenericType, MapBuilder<int, int>.new)
+          ..addBuilderFactory(
+              builtMapOfStringStringGenericType, MapBuilder<String, String>.new)
           ..addBuilderFactory(specifiedType,
-              () => MapBuilder<BuiltMap<int, int>, BuiltMap<String, String>>()))
+              MapBuilder<BuiltMap<int, int>, BuiltMap<String, String>>.new))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       [1, 1],
       ['one', 'one!'],
       [2, 2],
@@ -161,14 +160,12 @@ void main() {
 
     test('keeps generic type on deserialization', () {
       final genericSerializer = (serializers.toBuilder()
+            ..addBuilderFactory(specifiedType,
+                MapBuilder<BuiltMap<int, int>, BuiltMap<String, String>>.new)
             ..addBuilderFactory(
-                specifiedType,
-                () =>
-                    MapBuilder<BuiltMap<int, int>, BuiltMap<String, String>>())
-            ..addBuilderFactory(
-                builtMapOfIntIntGenericType, () => MapBuilder<int, int>())
+                builtMapOfIntIntGenericType, MapBuilder<int, int>.new)
             ..addBuilderFactory(builtMapOfStringStringGenericType,
-                () => MapBuilder<String, String>()))
+                MapBuilder<String, String>.new))
           .build();
 
       expect(
@@ -180,13 +177,13 @@ void main() {
   });
 
   group('BuiltMap with Object values', () {
-    var data = BuiltMap<int, Object>({1: 'one', 2: 2, 3: 'three'});
-    var specifiedType =
+    final data = BuiltMap<int, Object>({1: 'one', 2: 2, 3: 'three'});
+    final specifiedType =
         const FullType(BuiltMap, [FullType(int), FullType.unspecified]);
-    var serializers = (Serializers().toBuilder()
-          ..addBuilderFactory(specifiedType, () => MapBuilder<int, Object>()))
+    final serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, MapBuilder<int, Object>.new))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       1,
       ['String', 'one'],
       2,
@@ -207,14 +204,13 @@ void main() {
   });
 
   group('BuiltMap with Object keys', () {
-    var data = BuiltMap<Object, String>({1: 'one', 'two': 'two', 3: 'three'});
-    var specifiedType =
+    final data = BuiltMap<Object, String>({1: 'one', 'two': 'two', 3: 'three'});
+    final specifiedType =
         const FullType(BuiltMap, [FullType.unspecified, FullType(String)]);
-    var serializers = (Serializers().toBuilder()
-          ..addBuilderFactory(
-              specifiedType, () => MapBuilder<Object, String>()))
+    final serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, MapBuilder<Object, String>.new))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       ['int', 1],
       'one',
       ['String', 'two'],
@@ -235,10 +231,10 @@ void main() {
   });
 
   group('BuiltMap with Object keys and values', () {
-    var data = BuiltMap<Object, Object>({1: 'one', 'two': 2, 3: 'three'});
-    var specifiedType = const FullType(BuiltMap);
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([
+    final data = BuiltMap<Object, Object>({1: 'one', 'two': 2, 3: 'three'});
+    final specifiedType = const FullType(BuiltMap);
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([
       ['int', 1],
       ['String', 'one'],
       ['String', 'two'],
@@ -259,10 +255,10 @@ void main() {
   });
 
   group('BuiltMap with unknown specifiedType', () {
-    var data = BuiltMap<Object, Object>({1: 'one', 'two': 2, 3: 'three'});
-    var specifiedType = FullType.unspecified;
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([
+    final data = BuiltMap<Object, Object>({1: 'one', 'two': 2, 3: 'three'});
+    final specifiedType = FullType.unspecified;
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([
       'map',
       ['int', 1],
       ['String', 'one'],

--- a/built_types/built_value/test/built_set_multimap_serializer_test.dart
+++ b/built_types/built_value/test/built_set_multimap_serializer_test.dart
@@ -10,18 +10,18 @@ import 'package:test/test.dart';
 
 void main() {
   group('BuiltSetMultimap with known specifiedType and correct builder', () {
-    var data = BuiltSetMultimap<int, String>({
+    final data = BuiltSetMultimap<int, String>({
       1: ['one'],
       2: ['two'],
       3: ['three', '3hree']
     });
-    var specifiedType =
+    final specifiedType =
         const FullType(BuiltSetMultimap, [FullType(int), FullType(String)]);
-    var serializers = (Serializers().toBuilder()
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(
-              specifiedType, () => SetMultimapBuilder<int, String>()))
+              specifiedType, SetMultimapBuilder<int, String>.new))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       1,
       ['one'],
       2,

--- a/built_types/built_value/test/built_set_serializer_test.dart
+++ b/built_types/built_value/test/built_set_serializer_test.dart
@@ -13,10 +13,10 @@ import 'package:test/test.dart';
 // tests with "list" replaced by "set".
 void main() {
   group('BuiltSet with known specifiedType but missing builder', () {
-    var data = BuiltSet<int>([1, 2, 3]);
-    var specifiedType = const FullType(BuiltSet, [FullType(int)]);
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    final data = BuiltSet<int>([1, 2, 3]);
+    final specifiedType = const FullType(BuiltSet, [FullType(int)]);
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([1, 2, 3])) as Object;
 
     test('serialize throws', () {
       expect(() => serializers.serialize(data, specifiedType: specifiedType),
@@ -32,12 +32,12 @@ void main() {
   });
 
   group('BuiltSet with known specifiedType and correct builder', () {
-    var data = BuiltSet<int>([1, 2, 3]);
-    var specifiedType = const FullType(BuiltSet, [FullType(int)]);
-    var serializers = (Serializers().toBuilder()
-          ..addBuilderFactory(specifiedType, () => SetBuilder<int>()))
+    final data = BuiltSet<int>([1, 2, 3]);
+    final specifiedType = const FullType(BuiltSet, [FullType(int)]);
+    final serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, SetBuilder<int>.new))
         .build();
-    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    final serialized = json.decode(json.encode([1, 2, 3])) as Object;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -59,20 +59,20 @@ void main() {
   });
 
   group('BuiltSet nested with known specifiedType and correct builders', () {
-    var data = BuiltSet<BuiltSet<int>>([
+    final data = BuiltSet<BuiltSet<int>>([
       BuiltSet<int>([1, 2, 3]),
       BuiltSet<int>([4, 5, 6]),
       BuiltSet<int>([7, 8, 9])
     ]);
-    var specifiedType = const FullType(BuiltSet, [
+    final specifiedType = const FullType(BuiltSet, [
       FullType(BuiltSet, [FullType(int)])
     ]);
-    var serializers = (Serializers().toBuilder()
-          ..addBuilderFactory(specifiedType, () => SetBuilder<BuiltSet<int>>())
-          ..addBuilderFactory(const FullType(BuiltSet, [FullType(int)]),
-              () => SetBuilder<int>()))
+    final serializers = (Serializers().toBuilder()
+          ..addBuilderFactory(specifiedType, SetBuilder<BuiltSet<int>>.new)
+          ..addBuilderFactory(
+              const FullType(BuiltSet, [FullType(int)]), SetBuilder<int>.new))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       [1, 2, 3],
       [4, 5, 6],
       [7, 8, 9]
@@ -90,10 +90,10 @@ void main() {
   });
 
   group('BuiltSet with unknown specifiedType and no builders', () {
-    var data = BuiltSet<int>([1, 2, 3]);
-    var specifiedType = FullType.unspecified;
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([
+    final data = BuiltSet<int>([1, 2, 3]);
+    final specifiedType = FullType.unspecified;
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([
       'set',
       ['int', 1],
       ['int', 2],

--- a/built_types/built_value/test/built_value_test.dart
+++ b/built_types/built_value/test/built_value_test.dart
@@ -26,5 +26,5 @@ class YesNoEnum extends EnumClass {
   static const YesNoEnum yes = YesNoEnum._('yes');
   static const YesNoEnum no = YesNoEnum._('no');
 
-  const YesNoEnum._(String name) : super(name);
+  const YesNoEnum._(super.name);
 }

--- a/built_types/built_value/test/date_time_serializer_test.dart
+++ b/built_types/built_value/test/date_time_serializer_test.dart
@@ -8,12 +8,12 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('DateTime with known specifiedType', () {
-    var data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
-    var serialized = data.microsecondsSinceEpoch;
-    var specifiedType = const FullType(DateTime);
+    final data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
+    final serialized = data.microsecondsSinceEpoch;
+    final specifiedType = const FullType(DateTime);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -32,11 +32,11 @@ void main() {
   });
 
   group('DateTime with unknown specifiedType', () {
-    var data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
-    var serialized =
+    final data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
+    final serialized =
         json.decode(json.encode(['DateTime', data.microsecondsSinceEpoch]))
             as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/double_serializer_test.dart
+++ b/built_types/built_value/test/double_serializer_test.dart
@@ -8,12 +8,12 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('double with known specifiedType', () {
-    var data = 3.141592653589793;
-    var serialized = data;
-    var specifiedType = const FullType(double);
+    final data = 3.141592653589793;
+    final serialized = data;
+    final specifiedType = const FullType(double);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -27,9 +27,9 @@ void main() {
   });
 
   group('double with unknown specifiedType', () {
-    var data = 3.141592653589793;
-    var serialized = json.decode(json.encode(['double', data])) as Object;
-    var specifiedType = FullType.unspecified;
+    final data = 3.141592653589793;
+    final serialized = json.decode(json.encode(['double', data])) as Object;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -43,9 +43,9 @@ void main() {
   });
 
   group('double with NaN value', () {
-    var data = double.nan;
-    var serialized = 'NaN';
-    var specifiedType = const FullType(double);
+    final data = double.nan;
+    final serialized = 'NaN';
+    final specifiedType = const FullType(double);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -63,9 +63,9 @@ void main() {
   });
 
   group('double with -INF value', () {
-    var data = double.negativeInfinity;
-    var serialized = '-INF';
-    var specifiedType = const FullType(double);
+    final data = double.negativeInfinity;
+    final serialized = '-INF';
+    final specifiedType = const FullType(double);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -79,9 +79,9 @@ void main() {
   });
 
   group('double with INF value', () {
-    var data = double.infinity;
-    var serialized = 'INF';
-    var specifiedType = const FullType(double);
+    final data = double.infinity;
+    final serialized = 'INF';
+    final specifiedType = const FullType(double);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/duration_serializer_test.dart
+++ b/built_types/built_value/test/duration_serializer_test.dart
@@ -8,23 +8,23 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('Duration with known specifiedType', () {
-    var data = Duration(
+    final data = const Duration(
         days: 1,
         hours: 2,
         minutes: 3,
         seconds: 4,
         milliseconds: 5,
         microseconds: 6);
-    var serialized = 1 * 1000 * 1000 * 60 * 60 * 24 +
+    final serialized = 1 * 1000 * 1000 * 60 * 60 * 24 +
         2 * 1000 * 1000 * 60 * 60 +
         3 * 1000 * 1000 * 60 +
         4 * 1000 * 1000 +
         5 * 1000 +
         6;
-    var specifiedType = const FullType(Duration);
+    final specifiedType = const FullType(Duration);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -38,14 +38,14 @@ void main() {
   });
 
   group('Duration with unknown specifiedType', () {
-    var data = Duration(
+    final data = const Duration(
         days: 1,
         hours: 2,
         minutes: 3,
         seconds: 4,
         milliseconds: 5,
         microseconds: 6);
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       'Duration',
       1 * 1000 * 1000 * 60 * 60 * 24 +
           2 * 1000 * 1000 * 60 * 60 +
@@ -54,7 +54,7 @@ void main() {
           5 * 1000 +
           6,
     ])) as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/int32_serializer_test.dart
+++ b/built_types/built_value/test/int32_serializer_test.dart
@@ -9,12 +9,12 @@ import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('int32 with known specifiedType', () {
-    var data = Int32.MAX_VALUE;
-    var serialized = Int32.MAX_VALUE.toInt();
-    var specifiedType = const FullType(Int32);
+    final data = Int32.MAX_VALUE;
+    final serialized = Int32.MAX_VALUE.toInt();
+    final specifiedType = const FullType(Int32);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -28,10 +28,10 @@ void main() {
   });
 
   group('int32 with unknown specifiedType', () {
-    var data = Int32.MIN_VALUE;
-    var serialized =
+    final data = Int32.MIN_VALUE;
+    final serialized =
         json.decode(json.encode(['Int32', Int32.MIN_VALUE.toInt()])) as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/int64_serializer_test.dart
+++ b/built_types/built_value/test/int64_serializer_test.dart
@@ -9,12 +9,12 @@ import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('int64 with known specifiedType', () {
-    var data = Int64.MAX_VALUE;
-    var serialized = Int64.MAX_VALUE.toString();
-    var specifiedType = const FullType(Int64);
+    final data = Int64.MAX_VALUE;
+    final serialized = Int64.MAX_VALUE.toString();
+    final specifiedType = const FullType(Int64);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -28,10 +28,10 @@ void main() {
   });
 
   group('int64 with unknown specifiedType', () {
-    var data = Int64.MIN_VALUE;
-    var serialized = json
+    final data = Int64.MIN_VALUE;
+    final serialized = json
         .decode(json.encode(['Int64', Int64.MIN_VALUE.toString()])) as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/int_serializer_test.dart
+++ b/built_types/built_value/test/int_serializer_test.dart
@@ -8,12 +8,12 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('int with known specifiedType', () {
-    var data = 42;
-    var serialized = 42;
-    var specifiedType = const FullType(int);
+    final data = 42;
+    final serialized = 42;
+    final specifiedType = const FullType(int);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -27,9 +27,9 @@ void main() {
   });
 
   group('int with unknown specifiedType', () {
-    var data = 42;
-    var serialized = json.decode(json.encode(['int', 42])) as Object;
-    var specifiedType = FullType.unspecified;
+    final data = 42;
+    final serialized = json.decode(json.encode(['int', 42])) as Object;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/iso_8601_date_time_serializer_test.dart
+++ b/built_types/built_value/test/iso_8601_date_time_serializer_test.dart
@@ -9,13 +9,13 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers =
+  final serializers =
       (Serializers().toBuilder()..add(Iso8601DateTimeSerializer())).build();
 
   group('DateTime with known specifiedType', () {
-    var data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
-    var serialized = '1980-01-02T03:04:05.006007Z';
-    var specifiedType = const FullType(DateTime);
+    final data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
+    final serialized = '1980-01-02T03:04:05.006007Z';
+    final specifiedType = const FullType(DateTime);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -34,11 +34,11 @@ void main() {
   });
 
   group('DateTime with unknown specifiedType', () {
-    var data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
-    var serialized =
+    final data = DateTime.utc(1980, 1, 2, 3, 4, 5, 6, 7);
+    final serialized =
         json.decode(json.encode(['DateTime', '1980-01-02T03:04:05.006007Z']))
             as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/iso_8601_duration_serializer_test.dart
+++ b/built_types/built_value/test/iso_8601_duration_serializer_test.dart
@@ -7,7 +7,7 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers =
+  final serializers =
       (Serializers().toBuilder()..add(Iso8601DurationSerializer())).build();
 
   const testTable = [
@@ -40,7 +40,7 @@ void main() {
 
   group('Duration with known specifiedType', () {
     final specifiedType = const FullType(Duration);
-    testTable.forEach((testValue) {
+    for (final testValue in testTable) {
       test('can be serialized', () {
         expect(
             serializers.serialize(testValue[#d]!, specifiedType: specifiedType),
@@ -53,19 +53,19 @@ void main() {
                 specifiedType: specifiedType),
             testValue[#d]);
       });
-    });
-    badOnes.forEach((badOne) {
+    }
+    for (final badOne in badOnes) {
       test('deserialize throws if not ISO format', () {
         expect(
             () => serializers.deserialize(badOne, specifiedType: specifiedType),
             throwsA(const TypeMatcher<FormatException>()));
       });
-    });
+    }
   });
 
   group('Duration with unknown specifiedType', () {
     final specifiedType = FullType.unspecified;
-    testTable.forEach((testValue) {
+    for (final testValue in testTable) {
       test('can be serialized', () {
         expect(
             serializers.serialize(testValue[#d]!, specifiedType: specifiedType),
@@ -78,10 +78,10 @@ void main() {
                 specifiedType: specifiedType),
             testValue[#d]);
       });
-    });
+    }
 
     group('Duration with subsecond data', () {
-      final data = Duration(seconds: 2, milliseconds: 4);
+      final data = const Duration(seconds: 2, milliseconds: 4);
       final specifiedType = const FullType(Duration);
       test('throws an error upon serialization', () {
         expect(() => serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/json_object_serializer_test.dart
+++ b/built_types/built_value/test/json_object_serializer_test.dart
@@ -9,12 +9,12 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('JsonObject with known specifiedType holding bool', () {
-    var data = JsonObject(true);
-    var serialized = true;
-    var specifiedType = const FullType(JsonObject);
+    final data = JsonObject(true);
+    final serialized = true;
+    final specifiedType = const FullType(JsonObject);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -28,9 +28,9 @@ void main() {
   });
 
   group('JsonObject with unknown specifiedType holding bool', () {
-    var data = JsonObject(true);
-    var serialized = json.decode(json.encode(['JsonObject', true])) as Object;
-    var specifiedType = FullType.unspecified;
+    final data = JsonObject(true);
+    final serialized = json.decode(json.encode(['JsonObject', true])) as Object;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -44,9 +44,9 @@ void main() {
   });
 
   group('JsonObject with known specifiedType holding double', () {
-    var data = JsonObject(42.5);
-    var serialized = 42.5;
-    var specifiedType = const FullType(JsonObject);
+    final data = JsonObject(42.5);
+    final serialized = 42.5;
+    final specifiedType = const FullType(JsonObject);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -60,9 +60,9 @@ void main() {
   });
 
   group('JsonObject with unknown specifiedType holding double', () {
-    var data = JsonObject(42.5);
-    var serialized = json.decode(json.encode(['JsonObject', 42.5])) as Object;
-    var specifiedType = FullType.unspecified;
+    final data = JsonObject(42.5);
+    final serialized = json.decode(json.encode(['JsonObject', 42.5])) as Object;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -76,9 +76,9 @@ void main() {
   });
 
   group('JsonObject with known specifiedType holding list', () {
-    var data = JsonObject([1, 2, 3]);
-    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
-    var specifiedType = const FullType(JsonObject);
+    final data = JsonObject([1, 2, 3]);
+    final serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    final specifiedType = const FullType(JsonObject);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -92,12 +92,12 @@ void main() {
   });
 
   group('JsonObject with unknown specifiedType holding list', () {
-    var data = JsonObject([1, 2, 3]);
-    var serialized = json.decode(json.encode([
+    final data = JsonObject([1, 2, 3]);
+    final serialized = json.decode(json.encode([
       'JsonObject',
       [1, 2, 3],
     ])) as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -111,9 +111,9 @@ void main() {
   });
 
   group('JsonObject with known specifiedType holding map', () {
-    var data = JsonObject({'one': 1, 'two': 2, 'three': 3});
-    var serialized = {'one': 1, 'two': 2, 'three': 3};
-    var specifiedType = const FullType(JsonObject);
+    final data = JsonObject({'one': 1, 'two': 2, 'three': 3});
+    final serialized = {'one': 1, 'two': 2, 'three': 3};
+    final specifiedType = const FullType(JsonObject);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -127,12 +127,12 @@ void main() {
   });
 
   group('JsonObject with unknown specifiedType holding map', () {
-    var data = JsonObject({'one': 1, 'two': 2, 'three': 3});
-    var serialized = json.decode(json.encode([
+    final data = JsonObject({'one': 1, 'two': 2, 'three': 3});
+    final serialized = json.decode(json.encode([
       'JsonObject',
       {'one': 1, 'two': 2, 'three': 3},
     ])) as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -146,9 +146,9 @@ void main() {
   });
 
   group('JsonObject with known specifiedType holding int', () {
-    var data = JsonObject(42);
-    var serialized = 42;
-    var specifiedType = const FullType(JsonObject);
+    final data = JsonObject(42);
+    final serialized = 42;
+    final specifiedType = const FullType(JsonObject);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -162,9 +162,9 @@ void main() {
   });
 
   group('JsonObject with unknown specifiedType holding int', () {
-    var data = JsonObject(42);
-    var serialized = json.decode(json.encode(['JsonObject', 42])) as Object;
-    var specifiedType = FullType.unspecified;
+    final data = JsonObject(42);
+    final serialized = json.decode(json.encode(['JsonObject', 42])) as Object;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -178,9 +178,9 @@ void main() {
   });
 
   group('JsonObject with known specifiedType holding String', () {
-    var data = JsonObject('test');
-    var serialized = 'test';
-    var specifiedType = const FullType(JsonObject);
+    final data = JsonObject('test');
+    final serialized = 'test';
+    final specifiedType = const FullType(JsonObject);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -194,9 +194,10 @@ void main() {
   });
 
   group('JsonObject with unknown specifiedType holding String', () {
-    var data = JsonObject('test');
-    var serialized = json.decode(json.encode(['JsonObject', 'test'])) as Object;
-    var specifiedType = FullType.unspecified;
+    final data = JsonObject('test');
+    final serialized =
+        json.decode(json.encode(['JsonObject', 'test'])) as Object;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/json_object_test.dart
+++ b/built_types/built_value/test/json_object_test.dart
@@ -12,7 +12,7 @@ void main() {
     });
 
     test('allows access to Map<String?, dynamic>', () {
-      var map = JsonObject(<String?, dynamic>{'one': 1});
+      final map = JsonObject(<String?, dynamic>{'one': 1});
       expect(map.asMap['one'], 1);
     });
   });

--- a/built_types/built_value/test/list_serializer_test.dart
+++ b/built_types/built_value/test/list_serializer_test.dart
@@ -9,10 +9,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('List with known specifiedType but missing builder', () {
-    var data = <int>[1, 2, 3];
-    var specifiedType = const FullType(List, [FullType(int)]);
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    final data = <int>[1, 2, 3];
+    final specifiedType = const FullType(List, [FullType(int)]);
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([1, 2, 3])) as Object;
 
     test('serialize throws', () {
       expect(() => serializers.serialize(data, specifiedType: specifiedType),
@@ -28,12 +28,12 @@ void main() {
   });
 
   group('List with known specifiedType and correct builder', () {
-    var data = <int>[1, 2, 3];
-    var specifiedType = const FullType(List, [FullType(int)]);
-    var serializers = (Serializers().toBuilder()
+    final data = <int>[1, 2, 3];
+    final specifiedType = const FullType(List, [FullType(int)]);
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(specifiedType, () => <int>[]))
         .build();
-    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    final serialized = json.decode(json.encode([1, 2, 3])) as Object;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -55,20 +55,20 @@ void main() {
   });
 
   group('List nested with known specifiedType and correct builders', () {
-    var data = <List<int>>[
+    final data = <List<int>>[
       [1, 2, 3],
       [4, 5, 6],
       [7, 8, 9]
     ];
-    var specifiedType = const FullType(List, [
+    final specifiedType = const FullType(List, [
       FullType(List, [FullType(int)])
     ]);
-    var serializers = (Serializers().toBuilder()
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(specifiedType, () => <List<int>>[])
           ..addBuilderFactory(
               const FullType(List, [FullType(int)]), () => <int>[]))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       [1, 2, 3],
       [4, 5, 6],
       [7, 8, 9]
@@ -86,10 +86,10 @@ void main() {
   });
 
   group('List with unknown specifiedType and no builders', () {
-    var data = <int>[1, 2, 3];
-    var specifiedType = FullType.unspecified;
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([
+    final data = <int>[1, 2, 3];
+    final specifiedType = FullType.unspecified;
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([
       'List',
       ['int', 1],
       ['int', 2],

--- a/built_types/built_value/test/map_serializer_test.dart
+++ b/built_types/built_value/test/map_serializer_test.dart
@@ -9,10 +9,11 @@ import 'package:test/test.dart';
 
 void main() {
   group('Map with known specifiedType but missing builder', () {
-    var data = <int, String>{1: 'one', 2: 'two', 3: 'three'};
-    var specifiedType = const FullType(Map, [FullType(int), FullType(String)]);
-    var serializers = Serializers();
-    var serialized =
+    final data = <int, String>{1: 'one', 2: 'two', 3: 'three'};
+    final specifiedType =
+        const FullType(Map, [FullType(int), FullType(String)]);
+    final serializers = Serializers();
+    final serialized =
         json.decode(json.encode([1, 'one', 2, 'two', 3, 'three'])) as Object;
 
     test('cannot be serialized', () {
@@ -29,12 +30,13 @@ void main() {
   });
 
   group('Map with known specifiedType and correct builder', () {
-    var data = <int, String>{1: 'one', 2: 'two', 3: 'three'};
-    var specifiedType = const FullType(Map, [FullType(int), FullType(String)]);
-    var serializers = (Serializers().toBuilder()
+    final data = <int, String>{1: 'one', 2: 'two', 3: 'three'};
+    final specifiedType =
+        const FullType(Map, [FullType(int), FullType(String)]);
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(specifiedType, () => <int, String>{}))
         .build();
-    var serialized =
+    final serialized =
         json.decode(json.encode([1, 'one', 2, 'two', 3, 'three'])) as Object;
 
     test('can be serialized', () {
@@ -57,18 +59,19 @@ void main() {
   });
 
   group('Map nested left with known specifiedType', () {
-    var data = <Map<int, String>, String>{
+    final data = <Map<int, String>, String>{
       <int, String>{1: 'one'}: 'one!',
       <int, String>{2: 'two'}: 'two!'
     };
     const innerTypeLeft = FullType(Map, [FullType(int), FullType(String)]);
-    var specifiedType = const FullType(Map, [innerTypeLeft, FullType(String)]);
-    var serializers = (Serializers().toBuilder()
+    final specifiedType =
+        const FullType(Map, [innerTypeLeft, FullType(String)]);
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(innerTypeLeft, () => <int, String>{})
           ..addBuilderFactory(
               specifiedType, () => <Map<int, String>, String>{}))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       [1, 'one'],
       'one!',
       [2, 'two'],
@@ -92,18 +95,18 @@ void main() {
   });
 
   group('Map nested right with known specifiedType', () {
-    var data = <int, Map<String, String>>{
+    final data = <int, Map<String, String>>{
       1: <String, String>{'one': 'one!'},
       2: <String, String>{'two': 'two!'}
     };
     const innerTypeRight = FullType(Map, [FullType(String), FullType(String)]);
-    var specifiedType = const FullType(Map, [FullType(int), innerTypeRight]);
-    var serializers = (Serializers().toBuilder()
+    final specifiedType = const FullType(Map, [FullType(int), innerTypeRight]);
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(innerTypeRight, () => <String, String>{})
           ..addBuilderFactory(
               specifiedType, () => <int, Map<String, String>>{}))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       1,
       ['one', 'one!'],
       2,
@@ -122,7 +125,7 @@ void main() {
   });
 
   group('Map nested both with known specifiedType', () {
-    var data = <Map<int, int>, Map<String, String>>{
+    final data = <Map<int, int>, Map<String, String>>{
       <int, int>{1: 1}: <String, String>{'one': 'one!'},
       <int, int>{2: 2}: <String, String>{'two': 'two!'}
     };
@@ -130,16 +133,16 @@ void main() {
         FullType(Map, [FullType(int), FullType(int)]);
     const MapOfStringStringGenericType =
         FullType(Map, [FullType(String), FullType(String)]);
-    var specifiedType = const FullType(
+    final specifiedType = const FullType(
         Map, [MapOfIntIntGenericType, MapOfStringStringGenericType]);
-    var serializers = (Serializers().toBuilder()
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(MapOfIntIntGenericType, () => <int, int>{})
           ..addBuilderFactory(
               MapOfStringStringGenericType, () => <String, String>{})
           ..addBuilderFactory(
               specifiedType, () => <Map<int, int>, Map<String, String>>{}))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       [1, 1],
       ['one', 'one!'],
       [2, 2],
@@ -179,13 +182,13 @@ void main() {
   });
 
   group('Map with Object values', () {
-    var data = <int, Object>{1: 'one', 2: 2, 3: 'three'};
-    var specifiedType =
+    final data = <int, Object>{1: 'one', 2: 2, 3: 'three'};
+    final specifiedType =
         const FullType(Map, [FullType(int), FullType.unspecified]);
-    var serializers = (Serializers().toBuilder()
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(specifiedType, () => <int, Object>{}))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       1,
       ['String', 'one'],
       2,
@@ -206,13 +209,13 @@ void main() {
   });
 
   group('Map with Object keys', () {
-    var data = <Object, String>{1: 'one', 'two': 'two', 3: 'three'};
-    var specifiedType =
+    final data = <Object, String>{1: 'one', 'two': 'two', 3: 'three'};
+    final specifiedType =
         const FullType(Map, [FullType.unspecified, FullType(String)]);
-    var serializers = (Serializers().toBuilder()
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(specifiedType, () => <Object, String>{}))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       ['int', 1],
       'one',
       ['String', 'two'],
@@ -233,10 +236,10 @@ void main() {
   });
 
   group('Map with Object keys and values', () {
-    var data = <Object, Object>{1: 'one', 'two': 2, 3: 'three'};
-    var specifiedType = const FullType(Map);
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([
+    final data = <Object, Object>{1: 'one', 'two': 2, 3: 'three'};
+    final specifiedType = const FullType(Map);
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([
       ['int', 1],
       ['String', 'one'],
       ['String', 'two'],
@@ -257,10 +260,10 @@ void main() {
   });
 
   group('Map with unknown specifiedType', () {
-    var data = <Object, Object>{1: 'one', 'two': 2, 3: 'three'};
-    var specifiedType = FullType.unspecified;
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([
+    final data = <Object, Object>{1: 'one', 'two': 2, 3: 'three'};
+    final specifiedType = FullType.unspecified;
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([
       'Map',
       ['int', 1],
       ['String', 'one'],

--- a/built_types/built_value/test/num_serializer_test.dart
+++ b/built_types/built_value/test/num_serializer_test.dart
@@ -6,12 +6,12 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('num with known specifiedType', () {
-    var data = 42;
-    var serialized = 42;
-    var specifiedType = const FullType(num);
+    final data = 42;
+    final serialized = 42;
+    final specifiedType = const FullType(num);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -25,9 +25,9 @@ void main() {
   });
 
   group('num with NaN value', () {
-    var data = double.nan;
-    var serialized = 'NaN';
-    var specifiedType = const FullType(num);
+    final data = double.nan;
+    final serialized = 'NaN';
+    final specifiedType = const FullType(num);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -45,9 +45,9 @@ void main() {
   });
 
   group('num with -INF value', () {
-    var data = double.negativeInfinity;
-    var serialized = '-INF';
-    var specifiedType = const FullType(num);
+    final data = double.negativeInfinity;
+    final serialized = '-INF';
+    final specifiedType = const FullType(num);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -61,9 +61,9 @@ void main() {
   });
 
   group('num with INF value', () {
-    var data = double.infinity;
-    var serialized = 'INF';
-    var specifiedType = const FullType(num);
+    final data = double.infinity;
+    final serialized = 'INF';
+    final specifiedType = const FullType(num);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/regexp_serializer_test.dart
+++ b/built_types/built_value/test/regexp_serializer_test.dart
@@ -8,12 +8,12 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('RegExp with known specifiedType', () {
-    var data = RegExp(r'\d+, [A-Z](foo)?');
-    var serialized = r'\d+, [A-Z](foo)?';
-    var specifiedType = const FullType(RegExp);
+    final data = RegExp(r'\d+, [A-Z](foo)?');
+    final serialized = r'\d+, [A-Z](foo)?';
+    final specifiedType = const FullType(RegExp);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -27,10 +27,10 @@ void main() {
   });
 
   group('String with unknown specifiedType', () {
-    var data = RegExp('testing, testing');
-    var serialized =
+    final data = RegExp('testing, testing');
+    final serialized =
         json.decode(json.encode(['RegExp', 'testing, testing'])) as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/serializers_test.dart
+++ b/built_types/built_value/test/serializers_test.dart
@@ -9,39 +9,41 @@ import 'package:built_value/standard_json_plugin.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
   final moreSerializers = (serializers.toBuilder()
         ..addAll([TestSerializer()])
-        ..addBuilderFactory(FullType(TestSerializer), () => null))
+        ..addBuilderFactory(const FullType(TestSerializer), () => null))
       .build();
   final serializersWithPlugin =
       (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
 
   group(Serializers, () {
     test('exposes iterable of serializer', () {
-      expect(serializers.serializers, contains(TypeMatcher<IntSerializer>()));
+      expect(serializers.serializers,
+          contains(const TypeMatcher<IntSerializer>()));
     });
 
     test('can be added to', () {
-      expect(
-          moreSerializers.serializers, contains(TypeMatcher<TestSerializer>()));
+      expect(moreSerializers.serializers,
+          contains(const TypeMatcher<TestSerializer>()));
     });
 
     test('can be merged', () {
-      var mergedSerializers =
+      final mergedSerializers =
           (serializers.toBuilder()..mergeAll([moreSerializers])).build();
       expect(mergedSerializers.serializers,
-          contains(TypeMatcher<TestSerializer>()));
+          contains(const TypeMatcher<TestSerializer>()));
       expect(mergedSerializers.builderFactories.keys,
-          contains(FullType(TestSerializer)));
+          contains(const FullType(TestSerializer)));
     });
 
     test('can be merged by static method', () {
-      var mergedSerializers = Serializers.merge([serializers, moreSerializers]);
+      final mergedSerializers =
+          Serializers.merge([serializers, moreSerializers]);
       expect(mergedSerializers.serializers,
-          contains(TypeMatcher<TestSerializer>()));
+          contains(const TypeMatcher<TestSerializer>()));
       expect(mergedSerializers.builderFactories.keys,
-          contains(FullType(TestSerializer)));
+          contains(const FullType(TestSerializer)));
     });
 
     test('provides convenience toJson method', () {
@@ -55,22 +57,26 @@ void main() {
     });
 
     test('serializes null int to null', () {
-      expect(serializers.serialize(null, specifiedType: FullType(int)), null);
+      expect(serializers.serialize(null, specifiedType: const FullType(int)),
+          null);
     });
 
     test('deserializes null int from null', () {
-      expect(serializers.deserialize(null, specifiedType: FullType(int)), null);
+      expect(serializers.deserialize(null, specifiedType: const FullType(int)),
+          null);
     });
 
     test('serializes null int to null when plugin is installed', () {
       expect(
-          serializersWithPlugin.serialize(null, specifiedType: FullType(int)),
+          serializersWithPlugin.serialize(null,
+              specifiedType: const FullType(int)),
           null);
     });
 
     test('deserializes null int from null when plugin is installed', () {
       expect(
-          serializersWithPlugin.deserialize(null, specifiedType: FullType(int)),
+          serializersWithPlugin.deserialize(null,
+              specifiedType: const FullType(int)),
           null);
     });
 

--- a/built_types/built_value/test/set_serializer_test.dart
+++ b/built_types/built_value/test/set_serializer_test.dart
@@ -13,10 +13,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('Set with known specifiedType but missing builder', () {
-    var data = <int>{1, 2, 3};
-    var specifiedType = const FullType(Set, [FullType(int)]);
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    final data = <int>{1, 2, 3};
+    final specifiedType = const FullType(Set, [FullType(int)]);
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([1, 2, 3])) as Object;
 
     test('serialize throws', () {
       expect(() => serializers.serialize(data, specifiedType: specifiedType),
@@ -32,12 +32,12 @@ void main() {
   });
 
   group('Set with known specifiedType and correct builder', () {
-    var data = <int>{1, 2, 3};
-    var specifiedType = const FullType(Set, [FullType(int)]);
-    var serializers = (Serializers().toBuilder()
+    final data = <int>{1, 2, 3};
+    final specifiedType = const FullType(Set, [FullType(int)]);
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(specifiedType, () => <int>{}))
         .build();
-    var serialized = json.decode(json.encode([1, 2, 3])) as Object;
+    final serialized = json.decode(json.encode([1, 2, 3])) as Object;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -59,20 +59,20 @@ void main() {
   });
 
   group('Set nested with known specifiedType and correct builders', () {
-    var data = <Set<int>>{
+    final data = <Set<int>>{
       {1, 2, 3},
       {4, 5, 6},
       {7, 8, 9}
     };
-    var specifiedType = const FullType(Set, [
+    final specifiedType = const FullType(Set, [
       FullType(Set, [FullType(int)])
     ]);
-    var serializers = (Serializers().toBuilder()
+    final serializers = (Serializers().toBuilder()
           ..addBuilderFactory(specifiedType, () => <Set<int>>{})
           ..addBuilderFactory(
               const FullType(Set, [FullType(int)]), () => <int>{}))
         .build();
-    var serialized = json.decode(json.encode([
+    final serialized = json.decode(json.encode([
       [1, 2, 3],
       [4, 5, 6],
       [7, 8, 9]
@@ -90,10 +90,10 @@ void main() {
   });
 
   group('Set with unknown specifiedType and no builders', () {
-    var data = <int>{1, 2, 3};
-    var specifiedType = FullType.unspecified;
-    var serializers = Serializers();
-    var serialized = json.decode(json.encode([
+    final data = <int>{1, 2, 3};
+    final specifiedType = FullType.unspecified;
+    final serializers = Serializers();
+    final serialized = json.decode(json.encode([
       'Set',
       ['int', 1],
       ['int', 2],

--- a/built_types/built_value/test/standard_json_plugin_test.dart
+++ b/built_types/built_value/test/standard_json_plugin_test.dart
@@ -5,34 +5,34 @@
 import 'dart:convert';
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value/standard_json_plugin.dart';
 import 'package:built_value/serializer.dart';
+import 'package:built_value/standard_json_plugin.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = (Serializers().toBuilder()
+  final serializers = (Serializers().toBuilder()
         ..addPlugin(StandardJsonPlugin())
-        ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]),
-            () => ListBuilder<int>())
+        ..addBuilderFactory(
+            const FullType(BuiltList, [FullType(int)]), ListBuilder<int>.new)
         ..addBuilderFactory(
             const FullType(BuiltList, [
               FullType(BuiltList, [FullType(int)])
             ]),
-            () => ListBuilder<BuiltList<int>>())
+            ListBuilder<BuiltList<int>>.new)
         ..addBuilderFactory(
-            const FullType(BuiltSet, [FullType(int)]), () => SetBuilder<int>())
+            const FullType(BuiltSet, [FullType(int)]), SetBuilder<int>.new)
         ..addBuilderFactory(
             const FullType(BuiltMap, [FullType(int), FullType(String)]),
-            () => MapBuilder<int, String>())
+            MapBuilder<int, String>.new)
         ..addBuilderFactory(
             const FullType(BuiltMap, [FullType(String), FullType(String)]),
-            () => MapBuilder<String, String>())
+            MapBuilder<String, String>.new)
         ..addBuilderFactory(
             const FullType(BuiltMap, [
               FullType(BuiltMap, [FullType(int), FullType(String)]),
               FullType(BuiltMap, [FullType(int), FullType(String)])
             ]),
-            () => MapBuilder<BuiltMap<int, String>, BuiltMap<int, String>>()))
+            MapBuilder<BuiltMap<int, String>, BuiltMap<int, String>>.new))
       .build();
 
   group('Serializers with StandardJsonPlugin', () {

--- a/built_types/built_value/test/string_serializer_test.dart
+++ b/built_types/built_value/test/string_serializer_test.dart
@@ -8,12 +8,12 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('String with known specifiedType', () {
-    var data = 'testing, testing';
-    var serialized = 'testing, testing';
-    var specifiedType = const FullType(String);
+    final data = 'testing, testing';
+    final serialized = 'testing, testing';
+    final specifiedType = const FullType(String);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -27,10 +27,10 @@ void main() {
   });
 
   group('String with unknown specifiedType', () {
-    var data = 'testing, testing';
-    var serialized =
+    final data = 'testing, testing';
+    final serialized =
         json.decode(json.encode(['String', 'testing, testing'])) as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value/test/uint8_list_serializer_test.dart
+++ b/built_types/built_value/test/uint8_list_serializer_test.dart
@@ -9,13 +9,13 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('Uint8List with known specifiedType', () {
-    var serialized =
+    final serialized =
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
-    var data = base64Decode(serialized);
-    var specifiedType = const FullType(Uint8List);
+    final data = base64Decode(serialized);
+    final specifiedType = const FullType(Uint8List);
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),
@@ -29,16 +29,17 @@ void main() {
   });
 
   group('UInt8List with unknown specifiedType', () {
-    var rawData =
+    final rawData =
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
-    var serialized = json.decode(json.encode(['UInt8List', rawData])) as Object;
-    var data = base64Decode(rawData.toString());
-    var specifiedType = FullType.unspecified;
+    final serialized =
+        json.decode(json.encode(['UInt8List', rawData])) as Object;
+    final data = base64Decode(rawData.toString());
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
-      var serialized_by =
+      final serializedBy =
           serializers.serialize(data, specifiedType: specifiedType);
-      expect(serialized_by, serialized);
+      expect(serializedBy, serialized);
     });
 
     test('can be deserialized', () {

--- a/built_types/built_value/test/uri_serializer_test.dart
+++ b/built_types/built_value/test/uri_serializer_test.dart
@@ -8,12 +8,12 @@ import 'package:built_value/serializer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var serializers = Serializers();
+  final serializers = Serializers();
 
   group('SimpleUri with known specifiedType', () {
-    var data = Uri.parse('https://github.com');
-    var serialized = 'https://github.com';
-    var specifiedType = const FullType(Uri);
+    final data = Uri.parse('https://github.com');
+    final serialized = 'https://github.com';
+    final specifiedType = const FullType(Uri);
 
     test('has expected type', () {
       expect(data.runtimeType.toString(), '_SimpleUri');
@@ -31,9 +31,9 @@ void main() {
   });
 
   group('Uri with known specifiedType', () {
-    var data = Uri.parse('https://github.com:0/google/built_value.dart');
-    var serialized = 'https://github.com:0/google/built_value.dart';
-    var specifiedType = const FullType(Uri);
+    final data = Uri.parse('https://github.com:0/google/built_value.dart');
+    final serialized = 'https://github.com:0/google/built_value.dart';
+    final specifiedType = const FullType(Uri);
 
     test('has expected type', () {
       expect(data.runtimeType.toString(), '_Uri');
@@ -51,11 +51,11 @@ void main() {
   });
 
   group('Uri with unknown specifiedType', () {
-    var data = Uri.parse('https://github.com/google/built_value.dart');
-    var serialized = json.decode(
+    final data = Uri.parse('https://github.com/google/built_value.dart');
+    final serialized = json.decode(
             json.encode(['Uri', 'https://github.com/google/built_value.dart']))
         as Object;
-    var specifiedType = FullType.unspecified;
+    final specifiedType = FullType.unspecified;
 
     test('can be serialized', () {
       expect(serializers.serialize(data, specifiedType: specifiedType),

--- a/built_types/built_value_chat_example/analysis_options.yaml
+++ b/built_types/built_value_chat_example/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/built_types/built_value_chat_example/lib/client/client.dart
+++ b/built_types/built_value_chat_example/lib/client/client.dart
@@ -5,10 +5,10 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:built_value_chat_example/client/client_connection.dart';
-import 'package:built_value_chat_example/client/display.dart';
-import 'package:built_value_chat_example/data_model/data_model.dart';
-import 'package:built_value_chat_example/data_model/serializers.dart';
+import '../data_model/data_model.dart';
+import '../data_model/serializers.dart';
+import 'client_connection.dart';
+import 'display.dart';
 
 typedef CommandRunner = void Function(String command);
 

--- a/built_types/built_value_chat_example/lib/client/html_display.dart
+++ b/built_types/built_value_chat_example/lib/client/html_display.dart
@@ -5,8 +5,9 @@
 import 'dart:convert';
 import 'dart:js_interop';
 
-import 'package:built_value_chat_example/client/display.dart';
 import 'package:web/web.dart';
+
+import 'display.dart';
 
 /// [Display] using `dart:html`.
 class HtmlDisplay implements Display {
@@ -23,16 +24,15 @@ class HtmlDisplay implements Display {
 
   @override
   void addLocal(String text) {
-    _element.textContent = _element.textContent! +
-        '<div class="local">'
-            '${_htmlEscape.convert(text).replaceAll('\n', '<br>')}</div>';
+    _element.textContent =
+        '${_element.textContent!}<div class="local">${_htmlEscape.convert(text).replaceAll('\n', '<br>')}</div>';
     window.scrollTo(0.toJS, document.body!.scrollHeight);
   }
 
   @override
   void add(String text) {
-    _element.textContent = _element.textContent! +
-        '${_htmlEscape.convert(text).replaceAll('\n', '<br>')}<br>';
+    _element.textContent =
+        '${_element.textContent!}${_htmlEscape.convert(text).replaceAll('\n', '<br>')}<br>';
     window.scrollTo(0.toJS, document.body!.scrollHeight);
   }
 }

--- a/built_types/built_value_chat_example/lib/client/http_client_connection.dart
+++ b/built_types/built_value_chat_example/lib/client/http_client_connection.dart
@@ -5,8 +5,9 @@
 import 'dart:async';
 import 'dart:js_interop';
 
-import 'package:built_value_chat_example/client/client_connection.dart';
 import 'package:web/web.dart';
+
+import 'client_connection.dart';
 
 /// [ClientConnection] using a web socket.
 class HttpClientConnection implements ClientConnection {

--- a/built_types/built_value_chat_example/lib/data_model/data_model.dart
+++ b/built_types/built_value_chat_example/lib/data_model/data_model.dart
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 /// Data model for the built_value chat example.
-library data_model;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
@@ -58,7 +58,7 @@ class StatusType extends EnumClass {
   static const StatusType away = _$away;
   static const StatusType offline = _$offline;
 
-  const StatusType._(String name) : super(name);
+  const StatusType._(super.name);
 
   static BuiltSet<StatusType> get values => _$stValues;
   static StatusType valueOf(String name) => _$stValueOf(name);
@@ -88,7 +88,7 @@ class LoginResponse extends EnumClass implements Response {
   static const LoginResponse badPassword = _$badPassword;
   static const LoginResponse reset = _$reset;
 
-  const LoginResponse._(String name) : super(name);
+  const LoginResponse._(super.name);
 
   static BuiltSet<LoginResponse> get values => _$lrValues;
   static LoginResponse valueOf(String name) => _$lrValueOf(name);
@@ -140,7 +140,7 @@ abstract class Welcome implements Built<Welcome, WelcomeBuilder>, Response {
 
   @override
   String render() =>
-      log.map((response) => response.render()).join('\n') + '\n' + message;
+      '${log.map((response) => response.render()).join('\n')}\n$message';
 }
 
 /// Displays a list of users and their status messages.

--- a/built_types/built_value_chat_example/lib/data_model/serializers.dart
+++ b/built_types/built_value_chat_example/lib/data_model/serializers.dart
@@ -2,11 +2,11 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library serializers;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
-import 'package:built_value_chat_example/data_model/data_model.dart';
+import 'data_model.dart';
 
 part 'serializers.g.dart';
 

--- a/built_types/built_value_chat_example/lib/server/http_server_connection.dart
+++ b/built_types/built_value_chat_example/lib/server/http_server_connection.dart
@@ -4,8 +4,9 @@
 
 import 'dart:async';
 
-import 'package:built_value_chat_example/server/server_connection.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'server_connection.dart';
 
 /// [ServerConnection] using a web socket.
 class HttpServerConnection implements ServerConnection {

--- a/built_types/built_value_chat_example/lib/server/server.dart
+++ b/built_types/built_value_chat_example/lib/server/server.dart
@@ -6,9 +6,9 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value_chat_example/data_model/data_model.dart';
-import 'package:built_value_chat_example/data_model/serializers.dart';
-import 'package:built_value_chat_example/server/server_connection.dart';
+import '../data_model/data_model.dart';
+import '../data_model/serializers.dart';
+import 'server_connection.dart';
 
 /// Server-side logic for the built_value chat example.
 class Server {

--- a/built_types/built_value_chat_example/lib/testing/fake_client_connection.dart
+++ b/built_types/built_value_chat_example/lib/testing/fake_client_connection.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:built_value_chat_example/client/client_connection.dart';
+import '../client/client_connection.dart';
 
 /// Fake [ClientConnection] that exposes stream controllers.
 class FakeClientConnection implements ClientConnection {

--- a/built_types/built_value_chat_example/lib/testing/fake_display.dart
+++ b/built_types/built_value_chat_example/lib/testing/fake_display.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import 'package:built_value_chat_example/client/display.dart';
+import '../client/display.dart';
 
 /// Fake [Display] that stores added text.
 class FakeDisplay implements Display {

--- a/built_types/built_value_chat_example/lib/testing/fake_environment.dart
+++ b/built_types/built_value_chat_example/lib/testing/fake_environment.dart
@@ -4,12 +4,12 @@
 
 import 'dart:async';
 
-import 'package:built_value_chat_example/client/client.dart';
-import 'package:built_value_chat_example/server/server.dart';
-import 'package:built_value_chat_example/testing/fake_client_connection.dart';
-import 'package:built_value_chat_example/testing/fake_display.dart';
-import 'package:built_value_chat_example/testing/fake_server_connection.dart';
-import 'package:built_value_chat_example/testing/test_user.dart';
+import '../client/client.dart';
+import '../server/server.dart';
+import 'fake_client_connection.dart';
+import 'fake_display.dart';
+import 'fake_server_connection.dart';
+import 'test_user.dart';
 
 /// Environment for testing server and client logic together.
 ///
@@ -31,12 +31,10 @@ class FakeEnvironment {
     final clientConnection = FakeClientConnection();
     final serverConnection = FakeServerConnection();
 
-    clientConnection.toServerStreamController.stream.listen((string) {
-      serverConnection.fromClientStreamController.add(string);
-    });
-    serverConnection.toClientStreamController.stream.listen((string) {
-      clientConnection.fromServerStreamController.add(string);
-    });
+    clientConnection.toServerStreamController.stream
+        .listen(serverConnection.fromClientStreamController.add);
+    serverConnection.toClientStreamController.stream
+        .listen(clientConnection.fromServerStreamController.add);
 
     final keyboardInputController = StreamController<String>(sync: true);
     final display = FakeDisplay();

--- a/built_types/built_value_chat_example/lib/testing/fake_server_connection.dart
+++ b/built_types/built_value_chat_example/lib/testing/fake_server_connection.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:built_value_chat_example/server/server_connection.dart';
+import '../server/server_connection.dart';
 
 /// Fake [ServerConnection] that exposes stream controllers.
 class FakeServerConnection implements ServerConnection {

--- a/built_types/built_value_chat_example/lib/testing/test_user.dart
+++ b/built_types/built_value_chat_example/lib/testing/test_user.dart
@@ -4,8 +4,9 @@
 
 import 'dart:async';
 
-import 'package:built_value_chat_example/testing/fake_display.dart';
 import 'package:test/test.dart';
+
+import 'fake_display.dart';
 
 /// A test user connected to the fake environment.
 class TestUser {

--- a/built_types/built_value_chat_example/pubspec.yaml
+++ b/built_types/built_value_chat_example/pubspec.yaml
@@ -22,5 +22,5 @@ dev_dependencies:
   build_test: any
   build_web_compilers: any
   built_value_generator: ^8.13.0
-  pedantic: ^1.4.0
+  dart_flutter_team_lints: ^3.1.0
   test: ^1.0.0

--- a/built_types/built_value_chat_example/pubspec.yaml
+++ b/built_types/built_value_chat_example/pubspec.yaml
@@ -16,11 +16,10 @@ dependencies:
   shelf_web_socket: ^1.0.0
   web: ^1.1.1
   web_socket_channel: ^2.0.0
-
 dev_dependencies:
   build_runner: any
   build_test: any
   build_web_compilers: any
   built_value_generator: ^8.13.0
   dart_flutter_team_lints: ^3.1.0
-  test: ^1.0.0
+  test: any

--- a/built_types/built_value_example/analysis_options.yaml
+++ b/built_types/built_value_example/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/built_types/built_value_example/lib/collections.dart
+++ b/built_types/built_value_example/lib/collections.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library collections;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';

--- a/built_types/built_value_example/lib/enums.dart
+++ b/built_types/built_value_example/lib/enums.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library enums;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
@@ -31,7 +31,7 @@ class TestEnum extends EnumClass {
   static const TestEnum no = _$no;
   static const TestEnum maybe = _$maybe;
 
-  const TestEnum._(String name) : super(name);
+  const TestEnum._(super.name);
 
   static BuiltSet<TestEnum> get values => _$values;
   static TestEnum valueOf(String name) => _$valueOf(name);
@@ -47,7 +47,7 @@ class SecondTestEnum extends EnumClass {
   static const SecondTestEnum no = _$n;
   static const SecondTestEnum definitely = _$definitely;
 
-  const SecondTestEnum._(String name) : super(name);
+  const SecondTestEnum._(super.name);
 
   static BuiltSet<SecondTestEnum> get values => _$vls;
   static SecondTestEnum valueOf(String name) => _$vlOf(name);
@@ -68,7 +68,7 @@ class WireNameEnum extends EnumClass {
   @BuiltValueEnumConst(wireName: 'd')
   static const WireNameEnum definitely = _$wireDefinitely;
 
-  const WireNameEnum._(String name) : super(name);
+  const WireNameEnum._(super.name);
 
   static BuiltSet<WireNameEnum> get values => _$wireValues;
   static WireNameEnum valueOf(String name) => _$wireValueOf(name);

--- a/built_types/built_value_example/lib/example.dart
+++ b/built_types/built_value_example/lib/example.dart
@@ -1,8 +1,8 @@
 import 'package:built_value/standard_json_plugin.dart';
-import 'package:built_value_example/generics.dart';
-import 'package:built_value_example/polymorphism.dart';
-import 'package:built_value_example/serializers.dart';
-import 'package:built_value_example/values.dart';
+import 'generics.dart';
+import 'polymorphism.dart';
+import 'serializers.dart';
+import 'values.dart';
 
 /// Simple usage examples for built_value.
 void example() {
@@ -53,7 +53,7 @@ void example() {
       .toList();
 
   // Everything is serializable.
-  for (var object in [
+  for (final object in [
     value,
     value2,
     value3,
@@ -65,7 +65,7 @@ void example() {
     modifiedAnimals[0],
     modifiedAnimals[1],
   ]) {
-    var serialized = serializers.serialize(object);
+    final serialized = serializers.serialize(object);
     print(serialized);
     assert(serializers.deserialize(serialized) == object);
   }

--- a/built_types/built_value_example/lib/generics.dart
+++ b/built_types/built_value_example/lib/generics.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library generics;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';

--- a/built_types/built_value_example/lib/interfaces.dart
+++ b/built_types/built_value_example/lib/interfaces.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library interfaces;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
@@ -62,7 +62,7 @@ class EnumWithInt extends EnumClass implements HasInt {
   static const EnumWithInt two = _$two;
   static const EnumWithInt three = _$three;
 
-  const EnumWithInt._(String name) : super(name);
+  const EnumWithInt._(super.name);
 
   static BuiltSet<EnumWithInt> get values => _$values;
 

--- a/built_types/built_value_example/lib/polymorphism.dart
+++ b/built_types/built_value_example/lib/polymorphism.dart
@@ -1,4 +1,4 @@
-library polymorphism;
+library;
 
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';

--- a/built_types/built_value_example/lib/serializers.dart
+++ b/built_types/built_value_example/lib/serializers.dart
@@ -2,14 +2,14 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library serializers;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
-import 'package:built_value_example/generics.dart';
-import 'package:built_value_example/polymorphism.dart';
-import 'package:built_value_example/values.dart';
+import 'generics.dart';
+import 'polymorphism.dart';
+import 'values.dart';
 
 part 'serializers.g.dart';
 

--- a/built_types/built_value_example/lib/values.dart
+++ b/built_types/built_value_example/lib/values.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library values;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';

--- a/built_types/built_value_example/pubspec.yaml
+++ b/built_types/built_value_example/pubspec.yaml
@@ -14,6 +14,6 @@ dependencies:
 dev_dependencies:
   build_runner: '>=1.0.0 <3.0.0'
   built_value_generator: ^8.13.0
-  pedantic: ^1.4.0
+  dart_flutter_team_lints: ^3.1.0
   quiver: '>=0.21.0 <4.0.0'
   test: ^1.0.0

--- a/built_types/built_value_generator/analysis_options.yaml
+++ b/built_types/built_value_generator/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/built_types/built_value_generator/lib/builder.dart
+++ b/built_types/built_value_generator/lib/builder.dart
@@ -3,9 +3,9 @@
 // license that can be found in the LICENSE file.
 
 import 'package:build/build.dart';
-
-import 'package:built_value_generator/built_value_generator.dart';
 import 'package:source_gen/source_gen.dart';
 
+import 'built_value_generator.dart';
+
 Builder builtValue(BuilderOptions _) =>
-    SharedPartBuilder([BuiltValueGenerator()], 'built_value');
+    SharedPartBuilder([const BuiltValueGenerator()], 'built_value');

--- a/built_types/built_value_generator/lib/built_value_generator.dart
+++ b/built_types/built_value_generator/lib/built_value_generator.dart
@@ -4,11 +4,12 @@
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
-import 'package:built_value_generator/src/enum_source_library.dart';
-import 'package:built_value_generator/src/parsed_library_results.dart';
-import 'package:built_value_generator/src/serializer_source_library.dart';
-import 'package:built_value_generator/src/value_source_class.dart';
 import 'package:source_gen/source_gen.dart';
+
+import 'src/enum_source_library.dart';
+import 'src/parsed_library_results.dart';
+import 'src/serializer_source_library.dart';
+import 'src/value_source_class.dart';
 
 /// Generator for Enum Class and Built Values.
 ///
@@ -19,7 +20,7 @@ class BuiltValueGenerator extends Generator {
 
   @override
   Future<String?> generate(LibraryReader library, BuildStep buildStep) async {
-    var parsedLibraryResults = ParsedLibraryResults();
+    final parsedLibraryResults = ParsedLibraryResults();
 
     // Workaround for https://github.com/google/built_value.dart/issues/941.
     LibraryElement libraryElement;
@@ -40,7 +41,7 @@ class BuiltValueGenerator extends Generator {
       }
     }
 
-    var result = StringBuffer();
+    final result = StringBuffer();
     try {
       final enumCode = EnumSourceLibrary(
         parsedLibraryResults,
@@ -73,7 +74,7 @@ class BuiltValueGenerator extends Generator {
       );
     }
 
-    for (var element in libraryElement.classes) {
+    for (final element in libraryElement.classes) {
       if (ValueSourceClass.needsBuiltValue(element)) {
         try {
           result.writeln(
@@ -99,7 +100,7 @@ class BuiltValueGenerator extends Generator {
 }
 
 String _error(Object error) {
-  var lines = '$error'.split('\n');
-  var indented = lines.skip(1).map((l) => '//        $l'.trim()).join('\n');
+  final lines = '$error'.split('\n');
+  final indented = lines.skip(1).map((l) => '//        $l'.trim()).join('\n');
   return '// Error: ${lines.first}\n$indented';
 }

--- a/built_types/built_value_generator/lib/src/dart_types.dart
+++ b/built_types/built_value_generator/lib/src/dart_types.dart
@@ -6,8 +6,8 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:built_collection/built_collection.dart';
-import 'package:built_value_generator/src/parsed_library_results.dart';
-import 'package:built_value_generator/src/value_source_class.dart';
+import 'parsed_library_results.dart';
+import 'value_source_class.dart';
 
 BuiltSet<String> _builtCollectionNames = BuiltSet<String>([
   'BuiltList',
@@ -74,7 +74,7 @@ class DartTypes {
     DartType dartType, {
     bool withNullabilitySuffix = false,
   }) {
-    var suffix = withNullabilitySuffix &&
+    final suffix = withNullabilitySuffix &&
             dartType.nullabilitySuffix == NullabilitySuffix.question
         ? '?'
         : '';
@@ -89,14 +89,14 @@ class DartTypes {
       final parameters = StringBuffer();
 
       parameters.write(
-        dartType.normalParameterTypes.map((t) => getName(t)).join(', '),
+        dartType.normalParameterTypes.map(getName).join(', '),
       );
 
       if (dartType.optionalParameterTypes.isNotEmpty) {
         if (parameters.isNotEmpty) parameters.write(', ');
         parameters.write('[');
         parameters.write(
-          dartType.optionalParameterTypes.map((t) => getName(t)).join(', '),
+          dartType.optionalParameterTypes.map(getName).join(', '),
         );
         parameters.write(']');
       }
@@ -116,9 +116,9 @@ class DartTypes {
         parameters.write('}');
       }
 
-      return getName(dartType.returnType) + ' Function($parameters)$suffix';
+      return '${getName(dartType.returnType)} Function($parameters)$suffix';
     } else if (dartType is InterfaceType) {
-      var typeArguments = dartType.typeArguments;
+      final typeArguments = dartType.typeArguments;
       if (typeArguments.isEmpty) {
         return dartType.element.name! + suffix;
       } else {
@@ -134,7 +134,7 @@ class DartTypes {
     } else if (dartType is VoidType) {
       return 'void';
     } else if (dartType.isBottom) {
-      return 'Never' + suffix;
+      return 'Never$suffix';
     } else {
       throw UnimplementedError('(${dartType.runtimeType}) $dartType');
     }
@@ -142,7 +142,7 @@ class DartTypes {
 
   /// Turns a type name, optionally with generics, into just the type name.
   static String stripGenerics(String name) {
-    var genericsStart = name.indexOf('<');
+    final genericsStart = name.indexOf('<');
     return genericsStart == -1 ? name : name.substring(0, genericsStart);
   }
 }

--- a/built_types/built_value_generator/lib/src/enum_source_class.dart
+++ b/built_types/built_value_generator/lib/src/enum_source_class.dart
@@ -2,19 +2,19 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library built_value_generator.enum_source_class;
+library;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
-import 'package:built_value_generator/src/dart_types.dart';
-import 'package:built_value_generator/src/enum_source_field.dart';
-import 'package:built_value_generator/src/parsed_library_results.dart';
-import 'package:built_value_generator/src/strings.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 
+import 'dart_types.dart';
+import 'enum_source_field.dart';
 import 'library_elements.dart';
+import 'parsed_library_results.dart';
+import 'strings.dart';
 
 part 'enum_source_class.g.dart';
 
@@ -54,13 +54,13 @@ abstract class EnumSourceClass
 
   @memoized
   BuiltValueEnum get settings {
-    var annotations = element.metadata.annotations
+    final annotations = element.metadata.annotations
         .map((annotation) => annotation.computeConstantValue())
         .where(
           (value) => DartTypes.tryGetName(value?.type) == 'BuiltValueEnum',
         );
     if (annotations.isEmpty) return const BuiltValueEnum();
-    var annotation = annotations.single!;
+    final annotation = annotations.single!;
     return BuiltValueEnum(
       wireName: annotation.getField('wireName')?.toStringValue(),
     );
@@ -88,13 +88,13 @@ abstract class EnumSourceClass
 
   @memoized
   String? get valuesIdentifier {
-    var getter = element.getGetter('values');
+    final getter = element.getGetter('values');
     if (getter == null) return null;
-    var source = parsedLibrary
+    final source = parsedLibrary
         .getFragmentDeclaration(getter.firstFragment)!
         .node
         .toSource();
-    var matches = RegExp(
+    final matches = RegExp(
       r'static BuiltSet<' +
           RegExp.escape(element.displayName) +
           r'> get values => (_\$[\w$]+)\;',
@@ -104,13 +104,13 @@ abstract class EnumSourceClass
 
   @memoized
   String? get valueOfIdentifier {
-    var getter = element.getMethod('valueOf');
+    final getter = element.getMethod('valueOf');
     if (getter == null) return null;
-    var source = parsedLibrary
+    final source = parsedLibrary
         .getFragmentDeclaration(getter.firstFragment)!
         .node
         .toSource();
-    var matches = RegExp(
+    final matches = RegExp(
       r'static ' +
           RegExp.escape(element.displayName) +
           r' valueOf\((?:final )?String name\) \=\> (\_\$[\w$]+)\(name\)\;',
@@ -120,9 +120,9 @@ abstract class EnumSourceClass
 
   @memoized
   bool get usesMixin =>
-      element.library.getClass(name + 'Mixin') != null ||
+      element.library.getClass('${name}Mixin') != null ||
       element.library.firstFragment.typeAliases.any(
-        (a) => a.name == name + 'Mixin',
+        (a) => a.name == '${name}Mixin',
       );
 
   @memoized
@@ -130,7 +130,7 @@ abstract class EnumSourceClass
     return [
       valuesIdentifier,
       valueOfIdentifier,
-      for (var field in fields) field.generatedIdentifier,
+      for (final field in fields) field.generatedIdentifier,
     ].nonNulls.toList();
   }
 
@@ -159,9 +159,9 @@ abstract class EnumSourceClass
   }
 
   Iterable<String> _checkFallbackFields() {
-    var result = <String>[];
+    final result = <String>[];
 
-    var fallbackFields =
+    final fallbackFields =
         fields.where((field) => field.settings.fallback).toList();
     if (fallbackFields.length > 1) {
       result.add(
@@ -175,13 +175,13 @@ abstract class EnumSourceClass
   }
 
   Iterable<String> _checkConstructor() {
-    var expectedCode = RegExp(
+    final expectedCode = RegExp(
       'const ${RegExp.escape(name)}._\\((?:final )?String name\\) : super\\(name\\);',
     );
-    var expectedCode217 = RegExp(
+    final expectedCode217 = RegExp(
       'const (?:${RegExp.escape(name)}\\.|new )_\\(super\\.name\\);',
     );
-    var expectedCodeNew = RegExp(
+    final expectedCodeNew = RegExp(
       'const new _\\((?:final )?String name\\) : super\\(name\\);',
     );
     return constructors.length == 1 &&
@@ -196,7 +196,7 @@ abstract class EnumSourceClass
   }
 
   Iterable<String> _checkValuesGetter() {
-    var result = <String>[];
+    final result = <String>[];
     if (valuesIdentifier == null) {
       result.add('Add getter: static BuiltSet<$name> get values => _\$values');
     }
@@ -204,7 +204,7 @@ abstract class EnumSourceClass
   }
 
   Iterable<String> _checkValueOf() {
-    var result = <String>[];
+    final result = <String>[];
     if (valueOfIdentifier == null) {
       result.add(
         'Add method: '
@@ -215,9 +215,9 @@ abstract class EnumSourceClass
   }
 
   String generateCode() {
-    var result = StringBuffer();
+    final result = StringBuffer();
 
-    for (var field in fields) {
+    for (final field in fields) {
       result.writeln(
         'const $name ${field.generatedIdentifier} = '
         'const $name._(\'${escapeString(field.name)}\');',
@@ -230,14 +230,15 @@ abstract class EnumSourceClass
       '$name $valueOfIdentifier(String name) {'
       'switch (name) {',
     );
-    for (var field in fields) {
+    for (final field in fields) {
       result.writeln(
         "case '${escapeString(field.name)}':"
         ' return ${field.generatedIdentifier};',
       );
     }
 
-    var fallback = fields.firstWhereOrNull((field) => field.settings.fallback);
+    final fallback =
+        fields.firstWhereOrNull((field) => field.settings.fallback);
     if (fallback == null) {
       result.writeln('default: throw ArgumentError(name);');
     } else {
@@ -251,7 +252,7 @@ abstract class EnumSourceClass
       'final BuiltSet<$name> $valuesIdentifier ='
       'BuiltSet<$name>(const <$name>[',
     );
-    for (var field in fields) {
+    for (final field in fields) {
       result.writeln('${field.generatedIdentifier},');
     }
     result.writeln(']);');
@@ -264,12 +265,12 @@ abstract class EnumSourceClass
   }
 
   String _generateMixin() {
-    var result = StringBuffer();
+    final result = StringBuffer();
 
     result
       ..writeln('class _\$${name}Meta {')
       ..writeln('const _\$${name}Meta();');
-    for (var field in fields) {
+    for (final field in fields) {
       result.writeln(
         '$name get ${field.name} => ${field.generatedIdentifier};',
       );

--- a/built_types/built_value_generator/lib/src/enum_source_field.dart
+++ b/built_types/built_value_generator/lib/src/enum_source_field.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library built_value_generator.enum_source_field;
+library;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
@@ -33,13 +33,13 @@ abstract class EnumSourceField
 
   @memoized
   BuiltValueEnumConst get settings {
-    var annotations = element.metadata.annotations
+    final annotations = element.metadata.annotations
         .map((annotation) => annotation.computeConstantValue())
         .where(
           (value) => DartTypes.tryGetName(value?.type) == 'BuiltValueEnumConst',
         );
     if (annotations.isEmpty) return const BuiltValueEnumConst();
-    var annotation = annotations.single!;
+    final annotation = annotations.single!;
     return BuiltValueEnumConst(
       fallback: annotation.getField('fallback')?.toBoolValue() ?? false,
       wireName: annotation.getField('wireName')!.toStringValue(),
@@ -50,7 +50,7 @@ abstract class EnumSourceField
 
   @memoized
   String get generatedIdentifier {
-    var fieldName = element.displayName;
+    final fieldName = element.displayName;
     return parsedLibrary
         .getFragmentDeclaration(element.firstFragment)!
         .node
@@ -68,10 +68,10 @@ abstract class EnumSourceField
     ParsedLibraryResult parsedLibrary,
     InterfaceElement classElement,
   ) {
-    var result = ListBuilder<EnumSourceField>();
+    final result = ListBuilder<EnumSourceField>();
 
-    var enumName = classElement.displayName;
-    for (var fieldElement in classElement.fields) {
+    final enumName = classElement.displayName;
+    for (final fieldElement in classElement.fields) {
       final type = DartTypes.tryGetName(fieldElement.getter?.returnType);
       if (fieldElement.isOriginDeclaration &&
           (type == enumName || type == 'dynamic')) {
@@ -83,7 +83,7 @@ abstract class EnumSourceField
   }
 
   Iterable<String> get errors {
-    var result = <String>[];
+    final result = <String>[];
 
     if (type == 'dynamic') {
       result.add('Specify a type for field "$name".');

--- a/built_types/built_value_generator/lib/src/enum_source_library.dart
+++ b/built_types/built_value_generator/lib/src/enum_source_library.dart
@@ -2,15 +2,16 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library built_value_generator.enum_source_library;
+library;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
-import 'package:built_value_generator/src/enum_source_class.dart';
-import 'package:built_value_generator/src/parsed_library_results.dart';
 import 'package:source_gen/source_gen.dart';
+
+import 'enum_source_class.dart';
+import 'parsed_library_results.dart';
 
 part 'enum_source_library.g.dart';
 
@@ -45,9 +46,9 @@ abstract class EnumSourceLibrary
 
   @memoized
   BuiltList<EnumSourceClass> get classes {
-    var result = ListBuilder<EnumSourceClass>();
+    final result = ListBuilder<EnumSourceClass>();
 
-    for (var classElement in element.classes) {
+    for (final classElement in element.classes) {
       if (EnumSourceClass.needsEnumClass(classElement)) {
         result.add(EnumSourceClass(parsedLibraryResults, classElement));
       }
@@ -58,7 +59,7 @@ abstract class EnumSourceLibrary
   String? generateCode() {
     if (classes.isEmpty) return null;
 
-    var errors = _computeErrors();
+    final errors = _computeErrors();
     if (errors.isNotEmpty) throw _makeError(errors);
 
     return classes.map((c) => c.generateCode()).join('\n');
@@ -68,13 +69,13 @@ abstract class EnumSourceLibrary
     return [
       ..._checkPart(),
       ..._checkIdentifiers(),
-      for (var c in classes) ...c.computeErrors(),
+      for (final c in classes) ...c.computeErrors(),
     ];
   }
 
   Iterable<String> _checkPart() {
-    var expectedCode = "part '$fileName.g.dart';";
-    var alternativeExpectedCode = 'part "$fileName.g.dart";';
+    final expectedCode = "part '$fileName.g.dart';";
+    final alternativeExpectedCode = 'part "$fileName.g.dart";';
     return source.contains(expectedCode) ||
             source.contains(alternativeExpectedCode)
         ? <String>[]
@@ -82,12 +83,12 @@ abstract class EnumSourceLibrary
   }
 
   Iterable<String> _checkIdentifiers() {
-    var result = <String>[];
-    var seenIdentifiers = <String>{};
-    var reportedIdentifiers = <String>{};
+    final result = <String>[];
+    final seenIdentifiers = <String>{};
+    final reportedIdentifiers = <String>{};
 
-    for (var sourceClass in classes) {
-      for (var identifier in sourceClass.identifiers) {
+    for (final sourceClass in classes) {
+      for (final identifier in sourceClass.identifiers) {
         if (seenIdentifiers.contains(identifier) &&
             !reportedIdentifiers.contains(identifier)) {
           reportedIdentifiers.add(identifier);

--- a/built_types/built_value_generator/lib/src/field_mixin.dart
+++ b/built_types/built_value_generator/lib/src/field_mixin.dart
@@ -2,7 +2,7 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:built_value/built_value.dart';
-import 'package:built_value_generator/src/dart_types.dart';
+import 'dart_types.dart';
 
 /// Common logic between `ValueSourceField` and `SerializerSourceField`.
 mixin FieldMixin {

--- a/built_types/built_value_generator/lib/src/fields.dart
+++ b/built_types/built_value_generator/lib/src/fields.dart
@@ -22,7 +22,7 @@ BuiltList<PropertyInducingElement> collectFields(InterfaceElement element) =>
 /// If a field is overridden then just the closest (overriding) field is
 /// returned.
 BuiltList<PropertyInducingElement> collectFieldsForType(InterfaceType type) {
-  var fields = <PropertyInducingElement>[];
+  final fields = <PropertyInducingElement>[];
   // Add fields from this class before interfaces, so they're added to the set
   // first below. Re-added fields from interfaces are ignored.
   fields.addAll(_fieldElementsForType(type));
@@ -33,7 +33,7 @@ BuiltList<PropertyInducingElement> collectFieldsForType(InterfaceType type) {
 
   // Overridden fields have multiple declarations, so deduplicate by adding
   // to a set that compares on field name.
-  var fieldSet = LinkedHashSet<PropertyInducingElement>(
+  final fieldSet = LinkedHashSet<PropertyInducingElement>(
     equals: (a, b) => a.displayName == b.displayName,
     hashCode: (a) => a.displayName.hashCode,
   );
@@ -59,8 +59,8 @@ BuiltList<PropertyInducingElement> collectFieldsForType(InterfaceType type) {
 }
 
 BuiltList<PropertyInducingElement> _fieldElementsForType(InterfaceType type) {
-  var result = ListBuilder<PropertyInducingElement>();
-  for (var accessor in type.getters) {
+  final result = ListBuilder<PropertyInducingElement>();
+  for (final accessor in type.getters) {
     result.add(accessor.variable);
   }
   return result.build();

--- a/built_types/built_value_generator/lib/src/memoized_getter.dart
+++ b/built_types/built_value_generator/lib/src/memoized_getter.dart
@@ -1,11 +1,10 @@
-library built_value_generator.memoized_getter;
+library;
 
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:built_value/built_value.dart';
-import 'package:built_value_generator/src/dart_types.dart';
-import 'package:built_value_generator/src/metadata.dart'
-    show metadataToStringValue;
+import 'dart_types.dart';
+import 'metadata.dart' show metadataToStringValue;
 
 part 'memoized_getter.g.dart';
 

--- a/built_types/built_value_generator/lib/src/parsed_library_results.dart
+++ b/built_types/built_value_generator/lib/src/parsed_library_results.dart
@@ -14,14 +14,14 @@ class ParsedLibraryResults {
   ParsedLibraryResult parsedLibraryResultOrThrowingMock(
     LibraryElement element,
   ) {
-    var uri = element.uri;
+    final uri = element.uri;
     return _results[uri] ??= _parsedLibraryResultOrThrowingMock(element);
   }
 
   ParsedLibraryResult _parsedLibraryResultOrThrowingMock(
     LibraryElement element,
   ) {
-    var result = element.session.getParsedLibraryByElement(element);
+    final result = element.session.getParsedLibraryByElement(element);
     if (result is ParsedLibraryResult) {
       return result;
     }

--- a/built_types/built_value_generator/lib/src/serializer_source_class.dart
+++ b/built_types/built_value_generator/lib/src/serializer_source_class.dart
@@ -2,22 +2,22 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library built_value_generator.source_class;
+library;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
-import 'package:built_value_generator/src/enum_source_class.dart';
-import 'package:built_value_generator/src/enum_source_field.dart';
-import 'package:built_value_generator/src/fields.dart' show collectFields;
-import 'package:built_value_generator/src/parsed_library_results.dart';
-import 'package:built_value_generator/src/serializer_source_field.dart';
-import 'package:built_value_generator/src/strings.dart';
-import 'package:built_value_generator/src/value_source_class.dart';
 
 import 'dart_types.dart';
+import 'enum_source_class.dart';
+import 'enum_source_field.dart';
+import 'fields.dart' show collectFields;
+import 'parsed_library_results.dart';
+import 'serializer_source_field.dart';
+import 'strings.dart';
+import 'value_source_class.dart';
 
 part 'serializer_source_class.g.dart';
 
@@ -36,7 +36,7 @@ abstract class SerializerSourceClass
         parsedLibraryResults: parsedLibraryResults,
         element: element,
         builderElement:
-            element.library.getClass(element.displayName + 'Builder'),
+            element.library.getClass('${element.displayName}Builder'),
       );
 
   SerializerSourceClass._();
@@ -55,13 +55,13 @@ abstract class SerializerSourceClass
 
   @memoized
   BuiltValueSerializer get serializerSettings {
-    var serializerFields =
+    final serializerFields =
         element.fields.where((field) => field.name == 'serializer').toList();
     if (serializerFields.isEmpty) return const BuiltValueSerializer();
-    var serializerField = serializerFields.single;
+    final serializerField = serializerFields.single;
     if (serializerField.getter == null) return const BuiltValueSerializer();
 
-    var annotations = serializerField.getter!.metadata.annotations
+    final annotations = serializerField.getter!.metadata.annotations
         .map((annotation) => annotation.computeConstantValue())
         .where(
           (value) =>
@@ -69,7 +69,7 @@ abstract class SerializerSourceClass
         );
     if (annotations.isEmpty) return const BuiltValueSerializer();
 
-    var annotation = annotations.single!;
+    final annotation = annotations.single!;
     // If a field does not exist, that means an old `built_value` version; use
     // the default.
     return BuiltValueSerializer(
@@ -100,10 +100,10 @@ abstract class SerializerSourceClass
 
   @memoized
   String get serializerDeclaration {
-    var serializerFields =
+    final serializerFields =
         element.fields.where((field) => field.name == 'serializer').toList();
     if (serializerFields.isEmpty) return '';
-    var serializerField = serializerFields.single;
+    final serializerField = serializerFields.single;
     var result = parsedLibrary
             .getFragmentDeclaration(serializerField.getter!.firstFragment)
             ?.node
@@ -133,11 +133,7 @@ abstract class SerializerSourceClass
   @memoized
   String get genericBoundsOrObjectString => genericBounds.isEmpty
       ? ''
-      : '<' +
-          genericBounds
-              .map((bound) => bound.isEmpty ? 'Object?' : bound)
-              .join(', ') +
-          '>';
+      : '<${genericBounds.map((bound) => bound.isEmpty ? 'Object?' : bound).join(', ')}>';
 
   String get genericName => '$name$genericBoundsOrObjectString';
 
@@ -161,8 +157,8 @@ abstract class SerializerSourceClass
 
   @memoized
   BuiltList<SerializerSourceField> get fields {
-    var result = ListBuilder<SerializerSourceField>();
-    for (var fieldElement in collectFields(element)) {
+    final result = ListBuilder<SerializerSourceField>();
+    for (final fieldElement in collectFields(element)) {
       final builderFieldElement = builderElement?.getField(
         fieldElement.displayName,
       );
@@ -196,8 +192,8 @@ abstract class SerializerSourceClass
   BuiltSet<SerializerSourceClass> _fieldClassesWith(
     BuiltSet<SerializerSourceClass> initialClasses,
   ) {
-    var result = initialClasses.toBuilder();
-    for (var fieldElement in collectFields(element)) {
+    final result = initialClasses.toBuilder();
+    for (final fieldElement in collectFields(element)) {
       if (fieldElement.isStatic) continue;
       if (fieldElement.setter != null) continue;
 
@@ -258,7 +254,7 @@ abstract class SerializerSourceClass
   String get serializerInstanceName => '_\$${_toCamelCase(name)}Serializer';
 
   Iterable<String> computeErrors() {
-    var result = <String>[];
+    final result = <String>[];
 
     if (!serializerSettings.custom) {
       final expectedSerializerDeclaration =
@@ -279,7 +275,7 @@ abstract class SerializerSourceClass
       }
     }
 
-    for (var field in fields) {
+    for (final field in fields) {
       result.addAll(field.computeErrors());
     }
 
@@ -333,11 +329,11 @@ abstract class SerializerSourceClass
     if (isBuiltValue) {
       // Add local $cast function if it will be used in code generated by
       // _generateFieldDeserializers.
-      var needsCastFn = hasBuilder &&
+      final needsCastFn = hasBuilder &&
           fields.any(
             (f) => f.builderFieldUsesNestedBuilder && f.builderFieldIsNullable,
           );
-      var maybeCastFn = needsCastFn
+      final maybeCastFn = needsCastFn
           ? r'''
 T $cast<T>(dynamic any) => any as T;
 '''
@@ -466,7 +462,7 @@ class $serializerImplName implements PrimitiveSerializer<$genericName> {
   }
 
   String _generateNewBuilder() {
-    var parameters = _genericParametersUsedInFields;
+    final parameters = _genericParametersUsedInFields;
     if (parameters.isEmpty) {
       return '${name}Builder$genericBoundsOrObjectString()';
     }
@@ -487,9 +483,9 @@ class $serializerImplName implements PrimitiveSerializer<$genericName> {
       );
 
   String _generateGenericsSerializerPreamble() {
-    var parameters = _genericParametersUsedInFields;
+    final parameters = _genericParametersUsedInFields;
     if (parameters.isEmpty) return '';
-    var result = StringBuffer();
+    final result = StringBuffer();
     result.writeln(
       'final isUnderspecified = specifiedType.isUnspecified || '
       'specifiedType.parameters.isEmpty;',
@@ -497,7 +493,7 @@ class $serializerImplName implements PrimitiveSerializer<$genericName> {
     result.writeln(
       'if (!isUnderspecified) serializers.expectBuilder(specifiedType);',
     );
-    for (var parameter in parameters) {
+    for (final parameter in parameters) {
       final index = genericParameters.indexOf(parameter);
       result.writeln(
         'final parameter$parameter = '
@@ -523,33 +519,32 @@ class $serializerImplName implements PrimitiveSerializer<$genericName> {
   }
 
   String _generateNullableFieldSerializers() {
-    var nullableFields = fields.where((field) => field.isNullable).toList();
+    final nullableFields = fields.where((field) => field.isNullable).toList();
     if (nullableFields.isEmpty) return '';
 
-    return 'Object? value;' +
-        nullableFields.map((field) {
-          var serializeField = '''serializers.serialize(
+    return 'Object? value;${nullableFields.map((field) {
+      final serializeField = '''serializers.serialize(
           value,
           specifiedType:
           ${field.generateFullType(libraryFragment, genericParameters.toBuiltSet())})''';
 
-          return '''
+      return '''
           value = object.${field.name};
           ${serializerSettings.serializeNulls ? '' : 'if (value != null) {'}
             result
               ..add('${escapeString(field.wireName)}')
               ..add($serializeField);
           ${serializerSettings.serializeNulls ? '' : '}'}''';
-        }).join('');
+    }).join('')}';
   }
 
   /// Gets a map from generic parameter to its bound.
   ///
   /// 'Object' is substituted where there is no bound.
   BuiltMap<String, String> get _genericBoundsAsMap {
-    var genericBoundsOrObject =
+    final genericBoundsOrObject =
         genericBounds.map((bound) => bound.isEmpty ? 'Object' : bound).toList();
-    var result = MapBuilder<String, String>();
+    final result = MapBuilder<String, String>();
     for (var i = 0; i != genericParameters.length; ++i) {
       result[genericParameters[i]] = genericBoundsOrObject[i];
     }
@@ -564,7 +559,7 @@ class $serializerImplName implements PrimitiveSerializer<$genericName> {
       );
       final cast = field.generateCast(libraryFragment, _genericBoundsAsMap);
       // If cast exists and is not nullable.
-      var maybeNotNull = !field.isNullable && cast.isNotEmpty ? '!' : '';
+      final maybeNotNull = !field.isNullable && cast.isNotEmpty ? '!' : '';
       if (field.builderFieldUsesNestedBuilder) {
         if (hasBuilder && field.builderFieldIsNullable) {
           // The manually implemented builder might or might not return a
@@ -605,7 +600,7 @@ case '${escapeString(field.wireName)}':
         }
       } else {
         // `cast` is empty if no cast is needed.
-        var maybeOrNull = field.isNullable && cast.isNotEmpty ? '?' : '';
+        final maybeOrNull = field.isNullable && cast.isNotEmpty ? '?' : '';
         return '''
 case '${escapeString(field.wireName)}':
   result.${field.name} = serializers.deserialize(
@@ -620,7 +615,7 @@ case '${escapeString(field.wireName)}':
     var result = '';
     var upperCase = false;
     var firstCharacter = true;
-    for (var char in name.split('')) {
+    for (final char in name.split('')) {
       if (char == '_') {
         upperCase = true;
       } else if (char == '\$') {

--- a/built_types/built_value_generator/lib/src/serializer_source_field.dart
+++ b/built_types/built_value_generator/lib/src/serializer_source_field.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library built_value_generator.source_field;
+library;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
@@ -11,12 +11,11 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
-import 'package:built_value_generator/src/dart_types.dart';
-import 'package:built_value_generator/src/field_mixin.dart';
-import 'package:built_value_generator/src/metadata.dart'
-    show metadataToStringValue;
-import 'package:built_value_generator/src/parsed_library_results.dart';
-import 'package:built_value_generator/src/strings.dart';
+import 'dart_types.dart';
+import 'field_mixin.dart';
+import 'metadata.dart' show metadataToStringValue;
+import 'parsed_library_results.dart';
+import 'strings.dart';
 
 part 'serializer_source_field.g.dart';
 
@@ -64,13 +63,13 @@ abstract class SerializerSourceField
 
   @memoized
   BuiltValueField get builtValueField {
-    var annotations = element.getter!.metadata.annotations
+    final annotations = element.getter!.metadata.annotations
         .map((annotation) => annotation.computeConstantValue())
         .where(
           (value) => DartTypes.tryGetName(value?.type) == 'BuiltValueField',
         );
     if (annotations.isEmpty) return const BuiltValueField();
-    var annotation = annotations.single!;
+    final annotation = annotations.single!;
     return BuiltValueField(
       compare: annotation.getField('compare')?.toBoolValue(),
       serialize: annotation.getField('serialize')?.toBoolValue(),
@@ -117,12 +116,12 @@ abstract class SerializerSourceField
   /// The [type] plus any import prefix, without any nullability suffix.
   @memoized
   String get typeWithPrefixAndNullabilitySuffix {
-    var declaration =
+    final declaration =
         parsedLibrary.getFragmentDeclaration(element.getter!.firstFragment)!;
-    var typeFromAst =
+    final typeFromAst =
         (declaration.node as MethodDeclaration).returnType?.toString() ??
             'dynamic';
-    var typeFromElement = typeWithNullabilitySuffix;
+    final typeFromElement = typeWithNullabilitySuffix;
 
     // If the type is a function, we can't use the element result; it is
     // formatted incorrectly.
@@ -243,7 +242,7 @@ abstract class SerializerSourceField
     BuiltMap<String, String> classGenericBounds, {
     bool forReplace = false,
   }) {
-    var result = _generateCast(
+    final result = _generateCast(
       typeInLibraryFragment(libraryFragment),
       classGenericBounds,
       forReplace: forReplace,
@@ -252,7 +251,7 @@ abstract class SerializerSourceField
   }
 
   String generateBuilder() {
-    var bareType = _getBareType(type);
+    final bareType = _getBareType(type);
     if (typesWithBuilder.containsKey(bareType)) {
       return '${typesWithBuilder[bareType]}<${_getGenerics(type)}>()';
     } else {
@@ -265,10 +264,10 @@ abstract class SerializerSourceField
     BuiltSet<String> classGenericParameters, {
     bool includeNullability = false,
   }) {
-    var bareType = _getBareType(type);
-    var generics = _getGenerics(type);
-    var genericItems = _splitOnTopLevelCommas(generics);
-    var maybeNullability =
+    final bareType = _getBareType(type);
+    final generics = _getGenerics(type);
+    final genericItems = _splitOnTopLevelCommas(generics);
+    final maybeNullability =
         includeNullability && type.endsWith('?') ? '.nullable' : '';
 
     if (generics.isEmpty) {
@@ -299,8 +298,9 @@ abstract class SerializerSourceField
     bool topLevel = true,
     bool forReplace = false,
   }) {
-    var resultNullabilitySuffix = (!topLevel && type.endsWith('?')) ? '?' : '';
-    var bareType = _getBareType(type);
+    final resultNullabilitySuffix =
+        (!topLevel && type.endsWith('?')) ? '?' : '';
+    final bareType = _getBareType(type);
 
     // `built_collection` `replace` methods don't care about the full generic
     // type, so we can be less precise about the cast. This doesn't add any
@@ -331,7 +331,7 @@ abstract class SerializerSourceField
       generics = _getGenerics(type);
     }
 
-    var genericItems = _splitOnTopLevelCommas(generics);
+    final genericItems = _splitOnTopLevelCommas(generics);
 
     if (generics.isEmpty) {
       if (classGenericBounds.keys.contains(bareType)) {
@@ -349,15 +349,15 @@ abstract class SerializerSourceField
   }
 
   static String _getBareType(String name) {
-    var genericsStart = name.indexOf('<');
+    final genericsStart = name.indexOf('<');
     var result = genericsStart == -1 ? name : name.substring(0, genericsStart);
     if (result.endsWith('?')) result = result.substring(0, result.length - 1);
     return result;
   }
 
   static String _getGenerics(String name) {
-    var genericsStart = name.indexOf('<');
-    var hasNullableSuffix = name.endsWith('?');
+    final genericsStart = name.indexOf('<');
+    final hasNullableSuffix = name.endsWith('?');
     return genericsStart == -1
         ? ''
         : name.substring(genericsStart + 1).substring(
@@ -369,8 +369,8 @@ abstract class SerializerSourceField
   /// Splits a generic parameter string on top level commas; that means
   /// commas nested inside '<' and '>' are ignored.
   static BuiltList<String> _splitOnTopLevelCommas(String string) {
-    var result = ListBuilder<String>();
-    var accumulator = StringBuffer();
+    final result = ListBuilder<String>();
+    final accumulator = StringBuffer();
     var depth = 0;
     for (var i = 0; i != string.length; ++i) {
       if (string[i] == '<') ++depth;

--- a/built_types/built_value_generator/lib/src/serializer_source_library.dart
+++ b/built_types/built_value_generator/lib/src/serializer_source_library.dart
@@ -2,17 +2,17 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library built_value_generator.source_library;
+library;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
-import 'package:built_value_generator/src/parsed_library_results.dart';
-import 'package:built_value_generator/src/serializer_source_class.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'dart_types.dart';
+import 'parsed_library_results.dart';
+import 'serializer_source_class.dart';
 
 part 'serializer_source_library.g.dart';
 
@@ -42,8 +42,8 @@ abstract class SerializerSourceLibrary
   /// and the values are the `@SerializersFor` annotations.
   @memoized
   BuiltMap<String, ElementAnnotation> get serializersForAnnotations {
-    var result = MapBuilder<String, ElementAnnotation>();
-    var accessors = element.library.topLevelVariables
+    final result = MapBuilder<String, ElementAnnotation>();
+    final accessors = element.library.topLevelVariables
         .where(
           (element) =>
               element.getter != null &&
@@ -51,7 +51,7 @@ abstract class SerializerSourceLibrary
         )
         .toList();
 
-    for (var accessor in accessors) {
+    for (final accessor in accessors) {
       final annotations = accessor.metadata.annotations
           .where(
             (annotation) =>
@@ -73,8 +73,8 @@ abstract class SerializerSourceLibrary
   /// return type.
   @memoized
   BuiltList<String> get wrongSerializersDeclarations {
-    var result = ListBuilder<String>();
-    var accessors = element.topLevelVariables
+    final result = ListBuilder<String>();
+    final accessors = element.topLevelVariables
         .where(
           (element) =>
               element.getter != null &&
@@ -82,7 +82,7 @@ abstract class SerializerSourceLibrary
         )
         .toList();
 
-    for (var accessor in accessors) {
+    for (final accessor in accessors) {
       final annotations = accessor.metadata.annotations
           .where(
             (annotation) =>
@@ -105,9 +105,9 @@ abstract class SerializerSourceLibrary
   /// generated for each, except where the serializer is marked `custom`.
   @memoized
   BuiltSet<SerializerSourceClass> get sourceClasses {
-    var result = SetBuilder<SerializerSourceClass>();
-    var classElements = element.classes;
-    for (var classElement in classElements) {
+    final result = SetBuilder<SerializerSourceClass>();
+    final classElements = element.classes;
+    for (final classElement in classElements) {
       final sourceClass = SerializerSourceClass(
         parsedLibraryResults,
         classElement,
@@ -123,9 +123,9 @@ abstract class SerializerSourceLibrary
   /// that each serializer is required to be able to serialize.
   @memoized
   BuiltSetMultimap<String, SerializerSourceClass> get serializeForClasses {
-    var result = SetMultimapBuilder<String, SerializerSourceClass>();
+    final result = SetMultimapBuilder<String, SerializerSourceClass>();
 
-    for (var field in serializersForAnnotations.keys) {
+    for (final field in serializersForAnnotations.keys) {
       final serializersForAnnotation = serializersForAnnotations[field]!;
 
       final types = serializersForAnnotation
@@ -159,9 +159,9 @@ abstract class SerializerSourceLibrary
   @memoized
   BuiltSetMultimap<String, SerializerSourceClass>
       get serializeForTransitiveClasses {
-    var result = SetMultimapBuilder<String, SerializerSourceClass>();
+    final result = SetMultimapBuilder<String, SerializerSourceClass>();
 
-    for (var field in serializersForAnnotations.keys) {
+    for (final field in serializersForAnnotations.keys) {
       var currentResult = BuiltSet<SerializerSourceClass>(
         serializeForClasses[field]!.where(
           (serializerSourceClass) => serializerSourceClass.isSerializable,
@@ -192,7 +192,7 @@ abstract class SerializerSourceLibrary
   bool get needsBuiltJson => sourceClasses.isNotEmpty;
 
   Iterable<String> computeErrors() {
-    var result = <String>[];
+    final result = <String>[];
 
     if (wrongSerializersDeclarations.isNotEmpty) {
       result.add(
@@ -207,9 +207,9 @@ abstract class SerializerSourceLibrary
 
   /// Generates serializer source for this library.
   String generateCode() {
-    var errors = [
+    final errors = [
       ...computeErrors(),
-      for (var sourceClass in sourceClasses) ...sourceClass.computeErrors(),
+      for (final sourceClass in sourceClasses) ...sourceClass.computeErrors(),
     ];
 
     if (errors.isNotEmpty) throw _makeError(errors);
@@ -228,31 +228,20 @@ abstract class SerializerSourceLibrary
   String _generateSerializersTopLevelFields() => serializersForAnnotations.keys
       .map(
         (field) =>
-            'Serializers _\$$field = (Serializers().toBuilder()' +
-            (serializeForTransitiveClasses[field]!
-                    .map(
-                      (sourceClass) =>
-                          sourceClass.generateTransitiveSerializerAdder(),
-                    )
-                    .toList()
-                  ..sort())
-                .join('\n') +
-            (serializeForTransitiveClasses[field]!
-                    .map(
-                      (sourceClass) => sourceClass.generateBuilderFactoryAdders(
-                        element.library.firstFragment,
-                      ),
-                    )
-                    .toList()
-                  ..sort())
-                .join('\n') +
-            ').build();',
+            'Serializers _\$$field = (Serializers().toBuilder()${(serializeForTransitiveClasses[field]!.map(
+                  (sourceClass) =>
+                      sourceClass.generateTransitiveSerializerAdder(),
+                ).toList()..sort()).join('\n')}${(serializeForTransitiveClasses[field]!.map(
+                  (sourceClass) => sourceClass.generateBuilderFactoryAdders(
+                    element.library.firstFragment,
+                  ),
+                ).toList()..sort()).join('\n')}).build();',
       )
       .join('\n');
 }
 
 InvalidGenerationSourceError _makeError(Iterable<String> todos) {
-  var message = StringBuffer(
+  final message = StringBuffer(
     'Please make the following changes to use built_value serialization:\n',
   );
   for (var i = 0; i != todos.length; ++i) {

--- a/built_types/built_value_generator/lib/src/value_source_class.dart
+++ b/built_types/built_value_generator/lib/src/value_source_class.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library built_value_generator.source_class;
+library;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
@@ -11,17 +11,17 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
-import 'package:built_value_generator/src/fixes.dart';
-import 'package:built_value_generator/src/memoized_getter.dart';
-import 'package:built_value_generator/src/metadata.dart';
-import 'package:built_value_generator/src/parsed_library_results.dart';
-import 'package:built_value_generator/src/strings.dart';
-import 'package:built_value_generator/src/value_source_field.dart';
 import 'package:collection/collection.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'dart_types.dart';
+import 'fixes.dart';
 import 'library_elements.dart';
+import 'memoized_getter.dart';
+import 'metadata.dart';
+import 'parsed_library_results.dart';
+import 'strings.dart';
+import 'value_source_field.dart';
 
 part 'value_source_class.g.dart';
 
@@ -68,7 +68,7 @@ abstract class ValueSourceClass
 
   @memoized
   ClassElement? get builderElement {
-    var result = element.library.getClass(name + 'Builder');
+    final result = element.library.getClass('${name}Builder');
     if (result == null) return null;
     // If the builder is in a generated file, then we're analyzing _after_ code
     // generation. Ignore it. This happens when running as an analyzer plugin.
@@ -97,7 +97,7 @@ abstract class ValueSourceClass
     // This means it _is_ allowed to have concrete getters as well as
     // concrete and abstract methods.
 
-    for (var supertype in [
+    for (final supertype in [
       element.supertype,
       ...element.supertype!.element.allSupertypes,
     ]) {
@@ -134,11 +134,11 @@ abstract class ValueSourceClass
 
   @memoized
   BuiltValue get settings {
-    var annotations = element.metadata.annotations
+    final annotations = element.metadata.annotations
         .map((annotation) => annotation.computeConstantValue())
         .where((value) => DartTypes.tryGetName(value?.type) == 'BuiltValue');
     if (annotations.isEmpty) return const BuiltValue();
-    var annotation = annotations.single!;
+    final annotation = annotations.single!;
     // If a field does not exist, that means an old `built_value` version; use
     // the default.
     return BuiltValue(
@@ -168,7 +168,7 @@ abstract class ValueSourceClass
   @memoized
   BuiltList<String> get genericBounds => BuiltList<String>(
         element.typeParameters.map((element) {
-          var bound = element.bound;
+          final bound = element.bound;
           if (bound == null) return '';
           return DartTypes.getName(bound) +
               (element.bound!.nullabilitySuffix == NullabilitySuffix.question
@@ -203,15 +203,15 @@ abstract class ValueSourceClass
 
   @memoized
   BuiltMap<String, BuiltValueHook> get hooks {
-    var result = MapBuilder<String, BuiltValueHook>();
-    for (var method in element.methods) {
-      var annotations = method.metadata.annotations
+    final result = MapBuilder<String, BuiltValueHook>();
+    for (final method in element.methods) {
+      final annotations = method.metadata.annotations
           .map((annotation) => annotation.computeConstantValue())
           .where(
             (value) => DartTypes.tryGetName(value?.type) == 'BuiltValueHook',
           );
       if (annotations.isEmpty) continue;
-      var annotation = annotations.single!;
+      final annotation = annotations.single!;
       // If a field does not exist, that means an old `built_value` version; use
       // the default.
       result[method.name!] = BuiltValueHook(
@@ -230,7 +230,7 @@ abstract class ValueSourceClass
         .where((interfaceType) => interfaceType.element.name == 'Builder')
         .single
         .typeArguments
-        .map((type) => DartTypes.getName(type))
+        .map(DartTypes.getName)
         .join(', ');
   }
 
@@ -248,7 +248,7 @@ abstract class ValueSourceClass
 
   @memoized
   String get partStatement {
-    var fileName = element.library.firstFragment.source.shortName.replaceAll(
+    final fileName = element.library.firstFragment.source.shortName.replaceAll(
       '.dart',
       '',
     );
@@ -257,7 +257,7 @@ abstract class ValueSourceClass
 
   @memoized
   bool get hasPartStatement {
-    var expectedCode = partStatement;
+    final expectedCode = partStatement;
     return source.contains(expectedCode);
   }
 
@@ -370,11 +370,9 @@ abstract class ValueSourceClass
 
   String _parentBuilderInterfaceName(InterfaceType interface) {
     final displayName = DartTypes.getName(interface);
-    if (!displayName.contains('<')) return displayName + 'Builder';
+    if (!displayName.contains('<')) return '${displayName}Builder';
     final index = displayName.indexOf('<');
-    return displayName.substring(0, index) +
-        'Builder' +
-        displayName.substring(index);
+    return '${displayName.substring(0, index)}Builder${displayName.substring(index)}';
   }
 
   bool get _implementsParentBuilder =>
@@ -382,13 +380,13 @@ abstract class ValueSourceClass
 
   @memoized
   bool get implementsHashCode {
-    var getter = element.getGetter('hashCode');
+    final getter = element.getGetter('hashCode');
     return getter != null && !getter.isAbstract;
   }
 
   @memoized
   bool get declaresMemoizedHashCode {
-    var getter = element.getGetter('hashCode');
+    final getter = element.getGetter('hashCode');
     return getter != null &&
         getter.isAbstract &&
         getter.metadata.annotations.any(
@@ -403,8 +401,8 @@ abstract class ValueSourceClass
   bool get implementsToString {
     // Check for any `toString` implementation apart from the one defined on
     // `Object`.
-    var method = element.lookUpConcreteMethod('toString', element.library)!;
-    var clazz = method.enclosingElement;
+    final method = element.lookUpConcreteMethod('toString', element.library)!;
+    final clazz = method.enclosingElement;
     return clazz is! ClassElement || clazz.name != 'Object';
   }
 
@@ -431,14 +429,14 @@ abstract class ValueSourceClass
       ..._checkValueClass(),
       ..._checkBuilderClass(),
       ..._checkFieldList(),
-      for (var field in fields) ...field.computeErrors(),
+      for (final field in fields) ...field.computeErrors(),
     ];
   }
 
   Iterable<GeneratorError> _checkPart() {
     if (hasPartStatement) return [];
 
-    var directives = (classDeclaration.parent as CompilationUnit).directives;
+    final directives = (classDeclaration.parent as CompilationUnit).directives;
     if (directives.isEmpty) {
       return [
         GeneratorError(
@@ -480,7 +478,7 @@ abstract class ValueSourceClass
   }
 
   Iterable<GeneratorError> _checkValueClass() {
-    var result = <GeneratorError>[];
+    final result = <GeneratorError>[];
 
     if (!valueClassIsAbstract) {
       result.add(
@@ -516,10 +514,11 @@ abstract class ValueSourceClass
       );
     }
 
-    var implementsClause = classDeclaration.implementsClause;
-    var expectedInterface = 'Built<$name$_generics, ${name}Builder$_generics>';
+    final implementsClause = classDeclaration.implementsClause;
+    final expectedInterface =
+        'Built<$name$_generics, ${name}Builder$_generics>';
 
-    var implementsClauseIsCorrect = implementsClause != null &&
+    final implementsClauseIsCorrect = implementsClause != null &&
         implementsClause.interfaces.any(
           (type) => type.toSource() == expectedInterface,
         );
@@ -529,7 +528,7 @@ abstract class ValueSourceClass
     // case of the `Built` interface being implemented. This is to allow
     // omitting the `Built` interface to work around having to implement the
     // same interface twice with different type parameters.
-    var implementsClauseIsAllowedToBeIncorrect = !settings.instantiable &&
+    final implementsClauseIsAllowedToBeIncorrect = !settings.instantiable &&
         (implementsClause == null ||
             !implementsClause.interfaces.any(
               (type) =>
@@ -646,12 +645,12 @@ abstract class ValueSourceClass
           );
         }
       }
-      for (var hook in hooks.entries.where(
+      for (final hook in hooks.entries.where(
         (hook) => hook.value.initializeBuilder || hook.value.finalizeBuilder,
       )) {
         if (hook.key == '_initializeBuilder') continue;
         if (hook.key == '_finalizeBuilder') continue;
-        var method =
+        final method =
             element.methods.where((method) => method.name == hook.key).single;
         if (!isStaticBuilderHook(method)) {
           result.add(
@@ -687,7 +686,7 @@ abstract class ValueSourceClass
         );
       } else if (valueClassConstructors.length > 1) {
         var found = false;
-        for (var constructor in valueClassConstructors) {
+        for (final constructor in valueClassConstructors) {
           if (constructorCheck(constructor)) {
             found = true;
           } else {
@@ -728,7 +727,7 @@ abstract class ValueSourceClass
                   : 'Make class have exactly one constructor: $expectedConstructor'
               ..offset = valueClassConstructors.single.offset
               ..length = valueClassConstructors.single.length
-              ..fix = expectedConstructor + ';',
+              ..fix = '$expectedConstructor;',
           ),
         );
       }
@@ -799,7 +798,7 @@ abstract class ValueSourceClass
   }
 
   Iterable<GeneratorError> _checkBuilderClass() {
-    var result = <GeneratorError>[];
+    final result = <GeneratorError>[];
     if (!hasBuilder) return result;
 
     if (!builderClassIsAbstract) {
@@ -909,31 +908,29 @@ abstract class ValueSourceClass
         ? [
             GeneratorError(
               (b) => b
-                ..message = 'Make builder have exactly these fields: ' +
-                    fields.map((field) => field.name).join(', '),
+                ..message =
+                    'Make builder have exactly these fields: ${fields.map((field) => field.name).join(', ')}',
             ),
           ]
         : [];
   }
 
   String get _generics =>
-      genericParameters.isEmpty ? '' : '<' + genericParameters.join(', ') + '>';
+      genericParameters.isEmpty ? '' : '<${genericParameters.join(', ')}>';
 
   String get _boundedGenerics => genericParameters.isEmpty
       ? ''
-      : '<' +
-          IterableZip([genericParameters, genericBounds]).map((zipped) {
-            final parameter = zipped[0];
-            final bound = zipped[1];
-            return bound.isEmpty ? parameter : '$parameter extends $bound';
-          }).join(', ') +
-          '>';
+      : '<${IterableZip([genericParameters, genericBounds]).map((zipped) {
+          final parameter = zipped[0];
+          final bound = zipped[1];
+          return bound.isEmpty ? parameter : '$parameter extends $bound';
+        }).join(', ')}>';
 
   String generateCode() {
-    var errors = computeErrors();
+    final errors = computeErrors();
     if (errors.isNotEmpty) throw _makeError(errors);
 
-    var result = StringBuffer();
+    final result = StringBuffer();
     if (settings.instantiable) result.write(_generateImpl());
     if (settings.instantiable) {
       result.write(_generateBuilder());
@@ -945,19 +942,19 @@ abstract class ValueSourceClass
 
   /// Generates the value class implementation.
   String _generateImpl() {
-    var result = StringBuffer();
+    final result = StringBuffer();
     result.writeln(
       'class $implName$_boundedGenerics '
       'extends $name$_generics {',
     );
-    for (var field in fields) {
+    for (final field in fields) {
       final type = field.typeInLibraryFragment(libraryFragment);
       result.writeln('@override');
       result.writeln(
         'final $type${field.isNullable ? '?' : ''} ${field.name};',
       );
     }
-    for (var memoizedGetter in memoizedGetters) {
+    for (final memoizedGetter in memoizedGetters) {
       result.writeln('${memoizedGetter.returnType}? __${memoizedGetter.name};');
       if (memoizedGetter.isNullable) {
         // Nullable memoiozed getters needs a field to store whether they are
@@ -994,7 +991,7 @@ abstract class ValueSourceClass
       result.write('$implName._({');
       result.write(
         fields.map((field) {
-          var maybeRequired = field.isNullable ? '' : 'required ';
+          final maybeRequired = field.isNullable ? '' : 'required ';
           return '${maybeRequired}this.${field.name}';
         }).join(', '),
       );
@@ -1002,7 +999,7 @@ abstract class ValueSourceClass
     }
     result.writeln();
 
-    for (var memoizedGetter in memoizedGetters) {
+    for (final memoizedGetter in memoizedGetters) {
       result.writeln('@override');
       if (memoizedGetter.isNullable) {
         result.writeln(
@@ -1080,7 +1077,7 @@ abstract class ValueSourceClass
 
   /// Generates the builder implementation.
   String _generateBuilder() {
-    var result = StringBuffer();
+    final result = StringBuffer();
     if (hasBuilder) {
       result.writeln(
         'class ${implName}Builder$_boundedGenerics '
@@ -1103,7 +1100,7 @@ abstract class ValueSourceClass
     result.writeln('$implName$_generics? _\$v;');
     result.writeln('');
 
-    for (var field in fields) {
+    for (final field in fields) {
       late final String type;
 
       if (field.isNestedBuilder) {
@@ -1192,7 +1189,7 @@ abstract class ValueSourceClass
       if (hasBuilderInitializer) {
         result.writeln('$name._initializeBuilder(this);');
       }
-      for (var hook in hooks.entries) {
+      for (final hook in hooks.entries) {
         if (hook.value.initializeBuilder) {
           result.writeln('$name.${hook.key}(this);');
         }
@@ -1208,14 +1205,14 @@ abstract class ValueSourceClass
       result.writeln('${name}Builder$_generics get _\$this {');
       result.writeln('final \$v = _\$v;');
       result.writeln('if (\$v != null) {');
-      for (var field in fields) {
+      for (final field in fields) {
         final name = field.name;
         final nameInBuilder =
             field.builderFieldExists && !field.builderFieldIsAbstract
                 ? 'super.$name'
                 : '_$name';
         if (field.isNestedBuilder) {
-          var maybeOrNull = field.isNullable ? '?' : '';
+          final maybeOrNull = field.isNullable ? '?' : '';
           result.writeln(
             '$nameInBuilder = '
             '\$v.$name$maybeOrNull.toBuilder();',
@@ -1264,7 +1261,7 @@ abstract class ValueSourceClass
     if (hasBuilderFinalizer) {
       result.writeln('$name._finalizeBuilder(this);');
     }
-    for (var hook in hooks.entries) {
+    for (final hook in hooks.entries) {
       if (hook.value.finalizeBuilder) {
         result.writeln('$name.${hook.key}(this);');
       }
@@ -1273,10 +1270,10 @@ abstract class ValueSourceClass
     // Construct a map from field to how it's built. If it's a normal field,
     // this is just the field name; if it's a nested builder, this is an
     // invocation of the nested builder taking into account nullability.
-    var fieldBuilders = <String, String>{};
-    var needsNullCheck = <String>{};
-    var genericFields = <String, String>{};
-    fields.forEach((field) {
+    final fieldBuilders = <String, String>{};
+    final needsNullCheck = <String>{};
+    final genericFields = <String, String>{};
+    for (final field in fields) {
       final name = field.name;
       if (!field.isNestedBuilder) {
         fieldBuilders[name] = name;
@@ -1301,11 +1298,11 @@ abstract class ValueSourceClass
         fieldBuilders[name] = '_$name?.build()';
         if (!field.isNullable) needsNullCheck.add(name);
       }
-    });
+    }
 
     // If there are nested builders then wrap the build in a try/catch so we
     // can add information should a nested builder fail.
-    var needsTryCatchOnBuild = fieldBuilders.keys.any(
+    final needsTryCatchOnBuild = fieldBuilders.keys.any(
       (field) => fieldBuilders[field] != field,
     );
 
@@ -1378,20 +1375,20 @@ abstract class ValueSourceClass
   }
 
   String _generateEqualsAndHashcode({bool forBuilder = false}) {
-    var result = StringBuffer();
+    final result = StringBuffer();
 
-    var comparedFields = fields
+    final comparedFields = fields
         .where(
           (field) => field.builtValueField.compare ?? settings.defaultCompare,
         )
         .toList();
-    var comparedFunctionFields =
+    final comparedFunctionFields =
         comparedFields.where((field) => field.isFunctionType).toList();
     result.writeln('@override');
     result.writeln('bool operator==(Object other) {');
     result.writeln('  if (identical(other, this)) return true;');
 
-    var needsDynamic =
+    final needsDynamic =
         comparedFunctionFields.isNotEmpty && genericParameters.isNotEmpty;
 
     if (needsDynamic) {
@@ -1402,7 +1399,7 @@ abstract class ValueSourceClass
       result.writeln('&&');
       result.writeln(
         comparedFields.map((field) {
-          var nameOrThisDotName =
+          final nameOrThisDotName =
               field.name == 'other' ? 'this.other' : field.name;
           return needsDynamic && field.isFunctionType
               ? '$nameOrThisDotName == _\$dynamicOther.${field.name}'
@@ -1414,7 +1411,7 @@ abstract class ValueSourceClass
     result.writeln('}');
     result.writeln();
 
-    var generateMemoizedHashCode =
+    final generateMemoizedHashCode =
         declaresMemoizedHashCode && comparedFields.isNotEmpty;
     if (generateMemoizedHashCode) {
       result.writeln('int? __hashCode;');
@@ -1435,7 +1432,7 @@ abstract class ValueSourceClass
       final seed = forBuilder ? 1 : 0;
       result.writeln('var _\$hash  = $seed;');
 
-      for (var field in comparedFields) {
+      for (final field in comparedFields) {
         result.writeln('_\$hash = \$jc(_\$hash, ${field.name}.hashCode);');
       }
 
@@ -1455,13 +1452,13 @@ abstract class ValueSourceClass
 
   /// Generates an abstract builder with just abstract setters and getters.
   String _generateAbstractBuilder() {
-    var result = StringBuffer();
+    final result = StringBuffer();
 
     // The "Built" interface has been omitted to work around dart2js issue
     // https://github.com/dart-lang/sdk/issues/14729. So, we can't implement
     // "Builder". Add the methods explicitly. We can however implement any
     // other built_value interfaces.
-    var interfaces = [...builderImplements.skip(1), ...builderMixins];
+    final interfaces = [...builderImplements.skip(1), ...builderMixins];
 
     if (implementsBuilt) {
       result.writeln(
@@ -1471,7 +1468,7 @@ abstract class ValueSourceClass
     } else {
       result.writeln(
         'abstract $_class ${name}Builder$_boundedGenerics '
-        '${interfaces.isEmpty ? '' : 'implements ' + interfaces.join(', ')}'
+        '${interfaces.isEmpty ? '' : 'implements ${interfaces.join(', ')}'}'
         '{',
       );
 
@@ -1485,8 +1482,8 @@ abstract class ValueSourceClass
       );
     }
 
-    for (var field in fields) {
-      var type = field.isNestedBuilder
+    for (final field in fields) {
+      final type = field.isNestedBuilder
           ? field.typeInBuilder(libraryFragment)
           : field.typeInLibraryFragment(libraryFragment);
       final name = field.name;
@@ -1511,7 +1508,7 @@ abstract class ValueSourceClass
 }
 
 InvalidGenerationSourceError _makeError(Iterable<GeneratorError> todos) {
-  var message = StringBuffer(
+  final message = StringBuffer(
     'Please make the following changes to use BuiltValue:\n',
   );
   for (var i = 0; i != todos.length; ++i) {

--- a/built_types/built_value_generator/lib/src/value_source_field.dart
+++ b/built_types/built_value_generator/lib/src/value_source_field.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library built_value_generator.source_field;
+library;
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
@@ -11,13 +11,12 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
-import 'package:built_value_generator/src/dart_types.dart';
-import 'package:built_value_generator/src/field_mixin.dart';
-import 'package:built_value_generator/src/fields.dart' show collectFields;
-import 'package:built_value_generator/src/fixes.dart';
-import 'package:built_value_generator/src/metadata.dart'
-    show metadataToStringValue;
-import 'package:built_value_generator/src/parsed_library_results.dart';
+import 'dart_types.dart';
+import 'field_mixin.dart';
+import 'fields.dart' show collectFields;
+import 'fixes.dart';
+import 'metadata.dart' show metadataToStringValue;
+import 'parsed_library_results.dart';
 
 part 'value_source_field.g.dart';
 
@@ -77,7 +76,7 @@ abstract class ValueSourceField
     if (typeFromAst.endsWith('?')) {
       typeFromAst = typeFromAst.substring(0, typeFromAst.length - 1);
     }
-    var typeFromElement = type;
+    final typeFromElement = type;
 
     // If the type is a function, we can't use the element result; it is
     // formatted incorrectly.
@@ -125,13 +124,13 @@ abstract class ValueSourceField
 
   @memoized
   BuiltValueField get builtValueField {
-    var annotations = element.getter!.metadata.annotations
+    final annotations = element.getter!.metadata.annotations
         .map((annotation) => annotation.computeConstantValue())
         .where(
           (value) => DartTypes.tryGetName(value?.type) == 'BuiltValueField',
         );
     if (annotations.isEmpty) return const BuiltValueField();
-    var annotation = annotations.single!;
+    final annotation = annotations.single!;
     return BuiltValueField(
       compare: annotation.getField('compare')?.toBoolValue(),
       serialize: annotation.getField('serialize')?.toBoolValue(),
@@ -222,7 +221,7 @@ abstract class ValueSourceField
   String get builderElementTypeWithPrefix {
     // If it's a real field, it's a [VariableDeclaration] which is guaranteed
     // to have parent node [VariableDeclarationList] giving the type.
-    var fieldDeclaration = parsedLibrary.getFragmentDeclaration(
+    final fieldDeclaration = parsedLibrary.getFragmentDeclaration(
       builderElement!.firstFragment,
     );
     if (fieldDeclaration != null) {
@@ -284,9 +283,9 @@ abstract class ValueSourceField
     InterfaceElement classElement,
     ClassElement? builderClassElement,
   ) {
-    var result = ListBuilder<ValueSourceField>();
+    final result = ListBuilder<ValueSourceField>();
 
-    for (var field in collectFields(classElement)) {
+    for (final field in collectFields(classElement)) {
       if (!field.isStatic &&
           field.getter != null &&
           (field.getter!.isAbstract || !field.getter!.isOriginDeclaration)) {
@@ -325,7 +324,7 @@ abstract class ValueSourceField
   }
 
   Iterable<GeneratorError> computeErrors() {
-    var result = <GeneratorError>[];
+    final result = <GeneratorError>[];
 
     if (!isGetter) {
       result.add(
@@ -381,10 +380,10 @@ abstract class ValueSourceField
         element.type,
         type,
       );
-      if (builderElementTypeOrNull != type + '?' &&
+      if (builderElementTypeOrNull != '$type?' &&
           (builderType == null ||
               (builderElementTypeOrNull != builderType &&
-                  builderElementTypeOrNull != builderType + '?'))) {
+                  builderElementTypeOrNull != '$builderType?'))) {
         result.add(
           GeneratorError(
             (b) => b

--- a/built_types/built_value_generator/pubspec.yaml
+++ b/built_types/built_value_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_generator
-version: 8.13.0
+version: 8.13.1-wip
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library is the dev dependency.
@@ -27,5 +27,5 @@ dev_dependencies:
   build_test: ^3.0.0
   build_runner: '>=1.0.0 <3.0.0'
   logging: ^1.3.0
-  pedantic: ^1.4.0
+  dart_flutter_team_lints: ^3.1.0
   test: ^1.0.0

--- a/built_types/built_value_generator/test/built_value_generator_test.dart
+++ b/built_types/built_value_generator/test/built_value_generator_test.dart
@@ -1075,10 +1075,10 @@ abstract class _Value implements Built<_Value, _ValueBuilder> {
 
 final String pkgName = 'pkg';
 
-final Builder builder = PartBuilder([BuiltValueGenerator()], '.g.dart');
+final Builder builder = PartBuilder([const BuiltValueGenerator()], '.g.dart');
 
 Future<String> generate(String source) async {
-  var srcs = <String, String>{
+  final srcs = <String, String>{
     'built_value|lib/built_value.dart': builtValueSource,
     '$pkgName|lib/value.dart': source,
   };

--- a/built_types/built_value_generator/test/enum_class_generator_test.dart
+++ b/built_types/built_value_generator/test/enum_class_generator_test.dart
@@ -446,10 +446,8 @@ class TestEnum extends EnumClass {
     test('allows new constructor naming syntax with string parameter',
         () async {
       expect(
-          await generate('// @dart=3.14\n' +
-              correctInput.replaceAll(
-                  'const TestEnum._(String name) : super(name);',
-                  'const new _(String name) : super(name);')),
+          await generate(
+              '// @dart=3.14\n${correctInput.replaceAll('const TestEnum._(String name) : super(name);', 'const new _(String name) : super(name);')}'),
           contains(correctOutput.replaceFirst(
               'abstract class _\$TestEnumMixin', 'mixin _\$TestEnumMixin')));
     });
@@ -634,7 +632,7 @@ final String pkgName = 'pkg';
 
 // Recreate BuiltValueGenerator for each test because we repeatedly create
 // enums with the same name in the same library, which will clash.
-Builder get builder => PartBuilder([BuiltValueGenerator()], '.g.dart');
+Builder get builder => PartBuilder([const BuiltValueGenerator()], '.g.dart');
 
 Future<String> generate(String source) async {
   final srcs = <String, String>{

--- a/built_types/built_value_generator/test/serializer_generator_test.dart
+++ b/built_types/built_value_generator/test/serializer_generator_test.dart
@@ -261,10 +261,10 @@ abstract class Value implements Built<Value, ValueBuilder> {
 
 final String pkgName = 'pkg';
 
-final Builder builder = PartBuilder([BuiltValueGenerator()], '.g.dart');
+final Builder builder = PartBuilder([const BuiltValueGenerator()], '.g.dart');
 
 Future<String> generate(String source) async {
-  var srcs = <String, String>{
+  final srcs = <String, String>{
     'test_support|lib/test_support.dart': testSupportSource,
     '$pkgName|lib/value.dart': source,
   };

--- a/built_types/built_value_test/analysis_options.yaml
+++ b/built_types/built_value_test/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/built_types/built_value_test/pubspec.yaml
+++ b/built_types/built_value_test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_value_test
-version: 8.13.0
+version: 8.13.1-wip
 description: >
   Value types with builders, Dart classes as enums, and serialization.
   This library provides test support.
@@ -25,5 +25,5 @@ dependencies:
 dev_dependencies:
   built_value_generator: ^8.13.0
   build_runner: '>=1.0.0 <3.0.0'
-  pedantic: ^1.4.0
+  dart_flutter_team_lints: ^3.1.0
   test: ^1.0.0

--- a/built_types/built_value_test/test/values.dart
+++ b/built_types/built_value_test/test/values.dart
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library values;
+library;
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';


### PR DESCRIPTION
Switch to the standard lint set.

Enforce only the ones that can be mechanically fixed.

The first commit sets up the lint set and necessary exclusions.

The second commit is large but is generated using `dart fix` only :)