### PR TITLE
Fix DDC hot reload builds with generated entrypoints

### DIFF
--- a/builder_pkgs/build_web_compilers/CHANGELOG.md
+++ b/builder_pkgs/build_web_compilers/CHANGELOG.md
@@ -7,12 +7,19 @@
 - Prefer entrypoints closer to the root of a searched directory,
   and `main.dart` over other entrypoints alongside it.
 - Accept a list of directories for `web-assets-path`.
+- Fix `DdcFrontendServerBuilder` failing to compile generated entrypoints while
+  building dependency modules.
+- Fix `.web.entrypoint.json` being looked for in the package root rather than
+  where `WebEntrypointMarkerBuilder` writes it, which stopped the recorded
+  entrypoint from ever being restored on a later build.
+- Fix a crash when reading a `.web.entrypoint.json` that records no entrypoint.
 
 ## 4.8.10
 
 - Require Dart `3.13.0`.
 
 ## 4.8.9
+
 - Fix an issue where `DdcFrontendServerBuilder` accumulates changed files across builds.
 
 ## 4.8.8

--- a/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_resources.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_frontend_server/frontend_server_resources.dart
@@ -12,12 +12,36 @@ import 'package:scratch_space/scratch_space.dart';
 /// the Frontend Server.
 final frontendServerState = FrontendServerState();
 
+/// The asset in [package] that `WebEntrypointMarkerBuilder` records the app's
+/// entrypoint in.
+///
+/// That builder runs on the `$web$` placeholder, which is always `web/$web$`,
+/// so its `.web.entrypoint.json` output always lands directly under `web`.
+/// Everything that writes or reads the file goes through here so the two can't
+/// drift apart.
+AssetId webEntrypointStateAssetId(String package) =>
+    AssetId(package, 'web/.web.entrypoint.json');
+
 class FrontendServerState {
   /// The built app's main entrypoint file.
   ///
-  /// This must be set before any asset builders run when compiling with DDC and
-  /// hot reload.
+  /// This must be set before any asset builders run when
+  /// compiling with DDC and hot reload enabled.
+  ///
+  /// `WebEntrypointMarkerBuilder` sets it, and also stages it into the scratch
+  /// space; see [stagedEntrypointAssetId].
   AssetId? entrypointAssetId;
+
+  /// The entrypoint that has been copied into the scratch space, if any.
+  ///
+  /// Build steps in other packages can't read a generated entrypoint
+  /// themselves, so `WebEntrypointMarkerBuilder` stages a copy for them to
+  /// compile against and records it here.
+  ///
+  /// The scratch space outlives an individual build, so this is not reset
+  /// between builds; it is only unset for as long as nothing has been staged
+  /// into the current scratch space.
+  AssetId? stagedEntrypointAssetId;
 
   /// The scratch space where the Frontend Server writes its outputs (`.js`,
   /// `.map`, and `.metadata` files).
@@ -34,16 +58,21 @@ class FrontendServerState {
   /// Looks for and loads a `.web.entrypoint.json` file if it exists.
   ///
   /// Returns whether or not the `.web.entrypoint.json` was found and loaded.
+  ///
+  /// Note that a build step can never read its own output, so this only ever
+  /// loads state written by an earlier build phase, or by an earlier build.
   Future<bool> checkAndDeserializeState(BuildStep buildStep) async {
-    final webEntrypointAsset = AssetId(
+    final webEntrypointAsset = webEntrypointStateAssetId(
       buildStep.inputId.package,
-      '.web.entrypoint.json',
     );
-    if (await buildStep.canRead(webEntrypointAsset)) {
-      final contents = json.decode(
-        await buildStep.readAsString(webEntrypointAsset),
-      ) as Map<String, Object?>;
-      entrypointAssetId = AssetId.parse(contents['entrypoint'] as String);
+    if (!await buildStep.canRead(webEntrypointAsset)) return false;
+    final contents = json.decode(
+      await buildStep.readAsString(webEntrypointAsset),
+    ) as Map<String, Object?>;
+    // `WebEntrypointMarkerBuilder` writes an empty object when it doesn't find
+    // an entrypoint, in which case there is no state to restore.
+    if (contents['entrypoint'] case final String entrypoint) {
+      entrypointAssetId = AssetId.parse(entrypoint);
       return true;
     }
     return false;

--- a/builder_pkgs/build_web_compilers/lib/src/build_modules/build_modules.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/build_modules/build_modules.dart
@@ -3,7 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export '../build_frontend_server/frontend_server_resources.dart'
-    show frontendServerState, frontendServerStateResource;
+    show
+        FrontendServerState,
+        frontendServerState,
+        frontendServerStateResource,
+        webEntrypointStateAssetId;
 export '../common.dart' show fesManagerConfigPath, multiRootScheme;
 export 'ddc_names.dart';
 export 'errors.dart' show MissingModulesException, UnsupportedModules;

--- a/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/ddc_frontend_server_builder.dart
@@ -49,6 +49,23 @@ class DdcFrontendServerBuilder implements Builder {
       for (final dep in transitiveDeps) ...dep.sources,
     ];
     final scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
+    // The entrypoint always has to be in the scratch space: any module can
+    // trigger a compilation of the main app, including a deferred one.
+    //
+    // Stage it from here whenever this build step can read it, which also
+    // records it as an input so that this step is rerun when it changes. A
+    // generated entrypoint in another package can't be read here at all, as
+    // it's a hidden output of a build phase that runs after this one; fall
+    // back to the copy `WebEntrypointMarkerBuilder` staged in that case.
+    //
+    // The marker builder is guaranteed to have run first not because of its
+    // `runs_before`, which can only order builders within a single package,
+    // but because the DDC builders are optional: they are demand driven from
+    // the root package's entrypoint builder, which runs after the marker.
+    final entrypointIsStaged =
+        frontendServerState.stagedEntrypointAssetId == entrypointAssetId;
+    final stageEntrypoint =
+        !entrypointIsStaged || await buildStep.canRead(entrypointAssetId);
     final root = getRootPackageName();
     final driver = await buildStep.fetchResource(
       frontendServerProxyDriverResource,
@@ -68,7 +85,7 @@ class DdcFrontendServerBuilder implements Builder {
       final changedAssetUris = <Uri>[];
       frontendServerState.triggerSharedCompilation(entrypointAssetId, () async {
         await scratchSpace.ensureAssets([
-          entrypointAssetId,
+          if (stageEntrypoint) entrypointAssetId,
           ...module.sources,
           ...transitiveSources,
         ], buildStep);

--- a/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_builder.dart
@@ -368,8 +368,6 @@ class WebEntrypointBuilder implements Builder {
       final frontendServerStateWasLoaded = await frontendServerState
           .checkAndDeserializeState(buildStep);
       if (!frontendServerStateWasLoaded) {
-        final webEntrypointJson = <String, dynamic>{};
-        webEntrypointJson['entrypoint'] = dartEntrypointId.toString();
         frontendServerState.entrypointAssetId = dartEntrypointId;
       }
     }

--- a/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_marker_builder.dart
+++ b/builder_pkgs/build_web_compilers/lib/src/web_entrypoint_marker_builder.dart
@@ -53,33 +53,40 @@ class WebEntrypointMarkerBuilder implements Builder {
       buildStep,
     );
 
-    final webEntrypointJson = <String, Object?>{};
-
-    if (hasCachedState) {
-      final asset = frontendServerState.entrypointAssetId!;
-      webEntrypointJson['entrypoint'] = asset.toString();
-      webEntrypointJson['canonicalUri'] = sourceArg(asset);
-    } else {
-      final asset = await _findEntrypoint(buildStep);
-      if (asset != null) {
-        // We must save the main entrypoint as the recompilation target for
-        // the Frontend Server before any JS files are emitted.
-        frontendServerState.entrypointAssetId = asset;
-        webEntrypointJson['entrypoint'] = asset.toString();
-        webEntrypointJson['canonicalUri'] = sourceArg(asset);
-      }
+    final entrypointAssetId = hasCachedState
+        ? frontendServerState.entrypointAssetId!
+        : await _findEntrypoint(buildStep);
+    if (entrypointAssetId != null) {
+      // We must save the main entrypoint as the recompilation target for the
+      // Frontend Server before any JS files are emitted.
+      frontendServerState.entrypointAssetId = entrypointAssetId;
     }
 
-    final rootDir = p.dirname(buildStep.inputId.path);
-    final webEntrypointAsset = AssetId(
-      buildStep.inputId.package,
-      p.join(rootDir, '.web.entrypoint.json'),
+    await buildStep.writeAsString(
+      webEntrypointStateAssetId(buildStep.inputId.package),
+      jsonEncode(<String, Object?>{
+        if (entrypointAssetId != null) ...{
+          'entrypoint': entrypointAssetId.toString(),
+          'canonicalUri': sourceArg(entrypointAssetId),
+        },
+      }),
     );
 
-    await buildStep.writeAsString(
-      webEntrypointAsset,
-      jsonEncode(webEntrypointJson),
+    if (entrypointAssetId == null) return;
+
+    // A generated entrypoint can only be read from a build step in its own
+    // package. Stage it here, in the root package, so that the DDC builds of
+    // dependency packages can compile against it instead; see
+    // `DdcFrontendServerBuilder`.
+    //
+    // This runs after the state above is written so that a failure to read the
+    // entrypoint doesn't take the recorded state down with it.
+    final scratchSpace = await buildStep.fetchResource(scratchSpaceResource);
+    await buildStep.trackStage(
+      'EnsureAssets',
+      () => scratchSpace.ensureAssets([entrypointAssetId], buildStep),
     );
+    frontendServerState.stagedEntrypointAssetId = entrypointAssetId;
   }
 
   /// Searches for and returns the highest-priority web app entrypoint,

--- a/builder_pkgs/build_web_compilers/test/web_entrypoint_marker_builder_test.dart
+++ b/builder_pkgs/build_web_compilers/test/web_entrypoint_marker_builder_test.dart
@@ -164,11 +164,131 @@ void main() {
       );
     }
   });
+
+  test('stages a generated entrypoint in the scratch space', () async {
+    // The entrypoint is generated, so it can only be
+    // read from a build step in its own package.
+    // Staging it is what makes it available to
+    // the DDC builds of other packages.
+    final generateEntrypoint = TestBuilder(
+      buildExtensions: replaceExtension('.template', '.dart'),
+    );
+
+    // The scratch space is deleted once the build is over,
+    // so the staged file has to be read from within the build.
+    final readStagedEntrypoint = TestBuilder(
+      buildExtensions: replaceExtension(
+        '.web.entrypoint.json',
+        '.web.entrypoint.staged',
+      ),
+      build: (buildStep, _) async {
+        final scratchSpace = await buildStep.fetchResource(
+          scratchSpaceResource,
+        );
+        final entrypoint = AssetId(
+          buildStep.inputId.package,
+          'web/generated_main.dart',
+        );
+        await buildStep.writeAsString(
+          buildStep.allowedOutputs.single,
+          await scratchSpace.fileFor(entrypoint).readAsString(),
+        );
+      },
+    );
+
+    await testBuilders(
+      [
+        generateEntrypoint,
+        WebEntrypointMarkerBuilder(usesWebHotReload: true),
+        readStagedEntrypoint,
+      ],
+      {'a|web/\$web\$': '', 'a|web/generated_main.template': 'void main() {}'},
+      outputs: {
+        'a|web/generated_main.dart': 'void main() {}',
+        'a|web/.web.entrypoint.json': decodedMatches(
+          contains('web/generated_main.dart'),
+        ),
+        'a|web/.web.entrypoint.staged': 'void main() {}',
+      },
+    );
+
+    // The staged file is also there when a previous test left one behind, so
+    // check the signal `DdcFrontendServerBuilder` actually branches on.
+    expect(
+      frontendServerState.stagedEntrypointAssetId,
+      AssetId('a', 'web/generated_main.dart'),
+    );
+  });
+
+  test('records state that a later build step can load', () async {
+    // `checkAndDeserializeState` and the marker builder have to agree on where
+    // the state is written; a mismatch silently disables all state reuse.
+    final loadState = TestBuilder(
+      buildExtensions: replaceExtension('.dart', '.loaded'),
+      build: (buildStep, _) async {
+        // Deliberately not the shared state, which the marker builder in this
+        // same build has already populated in memory.
+        final state = FrontendServerState();
+        final loaded = await state.checkAndDeserializeState(buildStep);
+        await buildStep.writeAsString(
+          buildStep.allowedOutputs.single,
+          '$loaded ${state.entrypointAssetId}',
+        );
+      },
+    );
+
+    await testBuilders(
+      [WebEntrypointMarkerBuilder(usesWebHotReload: true), loadState],
+      {'a|web/\$web\$': '', 'a|web/main.dart': 'void main() {}'},
+      outputs: {
+        'a|web/.web.entrypoint.json': decodedMatches(contains('web/main.dart')),
+        'a|web/main.loaded': 'true a|web/main.dart',
+      },
+    );
+  });
+
+  test('does not record an entrypoint when there is none', () async {
+    await testBuilders(
+      [WebEntrypointMarkerBuilder(usesWebHotReload: true)],
+      {'a|web/\$web\$': '', 'a|web/no_main.dart': 'int x = 0;'},
+      outputs: {'a|web/.web.entrypoint.json': '{}'},
+    );
+
+    expect(frontendServerState.entrypointAssetId, isNull);
+    expect(frontendServerState.stagedEntrypointAssetId, isNull);
+  });
+
+  test(
+    'loading state without an entrypoint reports it as not loaded',
+    () async {
+      final loadState = TestBuilder(
+        buildExtensions: replaceExtension('.dart', '.loaded'),
+        build: (buildStep, _) async {
+          final state = FrontendServerState();
+          final loaded = await state.checkAndDeserializeState(buildStep);
+          await buildStep.writeAsString(
+            buildStep.allowedOutputs.single,
+            '$loaded ${state.entrypointAssetId}',
+          );
+        },
+      );
+
+      await testBuilders(
+        [loadState],
+        {
+          'a|web/.web.entrypoint.json': '{}',
+          'a|web/main.dart': 'void main() {}',
+        },
+        outputs: {'a|web/main.loaded': 'false null'},
+      );
+    },
+  );
 }
 
 void _resetFrontendServerState() {
   frontendServerState
     ..entrypointAssetId = null
+    ..stagedEntrypointAssetId = null
     ..needsRecompileRestart = false
     ..fesScratchSpace = null;
 }


### PR DESCRIPTION
Hot-reload builds are currently broken when the entrypoint is generated (e.g. when using Jaspr).

CC @parlough 
 
---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
